### PR TITLE
Mark functions inside block expressions

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -617,7 +617,8 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
    }
    else
    {
-      if ((pc->type == CT_FUNCTION) && !is_oc_block(pc))
+      if ((pc->type == CT_FUNCTION) &&
+          (pc->parent_type == CT_OC_BLOCK_EXPR || !is_oc_block(pc)))
       {
          mark_function(pc);
       }


### PR DESCRIPTION
Function calls inside Objective-C blocks are not being marked as function calls, instead they retain a `type` of `CT_FUNCTION`. As a consequence, the fallback condition in `do_space()` is being reached, resulting in a space being added between function names and their opening paren. For my code, this patch has fixed the problem.

I haven't written any tests, tonight is the first that I've looked at the uncrustify codebase and I only had time to fix the bug.

I believe this may fix #75.

thanks,
Dave
