### PR TITLE
Fix Issue 262

### DIFF
--- a/src/width.cpp
+++ b/src/width.cpp
@@ -195,8 +195,8 @@ static void try_split_here(cw_entry& ent, chunk_t *pc)
    }
    else
    {
-      if ((pc->level > ent.pc->level) &&
-          (pc_pri <= ent.pri))
+      if ((pc->level >= ent.pc->level) &&
+          (pc_pri < ent.pri))
       {
          change = true;
       }


### PR DESCRIPTION
I'm proposing a fix for issue 262, the culprit seems to be a bug in try_split_here: in a backward traversal, a candidate pc should be accepted if it has strictly lower priority and is at the same or higher level of nesting.
