### PR TITLE
Fix testing for CMake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,13 +222,10 @@ add_executable(uncrustify
 #
 if(BUILD_TESTING)
   find_package(PythonInterp REQUIRED)
-  add_custom_command(TARGET uncrustify POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-    "$<TARGET_FILE:uncrustify>" "${PROJECT_SOURCE_DIR}/src/"
-  )
   enable_testing()
   add_test(NAME test_uncrustify
-    COMMAND ${PYTHON_EXECUTABLE} "${PROJECT_SOURCE_DIR}/tests/run_tests.py"
+    COMMAND ${PYTHON_EXECUTABLE}
+      "${PROJECT_SOURCE_DIR}/tests/run_tests.py" "--exe=$<TARGET_FILE:uncrustify>"
     WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/tests/"
   )
 endif()

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -16,16 +16,16 @@ import filecmp
 
 # OK, so I just had way too much fun with the colors..
 
-if os.name == "nt":	# windoze doesn't support ansi sequences
-	NORMAL      = ""
-	BOLD        = ""
-	UNDERSCORE  = ""
-	REVERSE     = ""
+if os.name == "nt":    # windoze doesn't support ansi sequences
+    NORMAL      = ""
+    BOLD        = ""
+    UNDERSCORE  = ""
+    REVERSE     = ""
 else:
-	NORMAL      = "\033[0m"
-	BOLD        = "\033[1m"
-	UNDERSCORE  = "\033[1m"
-	REVERSE     = "\033[7m"
+    NORMAL      = "\033[0m"
+    BOLD        = "\033[1m"
+    UNDERSCORE  = "\033[1m"
+    REVERSE     = "\033[7m"
 
 FG_BLACK    = "\033[30m"
 FG_RED      = "\033[31m"
@@ -66,16 +66,16 @@ BGB_WHITE   = "\033[107m"
 
 # after all that, I chose c
 
-if os.name == "nt":	# windoze doesn't support ansi sequences
-	FAIL_COLOR     = ""
-	PASS_COLOR     = ""
-	MISMATCH_COLOR = ""
-	UNSTABLE_COLOR = ""
+if os.name == "nt":    # windoze doesn't support ansi sequences
+    FAIL_COLOR     = ""
+    PASS_COLOR     = ""
+    MISMATCH_COLOR = ""
+    UNSTABLE_COLOR = ""
 else:
-	FAIL_COLOR     = UNDERSCORE
-	PASS_COLOR     = FG_GREEN
-	MISMATCH_COLOR = FG_RED #REVERSE
-	UNSTABLE_COLOR = FGB_CYAN
+    FAIL_COLOR     = UNDERSCORE
+    PASS_COLOR     = FG_GREEN
+    MISMATCH_COLOR = FG_RED #REVERSE
+    UNSTABLE_COLOR = FGB_CYAN
 
 if os.name == "nt":
     bin_base_path = '../Win32/Debug'
@@ -89,166 +89,166 @@ else:
 log_level = 0
 
 def usage_exit():
-	print("Usage: \n" + sys.argv[0] + " testfile")
-	sys.exit()
+    print("Usage: \n" + sys.argv[0] + " testfile")
+    sys.exit()
 
 def run_tests(test_name, config_name, input_name, lang):
-	# print("Test:  ", test_name)
-	# print("Config:", config_name)
-	# print("Input: ", input_name)
-	# print('Output:', expected_name)
+    # print("Test:  ", test_name)
+    # print("Config:", config_name)
+    # print("Input: ", input_name)
+    # print('Output:', expected_name)
 
-	if not config_name.startswith(os.sep):
-		config_name = os.path.join('config', config_name)
+    if not config_name.startswith(os.sep):
+        config_name = os.path.join('config', config_name)
 
-	if test_name[-1] == '!':
-		test_name = test_name[:-1]
-		rerun_config = "%s.rerun%s" % os.path.splitext(config_name)
-	else:
-		rerun_config = config_name
+    if test_name[-1] == '!':
+        test_name = test_name[:-1]
+        rerun_config = "%s.rerun%s" % os.path.splitext(config_name)
+    else:
+        rerun_config = config_name
 
-	expected_name = os.path.join(os.path.dirname(input_name), test_name + '-' + os.path.basename(input_name))
-	resultname = os.path.join('results', expected_name)
-	outputname = os.path.join('output', expected_name)
-	try:
-		os.makedirs(os.path.dirname(resultname))
-	except:
-		pass
+    expected_name = os.path.join(os.path.dirname(input_name), test_name + '-' + os.path.basename(input_name))
+    resultname = os.path.join('results', expected_name)
+    outputname = os.path.join('output', expected_name)
+    try:
+        os.makedirs(os.path.dirname(resultname))
+    except:
+        pass
 
-	cmd = "%s/uncrustify -q -c %s -f input/%s %s > %s" % (os.path.abspath(bin_base_path), config_name, input_name, lang, resultname)
-	if log_level & 2:
-		print("RUN: " + cmd)
-	a = os.system(cmd)
-	if a != 0:
-		print(FAIL_COLOR + "FAILED: " + NORMAL + test_name)
-		return -1
+    cmd = "%s/uncrustify -q -c %s -f input/%s %s > %s" % (os.path.abspath(bin_base_path), config_name, input_name, lang, resultname)
+    if log_level & 2:
+        print("RUN: " + cmd)
+    a = os.system(cmd)
+    if a != 0:
+        print(FAIL_COLOR + "FAILED: " + NORMAL + test_name)
+        return -1
 
-	try:
-		if not filecmp.cmp(resultname, outputname):
-			print(MISMATCH_COLOR + "MISMATCH: " + NORMAL + test_name)
-			if log_level & 1:
-				cmd = "diff -u %s %s" % (outputname, resultname)
-				sys.stdout.flush()
-				os.system(cmd)
-			return -1
-	except:
-		print(MISMATCH_COLOR + "MISSING: " + NORMAL + test_name)
-		return -1
+    try:
+        if not filecmp.cmp(resultname, outputname):
+            print(MISMATCH_COLOR + "MISMATCH: " + NORMAL + test_name)
+            if log_level & 1:
+                cmd = "diff -u %s %s" % (outputname, resultname)
+                sys.stdout.flush()
+                os.system(cmd)
+            return -1
+    except:
+        print(MISMATCH_COLOR + "MISSING: " + NORMAL + test_name)
+        return -1
 
-	# The file in results matches the file in output.
-	# Re-run with the output file as the input to check stability.
-	cmd = "%s/uncrustify -q -c %s -f %s %s > %s" % (os.path.abspath(bin_base_path), rerun_config, outputname, lang, resultname)
-	if log_level & 2:
-		print("RUN: " + cmd)
-	a = os.system(cmd)
-	if a != 0:
-		print(FAIL_COLOR + "FAILED2: " + NORMAL + test_name)
-		return -1
+    # The file in results matches the file in output.
+    # Re-run with the output file as the input to check stability.
+    cmd = "%s/uncrustify -q -c %s -f %s %s > %s" % (os.path.abspath(bin_base_path), rerun_config, outputname, lang, resultname)
+    if log_level & 2:
+        print("RUN: " + cmd)
+    a = os.system(cmd)
+    if a != 0:
+        print(FAIL_COLOR + "FAILED2: " + NORMAL + test_name)
+        return -1
 
-	try:
-		if not filecmp.cmp(resultname, outputname):
-			print(UNSTABLE_COLOR + "UNSTABLE: " + NORMAL + test_name)
-			if log_level & 1:
-				cmd = "diff -u %s %s" % (outputname, resultname)
-				sys.stdout.flush()
-				os.system(cmd)
-			return -2
-	except:
-		# impossible
-		print(UNSTABLE_COLOR + "MISSING: " + NORMAL + test_name)
-		return -1
+    try:
+        if not filecmp.cmp(resultname, outputname):
+            print(UNSTABLE_COLOR + "UNSTABLE: " + NORMAL + test_name)
+            if log_level & 1:
+                cmd = "diff -u %s %s" % (outputname, resultname)
+                sys.stdout.flush()
+                os.system(cmd)
+            return -2
+    except:
+        # impossible
+        print(UNSTABLE_COLOR + "MISSING: " + NORMAL + test_name)
+        return -1
 
-	if log_level & 4:
-		print(PASS_COLOR + "PASSED: " + NORMAL + test_name)
-	return 0
+    if log_level & 4:
+        print(PASS_COLOR + "PASSED: " + NORMAL + test_name)
+    return 0
 
 def process_test_file(filename):
-	fd = open(filename, "r")
-	if fd == None:
-		print("Unable to open " + filename)
-		return None
-	print("Processing " + filename)
-	pass_count = 0
-	fail_count = 0
-	unst_count = 0
-	for line in fd:
-		line = line.strip()
-		parts = line.split()
-		if (len(parts) < 3) or (parts[0][0] == '#'):
-			continue
-		lang = ""
-		if len(parts) > 3:
-			lang = "-l " + parts[3]
-		rt = run_tests(parts[0], parts[1], parts[2], lang)
-		if rt < 0:
-			if rt == -1:
-				fail_count += 1
-			else:
-				unst_count += 1
-		else:
-			pass_count += 1
-	return [pass_count, fail_count, unst_count]
+    fd = open(filename, "r")
+    if fd == None:
+        print("Unable to open " + filename)
+        return None
+    print("Processing " + filename)
+    pass_count = 0
+    fail_count = 0
+    unst_count = 0
+    for line in fd:
+        line = line.strip()
+        parts = line.split()
+        if (len(parts) < 3) or (parts[0][0] == '#'):
+            continue
+        lang = ""
+        if len(parts) > 3:
+            lang = "-l " + parts[3]
+        rt = run_tests(parts[0], parts[1], parts[2], lang)
+        if rt < 0:
+            if rt == -1:
+                fail_count += 1
+            else:
+                unst_count += 1
+        else:
+            pass_count += 1
+    return [pass_count, fail_count, unst_count]
 
 #
 # entry point
 #
 def main(argv):
-	global log_level
-	args = []
-	the_tests = []
-	for arg in argv:
-		if arg.startswith('-'):
-			for cc in arg[1:]:
-				if cc == 'd':       # show diff on failure
-					log_level |= 1
-				elif cc == 'c':     # show commands
-					log_level |= 2
-				elif cc == 'p':     # show passes
-					log_level |= 4
-				else:
-					sys.exit('Unknown option "%s"' % (cc))
-		else:
-			args.append(arg)
+    global log_level
+    args = []
+    the_tests = []
+    for arg in argv:
+        if arg.startswith('-'):
+            for cc in arg[1:]:
+                if cc == 'd':       # show diff on failure
+                    log_level |= 1
+                elif cc == 'c':     # show commands
+                    log_level |= 2
+                elif cc == 'p':     # show passes
+                    log_level |= 4
+                else:
+                    sys.exit('Unknown option "%s"' % (cc))
+        else:
+            args.append(arg)
 
-	if len(args) == 0:
-		the_tests += "c-sharp c cpp d java pawn objective-c vala ecma".split()
-	else:
-		the_tests += args
+    if len(args) == 0:
+        the_tests += "c-sharp c cpp d java pawn objective-c vala ecma".split()
+    else:
+        the_tests += args
 
-	# do a sanity check on the executable
-	cmd = "%s/uncrustify > %s" % (os.path.abspath(bin_base_path), "usage.txt")
-	if log_level & 2:
-		print("RUN: " + cmd)
-	a = os.system(cmd)
-	if a != 0:
-		print(FAIL_COLOR + "FAILED: " + NORMAL + "Sanity check")
-		return -1
+    # do a sanity check on the executable
+    cmd = "%s/uncrustify > %s" % (os.path.abspath(bin_base_path), "usage.txt")
+    if log_level & 2:
+        print("RUN: " + cmd)
+    a = os.system(cmd)
+    if a != 0:
+        print(FAIL_COLOR + "FAILED: " + NORMAL + "Sanity check")
+        return -1
 
-	#print args
-	print("Tests: " + str(the_tests))
-	pass_count = 0
-	fail_count = 0
-	unst_count = 0
+    #print args
+    print("Tests: " + str(the_tests))
+    pass_count = 0
+    fail_count = 0
+    unst_count = 0
 
-	for item in the_tests:
-		if not item.endswith('.test'):
-			item += '.test'
-		passfail = process_test_file(item)
-		if passfail != None:
-			pass_count += passfail[0]
-			fail_count += passfail[1]
-			unst_count += passfail[2]
+    for item in the_tests:
+        if not item.endswith('.test'):
+            item += '.test'
+        passfail = process_test_file(item)
+        if passfail != None:
+            pass_count += passfail[0]
+            fail_count += passfail[1]
+            unst_count += passfail[2]
 
-	print("Passed %d / %d tests" % (pass_count, pass_count + fail_count))
-	if fail_count > 0:
-		print(BOLD + "Failed %d test(s)" % (fail_count) + NORMAL)
-		sys.exit(1)
-	else:
-		txt = BOLD + "All tests passed" + NORMAL
-		if unst_count > 0:
-			txt += ", but some files were unstable"
-		print(txt)
-		sys.exit(0)
+    print("Passed %d / %d tests" % (pass_count, pass_count + fail_count))
+    if fail_count > 0:
+        print(BOLD + "Failed %d test(s)" % (fail_count) + NORMAL)
+        sys.exit(1)
+    else:
+        txt = BOLD + "All tests passed" + NORMAL
+        if unst_count > 0:
+            txt += ", but some files were unstable"
+        print(txt)
+        sys.exit(0)
 
 if __name__ == '__main__':
-	sys.exit(main(sys.argv[1:]))
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
The hardcoded path in #485 broke testing with CMake on Windows (but great to have Python 3 compatibility!).

As mentioned in #492, I added a different hack in the CMake script to make testing work, but I believe a better solution is to allow the test script to take the path to the uncrustify executable it is supposed to test as an optional argument.

This PR adds a command line argument `--exe` which the CMake script uses to pass along the path to the uncrustify executable to test. For the Visual C++ solution files in `win32` and non-Windows builds, it defaults to the same paths as before.

I am using `argparse` which requires Python 2.7+ -- I don't know if that is a problem?

I also converted the indentation to 4 spaces (as per PEP 8), because the file contained a mixture of tabs and spaces.