### PR TITLE
Fixed indentation of closing bracket in multi-line ObjC array literal assignments

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -673,6 +673,7 @@ void indent_text(void)
                  (pc->type == CT_COMMA) ||
                  (pc->type == CT_BRACE_OPEN) ||
                  (pc->type == CT_SPAREN_CLOSE) ||
+                 ((pc->type == CT_SQUARE_OPEN) && (pc->parent_type == CT_OC_AT)) ||
                  ((pc->type == CT_SQUARE_OPEN) && (pc->parent_type == CT_ASSIGN))) &&
                  (pc->parent_type != CT_CPP_LAMBDA))
             {

--- a/tests/input/oc/literals.m
+++ b/tests/input/oc/literals.m
@@ -3,6 +3,11 @@ NSDictionary *dictionary = @{@0: @"red",  @1: @"green",  @2: @"blue"};
 
 NSArray *array = @[@0, @1, @2, @YES, @'Z', @42U];
 
+NSArray *multilineArray = @[
+@0, @1, @2, @YES, 
+@'Z', @42U
+];
+
 void main(int argc, const char *argv[]) {
   // character literals.
   NSNumber *theLetterZ = @'Z';          // equivalent to [NSNumber numberWithChar:'Z']

--- a/tests/output/oc/50009-literals.m
+++ b/tests/output/oc/50009-literals.m
@@ -5,6 +5,11 @@ NSDictionary *dictionary = @{
 
 NSArray *array = @[@0, @1, @2, @YES, @'Z', @42U];
 
+NSArray *multilineArray = @[
+   @0, @1, @2, @YES,
+   @'Z', @42U
+];
+
 void main(int argc, const char *argv[])
 {
    // character literals.


### PR DESCRIPTION
I noticed an indentation issue in assignment of array literals that span multiple lines. Unlike dictionaries, the closing bracket on arrays was being indented to match the opening bracket, leaving the content of the array looking like it is "outdented." 

Given a multiline array such as:

```
NSArray *multilineArray = @[
@0, @1, @2, @YES, 
@'Z', @42U
];
```

uncrustify was producing an indentation that aligned the closing bracket to the @ sign on the opening bracket.

```
NSArray *multilineArray = @[
   @0, @1, @2, @YES,
   @'Z', @42U
                          ];
```

It seems awkward and should probably follow what happens for a dictionary instead, where the closing bracket would be aligned with the `N` as follows:

```
NSArray *multilineArray = @[
   @0, @1, @2, @YES,
   @'Z', @42U
];
```

This pull request addresses the issue, hopefully in an acceptable and comprehensive fashion. I have not been able to duplicate this issue outside of assignments, so I only addressed this very specific case. The literals test has been updated to include both a single-line and multi-line array. There was a syntax error in the original test which has also been fixed.

The examples shown above are derived using the standard obj-c config that is used in the literals test.
