### PR TITLE
Added mod_full_brace_if_chain_only option

### DIFF
--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -30,7 +30,8 @@ static bool should_add_braces(chunk_t *vbopen);
 void do_braces(void)
 {
    LOG_FUNC_ENTRY();
-   if (cpd.settings[UO_mod_full_brace_if_chain].b)
+   if (cpd.settings[UO_mod_full_brace_if_chain].b
+       || cpd.settings[UO_mod_full_brace_if_chain_only].b )
    {
       mod_full_brace_if_chain();
    }
@@ -1103,6 +1104,13 @@ static void process_if_chain(chunk_t *br_start)
       {
          break;
       }
+
+      if (cpd.settings[UO_mod_full_brace_if_chain_only].b)
+      {
+         // There is an 'else' - we want full braces.
+         must_have_braces = true;
+      }
+
       pc = chunk_get_next_ncnl(pc, CNAV_PREPROC);
       if ((pc != NULL) && (pc->type == CT_ELSEIF))
       {
@@ -1141,8 +1149,11 @@ static void process_if_chain(chunk_t *br_start)
       }
       LOG_FMT(LBRCH, "\n");
    }
-   else
+   else if (cpd.settings[UO_mod_full_brace_if_chain].b)
    {
+      // This might run because either UO_mod_full_brace_if_chain or UO_mod_full_brace_if_chain_only is used.
+      // We only want to remove braces if the first one is active.
+
       LOG_FMT(LBRCH, "%s: remove braces on lines[%d]:", __func__, br_cnt);
       while (--br_cnt >= 0)
       {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1339,6 +1339,10 @@ void register_options(void)
    unc_add_option("mod_full_brace_if_chain", UO_mod_full_brace_if_chain, AT_BOOL,
                   "Make all if/elseif/else statements in a chain be braced or not. Overrides mod_full_brace_if.\n"
                   "If any must be braced, they are all braced.  If all can be unbraced, then the braces are removed.");
+   unc_add_option("mod_full_brace_if_chain_only", UO_mod_full_brace_if_chain_only, AT_BOOL,
+                  "Make all if/elseif/else statements with at least one 'else' or 'else if' fully braced.\n"
+                  "If mod_full_brace_if_chain is used together with this option, all if-else chains will get braces,\n"
+                  "and simple 'if' statements will lose them (if possible).\n");
    unc_add_option("mod_full_brace_nl", UO_mod_full_brace_nl, AT_NUM,
                   "Don't remove braces around statements that span N newlines", "", 0, 5000);
    unc_add_option("mod_full_brace_while", UO_mod_full_brace_while, AT_IARF,

--- a/src/options.h
+++ b/src/options.h
@@ -701,7 +701,8 @@ enum uncrustify_options
    UO_mod_paren_on_return,        // add or remove paren on return
    UO_mod_full_brace_nl,          // max number of newlines to span w/o braces
    UO_mod_full_brace_if,          // add or remove braces on single-line if
-   UO_mod_full_brace_if_chain,
+   UO_mod_full_brace_if_chain,      // make all if/elseif/else statements in a chain be braced or not
+   UO_mod_full_brace_if_chain_only, // make all if/elseif/else statements in a chain with at least one 'else' or 'else if' fully braced
    UO_mod_full_brace_for,         // add or remove braces on single-line for
    UO_mod_full_brace_do,          // add or remove braces on single-line do
    UO_mod_full_brace_while,       // add or remove braces on single-line while

--- a/tests/config/if_chain_braces_0.cfg
+++ b/tests/config/if_chain_braces_0.cfg
@@ -1,0 +1,1 @@
+mod_full_brace_if_chain      = true

--- a/tests/config/if_chain_braces_1.cfg
+++ b/tests/config/if_chain_braces_1.cfg
@@ -1,0 +1,1 @@
+mod_full_brace_if_chain_only = true

--- a/tests/config/if_chain_braces_2.cfg
+++ b/tests/config/if_chain_braces_2.cfg
@@ -1,0 +1,2 @@
+mod_full_brace_if_chain      = true
+mod_full_brace_if_chain_only = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -288,3 +288,8 @@
 33050 empty.cfg                        cpp/issue_523.cpp
 33051 empty.cfg                        cpp/bug_i_503.cpp
 33052 empty.cfg                        cpp/bug_i_512.cpp
+
+33061 empty.cfg                        cpp/if_chain_braces.cpp
+33062 if_chain_braces_0.cfg            cpp/if_chain_braces.cpp
+33063 if_chain_braces_1.cfg            cpp/if_chain_braces.cpp
+33064 if_chain_braces_2.cfg            cpp/if_chain_braces.cpp

--- a/tests/input/cpp/if_chain_braces.cpp
+++ b/tests/input/cpp/if_chain_braces.cpp
@@ -1,0 +1,28 @@
+
+int foo() {
+	if ( a )
+		return 1;
+	else if ( b )
+		return 2;
+
+	if ( a )
+		return 3;
+	else if ( b )
+		return 4;
+	else {
+		a = 5;
+		return 5;
+	}
+
+	if ( a )
+		return 6;
+	else
+		return 7;
+
+	if ( a )
+		return 8;
+
+	if ( b ) {
+		return 9;
+	}
+}

--- a/tests/output/cpp/33061-if_chain_braces.cpp
+++ b/tests/output/cpp/33061-if_chain_braces.cpp
@@ -1,0 +1,28 @@
+
+int foo() {
+	if ( a )
+		return 1;
+	else if ( b )
+		return 2;
+
+	if ( a )
+		return 3;
+	else if ( b )
+		return 4;
+	else {
+		a = 5;
+		return 5;
+	}
+
+	if ( a )
+		return 6;
+	else
+		return 7;
+
+	if ( a )
+		return 8;
+
+	if ( b ) {
+		return 9;
+	}
+}

--- a/tests/output/cpp/33062-if_chain_braces.cpp
+++ b/tests/output/cpp/33062-if_chain_braces.cpp
@@ -1,0 +1,29 @@
+
+int foo() {
+	if ( a )
+		return 1;
+	else if ( b )
+		return 2;
+
+	if ( a ) {
+		return 3;
+	}
+	else if ( b ) {
+		return 4;
+	}
+	else {
+		a = 5;
+		return 5;
+	}
+
+	if ( a )
+		return 6;
+	else
+		return 7;
+
+	if ( a )
+		return 8;
+
+	if ( b )
+		return 9;
+}

--- a/tests/output/cpp/33063-if_chain_braces.cpp
+++ b/tests/output/cpp/33063-if_chain_braces.cpp
@@ -1,0 +1,34 @@
+
+int foo() {
+	if ( a ) {
+		return 1;
+	}
+	else if ( b ) {
+		return 2;
+	}
+
+	if ( a ) {
+		return 3;
+	}
+	else if ( b ) {
+		return 4;
+	}
+	else {
+		a = 5;
+		return 5;
+	}
+
+	if ( a ) {
+		return 6;
+	}
+	else{
+		return 7;
+	}
+
+	if ( a )
+		return 8;
+
+	if ( b ) {
+		return 9;
+	}
+}

--- a/tests/output/cpp/33064-if_chain_braces.cpp
+++ b/tests/output/cpp/33064-if_chain_braces.cpp
@@ -1,0 +1,33 @@
+
+int foo() {
+	if ( a ) {
+		return 1;
+	}
+	else if ( b ) {
+		return 2;
+	}
+
+	if ( a ) {
+		return 3;
+	}
+	else if ( b ) {
+		return 4;
+	}
+	else {
+		a = 5;
+		return 5;
+	}
+
+	if ( a ) {
+		return 6;
+	}
+	else{
+		return 7;
+	}
+
+	if ( a )
+		return 8;
+
+	if ( b )
+		return 9;
+}


### PR DESCRIPTION
Instead of adding or removing braces from all if/elseif/else chains that mod_full_brace_if_chain does,
the new option simply adds braces to all if-else statements with at least one 'else' or 'else if'.
It will leave simple unbraced 'if ( foo ) bar();' statements alone, but make all if-else chains fully braced.