### PR TITLE
Ensure every error reported increments the error count

### DIFF
--- a/src/backup.cpp
+++ b/src/backup.cpp
@@ -103,11 +103,13 @@ int backup_copy_file(const char *filename, const vector<UINT8>& data)
       }
       LOG_FMT(LERR, "fwrite(%s) failed: %s (%d)\n",
               newpath, strerror(my_errno), my_errno);
+      cpd.error_count++;
    }
    else
    {
       LOG_FMT(LERR, "fopen(%s) failed: %s (%d)\n",
               newpath, strerror(errno), errno);
+      cpd.error_count++;
    }
    return(FAILURE);
 } // backup_copy_file
@@ -133,6 +135,7 @@ void backup_create_md5_file(const char *filename)
    {
       LOG_FMT(LERR, "%s: fopen(%s) failed: %s (%d)\n",
               __func__, filename, strerror(errno), errno);
+      cpd.error_count++;
       return;
    }
 

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -118,6 +118,7 @@ static chunk_t *flag_parens(chunk_t *po, UINT64 flags,
       LOG_FMT(LERR, "flag_parens: no match for [%s] at [%d:%d]",
               po->text(), po->orig_line, po->orig_col);
       log_func_stack_inline(LERR);
+      cpd.error_count++;
       return(NULL);
    }
 

--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -317,6 +317,7 @@ bool keywords_are_sorted(void)
       {
          fprintf(stderr, "%s: bad sort order at idx %d, words '%s' and '%s'\n",
                  __func__, idx - 1, keywords[idx - 1].tag, keywords[idx].tag);
+         cpd.error_count++;
          return(false);
       }
    }

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -223,6 +223,7 @@ static void redir_stdout(const char *output_file)
       {
          LOG_FMT(LERR, "Unable to open %s for write: %s (%d)\n",
                  output_file, strerror(errno), errno);
+         cpd.error_count++;
          usage_exit(NULL, NULL, 56);
       }
       LOG_FMT(LNOTE, "Redirecting output to %s\n", output_file);
@@ -636,6 +637,7 @@ int main(int argc, char *argv[])
       if (!read_stdin(fm))
       {
          LOG_FMT(LERR, "Failed to read stdin\n");
+         cpd.error_count++;
          return(100);
       }
 
@@ -877,6 +879,7 @@ static int load_mem_file(const char *filename, file_mem& fm)
       else if (!decode_unicode(fm.raw, fm.data, fm.enc, fm.bom))
       {
          LOG_FMT(LERR, "%s: failed to decode the file '%s'\n", __func__, filename);
+         cpd.error_count++;
       }
       else
       {
@@ -1801,6 +1804,7 @@ static void uncrustify_file(const file_mem& fm, FILE *pfout,
       {
          LOG_FMT(LERR, "%s: Failed to open '%s' for write: %s (%d)\n",
                  __func__, parsed_file, strerror(errno), errno);
+         cpd.error_count++;
       }
    }
 


### PR DESCRIPTION
The error count is used to return the error state to the caller. Uncrustify has been dropping many error conditions without reporting them because many error log calls weren't matched with an increment of error count. I addressed every instance I found.

(Would be better for this to be done in the log function itself, but there are cases we do multiple err-log output in a row for a single error, and don't want to deal with avoiding redundant counts for now.)