### PR TITLE
C++ comments with long first words were wrapped, leaving an empty comment line.

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -869,7 +869,19 @@ static void add_comment_text(const unc_text& text,
    int  tmp;
    int  len = text.size();
 
-   for (int idx = 0; idx < len; idx++)
+   /* If the '//' is included write it first else we may wrap an empty line */
+   int idx = 0;
+   if (text.startswith("//"))
+   {
+      add_text("//");
+      idx += 2;
+      while (unc_isspace(text[idx]))
+      {
+         add_char(text[idx++]);
+      }
+   }
+
+   for ( ; idx < len; idx++)
    {
       if (!was_dollar && cmt.kw_subst &&
           (text[idx] == '$') && (len > (idx + 3)) && (text[idx + 1] == '('))

--- a/tests/input/cpp/sef.cpp
+++ b/tests/input/cpp/sef.cpp
@@ -2,3 +2,5 @@ CFoo::CFoo(const DWORD something, const RECT& positionRect, const UINT aNumber, 
 thisIsReadOnly, windowTitle), m_pInfo(pInfo), m_width(widthOfSomething)
 {
 }
+
+// this_comment_has_a_first_word_that_is_too_long_to_fit_into_a_line_without_wrapping and should not start with a blank comment line.

--- a/tests/output/cpp/30740-sef.cpp
+++ b/tests/output/cpp/30740-sef.cpp
@@ -13,3 +13,5 @@ CFoo::CFoo(const DWORD something,
 }
 
 
+// this_comment_has_a_first_word_that_is_too_long_to_fit_into_a_line_without_wrapping
+// and should not start with a blank comment line.


### PR DESCRIPTION
If you use C++ // comments, and the first word of the comment is long enough to trigger comment wrapping, then you'd get an extra empty comment line before the comment started.  This is because we wrap when we find the whitespace before the triggering word and when we use "// verylongword" the space happens before the first word.
