### PR TITLE
FIX | issue 99 -> Type pointers in Objective-C block argument definitions and literal blocks star is arith rather than ptr_type

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -4080,6 +4080,8 @@ static void handle_oc_block(chunk_t *pc)
             if (tmp != NULL)
             {
                tmp->parent_type = CT_OC_BLOCK_ARG;
+               /* block arguments are just like function definitions */
+               fix_fcn_def_params(tmp);
 
                while ((tmp = chunk_get_next(tmp)) != NULL)
                {
@@ -4167,7 +4169,9 @@ static void handle_oc_block(chunk_t *pc)
                }
             }
 
-
+            /* block arguments are just like function definitions */
+            fix_fcn_def_params(tmp);
+             
             /* handle args */
             tmp = chunk_get_next(tmp);
             if (tmp != NULL)

--- a/uncrustify.xcodeproj/project.pbxproj
+++ b/uncrustify.xcodeproj/project.pbxproj
@@ -2304,6 +2304,7 @@
 				GCC_VERSION = com.apple.compilers.llvmgcc42;
 				INSTALL_PATH = /usr/local/bin;
 				PRODUCT_NAME = uncrustify;
+				SDKROOT = "";
 			};
 			name = Debug;
 		};
@@ -2317,6 +2318,7 @@
 				GCC_VERSION = com.apple.compilers.llvmgcc42;
 				INSTALL_PATH = /usr/local/bin;
 				PRODUCT_NAME = uncrustify;
+				SDKROOT = "";
 			};
 			name = Release;
 		};
@@ -2371,6 +2373,7 @@
 				GCC_VERSION = com.apple.compilers.llvmgcc42;
 				INSTALL_PATH = /usr/local/bin;
 				PRODUCT_NAME = uncrustify;
+				SDKROOT = "";
 				SEPARATE_STRIP = YES;
 				STRIP_INSTALLED_PRODUCT = YES;
 			};
@@ -2402,6 +2405,7 @@
 				GCC_VERSION = com.apple.compilers.llvmgcc42;
 				INSTALL_PATH = /usr/local/bin;
 				PRODUCT_NAME = uncrustify;
+				SDKROOT = "";
 			};
 			name = "Debug Clang";
 		};
@@ -2427,6 +2431,7 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INSTALL_PATH = /usr/local/bin;
 				PRODUCT_NAME = uncrustify;
+				SDKROOT = "";
 			};
 			name = "Release Clang";
 		};


### PR DESCRIPTION
Type pointers in Objective-C block argument definitions and literal
blocks star is arith rather than ptr_type.

Pass everything starting with the open paren through
fix_fcn_def_params(chunk_t *) to process the arguments like function
parameters.
