### PR TITLE
Added sp_func_[proto,def,class]_paren_empty

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -366,8 +366,12 @@ void register_options(void)
                   "A minimum of 1 is forced except for pointer return types.");
    unc_add_option("sp_func_proto_paren", UO_sp_func_proto_paren, AT_IARF,
                   "Add or remove space between function name and '(' on function declaration");
+   unc_add_option("sp_func_proto_paren_empty", UO_sp_func_proto_paren_empty, AT_IARF,
+                  "Add or remove space between function name and '()' on function declaration without parameters");
    unc_add_option("sp_func_def_paren", UO_sp_func_def_paren, AT_IARF,
                   "Add or remove space between function name and '(' on function definition");
+   unc_add_option("sp_func_def_paren_empty", UO_sp_func_def_paren_empty, AT_IARF,
+                  "Add or remove space between function name and '()' on function definition without parameters");
    unc_add_option("sp_inside_fparens", UO_sp_inside_fparens, AT_IARF,
                   "Add or remove space inside empty function '()'");
    unc_add_option("sp_inside_fparen", UO_sp_inside_fparen, AT_IARF,
@@ -392,6 +396,8 @@ void register_options(void)
                   "You need to set a keyword to be a user function, like this: 'set func_call_user _' in the config file.");
    unc_add_option("sp_func_class_paren", UO_sp_func_class_paren, AT_IARF,
                   "Add or remove space between a constructor/destructor and the open paren");
+   unc_add_option("sp_func_class_paren_empty", UO_sp_func_class_paren_empty, AT_IARF,
+                  "Add or remove space between a constructor without parameters or destructor and '()'");
    unc_add_option("sp_return_paren", UO_sp_return_paren, AT_IARF,
                   "Add or remove space between 'return' and '('");
    unc_add_option("sp_attribute_paren", UO_sp_attribute_paren, AT_IARF,

--- a/src/options.h
+++ b/src/options.h
@@ -293,11 +293,14 @@ enum uncrustify_options
    UO_sp_before_case_colon,     // space before case ':'
 
    UO_sp_func_def_paren,        // space between 'func' and '(' - 'foo (' vs 'foo('
+   UO_sp_func_def_paren_empty,  // space between 'func' and '()' - "foo ()" vs "foo()"
    UO_sp_func_call_paren,       // space between 'func' and '(' - 'foo (' vs 'foo('
    UO_sp_func_call_paren_empty,
    UO_sp_func_call_user_paren,
    UO_sp_func_proto_paren,      // space between 'func' and '(' - 'foo (' vs 'foo('
+   UO_sp_func_proto_paren_empty,// space between 'func' and '()' - "foo ()" vs "foo()"
    UO_sp_func_class_paren,      // space between ctor/dtor and '('
+   UO_sp_func_class_paren_empty,// space between ctor/dtor and '()'
 
    UO_sp_attribute_paren,       // space between '__attribute__' and '('
    UO_sp_defined_paren,

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -874,6 +874,16 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
    }
    if (first->type == CT_FUNC_DEF)
    {
+      if ((cpd.settings[UO_sp_func_def_paren_empty].a != AV_IGNORE) &&
+          (second->type == CT_FPAREN_OPEN))
+      {
+         next = chunk_get_next_ncnl(second);
+         if (next && (next->type == CT_FPAREN_CLOSE))
+         {
+            log_rule("sp_func_def_paren_empty");
+            return(cpd.settings[UO_sp_func_def_paren_empty].a);
+         }
+      }
       log_rule("sp_func_def_paren");
       return(cpd.settings[UO_sp_func_def_paren].a);
    }
@@ -925,12 +935,32 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
        ((second->type == CT_FPAREN_OPEN) &&
         (second->parent_type == CT_FUNC_PROTO)))
    {
+      if ((cpd.settings[UO_sp_func_proto_paren_empty].a != AV_IGNORE) &&
+          (second->type == CT_FPAREN_OPEN))
+      {
+         next = chunk_get_next_ncnl(second);
+         if (next && (next->type == CT_FPAREN_CLOSE))
+         {
+            log_rule("sp_func_proto_paren_empty");
+            return(cpd.settings[UO_sp_func_proto_paren_empty].a);
+         }
+      }
       log_rule("sp_func_proto_paren");
       return(cpd.settings[UO_sp_func_proto_paren].a);
    }
    if ((first->type == CT_FUNC_CLASS_DEF) ||
        (first->type == CT_FUNC_CLASS_PROTO))
    {
+      if ((cpd.settings[UO_sp_func_class_paren_empty].a != AV_IGNORE) &&
+          (second->type == CT_FPAREN_OPEN))
+      {
+         next = chunk_get_next_ncnl(second);
+         if (next && (next->type == CT_FPAREN_CLOSE))
+         {
+            log_rule("sp_func_class_paren_empty");
+            return(cpd.settings[UO_sp_func_class_paren_empty].a);
+         }
+      }
       log_rule("sp_func_class_paren");
       return(cpd.settings[UO_sp_func_class_paren].a);
    }

--- a/tests/config/sp_func_class_empty.cfg
+++ b/tests/config/sp_func_class_empty.cfg
@@ -1,0 +1,4 @@
+include sp_func_call_empty.cfg
+
+sp_func_class_paren           = remove
+sp_func_class_paren_empty     = force

--- a/tests/config/sp_func_def_empty.cfg
+++ b/tests/config/sp_func_def_empty.cfg
@@ -1,0 +1,4 @@
+include sp_func_call_empty.cfg
+
+sp_func_def_paren             = remove
+sp_func_def_paren_empty       = force

