### PR TITLE
Add indent_param parameter to use as continuation indent

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1369,7 +1369,14 @@ void indent_text(void)
                idx--;
                skipped = true;
             }
-            frm.pse[frm.pse_tos].indent = frm.pse[idx].indent + indent_size;
+            if (cpd.settings[UO_indent_param].n != 0)
+            {
+               frm.pse[frm.pse_tos].indent = frm.pse[idx].indent + cpd.settings[UO_indent_param].n;
+            }
+            else
+            {
+               frm.pse[frm.pse_tos].indent = frm.pse[idx].indent + indent_size;
+            }
             if (cpd.settings[UO_indent_func_param_double].b)
             {
                frm.pse[frm.pse_tos].indent += indent_size;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -566,6 +566,9 @@ void register_options(void)
    unc_add_option("indent_continue", UO_indent_continue, AT_NUM,
                   "The continuation indent. If non-zero, this overrides the indent of '(' and '=' continuation indents.\n"
                   "For FreeBSD, this is set to 4. Negative value is absolute and not increased for each ( level");
+   unc_add_option("indent_param", UO_indent_param, AT_NUM,
+                  "The continuation indent for func_*_param if they are true.\n"
+                  "If non-zero, this overrides the indent.");
    unc_add_option("indent_with_tabs", UO_indent_with_tabs, AT_NUM,
                   "How to use tabs when indenting code\n"
                   "0=spaces only\n"

--- a/src/options.h
+++ b/src/options.h
@@ -107,6 +107,7 @@ enum uncrustify_options
 
    UO_indent_columns,           // ie 3 or 8
    UO_indent_continue,
+   UO_indent_param,             // indent value of indent_*_param
    UO_indent_with_tabs,         // 1=only to the 'level' indent, 2=use tabs for indenting
    UO_indent_cmt_with_tabs,
    //UO_indent_brace_struct,      //TODO: spaces to indent brace after struct/enum/union def


### PR DESCRIPTION
Add indent_param parameter to use as continuation indent if func_*_param are true.

The style guidelines of [MuseScore](http://github.com/musescore/MuseSCore) requires a continuation indent of 3 while the normal indent is 6. I couldn't find a way to achieve this so I added a new option.
