### PR TITLE
Improved functions with arguments in multiple lines

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -908,10 +908,18 @@ void register_options(void)
                   "Overrides nl_func_decl_start when there is only one parameter.");
    unc_add_option("nl_func_def_start_single", UO_nl_func_def_start_single, AT_IARF,
                   "Overrides nl_func_def_start when there is only one parameter.");
+   unc_add_option("nl_func_decl_start_multi_line", UO_nl_func_decl_start_multi_line, AT_BOOL,
+                  "Whether to add newline after '(' in a function declaration if '(' and ')' are in different lines.");
+   unc_add_option("nl_func_def_start_multi_line", UO_nl_func_def_start_multi_line, AT_BOOL,
+                  "Whether to add newline after '(' in a function definition if '(' and ')' are in different lines.");
    unc_add_option("nl_func_decl_args", UO_nl_func_decl_args, AT_IARF,
                   "Add or remove newline after each ',' in a function declaration");
    unc_add_option("nl_func_def_args", UO_nl_func_def_args, AT_IARF,
                   "Add or remove newline after each ',' in a function definition");
+   unc_add_option("nl_func_decl_args_multi_line", UO_nl_func_decl_args_multi_line, AT_BOOL,
+                  "Whether to add newline after each ',' in a function declaration if '(' and ')' are in different lines.");
+   unc_add_option("nl_func_def_args_multi_line", UO_nl_func_def_args_multi_line, AT_BOOL,
+                  "Whether to add newline after each ',' in a function definition if '(' and ')' are in different lines.");
    unc_add_option("nl_func_decl_end", UO_nl_func_decl_end, AT_IARF,
                   "Add or remove newline before the ')' in a function declaration");
    unc_add_option("nl_func_def_end", UO_nl_func_def_end, AT_IARF,
@@ -920,10 +928,20 @@ void register_options(void)
                   "Overrides nl_func_decl_end when there is only one parameter.");
    unc_add_option("nl_func_def_end_single", UO_nl_func_def_end_single, AT_IARF,
                   "Overrides nl_func_def_end when there is only one parameter.");
+   unc_add_option("nl_func_decl_end_multi_line", UO_nl_func_decl_end_multi_line, AT_BOOL,
+                  "Whether to add newline before ')' in a function declaration if '(' and ')' are in different lines.");
+   unc_add_option("nl_func_def_end_multi_line", UO_nl_func_def_end_multi_line, AT_BOOL,
+                  "Whether to add newline before ')' in a function definition if '(' and ')' are in different lines.");
    unc_add_option("nl_func_decl_empty", UO_nl_func_decl_empty, AT_IARF,
                   "Add or remove newline between '()' in a function declaration.");
    unc_add_option("nl_func_def_empty", UO_nl_func_def_empty, AT_IARF,
                   "Add or remove newline between '()' in a function definition.");
+   unc_add_option("nl_func_call_start_multi_line", UO_nl_func_call_start_multi_line, AT_BOOL,
+                  "Whether to add newline after '(' in a function call if '(' and ')' are in different lines.");
+   unc_add_option("nl_func_call_args_multi_line", UO_nl_func_call_args_multi_line, AT_BOOL,
+                  "Whether to add newline after each ',' in a function call if '(' and ')' are in different lines.");
+   unc_add_option("nl_func_call_end_multi_line", UO_nl_func_call_end_multi_line, AT_BOOL,
+                  "Whether to add newline before ')' in a function call if '(' and ')' are in different lines.");
    unc_add_option("nl_oc_msg_args", UO_nl_oc_msg_args, AT_BOOL,
                   "Whether to put each OC message parameter on a separate line\n"
                   "See nl_oc_msg_leave_one_liner");

--- a/src/options.h
+++ b/src/options.h
@@ -495,12 +495,18 @@ enum uncrustify_options
    UO_nl_func_def_start,              // newline after the '(' in a function def
    UO_nl_func_decl_start_single,      // Overrides nl_func_decl_start when there is only one parameter
    UO_nl_func_def_start_single,       // Overrides nl_func_def_start when there is only one parameter
