### PR TITLE
Fixes typename var def

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1379,6 +1379,7 @@ void fix_symbols(void)
           (pc->flags & PCF_STMT_START) &&
           ((pc->type == CT_QUALIFIER) ||
            (pc->type == CT_TYPE) ||
+           (pc->type == CT_TYPENAME) ||
            (pc->type == CT_WORD)) &&
           (pc->parent_type != CT_ENUM) &&
           ((pc->flags & PCF_IN_ENUM) == 0))
@@ -2884,6 +2885,7 @@ static chunk_t *fix_var_def(chunk_t *start)
           ((pc->type == CT_TYPE) ||
            (pc->type == CT_WORD) ||
            (pc->type == CT_QUALIFIER) ||
+           (pc->type == CT_TYPENAME) ||
            (pc->type == CT_DC_MEMBER) ||
            (pc->type == CT_MEMBER) ||
            chunk_is_ptr_operator(pc)))

--- a/tests/config/issue_633_typename.cfg
+++ b/tests/config/issue_633_typename.cfg
@@ -1,0 +1,1 @@
+align_var_def_span=1

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -246,6 +246,8 @@
 32001 empty.cfg                        cpp/issue_547_for_each.cpp
 32000 sp_skip_vbrace_tokens.cfg        cpp/sp_skip_vbrace_tokens.cpp
 
+32003 issue_633_typename.cfg           cpp/issue_633_typename.cpp
+
 33000 tab-0-11.cfg                     cpp/tab-0.cpp
 33001 tab-1-11.cfg                     cpp/tab-1.cpp
 33002 comment_tab_f.cfg                cpp/cmt_convert_tab_to_spaces.cpp

--- a/tests/input/cpp/issue_633_typename.cpp
+++ b/tests/input/cpp/issue_633_typename.cpp
@@ -1,5 +1,28 @@
-char                       m_char;
-typename TImage::PixelType m_Label;
-NonPODType                 m_var;
-int                        m_Axis;
-bool                       m_Heuristic;
+template < typename TImage >
+class MorphologicalContourInterpolator:
+  public ImageToImageFilter< TImage, TImage >
+{
+  template < typename T >
+  friend class MorphologicalContourInterpolatorParallelInvoker;
+  friend class ::MultiLabelMeshPipeline;
+
+public:
+  /** Standard class typedefs. */
+  typedef MorphologicalContourInterpolator Self;
+
+protected:
+  MorphologicalContourInterpolator();
+  ~MorphologicalContourInterpolator() {}
+  typename TImage::PixelType m_Label;
+  int                        m_Axis;
+  bool                       m_HeuristicAlignment;
+  
+  aLongTypeNameButNotSpecial m_Label;
+  int                        m_Axis;
+  bool                       m_HeuristicAlignment;
+ 
+private:
+  MorphologicalContourInterpolator( const Self& ) ITK_DELETE_FUNCTION;
+  void
+  operator=( const Self& ) ITK_DELETE_FUNCTION;
+};

--- a/tests/input/cpp/issue_633_typename.cpp
+++ b/tests/input/cpp/issue_633_typename.cpp
@@ -1,0 +1,5 @@
+char                       m_char;
+typename TImage::PixelType m_Label;
+NonPODType                 m_var;
+int                        m_Axis;
+bool                       m_Heuristic;

--- a/tests/input/cpp/issue_633_typename.cpp
+++ b/tests/input/cpp/issue_633_typename.cpp
@@ -16,11 +16,7 @@ protected:
   typename TImage::PixelType m_Label;
   int                        m_Axis;
   bool                       m_HeuristicAlignment;
-  
-  aLongTypeNameButNotSpecial m_Label;
-  int                        m_Axis;
-  bool                       m_HeuristicAlignment;
- 
+
 private:
   MorphologicalContourInterpolator( const Self& ) ITK_DELETE_FUNCTION;
   void

--- a/tests/output/cpp/32003-issue_633_typename.cpp
+++ b/tests/output/cpp/32003-issue_633_typename.cpp
@@ -18,10 +18,6 @@ typename TImage::PixelType m_Label;
 int                        m_Axis;
 bool                       m_HeuristicAlignment;
 
-aLongTypeNameButNotSpecial m_Label;
-int                        m_Axis;
-bool                       m_HeuristicAlignment;
-
 private:
 MorphologicalContourInterpolator( const Self& ) ITK_DELETE_FUNCTION;
 void

--- a/tests/output/cpp/32003-issue_633_typename.cpp
+++ b/tests/output/cpp/32003-issue_633_typename.cpp
@@ -1,5 +1,29 @@
-char                       m_char;
+template < typename TImage >
+class MorphologicalContourInterpolator :
+	public ImageToImageFilter< TImage, TImage >
+{
+template < typename T >
+friend class MorphologicalContourInterpolatorParallelInvoker;
+friend class ::MultiLabelMeshPipeline;
+
+public:
+/** Standard class typedefs. */
+typedef MorphologicalContourInterpolator Self;
+
+protected:
+MorphologicalContourInterpolator();
+~MorphologicalContourInterpolator() {
+}
 typename TImage::PixelType m_Label;
-NonPODType                 m_var;
 int                        m_Axis;
-bool                       m_Heuristic;
+bool                       m_HeuristicAlignment;
+
+aLongTypeNameButNotSpecial m_Label;
+int                        m_Axis;
+bool                       m_HeuristicAlignment;
+
+private:
+MorphologicalContourInterpolator( const Self& ) ITK_DELETE_FUNCTION;
+void
+operator=( const Self& ) ITK_DELETE_FUNCTION;
+};

--- a/tests/output/cpp/32003-issue_633_typename.cpp
+++ b/tests/output/cpp/32003-issue_633_typename.cpp
@@ -1,0 +1,5 @@
+char                       m_char;
+typename TImage::PixelType m_Label;
+NonPODType                 m_var;
+int                        m_Axis;
+bool                       m_Heuristic;


### PR DESCRIPTION
A variable definition can start with the `typename` keyword so uncrustify should take this into account.

Fix for issue #633.