### PR TITLE
add missing files to Visual Studio project files

### DIFF
--- a/win32/Uncrustify_Win32.dsp
+++ b/win32/Uncrustify_Win32.dsp
@@ -163,6 +163,10 @@ SOURCE=..\src\options.cpp
 # End Source File
 # Begin Source File
 
+SOURCE=..\src\options_for_QT.cpp
+# End Source File
+# Begin Source File
+
 SOURCE=..\src\output.cpp
 # End Source File
 # Begin Source File
@@ -268,6 +272,10 @@ SOURCE=..\src\md5.h
 # Begin Source File
 
 SOURCE=..\src\options.h
+# End Source File
+# Begin Source File
+
+SOURCE=..\src\options_for_QT.h
 # End Source File
 # Begin Source File
 

--- a/win32/Uncrustify_Win32.vcproj
+++ b/win32/Uncrustify_Win32.vcproj
@@ -621,6 +621,28 @@
 				</FileConfiguration>
 			</File>
 			<File
+				RelativePath="..\src\options_for_QT.cpp"
+				>
+				<FileConfiguration
+					Name="Debug|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						AdditionalIncludeDirectories=""
+						PreprocessorDefinitions=""
+					/>
+				</FileConfiguration>
+			</File>
+			<File
 				RelativePath="..\src\output.cpp"
 				>
 				<FileConfiguration
@@ -955,6 +977,10 @@
 			</File>
 			<File
 				RelativePath="..\src\options.h"
+				>
+			</File>
+			<File
+				RelativePath="..\src\options_for_QT.h"
 				>
 			</File>
 			<File

--- a/win32/Uncrustify_Win32_2005.vcproj
+++ b/win32/Uncrustify_Win32_2005.vcproj
@@ -697,6 +697,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\src\options_for_QT.cpp"
+				>
+			</File>
+			<File
 				RelativePath="..\src\output.cpp"
 				>
 			</File>
@@ -803,6 +807,10 @@
 			</File>
 			<File
 				RelativePath="..\src\options.h"
+				>
+			</File>
+			<File
+				RelativePath="..\src\options_for_QT.h"
 				>
 			</File>
 			<File

--- a/win32/Uncrustify_Win32_2010.vcxproj
+++ b/win32/Uncrustify_Win32_2010.vcxproj
@@ -147,6 +147,7 @@
     <ClCompile Include="..\src\md5.cpp" />
     <ClCompile Include="..\src\newlines.cpp" />
     <ClCompile Include="..\src\options.cpp" />
+    <ClCompile Include="..\src\options_for_QT.cpp" />
     <ClCompile Include="..\src\output.cpp" />
     <ClCompile Include="..\src\parens.cpp" />
     <ClCompile Include="..\src\parse_frame.cpp" />
@@ -177,6 +178,7 @@
     <ClInclude Include="..\src\logmask.h" />
     <ClInclude Include="..\src\md5.h" />
     <ClInclude Include="..\src\options.h" />
+    <ClInclude Include="..\src\options_for_QT.h" />
     <ClInclude Include="..\src\prototypes.h" />
     <ClInclude Include="..\src\punctuators.h" />
     <ClInclude Include="..\src\token_enum.h" />

--- a/win32/Uncrustify_Win32_2011.vcxproj
+++ b/win32/Uncrustify_Win32_2011.vcxproj
@@ -150,6 +150,7 @@
     <ClCompile Include="..\src\md5.cpp" />
     <ClCompile Include="..\src\newlines.cpp" />
     <ClCompile Include="..\src\options.cpp" />
+    <ClCompile Include="..\src\options_for_QT.cpp" />
     <ClCompile Include="..\src\output.cpp" />
     <ClCompile Include="..\src\parens.cpp" />
     <ClCompile Include="..\src\parse_frame.cpp" />
@@ -180,6 +181,7 @@
     <ClInclude Include="..\src\logmask.h" />
     <ClInclude Include="..\src\md5.h" />
     <ClInclude Include="..\src\options.h" />
+    <ClInclude Include="..\src\options_for_QT.h" />
     <ClInclude Include="..\src\prototypes.h" />
     <ClInclude Include="..\src\punctuators.h" />
     <ClInclude Include="..\src\token_enum.h" />


### PR DESCRIPTION
Add `src/options_for_QT.cpp` and `src/options_for_QT.h` to the existing Visual Studio project files. Since I don't have any of these older versions I didn't test if they still compile as-is though.