### PR TITLE
Tweak align_oc_decl_colon to also align colons of Objective-C method prototypes

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -247,11 +247,6 @@ void align_all(void)
       align_oc_msg_colons();
    }
 
-   if (cpd.settings[UO_align_oc_decl_colon].b)
-   {
-      align_oc_decl_colon();
-   }
-
    /* Align variable definitions */
    if ((cpd.settings[UO_align_var_def_span].n > 0) ||
        (cpd.settings[UO_align_var_struct_span].n > 0))
@@ -281,6 +276,12 @@ void align_all(void)
    if (cpd.settings[UO_align_oc_msg_spec_span].n > 0)
    {
       align_oc_msg_spec(cpd.settings[UO_align_oc_msg_spec_span].n);
+   }
+
+   /* Align OC colons */
+   if (cpd.settings[UO_align_oc_decl_colon].b)
+   {
+      align_oc_decl_colon();
    }
 
    /* Align variable defs in function prototypes */
@@ -1938,7 +1939,8 @@ static void align_oc_decl_colon(void)
                 &&
                 ((tmp->type == CT_WORD) ||
                  (tmp->type == CT_TYPE) ||
-                 (tmp->type == CT_OC_MSG_DECL))
+                 (tmp->type == CT_OC_MSG_DECL) ||
+                 (tmp->type == CT_OC_MSG_SPEC))
                 &&
                 ((tmp2->type == CT_WORD) ||
                  (tmp2->type == CT_TYPE) ||


### PR DESCRIPTION
This is in reference to issue #18.

This commit tweaks _align_oc_decl_colon()_ to allow through Objective-C method prototypes as well, instead of just declarations.

It also moves _align_oc_decl_colon() to occur after *align_oc_msg_spec()_, to avoid the message spec alignment causing misalignment of the parameters of prototype, which was probably causing the weirdness in issue #18.

In my test case, after this change, the prototype:

```
- (id)initWithTitle:(NSString *)title
          message:(NSString *)message
 cancelButton:(NSString *)cancelButtonTitle     
    otherButton:(NSString *)otherButtonTitle    ;
```

Becomes:

```
- (id)initWithTitle:(NSString *)title
            message:(NSString *)message
       cancelButton:(NSString *)cancelButtonTitle
        otherButton:(NSString *)otherButtonTitle;
```

When _align_oc_decl_colon_ is set to _true_.
