### PR TITLE
Added nl_squeeze_ifdef_top_level

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -66,14 +66,18 @@ static bool can_increase_nl(chunk_t *nl)
 
    if (cpd.settings[UO_nl_squeeze_ifdef].b)
    {
-      if (prev && (prev->type == CT_PREPROC) &&
-          (prev->parent_type == CT_PP_ENDIF))
+      if (prev &&
+          (prev->type == CT_PREPROC) &&
+          (prev->parent_type == CT_PP_ENDIF) &&
+          (prev->level > 0 || cpd.settings[UO_nl_squeeze_ifdef_top_level].b))
       {
          LOG_FMT(LBLANKD, "%s: nl_squeeze_ifdef %d (prev) pp_lvl=%d rv=0\n", __func__, nl->orig_line, nl->pp_level);
          return(false);
       }
-      if (next && (next->type == CT_PREPROC) &&
-          (next->parent_type == CT_PP_ENDIF))
+      if (next &&
+          (next->type == CT_PREPROC) &&
+          (next->parent_type == CT_PP_ENDIF) &&
+          (next->level > 0 || cpd.settings[UO_nl_squeeze_ifdef_top_level].b))
       {
          bool rv = ifdef_over_whole_file() && (next->flags & PCF_WF_ENDIF);
          LOG_FMT(LBLANKD, "%s: nl_squeeze_ifdef %d (next) pp_lvl=%d rv=%d\n", __func__, nl->orig_line, nl->pp_level, rv);
@@ -3065,7 +3069,7 @@ void newlines_squeeze_ifdef(void)
 
    for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next_ncnl(pc))
    {
-      if ((pc->type == CT_PREPROC) && (pc->level > 0))
+      if ((pc->type == CT_PREPROC) && (pc->level > 0 || cpd.settings[UO_nl_squeeze_ifdef_top_level].b))
       {
          ppr = chunk_get_next(pc);
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -990,7 +990,9 @@ void register_options(void)
    unc_add_option("nl_define_macro", UO_nl_define_macro, AT_BOOL,
                   "Whether to alter newlines in '#define' macros");
    unc_add_option("nl_squeeze_ifdef", UO_nl_squeeze_ifdef, AT_BOOL,
-                  "Whether to remove blanks after '#ifxx' and '#elxx', or before '#elxx' and '#endif'. Does not affect the whole-file #ifdef.");
+                  "Whether to remove blanks after '#ifxx' and '#elxx', or before '#elxx' and '#endif'. Does not affect top-level #ifdefs.");
+   unc_add_option("nl_squeeze_ifdef_top_level", UO_nl_squeeze_ifdef_top_level, AT_BOOL,
+                  "Makes the nl_squeeze_ifdef option affect the top-level #ifdefs as well.");
    unc_add_option("nl_before_if", UO_nl_before_if, AT_IARF,
                   "Add or remove blank line before 'if'");
    unc_add_option("nl_after_if", UO_nl_after_if, AT_IARF,

--- a/src/options.h
+++ b/src/options.h
@@ -551,6 +551,7 @@ enum uncrustify_options
    UO_nl_brace_struct_var,            // force a newline after a brace close
    UO_nl_fcall_brace,                 // newline between function call and open brace
    UO_nl_squeeze_ifdef,               // no blanks after #ifxx, #elxx, or before #elxx and #endif
+   UO_nl_squeeze_ifdef_top_level,     // when set, nl_squeeze_ifdef will be applied to top-level #ifdefs as well
    UO_nl_enum_brace,                  // newline between enum and brace
    UO_nl_struct_brace,                // newline between struct and brace
    UO_nl_union_brace,                 // newline between union and brace
@@ -638,11 +639,11 @@ enum uncrustify_options
    UO_nl_create_while_one_liner,      // Change simple unbraced while statements into a one-liner
                                       // 'while (i<5)\n foo(i++);' => 'while (i<5) foo(i++);'
                                       // Change that back:
-   UO_nl_split_if_one_liner,          // Change a one-liner for statement into simple unbraced for 
+   UO_nl_split_if_one_liner,          // Change a one-liner for statement into simple unbraced for
                                       // 'if(b) i++;' => 'if(b)\n i++;'
-   UO_nl_split_for_one_liner,         // Change a one-liner while statement into simple unbraced while 
+   UO_nl_split_for_one_liner,         // Change a one-liner while statement into simple unbraced while
                                       // 'for (i=0;i<5;i++) foo(i);' => 'for (i=0;i<5;i++)\n foo(i);'
-   UO_nl_split_while_one_liner,       // Change a one-liner if statement into simple unbraced if 
+   UO_nl_split_while_one_liner,       // Change a one-liner if statement into simple unbraced if
                                       // 'while (i<5) foo(i++);' => 'while (i<5)\n foo(i++);'
 
    UO_nl_oc_msg_args,                 // Whether to put each OC message parameter on a separate line
@@ -787,7 +788,7 @@ enum uncrustify_options
                                       //   at the function call (if present)
                                       // To prevent the double use of the option value, use this option
                                       // with the value "true". Guy 2016-05-16
-   
+
    UO_use_options_overriding_for_qt_macros,     // SIGNAL/SLOT Qt macros have special formatting options. See options_for_QT.cpp for details.
 
    /* Levels to attach to warnings (log_sev_t; default = LWARN) */

--- a/tests/config/squeeze_ifdef_top.cfg
+++ b/tests/config/squeeze_ifdef_top.cfg
@@ -1,0 +1,3 @@
+include "squeeze_ifdef.cfg"
+
+nl_squeeze_ifdef_top_level = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -323,3 +323,4 @@
 33093 sp_angle_paren.cfg               cpp/sp_angle_paren.cpp
 33094 sp_angle_paren_empty.cfg         cpp/sp_angle_paren.cpp
 33095 bug_i_322.cfg                    cpp/bug_i_322.cpp
+33096 squeeze_ifdef_top.cfg            cpp/squeeze_ifdef.cpp

--- a/tests/output/c/00164-fcn_indent_func_def_col1.c
+++ b/tests/output/c/00164-fcn_indent_func_def_col1.c
@@ -5,6 +5,7 @@
 
 #if A
    void func1_1(void);
+
 #endif
 
 #if A

--- a/tests/output/c/00617-pp-if-indent.c
+++ b/tests/output/c/00617-pp-if-indent.c
@@ -105,6 +105,7 @@ void COMINL_vidInit(void)
       }
    #endif /* COMINL_coTX_MESSAGE_VAR == COMINL_coENABLE */
 }
+
 #endif
 
 

--- a/tests/output/cpp/30011-misc.cpp
+++ b/tests/output/cpp/30011-misc.cpp
@@ -53,4 +53,5 @@ bool foo(char c)
 #ifndef abc
 
 #define abc    123 /* some comment */
+
 #endif /* another comment

--- a/tests/output/cpp/33091-squeeze_ifdef.cpp
+++ b/tests/output/cpp/33091-squeeze_ifdef.cpp
@@ -1,16 +1,31 @@
+
+#if defined(A)
+
+extern int a;
+
+#elif defined(B)
+
+extern int b;
+
+#else
+
+extern int c;
+
+#endif
+
 int foo()
 {
 #if defined(A)
 
-	return 1;
+	return a;
 
 #elif defined(B)
 
-	return 2;
+	return b;
 
 #else
 
-	return 3;
+	return c;
 
 #endif
 }

--- a/tests/output/cpp/33092-squeeze_ifdef.cpp
+++ b/tests/output/cpp/33092-squeeze_ifdef.cpp
@@ -1,10 +1,25 @@
+
+#if defined(A)
+
+extern int a;
+
+#elif defined(B)
+
+extern int b;
+
+#else
+
+extern int c;
+
+#endif
+
 int foo()
 {
 #if defined(A)
-	return 1;
+	return a;
 #elif defined(B)
-	return 2;
+	return b;
 #else
-	return 3;
+	return c;
 #endif
 }

--- a/tests/output/cpp/33096-squeeze_ifdef.cpp
+++ b/tests/output/cpp/33096-squeeze_ifdef.cpp
@@ -1,25 +1,19 @@
 
 #if defined(A)
-
 extern int a;
-
 #elif defined(B)
-
 extern int b;
-
 #else
-
 extern int c;
-
 #endif
 
 int foo()
 {
 #if defined(A)
-    return a;
+	return a;
 #elif defined(B)
-    return b;
+	return b;
 #else
-    return c;
+	return c;
 #endif
 }


### PR DESCRIPTION
nl_squeeze_ifdef is not supposed to affect ifdefs at the highest (file) level.
nl_squeeze_ifdef_top_level makes it squeeze those as well.

Also fixed nl_squeeze_ifdef which was still squeezing some top-level #endifs,
and clarified the comment (it's not about "whole file" ifdefs, but rather "top level")