### PR TITLE
Experimental support for comments after long namespaces

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1213,6 +1213,9 @@ void register_options(void)
    unc_add_option("mod_add_long_function_closebrace_comment", UO_mod_add_long_function_closebrace_comment, AT_NUM,
                   "If a function body exceeds the specified number of newlines and doesn't have a comment after\n"
                   "the close brace, a comment will be added.");
+   unc_add_option("mod_add_long_namespace_closebrace_comment", UO_mod_add_long_namespace_closebrace_comment, AT_NUM,
+                  "If a namespace body exceeds the specified number of newlines and doesn't have a comment after\n"
+                  "the close brace, a comment will be added.");
    unc_add_option("mod_add_long_switch_closebrace_comment", UO_mod_add_long_switch_closebrace_comment, AT_NUM,
                   "If a switch body exceeds the specified number of newlines and doesn't have a comment after\n"
                   "the close brace, a comment will be added.");

--- a/src/options.h
+++ b/src/options.h
@@ -661,6 +661,9 @@ enum uncrustify_options
    UO_string_escape_char,       // the string escape char to use
    UO_string_escape_char2,      // the string escape char to use
 
+   /* Hack, add comments to the ends of namespaces */
+   UO_mod_add_long_namespace_closebrace_comment,
+   
    /* This is used to get the enumeration count */
    UO_option_count
 };

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1574,7 +1574,8 @@ static void uncrustify_file(const file_mem& fm, FILE *pfout,
 
       /* Insert trailing comments after certain close braces */
       if ((cpd.settings[UO_mod_add_long_switch_closebrace_comment].n > 0) ||
-          (cpd.settings[UO_mod_add_long_function_closebrace_comment].n > 0))
+          (cpd.settings[UO_mod_add_long_function_closebrace_comment].n > 0) ||
+          (cpd.settings[UO_mod_add_long_namespace_closebrace_comment].n > 0))
       {
          add_long_closebrace_comment();
       }


### PR DESCRIPTION
I added an option "mod_add_long_namespace_closebrace_comment" for namespaces similar to the existing options mod_add_long_function_closebrace_comment and
mod_add_long_switch_closebrace_comment.

Please have a look.

Thanks.
