### PR TITLE
Fix identifier parsing when it starts with an UCN character

### DIFF
--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -1736,6 +1736,7 @@ static bool parse_next(tok_ctx& ctx, chunk_t& pc)
 
    /* Check for pawn/ObjectiveC/Java and normal identifiers */
    if (CharTable::IsKw1(ctx.peek()) ||
+       ((ctx.peek() == '\\') && (unc_tolower(ctx.peek(1)) == 'u')) ||
        ((ctx.peek() == '@') && CharTable::IsKw1(ctx.peek(1))))
    {
       parse_word(ctx, pc, false);

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -313,4 +313,4 @@
 33081 bug_i_552.cfg                    cpp/bug_i_552.cpp
 33082 namespace_namespace.cfg          cpp/namespace_namespace.cpp
 
-#33090 empty.cfg                        cpp/gh555.cpp
+33090 empty.cfg                        cpp/gh555.cpp

--- a/tests/input/cpp/gh555.cpp
+++ b/tests/input/cpp/gh555.cpp
@@ -1,4 +1,8 @@
+class \u005FClass // underscore character
+{
+};
+
 int main()
 {
-   int IdentContainingTwoUCNCharacters\u1234\U00001234 = 0;
+   string IdentContainingTwoUCNCharacters\u1234\U00001234 = "\u005FClass";
 }

--- a/tests/output/cpp/33090-gh555.cpp
+++ b/tests/output/cpp/33090-gh555.cpp
@@ -1,4 +1,4 @@
 int main()
 {
-	int IdentContainingTwoUCNCharacters \ u1234 \ U00001234 = 0;
+	int IdentContainingTwoUCNCharacters\u1234\U00001234 = 0;
 }

--- a/tests/output/cpp/33090-gh555.cpp
+++ b/tests/output/cpp/33090-gh555.cpp
@@ -1,4 +1,8 @@
+class \u005FClass // underscore character
+{
+};
+
 int main()
 {
-	int IdentContainingTwoUCNCharacters\u1234\U00001234 = 0;
+	string IdentContainingTwoUCNCharacters\u1234\U00001234 = "\u005FClass";
 }


### PR DESCRIPTION
Fixes mistakes done directly on master.