### PR TITLE
Fix the paren continuation indent

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1397,6 +1397,7 @@ void indent_text(void)
                   sub = 2;
                }
                frm.pse[frm.pse_tos].indent = frm.pse[frm.pse_tos - sub].indent + indent_size;
+               frm.pse[frm.pse_tos].indent_tab = frm.pse[frm.pse_tos].indent;
                skipped = true;
             }
             else
@@ -1794,6 +1795,7 @@ void indent_text(void)
                   if (cpd.settings[UO_indent_paren_close].n != 2)
                   {
                      indent_column_set(frm.pse[frm.pse_tos + 1].indent_tmp);
+                     pc->column_indent = frm.pse[frm.pse_tos + 1].indent_tab;
                      if (cpd.settings[UO_indent_paren_close].n == 1)
                      {
                         indent_column--;

--- a/tests/output/c/00161-fcn_indent.c
+++ b/tests/output/c/00161-fcn_indent.c
@@ -20,7 +20,7 @@ typedef short (*hello1)(char coolParam,
                         unsigned int anotherone);
 
 typedef const unsigned char * (getfcn_t)(
-   int idx, ulong op);
+	int idx, ulong op);
 
 short (*hello2)(char coolParam,
                 ulong *,
@@ -28,8 +28,8 @@ short (*hello2)(char coolParam,
                 unsigned int anotherone);
 
 const unsigned char * (*getstr) (
-   int idx,
-   ulong op);
+	int idx,
+	ulong op);
 
 short hello3 (char coolParam,
               ushort *,

--- a/tests/output/c/00162-fcn_indent.c
+++ b/tests/output/c/00162-fcn_indent.c
@@ -20,7 +20,7 @@ typedef short (*hello1)(char coolParam,
                         unsigned int anotherone);
 
 typedef const unsigned char * (getfcn_t)(
-   int idx, ulong op);
+	int idx, ulong op);
 
 short (*hello2)(char coolParam,
                 ulong *,
@@ -28,8 +28,8 @@ short (*hello2)(char coolParam,
                 unsigned int anotherone);
 
 const unsigned char * (*getstr) (
-   int idx,
-   ulong op);
+	int idx,
+	ulong op);
 
 short
 hello3 (char coolParam,

--- a/tests/output/c/00430-paren-indent.c
+++ b/tests/output/c/00430-paren-indent.c
@@ -5,20 +5,20 @@ static void *foo(int param1,
 
 static void *foo
 (
-        int param1,
-        char *param2
+	int param1,
+	char *param2
 )
 {
 	for (
-	        int i = 0;
-	        i< 10;
-	        i++
-	        )
+		int i = 0;
+		i< 10;
+		i++
+		)
 	{
 		bar(
-		        arg1,
-		        arg2
-		        );
+			arg1,
+			arg2
+			);
 		if ( ( abc < bcd )
 		     &&( 123 < abc )
 		     )

--- a/tests/output/c/00431-paren-indent.c
+++ b/tests/output/c/00431-paren-indent.c
@@ -5,18 +5,18 @@ static void *foo( int param1
 
 static void *foo
 (
-        int param1
+	int param1
 , char *param2
 )
 {
 	for (
-	        int i = 0;
-	        i< 10;
-	        i++
+		int i = 0;
+		i< 10;
+		i++
 	    )
 	{
 		bar(
-		        arg1
+			arg1
 		   , arg2
 		   );
 		if ( ( abc < bcd )

--- a/tests/output/c/00432-paren-indent.c
+++ b/tests/output/c/00432-paren-indent.c
@@ -5,19 +5,19 @@ static void *foo(int param1,
 
 static void *foo
 (
-        int param1,
-        char *param2
+	int param1,
+	char *param2
 )
 {
 	for (
-	        int i = 0;
-	        i< 10;
-	        i++
+		int i = 0;
+		i< 10;
+		i++
 	)
 	{
 		bar(
-		        arg1,
-		        arg2
+			arg1,
+			arg2
 		);
 		if ( ( abc < bcd )
 		     &&( 123 < abc )

--- a/tests/output/cpp/30045-nl_func_decl.cpp
+++ b/tests/output/cpp/30045-nl_func_decl.cpp
@@ -18,16 +18,16 @@ void bla2
 
 void ble
 (
-        int a,
-        char b
+	int a,
+	char b
 )
 {
 }
 
 void ble2
 (
-        int a,
-        char b
+	int a,
+	char b
 )
 {
 }

--- a/tests/output/cpp/30046-nl_func_decl.cpp
+++ b/tests/output/cpp/30046-nl_func_decl.cpp
@@ -4,13 +4,13 @@ void bla
 );
 void ble
 (
-        int  a,
-        char b
+	int  a,
+	char b
 );
 void ble2
 (
-        int  a,
-        char b
+	int  a,
+	char b
 );
 
 

--- a/tests/output/cpp/30109-templates4.cpp
+++ b/tests/output/cpp/30109-templates4.cpp
@@ -1,15 +1,15 @@
 #define FOO(X) \
 	template <unsigned _blk_sz, typename _run_type, class __pos_type> \
 	inline X<_blk_sz, _run_type, __pos_type> operator - ( \
-	        const X<_blk_sz, _run_type, __pos_type> & a, \
-	        typename X<_blk_sz, _run_type, __pos_type>::_pos_type off) \
+		const X<_blk_sz, _run_type, __pos_type> & a, \
+		typename X<_blk_sz, _run_type, __pos_type>::_pos_type off) \
 	{ \
 		return X<_blk_sz, _run_type, __pos_type>(a.array, a.pos - off); \
 	} \
 	template <unsigned _blk_sz, typename _run_type, class __pos_type> \
 	inline X<_blk_sz, _run_type, __pos_type> & operator -= ( \
-	        X < _blk_sz, _run_type, __pos_type > & a, \
-	        typename X<_blk_sz, _run_type, __pos_type>::_pos_type off) \
+		X < _blk_sz, _run_type, __pos_type > & a, \
+		typename X<_blk_sz, _run_type, __pos_type>::_pos_type off) \
 	{ \
 		a.pos -= off; \
 		return a; \

--- a/tests/output/cpp/30205-cmt_right.cpp
+++ b/tests/output/cpp/30205-cmt_right.cpp
@@ -12,10 +12,10 @@ struct Zone
     }                                           // constructor for zone search
 
     inline Zone(
-        //int _a,
-        //int _b,
-        int _c,
-        int _d, double _e) :
+	//int _a,
+	//int _b,
+	int _c,
+	int _d, double _e) :
 	//a(_a),
 	//b(_b),
 	c(_c),

--- a/tests/output/cpp/30253-align_left_shift.cpp
+++ b/tests/output/cpp/30253-align_left_shift.cpp
@@ -34,8 +34,8 @@ void f() {
 	                            << "World!"
 	                            << std::endl);
 	A_LONG_MACRO_NAME(
-	        std::cout << "Hello, "
-	                  << "World!"
-	                  << std::endl);
+		std::cout << "Hello, "
+		          << "World!"
+		          << std::endl);
 }
 

--- a/tests/output/cpp/30254-align_left_shift2.cpp
+++ b/tests/output/cpp/30254-align_left_shift2.cpp
@@ -12,7 +12,7 @@ void g()
 void f()
 {
 	cout << something(
-	        arg);
+		arg);
 	cout
 	        << "something";
 	cout <<
@@ -23,10 +23,10 @@ void f()
 
 	RLOGD(m_log) <<
 	        base::sprintfT(
-	        "something %u ",
-	        m_pendingAccepts);
+		"something %u ",
+		m_pendingAccepts);
 
 	RLOGDD(m_log) << sprintfT(
-	        "something id=%u",
-	        newSocket->GetId());
+		"something id=%u",
+		newSocket->GetId());
 }

--- a/tests/output/cpp/30256-func_call.cpp
+++ b/tests/output/cpp/30256-func_call.cpp
@@ -1,14 +1,14 @@
 void f()
 {
 	auto x = func1(
-	        arg,
-	        arg);
+		arg,
+		arg);
 }
 
 void f()
 {
 	return func2(
-	        arg,
-	        arg);
+		arg,
+		arg);
 }
 

--- a/tests/output/cpp/30290-align_left_shift.cpp
+++ b/tests/output/cpp/30290-align_left_shift.cpp
@@ -34,8 +34,8 @@ void f() {
             << "World!"
             << std::endl);
     A_LONG_MACRO_NAME(
-            std::cout << "Hello, "
-            << "World!"
-            << std::endl);
+	    std::cout << "Hello, "
+	    << "World!"
+	    << std::endl);
 }
 


### PR DESCRIPTION
Fix the paren continuation indent, which should use tabs when indented at body level and indent_with_tabs=1.