### PR TITLE
Class literal bitfield

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2631,7 +2631,7 @@ void combine_labels(void)
                else if ((tmp == NULL) ||
                         ((tmp->type != CT_NUMBER) &&
                          (tmp->type != CT_SIZEOF) &&
-                         !(tmp->flags & PCF_IN_STRUCT)) ||
+                         !(tmp->flags & (PCF_IN_STRUCT | PCF_IN_CLASS))) ||
                         (tmp->type == CT_NEWLINE)
                   )
                {

--- a/tests/config/bug_i_568.cfg
+++ b/tests/config/bug_i_568.cfg
@@ -1,0 +1,1 @@
+indent_class=true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -320,7 +320,7 @@
 33083 bug_i_359.cfg                    cpp/bug_i_359.cpp
 33084 op_sym_empty.cfg                 cpp/op_sym_empty.cpp
 33085 bug_i_323.cfg                    cpp/bug_i_323.cpp
-33086 empty.cfg                        cpp/bug_i_568.cpp
+33086 bug_i_568.cfg                    cpp/bug_i_568.cpp
 33087 bug_i_596.cfg                    cpp/bug_i_596.cpp
 33088 empty.cfg                        cpp/bug_i_197.cpp
 

--- a/tests/input/cpp/bug_i_568.cpp
+++ b/tests/input/cpp/bug_i_568.cpp
@@ -7,4 +7,18 @@ struct foo
 {
   int bar : kEnumValue;
   int pad : 3;
-}
+};
+
+class cls
+{
+  int bar : kEnumValue;
+  int pad : 3;
+
+  void func()
+  {
+    goto end;
+    bar = 1;
+    end:
+    pad = 2;
+  }
+};

--- a/tests/output/cpp/33086-bug_i_568.cpp
+++ b/tests/output/cpp/33086-bug_i_568.cpp
@@ -7,4 +7,18 @@ struct foo
 {
 	int bar : kEnumValue;
 	int pad : 3;
-}
+};
+
+class cls
+{
+	int bar : kEnumValue;
+	int pad : 3;
+
+	void func()
+	{
+		goto end;
+		bar = 1;
+end:
+		pad = 2;
+	}
+};


### PR DESCRIPTION
Following commit 7504d84 which was about fixing issue #568 there was one more case which was omitted in which a literal bit-field was wrongly tagged as a label. Classes as well as structs can have bitfields and this was not handled in previous code.