### PR TITLE
Fix nested block indentation in Objective-C

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -870,7 +870,7 @@ void indent_text(void)
 
                if (cpd.settings[UO_indent_oc_block].b)
                {
-                  frm.pse[frm.pse_tos].indent = 1 + (pc->level * indent_size);
+                  frm.pse[frm.pse_tos].indent = 1 + ((pc->brace_level+1) * indent_size);
                   indent_column_set(frm.pse[frm.pse_tos].indent - indent_size);
                }
                else


### PR DESCRIPTION
I believe this patch fixes issues #152 and #137.  This is in regard to nested blocks not having their closing line indenting correctly.

I ran the tests and it didn't seem to cause any issues but you should probably confirm.
