### PR TITLE
avoid gcc's type-punned pointer warnings

### DIFF
--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -203,8 +203,8 @@ void MD5::Final(UINT8 digest[16])
    }
 
    /* Append length in bits and transform */
-   ((UINT32 *)m_in)[14] = m_bits[0];
-   ((UINT32 *)m_in)[15] = m_bits[1];
+   memcpy (&m_in[52], &m_bits[0], sizeof m_bits[0]);
+   memcpy (&m_in[56], &m_bits[1], sizeof m_bits[0]);
 
    Transform(m_buf, (UINT32 *)m_in);
    if (m_need_byteswap)


### PR DESCRIPTION
Hi Ben,

Building with gcc, I see only these two warnings, so wrote the patch:

md5.cpp: In member function 'void MD5::Final(UINT8*)':
  md5.cpp:206:23: warning: dereferencing type-punned pointer \
    will break strict-aliasing rules [-Wstrict-aliasing]
  md5.cpp:207:23: warning: dereferencing type-punned pointer \
    will break strict-aliasing rules [-Wstrict-aliasing]

The fix is to use memcpy rather than a type-punning assignment.
