### PR TITLE
Fix assignment continuation indent by tab.

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1491,6 +1491,7 @@ void indent_text(void)
                if (pc->type == CT_ASSIGN)
                {
                   frm.pse[frm.pse_tos].type = CT_ASSIGN_NL;
+                  frm.pse[frm.pse_tos].indent_tab = frm.pse[frm.pse_tos].indent;
                }
             }
             else

--- a/tests/output/c/00058-if_chain.c
+++ b/tests/output/c/00058-if_chain.c
@@ -47,11 +47,11 @@ void bar(void)
 			hw_priv->Counter[ port ].time =
 
 #ifdef SOME_DEFINE
-			        hw_priv->Counter[ port - 1 ].time + HZ * 2;
+				hw_priv->Counter[ port - 1 ].time + HZ * 2;
 		}
 
 #else /* ifdef SOME_DEFINE */
-			        hw_priv->Counter[ MAIN_PORT ].time + HZ * 2;
+				hw_priv->Counter[ MAIN_PORT ].time + HZ * 2;
 #endif /* ifdef SOME_DEFINE */
 	}
 }


### PR DESCRIPTION
The extra indent of the "value" line was done with spaces, while it is
supposed to be done with tabs.

variable =
    value;

There are likely other similar constructs that are not indented properly.