### PR TITLE
Support C++11 braced initializer lists.

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -3413,7 +3413,10 @@ static void mark_cpp_constructor(chunk_t *pc)
          tmp->type = CT_CLASS_COLON;
          hit_colon = true;
       }
-      if (hit_colon && chunk_is_paren_open(tmp) && (tmp->level == paren_open->level))
+      if (hit_colon &&
+          (chunk_is_paren_open(tmp) ||
+           chunk_is_opening_brace(tmp)) &&
+          (tmp->level == paren_open->level))
       {
          var = skip_template_prev(chunk_get_prev_ncnl(tmp));
          if ((var->type == CT_TYPE) || (var->type == CT_WORD))


### PR DESCRIPTION
C++11 allows to use braces or parens for member initialization in constructors initialisation lists.

This change simply skips the braces the same way it skips the parenthesis whenever a colon has been found after a C++ constructor, and whenever the token is preceded by a word or a type.
