### PR TITLE
C# keyword 'when' is not always used for exception filters

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -535,6 +535,11 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       {
          set_paren_parent(next, pc->type);
       }
+       
+      if ((pc->type == CT_WHEN) && (pc->next->type != CT_SPAREN_OPEN))
+      {
+          set_chunk_type(pc, CT_WORD);
+      }
    }
 
    if (pc->type == CT_NEW)

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -897,7 +897,8 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
    if ((first->type == CT_PAREN_CLOSE) &&
        (second->type == CT_WHEN))
    {
-      return(AV_FORCE);
+      log_rule("FORCE");
+      return(AV_FORCE); /* TODO: make this configurable? */
    }
 
    if ((first->type == CT_PAREN_CLOSE) &&

--- a/tests/input/cs/exception-filters.cs
+++ b/tests/input/cs/exception-filters.cs
@@ -3,6 +3,7 @@ class Test
 {
 void TestExceptionFilter()
 {
+var when = new Object();
 try {
   int i = 0;
 } catch (Exception e)
@@ -22,8 +23,8 @@ try {
   int j = -1;
 }
 try {
-  int i = 0;
+  int a = (int)when.foo();
 } catch (Exception e) when (DateTime.Now.DayOfWeek == DayOfWeek.Saturday)
 {
-  int j = -1;
+  string b = ((int)when.prop).ToString();
 }}}

--- a/tests/output/cs/10042-exception-filters.cs
+++ b/tests/output/cs/10042-exception-filters.cs
@@ -3,6 +3,8 @@ class Test
 {
    void TestExceptionFilter()
    {
+      var when = new Object();
+
       try
       {
          int i = 0;
@@ -29,11 +31,11 @@ class Test
       }
       try
       {
-         int i = 0;
+         int a = (int)when.foo();
       }
       catch (Exception e) when (DateTime.Now.DayOfWeek == DayOfWeek.Saturday)
       {
-         int j = -1;
+         string b = ((int)when.prop).ToString();
       }
    }
 }


### PR DESCRIPTION
The `CT_WHEN` token which was introduced to support the new exception filters feature from C# 6 should be treated as `CT_WORD` if it doesn't belong in a valid `catch when ()` for which there should always be a `CT_SPAREN_OPEN` token following.