### PR TITLE
Adds support for sorting @property in obj-c

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -4948,7 +4948,10 @@ static void handle_oc_message_send(chunk_t *os)
  */
 static void handle_oc_property_decl(chunk_t *os)
 {
-    if (cpd.settings[UO_mod_sort_oc_properties].b)
+    chunk_t *os_next = chunk_get_next_ncnl(os);
+    flag_parens(os_next, PCF_IN_OC_PROPERTY, CT_NONE, CT_NONE, false);
+    
+    if (cpd.settings[UO_mod_sort_oc_property_attributes].b)
     {
         typedef std::vector<chunk_t*> ChunkGroup;
 
@@ -5057,12 +5060,12 @@ static void handle_oc_property_decl(chunk_t *os)
             }
             close_paren = next;
 
-            int thread_w = cpd.settings[UO_mod_sort_oc_property_thread_safe_weight].n;
-            int readwrite_w = cpd.settings[UO_mod_sort_oc_property_readwrite_weight].n;
-            int ref_w = cpd.settings[UO_mod_sort_oc_property_reference_weight].n;
-            int getter_w = cpd.settings[UO_mod_sort_oc_property_getter_weight].n;
-            int setter_w = cpd.settings[UO_mod_sort_oc_property_setter_weight].n;
-            
+            int thread_w = cpd.settings[UO_mod_sort_oc_property_attribute_atomicity_weight].n;
+            int readwrite_w = cpd.settings[UO_mod_sort_oc_property_attribute_readwrite_weight].n;
+            int ref_w = cpd.settings[UO_mod_sort_oc_property_attribute_reference_weight].n;
+            int getter_w = cpd.settings[UO_mod_sort_oc_property_attribute_getter_weight].n;
+            int setter_w = cpd.settings[UO_mod_sort_oc_property_attribute_setter_weight].n;
+
             std::multimap< int, std::vector<ChunkGroup> > sorted_chunk_map;
             sorted_chunk_map.insert(pair< int, std::vector<ChunkGroup> >(thread_w, thread_chunks));
             sorted_chunk_map.insert(pair< int, std::vector<ChunkGroup> >(readwrite_w, readwrite_chunks));

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -43,6 +43,7 @@ static void handle_oc_block_literal(chunk_t *pc);
 static void handle_oc_block_type(chunk_t *pc);
 static void handle_oc_message_decl(chunk_t *pc);
 static void handle_oc_message_send(chunk_t *pc);
+static void handle_oc_property_decl(chunk_t *pc);
 static void handle_cs_square_stmt(chunk_t *pc);
 static void handle_cs_property(chunk_t *pc);
 static void handle_cpp_template(chunk_t *pc);
@@ -404,7 +405,13 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
             handle_oc_block_literal(pc);
          }
       }
+       
+      if (pc->type == CT_OC_PROPERTY)
+      {
+          handle_oc_property_decl(pc);
+      }
    }
+    
 
    /* C# stuff */
    if (cpd.lang_flags & LANG_CS)
@@ -863,16 +870,6 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       {
          mark_variable_definition(tmp);
       }