+   UO_nl_func_decl_start_multi_line,  // newline after the '(' in a function decl if '(' and ')' are on different lines
+   UO_nl_func_def_start_multi_line,   // newline after the '(' in a function def if '(' and ')' are on different lines
    UO_nl_func_decl_args,              // newline after each ',' in a function decl
    UO_nl_func_def_args,               // Add or remove newline after each ',' in a function definition
+   UO_nl_func_decl_args_multi_line,   // newline after each ',' in a function decl if '(' and ')' are on different lines
+   UO_nl_func_def_args_multi_line,    // Add or remove newline after each ',' in a function definition if '(' and ')' are on different lines
    UO_nl_func_decl_end,               // newline before the ')' in a function decl
-   UO_nl_func_def_end,                // newline before the ')' in a function decl
+   UO_nl_func_def_end,                // newline before the ')' in a function def
    UO_nl_func_decl_end_single,        // Overrides nl_func_decl_end when there is only one parameter
    UO_nl_func_def_end_single,         // Overrides nl_func_def_end when there is only one parameter
+   UO_nl_func_decl_end_multi_line,    // newline before the ')' in a function decl if '(' and ')' are on different lines
+   UO_nl_func_def_end_multi_line,     // newline before the ')' in a function def if '(' and ')' are on different lines
    UO_nl_func_decl_empty,             // as above, but for empty parens '()'
    UO_nl_func_def_empty,              // as above, but for empty parens '()'
    UO_nl_func_type_name,              // newline between return type and func name in def
@@ -508,6 +514,11 @@ enum uncrustify_options
    UO_nl_func_scope_name,             // Add or remove newline between function scope and name in a definition
                                       // Controls the newline after '::' in 'void A::f() { }'
    UO_nl_func_proto_type_name,        // nl_func_type_name, but for prottypes
+
+   UO_nl_func_call_start_multi_line,  // newline after the '(' in a function call if '(' and ')' are on different lines
+   UO_nl_func_call_args_multi_line,   // newline after each ',' in a function call if '(' and ')' are on different lines
+   UO_nl_func_call_end_multi_line,    // newline before the ')' in a function call if '(' and ')' are on different lines
+
    UO_nl_func_var_def_blk,            // newline after first block of func variable defs
    UO_nl_typedef_blk_start,           // newline before typedef block
    UO_nl_typedef_blk_end,             // newline after typedef block

--- a/tests/config/multi_line_0.cfg
+++ b/tests/config/multi_line_0.cfg
@@ -1,0 +1,2 @@
+
+code_width = 70

--- a/tests/config/multi_line_1.cfg
+++ b/tests/config/multi_line_1.cfg
@@ -1,0 +1,4 @@
+
+code_width = 70
+
+nl_func_decl_start_multi_line = true

--- a/tests/config/multi_line_10.cfg
+++ b/tests/config/multi_line_10.cfg
@@ -1,0 +1,3 @@
+
+code_width = 70
+nl_func_call_end_multi_line = true

--- a/tests/config/multi_line_2.cfg
+++ b/tests/config/multi_line_2.cfg
@@ -1,0 +1,4 @@
+
+code_width = 70
+
+nl_func_def_start_multi_line = true

--- a/tests/config/multi_line_3.cfg
+++ b/tests/config/multi_line_3.cfg
@@ -1,0 +1,4 @@
+
+code_width = 70
+
+nl_func_decl_end_multi_line = true

--- a/tests/config/multi_line_4.cfg
+++ b/tests/config/multi_line_4.cfg
@@ -1,0 +1,4 @@
+
+code_width = 70
+
+nl_func_def_end_multi_line = true

--- a/tests/config/multi_line_5.cfg
+++ b/tests/config/multi_line_5.cfg
@@ -1,0 +1,4 @@
+
+code_width = 70
+
+nl_func_decl_args_multi_line = true

