### PR TITLE
Make the "indent to token following a brace" optional

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1212,7 +1212,9 @@ void indent_text(void)
             next = chunk_get_next_ncnl(pc);
             if (!chunk_is_newline_between(pc, next))
             {
-               frm.pse[frm.pse_tos].indent = next->column;
+                if (cpd.settings[UO_indent_token_after_brace].b) {
+                    frm.pse[frm.pse_tos].indent = next->column;
+                }
             }
             frm.pse[frm.pse_tos].indent_tmp = frm.pse[frm.pse_tos].indent;
             frm.pse[frm.pse_tos].open_line  = pc->orig_line;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -740,6 +740,9 @@ void register_options(void)
    unc_add_option("indent_vbrace_open_on_tabstop", UO_indent_vbrace_open_on_tabstop, AT_BOOL,
                   "TRUE: When identing after virtual brace open and newline add further spaces "
                   "after regular indent to reach next tabstop.");
+   unc_add_option("indent_token_after_brace", UO_indent_token_after_brace, AT_BOOL,
+                  "If true, a brace followed by another token (not a newline) will indent all contained lines to match the token."
+                  "Default=True.");
 
    unc_begin_group(UG_newline, "Newline adding and removing options");
    unc_add_option("nl_collapse_empty_body", UO_nl_collapse_empty_body, AT_BOOL,
@@ -2174,6 +2177,7 @@ void set_option_defaults(void)
    cpd.defaults[UO_indent_oc_msg_prioritize_first_colon].b = true;
    cpd.defaults[UO_use_indent_func_call_param].b           = true;
    cpd.defaults[UO_use_options_overriding_for_qt_macros].b = true;
+   cpd.defaults[UO_indent_token_after_brace].b             = true;
 
    /* copy all the default values to settings array */
    for (int count = 0; count < UO_option_count; count++)

--- a/src/options.h
+++ b/src/options.h
@@ -203,6 +203,7 @@ enum uncrustify_options
 
    UO_indent_min_vbrace_open,        // min. indent after virtual brace open and newline
    UO_indent_vbrace_open_on_tabstop, // when identing after virtual brace open and newline add further spaces to reach next tabstop
+   UO_indent_token_after_brace,
 
    /*
     * Misc inter-element spacing

--- a/tests/config/namespace_namespace.cfg
+++ b/tests/config/namespace_namespace.cfg
@@ -1,0 +1,1 @@
+indent_token_after_brace = false

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -307,3 +307,4 @@
 33078 multi_line_8.cfg                 cpp/multi_line.cpp
 33079 multi_line_9.cfg                 cpp/multi_line.cpp
 33080 multi_line_10.cfg                cpp/multi_line.cpp
+33081 namespace_namespace.cfg          cpp/namespace_namespace.cpp

--- a/tests/input/cpp/namespace_namespace.cpp
+++ b/tests/input/cpp/namespace_namespace.cpp
@@ -1,0 +1,6 @@
+namespace hw { namespace stm32 {
+
+class RTC {
+}
+
+}} // namespace hw::stm32

--- a/tests/input/cpp/namespace_namespace.cpp
+++ b/tests/input/cpp/namespace_namespace.cpp
@@ -1,6 +1,6 @@
 namespace hw { namespace stm32 {
 
 class RTC {
-}
+};
 
 }} // namespace hw::stm32

--- a/tests/output/cpp/33081-namespace_namespace.cpp
+++ b/tests/output/cpp/33081-namespace_namespace.cpp
@@ -1,0 +1,6 @@
+namespace hw { namespace stm32 {
+
+class RTC {
+}
+
+}} // namespace hw::stm32

--- a/tests/output/cpp/33081-namespace_namespace.cpp
+++ b/tests/output/cpp/33081-namespace_namespace.cpp
@@ -1,6 +1,6 @@
 namespace hw { namespace stm32 {
 
 class RTC {
-}
+};
 
 }} // namespace hw::stm32


### PR DESCRIPTION
Hi, first time pull-requester here, so please explain if I've done any of this wrong.

Full explanation in the commit message, but basically a brace that's followed by something not a newline, indents the block's entire contents to be level with the "something". The motivation appears in the provided test-case of the new option, where (without it) the class would be shoved 13-odd spaces to the right, to align it with the `namespace stm32`.
