### PR TITLE
Separate handling of commas in enums

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3231,7 +3231,7 @@ void newlines_chunk_pos(c_token_t chunk_type, tokenpos_e mode)
    chunk_t *prev;
    int     nl_flag;
 
-   if ((mode & (TP_JOIN | TP_LEAD | TP_TRAIL)) == 0)
+   if ((mode & (TP_JOIN | TP_LEAD | TP_TRAIL)) == 0 && chunk_type != CT_COMMA)
    {
       return;
    }
@@ -3252,6 +3252,10 @@ void newlines_chunk_pos(c_token_t chunk_type, tokenpos_e mode)
             {
                // change mode
                mode_local = cpd.settings[UO_pos_class_comma].tp;
+            }
+            else if (pc->flags & PCF_IN_ENUM)
+            {
+               mode_local = cpd.settings[UO_pos_enum_comma].tp;
             }
             else
             {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1165,6 +1165,8 @@ void register_options(void)
                   "The position of conditional (b ? t : f) operators in wrapped expressions");
    unc_add_option("pos_comma", UO_pos_comma, AT_POS,
                   "The position of the comma in wrapped expressions");
+   unc_add_option("pos_enum_comma", UO_pos_enum_comma, AT_POS,
+                  "The position of the comma in enum entries");
    unc_add_option("pos_class_comma", UO_pos_class_comma, AT_POS,
                   "The position of the comma in the base class list if there are more than one line,\n"
                   "  (tied to nl_class_init_args).");

--- a/src/options.h
+++ b/src/options.h
@@ -665,6 +665,7 @@ enum uncrustify_options
    UO_pos_compare,                    // position of trailing/leading <=/>, etc
    UO_pos_conditional,                // position of trailing/leading (b ? t : f)
    UO_pos_comma,                      // position of comma in functions
+   UO_pos_enum_comma,                 // position of comma in enum entries
    UO_pos_class_comma,                // position of comma in the base class list if there are more than one line,
                                       //   (tied to UO_nl_class_init_args).
    UO_pos_constr_comma,               // position of comma in constructor init list

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1665,7 +1665,7 @@ static void uncrustify_file(const file_mem& fm, FILE *pfout,
             newlines_chunk_pos(CT_COND_COLON, cpd.settings[UO_pos_conditional].tp);
             newlines_chunk_pos(CT_QUESTION, cpd.settings[UO_pos_conditional].tp);
          }
-         if (cpd.settings[UO_pos_comma].tp != TP_IGNORE)
+         if (cpd.settings[UO_pos_comma].tp != TP_IGNORE || cpd.settings[UO_pos_enum_comma].tp != TP_IGNORE)
          {
             newlines_chunk_pos(CT_COMMA, cpd.settings[UO_pos_comma].tp);
          }

--- a/tests/config/enum_comma-1.cfg
+++ b/tests/config/enum_comma-1.cfg
@@ -1,0 +1,2 @@
+pos_comma = ignore   # ignore/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_enum_comma = trail_force   # ignore/lead/lead_break/lead_force/trail/trail_break/trail_force

--- a/tests/config/enum_comma-2.cfg
+++ b/tests/config/enum_comma-2.cfg
@@ -1,0 +1,2 @@
+pos_comma = lead_force   # ignore/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_enum_comma = ignore   # ignore/lead/lead_break/lead_force/trail/trail_break/trail_force

--- a/tests/config/enum_comma-3.cfg
+++ b/tests/config/enum_comma-3.cfg
@@ -1,0 +1,2 @@
+pos_comma = lead_break   # ignore/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_enum_comma = trail_break   # ignore/lead/lead_break/lead_force/trail/trail_break/trail_force

--- a/tests/config/enum_comma-4.cfg
+++ b/tests/config/enum_comma-4.cfg
@@ -1,0 +1,2 @@
+pos_comma = trail_force   # ignore/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_enum_comma = lead   # ignore/lead/lead_break/lead_force/trail/trail_break/trail_force

--- a/tests/config/enum_comma-5.cfg
+++ b/tests/config/enum_comma-5.cfg
@@ -1,0 +1,2 @@
+pos_comma = trail_break   # ignore/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_enum_comma = ignore   # ignore/lead/lead_break/lead_force/trail/trail_break/trail_force

--- a/tests/config/enum_comma-6.cfg
+++ b/tests/config/enum_comma-6.cfg
@@ -1,0 +1,3 @@
+pos_comma = trail_break   # ignore/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_enum_comma = lead_break   # ignore/lead/lead_break/lead_force/trail/trail_break/trail_force
+sp_after_comma = Force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -332,4 +332,11 @@
 33095 bug_i_322.cfg                    cpp/bug_i_322.cpp
 33096 squeeze_ifdef_top.cfg            cpp/squeeze_ifdef.cpp
 
+33097 enum_comma-1.cfg                 cpp/enum_comma.h
+33098 enum_comma-2.cfg                 cpp/enum_comma.h
+33099 enum_comma-3.cfg                 cpp/enum_comma.h
+33100 enum_comma-4.cfg                 cpp/enum_comma.h
+33101 enum_comma-5.cfg                 cpp/enum_comma.h
+33102 enum_comma-6.cfg                 cpp/enum_comma.h
+
 33200 first_len_minimum.cfg            cpp/first_len_minimum.cpp

--- a/tests/input/cpp/enum_comma.h
+++ b/tests/input/cpp/enum_comma.h
@@ -1,0 +1,8 @@
+
+void function(int a, int b, int c);
+
+enum Test {
+	A,   B
+	, C,
+	D, E
+}

--- a/tests/output/cpp/33097-enum_comma.h
+++ b/tests/output/cpp/33097-enum_comma.h
@@ -1,0 +1,10 @@
+
+void function(int a, int b, int c);
+
+enum Test {
+	A,
+	B,
+	C,
+	D,
+	E
+}

--- a/tests/output/cpp/33098-enum_comma.h
+++ b/tests/output/cpp/33098-enum_comma.h
@@ -1,0 +1,10 @@
+
+void function(int a
+              , int b
+              , int c);
+
+enum Test {
+	A,   B,
+	C,
+	D, E
+}

--- a/tests/output/cpp/33099-enum_comma.h
+++ b/tests/output/cpp/33099-enum_comma.h
@@ -1,0 +1,12 @@
+
+void function(int a
+              , int b
+              , int c);
+
+enum Test {
+	A,
+	B,
+	C,
+	D,
+	E
+}

--- a/tests/output/cpp/33100-enum_comma.h
+++ b/tests/output/cpp/33100-enum_comma.h
@@ -1,0 +1,10 @@
+
+void function(int a,
+              int b,
+              int c);
+
+enum Test {
+	A,   B
+	, C
+	,D, E
+}

--- a/tests/output/cpp/33101-enum_comma.h
+++ b/tests/output/cpp/33101-enum_comma.h
@@ -1,0 +1,10 @@
+
+void function(int a,
+              int b,
+              int c);
+
+enum Test {
+	A,   B,
+	C,
+	D, E
+}

--- a/tests/output/cpp/33102-enum_comma.h
+++ b/tests/output/cpp/33102-enum_comma.h
@@ -1,0 +1,12 @@
+
+void function(int a,
+              int b,
+              int c);
+
+enum Test {
+	A
+	, B
+	, C
+	, D
+	, E
+}


### PR DESCRIPTION
I like my functions simple:

```cpp
void foo(int a, int b, int c);
```

but like enums with entities on separate lines:

```cpp
enum Test
{
    A,
    B,
    C,
}
```

hence new option.