--- a/tests/config/multi_line_6.cfg
+++ b/tests/config/multi_line_6.cfg
@@ -1,0 +1,4 @@
+
+code_width = 70
+
+nl_func_def_args_multi_line = true

--- a/tests/config/multi_line_7.cfg
+++ b/tests/config/multi_line_7.cfg
@@ -1,0 +1,9 @@
+
+code_width = 70
+
+nl_func_decl_start_multi_line = true
+nl_func_def_start_multi_line = true
+nl_func_decl_args_multi_line = true
+nl_func_def_args_multi_line = true
+nl_func_decl_end_multi_line = true
+nl_func_def_end_multi_line = true

--- a/tests/config/multi_line_8.cfg
+++ b/tests/config/multi_line_8.cfg
@@ -1,0 +1,3 @@
+
+code_width = 70
+nl_func_call_start_multi_line = true

--- a/tests/config/multi_line_9.cfg
+++ b/tests/config/multi_line_9.cfg
@@ -1,0 +1,3 @@
+
+code_width = 70
+nl_func_call_args_multi_line = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -288,3 +288,14 @@
 33050 empty.cfg                        cpp/issue_523.cpp
 33051 empty.cfg                        cpp/bug_i_503.cpp
 33052 empty.cfg                        cpp/bug_i_512.cpp
+33070 multi_line_0.cfg                 cpp/multi_line.cpp
+33071 multi_line_1.cfg                 cpp/multi_line.cpp
+33072 multi_line_2.cfg                 cpp/multi_line.cpp
+33073 multi_line_3.cfg                 cpp/multi_line.cpp
+33074 multi_line_4.cfg                 cpp/multi_line.cpp
+33075 multi_line_5.cfg                 cpp/multi_line.cpp
+33076 multi_line_6.cfg                 cpp/multi_line.cpp
+33077 multi_line_7.cfg                 cpp/multi_line.cpp
+33078 multi_line_8.cfg                 cpp/multi_line.cpp
+33079 multi_line_9.cfg                 cpp/multi_line.cpp
+33080 multi_line_10.cfg                cpp/multi_line.cpp

--- a/tests/input/cpp/multi_line.cpp
+++ b/tests/input/cpp/multi_line.cpp
@@ -1,0 +1,43 @@
+
+void func_a ( int a, string b, char c );
+
+void func_b ( int a,
+              string b, char c );
+
+void func_c ( int a, string b, char c
+              );
+
+void func_d ( int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb, char cccccccccccccccccc );
+
+void func_a ( int a, string b, char c )
+{
+	return;
+}
+
+void func_b ( int a,
+              string b, char c )
+{
+	return;
+}
+
+void func_c ( int a, string b, char c
+              )
+{
+	return;
+}
+
+void func_d ( int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb, char cccccccccccccccccc )
+{
+	return;
+}
+
+void func_call()
+{
+  func_a ( 1, 2, 3);
+  func_b ( 4,
+           5, 6 );
+  func_c ( 7, 8, 9
+         );
+  
+  func_d ( "aaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbb", "cccccccccccccccccccccc" );
+}

--- a/tests/output/cpp/33070-multi_line.cpp
+++ b/tests/output/cpp/33070-multi_line.cpp
@@ -1,0 +1,46 @@
+
+void func_a ( int a, string b, char c );
+
+void func_b ( int a,
+              string b, char c );
+
+void func_c ( int a, string b, char c
+              );
+
+void func_d ( int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb,
+              char cccccccccccccccccc );
+
+void func_a ( int a, string b, char c )
+{
+	return;
+}
+
+void func_b ( int a,
+              string b, char c )
+{
+	return;
+}
+
+void func_c ( int a, string b, char c
+              )
+{
+	return;
+}
+
+void func_d ( int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb,
+              char cccccccccccccccccc )
+{
+	return;
+}
+
+void func_call()
+{
+	func_a ( 1, 2, 3);
+	func_b ( 4,
+	         5, 6 );
+	func_c ( 7, 8, 9
+	         );
+
+	func_d ( "aaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbb",
+	         "cccccccccccccccccccccc" );
+}

