### PR TITLE
Fix for parsing UTF8-encoded words

### DIFF
--- a/src/char_table.h
+++ b/src/char_table.h
@@ -47,13 +47,13 @@ struct CharTable
    }
 
 
-   static inline bool IsKw1(char ch)
+   static inline bool IsKw1(int ch)
    {
       return((Get(ch) & KW1) != 0);
    }
 
 
-   static inline bool IsKw2(char ch)
+   static inline bool IsKw2(int ch)
    {
       return((Get(ch) & KW2) != 0);
    }

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -847,6 +847,7 @@ static int load_mem_file(const char *filename, file_mem& fm)
          LOG_FMT(LNOTE, "%s: '%s' encoding looks like %s (%d)\n", __func__, filename,
                  fm.enc == ENC_ASCII ? "ASCII" :
                  fm.enc == ENC_BYTE ? "BYTES" :
+                 fm.enc == ENC_UTF8 ? "UTF-8" :
                  fm.enc == ENC_UTF16_LE ? "UTF-16-LE" :
                  fm.enc == ENC_UTF16_BE ? "UTF-16-BE" : "Error",
                  fm.enc);

--- a/tests/c.test
+++ b/tests/c.test
@@ -278,6 +278,7 @@
 02432 align_right_cmt_gap-2.cfg c/cmt_right_align.c
 
 02440 empty.cfg                 c/string_utf8.c
+02441 empty.cfg                 c/utf8-identifiers.c
 
 02451 return-1.cfg              c/nl_return_expr.c
 02452 return-2.cfg              c/nl_return_expr.c

--- a/tests/input/c/utf8-identifiers.c
+++ b/tests/input/c/utf8-identifiers.c
@@ -1,0 +1,13 @@
+void FooUtf8Сhar(void) // C is encoded in UTF-8
+{
+}
+
+struct テスト         // Japanese 'test'
+{
+    void トスト() {}  // Japanese 'toast'
+};
+
+int main() {
+    テスト パン;        // Japanese パン 'bread'
+    パン.トスト();
+}

--- a/tests/output/c/02441-utf8-identifiers.c
+++ b/tests/output/c/02441-utf8-identifiers.c
@@ -1,0 +1,14 @@
+void FooUtf8Сhar(void) // C is encoded in UTF-8
+{
+}
+
+struct テスト         // Japanese 'test'
+{
+	void トスト() {
+	}          // Japanese 'toast'
+};
+
+int main() {
+	テスト パン;    // Japanese パン 'bread'
+	パン.トスト();
+}


### PR DESCRIPTION
`parse_word` was not able to properly parse UTF-8 encoded words because the wide characters were truncated to a 1-byte characters and as a result Uncrustify was either generating wrong output or/and it was throwing away unparsed chunks complaining about `Garbage in col %d`.

For instance, in the provided test `C` was tokenized as `CT_NOT` because UTF-8 `C` character `0xD0A1` equivalent with Unicode char `\u421` was truncated to `0x21` which is `!`. Similarly, the Japanese characters were tokenized as `CT_UNKNOWN`.

Also, Uncrustify was adding a space after these badly parsed tokens. Not sure if that's correct.
In any case, the change fixes tokenization of UTF-8 encoded words.