### PR TITLE
Add support for add/remove newline before and after ObjC @interface/@implementation lines

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -4356,12 +4356,39 @@ static void handle_oc_class(chunk_t *pc)
             tmp->parent_type = CT_OC_CLASS;
          }
       }
+       if (tmp->type == CT_PAREN_OPEN)
+       {
+           chunk_t* next = chunk_get_next(tmp);
+           if (next)
+           {
+               if (next && next->type == CT_PAREN_CLOSE)
+               {
+                   tmp->parent_type = CT_OC_CLASS_EXT;
+                   next->parent_type = CT_OC_CLASS_EXT;
+               }
+               else
+               {
+                   tmp->parent_type = CT_OC_CATEGORY;
+                   tmp = chunk_get_next_type(tmp, CT_PAREN_CLOSE, tmp->level);
+                   if(tmp)
+                   {
+                       tmp->parent_type = CT_OC_CATEGORY;
+                   }
+               }
+           }
+       }
+       
       else if (tmp->type == CT_COLON)
       {
          tmp->type = hit_scope ? CT_OC_COLON : CT_CLASS_COLON;
          if (tmp->type == CT_CLASS_COLON)
          {
             tmp->parent_type = CT_OC_CLASS;
+             if ((tmp = chunk_get_next_nnl(tmp)) != NULL)
+             {
+                 tmp->type = CT_OC_SUPERCLASS;
+                 tmp->parent_type = CT_OC_CLASS;
+             }             
          }
       }
       else if (chunk_is_str(tmp, "-", 1) || chunk_is_str(tmp, "+", 1))

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -2472,6 +2472,28 @@ void newlines_cleanup_braces(bool first)
             nl_handle_define(pc);
          }
       }
