### PR TITLE
Added support for NS_ENUM and NS_OPTIONS modern Obj-C enums

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -606,7 +606,8 @@ chunk_t *align_assign(chunk_t *first, int span, int thresh)
 
          tmp = pc->orig_line;
 
-         if (pc->parent_type == CT_ENUM)
+         if ((pc->parent_type == CT_ENUM) || 
+             (pc->parent_type == CT_OC_NS_ENUM))
          {
             myspan   = cpd.settings[UO_align_enum_equ_span].n;
             mythresh = cpd.settings[UO_align_enum_equ_thresh].n;

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -489,6 +489,14 @@ static void parse_cleanup(struct parse_frame *frm, chunk_t *pc)
                pc->type = CT_FPAREN_OPEN;
                parent   = CT_FUNCTION;
             }
+            /* NS_ENUM and NS_OPTIONS are followed by a (type, name) pair */
+            else if ((prev->type == CT_OC_NS_ENUM) || 
+                     (prev->type == CT_OC_NS_OPTIONS))
+            {
+               /* Treat both as CT_OC_NS_ENUM since the syntax is identical */
+               pc->type = CT_FPAREN_OPEN;
+               parent   = CT_OC_NS_ENUM;
+            }
             else
             {
                /* no need to set parent */
@@ -508,6 +516,11 @@ static void parse_cleanup(struct parse_frame *frm, chunk_t *pc)
             else if (prev->type == CT_FPAREN_CLOSE)
             {
                parent = CT_FUNCTION;
+            }
+            else if ((prev->type == CT_FPAREN_CLOSE) && 
+                     (prev->parent_type == CT_OC_NS_ENUM))
+            {
+               parent = CT_OC_NS_ENUM;
             }
             else
             {

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -172,6 +172,7 @@ bool chunk_is_type(chunk_t *pc)
                            (pc->type == CT_QUALIFIER) ||
                            (pc->type == CT_STRUCT) ||
                            (pc->type == CT_ENUM) ||
+                           (pc->type == CT_OC_NS_ENUM) ||
                            (pc->type == CT_UNION)));
 }
 

--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -42,6 +42,8 @@ static const chunk_tag_t keywords[] =
    { "@synthesize",      CT_OC_DYNAMIC,   LANG_OC | LANG_CPP | LANG_C                                                 },
    { "@throw",           CT_THROW,        LANG_OC                                                                     },
    { "@try",             CT_TRY,          LANG_OC | LANG_CPP | LANG_C                                                 },
