### PR TITLE
Add option comment after long class names. Don't add function or clas…

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1421,6 +1421,9 @@ void register_options(void)
    unc_add_option("mod_add_long_namespace_closebrace_comment", UO_mod_add_long_namespace_closebrace_comment, AT_NUM,
                   "If a namespace body exceeds the specified number of newlines and doesn't have a comment after\n"
                   "the close brace, a comment will be added.");
+   unc_add_option("mod_add_long_class_closebrace_comment", UO_mod_add_long_class_closebrace_comment, AT_NUM,
+                  "If a class body exceeds the specified number of newlines and doesn't have a comment after\n"
+                  "the close brace, a comment will be added.");
    unc_add_option("mod_add_long_switch_closebrace_comment", UO_mod_add_long_switch_closebrace_comment, AT_NUM,
                   "If a switch body exceeds the specified number of newlines and doesn't have a comment after\n"
                   "the close brace, a comment will be added.");

--- a/src/options.h
+++ b/src/options.h
@@ -793,6 +793,7 @@ enum uncrustify_options
 
    /* Hack, add comments to the ends of namespaces */
    UO_mod_add_long_namespace_closebrace_comment,
+   UO_mod_add_long_class_closebrace_comment,
 
    UO_use_indent_func_call_param,     // use/don't use indent_func_call_param Guy 2015-09-24
    UO_use_indent_continue_only_once,  // The value of the indentation for a continuation line is calculate

--- a/tests/config/long_br_cmt.cfg
+++ b/tests/config/long_br_cmt.cfg
@@ -2,5 +2,6 @@ include "ben.cfg"
 
 mod_add_long_function_closebrace_comment  = 10
 mod_add_long_namespace_closebrace_comment = 10
+mod_add_long_class_closebrace_comment     = 8
 mod_add_long_switch_closebrace_comment    = 8
 indent_namespace = true

--- a/tests/input/cpp/cmt_insert.cpp
+++ b/tests/input/cpp/cmt_insert.cpp
@@ -39,3 +39,7 @@ map<string, int> func()
 int some_func(void)
 {
 }
+
+class some_class_declaration;
+
+int some_func_declaration();

--- a/tests/input/cpp/long_br_cmt.cpp
+++ b/tests/input/cpp/long_br_cmt.cpp
@@ -38,4 +38,22 @@ default:
   break;
 }
 }
+
+class long_class
+{
+private:
+
+int m_a;
+int m_name;
+
+public:
+long_class(int a) {}
+
+void f1() {}  
+
+void f2() {}
+
+void f3() {}
+
+};
 }

--- a/tests/output/cpp/30265-long_br_cmt.cpp
+++ b/tests/output/cpp/30265-long_br_cmt.cpp
@@ -33,4 +33,20 @@ namespace a::b
          break;
       } // switch
    } // foo::bar
+
+   class long_class
+   {
+ private:
+      int m_a;
+      int m_name;
+
+ public:
+      long_class(int a) {}
+
+      void f1() {}
+
+      void f2() {}
+
+      void f3() {}
+   }; // class long_class
 } // namespace a::b

--- a/tests/output/cpp/30870-cmt_insert.cpp
+++ b/tests/output/cpp/30870-cmt_insert.cpp
@@ -76,3 +76,7 @@ map<string, int> func()
 int some_func(void)
 {
 }
+
+class some_class_declaration;
+
+int some_func_declaration();

--- a/tests/output/cpp/30871-cmt_insert.cpp
+++ b/tests/output/cpp/30871-cmt_insert.cpp
@@ -100,3 +100,7 @@ map<string, int> func()
 int some_func(void)
 {
 }
+
+class some_class_declaration;
+
+int some_func_declaration();


### PR DESCRIPTION
…s headers for one liners.

You may want to add this into the main branch. I added an option for long class names (similar to long functions or namespaces), and had uncrustify ignore headers for single line function or class declarations. The latter could be made into options, but I didn't see the point.