### PR TITLE
Fixed nl_squeeze_ifdef option

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3075,7 +3075,7 @@ void newlines_squeeze_ifdef(void)
          {
             pnl = NULL;
             nnl = chunk_get_next_nl(ppr);
-            if (ppr->type == CT_PP_ENDIF)
+            if (ppr->type == CT_PP_ELSE || ppr->type == CT_PP_ENDIF)
             {
                pnl = chunk_get_prev_nl(pc);
             }
@@ -3097,7 +3097,8 @@ void newlines_squeeze_ifdef(void)
                              __func__, tmp1->orig_line, tmp2->orig_line);
                   }
                }
-               else
+
+               if (ppr->type == CT_PP_IF || ppr->type == CT_PP_ELSE)
                {
                   if (nnl->nl_count > 1)
                   {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -986,7 +986,7 @@ void register_options(void)
    unc_add_option("nl_define_macro", UO_nl_define_macro, AT_BOOL,
                   "Whether to alter newlines in '#define' macros");
    unc_add_option("nl_squeeze_ifdef", UO_nl_squeeze_ifdef, AT_BOOL,
-                  "Whether to not put blanks after '#ifxx', '#elxx', or before '#endif'. Does not affect the whole-file #ifdef.");
+                  "Whether to remove blanks after '#ifxx' and '#elxx', or before '#elxx' and '#endif'. Does not affect the whole-file #ifdef.");
    unc_add_option("nl_before_if", UO_nl_before_if, AT_IARF,
                   "Add or remove blank line before 'if'");
    unc_add_option("nl_after_if", UO_nl_after_if, AT_IARF,

--- a/src/options.h
+++ b/src/options.h
@@ -547,7 +547,7 @@ enum uncrustify_options
    UO_nl_after_vbrace_close,          // force a newline after a virtual brace close
    UO_nl_brace_struct_var,            // force a newline after a brace close
    UO_nl_fcall_brace,                 // newline between function call and open brace
-   UO_nl_squeeze_ifdef,               // no blanks after #ifxx, #elxx, or before #endif
+   UO_nl_squeeze_ifdef,               // no blanks after #ifxx, #elxx, or before #elxx and #endif
    UO_nl_enum_brace,                  // newline between enum and brace
    UO_nl_struct_brace,                // newline between struct and brace
    UO_nl_union_brace,                 // newline between union and brace

--- a/tests/config/no_squeeze_ifdef.cfg
+++ b/tests/config/no_squeeze_ifdef.cfg
@@ -1,0 +1,2 @@
+nl_before_return = true
+nl_after_return  = true

--- a/tests/config/squeeze_ifdef.cfg
+++ b/tests/config/squeeze_ifdef.cfg
@@ -1,0 +1,3 @@
+include "no_squeeze_ifdef.cfg"
+
+nl_squeeze_ifdef = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -315,3 +315,5 @@
 33083 bug_i_359.cfg                    cpp/bug_i_359.cpp
 
 33090 empty.cfg                        cpp/gh555.cpp
+33091 no_squeeze_ifdef.cfg             cpp/squeeze_ifdef.cpp
+33092 squeeze_ifdef.cfg                cpp/squeeze_ifdef.cpp

--- a/tests/input/cpp/squeeze_ifdef.cpp
+++ b/tests/input/cpp/squeeze_ifdef.cpp
@@ -1,0 +1,10 @@
+int foo()
+{
+#if defined(A)
+    return 1;
+#elif defined(B)
+    return 2;
+#else
+    return 3;
+#endif
+}

--- a/tests/output/cpp/33091-squeeze_ifdef.cpp
+++ b/tests/output/cpp/33091-squeeze_ifdef.cpp
@@ -1,0 +1,16 @@
+int foo()
+{
+#if defined(A)
+
+	return 1;
+
+#elif defined(B)
+
+	return 2;
+
+#else
+
+	return 3;
+
+#endif
+}

--- a/tests/output/cpp/33092-squeeze_ifdef.cpp
+++ b/tests/output/cpp/33092-squeeze_ifdef.cpp
@@ -1,0 +1,10 @@
+int foo()
+{
+#if defined(A)
+	return 1;
+#elif defined(B)
+	return 2;
+#else
+	return 3;
+#endif
+}


### PR DESCRIPTION
New lines were removed after '#if', '#else' and '#elif',
and removed before '#endif'. They were not removed
before '#elif' or '#else'. This change makes uncrustify
remove these as well.