### PR TITLE
Fixed comment indentation with rule 3

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2327,8 +2327,12 @@ static void indent_comment(chunk_t *pc, int col)
    if (chunk_is_comment(prev) && (nl->nl_count == 1))
    {
       int coldiff = prev->orig_col - pc->orig_col;
+      chunk_t *pp = chunk_get_prev(prev);
 
-      if ((coldiff <= 3) && (coldiff >= -3))
+      /* Here we want to align comments that are relatively close one to another
+       * but not when the previous comment is on the same line with a preproc */
+      if ((coldiff <= 3) && (coldiff >= -3) && 
+          !chunk_is_preproc(pp))
       {
          reindent_line(pc, prev->column);
          LOG_FMT(LCMTIND, "rule 3 - prev comment, coldiff = %d, now in %d\n",

--- a/tests/config/cmt_indent_pp.cfg
+++ b/tests/config/cmt_indent_pp.cfg
@@ -1,0 +1,7 @@
+indent_with_tabs = 0
+input_tab_size = 4
+indent_columns = 4
+indent_namespace = true
+indent_class = true
+indent_cmt_with_tabs = false
+align_right_cmt_mix = false

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -95,6 +95,7 @@
 30204 comment-align.cfg                cpp/comment-align.cpp
 30205 cmt_right.cfg                    cpp/cmt_right.cpp
 30206 empty.cfg                        cpp/cmt_backslash_eol.cpp
+30207 cmt_indent_pp.cfg                cpp/cmt_indent_pp.h
 
 30250 align_fcall.cfg                  cpp/align_fcall.cpp
 30251 align_fcall-2.cfg                cpp/align_fcall.cpp

--- a/tests/input/cpp/cmt_indent_pp.h
+++ b/tests/input/cpp/cmt_indent_pp.h
@@ -1,0 +1,8 @@
+class MyClass : public BaseClass
+{
+	//@{ BaseClass interface
+#if VERY_LONG_AND_COMPLICATED_DEFINE
+	void foo();
+#endif // VERY_LONG_AND_COMPLICATED_DEFINE
+	//@}
+};

--- a/tests/output/cpp/30207-cmt_indent_pp.h
+++ b/tests/output/cpp/30207-cmt_indent_pp.h
@@ -1,0 +1,8 @@
+class MyClass : public BaseClass
+{
+    //@{ BaseClass interface
+#if VERY_LONG_AND_COMPLICATED_DEFINE
+    void foo();
+#endif // VERY_LONG_AND_COMPLICATED_DEFINE
+    //@}
+};


### PR DESCRIPTION
Rule 3 didn't handled the case when the previous comment was related to a preprocessor directive.

Example failure from the diff file:

```cpp
 class MyClass : public BaseClass
 {
     //@{ BaseClass interface
 #if VERY_LONG_AND_COMPLICATED_DEFINE
     void foo();
 #endif // VERY_LONG_AND_COMPLICATED_DEFINE
-    //@}
+       //@}
 };
```
This practice is quite common so this fix is a strong want.

Interestingly enough, the option `align_right_cmt_mix` which says: 

> If aligning comments, mix with comments after '}' and #endif with less than 3 spaces before the comment

is partially related to this but was designed for alignment not indentation.