### PR TITLE
Add support for the embedded SQL dollar sign notation

### DIFF
--- a/tests/input/sql/mysql.sqc
+++ b/tests/input/sql/mysql.sqc
@@ -16,6 +16,16 @@ SELECT a, b, c
   FROM table1
  WHERE x = :hostvar1;
 
+/* dollar sign notation */
+$DECLARE cursorName CURSOR for
+  SELECT
+    a,
+    b
+  INTO
+    $struct->a,
+    $struct->b
+  FROM table;
+
 /*----------------------------------------------------------------*/
 void main (void)
 {

--- a/tests/output/sql/02400-mysql.sqc
+++ b/tests/output/sql/02400-mysql.sqc
@@ -16,6 +16,16 @@ EXEC SQL DECLARE csr1 CURSOR FOR
    FROM table1
    WHERE x = :hostvar1;
 
+/* dollar sign notation */
+$ DECLARE cursorName CURSOR for
+   SELECT
+   a,
+   b
+   INTO
+   $struct->a,
+   $struct->b
+   FROM table;
+
 /*----------------------------------------------------------------*/
 void main(void)
 {


### PR DESCRIPTION
We now support two formats: `EXEC SQL SQL_statement;` and `$SQL_statement;`

Fixes #386 