### PR TITLE
Introducing align_var_class_span and friends

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -283,7 +283,8 @@ void align_all(void)
 
    /* Align variable definitions */
    if ((cpd.settings[UO_align_var_def_span].n > 0) ||
-       (cpd.settings[UO_align_var_struct_span].n > 0))
+       (cpd.settings[UO_align_var_struct_span].n > 0) ||
+       (cpd.settings[UO_align_var_class_span].n > 0) )
    {
       align_var_def_brace(chunk_get_head(), cpd.settings[UO_align_var_def_span].n, NULL);
    }
@@ -1111,6 +1112,12 @@ static chunk_t *align_var_def_brace(chunk_t *start, int span, int *p_nl_count)
       myspan   = cpd.settings[UO_align_var_struct_span].n;
       mythresh = cpd.settings[UO_align_var_struct_thresh].n;
       mygap    = cpd.settings[UO_align_var_struct_gap].n;
+   }
+   else if (start->parent_type == CT_CLASS)
+   {
+       myspan = cpd.settings[UO_align_var_class_span].n;
+       mythresh = cpd.settings[UO_align_var_class_thresh].n;
+       mygap = cpd.settings[UO_align_var_class_gap].n;
    }
    else
    {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1235,12 +1235,18 @@ void register_options(void)
                   "The span for aligning on '=' in enums (0=don't align)", "", 0, 5000);
    unc_add_option("align_enum_equ_thresh", UO_align_enum_equ_thresh, AT_NUM,
                   "The threshold for aligning on '=' in enums (0=no limit)", "", 0, 5000);
+   unc_add_option("align_var_class_span", UO_align_var_class_span, AT_NUM,
+                  "The span for aligning class (0=don't align)", "", 0, 5000);
+   unc_add_option("align_var_class_thresh", UO_align_var_class_thresh, AT_NUM,
+                  "The threshold for aligning class member definitions (0=no limit)", "", 0, 5000);
+   unc_add_option("align_var_class_gap", UO_align_var_class_gap, AT_NUM,
+                  "The gap for aligning class member definitions");
    unc_add_option("align_var_struct_span", UO_align_var_struct_span, AT_NUM,
                   "The span for aligning struct/union (0=don't align)", "", 0, 5000);
    unc_add_option("align_var_struct_thresh", UO_align_var_struct_thresh, AT_NUM,
                   "The threshold for aligning struct/union member definitions (0=no limit)", "", 0, 5000);
    unc_add_option("align_var_struct_gap", UO_align_var_struct_gap, AT_NUM,
-                  "The gap for aligning struct/union member definitions");
+                  "The gap for aligning struct/union member definitions");                  
    unc_add_option("align_struct_init_span", UO_align_struct_init_span, AT_NUM,
                   "The span for aligning struct initializer values (0=don't align)", "", 0, 5000);
    unc_add_option("align_typedef_gap", UO_align_typedef_gap, AT_NUM,

--- a/src/options.h
+++ b/src/options.h
@@ -457,6 +457,9 @@ enum uncrustify_options
    UO_align_var_def_amp_style,    // see UO_align_typedef_star_style
    UO_align_var_def_colon,        // align the colon in struct bit fields
    UO_align_var_def_attribute,
+   UO_align_var_class_span,       // span for class (0=don't align)
+   UO_align_var_class_thresh,     // threshold for class, 0=no limit
+   UO_align_var_class_gap,        // gap for class
    UO_align_var_struct_span,      // span for struct/union (0=don't align)
    UO_align_var_struct_thresh,    // threshold for struct/union, 0=no limit
    UO_align_var_struct_gap,       // gap for struct/union

--- a/tests/config/align_var_class_span.cfg
+++ b/tests/config/align_var_class_span.cfg
@@ -1,0 +1,1 @@
+align_var_class_span=1

--- a/tests/config/ben.cfg
+++ b/tests/config/ben.cfg
@@ -91,6 +91,7 @@ align_number_left             = true
 align_asm_colon               = true
 align_func_params             = true
 align_var_def_span            = 2
+align_var_class_span          = 2
 align_var_def_star_style      = 1
 align_var_def_thresh          = 0
 align_var_def_colon           = true

--- a/tests/config/d.cfg
+++ b/tests/config/d.cfg
@@ -76,6 +76,7 @@ align_on_tabstop		= FALSE		# align on tabstops
 align_enum_equ_span		= 4
 align_nl_cont			= TRUE
 align_var_def_span		= 2
+align_var_class_span    = 2
 align_var_def_inline		= TRUE
 align_var_def_star_style	= 1
 align_var_def_colon		= TRUE

--- a/tests/config/d2.cfg
+++ b/tests/config/d2.cfg
@@ -85,6 +85,7 @@ align_on_tabstop		= FALSE		# align on tabstops
 align_enum_equ_span		= 4
 align_nl_cont			= TRUE
 align_var_def_span		= 2
+align_var_class_span    = 2
 align_var_def_inline		= TRUE
 align_var_def_star_style	= 1
 align_var_def_colon		= TRUE

--- a/tests/config/indent_var_def.cfg
+++ b/tests/config/indent_var_def.cfg
@@ -496,6 +496,7 @@ align_same_func_call_params              = false    # false/true
 
 # The span for aligning variable definitions (0=don't align)
 align_var_def_span                       = 1        # number
+align_var_class_span                     = 1        # number
 
 # How to align the star in variable definitions.
 #  0=Part of the type     'void *   foo;'

--- a/tests/config/issue_633_typename.cfg
+++ b/tests/config/issue_633_typename.cfg
@@ -1,1 +1,2 @@
 align_var_def_span=1
+align_var_class_span=1

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -247,6 +247,8 @@
 32001 empty.cfg                        cpp/issue_547_for_each.cpp
 32002 proto-wrap.cfg                   cpp/proto-wrap.cpp
 32003 issue_633_typename.cfg           cpp/issue_633_typename.cpp
+32004 empty.cfg                        cpp/issue_624_angle.cpp
+32005 align_var_class_span.cfg         cpp/issue_633_typename.cpp
 
 33000 tab-0-11.cfg                     cpp/tab-0.cpp
 33001 tab-1-11.cfg                     cpp/tab-1.cpp

--- a/tests/output/cpp/32005-issue_633_typename.cpp
+++ b/tests/output/cpp/32005-issue_633_typename.cpp
@@ -1,0 +1,25 @@
+template < typename TImage >
+class MorphologicalContourInterpolator :
+	public ImageToImageFilter< TImage, TImage >
+{
+template < typename T >
+friend class MorphologicalContourInterpolatorParallelInvoker;
+friend class ::MultiLabelMeshPipeline;
+
+public:
+/** Standard class typedefs. */
+typedef MorphologicalContourInterpolator Self;
+
+protected:
+MorphologicalContourInterpolator();
+~MorphologicalContourInterpolator() {
+}
+typename TImage::PixelType m_Label;
+int                        m_Axis;
+bool                       m_HeuristicAlignment;
+
+private:
+MorphologicalContourInterpolator( const Self& ) ITK_DELETE_FUNCTION;
+void
+operator=( const Self& ) ITK_DELETE_FUNCTION;
+};


### PR DESCRIPTION
#648 Adding align_var_class_span, align_var_class_thresh and align_var_class_gap
to have separate control over class member declaration alignment.
