### PR TITLE
Fix pos_constr_comma Trail

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3488,6 +3488,12 @@ void newlines_class_colon_pos(c_token_t tok)
                   {
                      newline_add_after(pc);
                   }
+                  prev = chunk_get_prev_nc(pc);
+                  if (chunk_is_newline(prev) && chunk_safe_to_del_nl(prev))
+                  {
+                      chunk_del(prev);
+                      MARK_CHANGE();
+                  }
                }
                else if (pcc & TP_LEAD)
                {

--- a/tests/config/initlist_leading_commas.cfg
+++ b/tests/config/initlist_leading_commas.cfg
@@ -1,0 +1,3 @@
+indent_columns 4
+nl_constr_init_args Force
+pos_constr_comma Trail

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -347,5 +347,6 @@
 33200 first_len_minimum.cfg            cpp/first_len_minimum.cpp
 
 33201 indent_ctor_members_twice.cfg    cpp/indent_ctor_members_twice.cpp
+33202 initlist_leading_commas.cfg      cpp/initlist_leading_commas.cpp
 
 34001 nl_before_after.cfg              cpp/nl_before_after.h

--- a/tests/input/cpp/initlist_leading_commas.cpp
+++ b/tests/input/cpp/initlist_leading_commas.cpp
@@ -1,0 +1,5 @@
+MyClass::MyClass(Type *var1, Type *var2) :
+    BaseClass(parent)
+  , mVar1(var1)
+  , mVar2(var2) {
+}

--- a/tests/output/cpp/33202-initlist_leading_commas.cpp
+++ b/tests/output/cpp/33202-initlist_leading_commas.cpp
@@ -1,0 +1,5 @@
+MyClass::MyClass(Type *var1, Type *var2) :
+    BaseClass(parent),
+    mVar1(var1),
+    mVar2(var2) {
+}


### PR DESCRIPTION
When `pos_constr_comma` is set to `Trail`, leading commas are not properly handled: preceding new line is not removed, but a following newline is added. This results in having commas in their own lines.

This patch fixes this behavior.