### PR TITLE
Indent constructor members

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1417,9 +1417,19 @@ void indent_text(void)
                else
                {
                   next = chunk_get_next(pc);
-                  if ((next != NULL) && !chunk_is_newline(next))
+                  if (next != NULL)
                   {
-                     frm.pse[frm.pse_tos].indent = next->column;
+                     if (cpd.settings[UO_indent_ctor_init].n != 0)
+                     {
+                        frm.pse[frm.pse_tos].indent     += cpd.settings[UO_indent_ctor_init].n;
+                        frm.pse[frm.pse_tos].indent_tmp += cpd.settings[UO_indent_ctor_init].n;
+                        frm.pse[frm.pse_tos].indent_tab += cpd.settings[UO_indent_ctor_init].n;
+                        indent_column_set(frm.pse[frm.pse_tos].indent_tmp);
+                     }
+                     else if (!chunk_is_newline(next))
+                     {
+                        frm.pse[frm.pse_tos].indent = next->column;
+                     }
                   }
                }
             }

--- a/tests/config/indent_ctor_members_twice.cfg
+++ b/tests/config/indent_ctor_members_twice.cfg
@@ -1,0 +1,6 @@
+indent_with_tabs 0
+indent_columns 4
+
+indent_class True
+indent_ctor_init 4
+indent_constr_colon True

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -343,3 +343,5 @@
 33102 enum_comma-6.cfg                 cpp/enum_comma.h
 
 33200 first_len_minimum.cfg            cpp/first_len_minimum.cpp
+
+33201 indent_ctor_members_twice.cfg    cpp/indent_ctor_members_twice.cpp

--- a/tests/input/cpp/indent_ctor_members_twice.cpp
+++ b/tests/input/cpp/indent_ctor_members_twice.cpp
@@ -1,0 +1,5 @@
+Foo::Foo() :
+    Base(12),
+    mValue(24) {
+    func();
+}

--- a/tests/output/cpp/33201-indent_ctor_members_twice.cpp
+++ b/tests/output/cpp/33201-indent_ctor_members_twice.cpp
@@ -1,0 +1,5 @@
+Foo::Foo() :
+        Base(12),
+        mValue(24) {
+    func();
+}


### PR DESCRIPTION
If one sets `indent_class`, `indent_ctor_init` and `indent_constr_colon`, initialized member variables were not indented twice.