### PR TITLE
Add option align_asm_colon

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -31,6 +31,7 @@ static void align_left_shift(void);
 static void align_oc_msg_colons();
 static void align_oc_msg_colon(chunk_t *so);
 static void align_oc_decl_colon(void);
+static void align_asm_colon(void);
 
 
 /*
@@ -314,6 +315,11 @@ void align_all(void)
    if (cpd.settings[UO_align_oc_decl_colon].b)
    {
       align_oc_decl_colon();
+   }
+
+   if (cpd.settings[UO_align_asm_colon].b)
+   {
+      align_asm_colon();
    }
 
    /* Align variable defs in function prototypes */
@@ -2181,6 +2187,62 @@ static void align_oc_decl_colon(void)
          pc = chunk_get_next(pc, CNAV_PREPROC);
       }
       nas.End();
+      cas.End();
+   }
+}
+
+
+/**
+ * Aligns asm declarations on the colon
+ * asm volatile (
+ *    "xxx"
+ *    : "x"(h),
+ *      "y"(l),
+ *    : "z"(h)
+ *    );
+ */
+static void align_asm_colon(void)
+{
+   LOG_FUNC_ENTRY();
+   chunk_t    *pc = chunk_get_head();
+   AlignStack cas;   /* for the colons */
+   int        level;
+   bool       did_nl;
+
+   cas.Start(4);
+
+   while (pc != NULL)
+   {
+      if (pc->type != CT_ASM_COLON)
+      {
+         pc = chunk_get_next(pc);
+         continue;
+      }
+
+      cas.Reset();
+
+      pc = chunk_get_next_ncnl(pc, CNAV_PREPROC);
+      level = pc->level;
+      did_nl = true;
+      while (pc->level >= level)
+      {
+         if (chunk_is_newline(pc))
+         {
+            cas.NewLines(pc->nl_count);
+            did_nl = true;
+         }
+         else if (pc->type == CT_ASM_COLON)
+         {
+            cas.Flush();
+            did_nl = true;
+         }
+         else if (did_nl)
+         {
+            did_nl = false;
+            cas.Add(pc);
+         }
+         pc = chunk_get_next_nc(pc, CNAV_PREPROC);
+      }
       cas.End();
    }
 }

--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -53,6 +53,7 @@ static const chunk_tag_t keywords[] =
    { "_Bool",            CT_TYPE,         LANG_CPP                                                                    },
    { "_Complex",         CT_TYPE,         LANG_CPP                                                                    },
    { "_Imaginary",       CT_TYPE,         LANG_CPP                                                                    },
+   { "__asm__",          CT_ASM,          LANG_C | LANG_CPP                                                           },
    { "__attribute__",    CT_ATTRIBUTE,    LANG_C | LANG_CPP                                                           },
    { "__block",          CT_QUALIFIER,    LANG_OC                                                                     },
    { "__const__",        CT_QUALIFIER,    LANG_C | LANG_CPP                                                           },

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1219,6 +1219,8 @@ void register_options(void)
                   "The span for aligning on '#define' bodies (0=don't align, other=number of lines including comments between blocks)", "", 0, 5000);
    unc_add_option("align_left_shift", UO_align_left_shift, AT_BOOL,
                   "Align lines that start with '<<' with previous '<<'. Default=true");
+   unc_add_option("align_asm_colon", UO_align_asm_colon, AT_BOOL,
+                  "Align text after asm volatile () colons.");
 
    unc_add_option("align_oc_msg_colon_span", UO_align_oc_msg_colon_span, AT_NUM,
                   "Span for aligning parameters in an Obj-C message call on the ':' (0=don't align)", 0, 5000);

--- a/src/options.h
+++ b/src/options.h
@@ -473,7 +473,7 @@ enum uncrustify_options
    UO_align_typedef_amp_style,     // align_typedef_star_style for ref '&' stuff
    //UO_align_struct_array_brace,  // TODO: align array of structure initializers
    UO_align_left_shift,
-//    UO_align_oc_msg_colon,
+   UO_align_asm_colon,
    UO_align_oc_msg_colon_span,
    UO_align_oc_msg_colon_first,
    UO_align_oc_decl_colon,

--- a/src/token_enum.h
+++ b/src/token_enum.h
@@ -119,6 +119,7 @@ typedef enum
    CT_SEMICOLON,
    CT_VSEMICOLON,          /* virtual semicolon for PAWN */
    CT_COLON,
+   CT_ASM_COLON,
    CT_CASE_COLON,
    CT_CLASS_COLON,         /* colon after a class def */
    CT_CONSTR_COLON,        /* colon after a constructor */

--- a/src/token_names.h
+++ b/src/token_names.h
@@ -97,6 +97,7 @@ const char *token_names[] =
    "SEMICOLON",
    "VSEMICOLON",
    "COLON",
+   "ASM_COLON",
    "CASE_COLON",
    "CLASS_COLON",
    "CONSTR_COLON",

--- a/tests/c.test
+++ b/tests/c.test
@@ -295,6 +295,8 @@
 
 02504 align_keep_extra.cfg      c/align_keep_extra.c
 
+02510 ben.cfg                   c/asm.c
+
 07630 indent-vbrace.cfg         c/indent-vbrace.c
 
 08399 ben.cfg                   c/gh399.c

--- a/tests/config/ben.cfg
+++ b/tests/config/ben.cfg
@@ -87,6 +87,7 @@ align_keep_tabs               = false
 align_with_tabs               = false
 align_on_tabstop              = false
 align_number_left             = true
+align_asm_colon               = true
 align_func_params             = true
 align_var_def_span            = 2
 align_var_def_star_style      = 1

--- a/tests/input/c/asm.c
+++ b/tests/input/c/asm.c
@@ -1,0 +1,9 @@
+void foo(void)
+{
+		asm __volatile__ (
+			"subl %2,%0\n\t"
+			"sbbl %3,%1"
+			:"=a" (l), "=d" (h)
+			:"g" (sl), "g" (sh),
+			"0" (l), "1" (h));
+}

--- a/tests/output/c/02510-asm.c
+++ b/tests/output/c/02510-asm.c
@@ -1,0 +1,9 @@
+void foo(void)
+{
+   asm __volatile__ (
+      "subl %2,%0\n\t"
+      "sbbl %3,%1"
+      : "=a" (l), "=d" (h)
+      : "g" (sl), "g" (sh),
+        "0" (l), "1" (h));
+}


### PR DESCRIPTION
Aligns the "0" under the "g" below:

	asm __volatile__ (
		"subl %2,%0\n\t"
		"sbbl %3,%1"
		: "=a" (l), "=d" (h)
		: "g" (sl), "g" (sh),
		  "0" (l), "1" (h));