### PR TITLE
Added option to control options overriding for Qt

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -562,9 +562,10 @@ void indent_text(void)
    pc = chunk_get_head();
    while (pc != NULL)
    {
-      if ((strcmp(pc->text(), "SIGNAL") == 0) ||
-          (strcmp(pc->text(), "SLOT") == 0))   // guy 2015-09-22
-      {
+      if ((cpd.settings[UO_use_options_overriding_for_qt_macros].b) &&
+         ((strcmp(pc->text(), "SIGNAL") == 0) ||
+          (strcmp(pc->text(), "SLOT") == 0)))
+      {  // guy 2015-09-22
 #ifdef DEBUG
          LOG_FMT(LGUY, "(%d) ", __LINE__);
 #endif

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1423,6 +1423,9 @@ void register_options(void)
                   "To prevent the double use of the option value, use this option with the value 'true'.\n"
                   "True:  indent_continue will be used only once\n"
                   "False: indent_continue will be used every time (default)");
+   unc_add_option("use_options_overriding_for_qt_macros", UO_use_options_overriding_for_qt_macros, AT_BOOL,
+                  "SIGNAL/SLOT Qt macros have special formatting options. See options_for_QT.cpp for details.\n"
+                  "Default=True.");
 } // register_options
 
 
@@ -2138,6 +2141,8 @@ void set_option_defaults(void)
    cpd.defaults[UO_indent_oc_msg_prioritize_first_colon].b = true;
    cpd.defaults[UO_use_indent_func_call_param].b           = true;
    cpd.defaults[UO_use_indent_continue_only_once].b        = false;
+   cpd.defaults[UO_use_options_overriding_for_qt_macros].b = true;
+
    /* copy all the default values to settings array */
    for (int count = 0; count < UO_option_count; count++)
    {

--- a/src/options.h
+++ b/src/options.h
@@ -768,6 +768,8 @@ enum uncrustify_options
                                       //   at the function call (if present)
                                       // To prevent the double use of the option value, use this option
                                       // with the value "true". Guy 2016-05-16
+   
+   UO_use_options_overriding_for_qt_macros,     // SIGNAL/SLOT Qt macros have special formatting options. See options_for_QT.cpp for details.
 
    /* This is used to get the enumeration count */
    UO_option_count

--- a/src/options_for_QT.cpp
+++ b/src/options_for_QT.cpp
@@ -31,6 +31,8 @@ argval_t SaveUO_sp_after_type_A           = AV_NOT_DEFINED;
 
 void save_set_options_for_QT(int level)
 {
+   assert(cpd.settings[UO_use_options_overriding_for_qt_macros].b);
+
    LOG_FMT(LGUY, "save values\n");
    // save the values
    QT_SIGNAL_SLOT_level             = level;
@@ -57,6 +59,8 @@ void save_set_options_for_QT(int level)
 
 void restore_options_for_QT()
 {
+   assert(cpd.settings[UO_use_options_overriding_for_qt_macros].b);
+
    LOG_FMT(LGUY, "restore values\n");
    // restore the values we had before SIGNAL/SLOT
    QT_SIGNAL_SLOT_level                       = 0;

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1787,8 +1787,9 @@ void space_text(void)
 #endif
       LOG_FMT(LGUY, "%s: %d:%d %s %s\n", __func__, pc->orig_line, pc->orig_col, pc->text(),
               get_token_name(pc->type));
-      if ((strcmp(pc->text(), "SIGNAL") == 0) ||
-          (strcmp(pc->text(), "SLOT") == 0))
+      if ((cpd.settings[UO_use_options_overriding_for_qt_macros].b) &&
+         ((strcmp(pc->text(), "SIGNAL") == 0) ||
+          (strcmp(pc->text(), "SLOT") == 0)))
       {  // guy 2015-09-22
 #ifdef DEBUG
          LOG_FMT(LGUY, "(%d) ", __LINE__);


### PR DESCRIPTION
Added new option to be able to avoid potentially unwanted Qt macro formatting `use_options_overriding_for_qt_macros`. The option is true by default to preserve current behaviour.