### PR TITLE
Support optional parens for PROTO_WRAP

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -5702,7 +5702,7 @@ static void handle_wrap(chunk_t *pc)
 /**
  * A proto wrap chunk and what follows should be treated as a function proto.
  *
- * RETTYPE PROTO_WRAP( NAME, PARAMS );
+ * RETTYPE PROTO_WRAP( NAME, PARAMS ); or RETTYPE PROTO_WRAP( NAME, (PARAMS) );
  * RETTYPE gets changed with make_type().
  * PROTO_WRAP is marked as CT_FUNC_PROTO or CT_FUNC_DEF.
  * NAME is marked as CT_WORD.
@@ -5719,7 +5719,6 @@ static void handle_proto_wrap(chunk_t *pc)
 
    if (!opp || !name || !clp || !cma || !tmp ||
        ((name->type != CT_WORD) && (name->type != CT_TYPE)) ||
-       (tmp->type != CT_PAREN_OPEN) ||
        (opp->type != CT_PAREN_OPEN))
    {
       return;
@@ -5740,7 +5739,17 @@ static void handle_proto_wrap(chunk_t *pc)
    set_chunk_parent(clp, pc->type);
 
    set_chunk_parent(tmp, CT_PROTO_WRAP);
-   fix_fcn_def_params(tmp);
+
+   if (tmp->type == CT_PAREN_OPEN)
+   {
+	  fix_fcn_def_params(tmp);
+   }
+   else
+   {
+      fix_fcn_def_params(opp);
+      set_chunk_type(name, CT_WORD);
+   }
+
    tmp = chunk_skip_to_match(tmp);
    if (tmp)
    {

--- a/src/token_enum.h
+++ b/src/token_enum.h
@@ -212,7 +212,7 @@ typedef enum
    CT_FUNC_CLASS_PROTO, /* ctor or dtor for a class */
    CT_FUNC_CTOR_VAR,    /* variable or class initialization */
    CT_FUNC_WRAP,        /* macro that wraps the function name */
-   CT_PROTO_WRAP,       /* macro: "RETVAL PROTO_WRAP( fcn_name, (PARAMS))" */
+   CT_PROTO_WRAP,       /* macro: "RETVAL PROTO_WRAP( fcn_name, (PARAMS))". Parens for PARAMS are optional. */
    CT_MACRO_FUNC,       /* function-like macro */
    CT_MACRO,            /* a macro def */
    CT_QUALIFIER,        /* static, const, etc */

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -82,6 +82,8 @@ static void split_off_angle_close(chunk_t *pc)
 
 void tokenize_cleanup(void)
 {
+   LOG_FUNC_ENTRY();
+
    chunk_t *pc   = chunk_get_head();
    chunk_t *prev = NULL;
    chunk_t *next;

--- a/tests/config/proto-wrap.cfg
+++ b/tests/config/proto-wrap.cfg
@@ -1,0 +1,3 @@
+set PROTO_WRAP WRAP_FUNCTION
+
+sp_arith = add

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -243,8 +243,9 @@
 31720 ben.cfg                          cpp/bit-colon.cpp
 31730 ms-style-ref.cfg                 cpp/ms-style-ref.cpp
 
-32001 empty.cfg                        cpp/issue_547_for_each.cpp
 32000 sp_skip_vbrace_tokens.cfg        cpp/sp_skip_vbrace_tokens.cpp
+32001 empty.cfg                        cpp/issue_547_for_each.cpp
+32002 proto-wrap.cfg                   cpp/proto-wrap.cpp
 
 33000 tab-0-11.cfg                     cpp/tab-0.cpp
 33001 tab-1-11.cfg                     cpp/tab-1.cpp

--- a/tests/input/cpp/proto-wrap.cpp
+++ b/tests/input/cpp/proto-wrap.cpp
@@ -1,0 +1,4 @@
+WRAP_FUNCTION(Foo, Bar& (void));
+WRAP_FUNCTION(Foo, Bar* (void));
+WRAP_FUNCTION(Foo, (Bar& (void)));
+WRAP_FUNCTION(Foo, (Bar* (void)));

--- a/tests/output/cpp/32002-proto-wrap.cpp
+++ b/tests/output/cpp/32002-proto-wrap.cpp
@@ -1,0 +1,4 @@
+WRAP_FUNCTION(Foo, Bar& (void));
+WRAP_FUNCTION(Foo, Bar* (void));
+WRAP_FUNCTION(Foo, (Bar& (void)));
+WRAP_FUNCTION(Foo, (Bar* (void)));


### PR DESCRIPTION
Previously, for prototype macro wrap functions, parameters with `CT_AMP` and `CT_STAR` where tokenized as `CT_ARITH` when they were not in parenthesis. The change makes parens optional.