### PR TITLE
Split CTest tests by language

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,11 +223,15 @@ add_executable(uncrustify
 if(BUILD_TESTING)
   find_package(PythonInterp REQUIRED)
   enable_testing()
-  add_test(NAME test_uncrustify
-    COMMAND ${PYTHON_EXECUTABLE}
-      "${PROJECT_SOURCE_DIR}/tests/run_tests.py" "--exe=$<TARGET_FILE:uncrustify>"
-    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/tests/"
-  )
+  foreach(test_lang c-sharp c cpp d java pawn objective-c vala ecma)
+    string(REGEX REPLACE "[^a-zA-Z0-9]" "_" test_name "uncrustify_test_${test_lang}")
+    add_test(NAME ${test_name}
+      COMMAND ${PYTHON_EXECUTABLE}
+        "${PROJECT_SOURCE_DIR}/tests/run_tests.py" ${test_lang} "--exe=$<TARGET_FILE:uncrustify>"
+      WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/tests"
+    )
+    unset(test_name)
+  endforeach()
 endif()
 
 #


### PR DESCRIPTION
Allows [running tests individually](https://cmake.org/Wiki/CMake/Testing_With_CTest#Running_Individual_Tests) by language through CTest.

One potential drawback is that the list of test languages has to be kept in sync between `CMakeLists.txt` and `run_tests.py`.