### PR TITLE
Skip vspace tokens in spacing

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -566,6 +566,9 @@ void register_options(void)
    unc_add_option("sp_annotation_paren", UO_sp_annotation_paren, AT_IARF,
                   "Control space between a Java annotation and the open paren.");
 
+   unc_add_option("sp_skip_vbrace_tokens", UO_sp_skip_vbrace_tokens, AT_BOOL,
+                  "If true, vbrace tokens are dropped to the previous token and skipped.");
+
    unc_begin_group(UG_indent, "Indenting");
    unc_add_option("indent_columns", UO_indent_columns, AT_NUM,
                   "The number of columns to indent per level.\n"

--- a/src/options.h
+++ b/src/options.h
@@ -406,6 +406,7 @@ enum uncrustify_options
    UO_sp_after_for_colon,
    UO_sp_before_for_colon,
    UO_sp_extern_paren,
+   UO_sp_skip_vbrace_tokens,
 
    /*
     * Line splitting options (for long lines)

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1804,16 +1804,23 @@ void space_text(void)
          save_set_options_for_QT(pc->level);
       } // guy
         // Bug # 637
-        //next = chunk_get_next(pc);
-        //while (chunk_is_blank(next) && !chunk_is_newline(next))
-        //{
-        //   LOG_FMT(LSPACE, "%s: %d:%d Skip %s (%d+%d)\n", __func__,
-        //           next->orig_line, next->orig_col, get_token_name(next->type),
-        //           pc->column, pc->str.size());
-        //   next->column = pc->column + pc->str.size();
-        //   next         = chunk_get_next(next);
-        //}
-      next = pc->next;
+      if (cpd.settings[UO_sp_skip_vbrace_tokens].b)
+      {
+         next = chunk_get_next(pc);
+         while (chunk_is_blank(next) && !chunk_is_newline(next) &&
+               (next->type == CT_VBRACE_OPEN || next->type == CT_VBRACE_CLOSE))
+         {
+            LOG_FMT(LSPACE, "%s: %d:%d Skip %s (%d+%d)\n", __func__,
+               next->orig_line, next->orig_col, get_token_name(next->type),
+               pc->column, pc->str.size());
+            next->column = pc->column + pc->str.size();
+            next = chunk_get_next(next);
+         }
+      }
+      else
+      {
+         next = pc->next;
+      }
       if (!next)
       {
          break;

--- a/tests/config/sp_skip_vbrace_tokens.cfg
+++ b/tests/config/sp_skip_vbrace_tokens.cfg
@@ -1,0 +1,5 @@
+# test for issue #546
+input_tab_size = 4
+indent_columns = 4
+indent_with_tabs = 0
+sp_skip_vbrace_tokens = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -238,6 +238,8 @@
 31720 ben.cfg                          cpp/bit-colon.cpp
 31730 ms-style-ref.cfg                 cpp/ms-style-ref.cpp
 
+32000 sp_skip_vbrace_tokens.cfg        cpp/sp_skip_vbrace_tokens.cpp
+
 33000 tab-0-11.cfg                     cpp/tab-0.cpp
 33001 tab-1-11.cfg                     cpp/tab-1.cpp
 33002 comment_tab_f.cfg                cpp/cmt_convert_tab_to_spaces.cpp

--- a/tests/input/cpp/sp_skip_vbrace_tokens.cpp
+++ b/tests/input/cpp/sp_skip_vbrace_tokens.cpp
@@ -1,4 +1,4 @@
-public void foo()
+void foo()
 {
 	if (data)	go = new ClassA();
 	else		go = new ClassB();

--- a/tests/input/cpp/sp_skip_vbrace_tokens.cpp
+++ b/tests/input/cpp/sp_skip_vbrace_tokens.cpp
@@ -1,0 +1,10 @@
+public void foo()
+{
+	if (data)	go = new ClassA();
+	else		go = new ClassB();
+
+	if (evt.alt)		modifiers += "Alt+";
+	if (evt.command)	modifiers += "Cmd+";
+	if (evt.control)	modifiers += "Ctrl+";
+	if (evt.shift)		modifiers += "Shift+";
+}

--- a/tests/output/cpp/32000-sp_skip_vbrace_tokens.cpp
+++ b/tests/output/cpp/32000-sp_skip_vbrace_tokens.cpp
@@ -1,4 +1,4 @@
-public void foo()
+void foo()
 {
     if (data)   go = new ClassA();
     else        go = new ClassB();

--- a/tests/output/cpp/32000-sp_skip_vbrace_tokens.cpp
+++ b/tests/output/cpp/32000-sp_skip_vbrace_tokens.cpp
@@ -1,0 +1,10 @@
+public void foo()
+{
+    if (data)   go = new ClassA();
+    else        go = new ClassB();
+
+    if (evt.alt)        modifiers += "Alt+";
+    if (evt.command)    modifiers += "Cmd+";
+    if (evt.control)    modifiers += "Ctrl+";
+    if (evt.shift)      modifiers += "Shift+";
+}


### PR DESCRIPTION
I've added a new option which will use the old behaviour from Uncrustify 0.62 for spacing of dropping the `CT_VBRACE_OPEN` and `CT_VBRACE_CLOSE` tokens to the previous token and skip them.

This fixes issue #546.