### PR TITLE
Request for fix to make ObjC handle method one liners (nl_func_leave_one_liners)

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -1743,6 +1743,13 @@ static bool one_liner_nl_ok(chunk_t *pc)
          return(false);
       }
 
+      if (cpd.settings[UO_nl_func_leave_one_liners].b &&
+          (pc->parent_type == CT_OC_MSG_DECL))
+      {
+         LOG_FMT(LNL1LINE, "false (method def)\n");
+         return(false);
+      }
+
       if (cpd.settings[UO_nl_if_leave_one_liners].b &&
           ((pc->parent_type == CT_IF) ||
            (pc->parent_type == CT_ELSE)))


### PR DESCRIPTION
Ie to make  nl_func_leave_one_liners apply to one line methods in ObjC as well. So the following:
- (NSInteger) count { return 0; }

will not be split across lines.

BTW I am normally a Mercurial user so I might have missed something in doing this pull request, but in any case the code fix worked on the real world examples I tried it on.

Thanks for the greg uncrustify utility!
