### PR TITLE
Update of "#include guard" management

### DIFF
--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -640,7 +640,7 @@ chunk_t *insert_comment_after(chunk_t *ref, c_token_t cmt_type,
    new_cmt.type  = cmt_type;
 
    /* allocate memory for the string */
-   txt = new char[txt_len];
+   txt = new char[txt_len + 1]; /* + 1 for '\0' */
    if (txt == NULL)
    {
       return(NULL);

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2920,6 +2920,13 @@ static void mark_class_ctor(chunk_t *start)
    chunk_t *pc   = chunk_get_next_ncnl(pclass, CNAV_PREPROC);
    int     level = pclass->brace_level + 1;
 
+   if (pc == NULL)
+   {
+      LOG_FMT(LFTOR, "%s: Called on %.*s on line %d. Bailed on NULL\n",
+		  __func__, pclass->len, pclass->str, pclass->orig_line);
+      return;
+   }
+
    LOG_FMT(LFTOR, "%s: Called on %.*s on line %d (next='%.*s')\n",
            __func__, pclass->len, pclass->str, pclass->orig_line,
            pc->len, pc->str);
@@ -3960,7 +3967,7 @@ static void handle_wrap(chunk_t *pc)
        ((name->type == CT_WORD) || (name->type == CT_TYPE)) &&
        (clp->type == CT_PAREN_CLOSE))
    {
-      new_name = new char[pc->len + 2 + name->len + 2];
+      new_name = new char[pc->len + 2 + name->len + 2 + 1]; /* + 1 for '\0' */
       if (new_name != NULL)
       {
          const char *fsp = (av & AV_ADD) ? " " : "";

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1221,6 +1221,14 @@ int load_option_file(const char *filename)
 
    cpd.line_number = 0;
 
+#ifdef WIN32
+   /* "/dev/null" not understood by "fopen" in windoze */
+   if (strcasecmp(filename, "/dev/null") == 0)
+   {
+	   return(0);
+   }
+#endif
+
    pfile = fopen(filename, "r");
    if (pfile == NULL)
    {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1073,7 +1073,7 @@ static void output_comment_multi(chunk_t *pc)
    line_len      = 0;
    cmt.column    = ccol;
    cmt.br_column = ccol;
-   line          = new char[remaining + 1024];
+   line          = new char[remaining + 1024 + 1]; /* + 1 for '\0' */
    while (remaining > 0)
    {
       ch = *cmt_str;

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -88,7 +88,7 @@ const char *path_basename(const char *path)
    while ((ch = *path) != 0)
    {
       path++;
-      if (ch == PATH_SEP)
+      if ((ch == '/') || (ch == '\\')) /* Update to be able to run python test script under windoze */
       {
          last_path = path;
       }
@@ -931,7 +931,7 @@ const char *fix_filename(const char *filename)
    char *tmp_file;
 
    /* Create 'outfile.uncrustify' */
-   tmp_file = new char[strlen(filename) + 16];
+   tmp_file = new char[strlen(filename) + 16 + 1]; /* + 1 for '\0' */
    if (tmp_file != NULL)
    {
       sprintf(tmp_file, "%s.uncrustify", filename);


### PR DESCRIPTION
Hi Ben,

Here is an update of the tool mainly to apply "#include guard" strategy to code.
I have not created an option as it seems that this update has no impact on tests.
But if you prefer I had an option, don't hesitate to ask me.

Specific actions were taken for preprocessor directives.
  It is now extended to all code:
    - code inside the "#include guard" is not indented
    - optimization of "ifdef_over_whole_file" to be able to call it several times
- Update of the comment of some options to clarify their actions

Ronan
