### PR TITLE
Fixing issues with 'auto'

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -3534,7 +3534,6 @@ static void mark_function(chunk_t *pc)
 
          /* If we are on a TYPE or WORD, then we must be on a proto or def */
          if ((prev->type == CT_TYPE) ||
-             (prev->type == CT_AUTO) ||
              (prev->type == CT_WORD))
          {
             if (!hit_star)

--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -92,7 +92,7 @@ static const chunk_tag_t keywords[] =
    { "assert",           CT_ASSERT,       LANG_JAVA                                                                   },
    { "assert",           CT_FUNCTION,     LANG_D | LANG_PAWN                                                          }, // PAWN
    { "assert",           CT_PP_ASSERT,    LANG_PAWN | FLAG_PP                                                         }, // PAWN
-   { "auto",             CT_AUTO,         LANG_C | LANG_CPP                                                           },
+   { "auto",             CT_TYPE,         LANG_C | LANG_CPP | LANG_D                                                  },
    { "base",             CT_BASE,         LANG_CS | LANG_VALA                                                         },
    { "bit",              CT_TYPE,         LANG_D                                                                      },
    { "bitand",           CT_ARITH,        LANG_C | LANG_CPP                                                           },

--- a/src/token_enum.h
+++ b/src/token_enum.h
@@ -216,7 +216,6 @@ typedef enum
    CT_MACRO_FUNC,       /* function-like macro */
    CT_MACRO,            /* a macro def */
    CT_QUALIFIER,        /* static, const, etc */
-   CT_AUTO,             /* auto */
    CT_EXTERN,           /* extern */
    CT_ALIGN,            /* paren'd qualifier: align(4) struct a { } */
    CT_TYPE,

--- a/tests/config/for_auto.cfg
+++ b/tests/config/for_auto.cfg
@@ -1,0 +1,4 @@
+input_tab_size                                    = 4
+indent_columns                                    = 4
+indent_with_tabs                                  = 0
+sp_arith                                          = add

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -288,3 +288,4 @@
 33050 empty.cfg                        cpp/issue_523.cpp
 33051 empty.cfg                        cpp/bug_i_503.cpp
 33052 empty.cfg                        cpp/bug_i_512.cpp
+33053 for_auto.cfg                     cpp/for_auto.cpp

--- a/tests/input/cpp/for_auto.cpp
+++ b/tests/input/cpp/for_auto.cpp
@@ -1,0 +1,16 @@
+void foo()
+{
+	for (auto const& item : list)
+		bar(item);
+	for (const auto& item : list)
+		bar(item);
+	for (auto& item : list)
+		bar(item);
+
+	auto* var = bar();
+	auto& var = bar();
+	auto var = bar();
+	auto const* var = bar();
+	auto const& var = bar();
+	auto const var = bar();
+}

--- a/tests/output/cpp/33053-for_auto.cpp
+++ b/tests/output/cpp/33053-for_auto.cpp
@@ -1,0 +1,16 @@
+void foo()
+{
+    for (auto const& item : list)
+        bar(item);
+    for (const auto& item : list)
+        bar(item);
+    for (auto& item : list)
+        bar(item);
+
+    auto* var = bar();
+    auto& var = bar();
+    auto var = bar();
+    auto const* var = bar();
+    auto const& var = bar();
+    auto const var = bar();
+}


### PR DESCRIPTION
'Auto' was being treated as a qualifier,
then it was changed to be treated as a separate token type
to fix a bug which, in turn, introduced other bugs.

This reverts 502b5e1 - removes CT_AUTO, but also treats 'auto' as a type, not a qualifier.

It fixes both the original and the new bugs.