### PR TITLE
Testing framework improvements

### DIFF
--- a/run_tests.bat
+++ b/run_tests.bat
@@ -1,0 +1,3 @@
+@echo off
+cd tests
+python run_tests.py %*

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -101,7 +101,7 @@ def run_tests(args, test_name, config_name, input_name, lang):
     except:
         pass
 
-    cmd = '"%s" -q -c %s -f input/%s %s -o %s %s' % (args.exe, config_name, input_name, lang, resultname, "-LA 2>" + resultname + ".log -p " + resultname + ".unc" if args.g else "")
+    cmd = '"%s" -q -c %s -f input/%s %s -o %s %s' % (args.exe, config_name, input_name, lang, resultname, "-LA 2>" + resultname + ".log -p " + resultname + ".unc" if args.g else "-L1,2")
     if args.c:
         print("RUN: " + cmd)
     a = os.system(cmd)


### PR DESCRIPTION
Improvements:
- added run_tests.bat to have an equivalent for run_tests.sh on Windows
- use `git diff` instead of `diff` to make `-d` option work on Windows also.
- added `-g` option to generate dump and log files.
- added `--results` option to override results folder output. Useful when you want to preserve the previous folder