-   }
-
-   if (pc->type == CT_OC_PROPERTY)
-   {
-      tmp = chunk_get_next_ncnl(pc);
-      if (chunk_is_paren_open(tmp))
-      {
-         tmp = chunk_get_next_ncnl(chunk_skip_to_match(tmp));
-      }
-      fix_var_def(tmp);
    }
 
    /**
@@ -4944,6 +4941,190 @@ static void handle_oc_message_send(chunk_t *os)
       }
       prev = tmp;
    }
+}
+
+/*
+ * Process @Property values and re-arrange them if necessary
+ */
+static void handle_oc_property_decl(chunk_t *os)
+{
+    if (cpd.settings[UO_mod_sort_oc_properties].b)
+    {
+        typedef std::vector<chunk_t*> ChunkGroup;
+
+        chunk_t *next = chunk_get_next(os);
+        chunk_t *open_paren = NULL;
+        chunk_t *close_paren = NULL;
+        
+        std::vector<ChunkGroup> thread_chunks;      // atomic/nonatomic
+        std::vector<ChunkGroup> readwrite_chunks;   // readwrite, readonly
+        std::vector<ChunkGroup> ref_chunks;         // retain, copy, assign, weak, strong
+        std::vector<ChunkGroup> getter_chunks;      // getter
+        std::vector<ChunkGroup> setter_chunks;      // setter
+        
+        if(next->type == CT_PAREN_OPEN)
+        {
+            open_paren = next;
+            next = chunk_get_next(next);
+            
+            // Determine location of the property attributes
+            // NOTE: Did not do this in the combine.cpp do_symbol_check as I was not sure
+            // what the ramifications of adding a new type for each of the below types would
+            // be. It did break some items when I attempted to add them so this is my hack for
+            // now.
+            while (next != NULL && next->type != CT_PAREN_CLOSE)
+            {
+                if (next->type == CT_WORD)
+                {
+                    if(chunk_is_str(next, "atomic", 6))
+                    {
+                        ChunkGroup chunkGroup;
+                        chunkGroup.push_back(next);
+                        thread_chunks.push_back(chunkGroup);
+                    }
+                    else if(chunk_is_str(next, "nonatomic", 9))
+                    {
+                        ChunkGroup chunkGroup;
+                        chunkGroup.push_back(next);
+                        thread_chunks.push_back(chunkGroup);
+                    }
+                    else if(chunk_is_str(next, "readonly", 8))
+                    {
+                        ChunkGroup chunkGroup;
+                        chunkGroup.push_back(next);
+                        readwrite_chunks.push_back(chunkGroup);
+                    }
+                    else if(chunk_is_str(next, "readwrite", 9))
+                    {
+                        ChunkGroup chunkGroup;
+                        chunkGroup.push_back(next);
+                        readwrite_chunks.push_back(chunkGroup);
+                    }
+                    else if(chunk_is_str(next, "assign", 6))
+                    {
+                        ChunkGroup chunkGroup;
+                        chunkGroup.push_back(next);
+                        ref_chunks.push_back(chunkGroup);
+                    }
+                    else if(chunk_is_str(next, "retain", 6))
+                    {
+                        ChunkGroup chunkGroup;
+                        chunkGroup.push_back(next);
+                        ref_chunks.push_back(chunkGroup);
+                    }
+                    else if(chunk_is_str(next, "copy", 4))
+                    {
+                        ChunkGroup chunkGroup;
+                        chunkGroup.push_back(next);
+                        ref_chunks.push_back(chunkGroup);
+                    }
+                    else if(chunk_is_str(next, "strong", 6))
+                    {
+                        ChunkGroup chunkGroup;
+                        chunkGroup.push_back(next);
+                        ref_chunks.push_back(chunkGroup);
+                    }
+                    else if(chunk_is_str(next, "weak", 4))
+                    {
+                        ChunkGroup chunkGroup;
+                        chunkGroup.push_back(next);
+                        ref_chunks.push_back(chunkGroup);
+                    }
+                    else if(chunk_is_str(next, "getter", 6))
+                    {
+                        ChunkGroup chunkGroup;
+                        do
+                        {
+                            chunkGroup.push_back(next);
+                            next = chunk_get_next(next);
+                        } while(next && next->type != CT_COMMA && next->type != CT_PAREN_CLOSE);
+                        next = next->prev;
+                        getter_chunks.push_back(chunkGroup);
+                    }
+                    else if(chunk_is_str(next, "setter", 6))
+                    {
+                        ChunkGroup chunkGroup;
+                        do
+                        {
+                            chunkGroup.push_back(next);
+                            next = chunk_get_next(next);
+                        } while(next && next->type != CT_COMMA && next->type != CT_PAREN_CLOSE);
+                        next = next->prev;
+                        setter_chunks.push_back(chunkGroup);
+                    }
+                }
+                next = chunk_get_next(next);
+            }
+            close_paren = next;
+
+            int thread_w = cpd.settings[UO_mod_sort_oc_property_thread_safe_weight].n;
+            int readwrite_w = cpd.settings[UO_mod_sort_oc_property_readwrite_weight].n;
+            int ref_w = cpd.settings[UO_mod_sort_oc_property_reference_weight].n;
+            int getter_w = cpd.settings[UO_mod_sort_oc_property_getter_weight].n;
+            int setter_w = cpd.settings[UO_mod_sort_oc_property_setter_weight].n;
+            
+            std::multimap< int, std::vector<ChunkGroup> > sorted_chunk_map;
+            sorted_chunk_map.insert(pair< int, std::vector<ChunkGroup> >(thread_w, thread_chunks));
+            sorted_chunk_map.insert(pair< int, std::vector<ChunkGroup> >(readwrite_w, readwrite_chunks));
+            sorted_chunk_map.insert(pair< int, std::vector<ChunkGroup> >(ref_w, ref_chunks));
+            sorted_chunk_map.insert(pair< int, std::vector<ChunkGroup> >(getter_w, getter_chunks));
+            sorted_chunk_map.insert(pair< int, std::vector<ChunkGroup> >(setter_w, setter_chunks));
+            
+            
+            chunk_t *curr_chunk = open_paren;
+            for (multimap<int, std::vector<ChunkGroup> >::reverse_iterator it = sorted_chunk_map.rbegin(); it != sorted_chunk_map.rend(); ++it)
+            {
+                std::vector<ChunkGroup> chunk_groups = (*it).second;
+                for(int i = 0; i < chunk_groups.size(); i++)
+                {
+                    ChunkGroup chunk_group = chunk_groups[i];
+                    for(int j = 0; j < chunk_group.size(); j++)
+                    {
+                        chunk_t *chunk = chunk_group[j];
+                        if(chunk != curr_chunk)
+                        {
+                            chunk_move_after(chunk, curr_chunk);
+                            curr_chunk = chunk;
+                        }
+                        else
+                        {
+                            curr_chunk = chunk_get_next(curr_chunk);
+                        }
+                    }
+                
+                    /* add the parens */
+                    chunk_t endchunk;
+                    endchunk.type        = CT_COMMA;
+                    endchunk.str         = ",";
+                    endchunk.level       = curr_chunk->level;
+                    endchunk.brace_level = curr_chunk->brace_level;
+                    endchunk.orig_line   = curr_chunk->orig_line;
+                    endchunk.parent_type = curr_chunk->parent_type;
+                    endchunk.flags       = curr_chunk->flags & PCF_COPY_FLAGS;
+                    chunk_add_after(&endchunk, curr_chunk);
+                    curr_chunk = curr_chunk->next;
+                }
+            }
+            
+            // Remove the extra comma's that we did not move
+            while(curr_chunk && curr_chunk->type != CT_PAREN_CLOSE)
+            {
+                chunk_t *rm_chunk = curr_chunk;
+                curr_chunk = chunk_get_next(curr_chunk);
+                chunk_del(rm_chunk);
+            }
+            
+        }
+
+    }
+    
+    
+    chunk_t *tmp = chunk_get_next_ncnl(os);
+    if (chunk_is_paren_open(tmp))
+    {
+        tmp = chunk_get_next_ncnl(chunk_skip_to_match(tmp));
+    }
+    fix_var_def(tmp);
 }
 
 

