### PR TITLE
Fix applying sp_before_dc rule with decltype

### DIFF
--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -100,6 +100,7 @@ static const chunk_tag_t keywords[] =
    { "dchar",            CT_TYPE,         LANG_D                                                                      },
    { "debug",            CT_DEBUG,        LANG_D                                                                      },
    { "debugger",         CT_DEBUGGER,     LANG_ECMA                                                                   },
+   { "decltype",         CT_SIZEOF,       LANG_CPP                                                                    },
    { "default",          CT_DEFAULT,      LANG_ALL                                                                    }, // PAWN
    { "define",           CT_PP_DEFINE,    LANG_ALL | FLAG_PP                                                          }, // PAWN
    { "defined",          CT_DEFINED,      LANG_PAWN                                                                   }, // PAWN

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -382,7 +382,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
       return(cpd.settings[UO_sp_after_dc].a);
    }
    if ((second->type == CT_DC_MEMBER) &&
-       ((first->type == CT_WORD) || (first->type == CT_TYPE) ||
+       ((first->type == CT_WORD) || (first->type == CT_TYPE) || (first->type == CT_PAREN_CLOSE) ||
         CharTable::IsKw1(first->str[0])))
    {
       log_rule("sp_before_dc");


### PR DESCRIPTION
Rule wasn't applied and one space was forcely added in the following example:
std::vector<uint8_t> v;
decltype(v)::const_iterator it;

It becomes:
std::vector<uint8_t> v;
decltype(v) ::const_iterator it;

I added decltype keyword by analogy with typeof. It would be better to create a separate rule for decltype/typeof in the future.
