### PR TITLE
Fix "finally" keyword in keywords.cpp

### DIFF
--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -130,7 +130,7 @@ static const chunk_tag_t keywords[] =
    { "false",            CT_WORD,         LANG_CPP | LANG_CS | LANG_D | LANG_JAVA | LANG_VALA                         },
    { "file",             CT_PP_FILE,      LANG_PAWN | FLAG_PP                                                         }, // PAWN
    { "final",            CT_QUALIFIER,    LANG_D | LANG_ECMA                                                          },
-   { "finally",          CT_FINALLY,      LANG_D | LANG_CS | LANG_ECMA                                                },
+   { "finally",          CT_FINALLY,      LANG_D | LANG_CS | LANG_ECMA | LANG_JAVA                                    },
    { "flags",            CT_TYPE,         LANG_VALA                                                                   },
    { "float",            CT_TYPE,         LANG_ALLC                                                                   },
    { "for",              CT_FOR,          LANG_ALL                                                                    }, // PAWN


### PR DESCRIPTION
Fixed support for "finaly" block formatting in Java code.
