### PR TITLE
Produce error on in-source CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,14 @@ cmake_minimum_required(VERSION 2.8)
 
 project(uncrustify)
 
+if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
+  message(FATAL_ERROR "
+    In-source builds are not supported, please remove the `CMakeFiles'
+    folder and `CMakeCache.txt', and create a folder for the build:
+    mkdir build; cd build; cmake ..
+  ")
+endif()
+
 include(CheckCXXCompilerFlag)
 include(CheckIncludeFileCXX)
 include(CheckSymbolExists)


### PR DESCRIPTION
This adds an error message if the user attempts to run cmake from the source folder.

CMake still generates the `CMakeFiles` folder and `CMakeCache.txt`, so the user has to remove those, or the following out-of-source build will fail.
