### PR TITLE
Allow Universal Character Names in identifiers

### DIFF
--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -1153,10 +1153,23 @@ bool parse_word(tok_ctx& ctx, chunk_t& pc, bool skipcheck)
    pc.str.clear();
    pc.str.append(ctx.get());
 
-   while (ctx.more() && CharTable::IsKw2(ctx.peek()))
+   while (ctx.more())
    {
-      ch = ctx.get();
-      pc.str.append(ch);
+      ch = ctx.peek();
+      if (CharTable::IsKw2(ch))
+      {
+         pc.str.append(ctx.get());
+      }
+      else if ((ch == '\\') && (unc_tolower(ctx.peek(1)) == 'u'))
+      {
+         pc.str.append(ctx.get());
+         pc.str.append(ctx.get());
+         skipcheck = true;
+      }
+      else
+      {
+         break;
+      }
 
       /* HACK: Non-ASCII character are only allowed in identifiers */
       if (ch > 0x7f)

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -312,3 +312,5 @@
 #33080 multi_line_10.cfg                cpp/multi_line.cpp
 33081 bug_i_552.cfg                    cpp/bug_i_552.cpp
 33082 namespace_namespace.cfg          cpp/namespace_namespace.cpp
+
+33090 empty.cfg                        cpp/gh555.cpp

--- a/tests/input/cpp/gh555.cpp
+++ b/tests/input/cpp/gh555.cpp
@@ -1,0 +1,4 @@
+int main()
+{
+   int IdentContainingTwoUCNCharacters\u1234\U00001234 = 0;
+}

--- a/tests/output/cpp/33090-gh555.cpp
+++ b/tests/output/cpp/33090-gh555.cpp
@@ -1,0 +1,4 @@
+int main()
+{
+	int IdentContainingTwoUCNCharacters\u1234\U00001234 = 0;
+}


### PR DESCRIPTION
This handles:
    int IdentContainingTwoUCNCharacters\u1234\U00001234;

No validation of the escape sequence is done.
This change just allows '\u' and '\U' in the identifier.

Fixes #555