+   { "NS_ENUM",          CT_OC_NS_ENUM,   LANG_OC                                                                     },
+   { "NS_OPTIONS",       CT_OC_NS_OPTIONS,LANG_OC                                                                     },
    { "_Bool",            CT_TYPE,         LANG_CPP                                                                    },
    { "_Complex",         CT_TYPE,         LANG_CPP                                                                    },
    { "_Imaginary",       CT_TYPE,         LANG_CPP                                                                    },

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -1802,7 +1802,8 @@ static bool one_liner_nl_ok(chunk_t *pc)
       }
 
       if (cpd.settings[UO_nl_enum_leave_one_liners].b &&
-          (pc->parent_type == CT_ENUM))
+          ((pc->parent_type == CT_ENUM) || 
+           (pc->parent_type == CT_OC_NS_ENUM)))
       {
          LOG_FMT(LNL1LINE, "false (enum)\n");
          return(false);
@@ -2077,6 +2078,7 @@ void newlines_cleanup_braces(bool first)
 
          if (cpd.settings[UO_nl_ds_struct_enum_cmt].b &&
              ((pc->parent_type == CT_ENUM) ||
+              (pc->parent_type == CT_OC_NS_ENUM) ||
               (pc->parent_type == CT_STRUCT) ||
               (pc->parent_type == CT_UNION)))
          {
@@ -2169,6 +2171,7 @@ void newlines_cleanup_braces(bool first)
          }
          else if (cpd.settings[UO_nl_ds_struct_enum_close_brace].b &&
                   ((pc->parent_type == CT_ENUM) ||
+                   (pc->parent_type == CT_OC_NS_ENUM) ||
                    (pc->parent_type == CT_STRUCT) ||
                    (pc->parent_type == CT_UNION)))
          {
@@ -2191,6 +2194,7 @@ void newlines_cleanup_braces(bool first)
          if ((cpd.settings[UO_nl_brace_struct_var].a != AV_IGNORE) &&
              ((pc->parent_type == CT_STRUCT) ||
               (pc->parent_type == CT_ENUM) ||
+              (pc->parent_type == CT_OC_NS_ENUM) ||
               (pc->parent_type == CT_UNION)))
          {
             next = chunk_get_next_ncnl(pc, CNAV_PREPROC);
@@ -2279,7 +2283,9 @@ void newlines_cleanup_braces(bool first)
       {
          newlines_struct_enum_union(pc, cpd.settings[UO_nl_union_brace].a, true);
       }
-      else if (pc->type == CT_ENUM)
+      else if ((pc->type == CT_ENUM) || 
+               (pc->type == CT_OC_NS_ENUM) || 
+               (pc->type == CT_OC_NS_OPTIONS))
       {
          newlines_struct_enum_union(pc, cpd.settings[UO_nl_enum_brace].a, true);
       }
@@ -3206,6 +3212,7 @@ void do_blank_lines(void)
            (prev->type == CT_BRACE_CLOSE)) &&
           ((prev->parent_type == CT_STRUCT) ||
            (prev->parent_type == CT_ENUM) ||
+           (prev->parent_type == CT_OC_NS_ENUM) ||
            (prev->parent_type == CT_UNION) ||
            (prev->parent_type == CT_CLASS)))
       {

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -814,7 +814,8 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
 
    if (second->type == CT_BRACE_CLOSE)
    {
-      if (second->parent_type == CT_ENUM)
+      if ((second->parent_type == CT_ENUM) || 
+          (second->parent_type == CT_OC_NS_ENUM))
       {
          log_rule("sp_inside_braces_enum");
          return(cpd.settings[UO_sp_inside_braces_enum].a);
@@ -1321,7 +1322,8 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
 
    if (first->type == CT_BRACE_OPEN)
    {
-      if (first->parent_type == CT_ENUM)
+      if ((first->parent_type == CT_ENUM) || 
+          (first->parent_type == CT_OC_NS_ENUM))
       {
          log_rule("sp_inside_braces_enum");
          return(cpd.settings[UO_sp_inside_braces_enum].a);
@@ -1341,7 +1343,8 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
 
    if (second->type == CT_BRACE_CLOSE)
    {
-      if (second->parent_type == CT_ENUM)
+      if ((second->parent_type == CT_ENUM) || 
+          (second->parent_type == CT_OC_NS_ENUM))
       {
          log_rule("sp_inside_braces_enum");
          return(cpd.settings[UO_sp_inside_braces_enum].a);
@@ -1359,6 +1362,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
    if ((first->type == CT_BRACE_CLOSE) &&
        (first->flags & PCF_IN_TYPEDEF) &&
        ((first->parent_type == CT_ENUM) ||
+        (first->parent_type == CT_OC_NS_ENUM) ||
         (first->parent_type == CT_STRUCT) ||
         (first->parent_type == CT_UNION)))
    {

--- a/src/token_enum.h
+++ b/src/token_enum.h
@@ -242,6 +242,8 @@ typedef enum
    CT_OC_BLOCK_EXPR,    /* ObjC: block expression with arg: '^(int arg) { arg++; };' and without (called a block literal): '^{ ... };' */
    CT_OC_BLOCK_CARET,   /* ObjC: block pointer caret: '^' */
    CT_OC_AT,            /* ObjC: boxed constants using '@' */
+   CT_OC_NS_ENUM,       /* ObjC: NS_ENUM modern enum */
+   CT_OC_NS_OPTIONS,    /* ObjC: NS_OPTIONS modern bitmask enum */
 
    /* start PP types */
    CT_PP_DEFINE,        /* #define */

--- a/src/token_names.h
+++ b/src/token_names.h
@@ -208,6 +208,8 @@ const char *token_names[] =
    "OC_BLOCK_EXPR",
    "OC_BLOCK_CARET",
    "OC_AT",
+   "OC_NS_ENUM",
+   "OC_NS_OPTIONS",
    "PP_DEFINE",
    "PP_DEFINED",
    "PP_INCLUDE",

--- a/tests/input/oc/ns_enum.m
+++ b/tests/input/oc/ns_enum.m
@@ -1,3 +1,27 @@
 // The semicolons at the end of these declarations are not superfluous.
 typedef NS_ENUM (NSUInteger, MyEnum) {MyValue1, MyValue2, MyValue3};
 typedef NS_OPTIONS (NSUInteger, MyBitmask) {MyBit1, MyBit2, MyBit3};
+
+// NS_ENUM specifies the type and name of the enum.
+typedef enum {
+MyValue1,
+MyValue2,
+MyValue3
+} MyEnum;
+typedef NS_ENUM (NSUInteger, MyEnum) {
+MyValue1,
+MyValue2,
+MyValue3
+};
+
+// NS_OPTIONS is equivalent to NS_ENUM, but semantically used for bitmask enums.
+typedef enum {
+MyBit1 = (1u << 0),
+MyBit2Longer = (1u << 1),
+MyBit3ThatIsConsiderablyMoreVerbose = (1u << 2)
+} MyBitmask;
+typedef NS_OPTIONS (NSUInteger, MyBitmask) {
+MyBit1 = (1u << 0),
+MyBit2Longer = (1u << 1),
+MyBit3ThatIsConsiderablyMoreVerbose = (1u << 2)
+};

--- a/tests/output/oc/50111-ns_enum.m
+++ b/tests/output/oc/50111-ns_enum.m
@@ -1,3 +1,27 @@
 // The semicolons at the end of these declarations are not superfluous.
 typedef NS_ENUM (NSUInteger, MyEnum) {MyValue1, MyValue2, MyValue3};
 typedef NS_OPTIONS (NSUInteger, MyBitmask) {MyBit1, MyBit2, MyBit3};
+
+// NS_ENUM specifies the type and name of the enum.
+typedef enum {
+	MyValue1,
+	MyValue2,
+	MyValue3
+} MyEnum;
+typedef NS_ENUM (NSUInteger, MyEnum) {
+	MyValue1,
+	MyValue2,
+	MyValue3
+};
+
+// NS_OPTIONS is equivalent to NS_ENUM, but semantically used for bitmask enums.
+typedef enum {
+	MyBit1 = (1u << 0),
+	MyBit2Longer = (1u << 1),
+	MyBit3ThatIsConsiderablyMoreVerbose = (1u << 2)
+} MyBitmask;
+typedef NS_OPTIONS (NSUInteger, MyBitmask) {
+	MyBit1 = (1u << 0),
+	MyBit2Longer = (1u << 1),
+	MyBit3ThatIsConsiderablyMoreVerbose = (1u << 2)
+};


### PR DESCRIPTION
This change allows standard enum formatting rules to be applied to `NS_ENUM` and `NS_OPTIONS`. The existing `ns_enum.m` test has been updated to include formatting of multiline enumerations. This should fix #143 as well as #201.

Regarding the implementation, I was hoping to avoid adding `CT_OC_NS_ENUM` as an alternate for `CT_ENUM` throughout the formatting code, but that did not quite work out. I would be glad to amend the pull request if you have any advice on how to better handle that! 

`NS_OPTIONS` and `NS_ENUM` have the same syntax, just a different semantic meaning. For that reason, the paren group following those identifiers is given the parent type `CT_OC_NS_ENUM` regardless of whether the parent was `NS_ENUM` or `NS_OPTIONS`. I considered mapping both keywords and the parent of the paren group and braces over to `CT_ENUM` but was unsure whether that would have negative consequences on constructs in other languages. I think it could be more maintainable if you have a suggestion for how to handle that.

This does not provide any new formatting options for Obj-C enums. The paren group is marked as `OC_FPAREN_*` since it follows that syntax, so it should currently be formatted according to function param formatting rules.