--- a/tests/config/sp_func_proto_empty.cfg
+++ b/tests/config/sp_func_proto_empty.cfg
@@ -1,0 +1,4 @@
+include sp_func_call_empty.cfg
+
+sp_func_proto_paren           = remove
+sp_func_proto_paren_empty     = force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -198,6 +198,9 @@
 30923 sp_before_ellipsis-f.cfg         cpp/sp_before_ellipsis.cpp
 30924 sp_before_ellipsis-r.cfg         cpp/sp_before_ellipsis.cpp
 30925 sp_func_call_empty.cfg           cpp/function-def.cpp
+30926 sp_func_class_empty.cfg          cpp/function-def.cpp
+30927 sp_func_def_empty.cfg            cpp/function-def.cpp
+30928 sp_func_proto_empty.cfg          cpp/function-def.cpp
 
 30930 indent_var_def.cfg               cpp/indent_var_def.cpp
 30931 indent_var_def_cont.cfg          cpp/indent_var_def_cont.cpp

--- a/tests/output/cpp/30926-function-def.cpp
+++ b/tests/output/cpp/30926-function-def.cpp
@@ -1,0 +1,82 @@
+int&Function()
+{
+   static int x;
+
+   return(x);
+}
+
+void foo1(int param1, int param2, char *param2);
+
+void foo2(int  param1,
+          int  param2,
+          char *param2);
+
+void foo3(int  param1,
+          int  param2,                                       // comment
+          char *param2
+          );
+
+struct whoopee *foo4(int param1, int param2, char *param2 /* comment */);
+
+const struct snickers *
+foo5(int param1, int param2, char *param2);
+
+
+void foo(int param1, int param2, char *param2)
+{
+   printf ("boo!\n");
+}
+
+int classname::method();
+
+int classname::method()
+{
+   foo();
+}
+
+int
+classname::method2();
+
+int
+classname::method2()
+{
+   foo2();
+}
+
+const int& className::method1(void) const
+{
+   // stuff
+}
+
+const longtypename& className::method2(void) const
+{
+   // stuff
+}
+
+int&foo();
+
+int&foo()
+{
+   list_for_each (a, b)
+   {
+      bar (a);
+   }
+   return(nuts);
+}
+
+void Foo::bar()
+{
+}
+
+Foo::Foo ()
+{
+}
+
+Foo::~Foo ()
+{
+}
+
+void func(void)
+{
+   Directory dir ("arg");
+}

--- a/tests/output/cpp/30927-function-def.cpp
+++ b/tests/output/cpp/30927-function-def.cpp
@@ -1,0 +1,82 @@
+int&Function ()
+{
+   static int x;
+
+   return(x);
+}
+
+void foo1(int param1, int param2, char *param2);
+
+void foo2(int  param1,
+          int  param2,
+          char *param2);
+
+void foo3(int  param1,
+          int  param2,                                       // comment
+          char *param2
+          );
+
+struct whoopee *foo4(int param1, int param2, char *param2 /* comment */);
+
+const struct snickers *
+foo5(int param1, int param2, char *param2);
+
+
+void foo(int param1, int param2, char *param2)
+{
+   printf ("boo!\n");
+}
+
+int classname::method();
+
+int classname::method ()
+{
+   foo();
+}
+
+int
+classname::method2();
+
+int
+classname::method2 ()
+{
+   foo2();
+}
+
+const int& className::method1(void) const
+{
+   // stuff
+}
+
+const longtypename& className::method2(void) const
+{
+   // stuff
+}
+
+int&foo();
+
+int&foo ()
+{
+   list_for_each (a, b)
+   {
+      bar (a);
+   }
+   return(nuts);
+}
+
+void Foo::bar ()
+{
+}
+
+Foo::Foo()
+{
+}
+
+Foo::~Foo()
+{
+}
+
+void func(void)
+{
+   Directory dir ("arg");
+}

--- a/tests/output/cpp/30928-function-def.cpp
+++ b/tests/output/cpp/30928-function-def.cpp
@@ -1,0 +1,82 @@
+int&Function()
+{
+   static int x;
+
+   return(x);
+}
+
+void foo1(int param1, int param2, char *param2);
+
+void foo2(int  param1,
+          int  param2,
+          char *param2);
+
+void foo3(int  param1,
+          int  param2,                                       // comment
+          char *param2
+          );
+
+struct whoopee *foo4(int param1, int param2, char *param2 /* comment */);
+
+const struct snickers *
+foo5(int param1, int param2, char *param2);
+
+
+void foo(int param1, int param2, char *param2)
+{
+   printf ("boo!\n");
+}
+
+int classname::method ();
+
+int classname::method()
+{
+   foo();
+}
+
+int
+classname::method2 ();
+
+int
+classname::method2()
+{
+   foo2();
+}
+
+const int& className::method1(void) const
+{
+   // stuff
+}
+
+const longtypename& className::method2(void) const
+{
+   // stuff
+}
+
+int&foo ();
+
+int&foo()
+{
+   list_for_each (a, b)
+   {
+      bar (a);
+   }
+   return(nuts);
+}
+
+void Foo::bar()
+{
+}
+
+Foo::Foo()
+{
+}
+
+Foo::~Foo()
+{
+}
+
+void func(void)
+{
+   Directory dir ("arg");
+}


### PR DESCRIPTION
There is a pair of options: sp_func_call_paren and sp_func_call_paren_empty
that control the spacing between 'func ( foo )' and 'func()' when calling,
but there are no options for declaring and defining functions/constructors without arguments.
This adds sp_func_proto_paren_empty, sp_func_def_paren_empty,
and sp_func_class_paren_empty.