### PR TITLE
Fix right shift (">>") turning into "> >" in C#

### DIFF
--- a/src/punctuators.cpp
+++ b/src/punctuators.cpp
@@ -68,7 +68,7 @@ static const chunk_tag_t symbols2[] =
    { "<>", CT_COMPARE,      LANG_D                                         },
    { "==", CT_COMPARE,      LANG_ALL                                       },
    { ">=", CT_COMPARE,      LANG_ALL                                       },
-   { ">>", CT_ARITH,        LANG_ALL & ~LANG_CS                            },
+   { ">>", CT_ARITH,        LANG_ALL                                       },
    { "[]", CT_TSQUARE,      LANG_ALL                                       },
    { "^=", CT_ASSIGN,       LANG_ALL                                       },
    { "|=", CT_ASSIGN,       LANG_ALL                                       },

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1652,8 +1652,8 @@ void space_text(void)
                      /* C++11 allows '>>' to mean '> >' in templates:
                       *   some_func<vector<string>>();
                       */
-                     if ((cpd.lang_flags & (LANG_CPP | LANG_JAVA)) &&
-                         cpd.settings[UO_sp_permit_cpp11_shift].b &&
+                     if ((((cpd.lang_flags & LANG_CPP) && cpd.settings[UO_sp_permit_cpp11_shift].b) ||
+                         ((cpd.lang_flags & LANG_JAVA) || (cpd.lang_flags & LANG_CS))) &&
                          (pc->type == CT_ANGLE_CLOSE) &&
                          (next->type == CT_ANGLE_CLOSE))
                      {


### PR DESCRIPTION
I've found right shifts in C# would get converted to "> >", obviously breaking the code. The change to punctuators.cpp fixed this. (Left shifts were OK.)

This however caused generics to gain a space where not desired, as in:

IEnumerable<Tuple<RectangleF, Point> > output;

The change to space.cpp adds an except for Java or C#, while maintaining the forced space restriction for the similar C++ construct.

Tests pass, but I've not done extensive testing on the changes - first time dipping into the uncrustify code, but I needed to fix this bug. :) Hope the changes are acceptable.
