### PR TITLE
c#: indent_cs_delegate_brace should also apply to keyword delegate

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1014,8 +1014,8 @@ void indent_text(void)
          indent_pse_push(frm, pc);
 
          if (cpd.settings[U0_indent_cs_delegate_brace].b &&
-             (pc->type == CT_BRACE_OPEN) &&
-             (pc->prev->type == CT_LAMBDA || pc->prev->prev->type == CT_LAMBDA))
+             (pc->prev->type == CT_DELEGATE || pc->prev->prev->type == CT_DELEGATE ||
+              pc->prev->type == CT_LAMBDA || pc->prev->prev->type == CT_LAMBDA))
          {
             frm.pse[frm.pse_tos].brace_indent = 1 + ((pc->brace_level+1) * indent_size);
             indent_column                     = frm.pse[frm.pse_tos].brace_indent;

--- a/tests/input/cs/delegate.cs
+++ b/tests/input/cs/delegate.cs
@@ -6,4 +6,8 @@ funcwithverylongname(() =>
 {
 func();
 });
+funcwithverylongname(delegate
+{
+func();
+});
 }

--- a/tests/output/cs/10160-delegate.cs
+++ b/tests/output/cs/10160-delegate.cs
@@ -6,4 +6,8 @@ void foo()
 	{
 		func();
 	});
+	funcwithverylongname(delegate
+	{
+		func();
+	});
 }

--- a/tests/output/cs/10161-delegate.cs
+++ b/tests/output/cs/10161-delegate.cs
@@ -6,4 +6,8 @@ void foo()
 		{
 			func();
 		});
+	funcwithverylongname(delegate
+		{
+			func();
+		});
 }


### PR DESCRIPTION
the initial commit only worked for delegates with lambda expression