### PR TITLE
Failing test cases for calling convention not fixed in bug #633

### DIFF
--- a/tests/config/bug_633.cfg
+++ b/tests/config/bug_633.cfg
@@ -1,1 +1,10 @@
 sp_arith=add
+indent_class=true
+
+# uncomment to work around bug 633
+#set COMMENT __stdcall
+#set COMMENT __clrcall
+#set COMMENT __fastcall
+#set COMMENT __thiscall
+#set COMMENT __vectorcall
+#set COMMENT __cdecl

--- a/tests/config/stdcall.cfg
+++ b/tests/config/stdcall.cfg
@@ -1,1 +1,0 @@
-sp_arith=add

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -259,7 +259,6 @@
 33014 kdepim.cfg                       cpp/DB.cpp
 33015 kdepim.cfg                       cpp/Q_FOREACH.cpp
 33016 indent_once.cfg                  cpp/indent.cpp
-33017 stdcall.cfg                      cpp/stdcall.cpp
 33018 byref-2.cfg                      cpp/byref-2.cpp
 33019 bug_657.cfg                      cpp/bug_657.cpp
 33020 bug_662.cfg                      cpp/bug_662.cpp

--- a/tests/input/cpp/bug_633.cpp
+++ b/tests/input/cpp/bug_633.cpp
@@ -1,2 +1,29 @@
 typedef void (*func)();
 typedef void (__stdcall *func)();
+
+class CDataObject : public IDataObject
+{
+public:
+    // IUnknown members
+    HRESULT __stdcall QueryInterface(REFIID iid, void ** ppvObject);
+    ULONG __stdcall AddRef(void);
+    ULONG __stdcall Release(void);
+
+    // IDataObject members
+    HRESULT __stdcall GetData(FORMATETC *pFormatEtc, STGMEDIUM *pmedium);
+    HRESULT __stdcall GetDataHere(FORMATETC *pFormatEtc, STGMEDIUM *pmedium);
+    HRESULT __stdcall QueryGetData(FORMATETC *pFormatEtc);
+    HRESULT __stdcall GetCanonicalFormatEtc(FORMATETC *pFormatEct,  FORMATETC *pFormatEtcOut);
+    HRESULT __stdcall SetData(FORMATETC *pFormatEtc, STGMEDIUM *pMedium, BOOL fRelease);
+    HRESULT __stdcall EnumFormatEtc(DWORD dwDirection, IEnumFORMATETC **ppEnumFormatEtc);
+    HRESULT __stdcall DAdvise(FORMATETC *pFormatEtc, DWORD advf, IAdviseSink *, DWORD *);
+    HRESULT __stdcall DUnadvise(DWORD dwConnection);
+    HRESULT __stdcall EnumDAdvise(IEnumSTATDATA **ppEnumAdvise);
+
+    // exercise others
+    HRESULT __cdecl GetData(FORMATETC *pFormatEtc, STGMEDIUM *pmedium);
+    HRESULT __clrcall GetData(FORMATETC *pFormatEtc, STGMEDIUM *pmedium);
+    HRESULT __fastcall GetData(FORMATETC *pFormatEtc, STGMEDIUM *pmedium);
+    HRESULT __thiscall GetData(FORMATETC *pFormatEtc, STGMEDIUM *pmedium);
+    HRESULT __vectorcall GetData(FORMATETC *pFormatEtc, STGMEDIUM *pmedium);
+}

--- a/tests/input/cpp/stdcall.cpp
+++ b/tests/input/cpp/stdcall.cpp
@@ -1,3 +1,0 @@
-// test for bug # 633
-typedef void (*func)();
-typedef void (__stdcall *func)();

--- a/tests/output/cpp/33017-stdcall.cpp
+++ b/tests/output/cpp/33017-stdcall.cpp
@@ -1,3 +1,0 @@
-// test for bug # 633
-typedef void (*func)();
-typedef void (__stdcall *func)();

--- a/tests/output/cpp/33021-bug_633.cpp
+++ b/tests/output/cpp/33021-bug_633.cpp
@@ -1,2 +1,29 @@
 typedef void (*func)();
 typedef void (__stdcall *func)();
+
+class CDataObject : public IDataObject
+{
+public:
+	// IUnknown members
+	HRESULT __stdcall QueryInterface(REFIID iid, void ** ppvObject);
+	ULONG __stdcall AddRef(void);
+	ULONG __stdcall Release(void);
+
+	// IDataObject members
+	HRESULT __stdcall GetData(FORMATETC *pFormatEtc, STGMEDIUM *pmedium);
+	HRESULT __stdcall GetDataHere(FORMATETC *pFormatEtc, STGMEDIUM *pmedium);
+	HRESULT __stdcall QueryGetData(FORMATETC *pFormatEtc);
+	HRESULT __stdcall GetCanonicalFormatEtc(FORMATETC *pFormatEct,  FORMATETC *pFormatEtcOut);
+	HRESULT __stdcall SetData(FORMATETC *pFormatEtc, STGMEDIUM *pMedium, BOOL fRelease);
+	HRESULT __stdcall EnumFormatEtc(DWORD dwDirection, IEnumFORMATETC **ppEnumFormatEtc);
+	HRESULT __stdcall DAdvise(FORMATETC *pFormatEtc, DWORD advf, IAdviseSink *, DWORD *);
+	HRESULT __stdcall DUnadvise(DWORD dwConnection);
+	HRESULT __stdcall EnumDAdvise(IEnumSTATDATA **ppEnumAdvise);
+
+	// exercise others
+	HRESULT __cdecl GetData(FORMATETC *pFormatEtc, STGMEDIUM *pmedium);
+	HRESULT __clrcall GetData(FORMATETC *pFormatEtc, STGMEDIUM *pmedium);
+	HRESULT __fastcall GetData(FORMATETC *pFormatEtc, STGMEDIUM *pmedium);
+	HRESULT __thiscall GetData(FORMATETC *pFormatEtc, STGMEDIUM *pmedium);
+	HRESULT __vectorcall GetData(FORMATETC *pFormatEtc, STGMEDIUM *pmedium);
+}


### PR DESCRIPTION
In January, fixes were made for this bug: https://sourceforge.net/p/uncrustify/bugs/633/

Previously, we had been using a workaround of marking "set COMMENT __stdcall" in our cfg files, so I tried removing them to validate the fix for 633. Definitely not fixed. You can see what's going on with the -p option to show the tokens. The presence of __stdcall will switch TYPE to WORD, FUNC_PROTO to FUNC_CALL, and PTR_TYPE to ARITH in many cases. We'll be continuing with our old workaround.

This PR adds more tests that demonstrate the problem more completely. Also removes a redundant test. 

Note that merging this PR will break tests, so it's meant only as a demonstration. (Though the test files updated here should be included in a real fix.)