--- a/src/detect.cpp
+++ b/src/detect.cpp
@@ -102,6 +102,8 @@ static void detect_space_options()
    SP_VOTE_VAR(sp_after_assign);
    SP_VOTE_VAR(sp_enum_before_assign);
    SP_VOTE_VAR(sp_enum_after_assign);
+   SP_VOTE_VAR(sp_oc_property_before_assign);
+   SP_VOTE_VAR(sp_oc_property_after_assign);
    SP_VOTE_VAR(sp_bool);
    SP_VOTE_VAR(sp_compare);
    SP_VOTE_VAR(sp_inside_paren);
@@ -167,15 +169,19 @@ static void detect_space_options()
       }
       if (pc->type == CT_ASSIGN)
       {
-         if ((pc->flags & PCF_IN_ENUM) == 0)
+         if ((pc->flags & PCF_IN_ENUM) == PCF_IN_ENUM) {
+             vote_sp_enum_before_assign.vote(prev, pc);
+             vote_sp_enum_after_assign.vote(pc, next);
+         }
+         else if ((pc->flags & PCF_IN_OC_PROPERTY) == PCF_IN_OC_PROPERTY)
          {
-            vote_sp_before_assign.vote(prev, pc);
-            vote_sp_after_assign.vote(pc, next);
+             vote_sp_oc_property_before_assign.vote(prev, pc);
+             vote_sp_oc_property_after_assign.vote(pc, next);
          }
          else
          {
-            vote_sp_enum_before_assign.vote(prev, pc);
-            vote_sp_enum_after_assign.vote(pc, next);
+             vote_sp_before_assign.vote(prev, pc);
+             vote_sp_after_assign.vote(pc, next);
          }
       }
       if (pc->type == CT_SQUARE_OPEN)

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -1267,7 +1267,8 @@ static void newlines_brace_pair(chunk_t *br_open)
        (br_open->parent_type == CT_FUNC_CLASS) ||
        (br_open->parent_type == CT_OC_MSG_DECL) ||
        (br_open->parent_type == CT_CS_PROPERTY) ||
