### PR TITLE
Added support for NS_ENUM and NS_OPTIONS modern Obj-C enums

### DIFF
--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -489,6 +489,14 @@ static void parse_cleanup(struct parse_frame *frm, chunk_t *pc)
                pc->type = CT_FPAREN_OPEN;
                parent   = CT_FUNCTION;
             }
+            /* NS_ENUM and NS_OPTIONS are followed by a (type, name) pair */
+            else if ((prev->type == CT_ENUM) &&
+                     (cpd.lang_flags & LANG_OC))
+            {
+               /* Treat both as CT_ENUM since the syntax is identical */
+               pc->type = CT_FPAREN_OPEN;
+               parent   = CT_ENUM;
+            }
             else
             {
                /* no need to set parent */
@@ -504,6 +512,13 @@ static void parse_cleanup(struct parse_frame *frm, chunk_t *pc)
             else if ((prev->type == CT_ASSIGN) && (prev->str[0] == '='))
             {
                parent = CT_ASSIGN;
+            }
+            /*  Carry through CT_ENUM parent in NS_ENUM (type, name) { */
+            else if ((prev->type == CT_FPAREN_CLOSE) && 
+                     (cpd.lang_flags & LANG_OC) &&
+                     (prev->parent_type == CT_ENUM))
+            {
+               parent = CT_ENUM;
             }
             else if (prev->type == CT_FPAREN_CLOSE)
             {

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2002,7 +2002,9 @@ static void fix_typedef(chunk_t *start)
       }
    }
 
-   if (last_op)
+   /* avoid interpreting typedef NS_ENUM (NSInteger, MyEnum) as a function def */
+   if (last_op && !((cpd.lang_flags & LANG_OC) &&
+       (last_op->parent_type == CT_ENUM)))
    {
       flag_parens(last_op, 0, CT_FPAREN_OPEN, CT_TYPEDEF, false);
       fix_fcn_def_params(last_op);

--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -42,6 +42,8 @@ static const chunk_tag_t keywords[] =
    { "@synthesize",      CT_OC_DYNAMIC,   LANG_OC | LANG_CPP | LANG_C                                                 },
    { "@throw",           CT_THROW,        LANG_OC                                                                     },
    { "@try",             CT_TRY,          LANG_OC | LANG_CPP | LANG_C                                                 },
+   { "NS_ENUM",          CT_ENUM,         LANG_OC                                                                     },
+   { "NS_OPTIONS",       CT_ENUM,         LANG_OC                                                                     },
    { "_Bool",            CT_TYPE,         LANG_CPP                                                                    },
    { "_Complex",         CT_TYPE,         LANG_CPP                                                                    },
    { "_Imaginary",       CT_TYPE,         LANG_CPP                                                                    },

--- a/tests/input/oc/ns_enum.m
+++ b/tests/input/oc/ns_enum.m
@@ -1,3 +1,27 @@
 // The semicolons at the end of these declarations are not superfluous.
 typedef NS_ENUM (NSUInteger, MyEnum) {MyValue1, MyValue2, MyValue3};
 typedef NS_OPTIONS (NSUInteger, MyBitmask) {MyBit1, MyBit2, MyBit3};
+
+// NS_ENUM specifies the type and name of the enum.
+typedef enum {
+MyValue1,
+MyValue2,
+MyValue3
+} MyEnum;
+typedef NS_ENUM (NSUInteger, MyEnum) {
+MyValue1,
+MyValue2,
+MyValue3
+};
+
+// NS_OPTIONS is equivalent to NS_ENUM, but semantically used for bitmask enums.
+typedef enum {
+MyBit1 = (1u << 0),
+MyBit2Longer = (1u << 1),
+MyBit3ThatIsConsiderablyMoreVerbose = (1u << 2)
+} MyBitmask;
+typedef NS_OPTIONS (NSUInteger, MyBitmask) {
+MyBit1 = (1u << 0),
+MyBit2Longer = (1u << 1),
+MyBit3ThatIsConsiderablyMoreVerbose = (1u << 2)
+};

--- a/tests/output/oc/50111-ns_enum.m
+++ b/tests/output/oc/50111-ns_enum.m
@@ -1,3 +1,27 @@
 // The semicolons at the end of these declarations are not superfluous.
 typedef NS_ENUM (NSUInteger, MyEnum) {MyValue1, MyValue2, MyValue3};
 typedef NS_OPTIONS (NSUInteger, MyBitmask) {MyBit1, MyBit2, MyBit3};
+
+// NS_ENUM specifies the type and name of the enum.
+typedef enum {
+	MyValue1,
+	MyValue2,
+	MyValue3
+} MyEnum;
+typedef NS_ENUM (NSUInteger, MyEnum) {
+	MyValue1,
+	MyValue2,
+	MyValue3
+};
+
+// NS_OPTIONS is equivalent to NS_ENUM, but semantically used for bitmask enums.
+typedef enum {
+	MyBit1 = (1u << 0),
+	MyBit2Longer = (1u << 1),
+	MyBit3ThatIsConsiderablyMoreVerbose = (1u << 2)
+} MyBitmask;
+typedef NS_OPTIONS (NSUInteger, MyBitmask) {
+	MyBit1 = (1u << 0),
+	MyBit2Longer = (1u << 1),
+	MyBit3ThatIsConsiderablyMoreVerbose = (1u << 2)
+};


### PR DESCRIPTION
This change allows standard enum formatting rules to be applied to `NS_ENUM` and `NS_OPTIONS`. The existing `ns_enum.m` test has been updated to include formatting of multiline enumerations. This should fix #143 as well as #201.

`NS_OPTIONS` and `NS_ENUM` have the same syntax, just a different semantic meaning. For that reason, the paren group following those identifiers is given the parent type `CT_ENUM` regardless of whether the parent was `NS_ENUM` or `NS_OPTIONS`.

This does not provide any new formatting options for Obj-C enums. The paren group is marked as `OC_FPAREN_*` since it follows that syntax, so it should currently be formatted according to function param formatting rules.
