### PR TITLE
Issue with bitfields with enumeration constants

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -36,7 +36,7 @@ Bugfix:
  - Bug #620 is fixed
  - Issues #359, #405, #408, #412, #478, #481, #495, #503, #509, #512, #513, #514,
     #518, #519, #520, #521, #522, #524, #529, #530, #533, #536, #539, #542,
-    #543, #544, #546 are fixed
+    #543, #544, #546, #568 are fixed
  - Proposals #409 and #477 are implemented
  - Issue #411 is partialy fixed
 

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2608,8 +2608,8 @@ void combine_labels(void)
                   set_chunk_type(next, CT_LABEL_COLON);
                }
                else if ((tmp == NULL) ||
-                        (tmp->type != CT_NUMBER &&
-                         tmp->type != CT_SIZEOF &&
+                        ((tmp->type != CT_NUMBER) &&
+                         (tmp->type != CT_SIZEOF) &&
                          !(tmp->flags & PCF_IN_STRUCT)) ||
                         (tmp->type == CT_NEWLINE)
                   )

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2476,6 +2476,10 @@ void combine_labels(void)
    /* unlikely that the file will start with a label... */
    while (next != NULL)
    {
+#ifdef DEBUG
+      LOG_FMT(LGUY, "(%d) ", __LINE__);
+#endif
+      LOG_FMT(LGUY, "%s: cur->text=%s, line=%d, col=%d\n", __func__, (cur->type == CT_NEWLINE) ? "<NL>" : cur->text(), cur->orig_line, cur->orig_col);
       if (!(next->flags & PCF_IN_OC_MSG) && /* filter OC case of [self class] msg send */
           ((next->type == CT_CLASS) ||
            (next->type == CT_OC_CLASS) ||
@@ -2592,14 +2596,26 @@ void combine_labels(void)
             else if (cur->type == CT_WORD)
             {
                tmp = chunk_get_next_nc(next, CNAV_PREPROC);
+#ifdef DEBUG
+               LOG_FMT(LGUY, "(%d) ", __LINE__);
+#endif
+               LOG_FMT(LGUY, "%s: %d:%d, tmp=%s\n", __func__,
+                       tmp->orig_line, tmp->orig_col, (tmp->type == CT_NEWLINE) ? "<NL>" : tmp->text());
+               log_pcf_flags(LGUY, tmp->flags);
                if (next->flags & PCF_IN_FCN_CALL)
                {
                   /* Must be a macro thingy, assume some sort of label */
                   set_chunk_type(next, CT_LABEL_COLON);
                }
-               else if ((tmp == NULL) || (tmp->type != CT_NUMBER && tmp->type != CT_SIZEOF))
+               else if ((tmp == NULL) ||
+                        (tmp->type != CT_NUMBER &&
+                         tmp->type != CT_SIZEOF &&
+                         !(tmp->flags & PCF_IN_STRUCT)) ||
+                        (tmp->type == CT_NEWLINE)
+                  )
                {
-                  /* the CT_SIZEOF isn't great - test 31720 happens to use a sizeof expr, but this really should be able to handle any constant expr */
+                  /* the CT_SIZEOF isn't great - test 31720 happens to use a sizeof expr,
+                     but this really should be able to handle any constant expr */
                   set_chunk_type(cur, CT_LABEL);
                   set_chunk_type(next, CT_LABEL_COLON);
                }

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -313,5 +313,6 @@
 33081 bug_i_552.cfg                    cpp/bug_i_552.cpp
 33082 namespace_namespace.cfg          cpp/namespace_namespace.cpp
 33083 bug_i_359.cfg                    cpp/bug_i_359.cpp
+33084 empty.cfg                        cpp/bug_i_568.cpp
 
 33090 empty.cfg                        cpp/gh555.cpp

--- a/tests/input/cpp/bug_i_568.cpp
+++ b/tests/input/cpp/bug_i_568.cpp
@@ -1,0 +1,10 @@
+enum
+{
+  kEnumValue = 5,
+};
+
+struct foo
+{
+  int bar : kEnumValue;
+  int pad : 3;
+}

--- a/tests/output/cpp/33084-bug_i_568.cpp
+++ b/tests/output/cpp/33084-bug_i_568.cpp
@@ -1,0 +1,10 @@
+enum
+{
+	kEnumValue = 5,
+};
+
+struct foo
+{
+	int bar : kEnumValue;
+	int pad : 3;
+}


### PR DESCRIPTION
bitfields with enumeration constants are tokenized as labels.
Issue #568 is fixed.