### PR TITLE
small simplifications

### DIFF
--- a/src/compat_posix.cpp
+++ b/src/compat_posix.cpp
@@ -26,11 +26,7 @@ bool unc_getenv(const char *name, std::string& str)
 
 bool unc_homedir(std::string& home)
 {
-   if (unc_getenv("HOME", home))
-   {
-      return(true);
-   }
-   return(false);
+   return(unc_getenv("HOME", home));
 }
 
 #endif /* ifndef WIN32 */

--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -309,7 +309,7 @@ static int kw_compare(const void *p1, const void *p2)
 }
 
 
-void keywords_are_sorted(void)
+bool keywords_are_sorted(void)
 {
    for (int idx = 1; idx < (int)ARRAY_SIZE(keywords); idx++)
    {
@@ -317,9 +317,11 @@ void keywords_are_sorted(void)
       {
          fprintf(stderr, "%s: bad sort order at idx %d, words '%s' and '%s'\n",
                  __func__, idx - 1, keywords[idx - 1].tag, keywords[idx].tag);
-         exit(EXIT_FAILURE);
+         return false;
       }
    }
+
+   return true;
 }
 
 

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -192,7 +192,7 @@ void add_keyword(const char *tag, c_token_t type);
 void print_keywords(FILE *pfile);
 void clear_keyword_file(void);
 pattern_class get_token_pattern_class(c_token_t tok);
-void keywords_are_sorted(void);
+bool keywords_are_sorted(void);
 
 
 /*

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -304,31 +304,27 @@ int main(int argc, char *argv[])
    {
       cfg_file = p_arg;
    }
-
-   /* Try to find a config file at an alternate location */
-   if (cfg_file.empty())
+   else if (!unc_getenv("UNCRUSTIFY_CONFIG", cfg_file))
    {
-      if (!unc_getenv("UNCRUSTIFY_CONFIG", cfg_file))
+      /* Try to find a config file at an alternate location */
+      string home;
+
+      if (unc_homedir(home))
       {
-         string home;
+         struct stat tmp_stat;
+         string      path;
 
-         if (unc_homedir(home))
+         path = home + "/uncrustify.cfg";
+         if (stat(path.c_str(), &tmp_stat) == 0)
          {
-            struct stat tmp_stat;
-            string      path;
-
-            path = home + "/uncrustify.cfg";
+            cfg_file = path;
+         }
+         else
+         {
+            path = home + "/.uncrustify.cfg";
             if (stat(path.c_str(), &tmp_stat) == 0)
             {
                cfg_file = path;
-            }
-            else
-            {
-               path = home + "/.uncrustify.cfg";
-               if (stat(path.c_str(), &tmp_stat) == 0)
-               {
-                  cfg_file = path;
-               }
             }
          }
       }

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -229,6 +229,13 @@ static void redir_stdout(const char *output_file)
 
 int main(int argc, char *argv[])
 {
+   /* If ran without options show the usage info */
+   if (argc == 1)
+   {
+      keywords_are_sorted();
+      usage_exit(NULL, argv[0], EXIT_SUCCESS);
+   }
+
    string     cfg_file;
    const char *parsed_file = NULL;
    const char *source_file = NULL;
@@ -237,13 +244,6 @@ int main(int argc, char *argv[])
    log_mask_t mask;
    int        idx;
    const char *p_arg;
-
-   /* If ran without options... check keyword sort and show the usage info */
-   if (argc == 1)
-   {
-      keywords_are_sorted();
-      usage_exit(NULL, argv[0], EXIT_SUCCESS);
-   }
 
    /* Build options map */
    register_options();

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -229,10 +229,11 @@ static void redir_stdout(const char *output_file)
 
 int main(int argc, char *argv[])
 {
+   assert(keywords_are_sorted());
+
    /* If ran without options show the usage info */
    if (argc == 1)
    {
-      keywords_are_sorted();
       usage_exit(NULL, argv[0], EXIT_SUCCESS);
    }
 


### PR DESCRIPTION
4#: I am not sure why keywords_are_sorted() is tested only when not enough args are available or why it is executed in a non debug context. 
Wouldn't it be better to move it into a ifdef debug guard or add it into an assert and disabling asserts in non debug mode ? 
What is your stance on the features of c++11 and c++14 ?  It maybe could be possible to make keywords_are_sorted() a constexpr which fails at compile time if something is wrong.