--- a/tests/output/cpp/33071-multi_line.cpp
+++ b/tests/output/cpp/33071-multi_line.cpp
@@ -1,0 +1,49 @@
+
+void func_a ( int a, string b, char c );
+
+void func_b (
+	int a,
+	string b, char c );
+
+void func_c (
+	int a, string b, char c
+	);
+
+void func_d (
+	int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb,
+	char cccccccccccccccccc );
+
+void func_a ( int a, string b, char c )
+{
+	return;
+}
+
+void func_b ( int a,
+              string b, char c )
+{
+	return;
+}
+
+void func_c ( int a, string b, char c
+              )
+{
+	return;
+}
+
+void func_d ( int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb,
+              char cccccccccccccccccc )
+{
+	return;
+}
+
+void func_call()
+{
+	func_a ( 1, 2, 3);
+	func_b ( 4,
+	         5, 6 );
+	func_c ( 7, 8, 9
+	         );
+
+	func_d ( "aaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbb",
+	         "cccccccccccccccccccccc" );
+}

--- a/tests/output/cpp/33072-multi_line.cpp
+++ b/tests/output/cpp/33072-multi_line.cpp
@@ -1,0 +1,49 @@
+
+void func_a ( int a, string b, char c );
+
+void func_b ( int a,
+              string b, char c );
+
+void func_c ( int a, string b, char c
+              );
+
+void func_d ( int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb,
+              char cccccccccccccccccc );
+
+void func_a ( int a, string b, char c )
+{
+	return;
+}
+
+void func_b (
+	int a,
+	string b, char c )
+{
+	return;
+}
+
+void func_c (
+	int a, string b, char c
+	)
+{
+	return;
+}
+
+void func_d (
+	int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb,
+	char cccccccccccccccccc )
+{
+	return;
+}
+
+void func_call()
+{
+	func_a ( 1, 2, 3);
+	func_b ( 4,
+	         5, 6 );
+	func_c ( 7, 8, 9
+	         );
+
+	func_d ( "aaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbb",
+	         "cccccccccccccccccccccc" );
+}

--- a/tests/output/cpp/33073-multi_line.cpp
+++ b/tests/output/cpp/33073-multi_line.cpp
@@ -1,0 +1,48 @@
+
+void func_a ( int a, string b, char c );
+
+void func_b ( int a,
+              string b, char c
+              );
+
+void func_c ( int a, string b, char c
+              );
+
+void func_d ( int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb,
+              char cccccccccccccccccc
+              );
+
+void func_a ( int a, string b, char c )
+{
+	return;
+}
+
+void func_b ( int a,
+              string b, char c )
+{
+	return;
+}
+
+void func_c ( int a, string b, char c
+              )
+{
+	return;
+}
+
+void func_d ( int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb,
+              char cccccccccccccccccc )
+{
+	return;
+}
+
+void func_call()
+{
+	func_a ( 1, 2, 3);
+	func_b ( 4,
+	         5, 6 );
+	func_c ( 7, 8, 9
+	         );
+
+	func_d ( "aaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbb",
+	         "cccccccccccccccccccccc" );
+}

--- a/tests/output/cpp/33074-multi_line.cpp
+++ b/tests/output/cpp/33074-multi_line.cpp
@@ -1,0 +1,48 @@
+
+void func_a ( int a, string b, char c );
+
+void func_b ( int a,
+              string b, char c );
+
+void func_c ( int a, string b, char c
+              );
+
+void func_d ( int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb,
+              char cccccccccccccccccc );
+
+void func_a ( int a, string b, char c )
+{
+	return;
+}
+
+void func_b ( int a,
+              string b, char c
+              )
+{
+	return;
+}
+
+void func_c ( int a, string b, char c
+              )
+{
+	return;
+}
+
+void func_d ( int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb,
+              char cccccccccccccccccc
+              )
+{
+	return;
+}
+
+void func_call()
+{
+	func_a ( 1, 2, 3);
+	func_b ( 4,
+	         5, 6 );
+	func_c ( 7, 8, 9
+	         );
+
+	func_d ( "aaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbb",
+	         "cccccccccccccccccccccc" );
+}

