### PR TITLE
Fixes for indent_cs_delegate_brace

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1028,9 +1028,8 @@ void indent_text(void)
 
             frm.pse[frm.pse_tos - 1].indent_tmp = frm.pse[frm.pse_tos].indent_tmp;
          }
-         else if (cpd.settings[UO_indent_cs_delegate_brace].b &&
-             (pc->type == CT_BRACE_OPEN) &&
-             (pc->prev->type == CT_LAMBDA || pc->prev->prev->type == CT_LAMBDA))
+         else if ((cpd.lang_flags & LANG_CS) && cpd.settings[UO_indent_cs_delegate_brace].b &&
+             pc->parent_type == CT_LAMBDA)
          {
             frm.pse[frm.pse_tos].brace_indent = 1 + ((pc->brace_level + 1) * indent_size);
             indent_column                     = frm.pse[frm.pse_tos].brace_indent;

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1029,7 +1029,7 @@ void indent_text(void)
             frm.pse[frm.pse_tos - 1].indent_tmp = frm.pse[frm.pse_tos].indent_tmp;
          }
          else if ((cpd.lang_flags & LANG_CS) && cpd.settings[UO_indent_cs_delegate_brace].b &&
-             pc->parent_type == CT_LAMBDA)
+             (pc->parent_type == CT_LAMBDA || pc->parent_type == CT_DELEGATE))
          {
             frm.pse[frm.pse_tos].brace_indent = 1 + ((pc->brace_level + 1) * indent_size);
             indent_column                     = frm.pse[frm.pse_tos].brace_indent;

--- a/tests/input/cpp/bug_i_568.cpp
+++ b/tests/input/cpp/bug_i_568.cpp
@@ -1,5 +1,4 @@
-enum
-{
+enum { // Keep this line as it is. It's a regression test for checking pc->prev->prev-> on CT_BRACE_OPEN.
   kEnumValue = 5,
 };
 

--- a/tests/input/cs/delegate.cs
+++ b/tests/input/cs/delegate.cs
@@ -7,3 +7,17 @@ funcwithverylongname(() =>
 func();
 });
 }
+
+Func(
+    "stuff",
+    foo =>
+    {
+        bar();
+    });
+
+Func(
+    "stuff",
+    foo =>
+{
+    bar();
+});

--- a/tests/input/cs/delegate.cs
+++ b/tests/input/cs/delegate.cs
@@ -21,3 +21,9 @@ Func(
 {
     bar();
 });
+
+data.Sort(
+    delegate(InputData lhs, InputData rhs)
+{
+    return lhs.m_Name.CompareTo(rhs.m_Name);
+});

--- a/tests/output/cpp/33086-bug_i_568.cpp
+++ b/tests/output/cpp/33086-bug_i_568.cpp
@@ -1,5 +1,4 @@
-enum
-{
+enum { // Keep this line as it is. It's a regression test for checking pc->prev->prev-> on CT_BRACE_OPEN.
 	kEnumValue = 5,
 };
 

--- a/tests/output/cs/10160-delegate.cs
+++ b/tests/output/cs/10160-delegate.cs
@@ -21,3 +21,9 @@ Func(
 {
 	bar();
 });
+
+data.Sort(
+	delegate(InputData lhs, InputData rhs)
+{
+	return lhs.m_Name.CompareTo(rhs.m_Name);
+});

--- a/tests/output/cs/10160-delegate.cs
+++ b/tests/output/cs/10160-delegate.cs
@@ -7,3 +7,17 @@ void foo()
 		func();
 	});
 }
+
+Func(
+	"stuff",
+	foo =>
+{
+	bar();
+});
+
+Func(
+	"stuff",
+	foo =>
+{
+	bar();
+});

--- a/tests/output/cs/10161-delegate.cs
+++ b/tests/output/cs/10161-delegate.cs
@@ -21,3 +21,9 @@ Func(
 	{
 		bar();
 	});
+
+data.Sort(
+	delegate(InputData lhs, InputData rhs)
+	{
+		return lhs.m_Name.CompareTo(rhs.m_Name);
+	});

--- a/tests/output/cs/10161-delegate.cs
+++ b/tests/output/cs/10161-delegate.cs
@@ -7,3 +7,17 @@ void foo()
 			func();
 		});
 }
+
+Func(
+	"stuff",
+	foo =>
+	{
+		bar();
+	});
+
+Func(
+	"stuff",
+	foo =>
+	{
+		bar();
+	});


### PR DESCRIPTION
Blindly stepping back testing `pc->prev->type` and `pc->prev->prev->type` to see if it's a LAMBDA token without checking for NULL pointer was risky in the first place (not saying that it was actually worse to do it like that and more than that it wasn't even a proper fix). Also, because the option wasn't checking it's language flag (just like many other options: `UO_indent_cpp_lambda_body`) it was crashing on cpp anonymous enums (for instance as depicted in the modified `33086-bug_i_568.cpp` test). That's why this bug slipped through and was not seen previously.

We still need to do a pass on all language specific options and see if they check the language flags. Users may be enabling C# options for C++ files and uncrustify should not crash. In that situation, the options should have no effect.