### PR TITLE
Prefer mingw-w64 for cross-compile

### DIFF
--- a/cmake/Toolchain-mingw32.cmake
+++ b/cmake/Toolchain-mingw32.cmake
@@ -5,12 +5,12 @@
 set(CMAKE_SYSTEM_NAME Windows)
 
 if(NOT COMPILER_PREFIX)
-  if(EXISTS /usr/i586-mingw32msvc)
-    # mingw
-    set(COMPILER_PREFIX "i586-mingw32msvc")
-  elseif(EXISTS /usr/i686-w64-mingw32)
+  if(EXISTS /usr/i686-w64-mingw32)
     # mingw-w64
     set(COMPILER_PREFIX "i686-w64-mingw32")
+  elseif(EXISTS /usr/i586-mingw32msvc)
+    # mingw
+    set(COMPILER_PREFIX "i586-mingw32msvc")
   else()
     message(FATAL_ERROR "Unable to detect cross-compiler prefix (COMPILER_PREFIX)")
   endif()

--- a/cmake/Toolchain-mingw64.cmake
+++ b/cmake/Toolchain-mingw64.cmake
@@ -5,12 +5,12 @@
 set(CMAKE_SYSTEM_NAME Windows)
 
 if(NOT COMPILER_PREFIX)
-  if(EXISTS /usr/amd64-mingw32msvc-gcc)
-    # mingw
-    set(COMPILER_PREFIX "amd64-mingw32msvc-gcc")
-  elseif(EXISTS /usr/x86_64-w64-mingw32)
+  if(EXISTS /usr/x86_64-w64-mingw32)
     # mingw-w64
     set(COMPILER_PREFIX "x86_64-w64-mingw32")
+  elseif(EXISTS /usr/amd64-mingw32msvc-gcc)
+    # mingw
+    set(COMPILER_PREFIX "amd64-mingw32msvc-gcc")
   else()
     message(FATAL_ERROR "Unable to detect cross-compiler prefix (COMPILER_PREFIX)")
   endif()


### PR DESCRIPTION
@gmaurel found some problems cross-compiling with the old mingw32 package, so check for mingw-w64 first, in case someone has both installed.