-       (br_open->parent_type == CT_CPP_LAMBDA))
+       (br_open->parent_type == CT_CPP_LAMBDA) ||
+       (br_open->parent_type == CT_OC_BLOCK_EXPR))
    {
       /* Need to force a newline before the close brace, if not in a class body */
       if ((br_open->flags & PCF_IN_CLASS) == 0)
@@ -1287,7 +1288,9 @@ static void newlines_brace_pair(chunk_t *br_open)
               cpd.settings[UO_nl_property_brace].a :
               ((br_open->parent_type == CT_CPP_LAMBDA) ?
                cpd.settings[UO_nl_cpp_ldef_brace].a :
-               cpd.settings[UO_nl_fcall_brace].a)));
+               ((br_open->parent_type == CT_OC_BLOCK_EXPR) ?
+                cpd.settings[UO_nl_block_fcall_brace].a :
+               cpd.settings[UO_nl_fcall_brace].a))));
 
       if (val != AV_IGNORE)
       {
@@ -2210,6 +2213,9 @@ void newlines_cleanup_braces(bool first)
             if ((next != NULL) &&
                 (next->type != CT_SEMICOLON) &&
                 (next->type != CT_COMMA) &&
+                (cpd.settings[UO_nl_after_brace_close_oc_skip_block_end].b ?
+                 (next->type != CT_SQUARE_CLOSE) && (next->type != CT_FPAREN_CLOSE) :
+                 true) &&
                 ((pc->flags & (PCF_IN_ARRAY_ASSIGN | PCF_IN_TYPEDEF)) == 0) &&
                 !chunk_is_newline(next) &&
                 !chunk_is_comment(next))

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1262,6 +1262,18 @@ void register_options(void)
                   "Will only remove the braces if there are no variable declarations in the block.");
    unc_add_option("mod_remove_empty_return", UO_mod_remove_empty_return, AT_BOOL,
                   "If TRUE, it will remove a void 'return;' that appears as the last statement in a function.");
+   unc_add_option("mod_sort_oc_properties", UO_mod_sort_oc_properties, AT_BOOL,
+                  "If TRUE, it will organize the properties (Obj-C)");
+   unc_add_option("mod_sort_oc_property_thread_safe_weight", UO_mod_sort_oc_property_thread_safe_weight, AT_NUM,
+                  "Determines weight of atomic/nonatomic (Obj-C)");
+   unc_add_option("mod_sort_oc_property_readwrite_weight", UO_mod_sort_oc_property_readwrite_weight, AT_NUM,
+                  "Determines weight of readwrite (Obj-C)");
+   unc_add_option("mod_sort_oc_property_reference_weight", UO_mod_sort_oc_property_reference_weight, AT_NUM,
+                  "Determines weight of reference type (retain, copy, assign, weak, strong) (Obj-C)");
+   unc_add_option("mod_sort_oc_property_getter_weight", UO_mod_sort_oc_property_getter_weight, AT_NUM,
+                  "Determines weight of getter type (getter=) (Obj-C)");
+   unc_add_option("mod_sort_oc_property_setter_weight", UO_mod_sort_oc_property_setter_weight, AT_NUM,
+                  "Determines weight of setter type (setter=) (Obj-C)");
 
    unc_begin_group(UG_preprocessor, "Preprocessor options");
    unc_add_option("pp_indent", UO_pp_indent, AT_IARF,

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -202,6 +202,12 @@ void register_options(void)
                   "Add or remove space before assignment '=' in enum. Overrides sp_enum_assign.");
    unc_add_option("sp_enum_after_assign", UO_sp_enum_after_assign, AT_IARF,
                   "Add or remove space after assignment '=' in enum. Overrides sp_enum_assign.");