--- a/tests/output/cpp/33075-multi_line.cpp
+++ b/tests/output/cpp/33075-multi_line.cpp
@@ -1,0 +1,50 @@
+
+void func_a ( int a, string b, char c );
+
+void func_b ( int a,
+              string b,
+              char c );
+
+void func_c ( int a,
+              string b,
+              char c
+              );
+
+void func_d ( int aaaaaaaaaaaaaa,
+              string bbbbbbbbbbbbbb,
+              char cccccccccccccccccc );
+
+void func_a ( int a, string b, char c )
+{
+	return;
+}
+
+void func_b ( int a,
+              string b, char c )
+{
+	return;
+}
+
+void func_c ( int a, string b, char c
+              )
+{
+	return;
+}
+
+void func_d ( int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb,
+              char cccccccccccccccccc )
+{
+	return;
+}
+
+void func_call()
+{
+	func_a ( 1, 2, 3);
+	func_b ( 4,
+	         5, 6 );
+	func_c ( 7, 8, 9
+	         );
+
+	func_d ( "aaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbb",
+	         "cccccccccccccccccccccc" );
+}

--- a/tests/output/cpp/33076-multi_line.cpp
+++ b/tests/output/cpp/33076-multi_line.cpp
@@ -1,0 +1,50 @@
+
+void func_a ( int a, string b, char c );
+
+void func_b ( int a,
+              string b, char c );
+
+void func_c ( int a, string b, char c
+              );
+
+void func_d ( int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb,
+              char cccccccccccccccccc );
+
+void func_a ( int a, string b, char c )
+{
+	return;
+}
+
+void func_b ( int a,
+              string b,
+              char c )
+{
+	return;
+}
+
+void func_c ( int a,
+              string b,
+              char c
+              )
+{
+	return;
+}
+
+void func_d ( int aaaaaaaaaaaaaa,
+              string bbbbbbbbbbbbbb,
+              char cccccccccccccccccc )
+{
+	return;
+}
+
+void func_call()
+{
+	func_a ( 1, 2, 3);
+	func_b ( 4,
+	         5, 6 );
+	func_c ( 7, 8, 9
+	         );
+
+	func_d ( "aaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbb",
+	         "cccccccccccccccccccccc" );
+}

--- a/tests/output/cpp/33077-multi_line.cpp
+++ b/tests/output/cpp/33077-multi_line.cpp
@@ -1,0 +1,64 @@
+
+void func_a ( int a, string b, char c );
+
+void func_b (
+	int a,
+	string b,
+	char c
+	);
+
+void func_c (
+	int a,
+	string b,
+	char c
+	);
+
+void func_d (
+	int aaaaaaaaaaaaaa,
+	string bbbbbbbbbbbbbb,
+	char cccccccccccccccccc
+	);
+
+void func_a ( int a, string b, char c )
+{
+	return;
+}
+
+void func_b (
+	int a,
+	string b,
+	char c
+	)
+{
+	return;
+}
+
+void func_c (
+	int a,
+	string b,
+	char c
+	)
+{
+	return;
+}
+
+void func_d (
+	int aaaaaaaaaaaaaa,
+	string bbbbbbbbbbbbbb,
+	char cccccccccccccccccc
+	)
+{
+	return;
+}
+
+void func_call()
+{
+	func_a ( 1, 2, 3);
+	func_b ( 4,
+	         5, 6 );
+	func_c ( 7, 8, 9
+	         );
+
+	func_d ( "aaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbb",
+	         "cccccccccccccccccccccc" );
+}

