### PR TITLE
Fix for bug #600

### DIFF
--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -721,6 +721,7 @@ void tokenize_cleanup(void)
             if (doit)
             {
                pc->str += next->str;
+               pc->orig_col_end = next->orig_col_end;
                chunk_del(next);
                next = tmp;
             }

--- a/tests/c-sharp.test
+++ b/tests/c-sharp.test
@@ -33,3 +33,5 @@
 10080 ben.cfg                  cs/property.cs
 
 10090 ben.cfg                  cs/string_multi.cs
+
+10100 bug_600.cfg              cs/bug_600.cs

--- a/tests/config/bug_600.cfg
+++ b/tests/config/bug_600.cfg
@@ -1,0 +1,1 @@
+sp_after_type=ignore

--- a/tests/input/cs/bug_600.cs
+++ b/tests/input/cs/bug_600.cs
@@ -1,0 +1,2 @@
+Vector2? a;
+Vector2 b;

--- a/tests/output/cs/10100-bug_600.cs
+++ b/tests/output/cs/10100-bug_600.cs
@@ -1,0 +1,2 @@
+Vector2? a;
+Vector2 b;


### PR DESCRIPTION
Fix for bug #600 (https://sourceforge.net/p/uncrustify/bugs/600/). The nullable type was consuming the CT_QUESTION and appending it to itself, but wasn't also adjusting its end column.
