### PR TITLE
Remove semicolons after namespace close brace

### DIFF
--- a/src/semicolons.cpp
+++ b/src/semicolons.cpp
@@ -31,7 +31,7 @@ static void remove_semicolon(chunk_t *pc)
 
 /**
  * Removes superfluous semicolons:
- *  - after brace close whose parent is IF, ELSE, SWITCH, WHILE, FOR
+ *  - after brace close whose parent is IF, ELSE, SWITCH, WHILE, FOR, NAMESPACE
  *  - after another semicolon where parent is not FOR
  *  - (D) after brace close whose parent is ENUM/STRUCT/UNION
  *  - after an open brace
@@ -65,7 +65,8 @@ void remove_extra_semicolons(void)
               (prev->parent_type == CT_FOR) ||
               (prev->parent_type == CT_FUNC_DEF) ||
               (prev->parent_type == CT_OC_MSG_DECL) ||
-              (prev->parent_type == CT_FUNC_CLASS)))
+              (prev->parent_type == CT_FUNC_CLASS) ||
+              (prev->parent_type == CT_NAMESPACE)))
          {
             remove_semicolon(pc);
          }


### PR DESCRIPTION
Semicolons are un-necessary after namespace close braces. This patch removes them.

Test:

```
$ echo "mod_remove_extra_semicolon = true" > unc.cnf
$ echo 'namespace test { int blah = 5; };' |  uncrustify -L59,60 -l cpp -c unc.cnf
Semi on 1:30, prev = '5' [NUMBER/NONE]
Semi on 1:33, prev = '}' [BRACE_CLOSE/NAMESPACE]
remove_semicolon: Removed semicolon at line 1, col 33
namespace test { int blah = 5; }
```
