### PR TITLE
nl_enum_own_lines

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -3,1416 +3,1494 @@
 # General options
 #
 
-newlines                                  { Auto, LF, CR, CRLF }
-  The type of line endings
+newlines                                          { Auto, LF, CR, CRLF }
+  The type of line endings. Default=Auto
 
-input_tab_size                            Number
-  The original size of tabs in the input
+input_tab_size                                    Number
+  The original size of tabs in the input. Default=8
 
-output_tab_size                           Number
-  The size of tabs in the output (only used if align_with_tabs=true)
+output_tab_size                                   Number
+  The size of tabs in the output (only used if align_with_tabs=true). Default=8
 
-string_escape_char                        Number
+string_escape_char                                Number
   The ASCII value of the string escape char, usually 92 (\) or 94 (^). (Pawn)
 
-string_escape_char2                       Number
+string_escape_char2                               Number
   Alternate string escape char for Pawn. Only works right before the quote char.
 
-string_replace_tab_chars                  { False, True }
+string_replace_tab_chars                          { False, True }
   Replace tab characters found in string literals with the escape sequence \t instead.
 
-tok_split_gte                             { False, True }
+tok_split_gte                                     { False, True }
   Allow interpreting '>=' and '>>=' as part of a template in 'void f(list<list<B>>=val);'.
-  If true (default), 'assert(x<0 && y>=3)' will be broken.
+  If true, 'assert(x<0 && y>=3)' will be broken. Default=False
   Improvements to template detection may make this option obsolete.
 
-disable_processing_cmt                    String
+disable_processing_cmt                            String
   Override the default ' *INDENT-OFF*' in comments for disabling processing of part of the file.
 
-enable_processing_cmt                     String
+enable_processing_cmt                             String
   Override the default ' *INDENT-ON*' in comments for enabling processing of part of the file.
 
-enable_digraphs                           { False, True }
-  Enable parsing of digraphs. Default=false
+enable_digraphs                                   { False, True }
+  Enable parsing of digraphs. Default=False
 
-utf8_bom                                  { Ignore, Add, Remove, Force }
+utf8_bom                                          { Ignore, Add, Remove, Force }
   Control what to do with the UTF-8 BOM (recommend 'remove')
 
-utf8_byte                                 { False, True }
+utf8_byte                                         { False, True }
   If the file contains bytes with values between 128 and 255, but is not UTF-8, then output as UTF-8
 
-utf8_force                                { False, True }
+utf8_force                                        { False, True }
   Force the output encoding to UTF-8
 
 #
 # Indenting
 #
 
-indent_columns                            Number
+indent_columns                                    Number
   The number of columns to indent per level.
-  Usually 2, 3, 4, or 8.
+  Usually 2, 3, 4, or 8. Default=8
 
-indent_continue                           Number
+indent_continue                                   Number
   The continuation indent. If non-zero, this overrides the indent of '(' and '=' continuation indents.
   For FreeBSD, this is set to 4. Negative value is absolute and not increased for each ( level
 
-indent_with_tabs                          Number
+indent_with_tabs                                  Number
   How to use tabs when indenting code
   0=spaces only
-  1=indent with tabs to brace level, align with spaces
+  1=indent with tabs to brace level, align with spaces (default)
   2=indent and align with tabs, using spaces when not on a tabstop
 
-indent_cmt_with_tabs                      { False, True }
+indent_cmt_with_tabs                              { False, True }
   Comments that are not a brace level are indented with tabs on a tabstop.
   Requires indent_with_tabs=2. If false, will use spaces.
 
-indent_align_string                       { False, True }
+indent_align_string                               { False, True }
   Whether to indent strings broken by '\' so that they line up
 
-indent_xml_string                         Number
+indent_xml_string                                 Number
   The number of spaces to indent multi-line XML strings.
   Requires indent_align_string=True
 
-indent_brace                              Number
+indent_brace                                      Number
   Spaces to indent '{' from level
 
-indent_braces                             { False, True }
+indent_braces                                     { False, True }
   Whether braces are indented to the body level
 
-indent_braces_no_func                     { False, True }
+indent_braces_no_func                             { False, True }
   Disabled indenting function braces if indent_braces is true
 
-indent_braces_no_class                    { False, True }
+indent_braces_no_class                            { False, True }
   Disabled indenting class braces if indent_braces is true
 
-indent_braces_no_struct                   { False, True }
+indent_braces_no_struct                           { False, True }
   Disabled indenting struct braces if indent_braces is true
 
-indent_brace_parent                       { False, True }
+indent_brace_parent                               { False, True }
   Indent based on the size of the brace parent, i.e. 'if' => 3 spaces, 'for' => 4 spaces, etc.
 
-indent_paren_open_brace                   { False, True }
+indent_paren_open_brace                           { False, True }
   Indent based on the paren open instead of the brace open in '({\n', default is to indent by brace.
 
-indent_namespace                          { False, True }
+indent_cs_delegate_brace                          { False, True }
+  indent a C# delegate by another level, default is to not indent by another level.
+
+indent_namespace                                  { False, True }
   Whether the 'namespace' body is indented
 
-indent_namespace_single_indent            { False, True }
+indent_namespace_single_indent                    { False, True }
   Only indent one namespace and no sub-namespaces.
   Requires indent_namespace=true.
 
-indent_namespace_level                    Number
+indent_namespace_level                            Number
   The number of spaces to indent a namespace block
 
-indent_namespace_limit                    Number
+indent_namespace_limit                            Number
   If the body of the namespace is longer than this number, it won't be indented.
   Requires indent_namespace=true. Default=0 (no limit)
 
-indent_extern                             { False, True }
+indent_extern                                     { False, True }
   Whether the 'extern "C"' body is indented
 
-indent_class                              { False, True }
+indent_class                                      { False, True }
   Whether the 'class' body is indented
 
-indent_class_colon                        { False, True }
+indent_class_colon                                { False, True }
   Whether to indent the stuff after a leading base class colon
 
-indent_class_on_colon                     { False, True }
+indent_class_on_colon                             { False, True }
   Indent based on a class colon instead of the stuff after the colon.
-  Requires indent_class_colon=true. Default=false
+  Requires indent_class_colon=true. Default=False
 
-indent_constr_colon                       { False, True }
+indent_constr_colon                               { False, True }
   Whether to indent the stuff after a leading class initializer colon
 
-indent_ctor_init_leading                  Number
-  Virtual indent from the ':' for member initializers. Default is 2
+indent_ctor_init_leading                          Number
+  Virtual indent from the ':' for member initializers. Default=2
 
-indent_ctor_init                          Number
+indent_ctor_init                                  Number
   Additional indenting for constructor initializer list
 
-indent_else_if                            { False, True }
+indent_else_if                                    { False, True }
   False=treat 'else\nif' as 'else if' for indenting purposes
   True=indent the 'if' one level
-  
 
-indent_var_def_blk                        Number
+indent_var_def_blk                                Number
   Amount to indent variable declarations after a open brace. neg=relative, pos=absolute
 
-indent_var_def_cont                       { False, True }
+indent_var_def_cont                               { False, True }
   Indent continued variable declarations instead of aligning.
 
-indent_shift                              { False, True }
+indent_shift                                      { False, True }
   Indent continued shift expressions ('<<' and '>>') instead of aligning.
   Turn align_left_shift off when enabling this.
 
-indent_func_def_force_col1                { False, True }
+indent_func_def_force_col1                        { False, True }
   True:  force indentation of function definition to start in column 1
   False: use the default behavior
 
-indent_func_call_param                    { False, True }
+indent_func_call_param                            { False, True }
   True:  indent continued function call parameters one indent level
   False: align parameters under the open paren
 
-indent_func_def_param                     { False, True }
+indent_func_def_param                             { False, True }
   Same as indent_func_call_param, but for function defs
 
-indent_func_proto_param                   { False, True }
+indent_func_proto_param                           { False, True }
   Same as indent_func_call_param, but for function protos
 
-indent_func_class_param                   { False, True }
+indent_func_class_param                           { False, True }
   Same as indent_func_call_param, but for class declarations
 
-indent_func_ctor_var_param                { False, True }
+indent_func_ctor_var_param                        { False, True }
   Same as indent_func_call_param, but for class variable constructors
 
-indent_template_param                     { False, True }
+indent_template_param                             { False, True }
   Same as indent_func_call_param, but for templates
 
-indent_func_param_double                  { False, True }
+indent_func_param_double                          { False, True }
   Double the indent for indent_func_xxx_param options
 
-indent_func_const                         Number
+indent_func_const                                 Number
   Indentation column for standalone 'const' function decl/proto qualifier
 
-indent_func_throw                         Number
+indent_func_throw                                 Number
   Indentation column for standalone 'throw' function decl/proto qualifier
 
-indent_member                             Number
+indent_member                                     Number
   The number of spaces to indent a continued '->' or '.'
   Usually set to 0, 1, or indent_columns.
 
-indent_sing_line_comments                 Number
+indent_sing_line_comments                         Number
   Spaces to indent single line ('//') comments on lines before code
 
-indent_relative_single_line_comments      { False, True }
+indent_relative_single_line_comments              { False, True }
   If set, will indent trailing single line ('//') comments relative
   to the code instead of trying to keep the same absolute column
 
-indent_switch_case                        Number
+indent_switch_case                                Number
   Spaces to indent 'case' from 'switch'
   Usually 0 or indent_columns.
 
-indent_case_shift                         Number
+indent_case_shift                                 Number
   Spaces to shift the 'case' line, without affecting any other lines
   Usually 0.
 
-indent_case_brace                         Number
+indent_case_brace                                 Number
   Spaces to indent '{' from 'case'.
   By default, the brace will appear under the 'c' in case.
   Usually set to 0 or indent_columns.
 
-indent_col1_comment                       { False, True }
+indent_col1_comment                               { False, True }
   Whether to indent comments found in first column
 
-indent_label                              Number
+indent_label                                      Number
   How to indent goto labels
     >0: absolute column where 1 is the leftmost column
    <=0: subtract from brace indent
+  Default=1
 
-indent_access_spec                        Number
-  Same as indent_label, but for access specifiers that are followed by a colon
+indent_access_spec                                Number
+  Same as indent_label, but for access specifiers that are followed by a colon. Default=1
 
-indent_access_spec_body                   { False, True }
+indent_access_spec_body                           { False, True }
   Indent the code after an access specifier by one level.
   If set, this option forces 'indent_access_spec=0'
 
-indent_paren_nl                           { False, True }
+indent_paren_nl                                   { False, True }
   If an open paren is followed by a newline, indent the next line so that it lines up after the open paren (not recommended)
 
-indent_paren_close                        Number
+indent_paren_close                                Number
   Controls the indent of a close paren after a newline.
   0: Indent to body level
   1: Align under the open paren
   2: Indent to the brace level
 
-indent_comma_paren                        { False, True }
+indent_comma_paren                                { False, True }
   Controls the indent of a comma when inside a paren.If TRUE, aligns under the open paren
 
-indent_bool_paren                         { False, True }
+indent_bool_paren                                 { False, True }
   Controls the indent of a BOOL operator when inside a paren.If TRUE, aligns under the open paren
 
-indent_first_bool_expr                    { False, True }
+indent_first_bool_expr                            { False, True }
   If 'indent_bool_paren' is true, controls the indent of the first expression. If TRUE, aligns the first expression to the following ones
 
-indent_square_nl                          { False, True }
+indent_square_nl                                  { False, True }
   If an open square is followed by a newline, indent the next line so that it lines up after the open square (not recommended)
 
-indent_preserve_sql                       { False, True }
+indent_preserve_sql                               { False, True }
   Don't change the relative indent of ESQL/C 'EXEC SQL' bodies
 
-indent_align_assign                       { False, True }
+indent_align_assign                               { False, True }
   Align continued statements at the '='. Default=True
   If FALSE or the '=' is followed by a newline, the next line is indent one tab.
 
-indent_oc_block                           { False, True }
+indent_oc_block                                   { False, True }
   Indent OC blocks at brace level instead of usual rules.
 
-indent_oc_block_msg                       Number
+indent_oc_block_msg                               Number
   Indent OC blocks in a message relative to the parameter name.
   0=use indent_oc_block rules, 1+=spaces to indent
 
-indent_oc_msg_colon                       Number
+indent_oc_msg_colon                               Number
   Minimum indent for subsequent parameters
 
-indent_oc_msg_prioritize_first_colon      { False, True }
+indent_oc_msg_prioritize_first_colon              { False, True }
   If true, prioritize aligning with initial colon (and stripping spaces from lines, if necessary).
-  Default is true.
+  Default=True.
 
-indent_oc_block_msg_xcode_style           { False, True }
+indent_oc_block_msg_xcode_style                   { False, True }
   If indent_oc_block_msg and this option are on, blocks will be indented the way that Xcode does by default (from keyword if the parameter is on its own line; otherwise, from the previous indentation level).
 
-indent_oc_block_msg_from_keyword          { False, True }
+indent_oc_block_msg_from_keyword                  { False, True }
   If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg keyword.
 
-indent_oc_block_msg_from_colon            { False, True }
+indent_oc_block_msg_from_colon                    { False, True }
   If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg colon.
 
-indent_oc_block_msg_from_caret            { False, True }
+indent_oc_block_msg_from_caret                    { False, True }
   If indent_oc_block_msg and this option are on, blocks will be indented from where the block caret is.
 
-indent_oc_block_msg_from_brace            { False, True }
+indent_oc_block_msg_from_brace                    { False, True }
   If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is.
 
-indent_min_vbrace_open                    Number
+indent_min_vbrace_open                            Number
   When identing after virtual brace open and newline add further spaces to reach this min. indent.
 
-indent_vbrace_open_on_tabstop             { False, True }
+indent_vbrace_open_on_tabstop                     { False, True }
   TRUE: When identing after virtual brace open and newline add further spaces after regular indent to reach next tabstop.
+
+indent_token_after_brace                          { False, True }
+  If true, a brace followed by another token (not a newline) will indent all contained lines to match the token.Default=True.
 
 #
 # Spacing options
 #
 
-sp_arith                                  { Ignore, Add, Remove, Force }
+sp_arith                                          { Ignore, Add, Remove, Force }
   Add or remove space around arithmetic operator '+', '-', '/', '*', etc
   also '>>>' '<<' '>>' '%' '|'
 
-sp_assign                                 { Ignore, Add, Remove, Force }
+sp_assign                                         { Ignore, Add, Remove, Force }
   Add or remove space around assignment operator '=', '+=', etc
 
-sp_cpp_lambda_assign                      { Ignore, Add, Remove, Force }
+sp_cpp_lambda_assign                              { Ignore, Add, Remove, Force }
   Add or remove space around '=' in C++11 lambda capture specifications. Overrides sp_assign
 
-sp_cpp_lambda_paren                       { Ignore, Add, Remove, Force }
+sp_cpp_lambda_paren                               { Ignore, Add, Remove, Force }
   Add or remove space after the capture specification in C++11 lambda.
 
-sp_assign_default                         { Ignore, Add, Remove, Force }
+sp_assign_default                                 { Ignore, Add, Remove, Force }
   Add or remove space around assignment operator '=' in a prototype
 
-sp_before_assign                          { Ignore, Add, Remove, Force }
+sp_before_assign                                  { Ignore, Add, Remove, Force }
   Add or remove space before assignment operator '=', '+=', etc. Overrides sp_assign.
 
-sp_after_assign                           { Ignore, Add, Remove, Force }
+sp_after_assign                                   { Ignore, Add, Remove, Force }
   Add or remove space after assignment operator '=', '+=', etc. Overrides sp_assign.
 
-sp_enum_paren                             { Ignore, Add, Remove, Force }
+sp_enum_paren                                     { Ignore, Add, Remove, Force }
   Add or remove space in 'NS_ENUM ('
 
-sp_enum_assign                            { Ignore, Add, Remove, Force }
+sp_enum_assign                                    { Ignore, Add, Remove, Force }
   Add or remove space around assignment '=' in enum
 
-sp_enum_before_assign                     { Ignore, Add, Remove, Force }
+sp_enum_before_assign                             { Ignore, Add, Remove, Force }
   Add or remove space before assignment '=' in enum. Overrides sp_enum_assign.
 
-sp_enum_after_assign                      { Ignore, Add, Remove, Force }
+sp_enum_after_assign                              { Ignore, Add, Remove, Force }
   Add or remove space after assignment '=' in enum. Overrides sp_enum_assign.
 
-sp_pp_concat                              { Ignore, Add, Remove, Force }
+sp_pp_concat                                      { Ignore, Add, Remove, Force }
   Add or remove space around preprocessor '##' concatenation operator. Default=Add
 
-sp_pp_stringify                           { Ignore, Add, Remove, Force }
+sp_pp_stringify                                   { Ignore, Add, Remove, Force }
   Add or remove space after preprocessor '#' stringify operator. Also affects the '#@' charizing operator.
 
-sp_before_pp_stringify                    { Ignore, Add, Remove, Force }
+sp_before_pp_stringify                            { Ignore, Add, Remove, Force }
   Add or remove space before preprocessor '#' stringify operator as in '#define x(y) L#y'.
 
-sp_bool                                   { Ignore, Add, Remove, Force }
+sp_bool                                           { Ignore, Add, Remove, Force }
   Add or remove space around boolean operators '&&' and '||'
 
-sp_compare                                { Ignore, Add, Remove, Force }
+sp_compare                                        { Ignore, Add, Remove, Force }
   Add or remove space around compare operator '<', '>', '==', etc
 
-sp_inside_paren                           { Ignore, Add, Remove, Force }
+sp_inside_paren                                   { Ignore, Add, Remove, Force }
   Add or remove space inside '(' and ')'
 
-sp_paren_paren                            { Ignore, Add, Remove, Force }
+sp_paren_paren                                    { Ignore, Add, Remove, Force }
   Add or remove space between nested parens: '((' vs ') )'
 
-sp_cparen_oparen                          { Ignore, Add, Remove, Force }
+sp_cparen_oparen                                  { Ignore, Add, Remove, Force }
   Add or remove space between back-to-back parens: ')(' vs ') ('
 
-sp_balance_nested_parens                  { False, True }
+sp_balance_nested_parens                          { False, True }
   Whether to balance spaces inside nested parens
 
-sp_paren_brace                            { Ignore, Add, Remove, Force }
+sp_paren_brace                                    { Ignore, Add, Remove, Force }
   Add or remove space between ')' and '{'
 
-sp_before_ptr_star                        { Ignore, Add, Remove, Force }
+sp_before_ptr_star                                { Ignore, Add, Remove, Force }
   Add or remove space before pointer star '*'
 
-sp_before_unnamed_ptr_star                { Ignore, Add, Remove, Force }
+sp_before_unnamed_ptr_star                        { Ignore, Add, Remove, Force }
   Add or remove space before pointer star '*' that isn't followed by a variable name
   If set to 'ignore', sp_before_ptr_star is used instead.
 
-sp_between_ptr_star                       { Ignore, Add, Remove, Force }
+sp_between_ptr_star                               { Ignore, Add, Remove, Force }
   Add or remove space between pointer stars '*'
 
-sp_after_ptr_star                         { Ignore, Add, Remove, Force }
+sp_after_ptr_star                                 { Ignore, Add, Remove, Force }
   Add or remove space after pointer star '*', if followed by a word.
 
-sp_after_ptr_star_qualifier               { Ignore, Add, Remove, Force }
+sp_after_ptr_star_qualifier                       { Ignore, Add, Remove, Force }
   Add or remove space after pointer star '*', if followed by a qualifier.
 
-sp_after_ptr_star_func                    { Ignore, Add, Remove, Force }
+sp_after_ptr_star_func                            { Ignore, Add, Remove, Force }
   Add or remove space after a pointer star '*', if followed by a func proto/def.
 
-sp_ptr_star_paren                         { Ignore, Add, Remove, Force }
+sp_ptr_star_paren                                 { Ignore, Add, Remove, Force }
   Add or remove space after a pointer star '*', if followed by an open paren (function types).
 
-sp_before_ptr_star_func                   { Ignore, Add, Remove, Force }
+sp_before_ptr_star_func                           { Ignore, Add, Remove, Force }
   Add or remove space before a pointer star '*', if followed by a func proto/def.
 
-sp_before_byref                           { Ignore, Add, Remove, Force }
+sp_before_byref                                   { Ignore, Add, Remove, Force }
   Add or remove space before a reference sign '&'
 
-sp_before_unnamed_byref                   { Ignore, Add, Remove, Force }
+sp_before_unnamed_byref                           { Ignore, Add, Remove, Force }
   Add or remove space before a reference sign '&' that isn't followed by a variable name
   If set to 'ignore', sp_before_byref is used instead.
 
-sp_after_byref                            { Ignore, Add, Remove, Force }
+sp_after_byref                                    { Ignore, Add, Remove, Force }
   Add or remove space after reference sign '&', if followed by a word.
 
-sp_after_byref_func                       { Ignore, Add, Remove, Force }
+sp_after_byref_func                               { Ignore, Add, Remove, Force }
   Add or remove space after a reference sign '&', if followed by a func proto/def.
 
-sp_before_byref_func                      { Ignore, Add, Remove, Force }
+sp_before_byref_func                              { Ignore, Add, Remove, Force }
   Add or remove space before a reference sign '&', if followed by a func proto/def.
 
-sp_after_type                             { Ignore, Add, Remove, Force }
+sp_after_type                                     { Ignore, Add, Remove, Force }
   Add or remove space between type and word. Default=Force
 
-sp_before_template_paren                  { Ignore, Add, Remove, Force }
+sp_before_template_paren                          { Ignore, Add, Remove, Force }
   Add or remove space before the paren in the D constructs 'template Foo(' and 'class Foo('.
 
-sp_template_angle                         { Ignore, Add, Remove, Force }
+sp_template_angle                                 { Ignore, Add, Remove, Force }
   Add or remove space in 'template <' vs 'template<'.
   If set to ignore, sp_before_angle is used.
 
-sp_before_angle                           { Ignore, Add, Remove, Force }
+sp_before_angle                                   { Ignore, Add, Remove, Force }
   Add or remove space before '<>'
 
-sp_inside_angle                           { Ignore, Add, Remove, Force }
+sp_inside_angle                                   { Ignore, Add, Remove, Force }
   Add or remove space inside '<' and '>'
 
-sp_after_angle                            { Ignore, Add, Remove, Force }
+sp_after_angle                                    { Ignore, Add, Remove, Force }
   Add or remove space after '<>'
 
-sp_angle_paren                            { Ignore, Add, Remove, Force }
-  Add or remove space between '<>' and '(' as found in 'new List<byte>();'
+sp_angle_paren                                    { Ignore, Add, Remove, Force }
+  Add or remove space between '<>' and '(' as found in 'new List<byte>(foo);'
 
-sp_angle_word                             { Ignore, Add, Remove, Force }
+sp_angle_paren_empty                              { Ignore, Add, Remove, Force }
+  Add or remove space between '<>' and '()' as found in 'new List<byte>();'
+
+sp_angle_word                                     { Ignore, Add, Remove, Force }
   Add or remove space between '<>' and a word as in 'List<byte> m;' or 'template <typename T> static ...'
 
-sp_angle_shift                            { Ignore, Add, Remove, Force }
+sp_angle_shift                                    { Ignore, Add, Remove, Force }
   Add or remove space between '>' and '>' in '>>' (template stuff C++/C# only). Default=Add
 
-sp_permit_cpp11_shift                     { False, True }
+sp_permit_cpp11_shift                             { False, True }
   Permit removal of the space between '>>' in 'foo<bar<int> >' (C++11 only). Default=False
   sp_angle_shift cannot remove the space without this option.
 
-sp_before_sparen                          { Ignore, Add, Remove, Force }
+sp_before_sparen                                  { Ignore, Add, Remove, Force }
   Add or remove space before '(' of 'if', 'for', 'switch', 'while', etc.
 
-sp_inside_sparen                          { Ignore, Add, Remove, Force }
+sp_inside_sparen                                  { Ignore, Add, Remove, Force }
   Add or remove space inside if-condition '(' and ')'
 
-sp_inside_sparen_close                    { Ignore, Add, Remove, Force }
+sp_inside_sparen_close                            { Ignore, Add, Remove, Force }
   Add or remove space before if-condition ')'. Overrides sp_inside_sparen.
 
-sp_inside_sparen_open                     { Ignore, Add, Remove, Force }
+sp_inside_sparen_open                             { Ignore, Add, Remove, Force }
   Add or remove space after if-condition '('. Overrides sp_inside_sparen.
 
-sp_after_sparen                           { Ignore, Add, Remove, Force }
+sp_after_sparen                                   { Ignore, Add, Remove, Force }
   Add or remove space after ')' of 'if', 'for', 'switch', and 'while', etc.
 
-sp_sparen_brace                           { Ignore, Add, Remove, Force }
+sp_sparen_brace                                   { Ignore, Add, Remove, Force }
   Add or remove space between ')' and '{' of 'if', 'for', 'switch', and 'while', etc.
 
-sp_invariant_paren                        { Ignore, Add, Remove, Force }
+sp_invariant_paren                                { Ignore, Add, Remove, Force }
   Add or remove space between 'invariant' and '(' in the D language.
 
-sp_after_invariant_paren                  { Ignore, Add, Remove, Force }
+sp_after_invariant_paren                          { Ignore, Add, Remove, Force }
   Add or remove space after the ')' in 'invariant (C) c' in the D language.
 
-sp_special_semi                           { Ignore, Add, Remove, Force }
+sp_special_semi                                   { Ignore, Add, Remove, Force }
   Add or remove space before empty statement ';' on 'if', 'for' and 'while'
 
-sp_before_semi                            { Ignore, Add, Remove, Force }
+sp_before_semi                                    { Ignore, Add, Remove, Force }
   Add or remove space before ';'. Default=Remove
 
-sp_before_semi_for                        { Ignore, Add, Remove, Force }
+sp_before_semi_for                                { Ignore, Add, Remove, Force }
   Add or remove space before ';' in non-empty 'for' statements
 
-sp_before_semi_for_empty                  { Ignore, Add, Remove, Force }
+sp_before_semi_for_empty                          { Ignore, Add, Remove, Force }
   Add or remove space before a semicolon of an empty part of a for statement.
 
-sp_after_semi                             { Ignore, Add, Remove, Force }
+sp_after_semi                                     { Ignore, Add, Remove, Force }
   Add or remove space after ';', except when followed by a comment. Default=Add
 
-sp_after_semi_for                         { Ignore, Add, Remove, Force }
+sp_after_semi_for                                 { Ignore, Add, Remove, Force }
   Add or remove space after ';' in non-empty 'for' statements. Default=Force
 
-sp_after_semi_for_empty                   { Ignore, Add, Remove, Force }
+sp_after_semi_for_empty                           { Ignore, Add, Remove, Force }
   Add or remove space after the final semicolon of an empty part of a for statement: for ( ; ; <here> ).
 
-sp_before_square                          { Ignore, Add, Remove, Force }
+sp_before_square                                  { Ignore, Add, Remove, Force }
   Add or remove space before '[' (except '[]')
 
-sp_before_squares                         { Ignore, Add, Remove, Force }
+sp_before_squares                                 { Ignore, Add, Remove, Force }
   Add or remove space before '[]'
 
-sp_inside_square                          { Ignore, Add, Remove, Force }
+sp_inside_square                                  { Ignore, Add, Remove, Force }
   Add or remove space inside a non-empty '[' and ']'
 
-sp_after_comma                            { Ignore, Add, Remove, Force }
+sp_after_comma                                    { Ignore, Add, Remove, Force }
   Add or remove space after ','
 
-sp_before_comma                           { Ignore, Add, Remove, Force }
-  Add or remove space before ','
+sp_before_comma                                   { Ignore, Add, Remove, Force }
+  Add or remove space before ','. Default=Remove
 
-sp_after_mdatype_commas                   { Ignore, Add, Remove, Force }
+sp_after_mdatype_commas                           { Ignore, Add, Remove, Force }
   Add or remove space between ',' and ']' in multidimensional array type 'int[,,]'
 
-sp_before_mdatype_commas                  { Ignore, Add, Remove, Force }
+sp_before_mdatype_commas                          { Ignore, Add, Remove, Force }
   Add or remove space between '[' and ',' in multidimensional array type 'int[,,]'
 
-sp_between_mdatype_commas                 { Ignore, Add, Remove, Force }
+sp_between_mdatype_commas                         { Ignore, Add, Remove, Force }
   Add or remove space between ',' in multidimensional array type 'int[,,]'
 
-sp_paren_comma                            { Ignore, Add, Remove, Force }
-  Add or remove space between an open paren and comma: '(,' vs '( ,'
-  
+sp_paren_comma                                    { Ignore, Add, Remove, Force }
+  Add or remove space between an open paren and comma: '(,' vs '( ,'. Default=Force
 
-sp_before_ellipsis                        { Ignore, Add, Remove, Force }
+sp_before_ellipsis                                { Ignore, Add, Remove, Force }
   Add or remove space before the variadic '...' when preceded by a non-punctuator
 
-sp_after_class_colon                      { Ignore, Add, Remove, Force }
+sp_after_class_colon                              { Ignore, Add, Remove, Force }
   Add or remove space after class ':'
 
-sp_before_class_colon                     { Ignore, Add, Remove, Force }
+sp_before_class_colon                             { Ignore, Add, Remove, Force }
   Add or remove space before class ':'
 
-sp_after_constr_colon                     { Ignore, Add, Remove, Force }
+sp_after_constr_colon                             { Ignore, Add, Remove, Force }
   Add or remove space after class constructor ':'
 
-sp_before_constr_colon                    { Ignore, Add, Remove, Force }
+sp_before_constr_colon                            { Ignore, Add, Remove, Force }
   Add or remove space before class constructor ':'
 
-sp_before_case_colon                      { Ignore, Add, Remove, Force }
+sp_before_case_colon                              { Ignore, Add, Remove, Force }
   Add or remove space before case ':'. Default=Remove
 
-sp_after_operator                         { Ignore, Add, Remove, Force }
+sp_after_operator                                 { Ignore, Add, Remove, Force }
   Add or remove space between 'operator' and operator sign
 
-sp_after_operator_sym                     { Ignore, Add, Remove, Force }
+sp_after_operator_sym                             { Ignore, Add, Remove, Force }
   Add or remove space between the operator symbol and the open paren, as in 'operator ++('
 
-sp_after_cast                             { Ignore, Add, Remove, Force }
+sp_after_operator_sym_empty                       { Ignore, Add, Remove, Force }
+  Add or remove space between the operator symbol and the open paren when the operator has no arguments, as in 'operator *()'
+
+sp_after_cast                                     { Ignore, Add, Remove, Force }
   Add or remove space after C/D cast, i.e. 'cast(int)a' vs 'cast(int) a' or '(int)a' vs '(int) a'
 
-sp_inside_paren_cast                      { Ignore, Add, Remove, Force }
+sp_inside_paren_cast                              { Ignore, Add, Remove, Force }
   Add or remove spaces inside cast parens
 
-sp_cpp_cast_paren                         { Ignore, Add, Remove, Force }
+sp_cpp_cast_paren                                 { Ignore, Add, Remove, Force }
   Add or remove space between the type and open paren in a C++ cast, i.e. 'int(exp)' vs 'int (exp)'
 
-sp_sizeof_paren                           { Ignore, Add, Remove, Force }
+sp_sizeof_paren                                   { Ignore, Add, Remove, Force }
   Add or remove space between 'sizeof' and '('
 
-sp_after_tag                              { Ignore, Add, Remove, Force }
+sp_after_tag                                      { Ignore, Add, Remove, Force }
   Add or remove space after the tag keyword (Pawn)
 
-sp_inside_braces_enum                     { Ignore, Add, Remove, Force }
+sp_inside_braces_enum                             { Ignore, Add, Remove, Force }
   Add or remove space inside enum '{' and '}'
 
-sp_inside_braces_struct                   { Ignore, Add, Remove, Force }
+sp_inside_braces_struct                           { Ignore, Add, Remove, Force }
   Add or remove space inside struct/union '{' and '}'
 
-sp_inside_braces                          { Ignore, Add, Remove, Force }
+sp_inside_braces                                  { Ignore, Add, Remove, Force }
   Add or remove space inside '{' and '}'
 
-sp_inside_braces_empty                    { Ignore, Add, Remove, Force }
+sp_inside_braces_empty                            { Ignore, Add, Remove, Force }
   Add or remove space inside '{}'
 
-sp_type_func                              { Ignore, Add, Remove, Force }
+sp_type_func                                      { Ignore, Add, Remove, Force }
   Add or remove space between return type and function name
   A minimum of 1 is forced except for pointer return types.
 
-sp_func_proto_paren                       { Ignore, Add, Remove, Force }
+sp_func_proto_paren                               { Ignore, Add, Remove, Force }
   Add or remove space between function name and '(' on function declaration
 
-sp_func_def_paren                         { Ignore, Add, Remove, Force }
+sp_func_proto_paren_empty                         { Ignore, Add, Remove, Force }
+  Add or remove space between function name and '()' on function declaration without parameters
+
+sp_func_def_paren                                 { Ignore, Add, Remove, Force }
   Add or remove space between function name and '(' on function definition
 
-sp_inside_fparens                         { Ignore, Add, Remove, Force }
+sp_func_def_paren_empty                           { Ignore, Add, Remove, Force }
+  Add or remove space between function name and '()' on function definition without parameters
+
+sp_inside_fparens                                 { Ignore, Add, Remove, Force }
   Add or remove space inside empty function '()'
 
-sp_inside_fparen                          { Ignore, Add, Remove, Force }
+sp_inside_fparen                                  { Ignore, Add, Remove, Force }
   Add or remove space inside function '(' and ')'
 
-sp_inside_tparen                          { Ignore, Add, Remove, Force }
+sp_inside_tparen                                  { Ignore, Add, Remove, Force }
   Add or remove space inside the first parens in the function type: 'void (*x)(...)'
 
-sp_after_tparen_close                     { Ignore, Add, Remove, Force }
+sp_after_tparen_close                             { Ignore, Add, Remove, Force }
   Add or remove between the parens in the function type: 'void (*x)(...)'
 
-sp_square_fparen                          { Ignore, Add, Remove, Force }
+sp_square_fparen                                  { Ignore, Add, Remove, Force }
   Add or remove space between ']' and '(' when part of a function call.
 
-sp_fparen_brace                           { Ignore, Add, Remove, Force }
+sp_fparen_brace                                   { Ignore, Add, Remove, Force }
   Add or remove space between ')' and '{' of function
 
-sp_fparen_dbrace                          { Ignore, Add, Remove, Force }
+sp_fparen_dbrace                                  { Ignore, Add, Remove, Force }
   Java: Add or remove space between ')' and '{{' of double brace initializer.
 
-sp_func_call_paren                        { Ignore, Add, Remove, Force }
+sp_func_call_paren                                { Ignore, Add, Remove, Force }
   Add or remove space between function name and '(' on function calls
 
-sp_func_call_paren_empty                  { Ignore, Add, Remove, Force }
+sp_func_call_paren_empty                          { Ignore, Add, Remove, Force }
   Add or remove space between function name and '()' on function calls without parameters.
   If set to 'ignore' (the default), sp_func_call_paren is used.
 
-sp_func_call_user_paren                   { Ignore, Add, Remove, Force }
+sp_func_call_user_paren                           { Ignore, Add, Remove, Force }
   Add or remove space between the user function name and '(' on function calls
   You need to set a keyword to be a user function, like this: 'set func_call_user _' in the config file.
 
-sp_func_class_paren                       { Ignore, Add, Remove, Force }
+sp_func_class_paren                               { Ignore, Add, Remove, Force }
   Add or remove space between a constructor/destructor and the open paren
 
-sp_return_paren                           { Ignore, Add, Remove, Force }
+sp_func_class_paren_empty                         { Ignore, Add, Remove, Force }
+  Add or remove space between a constructor without parameters or destructor and '()'
+
+sp_return_paren                                   { Ignore, Add, Remove, Force }
   Add or remove space between 'return' and '('
 
-sp_attribute_paren                        { Ignore, Add, Remove, Force }
+sp_attribute_paren                                { Ignore, Add, Remove, Force }
   Add or remove space between '__attribute__' and '('
 
-sp_defined_paren                          { Ignore, Add, Remove, Force }
+sp_defined_paren                                  { Ignore, Add, Remove, Force }
   Add or remove space between 'defined' and '(' in '#if defined (FOO)'
 
-sp_throw_paren                            { Ignore, Add, Remove, Force }
+sp_throw_paren                                    { Ignore, Add, Remove, Force }
   Add or remove space between 'throw' and '(' in 'throw (something)'
 
-sp_after_throw                            { Ignore, Add, Remove, Force }
+sp_after_throw                                    { Ignore, Add, Remove, Force }
   Add or remove space between 'throw' and anything other than '(' as in '@throw [...];'
 
-sp_catch_paren                            { Ignore, Add, Remove, Force }
+sp_catch_paren                                    { Ignore, Add, Remove, Force }
   Add or remove space between 'catch' and '(' in 'catch (something) { }'
   If set to ignore, sp_before_sparen is used.
 
-sp_version_paren                          { Ignore, Add, Remove, Force }
+sp_version_paren                                  { Ignore, Add, Remove, Force }
   Add or remove space between 'version' and '(' in 'version (something) { }' (D language)
   If set to ignore, sp_before_sparen is used.
 
-sp_scope_paren                            { Ignore, Add, Remove, Force }
+sp_scope_paren                                    { Ignore, Add, Remove, Force }
   Add or remove space between 'scope' and '(' in 'scope (something) { }' (D language)
   If set to ignore, sp_before_sparen is used.
 
-sp_macro                                  { Ignore, Add, Remove, Force }
+sp_super_paren                                    { Ignore, Add, Remove, Force }
+  Add or remove space between 'super' and '(' in 'super (something)'. Default=Remove
+
+sp_this_paren                                     { Ignore, Add, Remove, Force }
+  Add or remove space between 'this' and '(' in 'this (something)'. Default=Remove
+
+sp_macro                                          { Ignore, Add, Remove, Force }
   Add or remove space between macro and value
 
-sp_macro_func                             { Ignore, Add, Remove, Force }
+sp_macro_func                                     { Ignore, Add, Remove, Force }
   Add or remove space between macro function ')' and value
 
-sp_else_brace                             { Ignore, Add, Remove, Force }
+sp_else_brace                                     { Ignore, Add, Remove, Force }
   Add or remove space between 'else' and '{' if on the same line
 
-sp_brace_else                             { Ignore, Add, Remove, Force }
+sp_brace_else                                     { Ignore, Add, Remove, Force }
   Add or remove space between '}' and 'else' if on the same line
 
-sp_brace_typedef                          { Ignore, Add, Remove, Force }
+sp_brace_typedef                                  { Ignore, Add, Remove, Force }
   Add or remove space between '}' and the name of a typedef on the same line
 
-sp_catch_brace                            { Ignore, Add, Remove, Force }
+sp_catch_brace                                    { Ignore, Add, Remove, Force }
   Add or remove space between 'catch' and '{' if on the same line
 
-sp_brace_catch                            { Ignore, Add, Remove, Force }
+sp_brace_catch                                    { Ignore, Add, Remove, Force }
   Add or remove space between '}' and 'catch' if on the same line
 
-sp_finally_brace                          { Ignore, Add, Remove, Force }
+sp_finally_brace                                  { Ignore, Add, Remove, Force }
   Add or remove space between 'finally' and '{' if on the same line
 
-sp_brace_finally                          { Ignore, Add, Remove, Force }
+sp_brace_finally                                  { Ignore, Add, Remove, Force }
   Add or remove space between '}' and 'finally' if on the same line
 
-sp_try_brace                              { Ignore, Add, Remove, Force }
+sp_try_brace                                      { Ignore, Add, Remove, Force }
   Add or remove space between 'try' and '{' if on the same line
 
-sp_getset_brace                           { Ignore, Add, Remove, Force }
+sp_getset_brace                                   { Ignore, Add, Remove, Force }
   Add or remove space between get/set and '{' if on the same line
 
-sp_word_brace                             { Ignore, Add, Remove, Force }
-  Add or remove space between a variable and '{' for C++ uniform initialization
+sp_word_brace                                     { Ignore, Add, Remove, Force }
+  Add or remove space between a variable and '{' for C++ uniform initialization. Default=Add
 
-sp_word_brace_ns                          { Ignore, Add, Remove, Force }
-  Add or remove space between a variable and '{' for a namespace
+sp_word_brace_ns                                  { Ignore, Add, Remove, Force }
+  Add or remove space between a variable and '{' for a namespace. Default=Add
 
-sp_before_dc                              { Ignore, Add, Remove, Force }
+sp_before_dc                                      { Ignore, Add, Remove, Force }
   Add or remove space before the '::' operator
 
-sp_after_dc                               { Ignore, Add, Remove, Force }
+sp_after_dc                                       { Ignore, Add, Remove, Force }
   Add or remove space after the '::' operator
 
-sp_d_array_colon                          { Ignore, Add, Remove, Force }
+sp_d_array_colon                                  { Ignore, Add, Remove, Force }
   Add or remove around the D named array initializer ':' operator
 
-sp_not                                    { Ignore, Add, Remove, Force }
+sp_not                                            { Ignore, Add, Remove, Force }
   Add or remove space after the '!' (not) operator. Default=Remove
 
-sp_inv                                    { Ignore, Add, Remove, Force }
+sp_inv                                            { Ignore, Add, Remove, Force }
   Add or remove space after the '~' (invert) operator. Default=Remove
 
-sp_addr                                   { Ignore, Add, Remove, Force }
+sp_addr                                           { Ignore, Add, Remove, Force }
   Add or remove space after the '&' (address-of) operator. Default=Remove
   This does not affect the spacing after a '&' that is part of a type.
 
-sp_member                                 { Ignore, Add, Remove, Force }
+sp_member                                         { Ignore, Add, Remove, Force }
   Add or remove space around the '.' or '->' operators. Default=Remove
 
-sp_deref                                  { Ignore, Add, Remove, Force }
+sp_deref                                          { Ignore, Add, Remove, Force }
   Add or remove space after the '*' (dereference) operator. Default=Remove
   This does not affect the spacing after a '*' that is part of a type.
 
-sp_sign                                   { Ignore, Add, Remove, Force }
+sp_sign                                           { Ignore, Add, Remove, Force }
   Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'. Default=Remove
 
-sp_incdec                                 { Ignore, Add, Remove, Force }
+sp_incdec                                         { Ignore, Add, Remove, Force }
   Add or remove space before or after '++' and '--', as in '(--x)' or 'y++;'. Default=Remove
 
-sp_before_nl_cont                         { Ignore, Add, Remove, Force }
+sp_before_nl_cont                                 { Ignore, Add, Remove, Force }
   Add or remove space before a backslash-newline at the end of a line. Default=Add
 
-sp_after_oc_scope                         { Ignore, Add, Remove, Force }
+sp_after_oc_scope                                 { Ignore, Add, Remove, Force }
   Add or remove space after the scope '+' or '-', as in '-(void) foo;' or '+(int) bar;'
 
-sp_after_oc_colon                         { Ignore, Add, Remove, Force }
+sp_after_oc_colon                                 { Ignore, Add, Remove, Force }
   Add or remove space after the colon in message specs
   '-(int) f:(int) x;' vs '-(int) f: (int) x;'
 
-sp_before_oc_colon                        { Ignore, Add, Remove, Force }
+sp_before_oc_colon                                { Ignore, Add, Remove, Force }
   Add or remove space before the colon in message specs
   '-(int) f: (int) x;' vs '-(int) f : (int) x;'
 
-sp_after_oc_dict_colon                    { Ignore, Add, Remove, Force }
+sp_after_oc_dict_colon                            { Ignore, Add, Remove, Force }
   Add or remove space after the colon in immutable dictionary expression
   'NSDictionary *test = @{@"foo" :@"bar"};'
 
-sp_before_oc_dict_colon                   { Ignore, Add, Remove, Force }
+sp_before_oc_dict_colon                           { Ignore, Add, Remove, Force }
   Add or remove space before the colon in immutable dictionary expression
   'NSDictionary *test = @{@"foo" :@"bar"};'
 
-sp_after_send_oc_colon                    { Ignore, Add, Remove, Force }
+sp_after_send_oc_colon                            { Ignore, Add, Remove, Force }
   Add or remove space after the colon in message specs
   '[object setValue:1];' vs '[object setValue: 1];'
 
-sp_before_send_oc_colon                   { Ignore, Add, Remove, Force }
+sp_before_send_oc_colon                           { Ignore, Add, Remove, Force }
   Add or remove space before the colon in message specs
   '[object setValue:1];' vs '[object setValue :1];'
 
-sp_after_oc_type                          { Ignore, Add, Remove, Force }
+sp_after_oc_type                                  { Ignore, Add, Remove, Force }
   Add or remove space after the (type) in message specs
   '-(int)f: (int) x;' vs '-(int)f: (int)x;'
 
-sp_after_oc_return_type                   { Ignore, Add, Remove, Force }
+sp_after_oc_return_type                           { Ignore, Add, Remove, Force }
   Add or remove space after the first (type) in message specs
   '-(int) f:(int)x;' vs '-(int)f:(int)x;'
 
-sp_after_oc_at_sel                        { Ignore, Add, Remove, Force }
+sp_after_oc_at_sel                                { Ignore, Add, Remove, Force }
   Add or remove space between '@selector' and '('
   '@selector(msgName)' vs '@selector (msgName)'
   Also applies to @protocol() constructs
 
-sp_after_oc_at_sel_parens                 { Ignore, Add, Remove, Force }
+sp_after_oc_at_sel_parens                         { Ignore, Add, Remove, Force }
   Add or remove space between '@selector(x)' and the following word
   '@selector(foo) a:' vs '@selector(foo)a:'
 
-sp_inside_oc_at_sel_parens                { Ignore, Add, Remove, Force }
+sp_inside_oc_at_sel_parens                        { Ignore, Add, Remove, Force }
   Add or remove space inside '@selector' parens
   '@selector(foo)' vs '@selector( foo )'
   Also applies to @protocol() constructs
 
-sp_before_oc_block_caret                  { Ignore, Add, Remove, Force }
+sp_before_oc_block_caret                          { Ignore, Add, Remove, Force }
   Add or remove space before a block pointer caret
   '^int (int arg){...}' vs. ' ^int (int arg){...}'
 
-sp_after_oc_block_caret                   { Ignore, Add, Remove, Force }
+sp_after_oc_block_caret                           { Ignore, Add, Remove, Force }
   Add or remove space after a block pointer caret
   '^int (int arg){...}' vs. '^ int (int arg){...}'
 
-sp_after_oc_msg_receiver                  { Ignore, Add, Remove, Force }
+sp_after_oc_msg_receiver                          { Ignore, Add, Remove, Force }
   Add or remove space between the receiver and selector in a message.
   '[receiver selector ...]'
 
-sp_after_oc_property                      { Ignore, Add, Remove, Force }
+sp_after_oc_property                              { Ignore, Add, Remove, Force }
   Add or remove space after @property.
 
-sp_cond_colon                             { Ignore, Add, Remove, Force }
+sp_cond_colon                                     { Ignore, Add, Remove, Force }
   Add or remove space around the ':' in 'b ? t : f'
 
-sp_cond_colon_before                      { Ignore, Add, Remove, Force }
+sp_cond_colon_before                              { Ignore, Add, Remove, Force }
   Add or remove space before the ':' in 'b ? t : f'. Overrides sp_cond_colon.
 
-sp_cond_colon_after                       { Ignore, Add, Remove, Force }
+sp_cond_colon_after                               { Ignore, Add, Remove, Force }
   Add or remove space after the ':' in 'b ? t : f'. Overrides sp_cond_colon.
 
-sp_cond_question                          { Ignore, Add, Remove, Force }
+sp_cond_question                                  { Ignore, Add, Remove, Force }
   Add or remove space around the '?' in 'b ? t : f'
 
-sp_cond_question_before                   { Ignore, Add, Remove, Force }
+sp_cond_question_before                           { Ignore, Add, Remove, Force }
   Add or remove space before the '?' in 'b ? t : f'. Overrides sp_cond_question.
 
-sp_cond_question_after                    { Ignore, Add, Remove, Force }
+sp_cond_question_after                            { Ignore, Add, Remove, Force }
   Add or remove space after the '?' in 'b ? t : f'. Overrides sp_cond_question.
 
-sp_cond_ternary_short                     { Ignore, Add, Remove, Force }
+sp_cond_ternary_short                             { Ignore, Add, Remove, Force }
   In the abbreviated ternary form (a ?: b), add/remove space between ? and :.'. Overrides all other sp_cond_* options.
 
-sp_case_label                             { Ignore, Add, Remove, Force }
+sp_case_label                                     { Ignore, Add, Remove, Force }
   Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make sense here.
 
-sp_range                                  { Ignore, Add, Remove, Force }
+sp_range                                          { Ignore, Add, Remove, Force }
   Control the space around the D '..' operator.
 
-sp_after_for_colon                        { Ignore, Add, Remove, Force }
+sp_after_for_colon                                { Ignore, Add, Remove, Force }
   Control the spacing after ':' in 'for (TYPE VAR : EXPR)'
 
-sp_before_for_colon                       { Ignore, Add, Remove, Force }
+sp_before_for_colon                               { Ignore, Add, Remove, Force }
   Control the spacing before ':' in 'for (TYPE VAR : EXPR)'
 
-sp_extern_paren                           { Ignore, Add, Remove, Force }
+sp_extern_paren                                   { Ignore, Add, Remove, Force }
   Control the spacing in 'extern (C)' (D)
 
-sp_cmt_cpp_start                          { Ignore, Add, Remove, Force }
+sp_cmt_cpp_start                                  { Ignore, Add, Remove, Force }
   Control the space after the opening of a C++ comment '// A' vs '//A'
 
-sp_cmt_cpp_doxygen                        { False, True }
+sp_cmt_cpp_doxygen                                { False, True }
   TRUE: If space is added with sp_cmt_cpp_start, do it after doxygen sequences like '///', '///<', '//!' and '//!<'.
 
-sp_cmt_cpp_qttr                           { False, True }
+sp_cmt_cpp_qttr                                   { False, True }
   TRUE: If space is added with sp_cmt_cpp_start, do it after Qt translator or meta-data comments like '//:', '//=', and '//~'.
 
-sp_endif_cmt                              { Ignore, Add, Remove, Force }
+sp_endif_cmt                                      { Ignore, Add, Remove, Force }
   Controls the spaces between #else or #endif and a trailing comment
 
-sp_after_new                              { Ignore, Add, Remove, Force }
+sp_after_new                                      { Ignore, Add, Remove, Force }
   Controls the spaces after 'new', 'delete' and 'delete[]'
 
-sp_between_new_paren                      { Ignore, Add, Remove, Force }
+sp_between_new_paren                              { Ignore, Add, Remove, Force }
   Controls the spaces between new and '(' in 'new()'
 
-sp_before_tr_emb_cmt                      { Ignore, Add, Remove, Force }
+sp_before_tr_emb_cmt                              { Ignore, Add, Remove, Force }
   Controls the spaces before a trailing or embedded comment
 
-sp_num_before_tr_emb_cmt                  Number
+sp_num_before_tr_emb_cmt                          Number
   Number of spaces before a trailing or embedded comment
 
-sp_annotation_paren                       { Ignore, Add, Remove, Force }
+sp_annotation_paren                               { Ignore, Add, Remove, Force }
   Control space between a Java annotation and the open paren.
+
+sp_skip_vbrace_tokens                             { False, True }
+  If true, vbrace tokens are dropped to the previous token and skipped.
 
 #
 # Code alignment (not left column spaces/tabs)
 #
 
-align_keep_tabs                           { False, True }
+align_keep_tabs                                   { False, True }
   Whether to keep non-indenting tabs
 
-align_with_tabs                           { False, True }
+align_with_tabs                                   { False, True }
   Whether to use tabs for aligning
 
-align_on_tabstop                          { False, True }
+align_on_tabstop                                  { False, True }
   Whether to bump out to the next tab when aligning
 
-align_number_left                         { False, True }
+align_number_left                                 { False, True }
   Whether to left-align numbers
 
-align_keep_extra_space                    { False, True }
+align_keep_extra_space                            { False, True }
   Whether to keep whitespace not required for alignment.
 
-align_func_params                         { False, True }
+align_func_params                                 { False, True }
   Align variable definitions in prototypes and functions
 
-align_same_func_call_params               { False, True }
+align_same_func_call_params                       { False, True }
   Align parameters in single-line functions that have the same name.
   The function names must already be aligned with each other.
 
-align_var_def_span                        Number
+align_var_def_span                                Number
   The span for aligning variable definitions (0=don't align)
 
-align_var_def_star_style                  Number
+align_var_def_star_style                          Number
   How to align the star in variable definitions.
    0=Part of the type     'void *   foo;'
    1=Part of the variable 'void     *foo;'
    2=Dangling             'void    *foo;'
 
-align_var_def_amp_style                   Number
+align_var_def_amp_style                           Number
   How to align the '&' in variable definitions.
    0=Part of the type
    1=Part of the variable
    2=Dangling
 
-align_var_def_thresh                      Number
+align_var_def_thresh                              Number
   The threshold for aligning variable definitions (0=no limit)
 
-align_var_def_gap                         Number
+align_var_def_gap                                 Number
   The gap for aligning variable definitions
 
-align_var_def_colon                       { False, True }
+align_var_def_colon                               { False, True }
   Whether to align the colon in struct bit fields
 
-align_var_def_attribute                   { False, True }
+align_var_def_attribute                           { False, True }
   Whether to align any attribute after the variable name
 
-align_var_def_inline                      { False, True }
+align_var_def_inline                              { False, True }
   Whether to align inline struct/enum/union variable definitions
 
-align_assign_span                         Number
+align_assign_span                                 Number
   The span for aligning on '=' in assignments (0=don't align)
 
-align_assign_thresh                       Number
+align_assign_thresh                               Number
   The threshold for aligning on '=' in assignments (0=no limit)
 
-align_enum_equ_span                       Number
+align_enum_equ_span                               Number
   The span for aligning on '=' in enums (0=don't align)
 
-align_enum_equ_thresh                     Number
+align_enum_equ_thresh                             Number
   The threshold for aligning on '=' in enums (0=no limit)
 
-align_var_struct_span                     Number
+align_var_struct_span                             Number
   The span for aligning struct/union (0=don't align)
 
-align_var_struct_thresh                   Number
+align_var_struct_thresh                           Number
   The threshold for aligning struct/union member definitions (0=no limit)
 
-align_var_struct_gap                      Number
+align_var_struct_gap                              Number
   The gap for aligning struct/union member definitions
 
-align_struct_init_span                    Number
+align_struct_init_span                            Number
   The span for aligning struct initializer values (0=don't align)
 
-align_typedef_gap                         Number
+align_typedef_gap                                 Number
   The minimum space between the type and the synonym of a typedef
 
-align_typedef_span                        Number
+align_typedef_span                                Number
   The span for aligning single-line typedefs (0=don't align)
 
-align_typedef_func                        Number
+align_typedef_func                                Number
   How to align typedef'd functions with other typedefs
   0: Don't mix them at all
   1: align the open paren with the types
   2: align the function type name with the other type names
 
-align_typedef_star_style                  Number
+align_typedef_star_style                          Number
   Controls the positioning of the '*' in typedefs. Just try it.
   0: Align on typedef type, ignore '*'
   1: The '*' is part of type name: typedef int  *pint;
   2: The '*' is part of the type, but dangling: typedef int *pint;
 
-align_typedef_amp_style                   Number
+align_typedef_amp_style                           Number
   Controls the positioning of the '&' in typedefs. Just try it.
   0: Align on typedef type, ignore '&'
   1: The '&' is part of type name: typedef int  &pint;
   2: The '&' is part of the type, but dangling: typedef int &pint;
 
-align_right_cmt_span                      Number
+align_right_cmt_span                              Number
   The span for aligning comments that end lines (0=don't align)
 
-align_right_cmt_mix                       { False, True }
+align_right_cmt_mix                               { False, True }
   If aligning comments, mix with comments after '}' and #endif with less than 3 spaces before the comment
 
-align_right_cmt_gap                       Number
+align_right_cmt_gap                               Number
   If a trailing comment is more than this number of columns away from the text it follows,
   it will qualify for being aligned. This has to be > 0 to do anything.
 
-align_right_cmt_at_col                    Number
+align_right_cmt_at_col                            Number
   Align trailing comment at or beyond column N; 'pulls in' comments as a bonus side effect (0=ignore)
 
-align_func_proto_span                     Number
+align_func_proto_span                             Number
   The span for aligning function prototypes (0=don't align)
 
-align_func_proto_gap                      Number
+align_func_proto_gap                              Number
   Minimum gap between the return type and the function name.
 
-align_on_operator                         { False, True }
+align_on_operator                                 { False, True }
   Align function protos on the 'operator' keyword instead of what follows
 
-align_mix_var_proto                       { False, True }
+align_mix_var_proto                               { False, True }
   Whether to mix aligning prototype and variable declarations.
   If true, align_var_def_XXX options are used instead of align_func_proto_XXX options.
 
-align_single_line_func                    { False, True }
+align_single_line_func                            { False, True }
   Align single-line functions with function prototypes, uses align_func_proto_span
 
-align_single_line_brace                   { False, True }
+align_single_line_brace                           { False, True }
   Aligning the open brace of single-line functions.
   Requires align_single_line_func=true, uses align_func_proto_span
 
-align_single_line_brace_gap               Number
+align_single_line_brace_gap                       Number
   Gap for align_single_line_brace.
-  
 
-align_oc_msg_spec_span                    Number
+align_oc_msg_spec_span                            Number
   The span for aligning ObjC msg spec (0=don't align)
 
-align_nl_cont                             { False, True }
+align_nl_cont                                     { False, True }
   Whether to align macros wrapped with a backslash and a newline.
   This will not work right if the macro contains a multi-line comment.
 
-align_pp_define_together                  { False, True }
+align_pp_define_together                          { False, True }
   # Align macro functions and variables together
-  
 
-align_pp_define_gap                       Number
+align_pp_define_gap                               Number
   The minimum space between label and value of a preprocessor define
 
-align_pp_define_span                      Number
+align_pp_define_span                              Number
   The span for aligning on '#define' bodies (0=don't align, other=number of lines including comments between blocks)
 
-align_left_shift                          { False, True }
-  Align lines that start with '<<' with previous '<<'. Default=true
+align_left_shift                                  { False, True }
+  Align lines that start with '<<' with previous '<<'. Default=True
 
-align_asm_colon                           { False, True }
+align_asm_colon                                   { False, True }
   Align text after asm volatile () colons.
 
-align_oc_msg_colon_span                   Number
+align_oc_msg_colon_span                           Number
   Span for aligning parameters in an Obj-C message call on the ':' (0=don't align)
 
-align_oc_msg_colon_first                  { False, True }
+align_oc_msg_colon_first                          { False, True }
   If true, always align with the first parameter, even if it is too short.
 
-align_oc_decl_colon                       { False, True }
+align_oc_decl_colon                               { False, True }
   Aligning parameters in an Obj-C '+' or '-' declaration on the ':'
 
 #
 # Newline adding and removing options
 #
 
-nl_collapse_empty_body                    { False, True }
+nl_collapse_empty_body                            { False, True }
   Whether to collapse empty blocks between '{' and '}'
 
-nl_assign_leave_one_liners                { False, True }
+nl_assign_leave_one_liners                        { False, True }
   Don't split one-line braced assignments - 'foo_t f = { 1, 2 };'
 
-nl_class_leave_one_liners                 { False, True }
+nl_class_leave_one_liners                         { False, True }
   Don't split one-line braced statements inside a class xx { } body
 
-nl_enum_leave_one_liners                  { False, True }
+nl_enum_leave_one_liners                          { False, True }
   Don't split one-line enums: 'enum foo { BAR = 15 };'
 
-nl_getset_leave_one_liners                { False, True }
+nl_getset_leave_one_liners                        { False, True }
   Don't split one-line get or set functions
 
-nl_func_leave_one_liners                  { False, True }
+nl_func_leave_one_liners                          { False, True }
   Don't split one-line function definitions - 'int foo() { return 0; }'
 
-nl_cpp_lambda_leave_one_liners            { False, True }
+nl_cpp_lambda_leave_one_liners                    { False, True }
   Don't split one-line C++11 lambdas - '[]() { return 0; }'
 
-nl_if_leave_one_liners                    { False, True }
+nl_if_leave_one_liners                            { False, True }
   Don't split one-line if/else statements - 'if(a) b++;'
 
-nl_while_leave_one_liners                 { False, True }
+nl_while_leave_one_liners                         { False, True }
   Don't split one-line while statements - 'while(a) b++;'
 
-nl_oc_msg_leave_one_liner                 { False, True }
+nl_oc_msg_leave_one_liner                         { False, True }
   Don't split one-line OC messages
 
-nl_start_of_file                          { Ignore, Add, Remove, Force }
+nl_oc_block_brace                                 { Ignore, Add, Remove, Force }
+  Add or remove newline between Objective-C block signature and '{'
+
+nl_start_of_file                                  { Ignore, Add, Remove, Force }
   Add or remove newlines at the start of the file
 
-nl_start_of_file_min                      Number
+nl_start_of_file_min                              Number
   The number of newlines at the start of the file (only used if nl_start_of_file is 'add' or 'force'
 
-nl_end_of_file                            { Ignore, Add, Remove, Force }
+nl_end_of_file                                    { Ignore, Add, Remove, Force }
   Add or remove newline at the end of the file
 
-nl_end_of_file_min                        Number
+nl_end_of_file_min                                Number
   The number of newlines at the end of the file (only used if nl_end_of_file is 'add' or 'force')
 
-nl_assign_brace                           { Ignore, Add, Remove, Force }
+nl_assign_brace                                   { Ignore, Add, Remove, Force }
   Add or remove newline between '=' and '{'
 
-nl_assign_square                          { Ignore, Add, Remove, Force }
+nl_assign_square                                  { Ignore, Add, Remove, Force }
   Add or remove newline between '=' and '[' (D only)
 
-nl_after_square_assign                    { Ignore, Add, Remove, Force }
+nl_after_square_assign                            { Ignore, Add, Remove, Force }
   Add or remove newline after '= [' (D only). Will also affect the newline before the ']'
 
-nl_func_var_def_blk                       Number
+nl_func_var_def_blk                               Number
   The number of blank lines after a block of variable definitions at the top of a function body
   0 = No change (default)
 
-nl_typedef_blk_start                      Number
+nl_typedef_blk_start                              Number
   The number of newlines before a block of typedefs
   0 = No change (default)
   the option 'nl_after_access_spec' takes preference over 'nl_typedef_blk_start'
 
-nl_typedef_blk_end                        Number
+nl_typedef_blk_end                                Number
   The number of newlines after a block of typedefs
   0 = No change (default)
 
-nl_typedef_blk_in                         Number
+nl_typedef_blk_in                                 Number
   The maximum consecutive newlines within a block of typedefs
   0 = No change (default)
 
-nl_var_def_blk_start                      Number
+nl_var_def_blk_start                              Number
   The number of newlines before a block of variable definitions not at the top of a function body
   0 = No change (default)
   the option 'nl_after_access_spec' takes preference over 'nl_var_def_blk_start'
 
-nl_var_def_blk_end                        Number
+nl_var_def_blk_end                                Number
   The number of newlines after a block of variable definitions not at the top of a function body
   0 = No change (default)
 
-nl_var_def_blk_in                         Number
+nl_var_def_blk_in                                 Number
   The maximum consecutive newlines within a block of variable definitions
   0 = No change (default)
 
-nl_fcall_brace                            { Ignore, Add, Remove, Force }
+nl_fcall_brace                                    { Ignore, Add, Remove, Force }
   Add or remove newline between a function call's ')' and '{', as in:
   list_for_each(item, &list) { }
 
-nl_enum_brace                             { Ignore, Add, Remove, Force }
+nl_enum_brace                                     { Ignore, Add, Remove, Force }
   Add or remove newline between 'enum' and '{'
 
-nl_struct_brace                           { Ignore, Add, Remove, Force }
+nl_struct_brace                                   { Ignore, Add, Remove, Force }
   Add or remove newline between 'struct and '{'
 
-nl_union_brace                            { Ignore, Add, Remove, Force }
+nl_union_brace                                    { Ignore, Add, Remove, Force }
   Add or remove newline between 'union' and '{'
 
-nl_if_brace                               { Ignore, Add, Remove, Force }
+nl_if_brace                                       { Ignore, Add, Remove, Force }
   Add or remove newline between 'if' and '{'
 
-nl_brace_else                             { Ignore, Add, Remove, Force }
+nl_brace_else                                     { Ignore, Add, Remove, Force }
   Add or remove newline between '}' and 'else'
 
-nl_elseif_brace                           { Ignore, Add, Remove, Force }
+nl_elseif_brace                                   { Ignore, Add, Remove, Force }
   Add or remove newline between 'else if' and '{'
   If set to ignore, nl_if_brace is used instead
 
-nl_else_brace                             { Ignore, Add, Remove, Force }
+nl_else_brace                                     { Ignore, Add, Remove, Force }
   Add or remove newline between 'else' and '{'
 
-nl_else_if                                { Ignore, Add, Remove, Force }
+nl_else_if                                        { Ignore, Add, Remove, Force }
   Add or remove newline between 'else' and 'if'
 
-nl_brace_finally                          { Ignore, Add, Remove, Force }
+nl_brace_finally                                  { Ignore, Add, Remove, Force }
   Add or remove newline between '}' and 'finally'
 
-nl_finally_brace                          { Ignore, Add, Remove, Force }
+nl_finally_brace                                  { Ignore, Add, Remove, Force }
   Add or remove newline between 'finally' and '{'
 
-nl_try_brace                              { Ignore, Add, Remove, Force }
+nl_try_brace                                      { Ignore, Add, Remove, Force }
   Add or remove newline between 'try' and '{'
 
-nl_getset_brace                           { Ignore, Add, Remove, Force }
+nl_getset_brace                                   { Ignore, Add, Remove, Force }
   Add or remove newline between get/set and '{'
 
-nl_for_brace                              { Ignore, Add, Remove, Force }
+nl_for_brace                                      { Ignore, Add, Remove, Force }
   Add or remove newline between 'for' and '{'
 
-nl_catch_brace                            { Ignore, Add, Remove, Force }
+nl_catch_brace                                    { Ignore, Add, Remove, Force }
   Add or remove newline between 'catch' and '{'
 
-nl_brace_catch                            { Ignore, Add, Remove, Force }
+nl_brace_catch                                    { Ignore, Add, Remove, Force }
   Add or remove newline between '}' and 'catch'
 
-nl_brace_square                           { Ignore, Add, Remove, Force }
+nl_brace_square                                   { Ignore, Add, Remove, Force }
   Add or remove newline between '}' and ']'
 
-nl_brace_fparen                           { Ignore, Add, Remove, Force }
+nl_brace_fparen                                   { Ignore, Add, Remove, Force }
   Add or remove newline between '}' and ')' in a function invocation
 
-nl_while_brace                            { Ignore, Add, Remove, Force }
+nl_while_brace                                    { Ignore, Add, Remove, Force }
   Add or remove newline between 'while' and '{'
 
-nl_scope_brace                            { Ignore, Add, Remove, Force }
+nl_scope_brace                                    { Ignore, Add, Remove, Force }
   Add or remove newline between 'scope (x)' and '{' (D)
 
-nl_unittest_brace                         { Ignore, Add, Remove, Force }
+nl_unittest_brace                                 { Ignore, Add, Remove, Force }
   Add or remove newline between 'unittest' and '{' (D)
 
-nl_version_brace                          { Ignore, Add, Remove, Force }
+nl_version_brace                                  { Ignore, Add, Remove, Force }
   Add or remove newline between 'version (x)' and '{' (D)
 
-nl_using_brace                            { Ignore, Add, Remove, Force }
+nl_using_brace                                    { Ignore, Add, Remove, Force }
   Add or remove newline between 'using' and '{'
 
-nl_brace_brace                            { Ignore, Add, Remove, Force }
+nl_brace_brace                                    { Ignore, Add, Remove, Force }
   Add or remove newline between two open or close braces.
   Due to general newline/brace handling, REMOVE may not work.
 
-nl_do_brace                               { Ignore, Add, Remove, Force }
+nl_do_brace                                       { Ignore, Add, Remove, Force }
   Add or remove newline between 'do' and '{'
 
-nl_brace_while                            { Ignore, Add, Remove, Force }
+nl_brace_while                                    { Ignore, Add, Remove, Force }
   Add or remove newline between '}' and 'while' of 'do' statement
 
-nl_switch_brace                           { Ignore, Add, Remove, Force }
+nl_switch_brace                                   { Ignore, Add, Remove, Force }
   Add or remove newline between 'switch' and '{'
 
-nl_synchronized_brace                     { Ignore, Add, Remove, Force }
+nl_synchronized_brace                             { Ignore, Add, Remove, Force }
   Add or remove newline between 'synchronized' and '{'
 
-nl_multi_line_cond                        { False, True }
+nl_multi_line_cond                                { False, True }
   Add a newline between ')' and '{' if the ')' is on a different line than the if/for/etc.
   Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch and nl_catch_brace.
 
-nl_multi_line_define                      { False, True }
+nl_multi_line_define                              { False, True }
   Force a newline in a define after the macro name for multi-line defines.
 
-nl_before_case                            { False, True }
+nl_before_case                                    { False, True }
   Whether to put a newline before 'case' statement, not after the first 'case'
 
-nl_before_throw                           { Ignore, Add, Remove, Force }
+nl_before_throw                                   { Ignore, Add, Remove, Force }
   Add or remove newline between ')' and 'throw'
 
-nl_after_case                             { False, True }
+nl_after_case                                     { False, True }
   Whether to put a newline after 'case' statement
 
-nl_case_colon_brace                       { Ignore, Add, Remove, Force }
+nl_case_colon_brace                               { Ignore, Add, Remove, Force }
   Add or remove a newline between a case ':' and '{'. Overrides nl_after_case.
 
-nl_namespace_brace                        { Ignore, Add, Remove, Force }
+nl_namespace_brace                                { Ignore, Add, Remove, Force }
   Newline between namespace and {
 
-nl_template_class                         { Ignore, Add, Remove, Force }
+nl_template_class                                 { Ignore, Add, Remove, Force }
   Add or remove newline between 'template<>' and whatever follows.
 
-nl_class_brace                            { Ignore, Add, Remove, Force }
+nl_class_brace                                    { Ignore, Add, Remove, Force }
   Add or remove newline between 'class' and '{'
 
-nl_class_init_args                        { Ignore, Add, Remove, Force }
+nl_class_init_args                                { Ignore, Add, Remove, Force }
   Add or remove newline before/after each ',' in the base class list,
     (tied to pos_class_comma).
 
-nl_constr_init_args                       { Ignore, Add, Remove, Force }
+nl_constr_init_args                               { Ignore, Add, Remove, Force }
   Add or remove newline after each ',' in the constructor member initialization.
   Related to nl_constr_colon, pos_constr_colon and pos_constr_comma.
 
-nl_func_type_name                         { Ignore, Add, Remove, Force }
+nl_enum_own_lines                                 { Ignore, Add, Remove, Force }
+  Add or remove newline before first element, after comma, and after last element in enum
+
+nl_func_type_name                                 { Ignore, Add, Remove, Force }
   Add or remove newline between return type and function name in a function definition
 
-nl_func_type_name_class                   { Ignore, Add, Remove, Force }
+nl_func_type_name_class                           { Ignore, Add, Remove, Force }
   Add or remove newline between return type and function name inside a class {}
   Uses nl_func_type_name or nl_func_proto_type_name if set to ignore.
 
-nl_func_scope_name                        { Ignore, Add, Remove, Force }
+nl_func_class_scope                               { Ignore, Add, Remove, Force }
+  Add or remove newline between class specification and '::' in 'void A::f() { }'
+  Only appears in separate member implementation (does not appear with in-line implmementation)
+
+nl_func_scope_name                                { Ignore, Add, Remove, Force }
   Add or remove newline between function scope and name
   Controls the newline after '::' in 'void A::f() { }'
 
-nl_func_proto_type_name                   { Ignore, Add, Remove, Force }
+nl_func_proto_type_name                           { Ignore, Add, Remove, Force }
   Add or remove newline between return type and function name in a prototype
 
-nl_func_paren                             { Ignore, Add, Remove, Force }
+nl_func_paren                                     { Ignore, Add, Remove, Force }
   Add or remove newline between a function name and the opening '(' in the declaration
 
-nl_func_def_paren                         { Ignore, Add, Remove, Force }
+nl_func_def_paren                                 { Ignore, Add, Remove, Force }
   Add or remove newline between a function name and the opening '(' in the definition
 
-nl_func_decl_start                        { Ignore, Add, Remove, Force }
+nl_func_decl_start                                { Ignore, Add, Remove, Force }
   Add or remove newline after '(' in a function declaration
 
-nl_func_def_start                         { Ignore, Add, Remove, Force }
+nl_func_def_start                                 { Ignore, Add, Remove, Force }
   Add or remove newline after '(' in a function definition
 
-nl_func_decl_start_single                 { Ignore, Add, Remove, Force }
+nl_func_decl_start_single                         { Ignore, Add, Remove, Force }
   Overrides nl_func_decl_start when there is only one parameter.
 
-nl_func_def_start_single                  { Ignore, Add, Remove, Force }
+nl_func_def_start_single                          { Ignore, Add, Remove, Force }
   Overrides nl_func_def_start when there is only one parameter.
 
-nl_func_decl_args                         { Ignore, Add, Remove, Force }
+nl_func_decl_start_multi_line                     { False, True }
+  Whether to add newline after '(' in a function declaration if '(' and ')' are in different lines.
+
+nl_func_def_start_multi_line                      { False, True }
+  Whether to add newline after '(' in a function definition if '(' and ')' are in different lines.
+
+nl_func_decl_args                                 { Ignore, Add, Remove, Force }
   Add or remove newline after each ',' in a function declaration
 
-nl_func_def_args                          { Ignore, Add, Remove, Force }
+nl_func_def_args                                  { Ignore, Add, Remove, Force }
   Add or remove newline after each ',' in a function definition
 
-nl_func_decl_end                          { Ignore, Add, Remove, Force }
+nl_func_decl_args_multi_line                      { False, True }
+  Whether to add newline after each ',' in a function declaration if '(' and ')' are in different lines.
+
+nl_func_def_args_multi_line                       { False, True }
+  Whether to add newline after each ',' in a function definition if '(' and ')' are in different lines.
+
+nl_func_decl_end                                  { Ignore, Add, Remove, Force }
   Add or remove newline before the ')' in a function declaration
 
-nl_func_def_end                           { Ignore, Add, Remove, Force }
+nl_func_def_end                                   { Ignore, Add, Remove, Force }
   Add or remove newline before the ')' in a function definition
 
-nl_func_decl_end_single                   { Ignore, Add, Remove, Force }
+nl_func_decl_end_single                           { Ignore, Add, Remove, Force }
   Overrides nl_func_decl_end when there is only one parameter.
 
-nl_func_def_end_single                    { Ignore, Add, Remove, Force }
+nl_func_def_end_single                            { Ignore, Add, Remove, Force }
   Overrides nl_func_def_end when there is only one parameter.
 
-nl_func_decl_empty                        { Ignore, Add, Remove, Force }
+nl_func_decl_end_multi_line                       { False, True }
+  Whether to add newline before ')' in a function declaration if '(' and ')' are in different lines.
+
+nl_func_def_end_multi_line                        { False, True }
+  Whether to add newline before ')' in a function definition if '(' and ')' are in different lines.
+
+nl_func_decl_empty                                { Ignore, Add, Remove, Force }
   Add or remove newline between '()' in a function declaration.
 
-nl_func_def_empty                         { Ignore, Add, Remove, Force }
+nl_func_def_empty                                 { Ignore, Add, Remove, Force }
   Add or remove newline between '()' in a function definition.
 
-nl_oc_msg_args                            { False, True }
+nl_func_call_start_multi_line                     { False, True }
+  Whether to add newline after '(' in a function call if '(' and ')' are in different lines.
+
+nl_func_call_args_multi_line                      { False, True }
+  Whether to add newline after each ',' in a function call if '(' and ')' are in different lines.
+
+nl_func_call_end_multi_line                       { False, True }
+  Whether to add newline before ')' in a function call if '(' and ')' are in different lines.
+
+nl_oc_msg_args                                    { False, True }
   Whether to put each OC message parameter on a separate line
   See nl_oc_msg_leave_one_liner
 
-nl_fdef_brace                             { Ignore, Add, Remove, Force }
+nl_fdef_brace                                     { Ignore, Add, Remove, Force }
   Add or remove newline between function signature and '{'
 
-nl_cpp_ldef_brace                         { Ignore, Add, Remove, Force }
+nl_cpp_ldef_brace                                 { Ignore, Add, Remove, Force }
   Add or remove newline between C++11 lambda signature and '{'
 
-nl_return_expr                            { Ignore, Add, Remove, Force }
+nl_return_expr                                    { Ignore, Add, Remove, Force }
   Add or remove a newline between the return keyword and return expression.
 
-nl_after_semicolon                        { False, True }
+nl_after_semicolon                                { False, True }
   Whether to put a newline after semicolons, except in 'for' statements
 
-nl_paren_dbrace_open                      { Ignore, Add, Remove, Force }
+nl_paren_dbrace_open                              { Ignore, Add, Remove, Force }
   Java: Control the newline between the ')' and '{{' of the double brace initializer.
 
-nl_after_brace_open                       { False, True }
+nl_after_brace_open                               { False, True }
   Whether to put a newline after brace open.
   This also adds a newline before the matching brace close.
 
-nl_after_brace_open_cmt                   { False, True }
+nl_after_brace_open_cmt                           { False, True }
   If nl_after_brace_open and nl_after_brace_open_cmt are true, a newline is
   placed between the open brace and a trailing single-line comment.
 
-nl_after_vbrace_open                      { False, True }
+nl_after_vbrace_open                              { False, True }
   Whether to put a newline after a virtual brace open with a non-empty body.
   These occur in un-braced if/while/do/for statement bodies.
 
-nl_after_vbrace_open_empty                { False, True }
+nl_after_vbrace_open_empty                        { False, True }
   Whether to put a newline after a virtual brace open with an empty body.
   These occur in un-braced if/while/do/for statement bodies.
 
-nl_after_brace_close                      { False, True }
+nl_after_brace_close                              { False, True }
   Whether to put a newline after a brace close.
   Does not apply if followed by a necessary ';'.
 
-nl_after_vbrace_close                     { False, True }
+nl_after_vbrace_close                             { False, True }
   Whether to put a newline after a virtual brace close.
   Would add a newline before return in: 'if (foo) a++; return;'
 
-nl_brace_struct_var                       { Ignore, Add, Remove, Force }
+nl_brace_struct_var                               { Ignore, Add, Remove, Force }
   Control the newline between the close brace and 'b' in: 'struct { int a; } b;'
   Affects enums, unions and structures. If set to ignore, uses nl_after_brace_close
 
-nl_define_macro                           { False, True }
+nl_define_macro                                   { False, True }
   Whether to alter newlines in '#define' macros
 
-nl_squeeze_ifdef                          { False, True }
-  Whether to not put blanks after '#ifxx', '#elxx', or before '#endif'. Does not affect the whole-file #ifdef.
+nl_squeeze_ifdef                                  { False, True }
+  Whether to remove blanks after '#ifxx' and '#elxx', or before '#elxx' and '#endif'. Does not affect top-level #ifdefs.
 
-nl_before_if                              { Ignore, Add, Remove, Force }
+nl_squeeze_ifdef_top_level                        { False, True }
+  Makes the nl_squeeze_ifdef option affect the top-level #ifdefs as well.
+
+nl_before_if                                      { Ignore, Add, Remove, Force }
   Add or remove blank line before 'if'
 
-nl_after_if                               { Ignore, Add, Remove, Force }
+nl_after_if                                       { Ignore, Add, Remove, Force }
   Add or remove blank line after 'if' statement
 
-nl_before_for                             { Ignore, Add, Remove, Force }
+nl_before_for                                     { Ignore, Add, Remove, Force }
   Add or remove blank line before 'for'
 
-nl_after_for                              { Ignore, Add, Remove, Force }
+nl_after_for                                      { Ignore, Add, Remove, Force }
   Add or remove blank line after 'for' statement
 
-nl_before_while                           { Ignore, Add, Remove, Force }
+nl_before_while                                   { Ignore, Add, Remove, Force }
   Add or remove blank line before 'while'
 
-nl_after_while                            { Ignore, Add, Remove, Force }
+nl_after_while                                    { Ignore, Add, Remove, Force }
   Add or remove blank line after 'while' statement
 
-nl_before_switch                          { Ignore, Add, Remove, Force }
+nl_before_switch                                  { Ignore, Add, Remove, Force }
   Add or remove blank line before 'switch'
 
-nl_after_switch                           { Ignore, Add, Remove, Force }
+nl_after_switch                                   { Ignore, Add, Remove, Force }
   Add or remove blank line after 'switch' statement
 
-nl_before_synchronized                    { Ignore, Add, Remove, Force }
+nl_before_synchronized                            { Ignore, Add, Remove, Force }
   Add or remove blank line before 'synchronized'
 
-nl_after_synchronized                     { Ignore, Add, Remove, Force }
+nl_after_synchronized                             { Ignore, Add, Remove, Force }
   Add or remove blank line after 'synchronized' statement
 
-nl_before_do                              { Ignore, Add, Remove, Force }
+nl_before_do                                      { Ignore, Add, Remove, Force }
   Add or remove blank line before 'do'
 
-nl_after_do                               { Ignore, Add, Remove, Force }
+nl_after_do                                       { Ignore, Add, Remove, Force }
   Add or remove blank line after 'do/while' statement
 
-nl_ds_struct_enum_cmt                     { False, True }
+nl_ds_struct_enum_cmt                             { False, True }
   Whether to double-space commented-entries in struct/union/enum
 
-nl_ds_struct_enum_close_brace             { False, True }
+nl_ds_struct_enum_close_brace                     { False, True }
   force nl before } of a struct/union/enum
   (lower priority than 'eat_blanks_before_close_brace')
 
-nl_before_func_class_def                  Number
+nl_before_func_class_def                          Number
   Add or remove blank line before 'func_class_def'
 
-nl_before_func_class_proto                Number
+nl_before_func_class_proto                        Number
   Add or remove blank line before 'func_class_proto'
 
-nl_class_colon                            { Ignore, Add, Remove, Force }
+nl_class_colon                                    { Ignore, Add, Remove, Force }
   Add or remove a newline before/after a class colon,
     (tied to pos_class_colon).
 
-nl_constr_colon                           { Ignore, Add, Remove, Force }
+nl_constr_colon                                   { Ignore, Add, Remove, Force }
   Add or remove a newline around a class constructor colon.
   Related to nl_constr_init_args, pos_constr_colon and pos_constr_comma.
 
-nl_create_if_one_liner                    { False, True }
+nl_create_if_one_liner                            { False, True }
   Change simple unbraced if statements into a one-liner
   'if(b)\n i++;' => 'if(b) i++;'
 
-nl_create_for_one_liner                   { False, True }
+nl_create_for_one_liner                           { False, True }
   Change simple unbraced for statements into a one-liner
   'for (i=0;i<5;i++)\n foo(i);' => 'for (i=0;i<5;i++) foo(i);'
 
-nl_create_while_one_liner                 { False, True }
+nl_create_while_one_liner                         { False, True }
   Change simple unbraced while statements into a one-liner
+  'while (i<5)\n foo(i++);' => 'while (i<5) foo(i++);'
+
+nl_split_if_one_liner                             { False, True }
+   Change a one-liner if statement into simple unbraced if
+  'if(b) i++;' => 'if(b) i++;'
+
+nl_split_for_one_liner                            { False, True }
+  Change a one-liner for statement into simple unbraced for
+  'for (i=0;<5;i++) foo(i);' => 'for (i=0;<5;i++) foo(i);'
+
+nl_split_while_one_liner                          { False, True }
+  Change simple unbraced while statements into a one-liner while
   'while (i<5)\n foo(i++);' => 'while (i<5) foo(i++);'
 
 #
 # Positioning options
 #
 
-pos_arith                                 { Ignore, Lead, Trail }
+pos_arith                                         { Ignore, Lead, Trail }
   The position of arithmetic operators in wrapped expressions
 
-pos_assign                                { Ignore, Lead, Trail }
+pos_assign                                        { Ignore, Lead, Trail }
   The position of assignment in wrapped expressions.
   Do not affect '=' followed by '{'
 
-pos_bool                                  { Ignore, Lead, Trail }
+pos_bool                                          { Ignore, Lead, Trail }
   The position of boolean operators in wrapped expressions
 
-pos_compare                               { Ignore, Lead, Trail }
+pos_compare                                       { Ignore, Lead, Trail }
   The position of comparison operators in wrapped expressions
 
-pos_conditional                           { Ignore, Lead, Trail }
+pos_conditional                                   { Ignore, Lead, Trail }
   The position of conditional (b ? t : f) operators in wrapped expressions
 
-pos_comma                                 { Ignore, Lead, Trail }
+pos_comma                                         { Ignore, Lead, Trail }
   The position of the comma in wrapped expressions
 
-pos_class_comma                           { Ignore, Lead, Trail }
+pos_class_comma                                   { Ignore, Lead, Trail }
   The position of the comma in the base class list if there are more than one line,
     (tied to nl_class_init_args).
 
-pos_constr_comma                          { Ignore, Lead, Trail }
+pos_constr_comma                                  { Ignore, Lead, Trail }
   The position of the comma in the constructor initialization list.
   Related to nl_constr_colon, nl_constr_init_args and pos_constr_colon.
 
-pos_class_colon                           { Ignore, Lead, Trail }
+pos_class_colon                                   { Ignore, Lead, Trail }
   The position of trailing/leading class colon, between class and base class list
     (tied to nl_class_colon).
-  
 
-pos_constr_colon                          { Ignore, Lead, Trail }
+pos_constr_colon                                  { Ignore, Lead, Trail }
   The position of colons between constructor and member initialization,
   (tied to UO_nl_constr_colon).
   Related to nl_constr_colon, nl_constr_init_args and pos_constr_comma.
@@ -1421,333 +1499,373 @@ pos_constr_colon                          { Ignore, Lead, Trail }
 # Line Splitting options
 #
 
-code_width                                Number
+code_width                                        Number
   Try to limit code width to N number of columns
 
-ls_for_split_full                         { False, True }
+ls_for_split_full                                 { False, True }
   Whether to fully split long 'for' statements at semi-colons
 
-ls_func_split_full                        { False, True }
+ls_func_split_full                                { False, True }
   Whether to fully split long function protos/calls at commas
 
-ls_code_width                             { False, True }
+ls_code_width                                     { False, True }
   Whether to split lines as close to code_width as possible and ignore some groupings
 
 #
 # Blank line options
 #
 
-nl_max                                    Number
+nl_max                                            Number
   The maximum consecutive newlines (3 = 2 blank lines)
 
-nl_after_func_proto                       Number
+nl_after_func_proto                               Number
   The number of newlines after a function prototype, if followed by another function prototype
 
-nl_after_func_proto_group                 Number
+nl_after_func_proto_group                         Number
   The number of newlines after a function prototype, if not followed by another function prototype
 
-nl_before_func_body_def                   Number
+nl_after_func_class_proto                         Number
+  The number of newlines after a function class prototype, if followed by another function class prototype
+
+nl_after_func_class_proto_group                   Number
+  The number of newlines after a function class prototype, if not followed by another function class prototype
+
+nl_before_func_body_def                           Number
   The number of newlines before a multi-line function def body
 
-nl_before_func_body_proto                 Number
+nl_before_func_body_proto                         Number
   The number of newlines before a multi-line function prototype body
 
-nl_after_func_body                        Number
+nl_after_func_body                                Number
   The number of newlines after '}' of a multi-line function body
 
-nl_after_func_body_class                  Number
+nl_after_func_body_class                          Number
   The number of newlines after '}' of a multi-line function body in a class declaration
 
-nl_after_func_body_one_liner              Number
+nl_after_func_body_one_liner                      Number
   The number of newlines after '}' of a single line function body
 
-nl_before_block_comment                   Number
+nl_before_block_comment                           Number
   The minimum number of newlines before a multi-line comment.
   Doesn't apply if after a brace open or another multi-line comment.
 
-nl_before_c_comment                       Number
+nl_before_c_comment                               Number
   The minimum number of newlines before a single-line C comment.
   Doesn't apply if after a brace open or other single-line C comments.
 
-nl_before_cpp_comment                     Number
+nl_before_cpp_comment                             Number
   The minimum number of newlines before a CPP comment.
   Doesn't apply if after a brace open or other CPP comments.
 
-nl_after_multiline_comment                { False, True }
+nl_after_multiline_comment                        { False, True }
   Whether to force a newline after a multi-line comment.
 
-nl_after_label_colon                      { False, True }
+nl_after_label_colon                              { False, True }
   Whether to force a newline after a label's colon.
 
-nl_after_struct                           Number
+nl_after_struct                                   Number
   The number of newlines after '}' or ';' of a struct/enum/union definition
 
-nl_after_class                            Number
+nl_after_class                                    Number
   The number of newlines after '}' or ';' of a class definition
 
-nl_before_access_spec                     Number
+nl_before_access_spec                             Number
   The number of newlines before a 'private:', 'public:', 'protected:', 'signals:', or 'slots:' label.
   Will not change the newline count if after a brace open.
   0 = No change.
 
-nl_after_access_spec                      Number
+nl_after_access_spec                              Number
   The number of newlines after a 'private:', 'public:', 'protected:', 'signals:' or 'slots:' label.
   0 = No change.
   the option 'nl_after_access_spec' takes preference over 'nl_typedef_blk_start' and 'nl_var_def_blk_start'
 
-nl_comment_func_def                       Number
+nl_comment_func_def                               Number
   The number of newlines between a function def and the function comment.
   0 = No change.
 
-nl_after_try_catch_finally                Number
+nl_after_try_catch_finally                        Number
   The number of newlines after a try-catch-finally block that isn't followed by a brace close.
   0 = No change.
 
-nl_around_cs_property                     Number
+nl_around_cs_property                             Number
   The number of newlines before and after a property, indexer or event decl.
   0 = No change.
 
-nl_between_get_set                        Number
+nl_between_get_set                                Number
   The number of newlines between the get/set/add/remove handlers in C#.
   0 = No change.
 
-nl_property_brace                         { Ignore, Add, Remove, Force }
+nl_property_brace                                 { Ignore, Add, Remove, Force }
   Add or remove newline between C# property and the '{'
 
-eat_blanks_after_open_brace               { False, True }
+eat_blanks_after_open_brace                       { False, True }
   Whether to remove blank lines after '{'
 
-eat_blanks_before_close_brace             { False, True }
+eat_blanks_before_close_brace                     { False, True }
   Whether to remove blank lines before '}'
 
-nl_remove_extra_newlines                  Number
+nl_remove_extra_newlines                          Number
   How aggressively to remove extra newlines not in preproc.
   0: No change
   1: Remove most newlines not handled by other config
   2: Remove all newlines and reformat completely by config
 
-nl_before_return                          { False, True }
+nl_before_return                                  { False, True }
   Whether to put a blank line before 'return' statements, unless after an open brace.
 
-nl_after_return                           { False, True }
+nl_after_return                                   { False, True }
   Whether to put a blank line after 'return' statements, unless followed by a close brace.
 
-nl_after_annotation                       { Ignore, Add, Remove, Force }
+nl_after_annotation                               { Ignore, Add, Remove, Force }
   Whether to put a newline after a Java annotation statement.
   Only affects annotations that are after a newline.
 
-nl_between_annotation                     { Ignore, Add, Remove, Force }
+nl_between_annotation                             { Ignore, Add, Remove, Force }
   Controls the newline between two annotations.
 
 #
 # Code modifying options (non-whitespace)
 #
 
-mod_full_brace_do                         { Ignore, Add, Remove, Force }
+mod_full_brace_do                                 { Ignore, Add, Remove, Force }
   Add or remove braces on single-line 'do' statement
 
-mod_full_brace_for                        { Ignore, Add, Remove, Force }
+mod_full_brace_for                                { Ignore, Add, Remove, Force }
   Add or remove braces on single-line 'for' statement
 
-mod_full_brace_function                   { Ignore, Add, Remove, Force }
+mod_full_brace_function                           { Ignore, Add, Remove, Force }
   Add or remove braces on single-line function definitions. (Pawn)
 
-mod_full_brace_if                         { Ignore, Add, Remove, Force }
+mod_full_brace_if                                 { Ignore, Add, Remove, Force }
   Add or remove braces on single-line 'if' statement. Will not remove the braces if they contain an 'else'.
 
-mod_full_brace_if_chain                   { False, True }
+mod_full_brace_if_chain                           { False, True }
   Make all if/elseif/else statements in a chain be braced or not. Overrides mod_full_brace_if.
   If any must be braced, they are all braced.  If all can be unbraced, then the braces are removed.
 
-mod_full_brace_nl                         Number
+mod_full_brace_if_chain_only                      { False, True }
+  Make all if/elseif/else statements with at least one 'else' or 'else if' fully braced.
+  If mod_full_brace_if_chain is used together with this option, all if-else chains will get braces,
+  and simple 'if' statements will lose them (if possible).
+  
+
+mod_full_brace_nl                                 Number
   Don't remove braces around statements that span N newlines
 
-mod_full_brace_while                      { Ignore, Add, Remove, Force }
+mod_full_brace_while                              { Ignore, Add, Remove, Force }
   Add or remove braces on single-line 'while' statement
 
-mod_full_brace_using                      { Ignore, Add, Remove, Force }
+mod_full_brace_using                              { Ignore, Add, Remove, Force }
   Add or remove braces on single-line 'using ()' statement
 
-mod_paren_on_return                       { Ignore, Add, Remove, Force }
+mod_paren_on_return                               { Ignore, Add, Remove, Force }
   Add or remove unnecessary paren on 'return' statement
 
-mod_pawn_semicolon                        { False, True }
+mod_pawn_semicolon                                { False, True }
   Whether to change optional semicolons to real semicolons
 
-mod_full_paren_if_bool                    { False, True }
+mod_full_paren_if_bool                            { False, True }
   Add parens on 'while' and 'if' statement around bools
 
-mod_remove_extra_semicolon                { False, True }
+mod_remove_extra_semicolon                        { False, True }
   Whether to remove superfluous semicolons
 
-mod_add_long_function_closebrace_comment  Number
+mod_add_long_function_closebrace_comment          Number
   If a function body exceeds the specified number of newlines and doesn't have a comment after
   the close brace, a comment will be added.
 
-mod_add_long_namespace_closebrace_comment Number
+mod_add_long_namespace_closebrace_comment         Number
   If a namespace body exceeds the specified number of newlines and doesn't have a comment after
   the close brace, a comment will be added.
 
-mod_add_long_switch_closebrace_comment    Number
+mod_add_long_switch_closebrace_comment            Number
   If a switch body exceeds the specified number of newlines and doesn't have a comment after
   the close brace, a comment will be added.
 
-mod_add_long_ifdef_endif_comment          Number
+mod_add_long_ifdef_endif_comment                  Number
   If an #ifdef body exceeds the specified number of newlines and doesn't have a comment after
   the #endif, a comment will be added.
 
-mod_add_long_ifdef_else_comment           Number
+mod_add_long_ifdef_else_comment                   Number
   If an #ifdef or #else body exceeds the specified number of newlines and doesn't have a comment after
   the #else, a comment will be added.
 
-mod_sort_import                           { False, True }
+mod_sort_import                                   { False, True }
   If TRUE, will sort consecutive single-line 'import' statements [Java, D]
 
-mod_sort_using                            { False, True }
+mod_sort_using                                    { False, True }
   If TRUE, will sort consecutive single-line 'using' statements [C#]
 
-mod_sort_include                          { False, True }
+mod_sort_include                                  { False, True }
   If TRUE, will sort consecutive single-line '#include' statements [C/C++] and '#import' statements [Obj-C]
   This is generally a bad idea, as it may break your code.
 
-mod_move_case_break                       { False, True }
+mod_move_case_break                               { False, True }
   If TRUE, it will move a 'break' that appears after a fully braced 'case' before the close brace.
 
-mod_case_brace                            { Ignore, Add, Remove, Force }
+mod_case_brace                                    { Ignore, Add, Remove, Force }
   Will add or remove the braces around a fully braced case statement.
   Will only remove the braces if there are no variable declarations in the block.
 
-mod_remove_empty_return                   { False, True }
+mod_remove_empty_return                           { False, True }
   If TRUE, it will remove a void 'return;' that appears as the last statement in a function.
 
 #
 # Comment modifications
 #
 
-cmt_width                                 Number
+cmt_width                                         Number
   Try to wrap comments at cmt_width columns
 
-cmt_reflow_mode                           Number
+cmt_reflow_mode                                   Number
   Set the comment reflow mode (default: 0)
   0: no reflowing (apart from the line wrapping due to cmt_width)
   1: no touching at all
   2: full reflow
   
 
-cmt_convert_tab_to_spaces                 { False, True }
+cmt_convert_tab_to_spaces                         { False, True }
   Whether to convert all tabs to spaces in comments. Default is to leave tabs inside comments alone, unless used for indenting.
 
-cmt_indent_multi                          { False, True }
+cmt_indent_multi                                  { False, True }
   If false, disable all multi-line comment changes, including cmt_width. keyword substitution and leading chars.
-  Default is true.
+  Default=True.
 
-cmt_c_group                               { False, True }
+cmt_c_group                                       { False, True }
   Whether to group c-comments that look like they are in a block
 
-cmt_c_nl_start                            { False, True }
+cmt_c_nl_start                                    { False, True }
   Whether to put an empty '/*' on the first line of the combined c-comment
 
-cmt_c_nl_end                              { False, True }
+cmt_c_nl_end                                      { False, True }
   Whether to put a newline before the closing '*/' of the combined c-comment
 
-cmt_cpp_group                             { False, True }
+cmt_cpp_group                                     { False, True }
   Whether to group cpp-comments that look like they are in a block
 
-cmt_cpp_nl_start                          { False, True }
+cmt_cpp_nl_start                                  { False, True }
   Whether to put an empty '/*' on the first line of the combined cpp-comment
 
-cmt_cpp_nl_end                            { False, True }
+cmt_cpp_nl_end                                    { False, True }
   Whether to put a newline before the closing '*/' of the combined cpp-comment
 
-cmt_cpp_to_c                              { False, True }
+cmt_cpp_to_c                                      { False, True }
   Whether to change cpp-comments into c-comments
 
-cmt_star_cont                             { False, True }
+cmt_star_cont                                     { False, True }
   Whether to put a star on subsequent comment lines
 
-cmt_sp_before_star_cont                   Number
+cmt_sp_before_star_cont                           Number
   The number of spaces to insert at the start of subsequent comment lines
 
-cmt_sp_after_star_cont                    Number
+cmt_sp_after_star_cont                            Number
   The number of spaces to insert after the star on subsequent comment lines
 
-cmt_multi_check_last                      { False, True }
+cmt_multi_check_last                              { False, True }
   For multi-line comments with a '*' lead, remove leading spaces if the first and last lines of
   the comment are the same length. Default=True
 
-cmt_insert_file_header                    String
+cmt_insert_file_header                            String
   The filename that contains text to insert at the head of a file if the file doesn't start with a C/C++ comment.
   Will substitute $(filename) with the current file's name.
 
-cmt_insert_file_footer                    String
+cmt_insert_file_footer                            String
   The filename that contains text to insert at the end of a file if the file doesn't end with a C/C++ comment.
   Will substitute $(filename) with the current file's name.
 
-cmt_insert_func_header                    String
+cmt_insert_func_header                            String
   The filename that contains text to insert before a function implementation if the function isn't preceded with a C/C++ comment.
   Will substitute $(function) with the function name and $(javaparam) with the javadoc @param and @return stuff.
   Will also substitute $(fclass) with the class name: void CFoo::Bar() { ... }
 
-cmt_insert_class_header                   String
+cmt_insert_class_header                           String
   The filename that contains text to insert before a class if the class isn't preceded with a C/C++ comment.
   Will substitute $(class) with the class name.
 
-cmt_insert_oc_msg_header                  String
+cmt_insert_oc_msg_header                          String
   The filename that contains text to insert before a Obj-C message specification if the method isn't preceded with a C/C++ comment.
   Will substitute $(message) with the function name and $(javaparam) with the javadoc @param and @return stuff.
 
-cmt_insert_before_preproc                 { False, True }
+cmt_insert_before_preproc                         { False, True }
   If a preprocessor is encountered when stepping backwards from a function name, then
   this option decides whether the comment should be inserted.
   Affects cmt_insert_oc_msg_header, cmt_insert_func_header and cmt_insert_class_header.
+
+cmt_insert_before_inlines                         { False, True }
+  If a function is declared inline to a class definition, then
+  this option decides whether the comment should be inserted.
+  Affects cmt_insert_func_header.
+
+cmt_insert_before_ctor_dtor                       { False, True }
+  If the function is a constructor/destructor, then
+  this option decides whether the comment should be inserted.
+  Affects cmt_insert_func_header.
 
 #
 # Preprocessor options
 #
 
-pp_indent                                 { Ignore, Add, Remove, Force }
+pp_indent                                         { Ignore, Add, Remove, Force }
   Control indent of preprocessors inside #if blocks at brace level 0 (file-level)
 
-pp_indent_at_level                        { False, True }
+pp_indent_at_level                                { False, True }
   Whether to indent #if/#else/#endif at the brace level (true) or from column 1 (false)
 
-pp_indent_count                           Number
+pp_indent_count                                   Number
   Specifies the number of columns to indent preprocessors per level at brace level 0 (file-level).
   If pp_indent_at_level=false, specifies the number of columns to indent preprocessors per level at brace level > 0 (function-level).
   Default=1.
 
-pp_space                                  { Ignore, Add, Remove, Force }
+pp_space                                          { Ignore, Add, Remove, Force }
   Add or remove space after # based on pp_level of #if blocks
 
-pp_space_count                            Number
+pp_space_count                                    Number
   Sets the number of spaces added with pp_space
 
-pp_indent_region                          Number
+pp_indent_region                                  Number
   The indent for #region and #endregion in C# and '#pragma region' in C/C++
 
-pp_region_indent_code                     { False, True }
+pp_region_indent_code                             { False, True }
   Whether to indent the code between #region and #endregion
 
-pp_indent_if                              Number
+pp_indent_if                                      Number
   If pp_indent_at_level=true, sets the indent for #if, #else and #endif when not at file-level.
   0:  indent preprocessors using output_tab_size.
   >0: column at which all preprocessors will be indented.
 
-pp_if_indent_code                         { False, True }
+pp_if_indent_code                                 { False, True }
   Control whether to indent the code between #if, #else and #endif.
 
-pp_define_at_level                        { False, True }
+pp_define_at_level                                { False, True }
   Whether to indent '#define' at the brace level (true) or from column 1 (false)
 
 #
 # Use or Do not Use options
 #
 
-use_indent_func_call_param                { False, True }
-  True:  indent_func_call_param will be used
+use_indent_func_call_param                        { False, True }
+  True:  indent_func_call_param will be used (default)
   False: indent_func_call_param will NOT be used
 
-use_indent_continue_only_once             { False, True }
+use_indent_continue_only_once                     { False, True }
+  The value of the indentation for a continuation line is calculate differently if the line is:
+    a declaration :your case with QString fileName ...
+    an assigment  :your case with pSettings = new QSettings( ...
+  At the second case the option value might be used twice:
+    at the assigment
+    at the function call (if present)
+  To prevent the double use of the option value, use this option with the value 'true'.
   True:  indent_continue will be used only once
   False: indent_continue will be used every time (default)
+
+use_options_overriding_for_qt_macros              { False, True }
+  SIGNAL/SLOT Qt macros have special formatting options. See options_for_QT.cpp for details.
+  Default=True.
+
+#
+# Warn levels - 1: error, 2: warning (default), 3: note
+#
+
+warn_level_tabs_found_in_verbatim_string_literals Number
+  Warning is given if doing tab-to-\t replacement and we have found one in a C# verbatim string literal.
 

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -4,280 +4,287 @@
 # General options
 #
 
-# The type of line endings
-newlines                                  = auto     # auto/lf/crlf/cr
+# The type of line endings. Default=Auto
+newlines                                          = auto     # auto/lf/crlf/cr
 
-# The original size of tabs in the input
-input_tab_size                            = 8        # number
+# The original size of tabs in the input. Default=8
+input_tab_size                                    = 8        # number
 
-# The size of tabs in the output (only used if align_with_tabs=true)
-output_tab_size                           = 8        # number
+# The size of tabs in the output (only used if align_with_tabs=true). Default=8
+output_tab_size                                   = 8        # number
 
 # The ASCII value of the string escape char, usually 92 (\) or 94 (^). (Pawn)
-string_escape_char                        = 92       # number
+string_escape_char                                = 92       # number
 
 # Alternate string escape char for Pawn. Only works right before the quote char.
-string_escape_char2                       = 0        # number
+string_escape_char2                               = 0        # number
 
 # Replace tab characters found in string literals with the escape sequence \t instead.
-string_replace_tab_chars                  = false    # false/true
+string_replace_tab_chars                          = false    # false/true
 
 # Allow interpreting '>=' and '>>=' as part of a template in 'void f(list<list<B>>=val);'.
-# If true (default), 'assert(x<0 && y>=3)' will be broken.
+# If true, 'assert(x<0 && y>=3)' will be broken. Default=False
 # Improvements to template detection may make this option obsolete.
-tok_split_gte                             = false    # false/true
+tok_split_gte                                     = false    # false/true
 
 # Override the default ' *INDENT-OFF*' in comments for disabling processing of part of the file.
-disable_processing_cmt                    = ""         # string
+disable_processing_cmt                            = ""         # string
 
 # Override the default ' *INDENT-ON*' in comments for enabling processing of part of the file.
-enable_processing_cmt                     = ""         # string
+enable_processing_cmt                             = ""         # string
 
-# Enable parsing of digraphs. Default=false
-enable_digraphs                           = false    # false/true
+# Enable parsing of digraphs. Default=False
+enable_digraphs                                   = false    # false/true
 
 # Control what to do with the UTF-8 BOM (recommend 'remove')
-utf8_bom                                  = ignore   # ignore/add/remove/force
+utf8_bom                                          = ignore   # ignore/add/remove/force
 
 # If the file contains bytes with values between 128 and 255, but is not UTF-8, then output as UTF-8
-utf8_byte                                 = false    # false/true
+utf8_byte                                         = false    # false/true
 
 # Force the output encoding to UTF-8
-utf8_force                                = false    # false/true
+utf8_force                                        = false    # false/true
 
 #
 # Indenting
 #
 
 # The number of columns to indent per level.
-# Usually 2, 3, 4, or 8.
-indent_columns                            = 8        # number
+# Usually 2, 3, 4, or 8. Default=8
+indent_columns                                    = 8        # number
 
 # The continuation indent. If non-zero, this overrides the indent of '(' and '=' continuation indents.
 # For FreeBSD, this is set to 4. Negative value is absolute and not increased for each ( level
-indent_continue                           = 0        # number
+indent_continue                                   = 0        # number
 
 # How to use tabs when indenting code
 # 0=spaces only
-# 1=indent with tabs to brace level, align with spaces
+# 1=indent with tabs to brace level, align with spaces (default)
 # 2=indent and align with tabs, using spaces when not on a tabstop
-indent_with_tabs                          = 1        # number
+indent_with_tabs                                  = 1        # number
 
 # Comments that are not a brace level are indented with tabs on a tabstop.
 # Requires indent_with_tabs=2. If false, will use spaces.
-indent_cmt_with_tabs                      = false    # false/true
+indent_cmt_with_tabs                              = false    # false/true
 
 # Whether to indent strings broken by '\' so that they line up
-indent_align_string                       = false    # false/true
+indent_align_string                               = false    # false/true
 
 # The number of spaces to indent multi-line XML strings.
 # Requires indent_align_string=True
-indent_xml_string                         = 0        # number
+indent_xml_string                                 = 0        # number
 
 # Spaces to indent '{' from level
-indent_brace                              = 0        # number
+indent_brace                                      = 0        # number
 
 # Whether braces are indented to the body level
-indent_braces                             = false    # false/true
+indent_braces                                     = false    # false/true
 
 # Disabled indenting function braces if indent_braces is true
-indent_braces_no_func                     = false    # false/true
+indent_braces_no_func                             = false    # false/true
 
 # Disabled indenting class braces if indent_braces is true
-indent_braces_no_class                    = false    # false/true
+indent_braces_no_class                            = false    # false/true
 
 # Disabled indenting struct braces if indent_braces is true
-indent_braces_no_struct                   = false    # false/true
+indent_braces_no_struct                           = false    # false/true
 
 # Indent based on the size of the brace parent, i.e. 'if' => 3 spaces, 'for' => 4 spaces, etc.
-indent_brace_parent                       = false    # false/true
+indent_brace_parent                               = false    # false/true
 
 # Indent based on the paren open instead of the brace open in '({\n', default is to indent by brace.
-indent_paren_open_brace                   = false    # false/true
+indent_paren_open_brace                           = false    # false/true
+
+# indent a C# delegate by another level, default is to not indent by another level.
+indent_cs_delegate_brace                          = false    # false/true
 
 # Whether the 'namespace' body is indented
-indent_namespace                          = false    # false/true
+indent_namespace                                  = false    # false/true
 
 # Only indent one namespace and no sub-namespaces.
 # Requires indent_namespace=true.
-indent_namespace_single_indent            = false    # false/true
+indent_namespace_single_indent                    = false    # false/true
 
 # The number of spaces to indent a namespace block
-indent_namespace_level                    = 0        # number
+indent_namespace_level                            = 0        # number
 
 # If the body of the namespace is longer than this number, it won't be indented.
 # Requires indent_namespace=true. Default=0 (no limit)
-indent_namespace_limit                    = 0        # number
+indent_namespace_limit                            = 0        # number
 
 # Whether the 'extern "C"' body is indented
-indent_extern                             = false    # false/true
+indent_extern                                     = false    # false/true
 
 # Whether the 'class' body is indented
-indent_class                              = false    # false/true
+indent_class                                      = false    # false/true
 
 # Whether to indent the stuff after a leading base class colon
-indent_class_colon                        = false    # false/true
+indent_class_colon                                = false    # false/true
 
 # Indent based on a class colon instead of the stuff after the colon.
-# Requires indent_class_colon=true. Default=false
-indent_class_on_colon                     = false    # false/true
+# Requires indent_class_colon=true. Default=False
+indent_class_on_colon                             = false    # false/true
 
 # Whether to indent the stuff after a leading class initializer colon
-indent_constr_colon                       = false    # false/true
+indent_constr_colon                               = false    # false/true
 
-# Virtual indent from the ':' for member initializers. Default is 2
-indent_ctor_init_leading                  = 2        # number
+# Virtual indent from the ':' for member initializers. Default=2
+indent_ctor_init_leading                          = 2        # number
 
 # Additional indenting for constructor initializer list
-indent_ctor_init                          = 0        # number
+indent_ctor_init                                  = 0        # number
 
 # False=treat 'else\nif' as 'else if' for indenting purposes
 # True=indent the 'if' one level
-indent_else_if                            = false    # false/true
+indent_else_if                                    = false    # false/true
 
 # Amount to indent variable declarations after a open brace. neg=relative, pos=absolute
-indent_var_def_blk                        = 0        # number
+indent_var_def_blk                                = 0        # number
 
 # Indent continued variable declarations instead of aligning.
-indent_var_def_cont                       = false    # false/true
+indent_var_def_cont                               = false    # false/true
 
 # Indent continued shift expressions ('<<' and '>>') instead of aligning.
 # Turn align_left_shift off when enabling this.
-indent_shift                              = false    # false/true
+indent_shift                                      = false    # false/true
 
 # True:  force indentation of function definition to start in column 1
 # False: use the default behavior
-indent_func_def_force_col1                = false    # false/true
+indent_func_def_force_col1                        = false    # false/true
 
 # True:  indent continued function call parameters one indent level
 # False: align parameters under the open paren
-indent_func_call_param                    = false    # false/true
+indent_func_call_param                            = false    # false/true
 
 # Same as indent_func_call_param, but for function defs
-indent_func_def_param                     = false    # false/true
+indent_func_def_param                             = false    # false/true
 
 # Same as indent_func_call_param, but for function protos
-indent_func_proto_param                   = false    # false/true
+indent_func_proto_param                           = false    # false/true
 
 # Same as indent_func_call_param, but for class declarations
-indent_func_class_param                   = false    # false/true
+indent_func_class_param                           = false    # false/true
 
 # Same as indent_func_call_param, but for class variable constructors
-indent_func_ctor_var_param                = false    # false/true
+indent_func_ctor_var_param                        = false    # false/true
 
 # Same as indent_func_call_param, but for templates
-indent_template_param                     = false    # false/true
+indent_template_param                             = false    # false/true
 
 # Double the indent for indent_func_xxx_param options
-indent_func_param_double                  = false    # false/true
+indent_func_param_double                          = false    # false/true
 
 # Indentation column for standalone 'const' function decl/proto qualifier
-indent_func_const                         = 0        # number
+indent_func_const                                 = 0        # number
 
 # Indentation column for standalone 'throw' function decl/proto qualifier
-indent_func_throw                         = 0        # number
+indent_func_throw                                 = 0        # number
 
 # The number of spaces to indent a continued '->' or '.'
 # Usually set to 0, 1, or indent_columns.
-indent_member                             = 0        # number
+indent_member                                     = 0        # number
 
 # Spaces to indent single line ('//') comments on lines before code
-indent_sing_line_comments                 = 0        # number
+indent_sing_line_comments                         = 0        # number
 
 # If set, will indent trailing single line ('//') comments relative
 # to the code instead of trying to keep the same absolute column
-indent_relative_single_line_comments      = false    # false/true
+indent_relative_single_line_comments              = false    # false/true
 
 # Spaces to indent 'case' from 'switch'
 # Usually 0 or indent_columns.
-indent_switch_case                        = 0        # number
+indent_switch_case                                = 0        # number
 
 # Spaces to shift the 'case' line, without affecting any other lines
 # Usually 0.
-indent_case_shift                         = 0        # number
+indent_case_shift                                 = 0        # number
 
 # Spaces to indent '{' from 'case'.
 # By default, the brace will appear under the 'c' in case.
 # Usually set to 0 or indent_columns.
-indent_case_brace                         = 0        # number
+indent_case_brace                                 = 0        # number
 
 # Whether to indent comments found in first column
-indent_col1_comment                       = false    # false/true
+indent_col1_comment                               = false    # false/true
 
 # How to indent goto labels
 #   >0: absolute column where 1 is the leftmost column
 #  <=0: subtract from brace indent
-indent_label                              = 1        # number
+# Default=1
+indent_label                                      = 1        # number
 
-# Same as indent_label, but for access specifiers that are followed by a colon
-indent_access_spec                        = 1        # number
+# Same as indent_label, but for access specifiers that are followed by a colon. Default=1
+indent_access_spec                                = 1        # number
 
 # Indent the code after an access specifier by one level.
 # If set, this option forces 'indent_access_spec=0'
-indent_access_spec_body                   = false    # false/true
+indent_access_spec_body                           = false    # false/true
 
 # If an open paren is followed by a newline, indent the next line so that it lines up after the open paren (not recommended)
-indent_paren_nl                           = false    # false/true
+indent_paren_nl                                   = false    # false/true
 
 # Controls the indent of a close paren after a newline.
 # 0: Indent to body level
 # 1: Align under the open paren
 # 2: Indent to the brace level
-indent_paren_close                        = 0        # number
+indent_paren_close                                = 0        # number
 
 # Controls the indent of a comma when inside a paren.If TRUE, aligns under the open paren
-indent_comma_paren                        = false    # false/true
+indent_comma_paren                                = false    # false/true
 
 # Controls the indent of a BOOL operator when inside a paren.If TRUE, aligns under the open paren
-indent_bool_paren                         = false    # false/true
+indent_bool_paren                                 = false    # false/true
 
 # If 'indent_bool_paren' is true, controls the indent of the first expression. If TRUE, aligns the first expression to the following ones
-indent_first_bool_expr                    = false    # false/true
+indent_first_bool_expr                            = false    # false/true
 
 # If an open square is followed by a newline, indent the next line so that it lines up after the open square (not recommended)
-indent_square_nl                          = false    # false/true
+indent_square_nl                                  = false    # false/true
 
 # Don't change the relative indent of ESQL/C 'EXEC SQL' bodies
-indent_preserve_sql                       = false    # false/true
+indent_preserve_sql                               = false    # false/true
 
 # Align continued statements at the '='. Default=True
 # If FALSE or the '=' is followed by a newline, the next line is indent one tab.
-indent_align_assign                       = true     # false/true
+indent_align_assign                               = true     # false/true
 
 # Indent OC blocks at brace level instead of usual rules.
-indent_oc_block                           = false    # false/true
+indent_oc_block                                   = false    # false/true
 
 # Indent OC blocks in a message relative to the parameter name.
 # 0=use indent_oc_block rules, 1+=spaces to indent
-indent_oc_block_msg                       = 0        # number
+indent_oc_block_msg                               = 0        # number
 
 # Minimum indent for subsequent parameters
-indent_oc_msg_colon                       = 0        # number
+indent_oc_msg_colon                               = 0        # number
 
 # If true, prioritize aligning with initial colon (and stripping spaces from lines, if necessary).
-# Default is true.
-indent_oc_msg_prioritize_first_colon      = true     # false/true
+# Default=True.
+indent_oc_msg_prioritize_first_colon              = true     # false/true
 
 # If indent_oc_block_msg and this option are on, blocks will be indented the way that Xcode does by default (from keyword if the parameter is on its own line; otherwise, from the previous indentation level).
-indent_oc_block_msg_xcode_style           = false    # false/true
+indent_oc_block_msg_xcode_style                   = false    # false/true
 
 # If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg keyword.
-indent_oc_block_msg_from_keyword          = false    # false/true
+indent_oc_block_msg_from_keyword                  = false    # false/true
 
 # If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg colon.
-indent_oc_block_msg_from_colon            = false    # false/true
+indent_oc_block_msg_from_colon                    = false    # false/true
 
 # If indent_oc_block_msg and this option are on, blocks will be indented from where the block caret is.
-indent_oc_block_msg_from_caret            = false    # false/true
+indent_oc_block_msg_from_caret                    = false    # false/true
 
 # If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is.
-indent_oc_block_msg_from_brace            = false    # false/true
+indent_oc_block_msg_from_brace                    = false    # false/true
 
 # When identing after virtual brace open and newline add further spaces to reach this min. indent.
-indent_min_vbrace_open                    = 0        # number
+indent_min_vbrace_open                            = 0        # number
 
 # TRUE: When identing after virtual brace open and newline add further spaces after regular indent to reach next tabstop.
-indent_vbrace_open_on_tabstop             = false    # false/true
+indent_vbrace_open_on_tabstop                     = false    # false/true
+
+# If true, a brace followed by another token (not a newline) will indent all contained lines to match the token.Default=True.
+indent_token_after_brace                          = true     # false/true
 
 #
 # Spacing options
@@ -285,1466 +292,1581 @@ indent_vbrace_open_on_tabstop             = false    # false/true
 
 # Add or remove space around arithmetic operator '+', '-', '/', '*', etc
 # also '>>>' '<<' '>>' '%' '|'
-sp_arith                                  = ignore   # ignore/add/remove/force
+sp_arith                                          = ignore   # ignore/add/remove/force
 
 # Add or remove space around assignment operator '=', '+=', etc
-sp_assign                                 = ignore   # ignore/add/remove/force
+sp_assign                                         = ignore   # ignore/add/remove/force
 
 # Add or remove space around '=' in C++11 lambda capture specifications. Overrides sp_assign
-sp_cpp_lambda_assign                      = ignore   # ignore/add/remove/force
+sp_cpp_lambda_assign                              = ignore   # ignore/add/remove/force
 
 # Add or remove space after the capture specification in C++11 lambda.
-sp_cpp_lambda_paren                       = ignore   # ignore/add/remove/force
+sp_cpp_lambda_paren                               = ignore   # ignore/add/remove/force
 
 # Add or remove space around assignment operator '=' in a prototype
-sp_assign_default                         = ignore   # ignore/add/remove/force
+sp_assign_default                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space before assignment operator '=', '+=', etc. Overrides sp_assign.
-sp_before_assign                          = ignore   # ignore/add/remove/force
+sp_before_assign                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space after assignment operator '=', '+=', etc. Overrides sp_assign.
-sp_after_assign                           = ignore   # ignore/add/remove/force
+sp_after_assign                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space in 'NS_ENUM ('
-sp_enum_paren                             = ignore   # ignore/add/remove/force
+sp_enum_paren                                     = ignore   # ignore/add/remove/force
 
 # Add or remove space around assignment '=' in enum
-sp_enum_assign                            = ignore   # ignore/add/remove/force
+sp_enum_assign                                    = ignore   # ignore/add/remove/force
 
 # Add or remove space before assignment '=' in enum. Overrides sp_enum_assign.
-sp_enum_before_assign                     = ignore   # ignore/add/remove/force
+sp_enum_before_assign                             = ignore   # ignore/add/remove/force
 
 # Add or remove space after assignment '=' in enum. Overrides sp_enum_assign.
-sp_enum_after_assign                      = ignore   # ignore/add/remove/force
+sp_enum_after_assign                              = ignore   # ignore/add/remove/force
 
 # Add or remove space around preprocessor '##' concatenation operator. Default=Add
-sp_pp_concat                              = add      # ignore/add/remove/force
+sp_pp_concat                                      = add      # ignore/add/remove/force
 
 # Add or remove space after preprocessor '#' stringify operator. Also affects the '#@' charizing operator.
-sp_pp_stringify                           = ignore   # ignore/add/remove/force
+sp_pp_stringify                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space before preprocessor '#' stringify operator as in '#define x(y) L#y'.
-sp_before_pp_stringify                    = ignore   # ignore/add/remove/force
+sp_before_pp_stringify                            = ignore   # ignore/add/remove/force
 
 # Add or remove space around boolean operators '&&' and '||'
-sp_bool                                   = ignore   # ignore/add/remove/force
+sp_bool                                           = ignore   # ignore/add/remove/force
 
 # Add or remove space around compare operator '<', '>', '==', etc
-sp_compare                                = ignore   # ignore/add/remove/force
+sp_compare                                        = ignore   # ignore/add/remove/force
 
 # Add or remove space inside '(' and ')'
-sp_inside_paren                           = ignore   # ignore/add/remove/force
+sp_inside_paren                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space between nested parens: '((' vs ') )'
-sp_paren_paren                            = ignore   # ignore/add/remove/force
+sp_paren_paren                                    = ignore   # ignore/add/remove/force
 
 # Add or remove space between back-to-back parens: ')(' vs ') ('
-sp_cparen_oparen                          = ignore   # ignore/add/remove/force
+sp_cparen_oparen                                  = ignore   # ignore/add/remove/force
 
 # Whether to balance spaces inside nested parens
-sp_balance_nested_parens                  = false    # false/true
+sp_balance_nested_parens                          = false    # false/true
 
 # Add or remove space between ')' and '{'
-sp_paren_brace                            = ignore   # ignore/add/remove/force
+sp_paren_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove space before pointer star '*'
-sp_before_ptr_star                        = ignore   # ignore/add/remove/force
+sp_before_ptr_star                                = ignore   # ignore/add/remove/force
 
 # Add or remove space before pointer star '*' that isn't followed by a variable name
 # If set to 'ignore', sp_before_ptr_star is used instead.
-sp_before_unnamed_ptr_star                = ignore   # ignore/add/remove/force
+sp_before_unnamed_ptr_star                        = ignore   # ignore/add/remove/force
 
 # Add or remove space between pointer stars '*'
-sp_between_ptr_star                       = ignore   # ignore/add/remove/force
+sp_between_ptr_star                               = ignore   # ignore/add/remove/force
 
 # Add or remove space after pointer star '*', if followed by a word.
-sp_after_ptr_star                         = ignore   # ignore/add/remove/force
+sp_after_ptr_star                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space after pointer star '*', if followed by a qualifier.
-sp_after_ptr_star_qualifier               = ignore   # ignore/add/remove/force
+sp_after_ptr_star_qualifier                       = ignore   # ignore/add/remove/force
 
 # Add or remove space after a pointer star '*', if followed by a func proto/def.
-sp_after_ptr_star_func                    = ignore   # ignore/add/remove/force
+sp_after_ptr_star_func                            = ignore   # ignore/add/remove/force
 
 # Add or remove space after a pointer star '*', if followed by an open paren (function types).
-sp_ptr_star_paren                         = ignore   # ignore/add/remove/force
+sp_ptr_star_paren                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space before a pointer star '*', if followed by a func proto/def.
-sp_before_ptr_star_func                   = ignore   # ignore/add/remove/force
+sp_before_ptr_star_func                           = ignore   # ignore/add/remove/force
 
 # Add or remove space before a reference sign '&'
-sp_before_byref                           = ignore   # ignore/add/remove/force
+sp_before_byref                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space before a reference sign '&' that isn't followed by a variable name
 # If set to 'ignore', sp_before_byref is used instead.
-sp_before_unnamed_byref                   = ignore   # ignore/add/remove/force
+sp_before_unnamed_byref                           = ignore   # ignore/add/remove/force
 
 # Add or remove space after reference sign '&', if followed by a word.
-sp_after_byref                            = ignore   # ignore/add/remove/force
+sp_after_byref                                    = ignore   # ignore/add/remove/force
 
 # Add or remove space after a reference sign '&', if followed by a func proto/def.
-sp_after_byref_func                       = ignore   # ignore/add/remove/force
+sp_after_byref_func                               = ignore   # ignore/add/remove/force
 
 # Add or remove space before a reference sign '&', if followed by a func proto/def.
-sp_before_byref_func                      = ignore   # ignore/add/remove/force
+sp_before_byref_func                              = ignore   # ignore/add/remove/force
 
 # Add or remove space between type and word. Default=Force
-sp_after_type                             = force    # ignore/add/remove/force
+sp_after_type                                     = force    # ignore/add/remove/force
 
 # Add or remove space before the paren in the D constructs 'template Foo(' and 'class Foo('.
-sp_before_template_paren                  = ignore   # ignore/add/remove/force
+sp_before_template_paren                          = ignore   # ignore/add/remove/force
 
 # Add or remove space in 'template <' vs 'template<'.
 # If set to ignore, sp_before_angle is used.
-sp_template_angle                         = ignore   # ignore/add/remove/force
+sp_template_angle                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space before '<>'
-sp_before_angle                           = ignore   # ignore/add/remove/force
+sp_before_angle                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space inside '<' and '>'
-sp_inside_angle                           = ignore   # ignore/add/remove/force
+sp_inside_angle                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space after '<>'
-sp_after_angle                            = ignore   # ignore/add/remove/force
+sp_after_angle                                    = ignore   # ignore/add/remove/force
 
-# Add or remove space between '<>' and '(' as found in 'new List<byte>();'
-sp_angle_paren                            = ignore   # ignore/add/remove/force
+# Add or remove space between '<>' and '(' as found in 'new List<byte>(foo);'
+sp_angle_paren                                    = ignore   # ignore/add/remove/force
+
+# Add or remove space between '<>' and '()' as found in 'new List<byte>();'
+sp_angle_paren_empty                              = ignore   # ignore/add/remove/force
 
 # Add or remove space between '<>' and a word as in 'List<byte> m;' or 'template <typename T> static ...'
-sp_angle_word                             = ignore   # ignore/add/remove/force
+sp_angle_word                                     = ignore   # ignore/add/remove/force
 
 # Add or remove space between '>' and '>' in '>>' (template stuff C++/C# only). Default=Add
-sp_angle_shift                            = add      # ignore/add/remove/force
+sp_angle_shift                                    = add      # ignore/add/remove/force
 
 # Permit removal of the space between '>>' in 'foo<bar<int> >' (C++11 only). Default=False
 # sp_angle_shift cannot remove the space without this option.
-sp_permit_cpp11_shift                     = false    # false/true
+sp_permit_cpp11_shift                             = false    # false/true
 
 # Add or remove space before '(' of 'if', 'for', 'switch', 'while', etc.
-sp_before_sparen                          = ignore   # ignore/add/remove/force
+sp_before_sparen                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space inside if-condition '(' and ')'
-sp_inside_sparen                          = ignore   # ignore/add/remove/force
+sp_inside_sparen                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space before if-condition ')'. Overrides sp_inside_sparen.
-sp_inside_sparen_close                    = ignore   # ignore/add/remove/force
+sp_inside_sparen_close                            = ignore   # ignore/add/remove/force
 
 # Add or remove space after if-condition '('. Overrides sp_inside_sparen.
-sp_inside_sparen_open                     = ignore   # ignore/add/remove/force
+sp_inside_sparen_open                             = ignore   # ignore/add/remove/force
 
 # Add or remove space after ')' of 'if', 'for', 'switch', and 'while', etc.
-sp_after_sparen                           = ignore   # ignore/add/remove/force
+sp_after_sparen                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space between ')' and '{' of 'if', 'for', 'switch', and 'while', etc.
-sp_sparen_brace                           = ignore   # ignore/add/remove/force
+sp_sparen_brace                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'invariant' and '(' in the D language.
-sp_invariant_paren                        = ignore   # ignore/add/remove/force
+sp_invariant_paren                                = ignore   # ignore/add/remove/force
 
 # Add or remove space after the ')' in 'invariant (C) c' in the D language.
-sp_after_invariant_paren                  = ignore   # ignore/add/remove/force
+sp_after_invariant_paren                          = ignore   # ignore/add/remove/force
 
 # Add or remove space before empty statement ';' on 'if', 'for' and 'while'
-sp_special_semi                           = ignore   # ignore/add/remove/force
+sp_special_semi                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space before ';'. Default=Remove
-sp_before_semi                            = remove   # ignore/add/remove/force
+sp_before_semi                                    = remove   # ignore/add/remove/force
 
 # Add or remove space before ';' in non-empty 'for' statements
-sp_before_semi_for                        = ignore   # ignore/add/remove/force
+sp_before_semi_for                                = ignore   # ignore/add/remove/force
 
 # Add or remove space before a semicolon of an empty part of a for statement.
-sp_before_semi_for_empty                  = ignore   # ignore/add/remove/force
+sp_before_semi_for_empty                          = ignore   # ignore/add/remove/force
 
 # Add or remove space after ';', except when followed by a comment. Default=Add
-sp_after_semi                             = add      # ignore/add/remove/force
+sp_after_semi                                     = add      # ignore/add/remove/force
 
 # Add or remove space after ';' in non-empty 'for' statements. Default=Force
-sp_after_semi_for                         = force    # ignore/add/remove/force
+sp_after_semi_for                                 = force    # ignore/add/remove/force
 
 # Add or remove space after the final semicolon of an empty part of a for statement: for ( ; ; <here> ).
-sp_after_semi_for_empty                   = ignore   # ignore/add/remove/force
+sp_after_semi_for_empty                           = ignore   # ignore/add/remove/force
 
 # Add or remove space before '[' (except '[]')
-sp_before_square                          = ignore   # ignore/add/remove/force
+sp_before_square                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space before '[]'
-sp_before_squares                         = ignore   # ignore/add/remove/force
+sp_before_squares                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space inside a non-empty '[' and ']'
-sp_inside_square                          = ignore   # ignore/add/remove/force
+sp_inside_square                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space after ','
-sp_after_comma                            = ignore   # ignore/add/remove/force
+sp_after_comma                                    = ignore   # ignore/add/remove/force
 
-# Add or remove space before ','
-sp_before_comma                           = remove   # ignore/add/remove/force
+# Add or remove space before ','. Default=Remove
+sp_before_comma                                   = remove   # ignore/add/remove/force
 
 # Add or remove space between ',' and ']' in multidimensional array type 'int[,,]'
-sp_after_mdatype_commas                   = ignore   # ignore/add/remove/force
+sp_after_mdatype_commas                           = ignore   # ignore/add/remove/force
 
 # Add or remove space between '[' and ',' in multidimensional array type 'int[,,]'
-sp_before_mdatype_commas                  = ignore   # ignore/add/remove/force
+sp_before_mdatype_commas                          = ignore   # ignore/add/remove/force
 
 # Add or remove space between ',' in multidimensional array type 'int[,,]'
-sp_between_mdatype_commas                 = ignore   # ignore/add/remove/force
+sp_between_mdatype_commas                         = ignore   # ignore/add/remove/force
 
-# Add or remove space between an open paren and comma: '(,' vs '( ,'
-sp_paren_comma                            = force    # ignore/add/remove/force
+# Add or remove space between an open paren and comma: '(,' vs '( ,'. Default=Force
+sp_paren_comma                                    = force    # ignore/add/remove/force
 
 # Add or remove space before the variadic '...' when preceded by a non-punctuator
-sp_before_ellipsis                        = ignore   # ignore/add/remove/force
+sp_before_ellipsis                                = ignore   # ignore/add/remove/force
 
 # Add or remove space after class ':'
-sp_after_class_colon                      = ignore   # ignore/add/remove/force
+sp_after_class_colon                              = ignore   # ignore/add/remove/force
 
 # Add or remove space before class ':'
-sp_before_class_colon                     = ignore   # ignore/add/remove/force
+sp_before_class_colon                             = ignore   # ignore/add/remove/force
 
 # Add or remove space after class constructor ':'
-sp_after_constr_colon                     = ignore   # ignore/add/remove/force
+sp_after_constr_colon                             = ignore   # ignore/add/remove/force
 
 # Add or remove space before class constructor ':'
-sp_before_constr_colon                    = ignore   # ignore/add/remove/force
+sp_before_constr_colon                            = ignore   # ignore/add/remove/force
 
 # Add or remove space before case ':'. Default=Remove
-sp_before_case_colon                      = remove   # ignore/add/remove/force
+sp_before_case_colon                              = remove   # ignore/add/remove/force
 
 # Add or remove space between 'operator' and operator sign
-sp_after_operator                         = ignore   # ignore/add/remove/force
+sp_after_operator                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space between the operator symbol and the open paren, as in 'operator ++('
-sp_after_operator_sym                     = ignore   # ignore/add/remove/force
+sp_after_operator_sym                             = ignore   # ignore/add/remove/force
+
+# Add or remove space between the operator symbol and the open paren when the operator has no arguments, as in 'operator *()'
+sp_after_operator_sym_empty                       = ignore   # ignore/add/remove/force
 
 # Add or remove space after C/D cast, i.e. 'cast(int)a' vs 'cast(int) a' or '(int)a' vs '(int) a'
-sp_after_cast                             = ignore   # ignore/add/remove/force
+sp_after_cast                                     = ignore   # ignore/add/remove/force
 
 # Add or remove spaces inside cast parens
-sp_inside_paren_cast                      = ignore   # ignore/add/remove/force
+sp_inside_paren_cast                              = ignore   # ignore/add/remove/force
 
 # Add or remove space between the type and open paren in a C++ cast, i.e. 'int(exp)' vs 'int (exp)'
-sp_cpp_cast_paren                         = ignore   # ignore/add/remove/force
+sp_cpp_cast_paren                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'sizeof' and '('
-sp_sizeof_paren                           = ignore   # ignore/add/remove/force
+sp_sizeof_paren                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space after the tag keyword (Pawn)
-sp_after_tag                              = ignore   # ignore/add/remove/force
+sp_after_tag                                      = ignore   # ignore/add/remove/force
 
 # Add or remove space inside enum '{' and '}'
-sp_inside_braces_enum                     = ignore   # ignore/add/remove/force
+sp_inside_braces_enum                             = ignore   # ignore/add/remove/force
 
 # Add or remove space inside struct/union '{' and '}'
-sp_inside_braces_struct                   = ignore   # ignore/add/remove/force
+sp_inside_braces_struct                           = ignore   # ignore/add/remove/force
 
 # Add or remove space inside '{' and '}'
-sp_inside_braces                          = ignore   # ignore/add/remove/force
+sp_inside_braces                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space inside '{}'
-sp_inside_braces_empty                    = ignore   # ignore/add/remove/force
+sp_inside_braces_empty                            = ignore   # ignore/add/remove/force
 
 # Add or remove space between return type and function name
 # A minimum of 1 is forced except for pointer return types.
-sp_type_func                              = ignore   # ignore/add/remove/force
+sp_type_func                                      = ignore   # ignore/add/remove/force
 
 # Add or remove space between function name and '(' on function declaration
-sp_func_proto_paren                       = ignore   # ignore/add/remove/force
+sp_func_proto_paren                               = ignore   # ignore/add/remove/force
+
+# Add or remove space between function name and '()' on function declaration without parameters
+sp_func_proto_paren_empty                         = ignore   # ignore/add/remove/force
 
 # Add or remove space between function name and '(' on function definition
-sp_func_def_paren                         = ignore   # ignore/add/remove/force
+sp_func_def_paren                                 = ignore   # ignore/add/remove/force
+
+# Add or remove space between function name and '()' on function definition without parameters
+sp_func_def_paren_empty                           = ignore   # ignore/add/remove/force
 
 # Add or remove space inside empty function '()'
-sp_inside_fparens                         = ignore   # ignore/add/remove/force
+sp_inside_fparens                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space inside function '(' and ')'
-sp_inside_fparen                          = ignore   # ignore/add/remove/force
+sp_inside_fparen                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space inside the first parens in the function type: 'void (*x)(...)'
-sp_inside_tparen                          = ignore   # ignore/add/remove/force
+sp_inside_tparen                                  = ignore   # ignore/add/remove/force
 
 # Add or remove between the parens in the function type: 'void (*x)(...)'
-sp_after_tparen_close                     = ignore   # ignore/add/remove/force
+sp_after_tparen_close                             = ignore   # ignore/add/remove/force
 
 # Add or remove space between ']' and '(' when part of a function call.
-sp_square_fparen                          = ignore   # ignore/add/remove/force
+sp_square_fparen                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space between ')' and '{' of function
-sp_fparen_brace                           = ignore   # ignore/add/remove/force
+sp_fparen_brace                                   = ignore   # ignore/add/remove/force
 
 # Java: Add or remove space between ')' and '{{' of double brace initializer.
-sp_fparen_dbrace                          = ignore   # ignore/add/remove/force
+sp_fparen_dbrace                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space between function name and '(' on function calls
-sp_func_call_paren                        = ignore   # ignore/add/remove/force
+sp_func_call_paren                                = ignore   # ignore/add/remove/force
 
 # Add or remove space between function name and '()' on function calls without parameters.
 # If set to 'ignore' (the default), sp_func_call_paren is used.
-sp_func_call_paren_empty                  = ignore   # ignore/add/remove/force
+sp_func_call_paren_empty                          = ignore   # ignore/add/remove/force
 
 # Add or remove space between the user function name and '(' on function calls
 # You need to set a keyword to be a user function, like this: 'set func_call_user _' in the config file.
-sp_func_call_user_paren                   = ignore   # ignore/add/remove/force
+sp_func_call_user_paren                           = ignore   # ignore/add/remove/force
 
 # Add or remove space between a constructor/destructor and the open paren
-sp_func_class_paren                       = ignore   # ignore/add/remove/force
+sp_func_class_paren                               = ignore   # ignore/add/remove/force
+
+# Add or remove space between a constructor without parameters or destructor and '()'
+sp_func_class_paren_empty                         = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'return' and '('
-sp_return_paren                           = ignore   # ignore/add/remove/force
+sp_return_paren                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space between '__attribute__' and '('
-sp_attribute_paren                        = ignore   # ignore/add/remove/force
+sp_attribute_paren                                = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'defined' and '(' in '#if defined (FOO)'
-sp_defined_paren                          = ignore   # ignore/add/remove/force
+sp_defined_paren                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'throw' and '(' in 'throw (something)'
-sp_throw_paren                            = ignore   # ignore/add/remove/force
+sp_throw_paren                                    = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'throw' and anything other than '(' as in '@throw [...];'
-sp_after_throw                            = ignore   # ignore/add/remove/force
+sp_after_throw                                    = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'catch' and '(' in 'catch (something) { }'
 # If set to ignore, sp_before_sparen is used.
-sp_catch_paren                            = ignore   # ignore/add/remove/force
+sp_catch_paren                                    = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'version' and '(' in 'version (something) { }' (D language)
 # If set to ignore, sp_before_sparen is used.
-sp_version_paren                          = ignore   # ignore/add/remove/force
+sp_version_paren                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'scope' and '(' in 'scope (something) { }' (D language)
 # If set to ignore, sp_before_sparen is used.
-sp_scope_paren                            = ignore   # ignore/add/remove/force
+sp_scope_paren                                    = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'super' and '(' in 'super (something)'. Default=Remove
+sp_super_paren                                    = remove   # ignore/add/remove/force
+
+# Add or remove space between 'this' and '(' in 'this (something)'. Default=Remove
+sp_this_paren                                     = remove   # ignore/add/remove/force
 
 # Add or remove space between macro and value
-sp_macro                                  = ignore   # ignore/add/remove/force
+sp_macro                                          = ignore   # ignore/add/remove/force
 
 # Add or remove space between macro function ')' and value
-sp_macro_func                             = ignore   # ignore/add/remove/force
+sp_macro_func                                     = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'else' and '{' if on the same line
-sp_else_brace                             = ignore   # ignore/add/remove/force
+sp_else_brace                                     = ignore   # ignore/add/remove/force
 
 # Add or remove space between '}' and 'else' if on the same line
-sp_brace_else                             = ignore   # ignore/add/remove/force
+sp_brace_else                                     = ignore   # ignore/add/remove/force
 
 # Add or remove space between '}' and the name of a typedef on the same line
-sp_brace_typedef                          = ignore   # ignore/add/remove/force
+sp_brace_typedef                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'catch' and '{' if on the same line
-sp_catch_brace                            = ignore   # ignore/add/remove/force
+sp_catch_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove space between '}' and 'catch' if on the same line
-sp_brace_catch                            = ignore   # ignore/add/remove/force
+sp_brace_catch                                    = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'finally' and '{' if on the same line
-sp_finally_brace                          = ignore   # ignore/add/remove/force
+sp_finally_brace                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space between '}' and 'finally' if on the same line
-sp_brace_finally                          = ignore   # ignore/add/remove/force
+sp_brace_finally                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'try' and '{' if on the same line
-sp_try_brace                              = ignore   # ignore/add/remove/force
+sp_try_brace                                      = ignore   # ignore/add/remove/force
 
 # Add or remove space between get/set and '{' if on the same line
-sp_getset_brace                           = ignore   # ignore/add/remove/force
+sp_getset_brace                                   = ignore   # ignore/add/remove/force
 
-# Add or remove space between a variable and '{' for C++ uniform initialization
-sp_word_brace                             = add      # ignore/add/remove/force
+# Add or remove space between a variable and '{' for C++ uniform initialization. Default=Add
+sp_word_brace                                     = add      # ignore/add/remove/force
 
-# Add or remove space between a variable and '{' for a namespace
-sp_word_brace_ns                          = add      # ignore/add/remove/force
+# Add or remove space between a variable and '{' for a namespace. Default=Add
+sp_word_brace_ns                                  = add      # ignore/add/remove/force
 
 # Add or remove space before the '::' operator
-sp_before_dc                              = ignore   # ignore/add/remove/force
+sp_before_dc                                      = ignore   # ignore/add/remove/force
 
 # Add or remove space after the '::' operator
-sp_after_dc                               = ignore   # ignore/add/remove/force
+sp_after_dc                                       = ignore   # ignore/add/remove/force
 
 # Add or remove around the D named array initializer ':' operator
-sp_d_array_colon                          = ignore   # ignore/add/remove/force
+sp_d_array_colon                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space after the '!' (not) operator. Default=Remove
-sp_not                                    = remove   # ignore/add/remove/force
+sp_not                                            = remove   # ignore/add/remove/force
 
 # Add or remove space after the '~' (invert) operator. Default=Remove
-sp_inv                                    = remove   # ignore/add/remove/force
+sp_inv                                            = remove   # ignore/add/remove/force
 
 # Add or remove space after the '&' (address-of) operator. Default=Remove
 # This does not affect the spacing after a '&' that is part of a type.
-sp_addr                                   = remove   # ignore/add/remove/force
+sp_addr                                           = remove   # ignore/add/remove/force
 
 # Add or remove space around the '.' or '->' operators. Default=Remove
-sp_member                                 = remove   # ignore/add/remove/force
+sp_member                                         = remove   # ignore/add/remove/force
 
 # Add or remove space after the '*' (dereference) operator. Default=Remove
 # This does not affect the spacing after a '*' that is part of a type.
-sp_deref                                  = remove   # ignore/add/remove/force
+sp_deref                                          = remove   # ignore/add/remove/force
 
 # Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'. Default=Remove
-sp_sign                                   = remove   # ignore/add/remove/force
+sp_sign                                           = remove   # ignore/add/remove/force
 
 # Add or remove space before or after '++' and '--', as in '(--x)' or 'y++;'. Default=Remove
-sp_incdec                                 = remove   # ignore/add/remove/force
+sp_incdec                                         = remove   # ignore/add/remove/force
 
 # Add or remove space before a backslash-newline at the end of a line. Default=Add
-sp_before_nl_cont                         = add      # ignore/add/remove/force
+sp_before_nl_cont                                 = add      # ignore/add/remove/force
 
 # Add or remove space after the scope '+' or '-', as in '-(void) foo;' or '+(int) bar;'
-sp_after_oc_scope                         = ignore   # ignore/add/remove/force
+sp_after_oc_scope                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space after the colon in message specs
 # '-(int) f:(int) x;' vs '-(int) f: (int) x;'
-sp_after_oc_colon                         = ignore   # ignore/add/remove/force
+sp_after_oc_colon                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space before the colon in message specs
 # '-(int) f: (int) x;' vs '-(int) f : (int) x;'
-sp_before_oc_colon                        = ignore   # ignore/add/remove/force
+sp_before_oc_colon                                = ignore   # ignore/add/remove/force
 
 # Add or remove space after the colon in immutable dictionary expression
 # 'NSDictionary *test = @{@"foo" :@"bar"};'
-sp_after_oc_dict_colon                    = ignore   # ignore/add/remove/force
+sp_after_oc_dict_colon                            = ignore   # ignore/add/remove/force
 
 # Add or remove space before the colon in immutable dictionary expression
 # 'NSDictionary *test = @{@"foo" :@"bar"};'
-sp_before_oc_dict_colon                   = ignore   # ignore/add/remove/force
+sp_before_oc_dict_colon                           = ignore   # ignore/add/remove/force
 
 # Add or remove space after the colon in message specs
 # '[object setValue:1];' vs '[object setValue: 1];'
-sp_after_send_oc_colon                    = ignore   # ignore/add/remove/force
+sp_after_send_oc_colon                            = ignore   # ignore/add/remove/force
 
 # Add or remove space before the colon in message specs
 # '[object setValue:1];' vs '[object setValue :1];'
-sp_before_send_oc_colon                   = ignore   # ignore/add/remove/force
+sp_before_send_oc_colon                           = ignore   # ignore/add/remove/force
 
 # Add or remove space after the (type) in message specs
 # '-(int)f: (int) x;' vs '-(int)f: (int)x;'
-sp_after_oc_type                          = ignore   # ignore/add/remove/force
+sp_after_oc_type                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space after the first (type) in message specs
 # '-(int) f:(int)x;' vs '-(int)f:(int)x;'
-sp_after_oc_return_type                   = ignore   # ignore/add/remove/force
+sp_after_oc_return_type                           = ignore   # ignore/add/remove/force
 
 # Add or remove space between '@selector' and '('
 # '@selector(msgName)' vs '@selector (msgName)'
 # Also applies to @protocol() constructs
-sp_after_oc_at_sel                        = ignore   # ignore/add/remove/force
+sp_after_oc_at_sel                                = ignore   # ignore/add/remove/force
 
 # Add or remove space between '@selector(x)' and the following word
 # '@selector(foo) a:' vs '@selector(foo)a:'
-sp_after_oc_at_sel_parens                 = ignore   # ignore/add/remove/force
+sp_after_oc_at_sel_parens                         = ignore   # ignore/add/remove/force
 
 # Add or remove space inside '@selector' parens
 # '@selector(foo)' vs '@selector( foo )'
 # Also applies to @protocol() constructs
-sp_inside_oc_at_sel_parens                = ignore   # ignore/add/remove/force
+sp_inside_oc_at_sel_parens                        = ignore   # ignore/add/remove/force
 
 # Add or remove space before a block pointer caret
 # '^int (int arg){...}' vs. ' ^int (int arg){...}'
-sp_before_oc_block_caret                  = ignore   # ignore/add/remove/force
+sp_before_oc_block_caret                          = ignore   # ignore/add/remove/force
 
 # Add or remove space after a block pointer caret
 # '^int (int arg){...}' vs. '^ int (int arg){...}'
-sp_after_oc_block_caret                   = ignore   # ignore/add/remove/force
+sp_after_oc_block_caret                           = ignore   # ignore/add/remove/force
 
 # Add or remove space between the receiver and selector in a message.
 # '[receiver selector ...]'
-sp_after_oc_msg_receiver                  = ignore   # ignore/add/remove/force
+sp_after_oc_msg_receiver                          = ignore   # ignore/add/remove/force
 
 # Add or remove space after @property.
-sp_after_oc_property                      = ignore   # ignore/add/remove/force
+sp_after_oc_property                              = ignore   # ignore/add/remove/force
 
 # Add or remove space around the ':' in 'b ? t : f'
-sp_cond_colon                             = ignore   # ignore/add/remove/force
+sp_cond_colon                                     = ignore   # ignore/add/remove/force
 
 # Add or remove space before the ':' in 'b ? t : f'. Overrides sp_cond_colon.
-sp_cond_colon_before                      = ignore   # ignore/add/remove/force
+sp_cond_colon_before                              = ignore   # ignore/add/remove/force
 
 # Add or remove space after the ':' in 'b ? t : f'. Overrides sp_cond_colon.
-sp_cond_colon_after                       = ignore   # ignore/add/remove/force
+sp_cond_colon_after                               = ignore   # ignore/add/remove/force
 
 # Add or remove space around the '?' in 'b ? t : f'
-sp_cond_question                          = ignore   # ignore/add/remove/force
+sp_cond_question                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space before the '?' in 'b ? t : f'. Overrides sp_cond_question.
-sp_cond_question_before                   = ignore   # ignore/add/remove/force
+sp_cond_question_before                           = ignore   # ignore/add/remove/force
 
 # Add or remove space after the '?' in 'b ? t : f'. Overrides sp_cond_question.
-sp_cond_question_after                    = ignore   # ignore/add/remove/force
+sp_cond_question_after                            = ignore   # ignore/add/remove/force
 
 # In the abbreviated ternary form (a ?: b), add/remove space between ? and :.'. Overrides all other sp_cond_* options.
-sp_cond_ternary_short                     = ignore   # ignore/add/remove/force
+sp_cond_ternary_short                             = ignore   # ignore/add/remove/force
 
 # Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make sense here.
-sp_case_label                             = ignore   # ignore/add/remove/force
+sp_case_label                                     = ignore   # ignore/add/remove/force
 
 # Control the space around the D '..' operator.
-sp_range                                  = ignore   # ignore/add/remove/force
+sp_range                                          = ignore   # ignore/add/remove/force
 
 # Control the spacing after ':' in 'for (TYPE VAR : EXPR)'
-sp_after_for_colon                        = ignore   # ignore/add/remove/force
+sp_after_for_colon                                = ignore   # ignore/add/remove/force
 
 # Control the spacing before ':' in 'for (TYPE VAR : EXPR)'
-sp_before_for_colon                       = ignore   # ignore/add/remove/force
+sp_before_for_colon                               = ignore   # ignore/add/remove/force
 
 # Control the spacing in 'extern (C)' (D)
-sp_extern_paren                           = ignore   # ignore/add/remove/force
+sp_extern_paren                                   = ignore   # ignore/add/remove/force
 
 # Control the space after the opening of a C++ comment '// A' vs '//A'
-sp_cmt_cpp_start                          = ignore   # ignore/add/remove/force
+sp_cmt_cpp_start                                  = ignore   # ignore/add/remove/force
 
 # TRUE: If space is added with sp_cmt_cpp_start, do it after doxygen sequences like '///', '///<', '//!' and '//!<'.
-sp_cmt_cpp_doxygen                        = false    # false/true
+sp_cmt_cpp_doxygen                                = false    # false/true
 
 # TRUE: If space is added with sp_cmt_cpp_start, do it after Qt translator or meta-data comments like '//:', '//=', and '//~'.
-sp_cmt_cpp_qttr                           = false    # false/true
+sp_cmt_cpp_qttr                                   = false    # false/true
 
 # Controls the spaces between #else or #endif and a trailing comment
-sp_endif_cmt                              = ignore   # ignore/add/remove/force
+sp_endif_cmt                                      = ignore   # ignore/add/remove/force
 
 # Controls the spaces after 'new', 'delete' and 'delete[]'
-sp_after_new                              = ignore   # ignore/add/remove/force
+sp_after_new                                      = ignore   # ignore/add/remove/force
 
 # Controls the spaces between new and '(' in 'new()'
-sp_between_new_paren                      = ignore   # ignore/add/remove/force
+sp_between_new_paren                              = ignore   # ignore/add/remove/force
 
 # Controls the spaces before a trailing or embedded comment
-sp_before_tr_emb_cmt                      = ignore   # ignore/add/remove/force
+sp_before_tr_emb_cmt                              = ignore   # ignore/add/remove/force
 
 # Number of spaces before a trailing or embedded comment
-sp_num_before_tr_emb_cmt                  = 0        # number
+sp_num_before_tr_emb_cmt                          = 0        # number
 
 # Control space between a Java annotation and the open paren.
-sp_annotation_paren                       = ignore   # ignore/add/remove/force
+sp_annotation_paren                               = ignore   # ignore/add/remove/force
+
+# If true, vbrace tokens are dropped to the previous token and skipped.
+sp_skip_vbrace_tokens                             = false    # false/true
 
 #
 # Code alignment (not left column spaces/tabs)
 #
 
 # Whether to keep non-indenting tabs
-align_keep_tabs                           = false    # false/true
+align_keep_tabs                                   = false    # false/true
 
 # Whether to use tabs for aligning
-align_with_tabs                           = false    # false/true
+align_with_tabs                                   = false    # false/true
 
 # Whether to bump out to the next tab when aligning
-align_on_tabstop                          = false    # false/true
+align_on_tabstop                                  = false    # false/true
 
 # Whether to left-align numbers
-align_number_left                         = false    # false/true
+align_number_left                                 = false    # false/true
 
 # Whether to keep whitespace not required for alignment.
-align_keep_extra_space                    = false    # false/true
+align_keep_extra_space                            = false    # false/true
 
 # Align variable definitions in prototypes and functions
-align_func_params                         = false    # false/true
+align_func_params                                 = false    # false/true
 
 # Align parameters in single-line functions that have the same name.
 # The function names must already be aligned with each other.
-align_same_func_call_params               = false    # false/true
+align_same_func_call_params                       = false    # false/true
 
 # The span for aligning variable definitions (0=don't align)
-align_var_def_span                        = 0        # number
+align_var_def_span                                = 0        # number
 
 # How to align the star in variable definitions.
 #  0=Part of the type     'void *   foo;'
 #  1=Part of the variable 'void     *foo;'
 #  2=Dangling             'void    *foo;'
-align_var_def_star_style                  = 0        # number
+align_var_def_star_style                          = 0        # number
 
 # How to align the '&' in variable definitions.
 #  0=Part of the type
 #  1=Part of the variable
 #  2=Dangling
-align_var_def_amp_style                   = 0        # number
+align_var_def_amp_style                           = 0        # number
 
 # The threshold for aligning variable definitions (0=no limit)
-align_var_def_thresh                      = 0        # number
+align_var_def_thresh                              = 0        # number
 
 # The gap for aligning variable definitions
-align_var_def_gap                         = 0        # number
+align_var_def_gap                                 = 0        # number
 
 # Whether to align the colon in struct bit fields
-align_var_def_colon                       = false    # false/true
+align_var_def_colon                               = false    # false/true
 
 # Whether to align any attribute after the variable name
-align_var_def_attribute                   = false    # false/true
+align_var_def_attribute                           = false    # false/true
 
 # Whether to align inline struct/enum/union variable definitions
-align_var_def_inline                      = false    # false/true
+align_var_def_inline                              = false    # false/true
 
 # The span for aligning on '=' in assignments (0=don't align)
-align_assign_span                         = 0        # number
+align_assign_span                                 = 0        # number
 
 # The threshold for aligning on '=' in assignments (0=no limit)
-align_assign_thresh                       = 0        # number
+align_assign_thresh                               = 0        # number
 
 # The span for aligning on '=' in enums (0=don't align)
-align_enum_equ_span                       = 0        # number
+align_enum_equ_span                               = 0        # number
 
 # The threshold for aligning on '=' in enums (0=no limit)
-align_enum_equ_thresh                     = 0        # number
+align_enum_equ_thresh                             = 0        # number
 
 # The span for aligning struct/union (0=don't align)
-align_var_struct_span                     = 0        # number
+align_var_struct_span                             = 0        # number
 
 # The threshold for aligning struct/union member definitions (0=no limit)
-align_var_struct_thresh                   = 0        # number
+align_var_struct_thresh                           = 0        # number
 
 # The gap for aligning struct/union member definitions
-align_var_struct_gap                      = 0        # number
+align_var_struct_gap                              = 0        # number
 
 # The span for aligning struct initializer values (0=don't align)
-align_struct_init_span                    = 0        # number
+align_struct_init_span                            = 0        # number
 
 # The minimum space between the type and the synonym of a typedef
-align_typedef_gap                         = 0        # number
+align_typedef_gap                                 = 0        # number
 
 # The span for aligning single-line typedefs (0=don't align)
-align_typedef_span                        = 0        # number
+align_typedef_span                                = 0        # number
 
 # How to align typedef'd functions with other typedefs
 # 0: Don't mix them at all
 # 1: align the open paren with the types
 # 2: align the function type name with the other type names
-align_typedef_func                        = 0        # number
+align_typedef_func                                = 0        # number
 
 # Controls the positioning of the '*' in typedefs. Just try it.
 # 0: Align on typedef type, ignore '*'
 # 1: The '*' is part of type name: typedef int  *pint;
 # 2: The '*' is part of the type, but dangling: typedef int *pint;
-align_typedef_star_style                  = 0        # number
+align_typedef_star_style                          = 0        # number
 
 # Controls the positioning of the '&' in typedefs. Just try it.
 # 0: Align on typedef type, ignore '&'
 # 1: The '&' is part of type name: typedef int  &pint;
 # 2: The '&' is part of the type, but dangling: typedef int &pint;
-align_typedef_amp_style                   = 0        # number
+align_typedef_amp_style                           = 0        # number
 
 # The span for aligning comments that end lines (0=don't align)
-align_right_cmt_span                      = 0        # number
+align_right_cmt_span                              = 0        # number
 
 # If aligning comments, mix with comments after '}' and #endif with less than 3 spaces before the comment
-align_right_cmt_mix                       = false    # false/true
+align_right_cmt_mix                               = false    # false/true
 
 # If a trailing comment is more than this number of columns away from the text it follows,
 # it will qualify for being aligned. This has to be > 0 to do anything.
-align_right_cmt_gap                       = 0        # number
+align_right_cmt_gap                               = 0        # number
 
 # Align trailing comment at or beyond column N; 'pulls in' comments as a bonus side effect (0=ignore)
-align_right_cmt_at_col                    = 0        # number
+align_right_cmt_at_col                            = 0        # number
 
 # The span for aligning function prototypes (0=don't align)
-align_func_proto_span                     = 0        # number
+align_func_proto_span                             = 0        # number
 
 # Minimum gap between the return type and the function name.
-align_func_proto_gap                      = 0        # number
+align_func_proto_gap                              = 0        # number
 
 # Align function protos on the 'operator' keyword instead of what follows
-align_on_operator                         = false    # false/true
+align_on_operator                                 = false    # false/true
 
 # Whether to mix aligning prototype and variable declarations.
 # If true, align_var_def_XXX options are used instead of align_func_proto_XXX options.
-align_mix_var_proto                       = false    # false/true
+align_mix_var_proto                               = false    # false/true
 
 # Align single-line functions with function prototypes, uses align_func_proto_span
-align_single_line_func                    = false    # false/true
+align_single_line_func                            = false    # false/true
 
 # Aligning the open brace of single-line functions.
 # Requires align_single_line_func=true, uses align_func_proto_span
-align_single_line_brace                   = false    # false/true
+align_single_line_brace                           = false    # false/true
 
 # Gap for align_single_line_brace.
-align_single_line_brace_gap               = 0        # number
+align_single_line_brace_gap                       = 0        # number
 
 # The span for aligning ObjC msg spec (0=don't align)
-align_oc_msg_spec_span                    = 0        # number
+align_oc_msg_spec_span                            = 0        # number
 
 # Whether to align macros wrapped with a backslash and a newline.
 # This will not work right if the macro contains a multi-line comment.
-align_nl_cont                             = false    # false/true
+align_nl_cont                                     = false    # false/true
 
 # # Align macro functions and variables together
-align_pp_define_together                  = false    # false/true
+align_pp_define_together                          = false    # false/true
 
 # The minimum space between label and value of a preprocessor define
-align_pp_define_gap                       = 0        # number
+align_pp_define_gap                               = 0        # number
 
 # The span for aligning on '#define' bodies (0=don't align, other=number of lines including comments between blocks)
-align_pp_define_span                      = 0        # number
+align_pp_define_span                              = 0        # number
 
-# Align lines that start with '<<' with previous '<<'. Default=true
-align_left_shift                          = true     # false/true
+# Align lines that start with '<<' with previous '<<'. Default=True
+align_left_shift                                  = true     # false/true
 
 # Align text after asm volatile () colons.
-align_asm_colon                           = false    # false/true
+align_asm_colon                                   = false    # false/true
 
 # Span for aligning parameters in an Obj-C message call on the ':' (0=don't align)
-align_oc_msg_colon_span                   = 0        # number
+align_oc_msg_colon_span                           = 0        # number
 
 # If true, always align with the first parameter, even if it is too short.
-align_oc_msg_colon_first                  = false    # false/true
+align_oc_msg_colon_first                          = false    # false/true
 
 # Aligning parameters in an Obj-C '+' or '-' declaration on the ':'
-align_oc_decl_colon                       = false    # false/true
+align_oc_decl_colon                               = false    # false/true
 
 #
 # Newline adding and removing options
 #
 
 # Whether to collapse empty blocks between '{' and '}'
-nl_collapse_empty_body                    = false    # false/true
+nl_collapse_empty_body                            = false    # false/true
 
 # Don't split one-line braced assignments - 'foo_t f = { 1, 2 };'
-nl_assign_leave_one_liners                = false    # false/true
+nl_assign_leave_one_liners                        = false    # false/true
 
 # Don't split one-line braced statements inside a class xx { } body
-nl_class_leave_one_liners                 = false    # false/true
+nl_class_leave_one_liners                         = false    # false/true
 
 # Don't split one-line enums: 'enum foo { BAR = 15 };'
-nl_enum_leave_one_liners                  = false    # false/true
+nl_enum_leave_one_liners                          = false    # false/true
 
 # Don't split one-line get or set functions
-nl_getset_leave_one_liners                = false    # false/true
+nl_getset_leave_one_liners                        = false    # false/true
 
 # Don't split one-line function definitions - 'int foo() { return 0; }'
-nl_func_leave_one_liners                  = false    # false/true
+nl_func_leave_one_liners                          = false    # false/true
 
 # Don't split one-line C++11 lambdas - '[]() { return 0; }'
-nl_cpp_lambda_leave_one_liners            = false    # false/true
+nl_cpp_lambda_leave_one_liners                    = false    # false/true
 
 # Don't split one-line if/else statements - 'if(a) b++;'
-nl_if_leave_one_liners                    = false    # false/true
+nl_if_leave_one_liners                            = false    # false/true
 
 # Don't split one-line while statements - 'while(a) b++;'
-nl_while_leave_one_liners                 = false    # false/true
+nl_while_leave_one_liners                         = false    # false/true
 
 # Don't split one-line OC messages
-nl_oc_msg_leave_one_liner                 = false    # false/true
+nl_oc_msg_leave_one_liner                         = false    # false/true
+
+# Add or remove newline between Objective-C block signature and '{'
+nl_oc_block_brace                                 = ignore   # ignore/add/remove/force
 
 # Add or remove newlines at the start of the file
-nl_start_of_file                          = ignore   # ignore/add/remove/force
+nl_start_of_file                                  = ignore   # ignore/add/remove/force
 
 # The number of newlines at the start of the file (only used if nl_start_of_file is 'add' or 'force'
-nl_start_of_file_min                      = 0        # number
+nl_start_of_file_min                              = 0        # number
 
 # Add or remove newline at the end of the file
-nl_end_of_file                            = ignore   # ignore/add/remove/force
+nl_end_of_file                                    = ignore   # ignore/add/remove/force
 
 # The number of newlines at the end of the file (only used if nl_end_of_file is 'add' or 'force')
-nl_end_of_file_min                        = 0        # number
+nl_end_of_file_min                                = 0        # number
 
 # Add or remove newline between '=' and '{'
-nl_assign_brace                           = ignore   # ignore/add/remove/force
+nl_assign_brace                                   = ignore   # ignore/add/remove/force
 
 # Add or remove newline between '=' and '[' (D only)
-nl_assign_square                          = ignore   # ignore/add/remove/force
+nl_assign_square                                  = ignore   # ignore/add/remove/force
 
 # Add or remove newline after '= [' (D only). Will also affect the newline before the ']'
-nl_after_square_assign                    = ignore   # ignore/add/remove/force
+nl_after_square_assign                            = ignore   # ignore/add/remove/force
 
 # The number of blank lines after a block of variable definitions at the top of a function body
 # 0 = No change (default)
-nl_func_var_def_blk                       = 0        # number
+nl_func_var_def_blk                               = 0        # number
 
 # The number of newlines before a block of typedefs
 # 0 = No change (default)
 # the option 'nl_after_access_spec' takes preference over 'nl_typedef_blk_start'
-nl_typedef_blk_start                      = 0        # number
+nl_typedef_blk_start                              = 0        # number
 
 # The number of newlines after a block of typedefs
 # 0 = No change (default)
-nl_typedef_blk_end                        = 0        # number
+nl_typedef_blk_end                                = 0        # number
 
 # The maximum consecutive newlines within a block of typedefs
 # 0 = No change (default)
-nl_typedef_blk_in                         = 0        # number
+nl_typedef_blk_in                                 = 0        # number
 
 # The number of newlines before a block of variable definitions not at the top of a function body
 # 0 = No change (default)
 # the option 'nl_after_access_spec' takes preference over 'nl_var_def_blk_start'
-nl_var_def_blk_start                      = 0        # number
+nl_var_def_blk_start                              = 0        # number
 
 # The number of newlines after a block of variable definitions not at the top of a function body
 # 0 = No change (default)
-nl_var_def_blk_end                        = 0        # number
+nl_var_def_blk_end                                = 0        # number
 
 # The maximum consecutive newlines within a block of variable definitions
 # 0 = No change (default)
-nl_var_def_blk_in                         = 0        # number
+nl_var_def_blk_in                                 = 0        # number
 
 # Add or remove newline between a function call's ')' and '{', as in:
 # list_for_each(item, &list) { }
-nl_fcall_brace                            = ignore   # ignore/add/remove/force
+nl_fcall_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'enum' and '{'
-nl_enum_brace                             = ignore   # ignore/add/remove/force
+nl_enum_brace                                     = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'struct and '{'
-nl_struct_brace                           = ignore   # ignore/add/remove/force
+nl_struct_brace                                   = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'union' and '{'
-nl_union_brace                            = ignore   # ignore/add/remove/force
+nl_union_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'if' and '{'
-nl_if_brace                               = ignore   # ignore/add/remove/force
+nl_if_brace                                       = ignore   # ignore/add/remove/force
 
 # Add or remove newline between '}' and 'else'
-nl_brace_else                             = ignore   # ignore/add/remove/force
+nl_brace_else                                     = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'else if' and '{'
 # If set to ignore, nl_if_brace is used instead
-nl_elseif_brace                           = ignore   # ignore/add/remove/force
+nl_elseif_brace                                   = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'else' and '{'
-nl_else_brace                             = ignore   # ignore/add/remove/force
+nl_else_brace                                     = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'else' and 'if'
-nl_else_if                                = ignore   # ignore/add/remove/force
+nl_else_if                                        = ignore   # ignore/add/remove/force
 
 # Add or remove newline between '}' and 'finally'
-nl_brace_finally                          = ignore   # ignore/add/remove/force
+nl_brace_finally                                  = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'finally' and '{'
-nl_finally_brace                          = ignore   # ignore/add/remove/force
+nl_finally_brace                                  = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'try' and '{'
-nl_try_brace                              = ignore   # ignore/add/remove/force
+nl_try_brace                                      = ignore   # ignore/add/remove/force
 
 # Add or remove newline between get/set and '{'
-nl_getset_brace                           = ignore   # ignore/add/remove/force
+nl_getset_brace                                   = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'for' and '{'
-nl_for_brace                              = ignore   # ignore/add/remove/force
+nl_for_brace                                      = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'catch' and '{'
-nl_catch_brace                            = ignore   # ignore/add/remove/force
+nl_catch_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline between '}' and 'catch'
-nl_brace_catch                            = ignore   # ignore/add/remove/force
+nl_brace_catch                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline between '}' and ']'
-nl_brace_square                           = ignore   # ignore/add/remove/force
+nl_brace_square                                   = ignore   # ignore/add/remove/force
 
 # Add or remove newline between '}' and ')' in a function invocation
-nl_brace_fparen                           = ignore   # ignore/add/remove/force
+nl_brace_fparen                                   = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'while' and '{'
-nl_while_brace                            = ignore   # ignore/add/remove/force
+nl_while_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'scope (x)' and '{' (D)
-nl_scope_brace                            = ignore   # ignore/add/remove/force
+nl_scope_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'unittest' and '{' (D)
-nl_unittest_brace                         = ignore   # ignore/add/remove/force
+nl_unittest_brace                                 = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'version (x)' and '{' (D)
-nl_version_brace                          = ignore   # ignore/add/remove/force
+nl_version_brace                                  = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'using' and '{'
-nl_using_brace                            = ignore   # ignore/add/remove/force
+nl_using_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline between two open or close braces.
 # Due to general newline/brace handling, REMOVE may not work.
-nl_brace_brace                            = ignore   # ignore/add/remove/force
+nl_brace_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'do' and '{'
-nl_do_brace                               = ignore   # ignore/add/remove/force
+nl_do_brace                                       = ignore   # ignore/add/remove/force
 
 # Add or remove newline between '}' and 'while' of 'do' statement
-nl_brace_while                            = ignore   # ignore/add/remove/force
+nl_brace_while                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'switch' and '{'
-nl_switch_brace                           = ignore   # ignore/add/remove/force
+nl_switch_brace                                   = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'synchronized' and '{'
-nl_synchronized_brace                     = ignore   # ignore/add/remove/force
+nl_synchronized_brace                             = ignore   # ignore/add/remove/force
 
 # Add a newline between ')' and '{' if the ')' is on a different line than the if/for/etc.
 # Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch and nl_catch_brace.
-nl_multi_line_cond                        = false    # false/true
+nl_multi_line_cond                                = false    # false/true
 
 # Force a newline in a define after the macro name for multi-line defines.
-nl_multi_line_define                      = false    # false/true
+nl_multi_line_define                              = false    # false/true
 
 # Whether to put a newline before 'case' statement, not after the first 'case'
-nl_before_case                            = false    # false/true
+nl_before_case                                    = false    # false/true
 
 # Add or remove newline between ')' and 'throw'
-nl_before_throw                           = ignore   # ignore/add/remove/force
+nl_before_throw                                   = ignore   # ignore/add/remove/force
 
 # Whether to put a newline after 'case' statement
-nl_after_case                             = false    # false/true
+nl_after_case                                     = false    # false/true
 
 # Add or remove a newline between a case ':' and '{'. Overrides nl_after_case.
-nl_case_colon_brace                       = ignore   # ignore/add/remove/force
+nl_case_colon_brace                               = ignore   # ignore/add/remove/force
 
 # Newline between namespace and {
-nl_namespace_brace                        = ignore   # ignore/add/remove/force
+nl_namespace_brace                                = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'template<>' and whatever follows.
-nl_template_class                         = ignore   # ignore/add/remove/force
+nl_template_class                                 = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'class' and '{'
-nl_class_brace                            = ignore   # ignore/add/remove/force
+nl_class_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline before/after each ',' in the base class list,
 #   (tied to pos_class_comma).
-nl_class_init_args                        = ignore   # ignore/add/remove/force
+nl_class_init_args                                = ignore   # ignore/add/remove/force
 
 # Add or remove newline after each ',' in the constructor member initialization.
 # Related to nl_constr_colon, pos_constr_colon and pos_constr_comma.
-nl_constr_init_args                       = ignore   # ignore/add/remove/force
+nl_constr_init_args                               = ignore   # ignore/add/remove/force
+
+# Add or remove newline before first element, after comma, and after last element in enum
+nl_enum_own_lines                                 = ignore   # ignore/add/remove/force
 
 # Add or remove newline between return type and function name in a function definition
-nl_func_type_name                         = ignore   # ignore/add/remove/force
+nl_func_type_name                                 = ignore   # ignore/add/remove/force
 
 # Add or remove newline between return type and function name inside a class {}
 # Uses nl_func_type_name or nl_func_proto_type_name if set to ignore.
-nl_func_type_name_class                   = ignore   # ignore/add/remove/force
+nl_func_type_name_class                           = ignore   # ignore/add/remove/force
+
+# Add or remove newline between class specification and '::' in 'void A::f() { }'
+# Only appears in separate member implementation (does not appear with in-line implmementation)
+nl_func_class_scope                               = ignore   # ignore/add/remove/force
 
 # Add or remove newline between function scope and name
 # Controls the newline after '::' in 'void A::f() { }'
-nl_func_scope_name                        = ignore   # ignore/add/remove/force
+nl_func_scope_name                                = ignore   # ignore/add/remove/force
 
 # Add or remove newline between return type and function name in a prototype
-nl_func_proto_type_name                   = ignore   # ignore/add/remove/force
+nl_func_proto_type_name                           = ignore   # ignore/add/remove/force
 
 # Add or remove newline between a function name and the opening '(' in the declaration
-nl_func_paren                             = ignore   # ignore/add/remove/force
+nl_func_paren                                     = ignore   # ignore/add/remove/force
 
 # Add or remove newline between a function name and the opening '(' in the definition
-nl_func_def_paren                         = ignore   # ignore/add/remove/force
+nl_func_def_paren                                 = ignore   # ignore/add/remove/force
 
 # Add or remove newline after '(' in a function declaration
-nl_func_decl_start                        = ignore   # ignore/add/remove/force
+nl_func_decl_start                                = ignore   # ignore/add/remove/force
 
 # Add or remove newline after '(' in a function definition
-nl_func_def_start                         = ignore   # ignore/add/remove/force
+nl_func_def_start                                 = ignore   # ignore/add/remove/force
 
 # Overrides nl_func_decl_start when there is only one parameter.
-nl_func_decl_start_single                 = ignore   # ignore/add/remove/force
+nl_func_decl_start_single                         = ignore   # ignore/add/remove/force
 
 # Overrides nl_func_def_start when there is only one parameter.
-nl_func_def_start_single                  = ignore   # ignore/add/remove/force
+nl_func_def_start_single                          = ignore   # ignore/add/remove/force
+
+# Whether to add newline after '(' in a function declaration if '(' and ')' are in different lines.
+nl_func_decl_start_multi_line                     = false    # false/true
+
+# Whether to add newline after '(' in a function definition if '(' and ')' are in different lines.
+nl_func_def_start_multi_line                      = false    # false/true
 
 # Add or remove newline after each ',' in a function declaration
-nl_func_decl_args                         = ignore   # ignore/add/remove/force
+nl_func_decl_args                                 = ignore   # ignore/add/remove/force
 
 # Add or remove newline after each ',' in a function definition
-nl_func_def_args                          = ignore   # ignore/add/remove/force
+nl_func_def_args                                  = ignore   # ignore/add/remove/force
+
+# Whether to add newline after each ',' in a function declaration if '(' and ')' are in different lines.
+nl_func_decl_args_multi_line                      = false    # false/true
+
+# Whether to add newline after each ',' in a function definition if '(' and ')' are in different lines.
+nl_func_def_args_multi_line                       = false    # false/true
 
 # Add or remove newline before the ')' in a function declaration
-nl_func_decl_end                          = ignore   # ignore/add/remove/force
+nl_func_decl_end                                  = ignore   # ignore/add/remove/force
 
 # Add or remove newline before the ')' in a function definition
-nl_func_def_end                           = ignore   # ignore/add/remove/force
+nl_func_def_end                                   = ignore   # ignore/add/remove/force
 
 # Overrides nl_func_decl_end when there is only one parameter.
-nl_func_decl_end_single                   = ignore   # ignore/add/remove/force
+nl_func_decl_end_single                           = ignore   # ignore/add/remove/force
 
 # Overrides nl_func_def_end when there is only one parameter.
-nl_func_def_end_single                    = ignore   # ignore/add/remove/force
+nl_func_def_end_single                            = ignore   # ignore/add/remove/force
+
+# Whether to add newline before ')' in a function declaration if '(' and ')' are in different lines.
+nl_func_decl_end_multi_line                       = false    # false/true
+
+# Whether to add newline before ')' in a function definition if '(' and ')' are in different lines.
+nl_func_def_end_multi_line                        = false    # false/true
 
 # Add or remove newline between '()' in a function declaration.
-nl_func_decl_empty                        = ignore   # ignore/add/remove/force
+nl_func_decl_empty                                = ignore   # ignore/add/remove/force
 
 # Add or remove newline between '()' in a function definition.
-nl_func_def_empty                         = ignore   # ignore/add/remove/force
+nl_func_def_empty                                 = ignore   # ignore/add/remove/force
+
+# Whether to add newline after '(' in a function call if '(' and ')' are in different lines.
+nl_func_call_start_multi_line                     = false    # false/true
+
+# Whether to add newline after each ',' in a function call if '(' and ')' are in different lines.
+nl_func_call_args_multi_line                      = false    # false/true
+
+# Whether to add newline before ')' in a function call if '(' and ')' are in different lines.
+nl_func_call_end_multi_line                       = false    # false/true
 
 # Whether to put each OC message parameter on a separate line
 # See nl_oc_msg_leave_one_liner
-nl_oc_msg_args                            = false    # false/true
+nl_oc_msg_args                                    = false    # false/true
 
 # Add or remove newline between function signature and '{'
-nl_fdef_brace                             = ignore   # ignore/add/remove/force
+nl_fdef_brace                                     = ignore   # ignore/add/remove/force
 
 # Add or remove newline between C++11 lambda signature and '{'
-nl_cpp_ldef_brace                         = ignore   # ignore/add/remove/force
+nl_cpp_ldef_brace                                 = ignore   # ignore/add/remove/force
 
 # Add or remove a newline between the return keyword and return expression.
-nl_return_expr                            = ignore   # ignore/add/remove/force
+nl_return_expr                                    = ignore   # ignore/add/remove/force
 
 # Whether to put a newline after semicolons, except in 'for' statements
-nl_after_semicolon                        = false    # false/true
+nl_after_semicolon                                = false    # false/true
 
 # Java: Control the newline between the ')' and '{{' of the double brace initializer.
-nl_paren_dbrace_open                      = ignore   # ignore/add/remove/force
+nl_paren_dbrace_open                              = ignore   # ignore/add/remove/force
 
 # Whether to put a newline after brace open.
 # This also adds a newline before the matching brace close.
-nl_after_brace_open                       = false    # false/true
+nl_after_brace_open                               = false    # false/true
 
 # If nl_after_brace_open and nl_after_brace_open_cmt are true, a newline is
 # placed between the open brace and a trailing single-line comment.
-nl_after_brace_open_cmt                   = false    # false/true
+nl_after_brace_open_cmt                           = false    # false/true
 
 # Whether to put a newline after a virtual brace open with a non-empty body.
 # These occur in un-braced if/while/do/for statement bodies.
-nl_after_vbrace_open                      = false    # false/true
+nl_after_vbrace_open                              = false    # false/true
 
 # Whether to put a newline after a virtual brace open with an empty body.
 # These occur in un-braced if/while/do/for statement bodies.
-nl_after_vbrace_open_empty                = false    # false/true
+nl_after_vbrace_open_empty                        = false    # false/true
 
 # Whether to put a newline after a brace close.
 # Does not apply if followed by a necessary ';'.
-nl_after_brace_close                      = false    # false/true
+nl_after_brace_close                              = false    # false/true
 
 # Whether to put a newline after a virtual brace close.
 # Would add a newline before return in: 'if (foo) a++; return;'
-nl_after_vbrace_close                     = false    # false/true
+nl_after_vbrace_close                             = false    # false/true
 
 # Control the newline between the close brace and 'b' in: 'struct { int a; } b;'
 # Affects enums, unions and structures. If set to ignore, uses nl_after_brace_close
-nl_brace_struct_var                       = ignore   # ignore/add/remove/force
+nl_brace_struct_var                               = ignore   # ignore/add/remove/force
 
 # Whether to alter newlines in '#define' macros
-nl_define_macro                           = false    # false/true
+nl_define_macro                                   = false    # false/true
 
-# Whether to not put blanks after '#ifxx', '#elxx', or before '#endif'. Does not affect the whole-file #ifdef.
-nl_squeeze_ifdef                          = false    # false/true
+# Whether to remove blanks after '#ifxx' and '#elxx', or before '#elxx' and '#endif'. Does not affect top-level #ifdefs.
+nl_squeeze_ifdef                                  = false    # false/true
+
+# Makes the nl_squeeze_ifdef option affect the top-level #ifdefs as well.
+nl_squeeze_ifdef_top_level                        = false    # false/true
 
 # Add or remove blank line before 'if'
-nl_before_if                              = ignore   # ignore/add/remove/force
+nl_before_if                                      = ignore   # ignore/add/remove/force
 
 # Add or remove blank line after 'if' statement
-nl_after_if                               = ignore   # ignore/add/remove/force
+nl_after_if                                       = ignore   # ignore/add/remove/force
 
 # Add or remove blank line before 'for'
-nl_before_for                             = ignore   # ignore/add/remove/force
+nl_before_for                                     = ignore   # ignore/add/remove/force
 
 # Add or remove blank line after 'for' statement
-nl_after_for                              = ignore   # ignore/add/remove/force
+nl_after_for                                      = ignore   # ignore/add/remove/force
 
 # Add or remove blank line before 'while'
-nl_before_while                           = ignore   # ignore/add/remove/force
+nl_before_while                                   = ignore   # ignore/add/remove/force
 
 # Add or remove blank line after 'while' statement
-nl_after_while                            = ignore   # ignore/add/remove/force
+nl_after_while                                    = ignore   # ignore/add/remove/force
 
 # Add or remove blank line before 'switch'
-nl_before_switch                          = ignore   # ignore/add/remove/force
+nl_before_switch                                  = ignore   # ignore/add/remove/force
 
 # Add or remove blank line after 'switch' statement
-nl_after_switch                           = ignore   # ignore/add/remove/force
+nl_after_switch                                   = ignore   # ignore/add/remove/force
 
 # Add or remove blank line before 'synchronized'
-nl_before_synchronized                    = ignore   # ignore/add/remove/force
+nl_before_synchronized                            = ignore   # ignore/add/remove/force
 
 # Add or remove blank line after 'synchronized' statement
-nl_after_synchronized                     = ignore   # ignore/add/remove/force
+nl_after_synchronized                             = ignore   # ignore/add/remove/force
 
 # Add or remove blank line before 'do'
-nl_before_do                              = ignore   # ignore/add/remove/force
+nl_before_do                                      = ignore   # ignore/add/remove/force
 
 # Add or remove blank line after 'do/while' statement
-nl_after_do                               = ignore   # ignore/add/remove/force
+nl_after_do                                       = ignore   # ignore/add/remove/force
 
 # Whether to double-space commented-entries in struct/union/enum
-nl_ds_struct_enum_cmt                     = false    # false/true
+nl_ds_struct_enum_cmt                             = false    # false/true
 
 # force nl before } of a struct/union/enum
 # (lower priority than 'eat_blanks_before_close_brace')
-nl_ds_struct_enum_close_brace             = false    # false/true
+nl_ds_struct_enum_close_brace                     = false    # false/true
 
 # Add or remove blank line before 'func_class_def'
-nl_before_func_class_def                  = 0        # number
+nl_before_func_class_def                          = 0        # number
 
 # Add or remove blank line before 'func_class_proto'
-nl_before_func_class_proto                = 0        # number
+nl_before_func_class_proto                        = 0        # number
 
 # Add or remove a newline before/after a class colon,
 #   (tied to pos_class_colon).
-nl_class_colon                            = ignore   # ignore/add/remove/force
+nl_class_colon                                    = ignore   # ignore/add/remove/force
 
 # Add or remove a newline around a class constructor colon.
 # Related to nl_constr_init_args, pos_constr_colon and pos_constr_comma.
-nl_constr_colon                           = ignore   # ignore/add/remove/force
+nl_constr_colon                                   = ignore   # ignore/add/remove/force
 
 # Change simple unbraced if statements into a one-liner
 # 'if(b)\n i++;' => 'if(b) i++;'
-nl_create_if_one_liner                    = false    # false/true
+nl_create_if_one_liner                            = false    # false/true
 
 # Change simple unbraced for statements into a one-liner
 # 'for (i=0;i<5;i++)\n foo(i);' => 'for (i=0;i<5;i++) foo(i);'
-nl_create_for_one_liner                   = false    # false/true
+nl_create_for_one_liner                           = false    # false/true
 
 # Change simple unbraced while statements into a one-liner
 # 'while (i<5)\n foo(i++);' => 'while (i<5) foo(i++);'
-nl_create_while_one_liner                 = false    # false/true
+nl_create_while_one_liner                         = false    # false/true
+
+#  Change a one-liner if statement into simple unbraced if
+# 'if(b) i++;' => 'if(b) i++;'
+nl_split_if_one_liner                             = false    # false/true
+
+# Change a one-liner for statement into simple unbraced for
+# 'for (i=0;<5;i++) foo(i);' => 'for (i=0;<5;i++) foo(i);'
+nl_split_for_one_liner                            = false    # false/true
+
+# Change simple unbraced while statements into a one-liner while
+# 'while (i<5)\n foo(i++);' => 'while (i<5) foo(i++);'
+nl_split_while_one_liner                          = false    # false/true
 
 #
 # Positioning options
 #
 
 # The position of arithmetic operators in wrapped expressions
-pos_arith                                 = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_arith                                         = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of assignment in wrapped expressions.
 # Do not affect '=' followed by '{'
-pos_assign                                = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_assign                                        = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of boolean operators in wrapped expressions
-pos_bool                                  = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_bool                                          = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of comparison operators in wrapped expressions
-pos_compare                               = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_compare                                       = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of conditional (b ? t : f) operators in wrapped expressions
-pos_conditional                           = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_conditional                                   = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of the comma in wrapped expressions
-pos_comma                                 = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_comma                                         = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of the comma in the base class list if there are more than one line,
 #   (tied to nl_class_init_args).
-pos_class_comma                           = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_class_comma                                   = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of the comma in the constructor initialization list.
 # Related to nl_constr_colon, nl_constr_init_args and pos_constr_colon.
-pos_constr_comma                          = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_constr_comma                                  = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of trailing/leading class colon, between class and base class list
 #   (tied to nl_class_colon).
-pos_class_colon                           = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_class_colon                                   = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of colons between constructor and member initialization,
 # (tied to UO_nl_constr_colon).
 # Related to nl_constr_colon, nl_constr_init_args and pos_constr_comma.
-pos_constr_colon                          = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_constr_colon                                  = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 #
 # Line Splitting options
 #
 
 # Try to limit code width to N number of columns
-code_width                                = 0        # number
+code_width                                        = 0        # number
 
 # Whether to fully split long 'for' statements at semi-colons
-ls_for_split_full                         = false    # false/true
+ls_for_split_full                                 = false    # false/true
 
 # Whether to fully split long function protos/calls at commas
-ls_func_split_full                        = false    # false/true
+ls_func_split_full                                = false    # false/true
 
 # Whether to split lines as close to code_width as possible and ignore some groupings
-ls_code_width                             = false    # false/true
+ls_code_width                                     = false    # false/true
 
 #
 # Blank line options
 #
 
 # The maximum consecutive newlines (3 = 2 blank lines)
-nl_max                                    = 0        # number
+nl_max                                            = 0        # number
 
 # The number of newlines after a function prototype, if followed by another function prototype
-nl_after_func_proto                       = 0        # number
+nl_after_func_proto                               = 0        # number
 
 # The number of newlines after a function prototype, if not followed by another function prototype
-nl_after_func_proto_group                 = 0        # number
+nl_after_func_proto_group                         = 0        # number
+
+# The number of newlines after a function class prototype, if followed by another function class prototype
+nl_after_func_class_proto                         = 0        # number
+
+# The number of newlines after a function class prototype, if not followed by another function class prototype
+nl_after_func_class_proto_group                   = 0        # number
 
 # The number of newlines before a multi-line function def body
-nl_before_func_body_def                   = 0        # number
+nl_before_func_body_def                           = 0        # number
 
 # The number of newlines before a multi-line function prototype body
-nl_before_func_body_proto                 = 0        # number
+nl_before_func_body_proto                         = 0        # number
 
 # The number of newlines after '}' of a multi-line function body
-nl_after_func_body                        = 0        # number
+nl_after_func_body                                = 0        # number
 
 # The number of newlines after '}' of a multi-line function body in a class declaration
-nl_after_func_body_class                  = 0        # number
+nl_after_func_body_class                          = 0        # number
 
 # The number of newlines after '}' of a single line function body
-nl_after_func_body_one_liner              = 0        # number
+nl_after_func_body_one_liner                      = 0        # number
 
 # The minimum number of newlines before a multi-line comment.
 # Doesn't apply if after a brace open or another multi-line comment.
-nl_before_block_comment                   = 0        # number
+nl_before_block_comment                           = 0        # number
 
 # The minimum number of newlines before a single-line C comment.
 # Doesn't apply if after a brace open or other single-line C comments.
-nl_before_c_comment                       = 0        # number
+nl_before_c_comment                               = 0        # number
 
 # The minimum number of newlines before a CPP comment.
 # Doesn't apply if after a brace open or other CPP comments.
-nl_before_cpp_comment                     = 0        # number
+nl_before_cpp_comment                             = 0        # number
 
 # Whether to force a newline after a multi-line comment.
-nl_after_multiline_comment                = false    # false/true
+nl_after_multiline_comment                        = false    # false/true
 
 # Whether to force a newline after a label's colon.
-nl_after_label_colon                      = false    # false/true
+nl_after_label_colon                              = false    # false/true
 
 # The number of newlines after '}' or ';' of a struct/enum/union definition
-nl_after_struct                           = 0        # number
+nl_after_struct                                   = 0        # number
 
 # The number of newlines after '}' or ';' of a class definition
-nl_after_class                            = 0        # number
+nl_after_class                                    = 0        # number
 
 # The number of newlines before a 'private:', 'public:', 'protected:', 'signals:', or 'slots:' label.
 # Will not change the newline count if after a brace open.
 # 0 = No change.
-nl_before_access_spec                     = 0        # number
+nl_before_access_spec                             = 0        # number
 
 # The number of newlines after a 'private:', 'public:', 'protected:', 'signals:' or 'slots:' label.
 # 0 = No change.
 # the option 'nl_after_access_spec' takes preference over 'nl_typedef_blk_start' and 'nl_var_def_blk_start'
-nl_after_access_spec                      = 0        # number
+nl_after_access_spec                              = 0        # number
 
 # The number of newlines between a function def and the function comment.
 # 0 = No change.
-nl_comment_func_def                       = 0        # number
+nl_comment_func_def                               = 0        # number
 
 # The number of newlines after a try-catch-finally block that isn't followed by a brace close.
 # 0 = No change.
-nl_after_try_catch_finally                = 0        # number
+nl_after_try_catch_finally                        = 0        # number
 
 # The number of newlines before and after a property, indexer or event decl.
 # 0 = No change.
-nl_around_cs_property                     = 0        # number
+nl_around_cs_property                             = 0        # number
 
 # The number of newlines between the get/set/add/remove handlers in C#.
 # 0 = No change.
-nl_between_get_set                        = 0        # number
+nl_between_get_set                                = 0        # number
 
 # Add or remove newline between C# property and the '{'
-nl_property_brace                         = ignore   # ignore/add/remove/force
+nl_property_brace                                 = ignore   # ignore/add/remove/force
 
 # Whether to remove blank lines after '{'
-eat_blanks_after_open_brace               = false    # false/true
+eat_blanks_after_open_brace                       = false    # false/true
 
 # Whether to remove blank lines before '}'
-eat_blanks_before_close_brace             = false    # false/true
+eat_blanks_before_close_brace                     = false    # false/true
 
 # How aggressively to remove extra newlines not in preproc.
 # 0: No change
 # 1: Remove most newlines not handled by other config
 # 2: Remove all newlines and reformat completely by config
-nl_remove_extra_newlines                  = 0        # number
+nl_remove_extra_newlines                          = 0        # number
 
 # Whether to put a blank line before 'return' statements, unless after an open brace.
-nl_before_return                          = false    # false/true
+nl_before_return                                  = false    # false/true
 
 # Whether to put a blank line after 'return' statements, unless followed by a close brace.
-nl_after_return                           = false    # false/true
+nl_after_return                                   = false    # false/true
 
 # Whether to put a newline after a Java annotation statement.
 # Only affects annotations that are after a newline.
-nl_after_annotation                       = ignore   # ignore/add/remove/force
+nl_after_annotation                               = ignore   # ignore/add/remove/force
 
 # Controls the newline between two annotations.
-nl_between_annotation                     = ignore   # ignore/add/remove/force
+nl_between_annotation                             = ignore   # ignore/add/remove/force
 
 #
 # Code modifying options (non-whitespace)
 #
 
 # Add or remove braces on single-line 'do' statement
-mod_full_brace_do                         = ignore   # ignore/add/remove/force
+mod_full_brace_do                                 = ignore   # ignore/add/remove/force
 
 # Add or remove braces on single-line 'for' statement
-mod_full_brace_for                        = ignore   # ignore/add/remove/force
+mod_full_brace_for                                = ignore   # ignore/add/remove/force
 
 # Add or remove braces on single-line function definitions. (Pawn)
-mod_full_brace_function                   = ignore   # ignore/add/remove/force
+mod_full_brace_function                           = ignore   # ignore/add/remove/force
 
 # Add or remove braces on single-line 'if' statement. Will not remove the braces if they contain an 'else'.
-mod_full_brace_if                         = ignore   # ignore/add/remove/force
+mod_full_brace_if                                 = ignore   # ignore/add/remove/force
 
 # Make all if/elseif/else statements in a chain be braced or not. Overrides mod_full_brace_if.
 # If any must be braced, they are all braced.  If all can be unbraced, then the braces are removed.
-mod_full_brace_if_chain                   = false    # false/true
+mod_full_brace_if_chain                           = false    # false/true
+
+# Make all if/elseif/else statements with at least one 'else' or 'else if' fully braced.
+# If mod_full_brace_if_chain is used together with this option, all if-else chains will get braces,
+# and simple 'if' statements will lose them (if possible).
+mod_full_brace_if_chain_only                      = false    # false/true
 
 # Don't remove braces around statements that span N newlines
-mod_full_brace_nl                         = 0        # number
+mod_full_brace_nl                                 = 0        # number
 
 # Add or remove braces on single-line 'while' statement
-mod_full_brace_while                      = ignore   # ignore/add/remove/force
+mod_full_brace_while                              = ignore   # ignore/add/remove/force
 
 # Add or remove braces on single-line 'using ()' statement
-mod_full_brace_using                      = ignore   # ignore/add/remove/force
+mod_full_brace_using                              = ignore   # ignore/add/remove/force
 
 # Add or remove unnecessary paren on 'return' statement
-mod_paren_on_return                       = ignore   # ignore/add/remove/force
+mod_paren_on_return                               = ignore   # ignore/add/remove/force
 
 # Whether to change optional semicolons to real semicolons
-mod_pawn_semicolon                        = false    # false/true
+mod_pawn_semicolon                                = false    # false/true
 
 # Add parens on 'while' and 'if' statement around bools
-mod_full_paren_if_bool                    = false    # false/true
+mod_full_paren_if_bool                            = false    # false/true
 
 # Whether to remove superfluous semicolons
-mod_remove_extra_semicolon                = false    # false/true
+mod_remove_extra_semicolon                        = false    # false/true
 
 # If a function body exceeds the specified number of newlines and doesn't have a comment after
 # the close brace, a comment will be added.
-mod_add_long_function_closebrace_comment  = 0        # number
+mod_add_long_function_closebrace_comment          = 0        # number
 
 # If a namespace body exceeds the specified number of newlines and doesn't have a comment after
 # the close brace, a comment will be added.
-mod_add_long_namespace_closebrace_comment = 0        # number
+mod_add_long_namespace_closebrace_comment         = 0        # number
 
 # If a switch body exceeds the specified number of newlines and doesn't have a comment after
 # the close brace, a comment will be added.
-mod_add_long_switch_closebrace_comment    = 0        # number
+mod_add_long_switch_closebrace_comment            = 0        # number
 
 # If an #ifdef body exceeds the specified number of newlines and doesn't have a comment after
 # the #endif, a comment will be added.
-mod_add_long_ifdef_endif_comment          = 0        # number
+mod_add_long_ifdef_endif_comment                  = 0        # number
 
 # If an #ifdef or #else body exceeds the specified number of newlines and doesn't have a comment after
 # the #else, a comment will be added.
-mod_add_long_ifdef_else_comment           = 0        # number
+mod_add_long_ifdef_else_comment                   = 0        # number
 
 # If TRUE, will sort consecutive single-line 'import' statements [Java, D]
-mod_sort_import                           = false    # false/true
+mod_sort_import                                   = false    # false/true
 
 # If TRUE, will sort consecutive single-line 'using' statements [C#]
-mod_sort_using                            = false    # false/true
+mod_sort_using                                    = false    # false/true
 
 # If TRUE, will sort consecutive single-line '#include' statements [C/C++] and '#import' statements [Obj-C]
 # This is generally a bad idea, as it may break your code.
-mod_sort_include                          = false    # false/true
+mod_sort_include                                  = false    # false/true
 
 # If TRUE, it will move a 'break' that appears after a fully braced 'case' before the close brace.
-mod_move_case_break                       = false    # false/true
+mod_move_case_break                               = false    # false/true
 
 # Will add or remove the braces around a fully braced case statement.
 # Will only remove the braces if there are no variable declarations in the block.
-mod_case_brace                            = ignore   # ignore/add/remove/force
+mod_case_brace                                    = ignore   # ignore/add/remove/force
 
 # If TRUE, it will remove a void 'return;' that appears as the last statement in a function.
-mod_remove_empty_return                   = false    # false/true
+mod_remove_empty_return                           = false    # false/true
 
 #
 # Comment modifications
 #
 
 # Try to wrap comments at cmt_width columns
-cmt_width                                 = 0        # number
+cmt_width                                         = 0        # number
 
 # Set the comment reflow mode (default: 0)
 # 0: no reflowing (apart from the line wrapping due to cmt_width)
 # 1: no touching at all
 # 2: full reflow
-cmt_reflow_mode                           = 0        # number
+cmt_reflow_mode                                   = 0        # number
 
 # Whether to convert all tabs to spaces in comments. Default is to leave tabs inside comments alone, unless used for indenting.
-cmt_convert_tab_to_spaces                 = false    # false/true
+cmt_convert_tab_to_spaces                         = false    # false/true
 
 # If false, disable all multi-line comment changes, including cmt_width. keyword substitution and leading chars.
-# Default is true.
-cmt_indent_multi                          = true     # false/true
+# Default=True.
+cmt_indent_multi                                  = true     # false/true
 
 # Whether to group c-comments that look like they are in a block
-cmt_c_group                               = false    # false/true
+cmt_c_group                                       = false    # false/true
 
 # Whether to put an empty '/*' on the first line of the combined c-comment
-cmt_c_nl_start                            = false    # false/true
+cmt_c_nl_start                                    = false    # false/true
 
 # Whether to put a newline before the closing '*/' of the combined c-comment
-cmt_c_nl_end                              = false    # false/true
+cmt_c_nl_end                                      = false    # false/true
 
 # Whether to group cpp-comments that look like they are in a block
-cmt_cpp_group                             = false    # false/true
+cmt_cpp_group                                     = false    # false/true
 
 # Whether to put an empty '/*' on the first line of the combined cpp-comment
-cmt_cpp_nl_start                          = false    # false/true
+cmt_cpp_nl_start                                  = false    # false/true
 
 # Whether to put a newline before the closing '*/' of the combined cpp-comment
-cmt_cpp_nl_end                            = false    # false/true
+cmt_cpp_nl_end                                    = false    # false/true
 
 # Whether to change cpp-comments into c-comments
-cmt_cpp_to_c                              = false    # false/true
+cmt_cpp_to_c                                      = false    # false/true
 
 # Whether to put a star on subsequent comment lines
-cmt_star_cont                             = false    # false/true
+cmt_star_cont                                     = false    # false/true
 
 # The number of spaces to insert at the start of subsequent comment lines
-cmt_sp_before_star_cont                   = 0        # number
+cmt_sp_before_star_cont                           = 0        # number
 
 # The number of spaces to insert after the star on subsequent comment lines
-cmt_sp_after_star_cont                    = 0        # number
+cmt_sp_after_star_cont                            = 0        # number
 
 # For multi-line comments with a '*' lead, remove leading spaces if the first and last lines of
 # the comment are the same length. Default=True
-cmt_multi_check_last                      = true     # false/true
+cmt_multi_check_last                              = true     # false/true
 
 # The filename that contains text to insert at the head of a file if the file doesn't start with a C/C++ comment.
 # Will substitute $(filename) with the current file's name.
-cmt_insert_file_header                    = ""         # string
+cmt_insert_file_header                            = ""         # string
 
 # The filename that contains text to insert at the end of a file if the file doesn't end with a C/C++ comment.
 # Will substitute $(filename) with the current file's name.
-cmt_insert_file_footer                    = ""         # string
+cmt_insert_file_footer                            = ""         # string
 
 # The filename that contains text to insert before a function implementation if the function isn't preceded with a C/C++ comment.
 # Will substitute $(function) with the function name and $(javaparam) with the javadoc @param and @return stuff.
 # Will also substitute $(fclass) with the class name: void CFoo::Bar() { ... }
-cmt_insert_func_header                    = ""         # string
+cmt_insert_func_header                            = ""         # string
 
 # The filename that contains text to insert before a class if the class isn't preceded with a C/C++ comment.
 # Will substitute $(class) with the class name.
-cmt_insert_class_header                   = ""         # string
+cmt_insert_class_header                           = ""         # string
 
 # The filename that contains text to insert before a Obj-C message specification if the method isn't preceded with a C/C++ comment.
 # Will substitute $(message) with the function name and $(javaparam) with the javadoc @param and @return stuff.
-cmt_insert_oc_msg_header                  = ""         # string
+cmt_insert_oc_msg_header                          = ""         # string
 
 # If a preprocessor is encountered when stepping backwards from a function name, then
 # this option decides whether the comment should be inserted.
 # Affects cmt_insert_oc_msg_header, cmt_insert_func_header and cmt_insert_class_header.
-cmt_insert_before_preproc                 = false    # false/true
+cmt_insert_before_preproc                         = false    # false/true
+
+# If a function is declared inline to a class definition, then
+# this option decides whether the comment should be inserted.
+# Affects cmt_insert_func_header.
+cmt_insert_before_inlines                         = true     # false/true
+
+# If the function is a constructor/destructor, then
+# this option decides whether the comment should be inserted.
+# Affects cmt_insert_func_header.
+cmt_insert_before_ctor_dtor                       = false    # false/true
 
 #
 # Preprocessor options
 #
 
 # Control indent of preprocessors inside #if blocks at brace level 0 (file-level)
-pp_indent                                 = ignore   # ignore/add/remove/force
+pp_indent                                         = ignore   # ignore/add/remove/force
 
 # Whether to indent #if/#else/#endif at the brace level (true) or from column 1 (false)
-pp_indent_at_level                        = false    # false/true
+pp_indent_at_level                                = false    # false/true
 
 # Specifies the number of columns to indent preprocessors per level at brace level 0 (file-level).
 # If pp_indent_at_level=false, specifies the number of columns to indent preprocessors per level at brace level > 0 (function-level).
 # Default=1.
-pp_indent_count                           = 1        # number
+pp_indent_count                                   = 1        # number
 
 # Add or remove space after # based on pp_level of #if blocks
-pp_space                                  = ignore   # ignore/add/remove/force
+pp_space                                          = ignore   # ignore/add/remove/force
 
 # Sets the number of spaces added with pp_space
-pp_space_count                            = 0        # number
+pp_space_count                                    = 0        # number
 
 # The indent for #region and #endregion in C# and '#pragma region' in C/C++
-pp_indent_region                          = 0        # number
+pp_indent_region                                  = 0        # number
 
 # Whether to indent the code between #region and #endregion
-pp_region_indent_code                     = false    # false/true
+pp_region_indent_code                             = false    # false/true
 
 # If pp_indent_at_level=true, sets the indent for #if, #else and #endif when not at file-level.
 # 0:  indent preprocessors using output_tab_size.
 # >0: column at which all preprocessors will be indented.
-pp_indent_if                              = 0        # number
+pp_indent_if                                      = 0        # number
 
 # Control whether to indent the code between #if, #else and #endif.
-pp_if_indent_code                         = false    # false/true
+pp_if_indent_code                                 = false    # false/true
 
 # Whether to indent '#define' at the brace level (true) or from column 1 (false)
-pp_define_at_level                        = false    # false/true
+pp_define_at_level                                = false    # false/true
 
 #
 # Use or Do not Use options
 #
 
-# True:  indent_func_call_param will be used
+# True:  indent_func_call_param will be used (default)
 # False: indent_func_call_param will NOT be used
-use_indent_func_call_param                = true     # false/true
+use_indent_func_call_param                        = true     # false/true
 
+# The value of the indentation for a continuation line is calculate differently if the line is:
+#   a declaration :your case with QString fileName ...
+#   an assigment  :your case with pSettings = new QSettings( ...
+# At the second case the option value might be used twice:
+#   at the assigment
+#   at the function call (if present)
+# To prevent the double use of the option value, use this option with the value 'true'.
 # True:  indent_continue will be used only once
 # False: indent_continue will be used every time (default)
-use_indent_continue_only_once             = false    # false/true
+use_indent_continue_only_once                     = false    # false/true
+
+# SIGNAL/SLOT Qt macros have special formatting options. See options_for_QT.cpp for details.
+# Default=True.
+use_options_overriding_for_qt_macros              = true     # false/true
+
+#
+# Warn levels - 1: error, 2: warning (default), 3: note
+#
+
+# Warning is given if doing tab-to-\t replacement and we have found one in a C# verbatim string literal.
+warn_level_tabs_found_in_verbatim_string_literals = 2        # number
 
 # You can force a token to be a type with the 'type' option.
 # Example:

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -4,280 +4,287 @@
 # General options
 #
 
-# The type of line endings
-newlines                                  = auto     # auto/lf/crlf/cr
+# The type of line endings. Default=Auto
+newlines                                          = auto     # auto/lf/crlf/cr
 
-# The original size of tabs in the input
-input_tab_size                            = 8        # number
+# The original size of tabs in the input. Default=8
+input_tab_size                                    = 8        # number
 
-# The size of tabs in the output (only used if align_with_tabs=true)
-output_tab_size                           = 8        # number
+# The size of tabs in the output (only used if align_with_tabs=true). Default=8
+output_tab_size                                   = 8        # number
 
 # The ASCII value of the string escape char, usually 92 (\) or 94 (^). (Pawn)
-string_escape_char                        = 92       # number
+string_escape_char                                = 92       # number
 
 # Alternate string escape char for Pawn. Only works right before the quote char.
-string_escape_char2                       = 0        # number
+string_escape_char2                               = 0        # number
 
 # Replace tab characters found in string literals with the escape sequence \t instead.
-string_replace_tab_chars                  = false    # false/true
+string_replace_tab_chars                          = false    # false/true
 
 # Allow interpreting '>=' and '>>=' as part of a template in 'void f(list<list<B>>=val);'.
-# If true (default), 'assert(x<0 && y>=3)' will be broken.
+# If true, 'assert(x<0 && y>=3)' will be broken. Default=False
 # Improvements to template detection may make this option obsolete.
-tok_split_gte                             = false    # false/true
+tok_split_gte                                     = false    # false/true
 
 # Override the default ' *INDENT-OFF*' in comments for disabling processing of part of the file.
-disable_processing_cmt                    = ""         # string
+disable_processing_cmt                            = ""         # string
 
 # Override the default ' *INDENT-ON*' in comments for enabling processing of part of the file.
-enable_processing_cmt                     = ""         # string
+enable_processing_cmt                             = ""         # string
 
-# Enable parsing of digraphs. Default=false
-enable_digraphs                           = false    # false/true
+# Enable parsing of digraphs. Default=False
+enable_digraphs                                   = false    # false/true
 
 # Control what to do with the UTF-8 BOM (recommend 'remove')
-utf8_bom                                  = ignore   # ignore/add/remove/force
+utf8_bom                                          = ignore   # ignore/add/remove/force
 
 # If the file contains bytes with values between 128 and 255, but is not UTF-8, then output as UTF-8
-utf8_byte                                 = false    # false/true
+utf8_byte                                         = false    # false/true
 
 # Force the output encoding to UTF-8
-utf8_force                                = false    # false/true
+utf8_force                                        = false    # false/true
 
 #
 # Indenting
 #
 
 # The number of columns to indent per level.
-# Usually 2, 3, 4, or 8.
-indent_columns                            = 8        # number
+# Usually 2, 3, 4, or 8. Default=8
+indent_columns                                    = 8        # number
 
 # The continuation indent. If non-zero, this overrides the indent of '(' and '=' continuation indents.
 # For FreeBSD, this is set to 4. Negative value is absolute and not increased for each ( level
-indent_continue                           = 0        # number
+indent_continue                                   = 0        # number
 
 # How to use tabs when indenting code
 # 0=spaces only
-# 1=indent with tabs to brace level, align with spaces
+# 1=indent with tabs to brace level, align with spaces (default)
 # 2=indent and align with tabs, using spaces when not on a tabstop
-indent_with_tabs                          = 1        # number
+indent_with_tabs                                  = 1        # number
 
 # Comments that are not a brace level are indented with tabs on a tabstop.
 # Requires indent_with_tabs=2. If false, will use spaces.
-indent_cmt_with_tabs                      = false    # false/true
+indent_cmt_with_tabs                              = false    # false/true
 
 # Whether to indent strings broken by '\' so that they line up
-indent_align_string                       = false    # false/true
+indent_align_string                               = false    # false/true
 
 # The number of spaces to indent multi-line XML strings.
 # Requires indent_align_string=True
-indent_xml_string                         = 0        # number
+indent_xml_string                                 = 0        # number
 
 # Spaces to indent '{' from level
-indent_brace                              = 0        # number
+indent_brace                                      = 0        # number
 
 # Whether braces are indented to the body level
-indent_braces                             = false    # false/true
+indent_braces                                     = false    # false/true
 
 # Disabled indenting function braces if indent_braces is true
-indent_braces_no_func                     = false    # false/true
+indent_braces_no_func                             = false    # false/true
 
 # Disabled indenting class braces if indent_braces is true
-indent_braces_no_class                    = false    # false/true
+indent_braces_no_class                            = false    # false/true
 
 # Disabled indenting struct braces if indent_braces is true
-indent_braces_no_struct                   = false    # false/true
+indent_braces_no_struct                           = false    # false/true
 
 # Indent based on the size of the brace parent, i.e. 'if' => 3 spaces, 'for' => 4 spaces, etc.
-indent_brace_parent                       = false    # false/true
+indent_brace_parent                               = false    # false/true
 
 # Indent based on the paren open instead of the brace open in '({\n', default is to indent by brace.
-indent_paren_open_brace                   = false    # false/true
+indent_paren_open_brace                           = false    # false/true
+
+# indent a C# delegate by another level, default is to not indent by another level.
+indent_cs_delegate_brace                          = false    # false/true
 
 # Whether the 'namespace' body is indented
-indent_namespace                          = false    # false/true
+indent_namespace                                  = false    # false/true
 
 # Only indent one namespace and no sub-namespaces.
 # Requires indent_namespace=true.
-indent_namespace_single_indent            = false    # false/true
+indent_namespace_single_indent                    = false    # false/true
 
 # The number of spaces to indent a namespace block
-indent_namespace_level                    = 0        # number
+indent_namespace_level                            = 0        # number
 
 # If the body of the namespace is longer than this number, it won't be indented.
 # Requires indent_namespace=true. Default=0 (no limit)
-indent_namespace_limit                    = 0        # number
+indent_namespace_limit                            = 0        # number
 
 # Whether the 'extern "C"' body is indented
-indent_extern                             = false    # false/true
+indent_extern                                     = false    # false/true
 
 # Whether the 'class' body is indented
-indent_class                              = false    # false/true
+indent_class                                      = false    # false/true
 
 # Whether to indent the stuff after a leading base class colon
-indent_class_colon                        = false    # false/true
+indent_class_colon                                = false    # false/true
 
 # Indent based on a class colon instead of the stuff after the colon.
-# Requires indent_class_colon=true. Default=false
-indent_class_on_colon                     = false    # false/true
+# Requires indent_class_colon=true. Default=False
+indent_class_on_colon                             = false    # false/true
 
 # Whether to indent the stuff after a leading class initializer colon
-indent_constr_colon                       = false    # false/true
+indent_constr_colon                               = false    # false/true
 
-# Virtual indent from the ':' for member initializers. Default is 2
-indent_ctor_init_leading                  = 2        # number
+# Virtual indent from the ':' for member initializers. Default=2
+indent_ctor_init_leading                          = 2        # number
 
 # Additional indenting for constructor initializer list
-indent_ctor_init                          = 0        # number
+indent_ctor_init                                  = 0        # number
 
 # False=treat 'else\nif' as 'else if' for indenting purposes
 # True=indent the 'if' one level
-indent_else_if                            = false    # false/true
+indent_else_if                                    = false    # false/true
 
 # Amount to indent variable declarations after a open brace. neg=relative, pos=absolute
-indent_var_def_blk                        = 0        # number
+indent_var_def_blk                                = 0        # number
 
 # Indent continued variable declarations instead of aligning.
-indent_var_def_cont                       = false    # false/true
+indent_var_def_cont                               = false    # false/true
 
 # Indent continued shift expressions ('<<' and '>>') instead of aligning.
 # Turn align_left_shift off when enabling this.
-indent_shift                              = false    # false/true
+indent_shift                                      = false    # false/true
 
 # True:  force indentation of function definition to start in column 1
 # False: use the default behavior
-indent_func_def_force_col1                = false    # false/true
+indent_func_def_force_col1                        = false    # false/true
 
 # True:  indent continued function call parameters one indent level
 # False: align parameters under the open paren
-indent_func_call_param                    = false    # false/true
+indent_func_call_param                            = false    # false/true
 
 # Same as indent_func_call_param, but for function defs
-indent_func_def_param                     = false    # false/true
+indent_func_def_param                             = false    # false/true
 
 # Same as indent_func_call_param, but for function protos
-indent_func_proto_param                   = false    # false/true
+indent_func_proto_param                           = false    # false/true
 
 # Same as indent_func_call_param, but for class declarations
-indent_func_class_param                   = false    # false/true
+indent_func_class_param                           = false    # false/true
 
 # Same as indent_func_call_param, but for class variable constructors
-indent_func_ctor_var_param                = false    # false/true
+indent_func_ctor_var_param                        = false    # false/true
 
 # Same as indent_func_call_param, but for templates
-indent_template_param                     = false    # false/true
+indent_template_param                             = false    # false/true
 
 # Double the indent for indent_func_xxx_param options
-indent_func_param_double                  = false    # false/true
+indent_func_param_double                          = false    # false/true
 
 # Indentation column for standalone 'const' function decl/proto qualifier
-indent_func_const                         = 0        # number
+indent_func_const                                 = 0        # number
 
 # Indentation column for standalone 'throw' function decl/proto qualifier
-indent_func_throw                         = 0        # number
+indent_func_throw                                 = 0        # number
 
 # The number of spaces to indent a continued '->' or '.'
 # Usually set to 0, 1, or indent_columns.
-indent_member                             = 0        # number
+indent_member                                     = 0        # number
 
 # Spaces to indent single line ('//') comments on lines before code
-indent_sing_line_comments                 = 0        # number
+indent_sing_line_comments                         = 0        # number
 
 # If set, will indent trailing single line ('//') comments relative
 # to the code instead of trying to keep the same absolute column
-indent_relative_single_line_comments      = false    # false/true
+indent_relative_single_line_comments              = false    # false/true
 
 # Spaces to indent 'case' from 'switch'
 # Usually 0 or indent_columns.
-indent_switch_case                        = 0        # number
+indent_switch_case                                = 0        # number
 
 # Spaces to shift the 'case' line, without affecting any other lines
 # Usually 0.
-indent_case_shift                         = 0        # number
+indent_case_shift                                 = 0        # number
 
 # Spaces to indent '{' from 'case'.
 # By default, the brace will appear under the 'c' in case.
 # Usually set to 0 or indent_columns.
-indent_case_brace                         = 0        # number
+indent_case_brace                                 = 0        # number
 
 # Whether to indent comments found in first column
-indent_col1_comment                       = false    # false/true
+indent_col1_comment                               = false    # false/true
 
 # How to indent goto labels
 #   >0: absolute column where 1 is the leftmost column
 #  <=0: subtract from brace indent
-indent_label                              = 1        # number
+# Default=1
+indent_label                                      = 1        # number
 
-# Same as indent_label, but for access specifiers that are followed by a colon
-indent_access_spec                        = 1        # number
+# Same as indent_label, but for access specifiers that are followed by a colon. Default=1
+indent_access_spec                                = 1        # number
 
 # Indent the code after an access specifier by one level.
 # If set, this option forces 'indent_access_spec=0'
-indent_access_spec_body                   = false    # false/true
+indent_access_spec_body                           = false    # false/true
 
 # If an open paren is followed by a newline, indent the next line so that it lines up after the open paren (not recommended)
-indent_paren_nl                           = false    # false/true
+indent_paren_nl                                   = false    # false/true
 
 # Controls the indent of a close paren after a newline.
 # 0: Indent to body level
 # 1: Align under the open paren
 # 2: Indent to the brace level
-indent_paren_close                        = 0        # number
+indent_paren_close                                = 0        # number
 
 # Controls the indent of a comma when inside a paren.If TRUE, aligns under the open paren
-indent_comma_paren                        = false    # false/true
+indent_comma_paren                                = false    # false/true
 
 # Controls the indent of a BOOL operator when inside a paren.If TRUE, aligns under the open paren
-indent_bool_paren                         = false    # false/true
+indent_bool_paren                                 = false    # false/true
 
 # If 'indent_bool_paren' is true, controls the indent of the first expression. If TRUE, aligns the first expression to the following ones
-indent_first_bool_expr                    = false    # false/true
+indent_first_bool_expr                            = false    # false/true
 
 # If an open square is followed by a newline, indent the next line so that it lines up after the open square (not recommended)
-indent_square_nl                          = false    # false/true
+indent_square_nl                                  = false    # false/true
 
 # Don't change the relative indent of ESQL/C 'EXEC SQL' bodies
-indent_preserve_sql                       = false    # false/true
+indent_preserve_sql                               = false    # false/true
 
 # Align continued statements at the '='. Default=True
 # If FALSE or the '=' is followed by a newline, the next line is indent one tab.
-indent_align_assign                       = true     # false/true
+indent_align_assign                               = true     # false/true
 
 # Indent OC blocks at brace level instead of usual rules.
-indent_oc_block                           = false    # false/true
+indent_oc_block                                   = false    # false/true
 
 # Indent OC blocks in a message relative to the parameter name.
 # 0=use indent_oc_block rules, 1+=spaces to indent
-indent_oc_block_msg                       = 0        # number
+indent_oc_block_msg                               = 0        # number
 
 # Minimum indent for subsequent parameters
-indent_oc_msg_colon                       = 0        # number
+indent_oc_msg_colon                               = 0        # number
 
 # If true, prioritize aligning with initial colon (and stripping spaces from lines, if necessary).
-# Default is true.
-indent_oc_msg_prioritize_first_colon      = true     # false/true
+# Default=True.
+indent_oc_msg_prioritize_first_colon              = true     # false/true
 
 # If indent_oc_block_msg and this option are on, blocks will be indented the way that Xcode does by default (from keyword if the parameter is on its own line; otherwise, from the previous indentation level).
-indent_oc_block_msg_xcode_style           = false    # false/true
+indent_oc_block_msg_xcode_style                   = false    # false/true
 
 # If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg keyword.
-indent_oc_block_msg_from_keyword          = false    # false/true
+indent_oc_block_msg_from_keyword                  = false    # false/true
 
 # If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg colon.
-indent_oc_block_msg_from_colon            = false    # false/true
+indent_oc_block_msg_from_colon                    = false    # false/true
 
 # If indent_oc_block_msg and this option are on, blocks will be indented from where the block caret is.
-indent_oc_block_msg_from_caret            = false    # false/true
+indent_oc_block_msg_from_caret                    = false    # false/true
 
 # If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is.
-indent_oc_block_msg_from_brace            = false    # false/true
+indent_oc_block_msg_from_brace                    = false    # false/true
 
 # When identing after virtual brace open and newline add further spaces to reach this min. indent.
-indent_min_vbrace_open                    = 0        # number
+indent_min_vbrace_open                            = 0        # number
 
 # TRUE: When identing after virtual brace open and newline add further spaces after regular indent to reach next tabstop.
-indent_vbrace_open_on_tabstop             = false    # false/true
+indent_vbrace_open_on_tabstop                     = false    # false/true
+
+# If true, a brace followed by another token (not a newline) will indent all contained lines to match the token.Default=True.
+indent_token_after_brace                          = true     # false/true
 
 #
 # Spacing options
@@ -285,1466 +292,1581 @@ indent_vbrace_open_on_tabstop             = false    # false/true
 
 # Add or remove space around arithmetic operator '+', '-', '/', '*', etc
 # also '>>>' '<<' '>>' '%' '|'
-sp_arith                                  = ignore   # ignore/add/remove/force
+sp_arith                                          = ignore   # ignore/add/remove/force
 
 # Add or remove space around assignment operator '=', '+=', etc
-sp_assign                                 = ignore   # ignore/add/remove/force
+sp_assign                                         = ignore   # ignore/add/remove/force
 
 # Add or remove space around '=' in C++11 lambda capture specifications. Overrides sp_assign
-sp_cpp_lambda_assign                      = ignore   # ignore/add/remove/force
+sp_cpp_lambda_assign                              = ignore   # ignore/add/remove/force
 
 # Add or remove space after the capture specification in C++11 lambda.
-sp_cpp_lambda_paren                       = ignore   # ignore/add/remove/force
+sp_cpp_lambda_paren                               = ignore   # ignore/add/remove/force
 
 # Add or remove space around assignment operator '=' in a prototype
-sp_assign_default                         = ignore   # ignore/add/remove/force
+sp_assign_default                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space before assignment operator '=', '+=', etc. Overrides sp_assign.
-sp_before_assign                          = ignore   # ignore/add/remove/force
+sp_before_assign                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space after assignment operator '=', '+=', etc. Overrides sp_assign.
-sp_after_assign                           = ignore   # ignore/add/remove/force
+sp_after_assign                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space in 'NS_ENUM ('
-sp_enum_paren                             = ignore   # ignore/add/remove/force
+sp_enum_paren                                     = ignore   # ignore/add/remove/force
 
 # Add or remove space around assignment '=' in enum
-sp_enum_assign                            = ignore   # ignore/add/remove/force
+sp_enum_assign                                    = ignore   # ignore/add/remove/force
 
 # Add or remove space before assignment '=' in enum. Overrides sp_enum_assign.
-sp_enum_before_assign                     = ignore   # ignore/add/remove/force
+sp_enum_before_assign                             = ignore   # ignore/add/remove/force
 
 # Add or remove space after assignment '=' in enum. Overrides sp_enum_assign.
-sp_enum_after_assign                      = ignore   # ignore/add/remove/force
+sp_enum_after_assign                              = ignore   # ignore/add/remove/force
 
 # Add or remove space around preprocessor '##' concatenation operator. Default=Add
-sp_pp_concat                              = add      # ignore/add/remove/force
+sp_pp_concat                                      = add      # ignore/add/remove/force
 
 # Add or remove space after preprocessor '#' stringify operator. Also affects the '#@' charizing operator.
-sp_pp_stringify                           = ignore   # ignore/add/remove/force
+sp_pp_stringify                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space before preprocessor '#' stringify operator as in '#define x(y) L#y'.
-sp_before_pp_stringify                    = ignore   # ignore/add/remove/force
+sp_before_pp_stringify                            = ignore   # ignore/add/remove/force
 
 # Add or remove space around boolean operators '&&' and '||'
-sp_bool                                   = ignore   # ignore/add/remove/force
+sp_bool                                           = ignore   # ignore/add/remove/force
 
 # Add or remove space around compare operator '<', '>', '==', etc
-sp_compare                                = ignore   # ignore/add/remove/force
+sp_compare                                        = ignore   # ignore/add/remove/force
 
 # Add or remove space inside '(' and ')'
-sp_inside_paren                           = ignore   # ignore/add/remove/force
+sp_inside_paren                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space between nested parens: '((' vs ') )'
-sp_paren_paren                            = ignore   # ignore/add/remove/force
+sp_paren_paren                                    = ignore   # ignore/add/remove/force
 
 # Add or remove space between back-to-back parens: ')(' vs ') ('
-sp_cparen_oparen                          = ignore   # ignore/add/remove/force
+sp_cparen_oparen                                  = ignore   # ignore/add/remove/force
 
 # Whether to balance spaces inside nested parens
-sp_balance_nested_parens                  = false    # false/true
+sp_balance_nested_parens                          = false    # false/true
 
 # Add or remove space between ')' and '{'
-sp_paren_brace                            = ignore   # ignore/add/remove/force
+sp_paren_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove space before pointer star '*'
-sp_before_ptr_star                        = ignore   # ignore/add/remove/force
+sp_before_ptr_star                                = ignore   # ignore/add/remove/force
 
 # Add or remove space before pointer star '*' that isn't followed by a variable name
 # If set to 'ignore', sp_before_ptr_star is used instead.
-sp_before_unnamed_ptr_star                = ignore   # ignore/add/remove/force
+sp_before_unnamed_ptr_star                        = ignore   # ignore/add/remove/force
 
 # Add or remove space between pointer stars '*'
-sp_between_ptr_star                       = ignore   # ignore/add/remove/force
+sp_between_ptr_star                               = ignore   # ignore/add/remove/force
 
 # Add or remove space after pointer star '*', if followed by a word.
-sp_after_ptr_star                         = ignore   # ignore/add/remove/force
+sp_after_ptr_star                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space after pointer star '*', if followed by a qualifier.
-sp_after_ptr_star_qualifier               = ignore   # ignore/add/remove/force
+sp_after_ptr_star_qualifier                       = ignore   # ignore/add/remove/force
 
 # Add or remove space after a pointer star '*', if followed by a func proto/def.
-sp_after_ptr_star_func                    = ignore   # ignore/add/remove/force
+sp_after_ptr_star_func                            = ignore   # ignore/add/remove/force
 
 # Add or remove space after a pointer star '*', if followed by an open paren (function types).
-sp_ptr_star_paren                         = ignore   # ignore/add/remove/force
+sp_ptr_star_paren                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space before a pointer star '*', if followed by a func proto/def.
-sp_before_ptr_star_func                   = ignore   # ignore/add/remove/force
+sp_before_ptr_star_func                           = ignore   # ignore/add/remove/force
 
 # Add or remove space before a reference sign '&'
-sp_before_byref                           = ignore   # ignore/add/remove/force
+sp_before_byref                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space before a reference sign '&' that isn't followed by a variable name
 # If set to 'ignore', sp_before_byref is used instead.
-sp_before_unnamed_byref                   = ignore   # ignore/add/remove/force
+sp_before_unnamed_byref                           = ignore   # ignore/add/remove/force
 
 # Add or remove space after reference sign '&', if followed by a word.
-sp_after_byref                            = ignore   # ignore/add/remove/force
+sp_after_byref                                    = ignore   # ignore/add/remove/force
 
 # Add or remove space after a reference sign '&', if followed by a func proto/def.
-sp_after_byref_func                       = ignore   # ignore/add/remove/force
+sp_after_byref_func                               = ignore   # ignore/add/remove/force
 
 # Add or remove space before a reference sign '&', if followed by a func proto/def.
-sp_before_byref_func                      = ignore   # ignore/add/remove/force
+sp_before_byref_func                              = ignore   # ignore/add/remove/force
 
 # Add or remove space between type and word. Default=Force
-sp_after_type                             = force    # ignore/add/remove/force
+sp_after_type                                     = force    # ignore/add/remove/force
 
 # Add or remove space before the paren in the D constructs 'template Foo(' and 'class Foo('.
-sp_before_template_paren                  = ignore   # ignore/add/remove/force
+sp_before_template_paren                          = ignore   # ignore/add/remove/force
 
 # Add or remove space in 'template <' vs 'template<'.
 # If set to ignore, sp_before_angle is used.
-sp_template_angle                         = ignore   # ignore/add/remove/force
+sp_template_angle                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space before '<>'
-sp_before_angle                           = ignore   # ignore/add/remove/force
+sp_before_angle                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space inside '<' and '>'
-sp_inside_angle                           = ignore   # ignore/add/remove/force
+sp_inside_angle                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space after '<>'
-sp_after_angle                            = ignore   # ignore/add/remove/force
+sp_after_angle                                    = ignore   # ignore/add/remove/force
 
-# Add or remove space between '<>' and '(' as found in 'new List<byte>();'
-sp_angle_paren                            = ignore   # ignore/add/remove/force
+# Add or remove space between '<>' and '(' as found in 'new List<byte>(foo);'
+sp_angle_paren                                    = ignore   # ignore/add/remove/force
+
+# Add or remove space between '<>' and '()' as found in 'new List<byte>();'
+sp_angle_paren_empty                              = ignore   # ignore/add/remove/force
 
 # Add or remove space between '<>' and a word as in 'List<byte> m;' or 'template <typename T> static ...'
-sp_angle_word                             = ignore   # ignore/add/remove/force
+sp_angle_word                                     = ignore   # ignore/add/remove/force
 
 # Add or remove space between '>' and '>' in '>>' (template stuff C++/C# only). Default=Add
-sp_angle_shift                            = add      # ignore/add/remove/force
+sp_angle_shift                                    = add      # ignore/add/remove/force
 
 # Permit removal of the space between '>>' in 'foo<bar<int> >' (C++11 only). Default=False
 # sp_angle_shift cannot remove the space without this option.
-sp_permit_cpp11_shift                     = false    # false/true
+sp_permit_cpp11_shift                             = false    # false/true
 
 # Add or remove space before '(' of 'if', 'for', 'switch', 'while', etc.
-sp_before_sparen                          = ignore   # ignore/add/remove/force
+sp_before_sparen                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space inside if-condition '(' and ')'
-sp_inside_sparen                          = ignore   # ignore/add/remove/force
+sp_inside_sparen                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space before if-condition ')'. Overrides sp_inside_sparen.
-sp_inside_sparen_close                    = ignore   # ignore/add/remove/force
+sp_inside_sparen_close                            = ignore   # ignore/add/remove/force
 
 # Add or remove space after if-condition '('. Overrides sp_inside_sparen.
-sp_inside_sparen_open                     = ignore   # ignore/add/remove/force
+sp_inside_sparen_open                             = ignore   # ignore/add/remove/force
 
 # Add or remove space after ')' of 'if', 'for', 'switch', and 'while', etc.
-sp_after_sparen                           = ignore   # ignore/add/remove/force
+sp_after_sparen                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space between ')' and '{' of 'if', 'for', 'switch', and 'while', etc.
-sp_sparen_brace                           = ignore   # ignore/add/remove/force
+sp_sparen_brace                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'invariant' and '(' in the D language.
-sp_invariant_paren                        = ignore   # ignore/add/remove/force
+sp_invariant_paren                                = ignore   # ignore/add/remove/force
 
 # Add or remove space after the ')' in 'invariant (C) c' in the D language.
-sp_after_invariant_paren                  = ignore   # ignore/add/remove/force
+sp_after_invariant_paren                          = ignore   # ignore/add/remove/force
 
 # Add or remove space before empty statement ';' on 'if', 'for' and 'while'
-sp_special_semi                           = ignore   # ignore/add/remove/force
+sp_special_semi                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space before ';'. Default=Remove
-sp_before_semi                            = remove   # ignore/add/remove/force
+sp_before_semi                                    = remove   # ignore/add/remove/force
 
 # Add or remove space before ';' in non-empty 'for' statements
-sp_before_semi_for                        = ignore   # ignore/add/remove/force
+sp_before_semi_for                                = ignore   # ignore/add/remove/force
 
 # Add or remove space before a semicolon of an empty part of a for statement.
-sp_before_semi_for_empty                  = ignore   # ignore/add/remove/force
+sp_before_semi_for_empty                          = ignore   # ignore/add/remove/force
 
 # Add or remove space after ';', except when followed by a comment. Default=Add
-sp_after_semi                             = add      # ignore/add/remove/force
+sp_after_semi                                     = add      # ignore/add/remove/force
 
 # Add or remove space after ';' in non-empty 'for' statements. Default=Force
-sp_after_semi_for                         = force    # ignore/add/remove/force
+sp_after_semi_for                                 = force    # ignore/add/remove/force
 
 # Add or remove space after the final semicolon of an empty part of a for statement: for ( ; ; <here> ).
-sp_after_semi_for_empty                   = ignore   # ignore/add/remove/force
+sp_after_semi_for_empty                           = ignore   # ignore/add/remove/force
 
 # Add or remove space before '[' (except '[]')
-sp_before_square                          = ignore   # ignore/add/remove/force
+sp_before_square                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space before '[]'
-sp_before_squares                         = ignore   # ignore/add/remove/force
+sp_before_squares                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space inside a non-empty '[' and ']'
-sp_inside_square                          = ignore   # ignore/add/remove/force
+sp_inside_square                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space after ','
-sp_after_comma                            = ignore   # ignore/add/remove/force
+sp_after_comma                                    = ignore   # ignore/add/remove/force
 
-# Add or remove space before ','
-sp_before_comma                           = remove   # ignore/add/remove/force
+# Add or remove space before ','. Default=Remove
+sp_before_comma                                   = remove   # ignore/add/remove/force
 
 # Add or remove space between ',' and ']' in multidimensional array type 'int[,,]'
-sp_after_mdatype_commas                   = ignore   # ignore/add/remove/force
+sp_after_mdatype_commas                           = ignore   # ignore/add/remove/force
 
 # Add or remove space between '[' and ',' in multidimensional array type 'int[,,]'
-sp_before_mdatype_commas                  = ignore   # ignore/add/remove/force
+sp_before_mdatype_commas                          = ignore   # ignore/add/remove/force
 
 # Add or remove space between ',' in multidimensional array type 'int[,,]'
-sp_between_mdatype_commas                 = ignore   # ignore/add/remove/force
+sp_between_mdatype_commas                         = ignore   # ignore/add/remove/force
 
-# Add or remove space between an open paren and comma: '(,' vs '( ,'
-sp_paren_comma                            = force    # ignore/add/remove/force
+# Add or remove space between an open paren and comma: '(,' vs '( ,'. Default=Force
+sp_paren_comma                                    = force    # ignore/add/remove/force
 
 # Add or remove space before the variadic '...' when preceded by a non-punctuator
-sp_before_ellipsis                        = ignore   # ignore/add/remove/force
+sp_before_ellipsis                                = ignore   # ignore/add/remove/force
 
 # Add or remove space after class ':'
-sp_after_class_colon                      = ignore   # ignore/add/remove/force
+sp_after_class_colon                              = ignore   # ignore/add/remove/force
 
 # Add or remove space before class ':'
-sp_before_class_colon                     = ignore   # ignore/add/remove/force
+sp_before_class_colon                             = ignore   # ignore/add/remove/force
 
 # Add or remove space after class constructor ':'
-sp_after_constr_colon                     = ignore   # ignore/add/remove/force
+sp_after_constr_colon                             = ignore   # ignore/add/remove/force
 
 # Add or remove space before class constructor ':'
-sp_before_constr_colon                    = ignore   # ignore/add/remove/force
+sp_before_constr_colon                            = ignore   # ignore/add/remove/force
 
 # Add or remove space before case ':'. Default=Remove
-sp_before_case_colon                      = remove   # ignore/add/remove/force
+sp_before_case_colon                              = remove   # ignore/add/remove/force
 
 # Add or remove space between 'operator' and operator sign
-sp_after_operator                         = ignore   # ignore/add/remove/force
+sp_after_operator                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space between the operator symbol and the open paren, as in 'operator ++('
-sp_after_operator_sym                     = ignore   # ignore/add/remove/force
+sp_after_operator_sym                             = ignore   # ignore/add/remove/force
+
+# Add or remove space between the operator symbol and the open paren when the operator has no arguments, as in 'operator *()'
+sp_after_operator_sym_empty                       = ignore   # ignore/add/remove/force
 
 # Add or remove space after C/D cast, i.e. 'cast(int)a' vs 'cast(int) a' or '(int)a' vs '(int) a'
-sp_after_cast                             = ignore   # ignore/add/remove/force
+sp_after_cast                                     = ignore   # ignore/add/remove/force
 
 # Add or remove spaces inside cast parens
-sp_inside_paren_cast                      = ignore   # ignore/add/remove/force
+sp_inside_paren_cast                              = ignore   # ignore/add/remove/force
 
 # Add or remove space between the type and open paren in a C++ cast, i.e. 'int(exp)' vs 'int (exp)'
-sp_cpp_cast_paren                         = ignore   # ignore/add/remove/force
+sp_cpp_cast_paren                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'sizeof' and '('
-sp_sizeof_paren                           = ignore   # ignore/add/remove/force
+sp_sizeof_paren                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space after the tag keyword (Pawn)
-sp_after_tag                              = ignore   # ignore/add/remove/force
+sp_after_tag                                      = ignore   # ignore/add/remove/force
 
 # Add or remove space inside enum '{' and '}'
-sp_inside_braces_enum                     = ignore   # ignore/add/remove/force
+sp_inside_braces_enum                             = ignore   # ignore/add/remove/force
 
 # Add or remove space inside struct/union '{' and '}'
-sp_inside_braces_struct                   = ignore   # ignore/add/remove/force
+sp_inside_braces_struct                           = ignore   # ignore/add/remove/force
 
 # Add or remove space inside '{' and '}'
-sp_inside_braces                          = ignore   # ignore/add/remove/force
+sp_inside_braces                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space inside '{}'
-sp_inside_braces_empty                    = ignore   # ignore/add/remove/force
+sp_inside_braces_empty                            = ignore   # ignore/add/remove/force
 
 # Add or remove space between return type and function name
 # A minimum of 1 is forced except for pointer return types.
-sp_type_func                              = ignore   # ignore/add/remove/force
+sp_type_func                                      = ignore   # ignore/add/remove/force
 
 # Add or remove space between function name and '(' on function declaration
-sp_func_proto_paren                       = ignore   # ignore/add/remove/force
+sp_func_proto_paren                               = ignore   # ignore/add/remove/force
+
+# Add or remove space between function name and '()' on function declaration without parameters
+sp_func_proto_paren_empty                         = ignore   # ignore/add/remove/force
 
 # Add or remove space between function name and '(' on function definition
-sp_func_def_paren                         = ignore   # ignore/add/remove/force
+sp_func_def_paren                                 = ignore   # ignore/add/remove/force
+
+# Add or remove space between function name and '()' on function definition without parameters
+sp_func_def_paren_empty                           = ignore   # ignore/add/remove/force
 
 # Add or remove space inside empty function '()'
-sp_inside_fparens                         = ignore   # ignore/add/remove/force
+sp_inside_fparens                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space inside function '(' and ')'
-sp_inside_fparen                          = ignore   # ignore/add/remove/force
+sp_inside_fparen                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space inside the first parens in the function type: 'void (*x)(...)'
-sp_inside_tparen                          = ignore   # ignore/add/remove/force
+sp_inside_tparen                                  = ignore   # ignore/add/remove/force
 
 # Add or remove between the parens in the function type: 'void (*x)(...)'
-sp_after_tparen_close                     = ignore   # ignore/add/remove/force
+sp_after_tparen_close                             = ignore   # ignore/add/remove/force
 
 # Add or remove space between ']' and '(' when part of a function call.
-sp_square_fparen                          = ignore   # ignore/add/remove/force
+sp_square_fparen                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space between ')' and '{' of function
-sp_fparen_brace                           = ignore   # ignore/add/remove/force
+sp_fparen_brace                                   = ignore   # ignore/add/remove/force
 
 # Java: Add or remove space between ')' and '{{' of double brace initializer.
-sp_fparen_dbrace                          = ignore   # ignore/add/remove/force
+sp_fparen_dbrace                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space between function name and '(' on function calls
-sp_func_call_paren                        = ignore   # ignore/add/remove/force
+sp_func_call_paren                                = ignore   # ignore/add/remove/force
 
 # Add or remove space between function name and '()' on function calls without parameters.
 # If set to 'ignore' (the default), sp_func_call_paren is used.
-sp_func_call_paren_empty                  = ignore   # ignore/add/remove/force
+sp_func_call_paren_empty                          = ignore   # ignore/add/remove/force
 
 # Add or remove space between the user function name and '(' on function calls
 # You need to set a keyword to be a user function, like this: 'set func_call_user _' in the config file.
-sp_func_call_user_paren                   = ignore   # ignore/add/remove/force
+sp_func_call_user_paren                           = ignore   # ignore/add/remove/force
 
 # Add or remove space between a constructor/destructor and the open paren
-sp_func_class_paren                       = ignore   # ignore/add/remove/force
+sp_func_class_paren                               = ignore   # ignore/add/remove/force
+
+# Add or remove space between a constructor without parameters or destructor and '()'
+sp_func_class_paren_empty                         = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'return' and '('
-sp_return_paren                           = ignore   # ignore/add/remove/force
+sp_return_paren                                   = ignore   # ignore/add/remove/force
 
 # Add or remove space between '__attribute__' and '('
-sp_attribute_paren                        = ignore   # ignore/add/remove/force
+sp_attribute_paren                                = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'defined' and '(' in '#if defined (FOO)'
-sp_defined_paren                          = ignore   # ignore/add/remove/force
+sp_defined_paren                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'throw' and '(' in 'throw (something)'
-sp_throw_paren                            = ignore   # ignore/add/remove/force
+sp_throw_paren                                    = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'throw' and anything other than '(' as in '@throw [...];'
-sp_after_throw                            = ignore   # ignore/add/remove/force
+sp_after_throw                                    = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'catch' and '(' in 'catch (something) { }'
 # If set to ignore, sp_before_sparen is used.
-sp_catch_paren                            = ignore   # ignore/add/remove/force
+sp_catch_paren                                    = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'version' and '(' in 'version (something) { }' (D language)
 # If set to ignore, sp_before_sparen is used.
-sp_version_paren                          = ignore   # ignore/add/remove/force
+sp_version_paren                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'scope' and '(' in 'scope (something) { }' (D language)
 # If set to ignore, sp_before_sparen is used.
-sp_scope_paren                            = ignore   # ignore/add/remove/force
+sp_scope_paren                                    = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'super' and '(' in 'super (something)'. Default=Remove
+sp_super_paren                                    = remove   # ignore/add/remove/force
+
+# Add or remove space between 'this' and '(' in 'this (something)'. Default=Remove
+sp_this_paren                                     = remove   # ignore/add/remove/force
 
 # Add or remove space between macro and value
-sp_macro                                  = ignore   # ignore/add/remove/force
+sp_macro                                          = ignore   # ignore/add/remove/force
 
 # Add or remove space between macro function ')' and value
-sp_macro_func                             = ignore   # ignore/add/remove/force
+sp_macro_func                                     = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'else' and '{' if on the same line
-sp_else_brace                             = ignore   # ignore/add/remove/force
+sp_else_brace                                     = ignore   # ignore/add/remove/force
 
 # Add or remove space between '}' and 'else' if on the same line
-sp_brace_else                             = ignore   # ignore/add/remove/force
+sp_brace_else                                     = ignore   # ignore/add/remove/force
 
 # Add or remove space between '}' and the name of a typedef on the same line
-sp_brace_typedef                          = ignore   # ignore/add/remove/force
+sp_brace_typedef                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'catch' and '{' if on the same line
-sp_catch_brace                            = ignore   # ignore/add/remove/force
+sp_catch_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove space between '}' and 'catch' if on the same line
-sp_brace_catch                            = ignore   # ignore/add/remove/force
+sp_brace_catch                                    = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'finally' and '{' if on the same line
-sp_finally_brace                          = ignore   # ignore/add/remove/force
+sp_finally_brace                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space between '}' and 'finally' if on the same line
-sp_brace_finally                          = ignore   # ignore/add/remove/force
+sp_brace_finally                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'try' and '{' if on the same line
-sp_try_brace                              = ignore   # ignore/add/remove/force
+sp_try_brace                                      = ignore   # ignore/add/remove/force
 
 # Add or remove space between get/set and '{' if on the same line
-sp_getset_brace                           = ignore   # ignore/add/remove/force
+sp_getset_brace                                   = ignore   # ignore/add/remove/force
 
-# Add or remove space between a variable and '{' for C++ uniform initialization
-sp_word_brace                             = add      # ignore/add/remove/force
+# Add or remove space between a variable and '{' for C++ uniform initialization. Default=Add
+sp_word_brace                                     = add      # ignore/add/remove/force
 
-# Add or remove space between a variable and '{' for a namespace
-sp_word_brace_ns                          = add      # ignore/add/remove/force
+# Add or remove space between a variable and '{' for a namespace. Default=Add
+sp_word_brace_ns                                  = add      # ignore/add/remove/force
 
 # Add or remove space before the '::' operator
-sp_before_dc                              = ignore   # ignore/add/remove/force
+sp_before_dc                                      = ignore   # ignore/add/remove/force
 
 # Add or remove space after the '::' operator
-sp_after_dc                               = ignore   # ignore/add/remove/force
+sp_after_dc                                       = ignore   # ignore/add/remove/force
 
 # Add or remove around the D named array initializer ':' operator
-sp_d_array_colon                          = ignore   # ignore/add/remove/force
+sp_d_array_colon                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space after the '!' (not) operator. Default=Remove
-sp_not                                    = remove   # ignore/add/remove/force
+sp_not                                            = remove   # ignore/add/remove/force
 
 # Add or remove space after the '~' (invert) operator. Default=Remove
-sp_inv                                    = remove   # ignore/add/remove/force
+sp_inv                                            = remove   # ignore/add/remove/force
 
 # Add or remove space after the '&' (address-of) operator. Default=Remove
 # This does not affect the spacing after a '&' that is part of a type.
-sp_addr                                   = remove   # ignore/add/remove/force
+sp_addr                                           = remove   # ignore/add/remove/force
 
 # Add or remove space around the '.' or '->' operators. Default=Remove
-sp_member                                 = remove   # ignore/add/remove/force
+sp_member                                         = remove   # ignore/add/remove/force
 
 # Add or remove space after the '*' (dereference) operator. Default=Remove
 # This does not affect the spacing after a '*' that is part of a type.
-sp_deref                                  = remove   # ignore/add/remove/force
+sp_deref                                          = remove   # ignore/add/remove/force
 
 # Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'. Default=Remove
-sp_sign                                   = remove   # ignore/add/remove/force
+sp_sign                                           = remove   # ignore/add/remove/force
 
 # Add or remove space before or after '++' and '--', as in '(--x)' or 'y++;'. Default=Remove
-sp_incdec                                 = remove   # ignore/add/remove/force
+sp_incdec                                         = remove   # ignore/add/remove/force
 
 # Add or remove space before a backslash-newline at the end of a line. Default=Add
-sp_before_nl_cont                         = add      # ignore/add/remove/force
+sp_before_nl_cont                                 = add      # ignore/add/remove/force
 
 # Add or remove space after the scope '+' or '-', as in '-(void) foo;' or '+(int) bar;'
-sp_after_oc_scope                         = ignore   # ignore/add/remove/force
+sp_after_oc_scope                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space after the colon in message specs
 # '-(int) f:(int) x;' vs '-(int) f: (int) x;'
-sp_after_oc_colon                         = ignore   # ignore/add/remove/force
+sp_after_oc_colon                                 = ignore   # ignore/add/remove/force
 
 # Add or remove space before the colon in message specs
 # '-(int) f: (int) x;' vs '-(int) f : (int) x;'
-sp_before_oc_colon                        = ignore   # ignore/add/remove/force
+sp_before_oc_colon                                = ignore   # ignore/add/remove/force
 
 # Add or remove space after the colon in immutable dictionary expression
 # 'NSDictionary *test = @{@"foo" :@"bar"};'
-sp_after_oc_dict_colon                    = ignore   # ignore/add/remove/force
+sp_after_oc_dict_colon                            = ignore   # ignore/add/remove/force
 
 # Add or remove space before the colon in immutable dictionary expression
 # 'NSDictionary *test = @{@"foo" :@"bar"};'
-sp_before_oc_dict_colon                   = ignore   # ignore/add/remove/force
+sp_before_oc_dict_colon                           = ignore   # ignore/add/remove/force
 
 # Add or remove space after the colon in message specs
 # '[object setValue:1];' vs '[object setValue: 1];'
-sp_after_send_oc_colon                    = ignore   # ignore/add/remove/force
+sp_after_send_oc_colon                            = ignore   # ignore/add/remove/force
 
 # Add or remove space before the colon in message specs
 # '[object setValue:1];' vs '[object setValue :1];'
-sp_before_send_oc_colon                   = ignore   # ignore/add/remove/force
+sp_before_send_oc_colon                           = ignore   # ignore/add/remove/force
 
 # Add or remove space after the (type) in message specs
 # '-(int)f: (int) x;' vs '-(int)f: (int)x;'
-sp_after_oc_type                          = ignore   # ignore/add/remove/force
+sp_after_oc_type                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space after the first (type) in message specs
 # '-(int) f:(int)x;' vs '-(int)f:(int)x;'
-sp_after_oc_return_type                   = ignore   # ignore/add/remove/force
+sp_after_oc_return_type                           = ignore   # ignore/add/remove/force
 
 # Add or remove space between '@selector' and '('
 # '@selector(msgName)' vs '@selector (msgName)'
 # Also applies to @protocol() constructs
-sp_after_oc_at_sel                        = ignore   # ignore/add/remove/force
+sp_after_oc_at_sel                                = ignore   # ignore/add/remove/force
 
 # Add or remove space between '@selector(x)' and the following word
 # '@selector(foo) a:' vs '@selector(foo)a:'
-sp_after_oc_at_sel_parens                 = ignore   # ignore/add/remove/force
+sp_after_oc_at_sel_parens                         = ignore   # ignore/add/remove/force
 
 # Add or remove space inside '@selector' parens
 # '@selector(foo)' vs '@selector( foo )'
 # Also applies to @protocol() constructs
-sp_inside_oc_at_sel_parens                = ignore   # ignore/add/remove/force
+sp_inside_oc_at_sel_parens                        = ignore   # ignore/add/remove/force
 
 # Add or remove space before a block pointer caret
 # '^int (int arg){...}' vs. ' ^int (int arg){...}'
-sp_before_oc_block_caret                  = ignore   # ignore/add/remove/force
+sp_before_oc_block_caret                          = ignore   # ignore/add/remove/force
 
 # Add or remove space after a block pointer caret
 # '^int (int arg){...}' vs. '^ int (int arg){...}'
-sp_after_oc_block_caret                   = ignore   # ignore/add/remove/force
+sp_after_oc_block_caret                           = ignore   # ignore/add/remove/force
 
 # Add or remove space between the receiver and selector in a message.
 # '[receiver selector ...]'
-sp_after_oc_msg_receiver                  = ignore   # ignore/add/remove/force
+sp_after_oc_msg_receiver                          = ignore   # ignore/add/remove/force
 
 # Add or remove space after @property.
-sp_after_oc_property                      = ignore   # ignore/add/remove/force
+sp_after_oc_property                              = ignore   # ignore/add/remove/force
 
 # Add or remove space around the ':' in 'b ? t : f'
-sp_cond_colon                             = ignore   # ignore/add/remove/force
+sp_cond_colon                                     = ignore   # ignore/add/remove/force
 
 # Add or remove space before the ':' in 'b ? t : f'. Overrides sp_cond_colon.
-sp_cond_colon_before                      = ignore   # ignore/add/remove/force
+sp_cond_colon_before                              = ignore   # ignore/add/remove/force
 
 # Add or remove space after the ':' in 'b ? t : f'. Overrides sp_cond_colon.
-sp_cond_colon_after                       = ignore   # ignore/add/remove/force
+sp_cond_colon_after                               = ignore   # ignore/add/remove/force
 
 # Add or remove space around the '?' in 'b ? t : f'
-sp_cond_question                          = ignore   # ignore/add/remove/force
+sp_cond_question                                  = ignore   # ignore/add/remove/force
 
 # Add or remove space before the '?' in 'b ? t : f'. Overrides sp_cond_question.
-sp_cond_question_before                   = ignore   # ignore/add/remove/force
+sp_cond_question_before                           = ignore   # ignore/add/remove/force
 
 # Add or remove space after the '?' in 'b ? t : f'. Overrides sp_cond_question.
-sp_cond_question_after                    = ignore   # ignore/add/remove/force
+sp_cond_question_after                            = ignore   # ignore/add/remove/force
 
 # In the abbreviated ternary form (a ?: b), add/remove space between ? and :.'. Overrides all other sp_cond_* options.
-sp_cond_ternary_short                     = ignore   # ignore/add/remove/force
+sp_cond_ternary_short                             = ignore   # ignore/add/remove/force
 
 # Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make sense here.
-sp_case_label                             = ignore   # ignore/add/remove/force
+sp_case_label                                     = ignore   # ignore/add/remove/force
 
 # Control the space around the D '..' operator.
-sp_range                                  = ignore   # ignore/add/remove/force
+sp_range                                          = ignore   # ignore/add/remove/force
 
 # Control the spacing after ':' in 'for (TYPE VAR : EXPR)'
-sp_after_for_colon                        = ignore   # ignore/add/remove/force
+sp_after_for_colon                                = ignore   # ignore/add/remove/force
 
 # Control the spacing before ':' in 'for (TYPE VAR : EXPR)'
-sp_before_for_colon                       = ignore   # ignore/add/remove/force
+sp_before_for_colon                               = ignore   # ignore/add/remove/force
 
 # Control the spacing in 'extern (C)' (D)
-sp_extern_paren                           = ignore   # ignore/add/remove/force
+sp_extern_paren                                   = ignore   # ignore/add/remove/force
 
 # Control the space after the opening of a C++ comment '// A' vs '//A'
-sp_cmt_cpp_start                          = ignore   # ignore/add/remove/force
+sp_cmt_cpp_start                                  = ignore   # ignore/add/remove/force
 
 # TRUE: If space is added with sp_cmt_cpp_start, do it after doxygen sequences like '///', '///<', '//!' and '//!<'.
-sp_cmt_cpp_doxygen                        = false    # false/true
+sp_cmt_cpp_doxygen                                = false    # false/true
 
 # TRUE: If space is added with sp_cmt_cpp_start, do it after Qt translator or meta-data comments like '//:', '//=', and '//~'.
-sp_cmt_cpp_qttr                           = false    # false/true
+sp_cmt_cpp_qttr                                   = false    # false/true
 
 # Controls the spaces between #else or #endif and a trailing comment
-sp_endif_cmt                              = ignore   # ignore/add/remove/force
+sp_endif_cmt                                      = ignore   # ignore/add/remove/force
 
 # Controls the spaces after 'new', 'delete' and 'delete[]'
-sp_after_new                              = ignore   # ignore/add/remove/force
+sp_after_new                                      = ignore   # ignore/add/remove/force
 
 # Controls the spaces between new and '(' in 'new()'
-sp_between_new_paren                      = ignore   # ignore/add/remove/force
+sp_between_new_paren                              = ignore   # ignore/add/remove/force
 
 # Controls the spaces before a trailing or embedded comment
-sp_before_tr_emb_cmt                      = ignore   # ignore/add/remove/force
+sp_before_tr_emb_cmt                              = ignore   # ignore/add/remove/force
 
 # Number of spaces before a trailing or embedded comment
-sp_num_before_tr_emb_cmt                  = 0        # number
+sp_num_before_tr_emb_cmt                          = 0        # number
 
 # Control space between a Java annotation and the open paren.
-sp_annotation_paren                       = ignore   # ignore/add/remove/force
+sp_annotation_paren                               = ignore   # ignore/add/remove/force
+
+# If true, vbrace tokens are dropped to the previous token and skipped.
+sp_skip_vbrace_tokens                             = false    # false/true
 
 #
 # Code alignment (not left column spaces/tabs)
 #
 
 # Whether to keep non-indenting tabs
-align_keep_tabs                           = false    # false/true
+align_keep_tabs                                   = false    # false/true
 
 # Whether to use tabs for aligning
-align_with_tabs                           = false    # false/true
+align_with_tabs                                   = false    # false/true
 
 # Whether to bump out to the next tab when aligning
-align_on_tabstop                          = false    # false/true
+align_on_tabstop                                  = false    # false/true
 
 # Whether to left-align numbers
-align_number_left                         = false    # false/true
+align_number_left                                 = false    # false/true
 
 # Whether to keep whitespace not required for alignment.
-align_keep_extra_space                    = false    # false/true
+align_keep_extra_space                            = false    # false/true
 
 # Align variable definitions in prototypes and functions
-align_func_params                         = false    # false/true
+align_func_params                                 = false    # false/true
 
 # Align parameters in single-line functions that have the same name.
 # The function names must already be aligned with each other.
-align_same_func_call_params               = false    # false/true
+align_same_func_call_params                       = false    # false/true
 
 # The span for aligning variable definitions (0=don't align)
-align_var_def_span                        = 0        # number
+align_var_def_span                                = 0        # number
 
 # How to align the star in variable definitions.
 #  0=Part of the type     'void *   foo;'
 #  1=Part of the variable 'void     *foo;'
 #  2=Dangling             'void    *foo;'
-align_var_def_star_style                  = 0        # number
+align_var_def_star_style                          = 0        # number
 
 # How to align the '&' in variable definitions.
 #  0=Part of the type
 #  1=Part of the variable
 #  2=Dangling
-align_var_def_amp_style                   = 0        # number
+align_var_def_amp_style                           = 0        # number
 
 # The threshold for aligning variable definitions (0=no limit)
-align_var_def_thresh                      = 0        # number
+align_var_def_thresh                              = 0        # number
 
 # The gap for aligning variable definitions
-align_var_def_gap                         = 0        # number
+align_var_def_gap                                 = 0        # number
 
 # Whether to align the colon in struct bit fields
-align_var_def_colon                       = false    # false/true
+align_var_def_colon                               = false    # false/true
 
 # Whether to align any attribute after the variable name
-align_var_def_attribute                   = false    # false/true
+align_var_def_attribute                           = false    # false/true
 
 # Whether to align inline struct/enum/union variable definitions
-align_var_def_inline                      = false    # false/true
+align_var_def_inline                              = false    # false/true
 
 # The span for aligning on '=' in assignments (0=don't align)
-align_assign_span                         = 0        # number
+align_assign_span                                 = 0        # number
 
 # The threshold for aligning on '=' in assignments (0=no limit)
-align_assign_thresh                       = 0        # number
+align_assign_thresh                               = 0        # number
 
 # The span for aligning on '=' in enums (0=don't align)
-align_enum_equ_span                       = 0        # number
+align_enum_equ_span                               = 0        # number
 
 # The threshold for aligning on '=' in enums (0=no limit)
-align_enum_equ_thresh                     = 0        # number
+align_enum_equ_thresh                             = 0        # number
 
 # The span for aligning struct/union (0=don't align)
-align_var_struct_span                     = 0        # number
+align_var_struct_span                             = 0        # number
 
 # The threshold for aligning struct/union member definitions (0=no limit)
-align_var_struct_thresh                   = 0        # number
+align_var_struct_thresh                           = 0        # number
 
 # The gap for aligning struct/union member definitions
-align_var_struct_gap                      = 0        # number
+align_var_struct_gap                              = 0        # number
 
 # The span for aligning struct initializer values (0=don't align)
-align_struct_init_span                    = 0        # number
+align_struct_init_span                            = 0        # number
 
 # The minimum space between the type and the synonym of a typedef
-align_typedef_gap                         = 0        # number
+align_typedef_gap                                 = 0        # number
 
 # The span for aligning single-line typedefs (0=don't align)
-align_typedef_span                        = 0        # number
+align_typedef_span                                = 0        # number
 
 # How to align typedef'd functions with other typedefs
 # 0: Don't mix them at all
 # 1: align the open paren with the types
 # 2: align the function type name with the other type names
-align_typedef_func                        = 0        # number
+align_typedef_func                                = 0        # number
 
 # Controls the positioning of the '*' in typedefs. Just try it.
 # 0: Align on typedef type, ignore '*'
 # 1: The '*' is part of type name: typedef int  *pint;
 # 2: The '*' is part of the type, but dangling: typedef int *pint;
-align_typedef_star_style                  = 0        # number
+align_typedef_star_style                          = 0        # number
 
 # Controls the positioning of the '&' in typedefs. Just try it.
 # 0: Align on typedef type, ignore '&'
 # 1: The '&' is part of type name: typedef int  &pint;
 # 2: The '&' is part of the type, but dangling: typedef int &pint;
-align_typedef_amp_style                   = 0        # number
+align_typedef_amp_style                           = 0        # number
 
 # The span for aligning comments that end lines (0=don't align)
-align_right_cmt_span                      = 0        # number
+align_right_cmt_span                              = 0        # number
 
 # If aligning comments, mix with comments after '}' and #endif with less than 3 spaces before the comment
-align_right_cmt_mix                       = false    # false/true
+align_right_cmt_mix                               = false    # false/true
 
 # If a trailing comment is more than this number of columns away from the text it follows,
 # it will qualify for being aligned. This has to be > 0 to do anything.
-align_right_cmt_gap                       = 0        # number
+align_right_cmt_gap                               = 0        # number
 
 # Align trailing comment at or beyond column N; 'pulls in' comments as a bonus side effect (0=ignore)
-align_right_cmt_at_col                    = 0        # number
+align_right_cmt_at_col                            = 0        # number
 
 # The span for aligning function prototypes (0=don't align)
-align_func_proto_span                     = 0        # number
+align_func_proto_span                             = 0        # number
 
 # Minimum gap between the return type and the function name.
-align_func_proto_gap                      = 0        # number
+align_func_proto_gap                              = 0        # number
 
 # Align function protos on the 'operator' keyword instead of what follows
-align_on_operator                         = false    # false/true
+align_on_operator                                 = false    # false/true
 
 # Whether to mix aligning prototype and variable declarations.
 # If true, align_var_def_XXX options are used instead of align_func_proto_XXX options.
-align_mix_var_proto                       = false    # false/true
+align_mix_var_proto                               = false    # false/true
 
 # Align single-line functions with function prototypes, uses align_func_proto_span
-align_single_line_func                    = false    # false/true
+align_single_line_func                            = false    # false/true
 
 # Aligning the open brace of single-line functions.
 # Requires align_single_line_func=true, uses align_func_proto_span
-align_single_line_brace                   = false    # false/true
+align_single_line_brace                           = false    # false/true
 
 # Gap for align_single_line_brace.
-align_single_line_brace_gap               = 0        # number
+align_single_line_brace_gap                       = 0        # number
 
 # The span for aligning ObjC msg spec (0=don't align)
-align_oc_msg_spec_span                    = 0        # number
+align_oc_msg_spec_span                            = 0        # number
 
 # Whether to align macros wrapped with a backslash and a newline.
 # This will not work right if the macro contains a multi-line comment.
-align_nl_cont                             = false    # false/true
+align_nl_cont                                     = false    # false/true
 
 # # Align macro functions and variables together
-align_pp_define_together                  = false    # false/true
+align_pp_define_together                          = false    # false/true
 
 # The minimum space between label and value of a preprocessor define
-align_pp_define_gap                       = 0        # number
+align_pp_define_gap                               = 0        # number
 
 # The span for aligning on '#define' bodies (0=don't align, other=number of lines including comments between blocks)
-align_pp_define_span                      = 0        # number
+align_pp_define_span                              = 0        # number
 
-# Align lines that start with '<<' with previous '<<'. Default=true
-align_left_shift                          = true     # false/true
+# Align lines that start with '<<' with previous '<<'. Default=True
+align_left_shift                                  = true     # false/true
 
 # Align text after asm volatile () colons.
-align_asm_colon                           = false    # false/true
+align_asm_colon                                   = false    # false/true
 
 # Span for aligning parameters in an Obj-C message call on the ':' (0=don't align)
-align_oc_msg_colon_span                   = 0        # number
+align_oc_msg_colon_span                           = 0        # number
 
 # If true, always align with the first parameter, even if it is too short.
-align_oc_msg_colon_first                  = false    # false/true
+align_oc_msg_colon_first                          = false    # false/true
 
 # Aligning parameters in an Obj-C '+' or '-' declaration on the ':'
-align_oc_decl_colon                       = false    # false/true
+align_oc_decl_colon                               = false    # false/true
 
 #
 # Newline adding and removing options
 #
 
 # Whether to collapse empty blocks between '{' and '}'
-nl_collapse_empty_body                    = false    # false/true
+nl_collapse_empty_body                            = false    # false/true
 
 # Don't split one-line braced assignments - 'foo_t f = { 1, 2 };'
-nl_assign_leave_one_liners                = false    # false/true
+nl_assign_leave_one_liners                        = false    # false/true
 
 # Don't split one-line braced statements inside a class xx { } body
-nl_class_leave_one_liners                 = false    # false/true
+nl_class_leave_one_liners                         = false    # false/true
 
 # Don't split one-line enums: 'enum foo { BAR = 15 };'
-nl_enum_leave_one_liners                  = false    # false/true
+nl_enum_leave_one_liners                          = false    # false/true
 
 # Don't split one-line get or set functions
-nl_getset_leave_one_liners                = false    # false/true
+nl_getset_leave_one_liners                        = false    # false/true
 
 # Don't split one-line function definitions - 'int foo() { return 0; }'
-nl_func_leave_one_liners                  = false    # false/true
+nl_func_leave_one_liners                          = false    # false/true
 
 # Don't split one-line C++11 lambdas - '[]() { return 0; }'
-nl_cpp_lambda_leave_one_liners            = false    # false/true
+nl_cpp_lambda_leave_one_liners                    = false    # false/true
 
 # Don't split one-line if/else statements - 'if(a) b++;'
-nl_if_leave_one_liners                    = false    # false/true
+nl_if_leave_one_liners                            = false    # false/true
 
 # Don't split one-line while statements - 'while(a) b++;'
-nl_while_leave_one_liners                 = false    # false/true
+nl_while_leave_one_liners                         = false    # false/true
 
 # Don't split one-line OC messages
-nl_oc_msg_leave_one_liner                 = false    # false/true
+nl_oc_msg_leave_one_liner                         = false    # false/true
+
+# Add or remove newline between Objective-C block signature and '{'
+nl_oc_block_brace                                 = ignore   # ignore/add/remove/force
 
 # Add or remove newlines at the start of the file
-nl_start_of_file                          = ignore   # ignore/add/remove/force
+nl_start_of_file                                  = ignore   # ignore/add/remove/force
 
 # The number of newlines at the start of the file (only used if nl_start_of_file is 'add' or 'force'
-nl_start_of_file_min                      = 0        # number
+nl_start_of_file_min                              = 0        # number
 
 # Add or remove newline at the end of the file
-nl_end_of_file                            = ignore   # ignore/add/remove/force
+nl_end_of_file                                    = ignore   # ignore/add/remove/force
 
 # The number of newlines at the end of the file (only used if nl_end_of_file is 'add' or 'force')
-nl_end_of_file_min                        = 0        # number
+nl_end_of_file_min                                = 0        # number
 
 # Add or remove newline between '=' and '{'
-nl_assign_brace                           = ignore   # ignore/add/remove/force
+nl_assign_brace                                   = ignore   # ignore/add/remove/force
 
 # Add or remove newline between '=' and '[' (D only)
-nl_assign_square                          = ignore   # ignore/add/remove/force
+nl_assign_square                                  = ignore   # ignore/add/remove/force
 
 # Add or remove newline after '= [' (D only). Will also affect the newline before the ']'
-nl_after_square_assign                    = ignore   # ignore/add/remove/force
+nl_after_square_assign                            = ignore   # ignore/add/remove/force
 
 # The number of blank lines after a block of variable definitions at the top of a function body
 # 0 = No change (default)
-nl_func_var_def_blk                       = 0        # number
+nl_func_var_def_blk                               = 0        # number
 
 # The number of newlines before a block of typedefs
 # 0 = No change (default)
 # the option 'nl_after_access_spec' takes preference over 'nl_typedef_blk_start'
-nl_typedef_blk_start                      = 0        # number
+nl_typedef_blk_start                              = 0        # number
 
 # The number of newlines after a block of typedefs
 # 0 = No change (default)
-nl_typedef_blk_end                        = 0        # number
+nl_typedef_blk_end                                = 0        # number
 
 # The maximum consecutive newlines within a block of typedefs
 # 0 = No change (default)
-nl_typedef_blk_in                         = 0        # number
+nl_typedef_blk_in                                 = 0        # number
 
 # The number of newlines before a block of variable definitions not at the top of a function body
 # 0 = No change (default)
 # the option 'nl_after_access_spec' takes preference over 'nl_var_def_blk_start'
-nl_var_def_blk_start                      = 0        # number
+nl_var_def_blk_start                              = 0        # number
 
 # The number of newlines after a block of variable definitions not at the top of a function body
 # 0 = No change (default)
-nl_var_def_blk_end                        = 0        # number
+nl_var_def_blk_end                                = 0        # number
 
 # The maximum consecutive newlines within a block of variable definitions
 # 0 = No change (default)
-nl_var_def_blk_in                         = 0        # number
+nl_var_def_blk_in                                 = 0        # number
 
 # Add or remove newline between a function call's ')' and '{', as in:
 # list_for_each(item, &list) { }
-nl_fcall_brace                            = ignore   # ignore/add/remove/force
+nl_fcall_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'enum' and '{'
-nl_enum_brace                             = ignore   # ignore/add/remove/force
+nl_enum_brace                                     = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'struct and '{'
-nl_struct_brace                           = ignore   # ignore/add/remove/force
+nl_struct_brace                                   = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'union' and '{'
-nl_union_brace                            = ignore   # ignore/add/remove/force
+nl_union_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'if' and '{'
-nl_if_brace                               = ignore   # ignore/add/remove/force
+nl_if_brace                                       = ignore   # ignore/add/remove/force
 
 # Add or remove newline between '}' and 'else'
-nl_brace_else                             = ignore   # ignore/add/remove/force
+nl_brace_else                                     = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'else if' and '{'
 # If set to ignore, nl_if_brace is used instead
-nl_elseif_brace                           = ignore   # ignore/add/remove/force
+nl_elseif_brace                                   = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'else' and '{'
-nl_else_brace                             = ignore   # ignore/add/remove/force
+nl_else_brace                                     = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'else' and 'if'
-nl_else_if                                = ignore   # ignore/add/remove/force
+nl_else_if                                        = ignore   # ignore/add/remove/force
 
 # Add or remove newline between '}' and 'finally'
-nl_brace_finally                          = ignore   # ignore/add/remove/force
+nl_brace_finally                                  = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'finally' and '{'
-nl_finally_brace                          = ignore   # ignore/add/remove/force
+nl_finally_brace                                  = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'try' and '{'
-nl_try_brace                              = ignore   # ignore/add/remove/force
+nl_try_brace                                      = ignore   # ignore/add/remove/force
 
 # Add or remove newline between get/set and '{'
-nl_getset_brace                           = ignore   # ignore/add/remove/force
+nl_getset_brace                                   = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'for' and '{'
-nl_for_brace                              = ignore   # ignore/add/remove/force
+nl_for_brace                                      = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'catch' and '{'
-nl_catch_brace                            = ignore   # ignore/add/remove/force
+nl_catch_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline between '}' and 'catch'
-nl_brace_catch                            = ignore   # ignore/add/remove/force
+nl_brace_catch                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline between '}' and ']'
-nl_brace_square                           = ignore   # ignore/add/remove/force
+nl_brace_square                                   = ignore   # ignore/add/remove/force
 
 # Add or remove newline between '}' and ')' in a function invocation
-nl_brace_fparen                           = ignore   # ignore/add/remove/force
+nl_brace_fparen                                   = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'while' and '{'
-nl_while_brace                            = ignore   # ignore/add/remove/force
+nl_while_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'scope (x)' and '{' (D)
-nl_scope_brace                            = ignore   # ignore/add/remove/force
+nl_scope_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'unittest' and '{' (D)
-nl_unittest_brace                         = ignore   # ignore/add/remove/force
+nl_unittest_brace                                 = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'version (x)' and '{' (D)
-nl_version_brace                          = ignore   # ignore/add/remove/force
+nl_version_brace                                  = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'using' and '{'
-nl_using_brace                            = ignore   # ignore/add/remove/force
+nl_using_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline between two open or close braces.
 # Due to general newline/brace handling, REMOVE may not work.
-nl_brace_brace                            = ignore   # ignore/add/remove/force
+nl_brace_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'do' and '{'
-nl_do_brace                               = ignore   # ignore/add/remove/force
+nl_do_brace                                       = ignore   # ignore/add/remove/force
 
 # Add or remove newline between '}' and 'while' of 'do' statement
-nl_brace_while                            = ignore   # ignore/add/remove/force
+nl_brace_while                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'switch' and '{'
-nl_switch_brace                           = ignore   # ignore/add/remove/force
+nl_switch_brace                                   = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'synchronized' and '{'
-nl_synchronized_brace                     = ignore   # ignore/add/remove/force
+nl_synchronized_brace                             = ignore   # ignore/add/remove/force
 
 # Add a newline between ')' and '{' if the ')' is on a different line than the if/for/etc.
 # Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch and nl_catch_brace.
-nl_multi_line_cond                        = false    # false/true
+nl_multi_line_cond                                = false    # false/true
 
 # Force a newline in a define after the macro name for multi-line defines.
-nl_multi_line_define                      = false    # false/true
+nl_multi_line_define                              = false    # false/true
 
 # Whether to put a newline before 'case' statement, not after the first 'case'
-nl_before_case                            = false    # false/true
+nl_before_case                                    = false    # false/true
 
 # Add or remove newline between ')' and 'throw'
-nl_before_throw                           = ignore   # ignore/add/remove/force
+nl_before_throw                                   = ignore   # ignore/add/remove/force
 
 # Whether to put a newline after 'case' statement
-nl_after_case                             = false    # false/true
+nl_after_case                                     = false    # false/true
 
 # Add or remove a newline between a case ':' and '{'. Overrides nl_after_case.
-nl_case_colon_brace                       = ignore   # ignore/add/remove/force
+nl_case_colon_brace                               = ignore   # ignore/add/remove/force
 
 # Newline between namespace and {
-nl_namespace_brace                        = ignore   # ignore/add/remove/force
+nl_namespace_brace                                = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'template<>' and whatever follows.
-nl_template_class                         = ignore   # ignore/add/remove/force
+nl_template_class                                 = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'class' and '{'
-nl_class_brace                            = ignore   # ignore/add/remove/force
+nl_class_brace                                    = ignore   # ignore/add/remove/force
 
 # Add or remove newline before/after each ',' in the base class list,
 #   (tied to pos_class_comma).
-nl_class_init_args                        = ignore   # ignore/add/remove/force
+nl_class_init_args                                = ignore   # ignore/add/remove/force
 
 # Add or remove newline after each ',' in the constructor member initialization.
 # Related to nl_constr_colon, pos_constr_colon and pos_constr_comma.
-nl_constr_init_args                       = ignore   # ignore/add/remove/force
+nl_constr_init_args                               = ignore   # ignore/add/remove/force
+
+# Add or remove newline before first element, after comma, and after last element in enum
+nl_enum_own_lines                                 = ignore   # ignore/add/remove/force
 
 # Add or remove newline between return type and function name in a function definition
-nl_func_type_name                         = ignore   # ignore/add/remove/force
+nl_func_type_name                                 = ignore   # ignore/add/remove/force
 
 # Add or remove newline between return type and function name inside a class {}
 # Uses nl_func_type_name or nl_func_proto_type_name if set to ignore.
-nl_func_type_name_class                   = ignore   # ignore/add/remove/force
+nl_func_type_name_class                           = ignore   # ignore/add/remove/force
+
+# Add or remove newline between class specification and '::' in 'void A::f() { }'
+# Only appears in separate member implementation (does not appear with in-line implmementation)
+nl_func_class_scope                               = ignore   # ignore/add/remove/force
 
 # Add or remove newline between function scope and name
 # Controls the newline after '::' in 'void A::f() { }'
-nl_func_scope_name                        = ignore   # ignore/add/remove/force
+nl_func_scope_name                                = ignore   # ignore/add/remove/force
 
 # Add or remove newline between return type and function name in a prototype
-nl_func_proto_type_name                   = ignore   # ignore/add/remove/force
+nl_func_proto_type_name                           = ignore   # ignore/add/remove/force
 
 # Add or remove newline between a function name and the opening '(' in the declaration
-nl_func_paren                             = ignore   # ignore/add/remove/force
+nl_func_paren                                     = ignore   # ignore/add/remove/force
 
 # Add or remove newline between a function name and the opening '(' in the definition
-nl_func_def_paren                         = ignore   # ignore/add/remove/force
+nl_func_def_paren                                 = ignore   # ignore/add/remove/force
 
 # Add or remove newline after '(' in a function declaration
-nl_func_decl_start                        = ignore   # ignore/add/remove/force
+nl_func_decl_start                                = ignore   # ignore/add/remove/force
 
 # Add or remove newline after '(' in a function definition
-nl_func_def_start                         = ignore   # ignore/add/remove/force
+nl_func_def_start                                 = ignore   # ignore/add/remove/force
 
 # Overrides nl_func_decl_start when there is only one parameter.
-nl_func_decl_start_single                 = ignore   # ignore/add/remove/force
+nl_func_decl_start_single                         = ignore   # ignore/add/remove/force
 
 # Overrides nl_func_def_start when there is only one parameter.
-nl_func_def_start_single                  = ignore   # ignore/add/remove/force
+nl_func_def_start_single                          = ignore   # ignore/add/remove/force
+
+# Whether to add newline after '(' in a function declaration if '(' and ')' are in different lines.
+nl_func_decl_start_multi_line                     = false    # false/true
+
+# Whether to add newline after '(' in a function definition if '(' and ')' are in different lines.
+nl_func_def_start_multi_line                      = false    # false/true
 
 # Add or remove newline after each ',' in a function declaration
-nl_func_decl_args                         = ignore   # ignore/add/remove/force
+nl_func_decl_args                                 = ignore   # ignore/add/remove/force
 
 # Add or remove newline after each ',' in a function definition
-nl_func_def_args                          = ignore   # ignore/add/remove/force
+nl_func_def_args                                  = ignore   # ignore/add/remove/force
+
+# Whether to add newline after each ',' in a function declaration if '(' and ')' are in different lines.
+nl_func_decl_args_multi_line                      = false    # false/true
+
+# Whether to add newline after each ',' in a function definition if '(' and ')' are in different lines.
+nl_func_def_args_multi_line                       = false    # false/true
 
 # Add or remove newline before the ')' in a function declaration
-nl_func_decl_end                          = ignore   # ignore/add/remove/force
+nl_func_decl_end                                  = ignore   # ignore/add/remove/force
 
 # Add or remove newline before the ')' in a function definition
-nl_func_def_end                           = ignore   # ignore/add/remove/force
+nl_func_def_end                                   = ignore   # ignore/add/remove/force
 
 # Overrides nl_func_decl_end when there is only one parameter.
-nl_func_decl_end_single                   = ignore   # ignore/add/remove/force
+nl_func_decl_end_single                           = ignore   # ignore/add/remove/force
 
 # Overrides nl_func_def_end when there is only one parameter.
-nl_func_def_end_single                    = ignore   # ignore/add/remove/force
+nl_func_def_end_single                            = ignore   # ignore/add/remove/force
+
+# Whether to add newline before ')' in a function declaration if '(' and ')' are in different lines.
+nl_func_decl_end_multi_line                       = false    # false/true
+
+# Whether to add newline before ')' in a function definition if '(' and ')' are in different lines.
+nl_func_def_end_multi_line                        = false    # false/true
 
 # Add or remove newline between '()' in a function declaration.
-nl_func_decl_empty                        = ignore   # ignore/add/remove/force
+nl_func_decl_empty                                = ignore   # ignore/add/remove/force
 
 # Add or remove newline between '()' in a function definition.
-nl_func_def_empty                         = ignore   # ignore/add/remove/force
+nl_func_def_empty                                 = ignore   # ignore/add/remove/force
+
+# Whether to add newline after '(' in a function call if '(' and ')' are in different lines.
+nl_func_call_start_multi_line                     = false    # false/true
+
+# Whether to add newline after each ',' in a function call if '(' and ')' are in different lines.
+nl_func_call_args_multi_line                      = false    # false/true
+
+# Whether to add newline before ')' in a function call if '(' and ')' are in different lines.
+nl_func_call_end_multi_line                       = false    # false/true
 
 # Whether to put each OC message parameter on a separate line
 # See nl_oc_msg_leave_one_liner
-nl_oc_msg_args                            = false    # false/true
+nl_oc_msg_args                                    = false    # false/true
 
 # Add or remove newline between function signature and '{'
-nl_fdef_brace                             = ignore   # ignore/add/remove/force
+nl_fdef_brace                                     = ignore   # ignore/add/remove/force
 
 # Add or remove newline between C++11 lambda signature and '{'
-nl_cpp_ldef_brace                         = ignore   # ignore/add/remove/force
+nl_cpp_ldef_brace                                 = ignore   # ignore/add/remove/force
 
 # Add or remove a newline between the return keyword and return expression.
-nl_return_expr                            = ignore   # ignore/add/remove/force
+nl_return_expr                                    = ignore   # ignore/add/remove/force
 
 # Whether to put a newline after semicolons, except in 'for' statements
-nl_after_semicolon                        = false    # false/true
+nl_after_semicolon                                = false    # false/true
 
 # Java: Control the newline between the ')' and '{{' of the double brace initializer.
-nl_paren_dbrace_open                      = ignore   # ignore/add/remove/force
+nl_paren_dbrace_open                              = ignore   # ignore/add/remove/force
 
 # Whether to put a newline after brace open.
 # This also adds a newline before the matching brace close.
-nl_after_brace_open                       = false    # false/true
+nl_after_brace_open                               = false    # false/true
 
 # If nl_after_brace_open and nl_after_brace_open_cmt are true, a newline is
 # placed between the open brace and a trailing single-line comment.
-nl_after_brace_open_cmt                   = false    # false/true
+nl_after_brace_open_cmt                           = false    # false/true
 
 # Whether to put a newline after a virtual brace open with a non-empty body.
 # These occur in un-braced if/while/do/for statement bodies.
-nl_after_vbrace_open                      = false    # false/true
+nl_after_vbrace_open                              = false    # false/true
 
 # Whether to put a newline after a virtual brace open with an empty body.
 # These occur in un-braced if/while/do/for statement bodies.
-nl_after_vbrace_open_empty                = false    # false/true
+nl_after_vbrace_open_empty                        = false    # false/true
 
 # Whether to put a newline after a brace close.
 # Does not apply if followed by a necessary ';'.
-nl_after_brace_close                      = false    # false/true
+nl_after_brace_close                              = false    # false/true
 
 # Whether to put a newline after a virtual brace close.
 # Would add a newline before return in: 'if (foo) a++; return;'
-nl_after_vbrace_close                     = false    # false/true
+nl_after_vbrace_close                             = false    # false/true
 
 # Control the newline between the close brace and 'b' in: 'struct { int a; } b;'
 # Affects enums, unions and structures. If set to ignore, uses nl_after_brace_close
-nl_brace_struct_var                       = ignore   # ignore/add/remove/force
+nl_brace_struct_var                               = ignore   # ignore/add/remove/force
 
 # Whether to alter newlines in '#define' macros
-nl_define_macro                           = false    # false/true
+nl_define_macro                                   = false    # false/true
 
-# Whether to not put blanks after '#ifxx', '#elxx', or before '#endif'. Does not affect the whole-file #ifdef.
-nl_squeeze_ifdef                          = false    # false/true
+# Whether to remove blanks after '#ifxx' and '#elxx', or before '#elxx' and '#endif'. Does not affect top-level #ifdefs.
+nl_squeeze_ifdef                                  = false    # false/true
+
+# Makes the nl_squeeze_ifdef option affect the top-level #ifdefs as well.
+nl_squeeze_ifdef_top_level                        = false    # false/true
 
 # Add or remove blank line before 'if'
-nl_before_if                              = ignore   # ignore/add/remove/force
+nl_before_if                                      = ignore   # ignore/add/remove/force
 
 # Add or remove blank line after 'if' statement
-nl_after_if                               = ignore   # ignore/add/remove/force
+nl_after_if                                       = ignore   # ignore/add/remove/force
 
 # Add or remove blank line before 'for'
-nl_before_for                             = ignore   # ignore/add/remove/force
+nl_before_for                                     = ignore   # ignore/add/remove/force
 
 # Add or remove blank line after 'for' statement
-nl_after_for                              = ignore   # ignore/add/remove/force
+nl_after_for                                      = ignore   # ignore/add/remove/force
 
 # Add or remove blank line before 'while'
-nl_before_while                           = ignore   # ignore/add/remove/force
+nl_before_while                                   = ignore   # ignore/add/remove/force
 
 # Add or remove blank line after 'while' statement
-nl_after_while                            = ignore   # ignore/add/remove/force
+nl_after_while                                    = ignore   # ignore/add/remove/force
 
 # Add or remove blank line before 'switch'
-nl_before_switch                          = ignore   # ignore/add/remove/force
+nl_before_switch                                  = ignore   # ignore/add/remove/force
 
 # Add or remove blank line after 'switch' statement
-nl_after_switch                           = ignore   # ignore/add/remove/force
+nl_after_switch                                   = ignore   # ignore/add/remove/force
 
 # Add or remove blank line before 'synchronized'
-nl_before_synchronized                    = ignore   # ignore/add/remove/force
+nl_before_synchronized                            = ignore   # ignore/add/remove/force
 
 # Add or remove blank line after 'synchronized' statement
-nl_after_synchronized                     = ignore   # ignore/add/remove/force
+nl_after_synchronized                             = ignore   # ignore/add/remove/force
 
 # Add or remove blank line before 'do'
-nl_before_do                              = ignore   # ignore/add/remove/force
+nl_before_do                                      = ignore   # ignore/add/remove/force
 
 # Add or remove blank line after 'do/while' statement
-nl_after_do                               = ignore   # ignore/add/remove/force
+nl_after_do                                       = ignore   # ignore/add/remove/force
 
 # Whether to double-space commented-entries in struct/union/enum
-nl_ds_struct_enum_cmt                     = false    # false/true
+nl_ds_struct_enum_cmt                             = false    # false/true
 
 # force nl before } of a struct/union/enum
 # (lower priority than 'eat_blanks_before_close_brace')
-nl_ds_struct_enum_close_brace             = false    # false/true
+nl_ds_struct_enum_close_brace                     = false    # false/true
 
 # Add or remove blank line before 'func_class_def'
-nl_before_func_class_def                  = 0        # number
+nl_before_func_class_def                          = 0        # number
 
 # Add or remove blank line before 'func_class_proto'
-nl_before_func_class_proto                = 0        # number
+nl_before_func_class_proto                        = 0        # number
 
 # Add or remove a newline before/after a class colon,
 #   (tied to pos_class_colon).
-nl_class_colon                            = ignore   # ignore/add/remove/force
+nl_class_colon                                    = ignore   # ignore/add/remove/force
 
 # Add or remove a newline around a class constructor colon.
 # Related to nl_constr_init_args, pos_constr_colon and pos_constr_comma.
-nl_constr_colon                           = ignore   # ignore/add/remove/force
+nl_constr_colon                                   = ignore   # ignore/add/remove/force
 
 # Change simple unbraced if statements into a one-liner
 # 'if(b)\n i++;' => 'if(b) i++;'
-nl_create_if_one_liner                    = false    # false/true
+nl_create_if_one_liner                            = false    # false/true
 
 # Change simple unbraced for statements into a one-liner
 # 'for (i=0;i<5;i++)\n foo(i);' => 'for (i=0;i<5;i++) foo(i);'
-nl_create_for_one_liner                   = false    # false/true
+nl_create_for_one_liner                           = false    # false/true
 
 # Change simple unbraced while statements into a one-liner
 # 'while (i<5)\n foo(i++);' => 'while (i<5) foo(i++);'
-nl_create_while_one_liner                 = false    # false/true
+nl_create_while_one_liner                         = false    # false/true
+
+#  Change a one-liner if statement into simple unbraced if
+# 'if(b) i++;' => 'if(b) i++;'
+nl_split_if_one_liner                             = false    # false/true
+
+# Change a one-liner for statement into simple unbraced for
+# 'for (i=0;<5;i++) foo(i);' => 'for (i=0;<5;i++) foo(i);'
+nl_split_for_one_liner                            = false    # false/true
+
+# Change simple unbraced while statements into a one-liner while
+# 'while (i<5)\n foo(i++);' => 'while (i<5) foo(i++);'
+nl_split_while_one_liner                          = false    # false/true
 
 #
 # Positioning options
 #
 
 # The position of arithmetic operators in wrapped expressions
-pos_arith                                 = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_arith                                         = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of assignment in wrapped expressions.
 # Do not affect '=' followed by '{'
-pos_assign                                = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_assign                                        = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of boolean operators in wrapped expressions
-pos_bool                                  = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_bool                                          = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of comparison operators in wrapped expressions
-pos_compare                               = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_compare                                       = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of conditional (b ? t : f) operators in wrapped expressions
-pos_conditional                           = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_conditional                                   = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of the comma in wrapped expressions
-pos_comma                                 = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_comma                                         = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of the comma in the base class list if there are more than one line,
 #   (tied to nl_class_init_args).
-pos_class_comma                           = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_class_comma                                   = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of the comma in the constructor initialization list.
 # Related to nl_constr_colon, nl_constr_init_args and pos_constr_colon.
-pos_constr_comma                          = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_constr_comma                                  = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of trailing/leading class colon, between class and base class list
 #   (tied to nl_class_colon).
-pos_class_colon                           = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_class_colon                                   = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of colons between constructor and member initialization,
 # (tied to UO_nl_constr_colon).
 # Related to nl_constr_colon, nl_constr_init_args and pos_constr_comma.
-pos_constr_colon                          = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_constr_colon                                  = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 #
 # Line Splitting options
 #
 
 # Try to limit code width to N number of columns
-code_width                                = 0        # number
+code_width                                        = 0        # number
 
 # Whether to fully split long 'for' statements at semi-colons
-ls_for_split_full                         = false    # false/true
+ls_for_split_full                                 = false    # false/true
 
 # Whether to fully split long function protos/calls at commas
-ls_func_split_full                        = false    # false/true
+ls_func_split_full                                = false    # false/true
 
 # Whether to split lines as close to code_width as possible and ignore some groupings
-ls_code_width                             = false    # false/true
+ls_code_width                                     = false    # false/true
 
 #
 # Blank line options
 #
 
 # The maximum consecutive newlines (3 = 2 blank lines)
-nl_max                                    = 0        # number
+nl_max                                            = 0        # number
 
 # The number of newlines after a function prototype, if followed by another function prototype
-nl_after_func_proto                       = 0        # number
+nl_after_func_proto                               = 0        # number
 
 # The number of newlines after a function prototype, if not followed by another function prototype
-nl_after_func_proto_group                 = 0        # number
+nl_after_func_proto_group                         = 0        # number
+
+# The number of newlines after a function class prototype, if followed by another function class prototype
+nl_after_func_class_proto                         = 0        # number
+
+# The number of newlines after a function class prototype, if not followed by another function class prototype
+nl_after_func_class_proto_group                   = 0        # number
 
 # The number of newlines before a multi-line function def body
-nl_before_func_body_def                   = 0        # number
+nl_before_func_body_def                           = 0        # number
 
 # The number of newlines before a multi-line function prototype body
-nl_before_func_body_proto                 = 0        # number
+nl_before_func_body_proto                         = 0        # number
 
 # The number of newlines after '}' of a multi-line function body
-nl_after_func_body                        = 0        # number
+nl_after_func_body                                = 0        # number
 
 # The number of newlines after '}' of a multi-line function body in a class declaration
-nl_after_func_body_class                  = 0        # number
+nl_after_func_body_class                          = 0        # number
 
 # The number of newlines after '}' of a single line function body
-nl_after_func_body_one_liner              = 0        # number
+nl_after_func_body_one_liner                      = 0        # number
 
 # The minimum number of newlines before a multi-line comment.
 # Doesn't apply if after a brace open or another multi-line comment.
-nl_before_block_comment                   = 0        # number
+nl_before_block_comment                           = 0        # number
 
 # The minimum number of newlines before a single-line C comment.
 # Doesn't apply if after a brace open or other single-line C comments.
-nl_before_c_comment                       = 0        # number
+nl_before_c_comment                               = 0        # number
 
 # The minimum number of newlines before a CPP comment.
 # Doesn't apply if after a brace open or other CPP comments.
-nl_before_cpp_comment                     = 0        # number
+nl_before_cpp_comment                             = 0        # number
 
 # Whether to force a newline after a multi-line comment.
-nl_after_multiline_comment                = false    # false/true
+nl_after_multiline_comment                        = false    # false/true
 
 # Whether to force a newline after a label's colon.
-nl_after_label_colon                      = false    # false/true
+nl_after_label_colon                              = false    # false/true
 
 # The number of newlines after '}' or ';' of a struct/enum/union definition
-nl_after_struct                           = 0        # number
+nl_after_struct                                   = 0        # number
 
 # The number of newlines after '}' or ';' of a class definition
-nl_after_class                            = 0        # number
+nl_after_class                                    = 0        # number
 
 # The number of newlines before a 'private:', 'public:', 'protected:', 'signals:', or 'slots:' label.
 # Will not change the newline count if after a brace open.
 # 0 = No change.
-nl_before_access_spec                     = 0        # number
+nl_before_access_spec                             = 0        # number
 
 # The number of newlines after a 'private:', 'public:', 'protected:', 'signals:' or 'slots:' label.
 # 0 = No change.
 # the option 'nl_after_access_spec' takes preference over 'nl_typedef_blk_start' and 'nl_var_def_blk_start'
-nl_after_access_spec                      = 0        # number
+nl_after_access_spec                              = 0        # number
 
 # The number of newlines between a function def and the function comment.
 # 0 = No change.
-nl_comment_func_def                       = 0        # number
+nl_comment_func_def                               = 0        # number
 
 # The number of newlines after a try-catch-finally block that isn't followed by a brace close.
 # 0 = No change.
-nl_after_try_catch_finally                = 0        # number
+nl_after_try_catch_finally                        = 0        # number
 
 # The number of newlines before and after a property, indexer or event decl.
 # 0 = No change.
-nl_around_cs_property                     = 0        # number
+nl_around_cs_property                             = 0        # number
 
 # The number of newlines between the get/set/add/remove handlers in C#.
 # 0 = No change.
-nl_between_get_set                        = 0        # number
+nl_between_get_set                                = 0        # number
 
 # Add or remove newline between C# property and the '{'
-nl_property_brace                         = ignore   # ignore/add/remove/force
+nl_property_brace                                 = ignore   # ignore/add/remove/force
 
 # Whether to remove blank lines after '{'
-eat_blanks_after_open_brace               = false    # false/true
+eat_blanks_after_open_brace                       = false    # false/true
 
 # Whether to remove blank lines before '}'
-eat_blanks_before_close_brace             = false    # false/true
+eat_blanks_before_close_brace                     = false    # false/true
 
 # How aggressively to remove extra newlines not in preproc.
 # 0: No change
 # 1: Remove most newlines not handled by other config
 # 2: Remove all newlines and reformat completely by config
-nl_remove_extra_newlines                  = 0        # number
+nl_remove_extra_newlines                          = 0        # number
 
 # Whether to put a blank line before 'return' statements, unless after an open brace.
-nl_before_return                          = false    # false/true
+nl_before_return                                  = false    # false/true
 
 # Whether to put a blank line after 'return' statements, unless followed by a close brace.
-nl_after_return                           = false    # false/true
+nl_after_return                                   = false    # false/true
 
 # Whether to put a newline after a Java annotation statement.
 # Only affects annotations that are after a newline.
-nl_after_annotation                       = ignore   # ignore/add/remove/force
+nl_after_annotation                               = ignore   # ignore/add/remove/force
 
 # Controls the newline between two annotations.
-nl_between_annotation                     = ignore   # ignore/add/remove/force
+nl_between_annotation                             = ignore   # ignore/add/remove/force
 
 #
 # Code modifying options (non-whitespace)
 #
 
 # Add or remove braces on single-line 'do' statement
-mod_full_brace_do                         = ignore   # ignore/add/remove/force
+mod_full_brace_do                                 = ignore   # ignore/add/remove/force
 
 # Add or remove braces on single-line 'for' statement
-mod_full_brace_for                        = ignore   # ignore/add/remove/force
+mod_full_brace_for                                = ignore   # ignore/add/remove/force
 
 # Add or remove braces on single-line function definitions. (Pawn)
-mod_full_brace_function                   = ignore   # ignore/add/remove/force
+mod_full_brace_function                           = ignore   # ignore/add/remove/force
 
 # Add or remove braces on single-line 'if' statement. Will not remove the braces if they contain an 'else'.
-mod_full_brace_if                         = ignore   # ignore/add/remove/force
+mod_full_brace_if                                 = ignore   # ignore/add/remove/force
 
 # Make all if/elseif/else statements in a chain be braced or not. Overrides mod_full_brace_if.
 # If any must be braced, they are all braced.  If all can be unbraced, then the braces are removed.
-mod_full_brace_if_chain                   = false    # false/true
+mod_full_brace_if_chain                           = false    # false/true
+
+# Make all if/elseif/else statements with at least one 'else' or 'else if' fully braced.
+# If mod_full_brace_if_chain is used together with this option, all if-else chains will get braces,
+# and simple 'if' statements will lose them (if possible).
+mod_full_brace_if_chain_only                      = false    # false/true
 
 # Don't remove braces around statements that span N newlines
-mod_full_brace_nl                         = 0        # number
+mod_full_brace_nl                                 = 0        # number
 
 # Add or remove braces on single-line 'while' statement
-mod_full_brace_while                      = ignore   # ignore/add/remove/force
+mod_full_brace_while                              = ignore   # ignore/add/remove/force
 
 # Add or remove braces on single-line 'using ()' statement
-mod_full_brace_using                      = ignore   # ignore/add/remove/force
+mod_full_brace_using                              = ignore   # ignore/add/remove/force
 
 # Add or remove unnecessary paren on 'return' statement
-mod_paren_on_return                       = ignore   # ignore/add/remove/force
+mod_paren_on_return                               = ignore   # ignore/add/remove/force
 
 # Whether to change optional semicolons to real semicolons
-mod_pawn_semicolon                        = false    # false/true
+mod_pawn_semicolon                                = false    # false/true
 
 # Add parens on 'while' and 'if' statement around bools
-mod_full_paren_if_bool                    = false    # false/true
+mod_full_paren_if_bool                            = false    # false/true
 
 # Whether to remove superfluous semicolons
-mod_remove_extra_semicolon                = false    # false/true
+mod_remove_extra_semicolon                        = false    # false/true
 
 # If a function body exceeds the specified number of newlines and doesn't have a comment after
 # the close brace, a comment will be added.
-mod_add_long_function_closebrace_comment  = 0        # number
+mod_add_long_function_closebrace_comment          = 0        # number
 
 # If a namespace body exceeds the specified number of newlines and doesn't have a comment after
 # the close brace, a comment will be added.
-mod_add_long_namespace_closebrace_comment = 0        # number
+mod_add_long_namespace_closebrace_comment         = 0        # number
 
 # If a switch body exceeds the specified number of newlines and doesn't have a comment after
 # the close brace, a comment will be added.
-mod_add_long_switch_closebrace_comment    = 0        # number
+mod_add_long_switch_closebrace_comment            = 0        # number
 
 # If an #ifdef body exceeds the specified number of newlines and doesn't have a comment after
 # the #endif, a comment will be added.
-mod_add_long_ifdef_endif_comment          = 0        # number
+mod_add_long_ifdef_endif_comment                  = 0        # number
 
 # If an #ifdef or #else body exceeds the specified number of newlines and doesn't have a comment after
 # the #else, a comment will be added.
-mod_add_long_ifdef_else_comment           = 0        # number
+mod_add_long_ifdef_else_comment                   = 0        # number
 
 # If TRUE, will sort consecutive single-line 'import' statements [Java, D]
-mod_sort_import                           = false    # false/true
+mod_sort_import                                   = false    # false/true
 
 # If TRUE, will sort consecutive single-line 'using' statements [C#]
-mod_sort_using                            = false    # false/true
+mod_sort_using                                    = false    # false/true
 
 # If TRUE, will sort consecutive single-line '#include' statements [C/C++] and '#import' statements [Obj-C]
 # This is generally a bad idea, as it may break your code.
-mod_sort_include                          = false    # false/true
+mod_sort_include                                  = false    # false/true
 
 # If TRUE, it will move a 'break' that appears after a fully braced 'case' before the close brace.
-mod_move_case_break                       = false    # false/true
+mod_move_case_break                               = false    # false/true
 
 # Will add or remove the braces around a fully braced case statement.
 # Will only remove the braces if there are no variable declarations in the block.
-mod_case_brace                            = ignore   # ignore/add/remove/force
+mod_case_brace                                    = ignore   # ignore/add/remove/force
 
 # If TRUE, it will remove a void 'return;' that appears as the last statement in a function.
-mod_remove_empty_return                   = false    # false/true
+mod_remove_empty_return                           = false    # false/true
 
 #
 # Comment modifications
 #
 
 # Try to wrap comments at cmt_width columns
-cmt_width                                 = 0        # number
+cmt_width                                         = 0        # number
 
 # Set the comment reflow mode (default: 0)
 # 0: no reflowing (apart from the line wrapping due to cmt_width)
 # 1: no touching at all
 # 2: full reflow
-cmt_reflow_mode                           = 0        # number
+cmt_reflow_mode                                   = 0        # number
 
 # Whether to convert all tabs to spaces in comments. Default is to leave tabs inside comments alone, unless used for indenting.
-cmt_convert_tab_to_spaces                 = false    # false/true
+cmt_convert_tab_to_spaces                         = false    # false/true
 
 # If false, disable all multi-line comment changes, including cmt_width. keyword substitution and leading chars.
-# Default is true.
-cmt_indent_multi                          = true     # false/true
+# Default=True.
+cmt_indent_multi                                  = true     # false/true
 
 # Whether to group c-comments that look like they are in a block
-cmt_c_group                               = false    # false/true
+cmt_c_group                                       = false    # false/true
 
 # Whether to put an empty '/*' on the first line of the combined c-comment
-cmt_c_nl_start                            = false    # false/true
+cmt_c_nl_start                                    = false    # false/true
 
 # Whether to put a newline before the closing '*/' of the combined c-comment
-cmt_c_nl_end                              = false    # false/true
+cmt_c_nl_end                                      = false    # false/true
 
 # Whether to group cpp-comments that look like they are in a block
-cmt_cpp_group                             = false    # false/true
+cmt_cpp_group                                     = false    # false/true
 
 # Whether to put an empty '/*' on the first line of the combined cpp-comment
-cmt_cpp_nl_start                          = false    # false/true
+cmt_cpp_nl_start                                  = false    # false/true
 
 # Whether to put a newline before the closing '*/' of the combined cpp-comment
-cmt_cpp_nl_end                            = false    # false/true
+cmt_cpp_nl_end                                    = false    # false/true
 
 # Whether to change cpp-comments into c-comments
-cmt_cpp_to_c                              = false    # false/true
+cmt_cpp_to_c                                      = false    # false/true
 
 # Whether to put a star on subsequent comment lines
-cmt_star_cont                             = false    # false/true
+cmt_star_cont                                     = false    # false/true
 
 # The number of spaces to insert at the start of subsequent comment lines
-cmt_sp_before_star_cont                   = 0        # number
+cmt_sp_before_star_cont                           = 0        # number
 
 # The number of spaces to insert after the star on subsequent comment lines
-cmt_sp_after_star_cont                    = 0        # number
+cmt_sp_after_star_cont                            = 0        # number
 
 # For multi-line comments with a '*' lead, remove leading spaces if the first and last lines of
 # the comment are the same length. Default=True
-cmt_multi_check_last                      = true     # false/true
+cmt_multi_check_last                              = true     # false/true
 
 # The filename that contains text to insert at the head of a file if the file doesn't start with a C/C++ comment.
 # Will substitute $(filename) with the current file's name.
-cmt_insert_file_header                    = ""         # string
+cmt_insert_file_header                            = ""         # string
 
 # The filename that contains text to insert at the end of a file if the file doesn't end with a C/C++ comment.
 # Will substitute $(filename) with the current file's name.
-cmt_insert_file_footer                    = ""         # string
+cmt_insert_file_footer                            = ""         # string
 
 # The filename that contains text to insert before a function implementation if the function isn't preceded with a C/C++ comment.
 # Will substitute $(function) with the function name and $(javaparam) with the javadoc @param and @return stuff.
 # Will also substitute $(fclass) with the class name: void CFoo::Bar() { ... }
-cmt_insert_func_header                    = ""         # string
+cmt_insert_func_header                            = ""         # string
 
 # The filename that contains text to insert before a class if the class isn't preceded with a C/C++ comment.
 # Will substitute $(class) with the class name.
-cmt_insert_class_header                   = ""         # string
+cmt_insert_class_header                           = ""         # string
 
 # The filename that contains text to insert before a Obj-C message specification if the method isn't preceded with a C/C++ comment.
 # Will substitute $(message) with the function name and $(javaparam) with the javadoc @param and @return stuff.
-cmt_insert_oc_msg_header                  = ""         # string
+cmt_insert_oc_msg_header                          = ""         # string
 
 # If a preprocessor is encountered when stepping backwards from a function name, then
 # this option decides whether the comment should be inserted.
 # Affects cmt_insert_oc_msg_header, cmt_insert_func_header and cmt_insert_class_header.
-cmt_insert_before_preproc                 = false    # false/true
+cmt_insert_before_preproc                         = false    # false/true
+
+# If a function is declared inline to a class definition, then
+# this option decides whether the comment should be inserted.
+# Affects cmt_insert_func_header.
+cmt_insert_before_inlines                         = true     # false/true
+
+# If the function is a constructor/destructor, then
+# this option decides whether the comment should be inserted.
+# Affects cmt_insert_func_header.
+cmt_insert_before_ctor_dtor                       = false    # false/true
 
 #
 # Preprocessor options
 #
 
 # Control indent of preprocessors inside #if blocks at brace level 0 (file-level)
-pp_indent                                 = ignore   # ignore/add/remove/force
+pp_indent                                         = ignore   # ignore/add/remove/force
 
 # Whether to indent #if/#else/#endif at the brace level (true) or from column 1 (false)
-pp_indent_at_level                        = false    # false/true
+pp_indent_at_level                                = false    # false/true
 
 # Specifies the number of columns to indent preprocessors per level at brace level 0 (file-level).
 # If pp_indent_at_level=false, specifies the number of columns to indent preprocessors per level at brace level > 0 (function-level).
 # Default=1.
-pp_indent_count                           = 1        # number
+pp_indent_count                                   = 1        # number
 
 # Add or remove space after # based on pp_level of #if blocks
-pp_space                                  = ignore   # ignore/add/remove/force
+pp_space                                          = ignore   # ignore/add/remove/force
 
 # Sets the number of spaces added with pp_space
-pp_space_count                            = 0        # number
+pp_space_count                                    = 0        # number
 
 # The indent for #region and #endregion in C# and '#pragma region' in C/C++
-pp_indent_region                          = 0        # number
+pp_indent_region                                  = 0        # number
 
 # Whether to indent the code between #region and #endregion
-pp_region_indent_code                     = false    # false/true
+pp_region_indent_code                             = false    # false/true
 
 # If pp_indent_at_level=true, sets the indent for #if, #else and #endif when not at file-level.
 # 0:  indent preprocessors using output_tab_size.
 # >0: column at which all preprocessors will be indented.
-pp_indent_if                              = 0        # number
+pp_indent_if                                      = 0        # number
 
 # Control whether to indent the code between #if, #else and #endif.
-pp_if_indent_code                         = false    # false/true
+pp_if_indent_code                                 = false    # false/true
 
 # Whether to indent '#define' at the brace level (true) or from column 1 (false)
-pp_define_at_level                        = false    # false/true
+pp_define_at_level                                = false    # false/true
 
 #
 # Use or Do not Use options
 #
 
-# True:  indent_func_call_param will be used
+# True:  indent_func_call_param will be used (default)
 # False: indent_func_call_param will NOT be used
-use_indent_func_call_param                = true     # false/true
+use_indent_func_call_param                        = true     # false/true
 
+# The value of the indentation for a continuation line is calculate differently if the line is:
+#   a declaration :your case with QString fileName ...
+#   an assigment  :your case with pSettings = new QSettings( ...
+# At the second case the option value might be used twice:
+#   at the assigment
+#   at the function call (if present)
+# To prevent the double use of the option value, use this option with the value 'true'.
 # True:  indent_continue will be used only once
 # False: indent_continue will be used every time (default)
-use_indent_continue_only_once             = false    # false/true
+use_indent_continue_only_once                     = false    # false/true
+
+# SIGNAL/SLOT Qt macros have special formatting options. See options_for_QT.cpp for details.
+# Default=True.
+use_options_overriding_for_qt_macros              = true     # false/true
+
+#
+# Warn levels - 1: error, 2: warning (default), 3: note
+#
+
+# Warning is given if doing tab-to-\t replacement and we have found one in a C# verbatim string literal.
+warn_level_tabs_found_in_verbatim_string_literals = 2        # number
 
 # You can force a token to be a type with the 'type' option.
 # Example:

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -31,6 +31,7 @@
 
 
 static void newlines_double_space_struct_enum_union(chunk_t *open_brace);
+static void newlines_enum_entries(chunk_t *open_brace, argval_t av);
 static bool one_liner_nl_ok(chunk_t *pc);
 static void nl_handle_define(chunk_t *pc);
 
@@ -2440,6 +2441,12 @@ void newlines_cleanup_braces(bool first)
             }
          }
 
+         if ((pc->parent_type == CT_ENUM) &&
+             (cpd.settings[UO_nl_enum_own_lines].a != AV_IGNORE))
+         {
+            newlines_enum_entries(pc, cpd.settings[UO_nl_enum_own_lines].a);
+         }
+
          if (cpd.settings[UO_nl_ds_struct_enum_cmt].b &&
              ((pc->parent_type == CT_ENUM) ||
               (pc->parent_type == CT_STRUCT) ||
@@ -3849,6 +3856,30 @@ void newlines_cleanup_dup(void)
       }
       pc = next;
    }
+}
+
+
+/**
+ * If requested, make sure each entry in an enum is on its own line
+ */
+static void newlines_enum_entries(chunk_t *open_brace, argval_t av)
+{
+   LOG_FUNC_ENTRY();
+   chunk_t *pc = open_brace;
+
+   while (((pc = chunk_get_next_nc(pc)) != NULL) &&
+          (pc->level > open_brace->level))
+   {
+      if ((pc->level != (open_brace->level + 1)) ||
+          (pc->type != CT_COMMA))
+      {
+         continue;
+      }
+
+      newline_iarf(pc, av);
+   }
+
+   newline_iarf(open_brace, av);
 }
 
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -901,6 +901,8 @@ void register_options(void)
    unc_add_option("nl_constr_init_args", UO_nl_constr_init_args, AT_IARF,
                   "Add or remove newline after each ',' in the constructor member initialization.\n"
                   "Related to nl_constr_colon, pos_constr_colon and pos_constr_comma.");
+   unc_add_option("nl_enum_own_lines", UO_nl_enum_own_lines, AT_IARF,
+                  "Add or remove newline before first element, after comma, and after last element in enum");
    unc_add_option("nl_func_type_name", UO_nl_func_type_name, AT_IARF,
                   "Add or remove newline between return type and function name in a function definition");
    unc_add_option("nl_func_type_name_class", UO_nl_func_type_name_class, AT_IARF,

--- a/src/options.h
+++ b/src/options.h
@@ -624,6 +624,7 @@ enum uncrustify_options
    UO_nl_constr_colon,                // newline before/after class constr colon (tied to UO_pos_constr_colon)
    UO_nl_class_init_args,             // newline before/after each comma in the base class list (tied to UO_pos_class_comma)
    UO_nl_constr_init_args,            // newline after comma in class init args
+   UO_nl_enum_own_lines,              // put each element of an enum def. on its own line
    UO_nl_collapse_empty_body,         // change '{ \n }' into '{}'
    UO_nl_class_leave_one_liners,      // leave one-line function bodies in 'class xx { here }'
    UO_nl_assign_leave_one_liners,     // leave one-line assign bodies in 'foo_t f = { a, b, c };'

--- a/tests/c.test
+++ b/tests/c.test
@@ -143,6 +143,11 @@
 
 00440   bug_489.cfg c/bug_489.c
 
+00451   nl_enum_own_lines-1.cfg c/enum_gallery.c
+00452   nl_enum_own_lines-2.cfg c/enum_gallery.c
+00453   nl_enum_own_lines-3.cfg c/enum_gallery.c
+00454   nl_enum_own_lines-4.cfg c/enum_gallery.c
+
 # boolean and comma positioning
 00501   bool-pos-eol.cfg        c/bool-pos.c
 00502   bool-pos-sol.cfg        c/bool-pos.c

--- a/tests/config/nl_enum_own_lines-1.cfg
+++ b/tests/config/nl_enum_own_lines-1.cfg
@@ -1,0 +1,2 @@
+nl_enum_own_lines = ignore
+code_width=80

--- a/tests/config/nl_enum_own_lines-2.cfg
+++ b/tests/config/nl_enum_own_lines-2.cfg
@@ -1,0 +1,2 @@
+nl_enum_own_lines = add
+code_width=80

--- a/tests/config/nl_enum_own_lines-3.cfg
+++ b/tests/config/nl_enum_own_lines-3.cfg
@@ -1,0 +1,2 @@
+nl_enum_own_lines = remove
+code_width=80

--- a/tests/config/nl_enum_own_lines-4.cfg
+++ b/tests/config/nl_enum_own_lines-4.cfg
@@ -1,0 +1,4 @@
+nl_enum_own_lines = force
+code_width=80
+
+nl_remove_extra_newlines = 2

--- a/tests/input/c/enum_gallery.c
+++ b/tests/input/c/enum_gallery.c
@@ -1,0 +1,28 @@
+enum one { liner };
+
+enum not {
+
+a, one
+
+liner };
+
+enum foo { bar, baz, quux };
+
+/*
+ * In some tests, the following line remains longer than 80
+ * characters. Perhaps a bug?
+*/
+enum longer_enum_that { will, not, all, fit, on, one, line, as, longg, as, the, cutoff, is, reasonable, because, this, is, a, very, very, wide, line };
+
+enum q { w,
+e,r,
+t,
+
+
+y
+
+
+}
+
+
+;

--- a/tests/output/c/00451-enum_gallery.c
+++ b/tests/output/c/00451-enum_gallery.c
@@ -1,0 +1,26 @@
+enum one { liner };
+
+enum not {
+
+	a, one
+
+	liner
+};
+
+enum foo { bar, baz, quux };
+
+/*
+ * In some tests, the following line remains longer than 80
+ * characters. Perhaps a bug?
+ */
+enum longer_enum_that { will, not, all, fit, on, one, line, as, longg, as, the, cutoff, is, reasonable, because, this, is, a, very, very, wide, line };
+
+enum q { w,
+	 e,r,
+	 t,
+
+
+	 y}
+
+
+;

--- a/tests/output/c/00452-enum_gallery.c
+++ b/tests/output/c/00452-enum_gallery.c
@@ -1,0 +1,60 @@
+enum one {
+	liner
+};
+
+enum not {
+
+	a, one
+
+	liner
+};
+
+enum foo {
+	bar,
+	baz,
+	quux
+};
+
+/*
+ * In some tests, the following line remains longer than 80
+ * characters. Perhaps a bug?
+ */
+enum longer_enum_that {
+	will,
+	not,
+	all,
+	fit,
+	on,
+	one,
+	line,
+	as,
+	longg,
+	as,
+	the,
+	cutoff,
+	is,
+	reasonable,
+	because,
+	this,
+	is,
+	a,
+	very,
+	very,
+	wide,
+	line
+};
+
+enum q {
+	w,
+	e,
+	r,
+	t,
+
+
+	y
+
+
+}
+
+
+;

--- a/tests/output/c/00453-enum_gallery.c
+++ b/tests/output/c/00453-enum_gallery.c
@@ -1,0 +1,21 @@
+enum one { liner };
+
+enum not {
+
+	a, one
+
+	liner
+};
+
+enum foo { bar, baz, quux };
+
+/*
+ * In some tests, the following line remains longer than 80
+ * characters. Perhaps a bug?
+ */
+enum longer_enum_that { will, not, all, fit, on, one, line, as, longg, as, the, cutoff, is, reasonable, because, this, is, a, very, very, wide, line };
+
+enum q { w,e,r,t,y}
+
+
+;

--- a/tests/output/c/00454-enum_gallery.c
+++ b/tests/output/c/00454-enum_gallery.c
@@ -1,0 +1,41 @@
+enum one {
+	liner
+}; enum not {a, one liner }; enum foo {
+	bar,
+	baz,
+	quux
+};
+/*
+ * In some tests, the following line remains longer than 80
+ * characters. Perhaps a bug?
+ */
+enum longer_enum_that {
+	will,
+	not,
+	all,
+	fit,
+	on,
+	one,
+	line,
+	as,
+	longg,
+	as,
+	the,
+	cutoff,
+	is,
+	reasonable,
+	because,
+	this,
+	is,
+	a,
+	very,
+	very,
+	wide,
+	line
+}; enum q {
+	w,
+	e,
+	r,
+	t,
+	y
+};


### PR DESCRIPTION
Implement nl_enum_own_lines, an option which forces elements of C enums to appear on their own lines.  The nl_enum_leave_one_liners option overrides this option.  Add tests as well.