### PR TITLE
MinGW cross-compile support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,12 +250,47 @@ if(BUILD_TESTING)
 endif()
 
 #
+# Package
+#
+set(CPACK_PACKAGE_NAME "uncrustify")
+set(CPACK_PACKAGE_VERSION "${PACKAGE_VERSION}")
+set(CPACK_PACKAGE_VENDOR "Ben Gardner")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Code beautifier")
+set(CPACK_PACKAGE_DESCRIPTION_FILE "${PROJECT_SOURCE_DIR}/README.md")
+set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/COPYING")
+set(CPACK_RESOURCE_FILE_README "${PROJECT_SOURCE_DIR}/README.md")
+set(CPACK_SOURCE_IGNORE_FILES "/\\\\.git/;/\\\\.hg/;/tests/results/;/build.*/")
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY FALSE)
+  set(CPACK_GENERATOR "ZIP")
+endif()
+include(CPack)
+
+#
 # Install
 #
-include(GNUInstallDirs)
-install(TARGETS uncrustify
-  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/uncrustify.1"
-  DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
-)
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  install(TARGETS uncrustify DESTINATION ".")
+  install(
+    FILES
+      "${PROJECT_SOURCE_DIR}/README.md"
+      "${PROJECT_SOURCE_DIR}/BUGS"
+      "${PROJECT_SOURCE_DIR}/ChangeLog"
+    DESTINATION "."
+  )
+  install(FILES "${PROJECT_SOURCE_DIR}/documentation/htdocs/index.html"
+    DESTINATION "doc"
+  )
+  install(DIRECTORY "${PROJECT_SOURCE_DIR}/etc/"
+    DESTINATION "cfg"
+    FILES_MATCHING PATTERN "*.cfg"
+  )
+else()
+  include(GNUInstallDirs)
+  install(TARGETS uncrustify
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  )
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/uncrustify.1"
+    DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
+  )
+endif()

--- a/cmake/Toolchain-mingw32.cmake
+++ b/cmake/Toolchain-mingw32.cmake
@@ -1,0 +1,28 @@
+#
+# Toolchain file for cross-compiling from Linux to Win32 using MinGW
+#
+
+set(CMAKE_SYSTEM_NAME Windows)
+
+if(NOT COMPILER_PREFIX)
+  if(EXISTS /usr/i586-mingw32msvc)
+    # mingw
+    set(COMPILER_PREFIX "i586-mingw32msvc")
+  elseif(EXISTS /usr/i686-w64-mingw32)
+    # mingw-w64
+    set(COMPILER_PREFIX "i686-w64-mingw32")
+  else()
+    message(FATAL_ERROR "Unable to detect cross-compiler prefix (COMPILER_PREFIX)")
+  endif()
+endif()
+
+find_program(CMAKE_C_COMPILER NAMES ${COMPILER_PREFIX}-gcc)
+find_program(CMAKE_CXX_COMPILER NAMES ${COMPILER_PREFIX}-g++)
+find_program(CMAKE_RC_COMPILER NAMES ${COMPILER_PREFIX}-windres)
+
+set(CMAKE_FIND_ROOT_PATH /usr/${COMPILER_PREFIX})
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/cmake/Toolchain-mingw64.cmake
+++ b/cmake/Toolchain-mingw64.cmake
@@ -1,0 +1,28 @@
+#
+# Toolchain file for cross-compiling from Linux to Win64 using MinGW
+#
+
+set(CMAKE_SYSTEM_NAME Windows)
+
+if(NOT COMPILER_PREFIX)
+  if(EXISTS /usr/amd64-mingw32msvc-gcc)
+    # mingw
+    set(COMPILER_PREFIX "amd64-mingw32msvc-gcc")
+  elseif(EXISTS /usr/x86_64-w64-mingw32)
+    # mingw-w64
+    set(COMPILER_PREFIX "x86_64-w64-mingw32")
+  else()
+    message(FATAL_ERROR "Unable to detect cross-compiler prefix (COMPILER_PREFIX)")
+  endif()
+endif()
+
+find_program(CMAKE_C_COMPILER NAMES ${COMPILER_PREFIX}-gcc)
+find_program(CMAKE_CXX_COMPILER NAMES ${COMPILER_PREFIX}-g++)
+find_program(CMAKE_RC_COMPILER NAMES ${COMPILER_PREFIX}-windres)
+
+set(CMAKE_FIND_ROOT_PATH /usr/${COMPILER_PREFIX})
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)


### PR DESCRIPTION
This adds [toolchain files](http://www.vtk.org/Wiki/CMake_Cross_Compiling) for MinGW cross-compilers from the mingw and mingw-w64 packages. I have only tested it on [Fedora](https://fedoraproject.org/wiki/MinGW/Tutorial), but I believe it should work on Ubuntu as well.

Basically, you install the mingw cross-compiler packages (on Fedora these are `mingw32-gcc`, `mingw32-gcc-c++`, and `mingw32-winpthreads-static` for Win32), and then build with:

~~~.bash
mkdir buildwin
cd buildwin
cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-mingw32.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="-static -s" ..
make
~~~

I hadn't used CPack before, but after a little googling around I think I got it to build a zip package close to the one `make_win32.sh` produces. After the above, just do `cpack`, and you get a zip file.
