### PR TITLE
Fix build on Windows

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -11,6 +11,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <algorithm>
 #include <cerrno>
 #include "unc_ctype.h"
 

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <cerrno>
+#include <algorithm>
 #include "unc_ctype.h"
 
 


### PR DESCRIPTION
Added the missing include statements to build uncrustify
on Windows (using Visual Studio Express 2013).
