### PR TITLE
Allow removal or addition of newlines after blocks.

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -2152,7 +2152,25 @@ void newlines_cleanup_braces(bool first)
             {
                newline_iarf_pair(pc, next, cpd.settings[UO_nl_brace_brace].a);
             }
-         }
+        }
+
+        if (cpd.settings[UO_nl_brace_square].a != AV_IGNORE)
+        {
+            next = chunk_get_next_nc(pc, CNAV_PREPROC);
+            if ((next != NULL) && (next->type == CT_SQUARE_CLOSE))
+            {
+                newline_iarf_pair(pc, next, cpd.settings[UO_nl_brace_square].a);
+            }
+        }
+         
+        if (cpd.settings[UO_nl_brace_fparen].a != AV_IGNORE)
+        {
+            next = chunk_get_next_nc(pc, CNAV_PREPROC);
+            if ((next != NULL) && (next->type == CT_FPAREN_CLOSE))
+            {
+                newline_iarf_pair(pc, next, cpd.settings[UO_nl_brace_fparen].a);
+            }
+        }
 
          if (cpd.settings[UO_eat_blanks_before_close_brace].b)
          {
@@ -2210,6 +2228,8 @@ void newlines_cleanup_braces(bool first)
             if ((next != NULL) &&
                 (next->type != CT_SEMICOLON) &&
                 (next->type != CT_COMMA) &&
+                (next->type != CT_SQUARE_CLOSE) &&
+                (next->type != CT_FPAREN_CLOSE) &&
                 ((pc->flags & (PCF_IN_ARRAY_ASSIGN | PCF_IN_TYPEDEF)) == 0) &&
                 !chunk_is_newline(next) &&
                 !chunk_is_comment(next))

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -767,6 +767,10 @@ void register_options(void)
                   "Add or remove newline between 'catch' and '{'");
    unc_add_option("nl_brace_catch", UO_nl_brace_catch, AT_IARF,
                   "Add or remove newline between '}' and 'catch'");
