### PR TITLE
Make 'pp_define_at_level = True' work with #undef and #pragma

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -641,7 +641,9 @@ void indent_text(void)
          frm.level++;
          indent_pse_push(frm, chunk_get_next(pc));
 
-         if (pc->parent_type == CT_PP_DEFINE)
+         if ((pc->parent_type == CT_PP_DEFINE) ||
+             (pc->parent_type == CT_PP_UNDEF) ||
+             (pc->parent_type == CT_PP_PRAGMA))
          {
             frm.pse[frm.pse_tos].indent_tmp = cpd.settings[UO_pp_define_at_level].b ?
                                               frm.pse[frm.pse_tos - 1].indent_tmp : 1;

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -642,11 +642,17 @@ void indent_text(void)
          indent_pse_push(frm, chunk_get_next(pc));
 
          if ((pc->parent_type == CT_PP_DEFINE) ||
-             (pc->parent_type == CT_PP_UNDEF) ||
-             (pc->parent_type == CT_PP_PRAGMA))
+             (pc->parent_type == CT_PP_UNDEF))
          {
             frm.pse[frm.pse_tos].indent_tmp = cpd.settings[UO_pp_define_at_level].b ?
                                               frm.pse[frm.pse_tos - 1].indent_tmp : 1;
+            frm.pse[frm.pse_tos].indent     = frm.pse[frm.pse_tos].indent_tmp + indent_size;
+            frm.pse[frm.pse_tos].indent_tab = frm.pse[frm.pse_tos].indent;
+         }
+         else if ((pc->parent_type == CT_PP_PRAGMA) &&
+                  cpd.settings[UO_pp_define_at_level].b)
+         {
+            frm.pse[frm.pse_tos].indent_tmp = frm.pse[frm.pse_tos - 1].indent_tmp;
             frm.pse[frm.pse_tos].indent     = frm.pse[frm.pse_tos].indent_tmp + indent_size;
             frm.pse[frm.pse_tos].indent_tab = frm.pse[frm.pse_tos].indent;
          }

--- a/tests/output/c/00618-pp-if-indent.c
+++ b/tests/output/c/00618-pp-if-indent.c
@@ -106,7 +106,7 @@ void myfunction(void)
     int i;
     #ifdef COMINL_coTX_MESSAGE_VAR
 	#ifndef COMINL_coMIXED_MODE
-	#pragma MyPragma
+	    #pragma MyPragma
 	    int j;
 	#endif
     #endif


### PR DESCRIPTION
The `pp_define_at_level = True` option currently seems to only affect `#define`.  However, this may lead to inconsistent indentation of code using `#undef` and `#pragma`.  Here is an example:
```
#include <stdio.h>
int main(int argc, char** argv)
{
#ifdef DEBUG
#define FORMAT "argc=%d\n"
std::printf(FORMAT,argc);
#undef FORMAT
#endif DEBUG
#ifdef _OPENMP
#pragma omp parallel
{
printf("Hello from thread!\n");
}
#endif
return 0;
}
```
And the corresponding configuration file:
```
pp_indent_at_level    True
pp_define_at_level    True
pp_if_indent_code     True
```

Output w/o the patch:
```
#include <stdio.h>
int main(int argc, char** argv)
{
	#ifdef DEBUG
		#define FORMAT "argc=%d\n"
		std::printf(FORMAT,argc);
	#undef FORMAT
	#endif DEBUG
	#ifdef _OPENMP
	#pragma omp parallel
		{
			printf("Hello from thread!\n");
		}
	#endif
	return 0;
}
```

Output with this PR applied:
```
#include <stdio.h>
int main(int argc, char** argv)
{
	#ifdef DEBUG
		#define FORMAT "argc=%d\n"
		std::printf(FORMAT,argc);
		#undef FORMAT
	#endif DEBUG
	#ifdef _OPENMP
		#pragma omp parallel
		{
			printf("Hello from thread!\n");
		}
	#endif
	return 0;
}
```

If desired, the indentation of `#pragma` could be made a separate configuration option, though the `#undef` should IMO be handled in the same way than `#define`.