### PR TITLE
c#: indent_cs_delegate_brace should also apply to keyword delegate

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -549,7 +549,8 @@ void indent_text(void)
    int                sql_orig_col = 0;
    bool               in_func_def  = false;
    c_token_t          memtype;
-   bool               indent_delegate     = false;
+   bool               in_delegate     = false;
+   int                delegate_column = 0;
 
    memset(&frm, 0, sizeof(frm));
    cpd.frame_count = 0;
@@ -971,11 +972,12 @@ void indent_text(void)
       }
 
       if (pc->type == CT_DELEGATE || pc->type == CT_LAMBDA) {
-         indent_delegate = true;
+         in_delegate = true;
+         delegate_column = pc->column_indent;
       }
 
       if (pc->type == CT_SEMICOLON) {
-         indent_delegate = false;
+         in_delegate = false;
       }
 
       if (pc->type == CT_BRACE_CLOSE)
@@ -1022,16 +1024,25 @@ void indent_text(void)
          frm.level++;
          indent_pse_push(frm, pc);
 
-         if (cpd.settings[U0_indent_cs_delegate_brace].b && indent_delegate)
+         if (cpd.settings[U0_indent_cs_delegate_brace].b && in_delegate)
          {
-            frm.pse[frm.pse_tos].brace_indent = 1 + ((pc->brace_level+1) * indent_size);
+            // if delegate keyword first on new line
+            if (delegate_column != 0)
+            {
+                frm.pse[frm.pse_tos].brace_indent = delegate_column + indent_size;
+            }
+            else
+            {
+                frm.pse[frm.pse_tos].brace_indent = 1 + ((pc->brace_level+1) * indent_size);
+            }
+
             indent_column                     = frm.pse[frm.pse_tos].brace_indent;
             frm.pse[frm.pse_tos].indent       = indent_column + indent_size;
             frm.pse[frm.pse_tos].indent_tab   = frm.pse[frm.pse_tos].indent;
             frm.pse[frm.pse_tos].indent_tmp   = frm.pse[frm.pse_tos].indent;
 
             frm.pse[frm.pse_tos - 1].indent_tmp = frm.pse[frm.pse_tos].indent_tmp;
-            indent_delegate = false;
+            in_delegate = false;
          }
          /* any '{' that is inside of a '(' overrides the '(' indent */
          else if (!cpd.settings[UO_indent_paren_open_brace].b &&

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1014,8 +1014,8 @@ void indent_text(void)
          indent_pse_push(frm, pc);
 
          if (cpd.settings[U0_indent_cs_delegate_brace].b &&
-             (pc->type == CT_BRACE_OPEN) &&
-             (pc->prev->type == CT_LAMBDA || pc->prev->prev->type == CT_LAMBDA))
+             (pc->prev->type == CT_DELEGATE || pc->prev->prev->type == CT_DELEGATE ||
+              pc->prev->type == CT_LAMBDA || pc->prev->prev->type == CT_LAMBDA))
          {
             frm.pse[frm.pse_tos].brace_indent = 1 + ((pc->brace_level+1) * indent_size);
             indent_column                     = frm.pse[frm.pse_tos].brace_indent;

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -971,7 +971,11 @@ void indent_text(void)
       }
 
       if (pc->type == CT_DELEGATE || pc->type == CT_LAMBDA) {
-         indent_delegate=true;
+         indent_delegate = true;
+      }
+
+      if (pc->type == CT_SEMICOLON) {
+         indent_delegate = false;
       }
 
       if (pc->type == CT_BRACE_CLOSE)

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -549,6 +549,7 @@ void indent_text(void)
    int                sql_orig_col = 0;
    bool               in_func_def  = false;
    c_token_t          memtype;
+   bool               indent_delegate     = false;
 
    memset(&frm, 0, sizeof(frm));
    cpd.frame_count = 0;
@@ -969,6 +970,10 @@ void indent_text(void)
                           (pc->parent_type != CT_STRUCT)));
       }
 
