### PR TITLE
 Only indent one namespace and no sub-namepaces #281

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1013,7 +1013,8 @@ void indent_text(void)
             else if (pc->parent_type == CT_NAMESPACE)
             {
                if ((pc->flags & PCF_LONG_BLOCK) ||
-                   !cpd.settings[UO_indent_namespace].b)
+                   !cpd.settings[UO_indent_namespace].b ||
+                   (cpd.settings[UO_indent_namespace_single_indent].b && frm.pse[frm.pse_tos].level >= 1))
                {
                   /* don't indent long blocks */
                   frm.pse[frm.pse_tos].indent -= indent_size;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -572,6 +572,9 @@ void register_options(void)
                   "Whether the 'namespace' body is indented");
    unc_add_option("indent_namespace_level", UO_indent_namespace_level, AT_NUM,
                   "The number of spaces to indent a namespace block");
+   unc_add_option("indent_namespace_single_indent", UO_indent_namespace_single_indent, AT_BOOL,
+                  "Only indent one namespace and no sub-namepaces.\n"
+                  "Requires indent_namespace=true.");
    unc_add_option("indent_namespace_limit", UO_indent_namespace_limit, AT_NUM,
                   "If the body of the namespace is longer than this number, it won't be indented.\n"
                   "Requires indent_namespace=true. Default=0 (no limit)", NULL, 0, 255);

--- a/src/options.h
+++ b/src/options.h
@@ -161,6 +161,7 @@ enum uncrustify_options
 
    UO_indent_namespace,                     // indent stuff inside namespace braces
    UO_indent_namespace_level,               // level to indent namespace blocks
+   UO_indent_namespace_single_indent,       // indent one namespace and no sub-namepaces
    UO_indent_namespace_limit,               // no indent if namespace is longer than this
    UO_indent_extern,
    UO_indent_class,                         // indent stuff inside class braces

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -358,6 +358,20 @@ void output_text(FILE *pfile)
       }
       else if (pc->type == CT_COMMENT_CPP)
       {
+         if (pc->prev != NULL &&
+             pc->prev->parent_type == CT_NAMESPACE &&
+             cpd.settings[UO_indent_namespace].b &&
+             cpd.settings[UO_indent_namespace_single_indent].b &&
+             (pc->level > 1 || (pc->prev->type == CT_BRACE_CLOSE && pc->level == 1))) 
+         {
+             int column = pc->column - cpd.settings[UO_indent_namespace_level].n;
+             if (!cpd.settings[UO_indent_relative_single_line_comments].b) 
+             {
+               if (column < pc->orig_col)
+                 column = pc->orig_col;
+             }
+             pc->column = column;
+         }
          pc = output_comment_cpp(pc);
       }
       else if (pc->type == CT_COMMENT)
@@ -433,6 +447,17 @@ void output_text(FILE *pfile)
                allow_tabs |= pc->after_tab;
             }
             LOG_FMT(LOUTIND, " %d(%d) -", pc->column, allow_tabs);
+         }
+
+         if (cpd.settings[UO_indent_namespace].b &&
+             cpd.settings[UO_indent_namespace_single_indent].b &&
+             pc->level >= 1 &&
+             ((pc->type == CT_NAMESPACE && pc->parent_type != CT_USING) ||
+              (pc->prev != NULL &&
+               pc->parent_type == CT_NAMESPACE &&
+               pc->prev->parent_type != CT_USING))) 
+         {
+             pc->column -= cpd.settings[UO_indent_namespace_level].n;
          }
 
          output_to_column(pc->column, allow_tabs);


### PR DESCRIPTION
Indent only the inner namespace and leave the rest not indented.

New option:
indent_namespace_single_indent
