### PR TITLE
Fix typo in documentation

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -3176,7 +3176,7 @@ static void mark_function(chunk_t *pc)
          {
             LOG_FMT(LFCN, " --> Stopping on %s [%s]\n",
                     prev->str.c_str(), get_token_name(prev->type));
-            /* certain tokens are unlikely to preceed a proto or def */
+            /* certain tokens are unlikely to precede a proto or def */
             if ((prev->type == CT_ARITH) ||
                 (prev->type == CT_ASSIGN) ||
                 (prev->type == CT_COMMA) ||

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1206,7 +1206,7 @@ void register_options(void)
                   "The filename that contains text to insert before a class if the class isn't preceded with a C/C++ comment.\n"
                   "Will substitute $(class) with the class name.");
    unc_add_option("cmt_insert_oc_msg_header", UO_cmt_insert_oc_msg_header, AT_STRING,
-                  "The filename that contains text to insert before a Obj-C message specification if the method isn't preceeded with a C/C++ comment.\n"
+                  "The filename that contains text to insert before a Obj-C message specification if the method isn't preceded with a C/C++ comment.\n"
                   "Will substitute $(message) with the function name and $(javaparam) with the javadoc @param and @return stuff.");
    unc_add_option("cmt_insert_before_preproc", UO_cmt_insert_before_preproc, AT_BOOL,
                   "If a preprocessor is encountered when stepping backwards from a function name, then\n"


### PR DESCRIPTION
Fixed a minor spelling error in a comment and more important in the user visible documentation.
