### PR TITLE
Fixes make_version.py with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,13 +121,28 @@ endif()
 #
 # Generate uncrustify_version.h
 #
-file(STRINGS configure.ac PACKAGE_VERSION REGEX "^AC_INIT")
+set(PACKAGE_VERSION "0.63")
 
-if(${PACKAGE_VERSION} MATCHES "^AC_INIT\\(uncrustify,([^,]+),")
-  set(PACKAGE_VERSION "${CMAKE_MATCH_1}")
-  message(STATUS "PACKAGE_VERSION: ${PACKAGE_VERSION}")
-else()
-  message(FATAL_ERROR "Unable to determine PACKAGE_VERSION")
+if (MAKE_VERSION)
+  find_package(PythonInterp REQUIRED)
+  execute_process(
+    COMMAND ${PYTHON_EXECUTABLE} make_version.py
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    RESULT_VARIABLE make_version_error
+    OUTPUT_VARIABLE make_version_output
+  )
+
+  if (make_version_error)
+    message(WARNING ${make_version_output})
+  else()
+    if (${make_version_output} MATCHES "full version: (.*)\n tag version: (.*)")
+      set(full_version ${CMAKE_MATCH_1})
+      set(tag_version ${CMAKE_MATCH_2})
+      message(STATUS "Uncrustify full version: ${full_version}")
+      message(STATUS "Uncrustify  tag version: ${tag_version}")
+    endif()
+    set(PACKAGE_VERSION "${full_version}")
+  endif()
 endif()
 
 configure_file(src/uncrustify_version.h.in uncrustify_version.h @ONLY)

--- a/make_version.py
+++ b/make_version.py
@@ -19,8 +19,9 @@ def main (argv):
             return 1
     elif os.path.exists(hg_path):
         try:
-            branch = subprocess.check_output(['hg', 'log', '-r', '.', '--template', '{latesttag}']).strip()
-            txt = subprocess.check_output(['git', '--git-dir=.hg/git', 'describe', '--long', '--always', branch]).strip()
+            subprocess.check_call(['hg', 'gexport'])
+            node = subprocess.check_output(['hg', '--config', 'defaults.log=', 'log', '-r', '.', '--template', '{gitnode}']).strip()
+            txt = subprocess.check_output(['git', '--git-dir=.hg/git', 'describe', '--long', '--tags', '--always', node]).strip()
         except:
             print "Failed to retrieve version from hg"
             return 1

--- a/make_version.py
+++ b/make_version.py
@@ -36,24 +36,6 @@ def main (argv):
     print 'full version:', full_vers
     print ' tag version:', tag_vers
 
-    # rebuild uncrustify_version.h
-    fn = os.path.join(root, 'src', 'uncrustify_version.h.in')
-    with open(fn, 'rb') as fh:
-        data = fh.read()
-    with open(fn[:-3], 'wb') as fh:
-        fh.write(data.replace('@PACKAGE_VERSION@', full_vers))
-
-    # rebuild configure.in
-    fn = os.path.join(root, 'configure.ac')
-    with open(fn, 'rb') as fh:
-        data = fh.read()
-    with open(fn, 'wb') as fh:
-        for line in data.splitlines():
-            if line.startswith('AC_INIT(uncrustify'):
-                pts = line.split(',', 2)
-                line = '%s,%s,%s' % (pts[0], tag_vers, pts[2])
-            fh.write(line)
-            fh.write('\n')
     return 0
 
 if __name__ == '__main__':


### PR DESCRIPTION
If cmake is launched with `cmake -DMAKE_VERSION=1 ..` then the package version is set to be the full version from VCS.

`make_version.py` is used during the process and it doesn't modify configure.ac nor it doesn't configure the old `src/uncrustify_version.h.in` any more. Only it's console output it's used and parsed in cmake.

Note that this change is incompatible with gnu autotools workflow and it's part of #604.