### PR TITLE
Fixed an infinite loop in parse_word.

### DIFF
--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -914,7 +914,7 @@ bool parse_word(tok_ctx& ctx, chunk_t& pc, bool skipcheck)
    pc.str.clear();
    pc.str.append(ctx.get());
 
-   while (CharTable::IsKw2(ctx.peek()))
+   while (ctx.more() && CharTable::IsKw2(ctx.peek()))
    {
       ch = ctx.get();
       pc.str.append(ch);


### PR DESCRIPTION
When there are no more characters in the context, the parsing fails.
Create a file with just #x in it and without a new line to reproduce.