+   unc_add_option("sp_oc_property_assign", UO_sp_oc_property_assign, AT_IARF,
+                   "Add or remove space around assignment '=' in objective-c property");
+   unc_add_option("sp_oc_property_before_assign", UO_sp_oc_property_before_assign, AT_IARF,
+                  "Add or remove space before assignment '=' in objectice-c property. Overrides sp_oc_property_assign.");
+   unc_add_option("sp_oc_property_after_assign", UO_sp_oc_property_after_assign, AT_IARF,
+                  "Add or remove space after assignment '=' in objectice-c property. Overrides sp_oc_property_assign.");
    unc_add_option("sp_pp_concat", UO_sp_pp_concat, AT_IARF,
                   "Add or remove space around preprocessor '##' concatenation operator. Default=Add");
    unc_add_option("sp_pp_stringify", UO_sp_pp_stringify, AT_IARF,
@@ -736,6 +742,9 @@ void register_options(void)
    unc_add_option("nl_fcall_brace", UO_nl_fcall_brace, AT_IARF,
                   "Add or remove newline between a function call's ')' and '{', as in:\n"
                   "list_for_each(item, &list) { }");
+   unc_add_option("nl_block_fcall_brace", UO_nl_block_fcall_brace, AT_IARF,
+                  "Add or remove newline between a block definitions )' and '{', as in:\n"
+                  "^(bool temp) { }");
    unc_add_option("nl_enum_brace", UO_nl_enum_brace, AT_IARF,
                   "Add or remove newline between 'enum' and '{'");
    unc_add_option("nl_struct_brace", UO_nl_struct_brace, AT_IARF,
@@ -876,6 +885,8 @@ void register_options(void)
    unc_add_option("nl_after_vbrace_close", UO_nl_after_vbrace_close, AT_BOOL,
                   "Whether to put a newline after a virtual brace close.\n"
                   "Would add a newline before return in: 'if (foo) a++; return;'");
+   unc_add_option("nl_after_brace_close_oc_skip_block_end", UO_nl_after_brace_close_oc_skip_block_end, AT_BOOL,
+                  "Whether to put a newline after a block brace close. Only works if nl_after_brace_close is used.\n");
    unc_add_option("nl_brace_struct_var", UO_nl_brace_struct_var, AT_IARF,
                   "Control the newline between the close brace and 'b' in: 'struct { int a; } b;'\n"
                   "Affects enums, unions, and structures. If set to ignore, uses nl_after_brace_close");
@@ -1262,18 +1273,18 @@ void register_options(void)
                   "Will only remove the braces if there are no variable declarations in the block.");
    unc_add_option("mod_remove_empty_return", UO_mod_remove_empty_return, AT_BOOL,
                   "If TRUE, it will remove a void 'return;' that appears as the last statement in a function.");
-   unc_add_option("mod_sort_oc_properties", UO_mod_sort_oc_properties, AT_BOOL,
-                  "If TRUE, it will organize the properties (Obj-C)");
-   unc_add_option("mod_sort_oc_property_thread_safe_weight", UO_mod_sort_oc_property_thread_safe_weight, AT_NUM,
-                  "Determines weight of atomic/nonatomic (Obj-C)");
-   unc_add_option("mod_sort_oc_property_readwrite_weight", UO_mod_sort_oc_property_readwrite_weight, AT_NUM,
-                  "Determines weight of readwrite (Obj-C)");
-   unc_add_option("mod_sort_oc_property_reference_weight", UO_mod_sort_oc_property_reference_weight, AT_NUM,
-                  "Determines weight of reference type (retain, copy, assign, weak, strong) (Obj-C)");
-   unc_add_option("mod_sort_oc_property_getter_weight", UO_mod_sort_oc_property_getter_weight, AT_NUM,
-                  "Determines weight of getter type (getter=) (Obj-C)");
-   unc_add_option("mod_sort_oc_property_setter_weight", UO_mod_sort_oc_property_setter_weight, AT_NUM,
-                  "Determines weight of setter type (setter=) (Obj-C)");
+   unc_add_option("mod_sort_oc_property_attributes", UO_mod_sort_oc_property_attributes, AT_BOOL,
+                  "If TRUE, it will organize the property attributes based on weights (higher the weight, the closer the property will be to the start of the decleration)  (Obj-C)");
+   unc_add_option("mod_sort_oc_property_attribute_atomicity_weight", UO_mod_sort_oc_property_attribute_atomicity_weight, AT_NUM,
+                  "Determines weight of atomic/nonatomic. See mod_sort_oc_property_attributes for more details. (Obj-C)");
+   unc_add_option("mod_sort_oc_property_attribute_readwrite_weight", UO_mod_sort_oc_property_attribute_readwrite_weight, AT_NUM,
+                  "Determines weight of readwrite. See mod_sort_oc_property_attributes for more details. (Obj-C)");
+   unc_add_option("mod_sort_oc_property_attribute_reference_weight", UO_mod_sort_oc_property_attribute_reference_weight, AT_NUM,
+                  "Determines weight of reference type (retain, copy, assign, weak, strong). See mod_sort_oc_property_attributes for more details. (Obj-C)");
+   unc_add_option("mod_sort_oc_property_attribute_getter_weight", UO_mod_sort_oc_property_attribute_getter_weight, AT_NUM,
+                  "Determines weight of getter type (getter=). See mod_sort_oc_property_attributes for more details. (Obj-C)");
+   unc_add_option("mod_sort_oc_property_attribute_setter_weight", UO_mod_sort_oc_property_attribute_setter_weight, AT_NUM,
+                  "Determines weight of setter type (setter=). See mod_sort_oc_property_attributes for more details. (Obj-C)");
 
    unc_begin_group(UG_preprocessor, "Preprocessor options");
    unc_add_option("pp_indent", UO_pp_indent, AT_IARF,

--- a/src/options.h
+++ b/src/options.h
@@ -638,11 +638,20 @@ enum uncrustify_options
    UO_mod_sort_import,
    UO_mod_sort_using,
    UO_mod_sort_include,
+   UO_mod_sort_oc_properties,      // organizes objective c properties
    UO_mod_move_case_break,
    UO_mod_case_brace,
    UO_mod_remove_empty_return,
 
-
+   /*
+    * Sorting options for objc properties
+    */
+   UO_mod_sort_oc_property_thread_safe_weight,  // Determines weight of atomic/nonatomic
+   UO_mod_sort_oc_property_readwrite_weight,    // Determines weight of readwrite
+   UO_mod_sort_oc_property_reference_weight,    // Determines weight of reference type (retain, copy, assign, weak, strong)
+   UO_mod_sort_oc_property_getter_weight,       // Determines weight of getter type (getter=)
+   UO_mod_sort_oc_property_setter_weight,       // Determines weight of setter type (setter=)
+    
    /*
     * Comment modifications
     */

--- a/src/options.h
+++ b/src/options.h
@@ -257,6 +257,10 @@ enum uncrustify_options
    UO_sp_enum_assign,           // space around = in enum
    UO_sp_enum_before_assign,    // space before = in enum
    UO_sp_enum_after_assign,     // space after = in enum
+   UO_sp_oc_property_assign,
+   UO_sp_oc_property_before_assign, // space before = in a objective c property
+   UO_sp_oc_property_after_assign,  // space after = in a objective c property
+
    UO_sp_after_class_colon,     // space after class ':'
    UO_sp_before_class_colon,    // space before class ':'
    UO_sp_after_constr_colon,
@@ -493,8 +497,10 @@ enum uncrustify_options
    UO_nl_after_vbrace_open_empty,    // force a newline after a virtual brace open
    UO_nl_after_brace_close,          // force a newline after a brace close
    UO_nl_after_vbrace_close,         // force a newline after a virtual brace close
+   UO_nl_after_brace_close_oc_skip_block_end,       // force a newline after a block brace close
    UO_nl_brace_struct_var,           // force a newline after a brace close
    UO_nl_fcall_brace,                /* newline between function call and open brace */
+   UO_nl_block_fcall_brace,          /* newline between block definition and open brace */
    UO_nl_squeeze_ifdef,              /* no blanks after #ifxx, #elxx, or before #endif */
    UO_nl_enum_brace,                 /* nl between enum and brace */
    UO_nl_struct_brace,               /* nl between struct and brace */
@@ -646,11 +652,12 @@ enum uncrustify_options
    /*
     * Sorting options for objc properties
     */
-   UO_mod_sort_oc_property_thread_safe_weight,  // Determines weight of atomic/nonatomic
-   UO_mod_sort_oc_property_readwrite_weight,    // Determines weight of readwrite
-   UO_mod_sort_oc_property_reference_weight,    // Determines weight of reference type (retain, copy, assign, weak, strong)
-   UO_mod_sort_oc_property_getter_weight,       // Determines weight of getter type (getter=)
-   UO_mod_sort_oc_property_setter_weight,       // Determines weight of setter type (setter=)
+   UO_mod_sort_oc_property_attributes,                  // organizes objective c properties
+   UO_mod_sort_oc_property_attribute_atomicity_weight,  // Determines weight of atomic/nonatomic
+   UO_mod_sort_oc_property_attribute_readwrite_weight,  // Determines weight of readwrite
+   UO_mod_sort_oc_property_attribute_reference_weight,  // Determines weight of reference type (retain, copy, assign, weak, strong)
+   UO_mod_sort_oc_property_attribute_getter_weight,     // Determines weight of getter type (getter=)
+   UO_mod_sort_oc_property_attribute_setter_weight,     // Determines weight of setter type (setter=)
     
    /*
     * Comment modifications

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -527,6 +527,17 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
          log_rule("sp_enum_assign");
          return(cpd.settings[UO_sp_enum_assign].a);
       }
+      if (first->flags & PCF_IN_OC_PROPERTY)
+      {
+          if (cpd.settings[UO_sp_oc_property_before_assign].a != AV_IGNORE)
+          {
+              log_rule("UO_sp_oc_property_before_assign");
+              return(cpd.settings[UO_sp_oc_property_before_assign].a);
+          }
+          log_rule("sp_enum_assign");
+          return(cpd.settings[UO_sp_oc_property_assign].a);
+      }
+       
       if ((cpd.settings[UO_sp_assign_default].a != AV_IGNORE) &&
           (second->parent_type == CT_FUNC_PROTO))
       {
@@ -553,6 +564,16 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
          }
          log_rule("sp_enum_assign");
          return(cpd.settings[UO_sp_enum_assign].a);
+      }
+      if (first->flags & PCF_IN_OC_PROPERTY)
+      {
+          if (cpd.settings[UO_sp_oc_property_after_assign].a != AV_IGNORE)
+          {
+              log_rule("UO_sp_oc_property_after_assign");
+              return(cpd.settings[UO_sp_oc_property_after_assign].a);
+          }
+          log_rule("sp_enum_assign");
+          return(cpd.settings[UO_sp_oc_property_assign].a);
       }
       if ((cpd.settings[UO_sp_assign_default].a != AV_IGNORE) &&
           (first->parent_type == CT_FUNC_PROTO))

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -133,6 +133,7 @@ struct parse_frame
 #define PCF_IN_NAMESPACE       PCF_BIT(12)
 #define PCF_IN_FOR             PCF_BIT(13)
 #define PCF_IN_OC_MSG          PCF_BIT(14)
+#define PCF_IN_OC_PROPERTY     PCF_BIT(15)
 
 /* Non-Copy flags are in the upper 48 bits */
 #define PCF_FORCE_SPACE        PCF_BIT(16)  /* must have a space after this token */
@@ -179,7 +180,7 @@ static const char *pcf_names[] =
    "IN_NAMESPACE",      // 12
    "IN_FOR",            // 13
    "IN_OC_MSG",         // 14
-   "#15",               // 15
+   "IN_OC_PROPERTY",    // 15
    "FORCE_SPACE",       // 16
    "STMT_START",        // 17
    "EXPR_START",        // 18


### PR DESCRIPTION
Adds ability to sort property semantics. E.g.

@property (nonatomic, readonly, assign) NSString *foo;
@property (readonly, assign, nonatomic) NSString *bar;

can become:

@property (nonatomic, readonly, assign) NSString *foo;
@property (nonatomic, readonly, assign) NSString *bar;

The implementation is more convoluted then I had hoped/expected. The setter=foobar and getter=barfoo property specifiers messed up my initial implementation a bit and needed to be modified.

Control over the order that items will appear in is controlled via weights. The heigher the weight, the closer to the front it will be.

Don't expect this code to necessarily be accepted, but figured I would make the pull request so its a bit more public and others might pick it up / use it if they want.
