### PR TITLE
Call LOG_FUNC_CALL() before set_chunk_type() and set_chunk_parent()

### DIFF
--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -673,7 +673,7 @@ chunk_t *chunk_get_prev_nvb(chunk_t *cur, chunk_nav_t nav)
 }
 
 
-void set_chunk_type(chunk_t *pc, c_token_t tt)
+void set_chunk_type_real(chunk_t *pc, c_token_t tt)
 {
    LOG_FUNC_ENTRY();
    if (pc && (pc->type != tt))
@@ -688,7 +688,7 @@ void set_chunk_type(chunk_t *pc, c_token_t tt)
 }
 
 
-void set_chunk_parent(chunk_t *pc, c_token_t pt)
+void set_chunk_parent_real(chunk_t *pc, c_token_t pt)
 {
    LOG_FUNC_ENTRY();
    if (pc && (pc->parent_type != pt))

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -340,7 +340,18 @@ bool chunk_is_forin(chunk_t *pc)
 }
 
 
-void set_chunk_type(chunk_t *pc, c_token_t tt);
-void set_chunk_parent(chunk_t *pc, c_token_t tt);
+void set_chunk_type_real(chunk_t *pc, c_token_t tt);
+void set_chunk_parent_real(chunk_t *pc, c_token_t tt);
+
+#define set_chunk_type(pc, tt)   do { \
+      LOG_FUNC_CALL(); \
+      set_chunk_type_real((pc), (tt)); \
+   } while (false)
+
+#define set_chunk_parent(pc, tt)   do { \
+      LOG_FUNC_CALL(); \
+      set_chunk_parent_real((pc), (tt)); \
+   } while (false)
+
 
 #endif /* CHUNK_LIST_H_INCLUDED */


### PR DESCRIPTION
This will give the right line number in the "call stack".