### PR TITLE
Add support for D's new lambda operator

### DIFF
--- a/src/punctuators.cpp
+++ b/src/punctuators.cpp
@@ -75,7 +75,7 @@ static const chunk_tag_t symbols2[] =
    { "||", CT_BOOL,         LANG_ALL                                       },
    { "~=", CT_COMPARE,      LANG_D                                         },
    { "~~", CT_COMPARE,      LANG_D                                         },
-   { "=>", CT_LAMBDA,       LANG_VALA | LANG_CS                            },
+   { "=>", CT_LAMBDA,       LANG_VALA | LANG_CS | LANG_D                   },
    { "??", CT_COMPARE,      LANG_CS                                        },
 };
 


### PR DESCRIPTION
The "=>" syntax for lambda was added in D's [2.058 release.](http://dlang.org/changelog.html#new2_058) This is a simple change that marks the => operator as being a part of the D language.
