### PR TITLE
Differentiate between normal ternary (a ? b : c) and short ternary, (b ?: c)

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -507,6 +507,8 @@ void register_options(void)
                   "Add or remove space before the '?' in 'b ? t : f'. Overrides sp_cond_question.");
    unc_add_option("sp_cond_question_after", UO_sp_cond_question_after, AT_IARF,
                   "Add or remove space after the '?' in 'b ? t : f'. Overrides sp_cond_question.");
+   unc_add_option("sp_cond_ternary_short", UO_sp_cond_ternary_short, AT_IARF,
+                  "In the abbreviated ternary form (a ?: b), add/remove space between ? and :.'. Overrides all other sp_cond_* options.");
    unc_add_option("sp_case_label", UO_sp_case_label, AT_IARF,
                   "Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make sense here.");
    unc_add_option("sp_range", UO_sp_range, AT_IARF,

--- a/src/options.h
+++ b/src/options.h
@@ -358,6 +358,7 @@ enum uncrustify_options
    UO_sp_cond_question,
    UO_sp_cond_question_before,
    UO_sp_cond_question_after,
+   UO_sp_cond_ternary_short,
    UO_sp_case_label,
    UO_sp_range,
    UO_sp_cmt_cpp_start,

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -210,6 +210,14 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
       }
    }
 
+   if (first->type == CT_QUESTION && second->type == CT_COND_COLON)
+   {
+       if (cpd.settings[UO_sp_cond_ternary_short].a != AV_IGNORE)
+       {
+           return cpd.settings[UO_sp_cond_ternary_short].a;
+       }
+   }
+
    if ((first->type == CT_COND_COLON) || (second->type == CT_COND_COLON))
    {
       if ((second->type == CT_COND_COLON) &&

--- a/tests/config/obj-c.cfg
+++ b/tests/config/obj-c.cfg
@@ -219,6 +219,8 @@ sp_after_oc_block_caret = remove
 sp_after_ptr_star_func = remove
 sp_ptr_star_paren = remove
 
+sp_cond_ternary_short = remove  # short ternary is b ?: c, instead of a ? b : c. add/remove space between ? and :
+
 indent_oc_block = true
 
 nl_oc_msg_args = true

--- a/tests/input/oc/ternary.m
+++ b/tests/input/oc/ternary.m
@@ -1,0 +1,1 @@
+NSString *str = (otherString ?: @"this is the placeholder");

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -21,6 +21,8 @@
 
 50015  obj-c.cfg                                    oc/receiver.m
 
+50016  obj-c.cfg                                    oc/ternary.m
+
 50020  sp_after_oc_at_sel_add.cfg                   oc/selector.m
 50021  sp_after_oc_at_sel_force.cfg                 oc/selector.m
 50022  sp_after_oc_at_sel_remove.cfg                oc/selector.m

--- a/tests/output/oc/50016-ternary.m
+++ b/tests/output/oc/50016-ternary.m
@@ -1,0 +1,1 @@
+NSString *str = (otherString ?: @"this is the placeholder");


### PR DESCRIPTION
Differentiate between normal ternary (a ? b : c) and short ternary, (b ?: c) with option `sp_cond_ternary_short`.
