### PR TITLE
Keep semicolon after NS_ENUM & NS_OPTIONS declaration (OC).

### DIFF
--- a/src/semicolons.cpp
+++ b/src/semicolons.cpp
@@ -102,6 +102,7 @@ void remove_extra_semicolons(void)
  * We are on a semicolon that is after an unidentified brace close.
  * Check for what is before the brace open.
  * Do not remove if it is a square close, word or type.
+ * (OC) Do not remove if following NS_ENUM or NS_OPTIONS declaration.
  */
 static void check_unknown_brace_close(chunk_t *semi, chunk_t *brace_close)
 {
@@ -109,6 +110,23 @@ static void check_unknown_brace_close(chunk_t *semi, chunk_t *brace_close)
 
    pc = chunk_get_prev_type(brace_close, CT_BRACE_OPEN, brace_close->level);
    pc = chunk_get_prev_ncnl(pc);
+
+   if ((pc != NULL) &&
+       (cpd.lang_flags & LANG_OC) &&
+       (pc->parent_type == CT_TYPEDEF))
+   {
+      chunk_t *ppc;
+
+      ppc = chunk_get_prev_type(brace_close, CT_FPAREN_OPEN, brace_close->level);
+      ppc = chunk_get_prev_ncnl(ppc);
+
+      if ((strcmp(ppc->str.c_str(), "NS_ENUM") == 0) ||
+          (strcmp(ppc->str.c_str(), "NS_OPTIONS") == 0))
+      {
+         return;
+      }
+   }
+
    if ((pc != NULL) &&
        (pc->type != CT_WORD) &&
        (pc->type != CT_TYPE) &&

--- a/tests/input/oc/ns_enum.m
+++ b/tests/input/oc/ns_enum.m
@@ -1,0 +1,3 @@
+// The semicolons at the end of these declarations are not superfluous.
+typedef NS_ENUM (NSUInteger, MyEnum) {MyValue1, MyValue2, MyValue3};
+typedef NS_OPTIONS (NSUInteger, MyBitmask) {MyBit1, MyBit2, MyBit3};

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -58,3 +58,4 @@
 50100  bug_340.cfg                                  oc/bug_340.m
 
 50110  obj-c.cfg                                    oc/msg_align.m
+50111  del_semicolon.cfg                            oc/ns_enum.m

--- a/tests/output/oc/50111-ns_enum.m
+++ b/tests/output/oc/50111-ns_enum.m
@@ -1,0 +1,3 @@
+// The semicolons at the end of these declarations are not superfluous.
+typedef NS_ENUM (NSUInteger, MyEnum) {MyValue1, MyValue2, MyValue3};
+typedef NS_OPTIONS (NSUInteger, MyBitmask) {MyBit1, MyBit2, MyBit3};

--- a/uncrustify.xcodeproj/project.pbxproj
+++ b/uncrustify.xcodeproj/project.pbxproj
@@ -71,6 +71,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2E6EEE7D16A62A27001EFF54 /* ns_enum.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ns_enum.m; sourceTree = "<group>"; };
+		2E6EEE7F16A62A4E001EFF54 /* 50111-ns_enum.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "50111-ns_enum.m"; sourceTree = "<group>"; };
 		3DFFDA26154983A800A1185B /* compat_posix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = compat_posix.cpp; sourceTree = "<group>"; };
 		654C6B42108ED8FC00556CD9 /* real_world_file.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = real_world_file.m; sourceTree = "<group>"; };
 		654C6C70108F238800556CD9 /* 50050-real_world_file.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "50050-real_world_file.m"; sourceTree = "<group>"; };
@@ -1563,6 +1565,7 @@
 				654C6B42108ED8FC00556CD9 /* real_world_file.m */,
 				654C6FB2108FB40D00556CD9 /* more_blocks.m */,
 				654C70BA1090E89400556CD9 /* blocks.m */,
+				2E6EEE7D16A62A27001EFF54 /* ns_enum.m */,
 			);
 			path = oc;
 			sourceTree = "<group>";
@@ -1957,6 +1960,7 @@
 				65A4632D1092D346007F6EBA /* 50081-more_blocks.m */,
 				65A4632E1092D346007F6EBA /* 50082-more_blocks.m */,
 				65A4632F1092D346007F6EBA /* 50083-more_blocks.m */,
+				2E6EEE7F16A62A4E001EFF54 /* 50111-ns_enum.m */,
 			);
 			path = oc;
 			sourceTree = "<group>";


### PR DESCRIPTION
In Objective-C, `mod_remove_extra_semicolon` should not treat the semicolon after an `NS_ENUM` or `NS_OPTIONS` declaration as superfluous.

I've added a test case that reproduces the problem, and a patch that appears to fix it. (C++ is not my strength, so it may need improving.)
