### PR TITLE
Added sp_super_paren and sp_this_paren options.

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -417,6 +417,10 @@ void register_options(void)
    unc_add_option("sp_scope_paren", UO_sp_scope_paren, AT_IARF,
                   "Add or remove space between 'scope' and '(' in 'scope (something) { }' (D language)\n"
                   "If set to ignore, sp_before_sparen is used.");
+   unc_add_option("sp_super_paren", UO_sp_super_paren, AT_IARF,
+                  "Add or remove space between 'super' and '(' in 'super (something)'. Default=Remove");
+   unc_add_option("sp_this_paren", UO_sp_this_paren, AT_IARF,
+                  "Add or remove space between 'this' and '(' in 'this (something)'. Default=Remove");
    unc_add_option("sp_macro", UO_sp_macro, AT_IARF,
                   "Add or remove space between macro and value");
    unc_add_option("sp_macro_func", UO_sp_macro_func, AT_IARF,
@@ -2177,6 +2181,8 @@ void set_option_defaults(void)
    cpd.defaults[UO_sp_angle_shift].a                       = AV_ADD;
    cpd.defaults[UO_sp_word_brace].a                        = AV_ADD;
    cpd.defaults[UO_sp_word_brace_ns].a                     = AV_ADD;
+   cpd.defaults[UO_sp_super_paren].a                       = AV_REMOVE;
+   cpd.defaults[UO_sp_this_paren].a                        = AV_REMOVE;
    cpd.defaults[UO_indent_oc_msg_prioritize_first_colon].b = true;
    cpd.defaults[UO_use_indent_func_call_param].b           = true;
    cpd.defaults[UO_use_options_overriding_for_qt_macros].b = true;

--- a/src/options.h
+++ b/src/options.h
@@ -311,6 +311,9 @@ enum uncrustify_options
    UO_sp_version_paren,
    UO_sp_scope_paren,
 
+   UO_sp_super_paren,
+   UO_sp_this_paren,
+
    UO_sp_type_func,                // space between return type and 'func'
    // a minimum of 1 is forced except for '*'
    UO_sp_before_ptr_star,          // space before a '*' that is part of a type

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1022,8 +1022,8 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
 
    if ((first->type == CT_THIS) && (second->type == CT_PAREN_OPEN))
    {
-      log_rule("REMOVE");
-      return(AV_REMOVE);
+      log_rule("sp_this_paren");
+      return(cpd.settings[UO_sp_this_paren].a);
    }
 
    if ((first->type == CT_STATE) && (second->type == CT_PAREN_OPEN))
@@ -1053,8 +1053,8 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
 
    if ((first->type == CT_SUPER) && (second->type == CT_PAREN_OPEN))
    {
-      log_rule("REMOVE");
-      return(AV_REMOVE);
+      log_rule("sp_super_paren");
+      return(cpd.settings[UO_sp_super_paren].a);
    }
 
    if ((first->type == CT_FPAREN_CLOSE) && (second->type == CT_BRACE_OPEN))

--- a/tests/config/sp_this_paren.cfg
+++ b/tests/config/sp_this_paren.cfg
@@ -1,0 +1,2 @@
+sp_this_paren  = force
+sp_super_paren = force

--- a/tests/input/java/sp_this_paren.java
+++ b/tests/input/java/sp_this_paren.java
@@ -1,0 +1,9 @@
+public class JavaClass {
+    public JavaClass() {
+        this(1);
+    }
+
+    public JavaClass(int i) {
+        super(i);
+    }
+}

--- a/tests/java.test
+++ b/tests/java.test
@@ -17,5 +17,6 @@
 80051 jdbi-f.cfg              java/double_brace.java
 80060 java_synchronized_1.cfg java/synchronized.java
 80061 java_synchronized_2.cfg java/synchronized.java
+80062 sp_this_paren.cfg       java/sp_this_paren.java
 
 80100 sf567.cfg               java/sf567.java

--- a/tests/output/java/80062-sp_this_paren.java
+++ b/tests/output/java/80062-sp_this_paren.java
@@ -1,0 +1,9 @@
+public class JavaClass {
+public JavaClass() {
+	this (1);
+}
+
+public JavaClass(int i) {
+	super (i);
+}
+}


### PR DESCRIPTION
Allows to control the space before '(' in 'this(foo)' and 'super(bar)'.