### PR TITLE
parse_pawn_pattern: do not include an escaped newline

### DIFF
--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -1312,6 +1312,15 @@ static void parse_pawn_pattern(tok_ctx& ctx, chunk_t& pc, c_token_t tt)
    pc.type = tt;
    while (!unc_isspace(ctx.peek()))
    {
+      /* end the pattern on an escaped newline */
+      if (ctx.peek() == '\\')
+      {
+         int ch = ctx.peek(1);
+         if ((ch == '\n') || (ch == '\r'))
+         {
+            break;
+         }
+      }
       pc.str.append(ctx.get());
    }
 }

--- a/tests/input/pawn/preproc.pawn
+++ b/tests/input/pawn/preproc.pawn
@@ -1,4 +1,7 @@
 #define SetTeleType(%1,%2) set_pev( %1, pev_iuser1, %2 )
 #define SetTeleMate(%1,%2) set_pev( %1, pev_iuser2, %2*7)
 
+#define x(%0,%1)\
+        y(%1,%0)
+
 #emit CONST.pri 1911

--- a/tests/output/pawn/60040-preproc.pawn
+++ b/tests/output/pawn/60040-preproc.pawn
@@ -1,4 +1,7 @@
 #define SetTeleType(%1,%2)	set_pev(%1, pev_iuser1, %2)
 #define SetTeleMate(%1,%2)	set_pev(%1, pev_iuser2, %2 * 7)
 
+#define x(%0,%1) \
+	y(%1, %0)
+
 #emit CONST.pri 1911


### PR DESCRIPTION
This was getting parsed wrong, as the backslash was included as part of the
pattern.

#define x(%0,%1)\
    y(%1,%0)