### PR TITLE
Fixed a crash in indent_text.

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1102,7 +1102,7 @@ void indent_text(void)
             }
             else
             {
-               if (!chunk_is_comment(next))
+               if (next && !chunk_is_comment(next))
                {
                   if (next->type == CT_SPACE)
                   {


### PR DESCRIPTION
When a closing paren is missing at the end of a file, the next token is NULL.
To reproduce, create a file with just x( in it and without a newline.
