### PR TITLE
logmask now uses STL bitset

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -92,7 +92,7 @@ void log_set_mask(const log_mask_t *mask)
 {
    if (mask != NULL)
    {
-	   g_log.mask.bits = mask->bits;
+      g_log.mask.bits = mask->bits;
    }
 }
 
@@ -106,7 +106,7 @@ void log_get_mask(log_mask_t *mask)
 {
    if (mask != NULL)
    {
-	   mask->bits = g_log.mask.bits;
+      mask->bits = g_log.mask.bits;
    }
 }
 

--- a/src/logmask.h
+++ b/src/logmask.h
@@ -21,7 +21,7 @@ typedef UINT8   log_sev_t;
 /** A simple array of 256 bits */
 typedef struct
 {
-   bitset<256> bits;   /* 256 levels */
+   bitset<256> bits;    /* 256 levels */
 } log_mask_t;
 
 
@@ -33,7 +33,7 @@ typedef struct
  */
 static_inline bool logmask_test(const log_mask_t *mask, log_sev_t sev)
 {
-	return mask->bits.test(sev);
+   return mask->bits.test(sev);
 }
 
 
@@ -47,11 +47,11 @@ static_inline void logmask_set_sev(log_mask_t *mask, log_sev_t sev, bool value)
 {
    if (value)
    {
-	   mask->bits.set(sev);
+      mask->bits.set(sev);
    }
    else
    {
-	   mask->bits.reset(sev);
+      mask->bits.reset(sev);
    }
 }
 
@@ -65,11 +65,11 @@ static_inline void logmask_set_all(log_mask_t *mask, bool value)
 {
    if (value)
    {
-	   mask->bits.set();
+      mask->bits.set();
    }
    else
    {
-	   mask->bits.reset();
+      mask->bits.reset();
    }
 }
 


### PR DESCRIPTION
Sorry for taking so long, but, for pesonal reasons, I was kind of busy.

Anyways, as promised, I used the STL bitset for the logmask (instead of the original UINT8 bits[32]) and made all the necessary changes so the code can compile. Hope you find it helpful.
