### PR TITLE
Fix close angle attributed to template

### DIFF
--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -945,7 +945,7 @@ static void check_template(chunk_t *start)
 
          if ((tokens[num_tokens - 1] == CT_ANGLE_OPEN) &&
              (pc->str[0] == '>') && (pc->len() > 1) &&
-             (cpd.settings[UO_tok_split_gte].b || chunk_is_str(pc, ">>", 2)))
+             (cpd.settings[UO_tok_split_gte].b || (chunk_is_str(pc, ">>", 2) && (num_tokens >= 2))))
          {
             LOG_FMT(LTEMPL, " {split '%s' at %d:%d}",
                     pc->text(), pc->orig_line, pc->orig_col);
@@ -990,12 +990,12 @@ static void check_template(chunk_t *start)
             {
                break;
             }
-            tokens[num_tokens++] = pc->type;
+            tokens[num_tokens++] = CT_PAREN_OPEN;
          }
          else if (pc->type == CT_PAREN_CLOSE)
          {
             num_tokens--;
-            if (tokens[num_tokens] != (pc->type - 1))
+            if (tokens[num_tokens] != CT_PAREN_OPEN)
             {
                /* unbalanced parens */
                break;

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -245,6 +245,7 @@
 
 32001 empty.cfg                        cpp/issue_547_for_each.cpp
 32000 sp_skip_vbrace_tokens.cfg        cpp/sp_skip_vbrace_tokens.cpp
+32004 empty.cfg                        cpp/issue_624_angle.cpp
 
 33000 tab-0-11.cfg                     cpp/tab-0.cpp
 33001 tab-1-11.cfg                     cpp/tab-1.cpp

--- a/tests/input/cpp/issue_624_angle.cpp
+++ b/tests/input/cpp/issue_624_angle.cpp
@@ -1,0 +1,2 @@
+auto c = a < b >> 1;
+auto c = a < b;

--- a/tests/output/cpp/32004-issue_624_angle.cpp
+++ b/tests/output/cpp/32004-issue_624_angle.cpp
@@ -1,0 +1,2 @@
+auto c = a < b >> 1;
+auto c = a < b;


### PR DESCRIPTION
The close angle from the right shift was wrongly attributed to a template (issue #624).

```cpp
    auto c = a < b >> 1;
    auto c = a < b;
```

The fix takes into account that it should have at least two previous angle open to allow the split to be made.