### PR TITLE
fix compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include(CTest)
 # Check compiler flags
 #
 if(MSVC)
-  add_definitions(/D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_WARNINGS)
+  add_definitions(/D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_WARNINGS /wd4267)
 elseif(CMAKE_COMPILER_IS_GNUCXX)
   set(gcc_warning_flags
     -Wall

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -1513,6 +1513,7 @@ static chunk_t *skip_c99_array(chunk_t *sq_open)
  */
 static chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
 {
+   (void)first_pass;
    LOG_FUNC_ENTRY();
    chunk_t *pc;
    chunk_t *next;

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -73,6 +73,7 @@ static int preproc_start(struct parse_frame *frm, chunk_t *pc)
 static void print_stack(log_sev_t logsev, const char *str,
                         struct parse_frame *frm, chunk_t *pc)
 {
+   (void)pc;
    LOG_FUNC_ENTRY();
    if (log_sev_on(logsev))
    {

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2657,6 +2657,7 @@ void combine_labels(void)
 
 static void mark_variable_stack(ChunkStack& cs, log_sev_t sev)
 {
+   (void)sev;
    LOG_FUNC_ENTRY();
    chunk_t *var_name;
    chunk_t *word_type;

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -539,7 +539,6 @@ void indent_text(void)
    int                vardefcol    = 0;
    int                shiftcontcol = 0;
    int                indent_size  = cpd.settings[UO_indent_columns].n;
-   int                tmp;
    struct parse_frame frm;
    bool               in_preproc = false;
    int                indent_column;
@@ -1269,7 +1268,7 @@ void indent_text(void)
       else if (pc->type == CT_CASE)
       {
          /* Start a case - indent UO_indent_switch_case from the switch level */
-         tmp = frm.pse[frm.pse_tos].indent + cpd.settings[UO_indent_switch_case].n;
+         int tmp = frm.pse[frm.pse_tos].indent + cpd.settings[UO_indent_switch_case].n;
 
          indent_pse_push(frm, pc);
 
@@ -1331,7 +1330,7 @@ void indent_text(void)
       {
          if (cpd.settings[UO_indent_access_spec_body].b)
          {
-            tmp = frm.pse[frm.pse_tos].indent + indent_size;
+            int tmp = frm.pse[frm.pse_tos].indent + indent_size;
 
             indent_pse_push(frm, pc);
 
@@ -1740,7 +1739,7 @@ void indent_text(void)
                   tmp->type != CT_SPAREN_CLOSE);
 
          chunk_t *prev_nonl = chunk_get_prev_ncnl(pc);
-         chunk_t *prev      = chunk_get_prev_nc(pc);
+         chunk_t *prev2     = chunk_get_prev_nc(pc);
 
          if (prev_nonl &&
              (chunk_is_semicolon(prev_nonl) || prev_nonl->type == CT_BRACE_OPEN ||
@@ -1753,7 +1752,7 @@ void indent_text(void)
             in_shift = false;
          }
 
-         if (prev && prev->type == CT_NEWLINE && in_shift)
+         if (prev2 && prev2->type == CT_NEWLINE && in_shift)
          {
             shiftcontcol                     = calc_indent_continue(frm, frm.pse_tos);
             frm.pse[frm.pse_tos].indent_cont = true;
@@ -1881,7 +1880,7 @@ void indent_text(void)
                     ((prev->type == CT_MEMBER) ||
                      (prev->type == CT_DC_MEMBER)))))
          {
-            tmp = cpd.settings[UO_indent_member].n + indent_column;
+            int tmp = cpd.settings[UO_indent_member].n + indent_column;
             LOG_FMT(LINDENT, "%s: %d] member => %d\n",
                     __func__, pc->orig_line, tmp);
             reindent_line(pc, tmp);
@@ -1910,7 +1909,7 @@ void indent_text(void)
          else if ((pc->type == CT_STRING) && (prev != NULL) && (prev->type == CT_STRING) &&
                   cpd.settings[UO_indent_align_string].b)
          {
-            tmp = (xml_indent != 0) ? xml_indent : prev->column;
+            int tmp = (xml_indent != 0) ? xml_indent : prev->column;
 
             LOG_FMT(LINDENT, "%s: %d] String => %d\n",
                     __func__, pc->orig_line, tmp);
@@ -2119,7 +2118,7 @@ void indent_text(void)
             if (!frm.pse[frm.pse_tos].non_vardef &&
                 (frm.pse[frm.pse_tos].type == CT_BRACE_OPEN))
             {
-               tmp = indent_column;
+               int tmp = indent_column;
                if (cpd.settings[UO_indent_var_def_blk].n > 0)
                {
                   tmp = cpd.settings[UO_indent_var_def_blk].n;

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -19,9 +19,9 @@
 
 struct log_fcn_info
 {
-   log_fcn_info(const char *name, int line)
-      : name(name)
-      , line(line)
+   log_fcn_info(const char *name_, int line_)
+      : name(name_)
+      , line(line_)
    {
    }
 

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -2210,7 +2210,6 @@ void newlines_cleanup_braces(bool first)
    chunk_t  *next;
    chunk_t  *prev;
    chunk_t  *tmp;
-   argval_t arg;
 
    for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next_ncnl(pc))
    {
@@ -2220,7 +2219,7 @@ void newlines_cleanup_braces(bool first)
       }
       else if (pc->type == CT_ELSEIF)
       {
-         arg = cpd.settings[UO_nl_elseif_brace].a;
+         argval_t arg = cpd.settings[UO_nl_elseif_brace].a;
          newlines_if_for_while_switch(
             pc, (arg != AV_IGNORE) ? arg : cpd.settings[UO_nl_if_brace].a);
       }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1780,14 +1780,14 @@ int load_option_file(const char *filename)
          }
          else
          {
-            c_token_t id = find_token_name(args[1]);
-            if (id != CT_NONE)
+            c_token_t token = find_token_name(args[1]);
+            if (token != CT_NONE)
             {
                LOG_FMT(LNOTE, "%s:%d set '%s':", filename, cpd.line_number, args[1]);
                for (idx = 2; idx < argc; idx++)
                {
                   LOG_FMT(LNOTE, " '%s'", args[idx]);
-                  add_keyword(args[idx], id);
+                  add_keyword(args[idx], token);
                }
                LOG_FMT(LNOTE, "\n");
             }
@@ -2035,10 +2035,8 @@ void print_options(FILE *pfile)
       "String",
    };
 
-   option_name_map_it it;
-
    /* Find the max width of the names */
-   for (it = option_name_map.begin(); it != option_name_map.end(); it++)
+   for (option_name_map_it it = option_name_map.begin(); it != option_name_map.end(); it++)
    {
       cur_width = strlen(it->second.name);
       if (cur_width > max_width)

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -985,7 +985,7 @@ static chunk_t *output_comment_c(chunk_t *first)
 static chunk_t *output_comment_cpp(chunk_t *first)
 {
    cmt_reflow cmt;
-   unc_text   tmp, leadin;
+   unc_text   leadin;
 
    output_cmt_start(cmt, first);
    cmt.reflow = (cpd.settings[UO_cmt_reflow_mode].n != 1);
@@ -1076,6 +1076,7 @@ static chunk_t *output_comment_cpp(chunk_t *first)
    cmt.cont_text = cpd.settings[UO_cmt_star_cont].b ? " * " : "   ";
    LOG_CONTTEXT();
 
+   unc_text tmp;
    /* See if we can combine this comment with the next comment */
    if (!cpd.settings[UO_cmt_cpp_group].b ||
        !can_combine_comment(first, cmt))
@@ -1467,6 +1468,7 @@ static void output_comment_multi(chunk_t *pc)
 
 static bool kw_fcn_filename(chunk_t *cmt, unc_text& out_txt)
 {
+   (void)cmt;
    out_txt.append(path_basename(cpd.filename));
    return(true);
 }
@@ -1557,7 +1559,6 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text& out_txt)
 
    chunk_t *fpo;
    chunk_t *fpc;
-   chunk_t *tmp;
    chunk_t *prev;
    bool    has_param = true;
    bool    need_nl   = false;
@@ -1609,6 +1610,7 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text& out_txt)
       }
    }
 
+   chunk_t *tmp;
    /* Check for 'foo()' and 'foo(void)' */
    if (chunk_get_next_ncnl(fpo) == fpc)
    {
@@ -1790,6 +1792,7 @@ static void do_kw_subst(chunk_t *pc)
  */
 static void output_comment_multi_simple(chunk_t *pc, bool kw_subst)
 {
+   (void)kw_subst;
    int        cmt_idx;
    int        ch;
    int        line_count = 0;

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -1404,7 +1404,7 @@ static bool parse_ignored(tok_ctx& ctx, chunk_t& pc)
 static bool parse_next(tok_ctx& ctx, chunk_t& pc)
 {
    const chunk_tag_t *punc;
-   int               ch, ch1;
+   int               ch1;
 
    if (!ctx.more())
    {
@@ -1536,7 +1536,7 @@ static bool parse_next(tok_ctx& ctx, chunk_t& pc)
    }
 
    /* handle C++0x strings u8"x" u"x" U"x" R"x" u8R"XXX(I'm a "raw UTF-8" string.)XXX" */
-   ch = ctx.peek();
+   int ch = ctx.peek();
    if ((cpd.lang_flags & LANG_CPP) &&
        ((ch == 'u') || (ch == 'U') || (ch == 'R')))
    {

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -333,9 +333,9 @@ void tokenize_cleanup(void)
             pc->str.insert(0, prev->str);
             pc->orig_col  = prev->orig_col;
             pc->orig_line = prev->orig_line;
-            chunk_t *tmp = prev;
+            chunk_t *to_be_deleted = prev;
             prev = chunk_get_prev_ncnl(prev);
-            chunk_del(tmp);
+            chunk_del(to_be_deleted);
          }
       }
 

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -146,11 +146,11 @@ void unc_text::set(const unc_text& ref)
 
 void unc_text::set(const unc_text& ref, int idx, int len)
 {
-   int size = ref.size();
+   int ref_size = ref.size();
 
-   fix_len_idx(size, idx, len);
+   fix_len_idx(ref_size, idx, len);
    m_logok = false;
-   if ((idx == 0) && (len == size))
+   if ((idx == 0) && (len == ref_size))
    {
       m_chars = ref.m_chars;
    }


### PR DESCRIPTION
This patch fixes the compiler warnings which became visible by the added compiler flags from https://github.com/uncrustify/uncrustify/pull/492/files#diff-af3b638bc2a3e6c650974192a53c7291R18.

I tried to maintain current behavior of the code.