### PR TITLE
New option to warn about tabs in C# verbatim strings

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1465,6 +1465,10 @@ void register_options(void)
    unc_add_option("use_options_overriding_for_qt_macros", UO_use_options_overriding_for_qt_macros, AT_BOOL,
                   "SIGNAL/SLOT Qt macros have special formatting options. See options_for_QT.cpp for details.\n"
                   "Default=True.");
+
+   unc_begin_group(UG_warnlevels, "Warn levels - 1: error, 2: warning (default), 3: note");
+   unc_add_option("warn_level_tabs_found_in_verbatim_string_literals", UO_warn_level_tabs_found_in_verbatim_string_literals, AT_NUM,
+                  "Warning is given if doing tab-to-\\t replacement and we have found one in a C# verbatim string literal.", "", 1, 3);
 } // register_options
 
 
@@ -2183,6 +2187,7 @@ void set_option_defaults(void)
    cpd.defaults[UO_use_indent_func_call_param].b           = true;
    cpd.defaults[UO_use_options_overriding_for_qt_macros].b = true;
    cpd.defaults[UO_indent_token_after_brace].b             = true;
+   cpd.defaults[UO_warn_level_tabs_found_in_verbatim_string_literals].n = LWARN;
 
    /* copy all the default values to settings array */
    for (int count = 0; count < UO_option_count; count++)

--- a/src/options.h
+++ b/src/options.h
@@ -84,6 +84,7 @@ enum uncrustify_groups
    UG_comment,
    UG_preprocessor,
    UG_Use_Ext,
+   UG_warnlevels,
    UG_group_count
 };
 
@@ -787,6 +788,9 @@ enum uncrustify_options
                                       // with the value "true". Guy 2016-05-16
    
    UO_use_options_overriding_for_qt_macros,     // SIGNAL/SLOT Qt macros have special formatting options. See options_for_QT.cpp for details.
+
+   /* Levels to attach to warnings (log_sev_t; default = LWARN) */
+   UO_warn_level_tabs_found_in_verbatim_string_literals, // if UO_string_replace_tab_chars is set, then we should warn about cases we can't do the replacement
 
    /* This is used to get the enumeration count */
    UO_option_count

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1762,6 +1762,7 @@ static void uncrustify_end()
    memset(cpd.le_counts, 0, sizeof(cpd.le_counts));
    cpd.preproc_ncnl_count    = 0;
    cpd.ifdef_over_whole_file = 0;
+   cpd.warned_unable_string_replace_tab_chars = false;
 }
 
 

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -432,6 +432,8 @@ struct cp_data
    int                al_cnt;
    bool               al_c99_array;
 
+   bool               warned_unable_string_replace_tab_chars;
+
    /* Here are all the settings */
    op_val_t           settings[UO_option_count];
    int                max_option_name_len;

--- a/tests/c-sharp.test
+++ b/tests/c-sharp.test
@@ -56,3 +56,5 @@
 12001 bug_620.cfg              cs/bug_620.cs
 12002 empty.cfg                cs/nullable_prop.cs
 12003 ben.cfg                  cs/fncall_as_ctor_in_attr.cs
+12004 verbatim_strings.cfg     cs/verbatim_strings.cs
+

--- a/tests/config/verbatim_strings.cfg
+++ b/tests/config/verbatim_strings.cfg
@@ -1,0 +1,9 @@
+input_tab_size=4
+
+indent_columns=4
+indent_with_tabs=0
+indent_class=true
+
+string_replace_tab_chars=true
+
+warn_level_tabs_found_in_verbatim_string_literals=3

--- a/tests/config/verbatim_strings.rerun.cfg
+++ b/tests/config/verbatim_strings.rerun.cfg
@@ -1,0 +1,2 @@
+include "verbatim_strings.cfg"
+warn_level_tabs_found_in_verbatim_string_literals=1

--- a/tests/input/cs/verbatim_strings.cs
+++ b/tests/input/cs/verbatim_strings.cs
@@ -1,0 +1,7 @@
+class Class
+{
+	public string s1 = "		Foo";
+	public string s2 = @"
+		Foo
+";
+};

--- a/tests/output/cs/12004-verbatim_strings.cs
+++ b/tests/output/cs/12004-verbatim_strings.cs
@@ -1,0 +1,7 @@
+class Class
+{
+    public string s1 = "\t\tFoo";
+    public string s2 = @"
+		Foo
+";
+};


### PR DESCRIPTION
Tabs can't be replaced with `\t` because escapes don't work in C# verbatim strings. The best we can do is to give a warning and its level can be controlled using this option.

Testing framework doesn't support testing errors but the rerun configuration can validate the new behaviour of the added option. Just add a `!` after test number and the test will fail because the warning level is raised to error level.