### PR TITLE
Fixed parsing nullable C-Sharp properties

### DIFF
--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -749,7 +749,8 @@ void tokenize_cleanup(void)
                if ((tmp2 != NULL) &&
                    ((tmp2->type == CT_SEMICOLON) ||
                     (tmp2->type == CT_ASSIGN) ||
-                    (tmp2->type == CT_COMMA)))
+                    (tmp2->type == CT_COMMA) ||
+                    (tmp2->type == CT_BRACE_OPEN)))
                {
                   doit = true;
                }

--- a/tests/c-sharp.test
+++ b/tests/c-sharp.test
@@ -54,3 +54,4 @@
 10160 cs_delegate_default.cfg  cs/delegate.cs
 10161 cs_delegate_indent.cfg   cs/delegate.cs
 12001 bug_620.cfg              cs/bug_620.cs
+12002 empty.cfg                cs/nullable_prop.cs

--- a/tests/input/cs/nullable_prop.cs
+++ b/tests/input/cs/nullable_prop.cs
@@ -1,0 +1,18 @@
+
+namespace Foo
+{
+
+public class Bar
+{
+public int? Val;
+
+public int? Prop
+{
+	get
+	{
+		return 1;
+	}
+}
+}
+}
+

--- a/tests/output/cs/12002-nullable_prop.cs
+++ b/tests/output/cs/12002-nullable_prop.cs
@@ -1,0 +1,18 @@
+
+namespace Foo
+{
+
+public class Bar
+{
+public int? Val;
+
+public int? Prop
+{
+	get
+	{
+		return 1;
+	}
+}
+}
+}
+


### PR DESCRIPTION
When there is a nullable type used for a variable ( int? var; ),
the '?' is merged with 'int', since it is a part of the type.

However, if it was a property using a nullable type ( int? prop { get { return 1; } } ),
'?' was not treated as part of the type (resulting in 'int ? prop (...)' - which is clearly wrong).

This change fixes that.