--- a/tests/output/cpp/33078-multi_line.cpp
+++ b/tests/output/cpp/33078-multi_line.cpp
@@ -1,0 +1,49 @@
+
+void func_a ( int a, string b, char c );
+
+void func_b ( int a,
+              string b, char c );
+
+void func_c ( int a, string b, char c
+              );
+
+void func_d ( int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb,
+              char cccccccccccccccccc );
+
+void func_a ( int a, string b, char c )
+{
+	return;
+}
+
+void func_b ( int a,
+              string b, char c )
+{
+	return;
+}
+
+void func_c ( int a, string b, char c
+              )
+{
+	return;
+}
+
+void func_d ( int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb,
+              char cccccccccccccccccc )
+{
+	return;
+}
+
+void func_call()
+{
+	func_a ( 1, 2, 3);
+	func_b (
+		4,
+		5, 6 );
+	func_c (
+		7, 8, 9
+		);
+
+	func_d (
+		"aaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbb",
+		"cccccccccccccccccccccc" );
+}

--- a/tests/output/cpp/33079-multi_line.cpp
+++ b/tests/output/cpp/33079-multi_line.cpp
@@ -1,0 +1,50 @@
+
+void func_a ( int a, string b, char c );
+
+void func_b ( int a,
+              string b, char c );
+
+void func_c ( int a, string b, char c
+              );
+
+void func_d ( int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb,
+              char cccccccccccccccccc );
+
+void func_a ( int a, string b, char c )
+{
+	return;
+}
+
+void func_b ( int a,
+              string b, char c )
+{
+	return;
+}
+
+void func_c ( int a, string b, char c
+              )
+{
+	return;
+}
+
+void func_d ( int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb,
+              char cccccccccccccccccc )
+{
+	return;
+}
+
+void func_call()
+{
+	func_a ( 1, 2, 3);
+	func_b ( 4,
+	         5,
+	         6 );
+	func_c ( 7,
+	         8,
+	         9
+	         );
+
+	func_d ( "aaaaaaaaaaaaaaaaaa",
+	         "bbbbbbbbbbbbbbbbbb",
+	         "cccccccccccccccccccccc" );
+}

--- a/tests/output/cpp/33080-multi_line.cpp
+++ b/tests/output/cpp/33080-multi_line.cpp
@@ -1,0 +1,48 @@
+
+void func_a ( int a, string b, char c );
+
+void func_b ( int a,
+              string b, char c );
+
+void func_c ( int a, string b, char c
+              );
+
+void func_d ( int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb,
+              char cccccccccccccccccc );
+
+void func_a ( int a, string b, char c )
+{
+	return;
+}
+
+void func_b ( int a,
+              string b, char c )
+{
+	return;
+}
+
+void func_c ( int a, string b, char c
+              )
+{
+	return;
+}
+
+void func_d ( int aaaaaaaaaaaaaa, string bbbbbbbbbbbbbb,
+              char cccccccccccccccccc )
+{
+	return;
+}
+
+void func_call()
+{
+	func_a ( 1, 2, 3);
+	func_b ( 4,
+	         5, 6
+	         );
+	func_c ( 7, 8, 9
+	         );
+
+	func_d ( "aaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbb",
+	         "cccccccccccccccccccccc"
+	         );
+}


### PR DESCRIPTION
It was possible to control newlines after and before '(' and ')'
while declaring/defining functions, as well as adding newlines
after each argument. It was also possible to treat functions
with no arguments differently.

This change adds options for adding newlines when function
has some arguments, but only if they span multiple lines.
It adds options for controlling function declarations
and definitions, as well as function calls.

So if the opening '(' and closing ')' are on different lines
(after applying all other options), it is possible to add
a newline after '(', before ')', and/or after each argument.

This way it's possible to say that if function's arguments
fit in the same line then they are not broken at all,
but if they don't - each argument ends up on a separate line.
With the option to add (or not) a newline after '(' and/or before ')'.

This also fixes the behaviour when some of nl_func_*_single are specified,
but no other nl_func_* options are used (the nl_func_*_single options would
be silently ignored).