+   unc_add_option("nl_brace_square", UO_nl_brace_square, AT_IARF,
+                   "Add or remove newline between '}' and ']'");
+   unc_add_option("nl_brace_square", UO_nl_brace_fparen, AT_IARF,
+                   "Add or remove newline between '}' and ')' in a function invocation");
    unc_add_option("nl_while_brace", UO_nl_while_brace, AT_IARF,
                   "Add or remove newline between 'while' and '{'");
    unc_add_option("nl_scope_brace", UO_nl_scope_brace, AT_IARF,

--- a/src/options.h
+++ b/src/options.h
@@ -517,6 +517,8 @@ enum uncrustify_options
    UO_nl_getset_brace,               /* nl between get/set and { */
    UO_nl_catch_brace,                /* nl between catch and { */
    UO_nl_brace_catch,                /* nl between } and catch */
+   UO_nl_brace_square,               /* nl between } and ] */
+   UO_nl_brace_fparen,                /* nl between } and ) of a function invocation */
    UO_nl_while_brace,                /* nl between while and { */
    UO_nl_unittest_brace,             /* nl between unittest and { */
    UO_nl_scope_brace,

--- a/tests/config/nl_brace_square.cfg
+++ b/tests/config/nl_brace_square.cfg
@@ -1,0 +1,9 @@
+
+include "obj-c.cfg"
+
+output_tab_size          = 4     # new tab size
+indent_columns           = output_tab_size
+
+nl_brace_square = remove
+nl_brace_fparen = remove
+nl_after_brace_close = true

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -51,6 +51,7 @@
 50081  sp_after_oc_block_caret_force.cfg            oc/more_blocks.m
 50082  sp_after_oc_block_caret_remove.cfg           oc/more_blocks.m
 50083  sp_before_after_oc_block_caret_remove.cfg    oc/more_blocks.m
+50084  nl_brace_square.cfg                          oc/more_blocks.m
 
 50090  obj-c.cfg                                    oc/kw.m
 

--- a/tests/output/oc/50084-more_blocks.m
+++ b/tests/output/oc/50084-more_blocks.m
@@ -1,0 +1,73 @@
+int (^myBlock)(int) = ^(int num) {
+    return num * multiplier;
+};
+// for comparison
+int (*fcnptr)(int);
+
+int d = i % 10;
+repeat(10, ^{ putc('0' + d);
+});
+
+
+void (^block)(void);
+typedef void (^vstr_t)(char *);
+typedef void (^workBlk_t)(void);
+
+void AllLinesInFile(char *f, vstr_t block)
+{
+    FILE *fp = fopen(f, "r");
+
+    if (!fp)
+    {
+        return;
+    }
+    char line[1024];
+    while (fgets(line, 1024, fp))
+    {
+        block(line);
+    }
+    fclose(fp);
+}
+
+
+@implementation NSArray (WWDC)
+-(NSArray *)map: (id (^)(id)) xform
+{
+    id result = [NSMutableArray array];
+
+    for (id elem in self)
+    {
+        [result addObject: xform(elem)];
+    }
+    return result;
+}
+
+-(NSArray *)collect: (BOOL (^)(id)) predicate
+{
+    id result = [NSMutableArray array];
+
+    for (id elem in self)
+    {
+        if (predicate(elem))
+        {
+            [result addObject: elem];
+        }
+    }
+    return result;
+}
+
+// corner case: block literal in use with return type
+id longLines = [allLines collect: ^BOOL (id item) {
+    return [item length] > 20;
+}];
+
+// corner case: block literal in use with return type
+id longLines = [allLines collect: ^BOOL *(id item) {
+    return [item length] > 20;
+}];
+
+@end
+
+// 1. block literal: ^{ ... };
+// 2. block declaration: return_t (^name) (int arg1, int arg2, ...) NB: return_t is optional and name is also optional
+// 3. block inline call ^ return_t (int arg) { ... }; NB: return_t is optional

--- a/uncrustify.xcodeproj/project.pbxproj
+++ b/uncrustify.xcodeproj/project.pbxproj
@@ -959,6 +959,8 @@
 		89794F7114544FD900E38ACC /* unc_text.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = unc_text.cpp; sourceTree = "<group>"; };
 		89794F731454502900E38ACC /* unicode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = unicode.cpp; sourceTree = "<group>"; };
 		8DD76F6C0486A84900D96B5E /* uncrustify */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = uncrustify; sourceTree = BUILT_PRODUCTS_DIR; };
+		A00EAF72185655CF007D4EDC /* nl_brace_square.cfg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = nl_brace_square.cfg; sourceTree = "<group>"; };
+		A00EAF73185656A2007D4EDC /* 50084-more_blocks.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "50084-more_blocks.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1204,6 +1206,7 @@
 				65536346107EB6D900E08A01 /* nl_after_func_body.cfg */,
 				65536347107EB6D900E08A01 /* nl_assign1.cfg */,
 				65536348107EB6D900E08A01 /* nl_assign2.cfg */,
+				A00EAF72185655CF007D4EDC /* nl_brace_square.cfg */,
 				65536349107EB6D900E08A01 /* nl_brace_test.cfg */,
 				6553634A107EB6D900E08A01 /* nl_class-a.cfg */,
 				6553634B107EB6D900E08A01 /* nl_class-r.cfg */,
@@ -1960,6 +1963,7 @@
 				65A4632D1092D346007F6EBA /* 50081-more_blocks.m */,
 				65A4632E1092D346007F6EBA /* 50082-more_blocks.m */,
 				65A4632F1092D346007F6EBA /* 50083-more_blocks.m */,
+				A00EAF73185656A2007D4EDC /* 50084-more_blocks.m */,
 				2E6EEE7F16A62A4E001EFF54 /* 50111-ns_enum.m */,
 			);
 			path = oc;


### PR DESCRIPTION
I'd like to use uncrustify for Objective-C but it's not fully configurable for my needs, especially when it comes to blocks.

I took a stab at trying to add a new rule: to allow `nl_after_brace_close` to be true while still nesting blocks inside messages like so:

```
[self.sendMessage withBlock:^{
    .....
}];
```

instead of

```
[self.sendMessage withBlock:^{
    .....
}
];
```

I'm not sure if this change fits into the larger scheme of things; this is the result of my investigating how to add new rules, so please send any feedback my way.
