### PR TITLE
Handle Xcode code placeholders.

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -173,6 +173,8 @@ void register_options(void)
                   "Allow interpreting '>=' and '>>=' as part of a template in 'void f(list<list<B>>=val);'.\n"
                   "If true (default), 'assert(x<0 && y>=3)' will be broken.\n"
                   "Improvements to template detection may make this option obsolete.");
+   unc_add_option("dont_protect_xcode_code_placeholders", UO_dont_protect_xcode_code_placeholders, AT_BOOL,
+                  "Xcode inserts <#code placeholders#> into files that will otherwise be mangled. Turn option on to ignore these.");
 
    unc_add_option("utf8_bom", UO_utf8_bom, AT_IARF,
                   "Control what to do with the UTF-8 BOM (recommend 'remove')");

--- a/src/options.h
+++ b/src/options.h
@@ -100,6 +100,8 @@ enum uncrustify_options
    UO_utf8_force,
    UO_utf8_bom,
 
+   UO_dont_protect_xcode_code_placeholders,
+
    UO_input_tab_size,           // tab size on input file: usually 8
    UO_output_tab_size,          // tab size for output: usually 8
 

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -469,6 +469,50 @@ static bool parse_comment(tok_ctx& ctx, chunk_t& pc)
    return(true);
 }
 
+/**
+ * Figure of the length of the code placeholder at text, if present.
+ * This is only for Xcode which sometimes inserts temporary code placeholder chunks, which in plaintext <#look like this#>.
+ *
+ * @param pc   The structure to update, str is an input.
+ * @return     Whether a placeholder was parsed.
+ */
+static bool parse_code_placeholder(tok_ctx& ctx, chunk_t& pc)
+{
+   int  ch;
+
+   if (!(ctx.peek() == '<' && ctx.peek(1) == '#'))
+   {
+      return(false);
+   }
+
+   ctx.save();
+
+   /* account for opening two chars */
+   pc.str = ctx.get();   /* opening '/' */
+   ch = ctx.get();
+   pc.str.append(ch);    /* second char */
+
+   pc.type = CT_WORD;
+   while (ctx.more())
+   {
+      if ((ctx.peek() == '#') && (ctx.peek(1) == '>'))
+      {
+         pc.str.append(ctx.get());  /* store the '#' */
+         pc.str.append(ctx.get());  /* store the '>' */
+
+         tok_info ss;
+         ctx.save(ss);
+
+         return(true);
+      }
+
+      ch = ctx.get();
+      pc.str.append(ch);
+   }
+
+   return(false);
+}
+
 
 /**
  * Parse any attached suffix, which may be a user-defined literal suffix.
@@ -1263,6 +1307,11 @@ static bool parse_next(tok_ctx& ctx, chunk_t& pc)
     */
    if (parse_comment(ctx, pc))
    {
+      return(true);
+   }
+
+   /* Parse code placeholders */
+   if (parse_code_placeholder(ctx, pc) && !cpd.settings[UO_dont_protect_xcode_code_placeholders].b) {
       return(true);
    }
 

--- a/tests/input/oc/code_placeholder.m
+++ b/tests/input/oc/code_placeholder.m
@@ -1,0 +1,5 @@
+double delayInSeconds = 2.0;
+dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
+dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+    <#code to be executed on the main queue after delay#>
+});

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -76,3 +76,5 @@
 50300  obj-c.cfg                                    oc/msg.m
 
 50400  obj-c.cfg                                    oc/for.m
+
+50500  obj-c.cfg                                    oc/code_placeholder.m

--- a/tests/output/oc/50500-code_placeholder.m
+++ b/tests/output/oc/50500-code_placeholder.m
@@ -1,0 +1,5 @@
+double          delayInSeconds = 2.0;
+dispatch_time_t popTime        = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
+dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+   <#code to be executed on the main queue after delay#>
+});


### PR DESCRIPTION
If you uncrustify while editing a file in Xcode (which I very frequently do), any code placeholders inserted by Xcode will be mangled. This commit fixes that.

I'm very open to changing the option or removing it (`<#` and `#>` don't appear to conflict with anything in any other language). Is there a way to have a boolean option set to `true` by default? 