+      if (pc->type == CT_DELEGATE || pc->type == CT_LAMBDA) {
+         indent_delegate=true;
+      }
+
       if (pc->type == CT_BRACE_CLOSE)
       {
          if (frm.pse[frm.pse_tos].type == CT_BRACE_OPEN)
@@ -1013,9 +1018,7 @@ void indent_text(void)
          frm.level++;
          indent_pse_push(frm, pc);
 
-         if (cpd.settings[U0_indent_cs_delegate_brace].b &&
-             (pc->prev->type == CT_DELEGATE || pc->prev->prev->type == CT_DELEGATE ||
-              pc->prev->type == CT_LAMBDA || pc->prev->prev->type == CT_LAMBDA))
+         if (cpd.settings[U0_indent_cs_delegate_brace].b && indent_delegate)
          {
             frm.pse[frm.pse_tos].brace_indent = 1 + ((pc->brace_level+1) * indent_size);
             indent_column                     = frm.pse[frm.pse_tos].brace_indent;
@@ -1024,6 +1027,7 @@ void indent_text(void)
             frm.pse[frm.pse_tos].indent_tmp   = frm.pse[frm.pse_tos].indent;
 
             frm.pse[frm.pse_tos - 1].indent_tmp = frm.pse[frm.pse_tos].indent_tmp;
+            indent_delegate = false;
          }
          /* any '{' that is inside of a '(' overrides the '(' indent */
          else if (!cpd.settings[UO_indent_paren_open_brace].b &&

--- a/tests/input/cs/delegate.cs
+++ b/tests/input/cs/delegate.cs
@@ -10,4 +10,8 @@ funcwithverylongname(delegate
 {
 func();
 });
+funcwithverylongname(delegate(int i)
+{
+func();
+});
 }

--- a/tests/input/cs/delegate.cs
+++ b/tests/input/cs/delegate.cs
@@ -1,3 +1,5 @@
+delegate void MyDelegate(int i);
+
 void foo()
 {
 obj.cb += () => { };

--- a/tests/input/cs/delegate.cs
+++ b/tests/input/cs/delegate.cs
@@ -16,4 +16,8 @@ funcwithverylongname(delegate(int i)
 {
 func();
 });
+myCallback =
+new MyCallback(
+delegate 
+{ return true; });
 }

--- a/tests/input/cs/delegate.cs
+++ b/tests/input/cs/delegate.cs
@@ -6,4 +6,8 @@ funcwithverylongname(() =>
 {
 func();
 });
+funcwithverylongname(delegate
+{
+func();
+});
 }

--- a/tests/output/cs/10160-delegate.cs
+++ b/tests/output/cs/10160-delegate.cs
@@ -6,4 +6,8 @@ void foo()
 	{
 		func();
 	});
+	funcwithverylongname(delegate
+	{
+		func();
+	});
 }

--- a/tests/output/cs/10160-delegate.cs
+++ b/tests/output/cs/10160-delegate.cs
@@ -10,4 +10,8 @@ void foo()
 	{
 		func();
 	});
+	funcwithverylongname(delegate(int i)
+	{
+		func();
+	});
 }

--- a/tests/output/cs/10160-delegate.cs
+++ b/tests/output/cs/10160-delegate.cs
@@ -1,3 +1,5 @@
+delegate void MyDelegate(int i);
+
 void foo()
 {
 	obj.cb += () => { };

--- a/tests/output/cs/10160-delegate.cs
+++ b/tests/output/cs/10160-delegate.cs
@@ -16,4 +16,8 @@ void foo()
 	{
 		func();
 	});
+	myCallback =
+		new MyCallback(
+			delegate
+			{ return true; });
 }

--- a/tests/output/cs/10161-delegate.cs
+++ b/tests/output/cs/10161-delegate.cs
@@ -16,4 +16,8 @@ void foo()
 		{
 			func();
 		});
+	myCallback =
+		new MyCallback(
+			delegate
+				{ return true; });
 }

--- a/tests/output/cs/10161-delegate.cs
+++ b/tests/output/cs/10161-delegate.cs
@@ -1,3 +1,5 @@
+delegate void MyDelegate(int i);
+
 void foo()
 {
 	obj.cb += () => { };

--- a/tests/output/cs/10161-delegate.cs
+++ b/tests/output/cs/10161-delegate.cs
@@ -10,4 +10,8 @@ void foo()
 		{
 			func();
 		});
+	funcwithverylongname(delegate(int i)
+		{
+			func();
+		});
 }

--- a/tests/output/cs/10161-delegate.cs
+++ b/tests/output/cs/10161-delegate.cs
@@ -6,4 +6,8 @@ void foo()
 		{
 			func();
 		});
+	funcwithverylongname(delegate
+		{
+			func();
+		});
 }


### PR DESCRIPTION
the initial patch for bug sf#674 only worked for delegates with lambda expression