### PR TITLE
Added sp_after_operator_sym_empty option

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -343,6 +343,8 @@ void register_options(void)
                   "Add or remove space between 'operator' and operator sign");
    unc_add_option("sp_after_operator_sym", UO_sp_after_operator_sym, AT_IARF,
                   "Add or remove space between the operator symbol and the open paren, as in 'operator ++('");
+   unc_add_option("sp_after_operator_sym_empty", UO_sp_after_operator_sym_empty, AT_IARF,
+                  "Add or remove space between the operator symbol and the open paren when the operator has no arguments, as in 'operator *()'");
    unc_add_option("sp_after_cast", UO_sp_after_cast, AT_IARF,
                   "Add or remove space after C/D cast, i.e. 'cast(int)a' vs 'cast(int) a' or '(int)a' vs '(int) a'");
    unc_add_option("sp_inside_paren_cast", UO_sp_inside_paren_cast, AT_IARF,

--- a/src/options.h
+++ b/src/options.h
@@ -345,6 +345,7 @@ enum uncrustify_options
 
    UO_sp_after_operator,        // space after operator when followed by a punctuator
    UO_sp_after_operator_sym,    // space after operator when followed by a punctuator
+   UO_sp_after_operator_sym_empty,// space after operator sign when the operator has no arguments
    UO_sp_else_brace,
    UO_sp_brace_else,
    UO_sp_brace_typedef,

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -844,6 +844,17 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
        (first->parent_type == CT_OPERATOR) &&
        (cpd.settings[UO_sp_after_operator_sym].a != AV_IGNORE))
    {
+      if ((cpd.settings[UO_sp_after_operator_sym_empty].a != AV_IGNORE) &&
+          (second->type == CT_FPAREN_OPEN))
+      {
+         next = chunk_get_next_ncnl(second);
+         if (next && (next->type == CT_FPAREN_CLOSE))
+         {
+            log_rule("sp_after_operator_sym_empty");
+            return(cpd.settings[UO_sp_after_operator_sym_empty].a);
+         }
+      }
+
       log_rule("sp_after_operator_sym");
       return(cpd.settings[UO_sp_after_operator_sym].a);
    }

--- a/tests/config/op_sym_empty.cfg
+++ b/tests/config/op_sym_empty.cfg
@@ -1,0 +1,4 @@
+sp_after_operator           = remove
+sp_after_operator_sym       = force
+sp_after_operator_sym_empty = remove
+sp_inside_fparens           = remove

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -313,5 +313,6 @@
 33081 bug_i_552.cfg                    cpp/bug_i_552.cpp
 33082 namespace_namespace.cfg          cpp/namespace_namespace.cpp
 33083 bug_i_359.cfg                    cpp/bug_i_359.cpp
+33084 op_sym_empty.cfg                 cpp/op_sym_empty.cpp
 
 33090 empty.cfg                        cpp/gh555.cpp

--- a/tests/input/cpp/op_sym_empty.cpp
+++ b/tests/input/cpp/op_sym_empty.cpp
@@ -1,0 +1,5 @@
+class Foo
+{
+bool operator ==( const Foo & other ) const;
+Bar & operator * ( ) const;
+};

--- a/tests/output/cpp/33084-op_sym_empty.cpp
+++ b/tests/output/cpp/33084-op_sym_empty.cpp
@@ -1,0 +1,5 @@
+class Foo
+{
+bool operator== ( const Foo & other ) const;
+Bar & operator*() const;
+};


### PR DESCRIPTION
Similar to sp_func_def_paren_empty (and others),
it controls the space between operator's symbol
and '(' when operator has no arguments - like 'operator*()'