### PR TITLE
Don't use backslash in Unix file path in the man page

### DIFF
--- a/man/uncrustify.1.in
+++ b/man/uncrustify.1.in
@@ -27,7 +27,7 @@ Errors are always dumped to stderr
 \fB\-c\fI CFG
 Use the config file \fICFG\fR.
 .br
-If not specified, uncrustify will use \fB$UNCRUSTIFY_CONFIG\fR or \fB$HOME\\.uncrustify.cfg\fR.
+If not specified, uncrustify will use \fB$UNCRUSTIFY_CONFIG\fR or \fB$HOME/.uncrustify.cfg\fR.
 .TP
 \fB\-f\fI FILE
 Process the single file \fIFILE\fR, sending output to stdout or the file specified with \fB\-o\fR.


### PR DESCRIPTION
The default configuration file path used backslash in its path, fix it to use
the correct slash instead.

----
Not a big deal, but it was just annoying to see a backslash in a Unix man page.