### PR TITLE
refs #410 add option to indent lambda

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1017,7 +1017,18 @@ void indent_text(void)
          frm.level++;
          indent_pse_push(frm, pc);
 
-         if (cpd.settings[UO_indent_cs_delegate_brace].b &&
+         if (cpd.settings[UO_indent_cpp_lambda_body].b &&
+             pc->parent_type == CT_CPP_LAMBDA)
+         {
+            frm.pse[frm.pse_tos].brace_indent = frm.pse[frm.pse_tos-1].indent;
+            indent_column                     = frm.pse[frm.pse_tos].brace_indent;
+            frm.pse[frm.pse_tos].indent       = indent_column + indent_size;
+            frm.pse[frm.pse_tos].indent_tab   = frm.pse[frm.pse_tos].indent;
+            frm.pse[frm.pse_tos].indent_tmp   = frm.pse[frm.pse_tos].indent;
+
+            frm.pse[frm.pse_tos - 1].indent_tmp = frm.pse[frm.pse_tos].indent_tmp;
+         }
+         else if (cpd.settings[UO_indent_cs_delegate_brace].b &&
              (pc->type == CT_BRACE_OPEN) &&
              (pc->prev->type == CT_LAMBDA || pc->prev->prev->type == CT_LAMBDA))
          {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -754,6 +754,9 @@ void register_options(void)
    unc_add_option("indent_token_after_brace", UO_indent_token_after_brace, AT_BOOL,
                   "If true, a brace followed by another token (not a newline) will indent all contained lines to match the token."
                   "Default=True.");
+   unc_add_option("indent_cpp_lambda_body", UO_indent_cpp_lambda_body, AT_BOOL,
+                  "If true, cpp lambda body will be indented"
+                  "Default=False.");
 
    unc_begin_group(UG_newline, "Newline adding and removing options");
    unc_add_option("nl_collapse_empty_body", UO_nl_collapse_empty_body, AT_BOOL,
@@ -2200,6 +2203,7 @@ void set_option_defaults(void)
    cpd.defaults[UO_use_indent_func_call_param].b           = true;
    cpd.defaults[UO_use_options_overriding_for_qt_macros].b = true;
    cpd.defaults[UO_indent_token_after_brace].b             = true;
+   cpd.defaults[UO_indent_cpp_lambda_body].b               = false;
    cpd.defaults[UO_warn_level_tabs_found_in_verbatim_string_literals].n = LWARN;
 
    /* copy all the default values to settings array */

--- a/src/options.h
+++ b/src/options.h
@@ -206,6 +206,8 @@ enum uncrustify_options
    UO_indent_vbrace_open_on_tabstop, // when identing after virtual brace open and newline add further spaces to reach next tabstop
    UO_indent_token_after_brace,
 
+   UO_indent_cpp_lambda_body,        // indent cpp lambda or not
+
    /*
     * Misc inter-element spacing
     */


### PR DESCRIPTION
append new option parameter 'UO_indent_cpp_lambda_body' to detect lambda parent and set brace indent same as previous level