### PR TITLE
Take care of &

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ New:
     Null conditional operator (?.) is now supported.
 
 New options:
+ - sp_angle_paren_empty
  - sp_skip_vbrace_tokens
  - indent_token_after_brace
  - use_options_overriding_for_qt_macros
@@ -34,7 +35,7 @@ New options:
 
 Bugfix:
  - Bug #620 is fixed
- - Issues #359, #405, #408, #412, #478, #481, #495, #503, #509, #512, #513, #514,
+ - Issues #323, #359, #405, #408, #412, #478, #481, #495, #503, #509, #512, #513, #514,
     #518, #519, #520, #521, #522, #524, #529, #530, #533, #536, #539, #542,
     #543, #544, #546 are fixed
  - Proposals #409 and #477 are implemented

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -214,9 +214,33 @@ bool chunk_is_star(chunk_t *pc)
 static_inline
 bool chunk_is_addr(chunk_t *pc)
 {
-   return((pc != NULL) &&
+   bool ret = ((pc != NULL) &&
           ((pc->type == CT_BYREF) ||
            ((pc->len() == 1) && (pc->str[0] == '&') && (pc->type != CT_OPERATOR_VAL))));
+   if (ret)
+   {
+      if (pc->flags & PCF_IN_TEMPLATE)
+      {
+         chunk_t *prev = chunk_get_prev(pc);
+         if ((prev->type == CT_COMMA) ||
+             (prev->type == CT_ANGLE_OPEN))
+         {
+            return(false);
+         }
+         else
+         {
+            return(true);
+         }
+      }
+      else
+      {
+         return(true);
+      }
+   }
+   else
+   {
+      return(false);
+   }
 }
 
 

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -214,36 +214,22 @@ bool chunk_is_star(chunk_t *pc)
 static_inline
 bool chunk_is_addr(chunk_t *pc)
 {
-   bool ret = ((pc != NULL) &&
-          ((pc->type == CT_BYREF) ||
-           ((pc->len() == 1) && (pc->str[0] == '&') && (pc->type != CT_OPERATOR_VAL))));
-   if (ret)
+   if ((pc != NULL) &&
+       ((pc->type == CT_BYREF)
+        || ((pc->len() == 1) && (pc->str[0] == '&') && (pc->type != CT_OPERATOR_VAL))))
    {
-      if (pc->flags & PCF_IN_TEMPLATE)
+      chunk_t *prev = chunk_get_prev(pc);
+
+      if ((pc->flags & PCF_IN_TEMPLATE) &&
+           ((prev != NULL) && ((prev->type == CT_COMMA) || (prev->type == CT_ANGLE_OPEN))))
       {
-         chunk_t *prev = chunk_get_prev(pc);
-         if (prev != NULL)
-         {
-            if ((prev->type == CT_COMMA) ||
-                (prev->type == CT_ANGLE_OPEN))
-            {
-               return(false);
-            }
-            else
-            {
-               return(true);
-            }
-         }
+         return(false);
       }
-      else
-      {
-         return(true);
-      }
+
+      return(true);
    }
-   else
-   {
-      return(false);
-   }
+
+   return(false);
 }
 
 

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -222,14 +222,17 @@ bool chunk_is_addr(chunk_t *pc)
       if (pc->flags & PCF_IN_TEMPLATE)
       {
          chunk_t *prev = chunk_get_prev(pc);
-         if ((prev->type == CT_COMMA) ||
-             (prev->type == CT_ANGLE_OPEN))
+         if (prev != NULL)
          {
-            return(false);
-         }
-         else
-         {
-            return(true);
+            if ((prev->type == CT_COMMA) ||
+                (prev->type == CT_ANGLE_OPEN))
+            {
+               return(false);
+            }
+            else
+            {
+               return(true);
+            }
          }
       }
       else

--- a/tests/config/bug_i_323.cfg
+++ b/tests/config/bug_i_323.cfg
@@ -1,0 +1,2 @@
+indent_with_tabs=0
+sp_after_byref=add

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -314,6 +314,7 @@
 33082 namespace_namespace.cfg          cpp/namespace_namespace.cpp
 33083 bug_i_359.cfg                    cpp/bug_i_359.cpp
 33084 op_sym_empty.cfg                 cpp/op_sym_empty.cpp
+33085 bug_i_323.cfg                    cpp/bug_i_323.cpp
 
 33090 empty.cfg                        cpp/gh555.cpp
 33091 no_squeeze_ifdef.cfg             cpp/squeeze_ifdef.cpp

--- a/tests/input/cpp/bug_i_323.cpp
+++ b/tests/input/cpp/bug_i_323.cpp
@@ -1,0 +1,4 @@
+class ATL_NO_VTABLE CProxy :
+    public ATL::CComCoClass<CProxy, &CLSID_Proxy>
+{
+}

--- a/tests/output/cpp/33085-bug_i_323.cpp
+++ b/tests/output/cpp/33085-bug_i_323.cpp
@@ -1,0 +1,4 @@
+class ATL_NO_VTABLE CProxy :
+        public ATL::CComCoClass<CProxy, &CLSID_Proxy>
+{
+}


### PR DESCRIPTION
`class ATL_NO_VTABLE CProxy :
           public ATL::CComCoClass<CProxy, &CLSID_Proxy>`

The token & must be addr and not byref
Issue #323 is fixed