### PR TITLE
update create_uncrustify_version_header.bat to use configure.ac

### DIFF
--- a/scripts/create_uncrustify_version_header.bat
+++ b/scripts/create_uncrustify_version_header.bat
@@ -1,10 +1,10 @@
 @echo off
 rem Filter the package version number from the configure file
 
-set configuration_file="..\\configure"
+set configuration_file="..\\configure.ac"
 set package_version_token=PACKAGE_VERSION
 
-FOR /F "tokens=2 delims='" %%A IN ('findstr /B /R "^%package_version_token%=.*" %configuration_file%') DO set package_version=%%A
+FOR /F "tokens=2 delims=," %%A IN ('findstr /B /R "^AC_INIT(uncrustify.*" %configuration_file%') DO set package_version=%%A
 
 rem Delete existing header_output_file and create new empty one
 


### PR DESCRIPTION
With the recent removal of the `configure` file from the repo (https://github.com/uncrustify/uncrustify/commit/d44b486696f946f8bf66604b80850fe6c19b59b2#diff-e2d5a00791bce9a01f99bc6fd613a39d) this script stopped working. This patched version will get the version number from the `configure.ac` file instead.