+      else if (pc->type == CT_OC_INTF || pc->type == CT_OC_IMPL)
+      {
+         const int before_setting = pc->type == CT_OC_INTF ? UO_nl_oc_before_intf : UO_nl_oc_before_impl;
+         const int after_setting = pc->type == CT_OC_INTF ? UO_nl_oc_after_intf : UO_nl_oc_after_impl;
+         argval_t arg = cpd.settings[before_setting].a;
+         prev = chunk_get_prev(pc);
+         newline_iarf(prev, arg);
+          
+         arg = cpd.settings[after_setting].a;
+         tmp = pc;
+         do
+         {
+            prev = tmp;
+            tmp = chunk_get_next_ncnlnp(tmp);
+         }
+         while (tmp != NULL && tmp->type != CT_OC_END && tmp->type != CT_OC_PROPERTY && tmp->type != CT_OC_SCOPE && tmp->type != CT_BRACE_OPEN);
+          
+         if (prev)
+         {
+            newline_iarf(prev, arg);
+         }
+      }
       else if (first && (cpd.settings[UO_nl_remove_extra_newlines].n == 1) &&
                !(pc->flags & PCF_IN_PREPROC))
       {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -850,6 +850,15 @@ void register_options(void)
    unc_add_option("nl_oc_msg_args", UO_nl_oc_msg_args, AT_BOOL,
                   "Whether to put each OC message parameter on a separate line\n"
                   "See nl_oc_msg_leave_one_liner");
+   unc_add_option("nl_oc_before_intf", UO_nl_oc_before_intf, AT_IARF,
+                  "Add or remove newline before each OC @interface declaration");
+   unc_add_option("nl_oc_after_intf", UO_nl_oc_after_intf, AT_IARF,
+                  "Add or remove newline after each OC @interface declaration");
+   unc_add_option("nl_oc_before_impl", UO_nl_oc_before_impl, AT_IARF,
+                   "Add or remove newline before each OC @implementation declaration");
+   unc_add_option("nl_oc_after_impl", UO_nl_oc_after_impl, AT_IARF,
+                   "Add or remove newline after each OC @implementation declaration");
+
    unc_add_option("nl_fdef_brace", UO_nl_fdef_brace, AT_IARF,
                   "Add or remove newline between function signature and '{'");
    unc_add_option("nl_cpp_ldef_brace", UO_nl_cpp_ldef_brace, AT_IARF,

--- a/src/options.h
+++ b/src/options.h
@@ -570,6 +570,11 @@ enum uncrustify_options
    UO_nl_create_for_one_liner,
    UO_nl_create_while_one_liner,
 
+   UO_nl_oc_before_intf, // newline before @interface
+   UO_nl_oc_after_intf,  // newline after @interface and before ivars, properties, or methods
+   UO_nl_oc_before_impl, // newline before @implementation
+   UO_nl_oc_after_impl,  // newline after @implementation and before ivars or method definitions
+
    UO_nl_oc_msg_args,
    UO_nl_oc_msg_leave_one_liner,
 

--- a/src/token_enum.h
+++ b/src/token_enum.h
@@ -221,6 +221,7 @@ typedef enum
    CT_OC_PROTO_LIST,    /* ObjC: protocol list < > (parent token only) */
    CT_OC_PROPERTY,      /* ObjC: @property */
    CT_OC_CLASS,         /* ObjC: the name after @interface or @implementation */
+   CT_OC_SUPERCLASS,    /* ObjC: the name after the class colon in an @interface or @implementation */
    CT_OC_CLASS_EXT,     /* ObjC: a pair of empty parens after the class name in a @interface or @implementation */
    CT_OC_CATEGORY,      /* ObjC: the category name in parens after the class name in a @interface or @implementation */
    CT_OC_SCOPE,         /* ObjC: the '-' or '+' in '-(void) func: (int) i;' */

--- a/src/token_names.h
+++ b/src/token_names.h
@@ -187,6 +187,7 @@ const char *token_names[] =
    "OC_PROTO_LIST",
    "OC_PROPERTY",
    "OC_CLASS",
+   "OC_SUPERCLASS",
    "OC_CLASS_EXT",
    "OC_CATEGORY",
    "OC_SCOPE",

--- a/tests/config/objc_nl_after_implementation_add.cfg
+++ b/tests/config/objc_nl_after_implementation_add.cfg
@@ -1,0 +1,1 @@
+nl_oc_after_impl=add

--- a/tests/config/objc_nl_after_implementation_remove.cfg
+++ b/tests/config/objc_nl_after_implementation_remove.cfg
@@ -1,0 +1,1 @@
+nl_oc_after_impl=remove

--- a/tests/config/objc_nl_after_interface_add.cfg
+++ b/tests/config/objc_nl_after_interface_add.cfg
@@ -1,0 +1,1 @@
+nl_oc_after_intf=add

--- a/tests/config/objc_nl_after_interface_remove.cfg
+++ b/tests/config/objc_nl_after_interface_remove.cfg
@@ -1,0 +1,1 @@
+nl_oc_after_intf=remove

--- a/tests/config/objc_nl_before_implementation_add.cfg
+++ b/tests/config/objc_nl_before_implementation_add.cfg
@@ -1,0 +1,1 @@
+nl_oc_before_impl=add

--- a/tests/config/objc_nl_before_implementation_remove.cfg
+++ b/tests/config/objc_nl_before_implementation_remove.cfg
@@ -1,0 +1,1 @@
+nl_oc_before_impl=remove

--- a/tests/config/objc_nl_before_interface_add.cfg
+++ b/tests/config/objc_nl_before_interface_add.cfg
@@ -1,0 +1,1 @@
+nl_oc_before_intf=add

--- a/tests/config/objc_nl_before_interface_remove.cfg
+++ b/tests/config/objc_nl_before_interface_remove.cfg
@@ -1,0 +1,1 @@
+nl_oc_before_intf=remove

--- a/tests/input/oc/nl_implementation.m
+++ b/tests/input/oc/nl_implementation.m
@@ -1,0 +1,26 @@
+
+
+/* add case */ @implementation FooIvarAdd { int ivar; } @end
+
+// remove case
+
+@implementation FooIvarRemove { int ivar; } @end
+
+// force case
+@implementation FooIvarForce { int ivar; } @end
+
+
+/* add case */ @implementation FooScopeAdd +(NSURL*)url { return nil; } @end
+
+// remove case
+
+@implementation FooScopeRemove
+
++(NSURL*)url { return nil; }
+@end
+
+// force case
+@implementation FooScopeForce
++(NSURL*)url { return nil; }
+@end
+

--- a/tests/input/oc/nl_interface.h
+++ b/tests/input/oc/nl_interface.h
@@ -1,0 +1,40 @@
+
+
+/* add case */ @interface FooIvarAdd : NSObject { int ivar; } @end
+
+// remove case
+
+@interface FooIvarRemove : NSObject { int ivar; } @end
+
+// force case
+@interface FooIvarForce : NSObject { int ivar; } @end
+
+
+/* add case */ @interface FooPropAdd : NSObject @property (nonatomic, readonly, copy) NSURL* url; @end
+
+// remove case
+
+@interface FooPropRemove : NSObject
+
+@property (nonatomic, readonly, copy) NSURL* url;
+@end
+
+// force case
+@interface FooPropForce : NSObject
+@property (nonatomic, readonly, copy) NSURL* url;
+@end
+
+/* add case */ @interface FooScopeAdd : NSObject +(NSURL*)url; @end
+
+// remove case
+
+@interface FooScopeRemove : NSObject
+
++(NSURL*)url;
+@end
+
+// force case
+@interface FooScopeForce : NSObject
++(NSURL*)url;
+@end
+

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -61,3 +61,12 @@
 50111  del_semicolon.cfg                            oc/ns_enum.m
 
 50120  gh137.cfg                                    oc/gh137.m
+
+50130  objc_nl_after_implementation_add.cfg         oc/nl_implementation.m
+50131  objc_nl_after_implementation_remove.cfg      oc/nl_implementation.m
+50132  objc_nl_after_interface_add.cfg              oc/nl_interface.h OC
+50133  objc_nl_after_interface_remove.cfg           oc/nl_interface.h OC
+50134  objc_nl_before_implementation_add.cfg        oc/nl_implementation.m
+50135  objc_nl_before_implementation_remove.cfg     oc/nl_implementation.m
+50136  objc_nl_before_interface_add.cfg             oc/nl_interface.h OC
+50137  objc_nl_before_interface_remove.cfg          oc/nl_interface.h OC

--- a/tests/output/oc/50130-nl_implementation.m
+++ b/tests/output/oc/50130-nl_implementation.m
@@ -1,0 +1,37 @@
+
+
+/* add case */ @implementation FooIvarAdd
+{ int ivar; } @end
+
+// remove case
+
+@implementation FooIvarRemove
+{ int ivar; } @end
+
+// force case
+@implementation FooIvarForce
+{ int ivar; } @end
+
+
+/* add case */ @implementation FooScopeAdd
++(NSURL*)url {
+	return nil;
+}
+@end
+
+// remove case
+
+@implementation FooScopeRemove
+
++(NSURL*)url {
+	return nil;
+}
+@end
+
+// force case
+@implementation FooScopeForce
++(NSURL*)url {
+	return nil;
+}
+@end
+

--- a/tests/output/oc/50131-nl_implementation.m
+++ b/tests/output/oc/50131-nl_implementation.m
@@ -1,0 +1,30 @@
+
+
+/* add case */ @implementation FooIvarAdd { int ivar; } @end
+
+// remove case
+
+@implementation FooIvarRemove { int ivar; } @end
+
+// force case
+@implementation FooIvarForce { int ivar; } @end
+
+
+/* add case */ @implementation FooScopeAdd +(NSURL*)url {
+	return nil;
+}
+@end
+
+// remove case
+
+@implementation FooScopeRemove +(NSURL*)url {
+	return nil;
+}
+@end
+
+// force case
+@implementation FooScopeForce +(NSURL*)url {
+	return nil;
+}
+@end
+

--- a/tests/output/oc/50132-nl_interface.h
+++ b/tests/output/oc/50132-nl_interface.h
@@ -1,0 +1,45 @@
+
+
+/* add case */ @interface FooIvarAdd : NSObject
+{ int ivar; } @end
+
+// remove case
+
+@interface FooIvarRemove : NSObject
+{ int ivar; } @end
+
+// force case
+@interface FooIvarForce : NSObject
+{ int ivar; } @end
+
+
+/* add case */ @interface FooPropAdd : NSObject
+@property (nonatomic, readonly, copy) NSURL* url; @end
+
+// remove case
+
+@interface FooPropRemove : NSObject
+
+@property (nonatomic, readonly, copy) NSURL* url;
+@end
+
+// force case
+@interface FooPropForce : NSObject
+@property (nonatomic, readonly, copy) NSURL* url;
+@end
+
+/* add case */ @interface FooScopeAdd : NSObject +(NSURL*)url;
+@end
+
+// remove case
+
+@interface FooScopeRemove : NSObject
+
++(NSURL*)url;
+@end
+
+// force case
+@interface FooScopeForce : NSObject
++(NSURL*)url;
+@end
+

--- a/tests/output/oc/50133-nl_interface.h
+++ b/tests/output/oc/50133-nl_interface.h
@@ -1,0 +1,34 @@
+
+
+/* add case */ @interface FooIvarAdd : NSObject { int ivar; } @end
+
+// remove case
+
+@interface FooIvarRemove : NSObject { int ivar; } @end
+
+// force case
+@interface FooIvarForce : NSObject { int ivar; } @end
+
+
+/* add case */ @interface FooPropAdd : NSObject @property (nonatomic, readonly, copy) NSURL* url; @end
+
+// remove case
+
+@interface FooPropRemove : NSObject @property (nonatomic, readonly, copy) NSURL* url;
+@end
+
+// force case
+@interface FooPropForce : NSObject @property (nonatomic, readonly, copy) NSURL* url;
+@end
+
+/* add case */ @interface FooScopeAdd : NSObject +(NSURL*)url; @end
+
+// remove case
+
+@interface FooScopeRemove : NSObject +(NSURL*)url;
+@end
+
+// force case
+@interface FooScopeForce : NSObject +(NSURL*)url;
+@end
+

--- a/tests/output/oc/50134-nl_implementation.m
+++ b/tests/output/oc/50134-nl_implementation.m
@@ -1,0 +1,35 @@
+
+
+/* add case */
+@implementation FooIvarAdd { int ivar; } @end
+
+// remove case
+
+@implementation FooIvarRemove { int ivar; } @end
+
+// force case
+@implementation FooIvarForce { int ivar; } @end
+
+
+/* add case */
+@implementation FooScopeAdd +(NSURL*)url {
+	return nil;
+}
+@end
+
+// remove case
+
+@implementation FooScopeRemove
+
++(NSURL*)url {
+	return nil;
+}
+@end
+
+// force case
+@implementation FooScopeForce
++(NSURL*)url {
+	return nil;
+}
+@end
+

--- a/tests/output/oc/50135-nl_implementation.m
+++ b/tests/output/oc/50135-nl_implementation.m
@@ -1,0 +1,31 @@
+
+
+/* add case */ @implementation FooIvarAdd { int ivar; } @end
+
+// remove case
+@implementation FooIvarRemove { int ivar; } @end
+
+// force case
+@implementation FooIvarForce { int ivar; } @end
+
+
+/* add case */ @implementation FooScopeAdd +(NSURL*)url {
+	return nil;
+}
+@end
+
+// remove case
+@implementation FooScopeRemove
+
++(NSURL*)url {
+	return nil;
+}
+@end
+
+// force case
+@implementation FooScopeForce
++(NSURL*)url {
+	return nil;
+}
+@end
+

--- a/tests/output/oc/50136-nl_interface.h
+++ b/tests/output/oc/50136-nl_interface.h
@@ -1,0 +1,43 @@
+
+
+/* add case */
+@interface FooIvarAdd : NSObject { int ivar; } @end
+
+// remove case
+
+@interface FooIvarRemove : NSObject { int ivar; } @end
+
+// force case
+@interface FooIvarForce : NSObject { int ivar; } @end
+
+
+/* add case */
+@interface FooPropAdd : NSObject @property (nonatomic, readonly, copy) NSURL* url; @end
+
+// remove case
+
+@interface FooPropRemove : NSObject
+
+@property (nonatomic, readonly, copy) NSURL* url;
+@end
+
+// force case
+@interface FooPropForce : NSObject
+@property (nonatomic, readonly, copy) NSURL* url;
+@end
+
+/* add case */
+@interface FooScopeAdd : NSObject +(NSURL*)url; @end
+
+// remove case
+
+@interface FooScopeRemove : NSObject
+
++(NSURL*)url;
+@end
+
+// force case
+@interface FooScopeForce : NSObject
++(NSURL*)url;
+@end
+

--- a/tests/output/oc/50137-nl_interface.h
+++ b/tests/output/oc/50137-nl_interface.h
@@ -1,0 +1,37 @@
+
+
+/* add case */ @interface FooIvarAdd : NSObject { int ivar; } @end
+
+// remove case
+@interface FooIvarRemove : NSObject { int ivar; } @end
+
+// force case
+@interface FooIvarForce : NSObject { int ivar; } @end
+
+
+/* add case */ @interface FooPropAdd : NSObject @property (nonatomic, readonly, copy) NSURL* url; @end
+
+// remove case
+@interface FooPropRemove : NSObject
+
+@property (nonatomic, readonly, copy) NSURL* url;
+@end
+
+// force case
+@interface FooPropForce : NSObject
+@property (nonatomic, readonly, copy) NSURL* url;
+@end
+
+/* add case */ @interface FooScopeAdd : NSObject +(NSURL*)url; @end
+
+// remove case
+@interface FooScopeRemove : NSObject
+
++(NSURL*)url;
+@end
+
+// force case
+@interface FooScopeForce : NSObject
++(NSURL*)url;
+@end
+


### PR DESCRIPTION
Add support for add/remove newline before and after ObjC @interface/@implementation lines. For example:

```
@interface Foo : NSObject {
    int ivar;
}
@end
```

…becomes…

```
@interface Foo : NSObject 
{
    int ivar;
}
@end
```

and things like that. Unit test coverage included.

Improve typing of chunks in ObjC @interface/@implementation lines.
Admittedly, ObjC being largely whitespace agnostic, there could have been many more options
(i.e. nl before/after class colon, category name, superclass, protocol list) but this is the
option I needed, so it's the one I built.
