### PR TITLE
Add man page to CMake script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,11 @@ add_executable(uncrustify
 )
 
 #
+# Generate uncrustify.1
+#
+configure_file(man/uncrustify.1.in uncrustify.1 @ONLY)
+
+#
 # Tests
 #
 if(BUILD_TESTING)
@@ -233,6 +238,10 @@ endif()
 #
 # Install
 #
+include(GNUInstallDirs)
 install(TARGETS uncrustify
-  RUNTIME DESTINATION bin
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/uncrustify.1"
+  DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
 )


### PR DESCRIPTION
Generating the man page appears to be just a question of expanding the `PACKAGE_VERSION` variable.

This should add such generation and install for the man page to the CMake script.