### PR TITLE
register each test separately

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,4 +63,6 @@ before_script:
     esac
 
 
-script: make VERBOSE=1 && make test
+script:
+  - make VERBOSE=1
+  - ctest -V

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,14 +238,32 @@ configure_file(man/uncrustify.1.in uncrustify.1 @ONLY)
 if(BUILD_TESTING)
   find_package(PythonInterp REQUIRED)
   enable_testing()
+  # parse the .test files and create one test per line
   foreach(test_lang c-sharp c cpp d java pawn objective-c vala ecma)
-    string(REGEX REPLACE "[^a-zA-Z0-9]" "_" test_name "uncrustify_test_${test_lang}")
-    add_test(NAME ${test_name}
-      COMMAND ${PYTHON_EXECUTABLE}
-        "${PROJECT_SOURCE_DIR}/tests/run_tests.py" ${test_lang} "--exe=$<TARGET_FILE:uncrustify>"
-      WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/tests"
-    )
-    unset(test_name)
+    file(READ "tests/${test_lang}.test" content)
+    string(REPLACE "\n" ";" lines "${content}")
+    foreach(line ${lines})
+      string(STRIP "${line}" line)
+      string(SUBSTRING "${line}" 0 1 first)
+      # trailing space avoids double evaluation with older CMake versions
+      if(NOT "${first} " STREQUAL "# ")
+        separate_arguments(parts UNIX_COMMAND "${line}")
+        list(LENGTH parts length)
+        if(length EQUAL 3)
+          list(GET parts 0 test_number)
+          string(REGEX REPLACE "[^0-9]" "" test_number "${test_number}")
+          string(REGEX REPLACE "[^a-zA-Z0-9_]" "_" test_name "${test_lang}_${test_number}")
+          add_test(NAME ${test_name}
+            COMMAND ${PYTHON_EXECUTABLE}
+              "${PROJECT_SOURCE_DIR}/tests/run_tests.py" ${test_lang} "-r" "${test_number}" "--exe=$<TARGET_FILE:uncrustify>"
+            WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/tests"
+          )
+          set_tests_properties(${test_name}
+            PROPERTIES LABELS "${test_lang}"
+          )
+        endif()
+      endif()
+    endforeach()
   endforeach()
 endif()
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,5 @@ build_script:
   - set MSBuildOptions=/v:m /p:Configuration=%CONFIG% /logger:%MSBuildLogger%
   - msbuild %MSBuildOptions% uncrustify.sln
 test_script:
-  - cd c:\projects\uncrustify\tests
-  - python -u run_tests.py --exe C:\projects\uncrustify\build\%CONFIG%\uncrustify.exe
+  - ctest -C %CONFIG% -V
 deploy: off


### PR DESCRIPTION
By registering each test separately you can leverage the full power of `ctest`, e.g. filter by labels (each language), by regex, rerun the test which failed on the last run, etc.

Since the `run_tests.py` script already allows passing in an optional language and number range this PR only needed to touch the CMake code.

The downside regarding speed: Python is being invoke for every test (which requires several milliseconds of startup time of the interpreter per test).

The upside regarding speed: you can use `ctest -j N` to run the tests in parallel