### PR TITLE
If there is only one separate typedef, don't use the option …

### DIFF
--- a/src/align_stack.cpp
+++ b/src/align_stack.cpp
@@ -346,7 +346,22 @@ void AlignStack::Flush()
    const ChunkStack::Entry *ce = NULL;
    chunk_t                 *pc;
 
+   LOG_FMT(LAS, "%s: m_aligned.Len()=%d\n", __func__, m_aligned.Len());
    LOG_FMT(LAS, "Flush (min=%d, max=%d)\n", m_min_col, m_max_col);
+   if (m_aligned.Len() == 1)
+   {
+      // check if we have *one* typedef in the line
+      pc = m_aligned.Get(0)->m_pc;
+      chunk_t *temp = chunk_get_prev_type(pc, CT_TYPEDEF, pc->level);
+      if (temp != NULL)
+      {
+         if (pc->orig_line == temp->orig_line )
+         {
+             // reset the gap only for *this* stack
+             m_gap = 1;
+         }
+      }
+   }
 
    m_last_added = 0;
    m_max_col    = 0;

--- a/tests/config/bug_i_793.cfg
+++ b/tests/config/bug_i_793.cfg
@@ -1,0 +1,5 @@
+indent_columns     = 3
+indent_with_tabs   = 0
+
+align_typedef_gap  = 5
+align_typedef_span = 2

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -349,3 +349,4 @@
 33202 initlist_leading_commas.cfg      cpp/initlist_leading_commas.cpp
 
 34001 nl_before_after.cfg              cpp/nl_before_after.h
+34002 bug_i_793.cfg                    cpp/bug_i_793.cpp

--- a/tests/input/cpp/bug_i_793.cpp
+++ b/tests/input/cpp/bug_i_793.cpp
@@ -1,0 +1,4 @@
+static void h()
+{
+   typedef int           IntGroup;
+}

--- a/tests/output/c/00801-fcn_type.c
+++ b/tests/output/c/00801-fcn_type.c
@@ -6,7 +6,7 @@ typedef enum foo *(*my_fcn_ptr)(char *, int);
 typedef const struct foo *(*my_fcn_ptr)(char *, int);
 typedef BOOL (my_fcn_ptr)(char *, int);
 typedef INT32 (*my_fcn_ptr)(char *, int);
-typedef int   INT32;
+typedef int INT32;
 typedef struct foo
 {
    int a;

--- a/tests/output/c/02001-directfb.h
+++ b/tests/output/c/02001-directfb.h
@@ -233,7 +233,7 @@ typedef int                  register_t __attribute__((__mode__(__word__)));
 
 #1 "/usr/include/bits/sigset.h" 1 3 4
 #23 "/usr/include/bits/sigset.h" 3 4
-typedef int   __sig_atomic_t;
+typedef int __sig_atomic_t;
 
 
 
@@ -245,7 +245,7 @@ typedef struct
 
 
 
-typedef __sigset_t   sigset_t;
+typedef __sigset_t sigset_t;
 
 
 
@@ -268,11 +268,11 @@ struct timeval
 #47 "/usr/include/sys/select.h" 2 3 4
 
 
-typedef __suseconds_t   suseconds_t;
+typedef __suseconds_t suseconds_t;
 
 
 
-typedef long int        __fd_mask;
+typedef long int      __fd_mask;
 #67 "/usr/include/sys/select.h" 3 4
 typedef struct
 {
@@ -281,7 +281,7 @@ typedef struct
 
 
 
-typedef __fd_mask   fd_mask;
+typedef __fd_mask fd_mask;
 #99 "/usr/include/sys/select.h" 3 4
 
 #109 "/usr/include/sys/select.h" 3 4
@@ -331,15 +331,15 @@ __attribute__((__nothrow__)) gnu_dev_makedev(unsigned int __major, unsigned int 
 
 #220 "/usr/include/sys/types.h" 2 3 4
 #231 "/usr/include/sys/types.h" 3 4
-typedef __blkcnt_t     blkcnt_t;
+typedef __blkcnt_t   blkcnt_t;
 
 
 
-typedef __fsblkcnt_t   fsblkcnt_t;
+typedef __fsblkcnt_t fsblkcnt_t;
 
 
 
-typedef __fsfilcnt_t   fsfilcnt_t;
+typedef __fsfilcnt_t fsfilcnt_t;
 #266 "/usr/include/sys/types.h" 3 4
 #1 "/usr/include/bits/pthreadtypes.h" 1 3 4
 #23 "/usr/include/bits/pthreadtypes.h" 3 4
@@ -351,7 +351,7 @@ struct __sched_param
 };
 #24 "/usr/include/bits/pthreadtypes.h" 2 3 4
 
-typedef int   __atomic_lock_t;
+typedef int __atomic_lock_t;
 
 
 struct _pthread_fastlock
@@ -362,7 +362,7 @@ struct _pthread_fastlock
 
 
 
-typedef struct _pthread_descr_struct * _pthread_descr;
+typedef struct _pthread_descr_struct *_pthread_descr;
 
 
 
@@ -381,7 +381,7 @@ typedef struct __pthread_attr_s
 
 
 
-__extension__ typedef long long   __pthread_cond_align_t;
+__extension__ typedef long long __pthread_cond_align_t;
 
 
 
@@ -402,7 +402,7 @@ typedef struct
 } pthread_condattr_t;
 
 
-typedef unsigned int   pthread_key_t;
+typedef unsigned int pthread_key_t;
 
 
 
@@ -424,9 +424,9 @@ typedef struct
 
 
 
-typedef int                 pthread_once_t;
+typedef int               pthread_once_t;
 #152 "/usr/include/bits/pthreadtypes.h" 3 4
-typedef unsigned long int   pthread_t;
+typedef unsigned long int pthread_t;
 #267 "/usr/include/sys/types.h" 2 3 4
 
 
@@ -452,8 +452,8 @@ typedef struct
 typedef void (*__kernel_sighandler_t)(int);
 
 
-typedef int   __kernel_key_t;
-typedef int   __kernel_mqd_t;
+typedef int __kernel_key_t;
+typedef int __kernel_mqd_t;
 
 #1 "/usr/lib/gcc/i486-linux-gnu/4.0.3/include/asm/posix_types.h" 1 3 4
 #14 "/usr/lib/gcc/i486-linux-gnu/4.0.3/include/asm/posix_types.h" 3 4
@@ -461,35 +461,35 @@ typedef int   __kernel_mqd_t;
 #11 "/usr/include/asm/posix_types.h" 3 4
 #1 "/usr/include/asm-i386/posix_types.h" 1 3 4
 #10 "/usr/include/asm-i386/posix_types.h" 3 4
-typedef unsigned long    __kernel_ino_t;
-typedef unsigned short   __kernel_mode_t;
-typedef unsigned short   __kernel_nlink_t;
-typedef long             __kernel_off_t;
-typedef int              __kernel_pid_t;
-typedef unsigned short   __kernel_ipc_pid_t;
-typedef unsigned short   __kernel_uid_t;
-typedef unsigned short   __kernel_gid_t;
-typedef unsigned int     __kernel_size_t;
-typedef int              __kernel_ssize_t;
-typedef int              __kernel_ptrdiff_t;
-typedef long             __kernel_time_t;
-typedef long             __kernel_suseconds_t;
-typedef long             __kernel_clock_t;
-typedef int              __kernel_timer_t;
-typedef int              __kernel_clockid_t;
-typedef int              __kernel_daddr_t;
-typedef char *           __kernel_caddr_t;
-typedef unsigned short   __kernel_uid16_t;
-typedef unsigned short   __kernel_gid16_t;
-typedef unsigned int     __kernel_uid32_t;
-typedef unsigned int     __kernel_gid32_t;
+typedef unsigned long  __kernel_ino_t;
+typedef unsigned short __kernel_mode_t;
+typedef unsigned short __kernel_nlink_t;
+typedef long           __kernel_off_t;
+typedef int            __kernel_pid_t;
+typedef unsigned short __kernel_ipc_pid_t;
+typedef unsigned short __kernel_uid_t;
+typedef unsigned short __kernel_gid_t;
+typedef unsigned int   __kernel_size_t;
+typedef int            __kernel_ssize_t;
+typedef int            __kernel_ptrdiff_t;
+typedef long           __kernel_time_t;
+typedef long           __kernel_suseconds_t;
+typedef long           __kernel_clock_t;
+typedef int            __kernel_timer_t;
+typedef int            __kernel_clockid_t;
+typedef int            __kernel_daddr_t;
+typedef char *         __kernel_caddr_t;
+typedef unsigned short __kernel_uid16_t;
+typedef unsigned short __kernel_gid16_t;
+typedef unsigned int   __kernel_uid32_t;
+typedef unsigned int   __kernel_gid32_t;
 
-typedef unsigned short   __kernel_old_uid_t;
-typedef unsigned short   __kernel_old_gid_t;
-typedef unsigned short   __kernel_old_dev_t;
+typedef unsigned short __kernel_old_uid_t;
+typedef unsigned short __kernel_old_gid_t;
+typedef unsigned short __kernel_old_dev_t;
 
 
-typedef long long        __kernel_loff_t;
+typedef long long      __kernel_loff_t;
 
 
 typedef struct
@@ -506,34 +506,34 @@ typedef struct
 
 
 
-typedef unsigned short         umode_t;
+typedef unsigned short       umode_t;
 
 
 
-typedef __signed__ char        __s8;
-typedef unsigned char          __u8;
+typedef __signed__ char      __s8;
+typedef unsigned char        __u8;
 
-typedef __signed__ short       __s16;
-typedef unsigned short         __u16;
+typedef __signed__ short     __s16;
+typedef unsigned short       __u16;
 
-typedef __signed__ int         __s32;
-typedef unsigned int           __u32;
+typedef __signed__ int       __s32;
+typedef unsigned int         __u32;
 
 
-typedef __signed__ long long   __s64;
-typedef unsigned long long     __u64;
+typedef __signed__ long long __s64;
+typedef unsigned long long   __u64;
 #12 "/usr/include/asm/types.h" 2 3 4
 #7 "/usr/include/linux/types.h" 2 3 4
 #133 "/usr/include/linux/types.h" 3 4
-typedef __u16                  __le16;
-typedef __u16                  __be16;
-typedef __u32                  __le32;
-typedef __u32                  __be32;
+typedef __u16                __le16;
+typedef __u16                __be16;
+typedef __u32                __le32;
+typedef __u32                __be32;
 
 
 
-typedef __u64                  __le64;
-typedef __u64                  __be64;
+typedef __u64                __le64;
+typedef __u64                __be64;
 #6 "/usr/include/directfb/dfb_types.h" 2
 #32 "/usr/include/directfb/directfb.h" 2
 #1 "/usr/include/sys/time.h" 1 3 4
@@ -552,7 +552,7 @@ struct timezone
    int tz_dsttime;
 };
 
-typedef struct timezone *__restrict   __timezone_ptr_t;
+typedef struct timezone *__restrict __timezone_ptr_t;
 #72 "/usr/include/sys/time.h" 3 4
 extern int gettimeofday(struct timeval *__restrict __tv,
                         __timezone_ptr_t __tz) __attribute__((__nothrow__));
@@ -592,7 +592,7 @@ struct itimerval
 
 
 
-typedef int   __itimer_which_t;
+typedef int __itimer_which_t;
 
 
 
@@ -1130,55 +1130,55 @@ const char *DirectFBCheckVersion(unsigned int required_major,
 
 
 
-typedef struct _IDirectFB                IDirectFB;
+typedef struct _IDirectFB              IDirectFB;
 
 
 
-typedef struct _IDirectFBScreen          IDirectFBScreen;
+typedef struct _IDirectFBScreen        IDirectFBScreen;
 
 
 
-typedef struct _IDirectFBDisplayLayer    IDirectFBDisplayLayer;
+typedef struct _IDirectFBDisplayLayer  IDirectFBDisplayLayer;
 
 
 
-typedef struct _IDirectFBSurface         IDirectFBSurface;
+typedef struct _IDirectFBSurface       IDirectFBSurface;
 
 
 
-typedef struct _IDirectFBPalette         IDirectFBPalette;
+typedef struct _IDirectFBPalette       IDirectFBPalette;
 
 
 
-typedef struct _IDirectFBWindow          IDirectFBWindow;
+typedef struct _IDirectFBWindow        IDirectFBWindow;
 
 
 
-typedef struct _IDirectFBInputDevice     IDirectFBInputDevice;
+typedef struct _IDirectFBInputDevice   IDirectFBInputDevice;
 
 
 
-typedef struct _IDirectFBEventBuffer     IDirectFBEventBuffer;
+typedef struct _IDirectFBEventBuffer   IDirectFBEventBuffer;
 
 
 
-typedef struct _IDirectFBFont            IDirectFBFont;
+typedef struct _IDirectFBFont          IDirectFBFont;
 
 
 
-typedef struct _IDirectFBImageProvider   IDirectFBImageProvider;
+typedef struct _IDirectFBImageProvider IDirectFBImageProvider;
 
 
 
-typedef struct _IDirectFBVideoProvider   IDirectFBVideoProvider;
+typedef struct _IDirectFBVideoProvider IDirectFBVideoProvider;
 
 
 
-typedef struct _IDirectFBDataBuffer      IDirectFBDataBuffer;
+typedef struct _IDirectFBDataBuffer    IDirectFBDataBuffer;
 
 
 
-typedef struct _IDirectFBGL              IDirectFBGL;
+typedef struct _IDirectFBGL            IDirectFBGL;
 
 
 
@@ -1359,13 +1359,13 @@ DFBResult DirectFBCreate(
    );
 
 
-typedef unsigned int   DFBScreenID;
-typedef unsigned int   DFBDisplayLayerID;
-typedef unsigned int   DFBDisplayLayerSourceID;
-typedef unsigned int   DFBWindowID;
-typedef unsigned int   DFBInputDeviceID;
+typedef unsigned int DFBScreenID;
+typedef unsigned int DFBDisplayLayerID;
+typedef unsigned int DFBDisplayLayerSourceID;
+typedef unsigned int DFBWindowID;
+typedef unsigned int DFBInputDeviceID;
 
-typedef __u32          DFBDisplayLayerIDs;
+typedef __u32        DFBDisplayLayerIDs;
 #428 "/usr/include/directfb/directfb.h"
 typedef enum
 {

--- a/tests/output/cpp/30022-extern_c.h
+++ b/tests/output/cpp/30022-extern_c.h
@@ -3,7 +3,7 @@
 
 #include "DIS/cPduSnapshot.h"
 
-typedef void * disConnectionH;
+typedef void *disConnectionH;
 
 #ifdef __cplusplus
 extern "C"

--- a/tests/output/cpp/30741-al.cpp
+++ b/tests/output/cpp/30741-al.cpp
@@ -30,7 +30,7 @@ int this_works(int x);
 int bug(int); /* BUG: left-aligned */
 
 
-typedef int    fooman;
+typedef int fooman;
 enum FLAGS
 {
     FLAGS_decimal  = 1,    /* decimal */

--- a/tests/output/cpp/30812-misc4.cpp
+++ b/tests/output/cpp/30812-misc4.cpp
@@ -10,7 +10,7 @@ struct X
 
 int f(bool b)
 {
-   typedef int   mytype;
+   typedef int mytype;
    if (b)
    {
       return(int(42.0));

--- a/tests/output/cpp/30813-misc5.cpp
+++ b/tests/output/cpp/30813-misc5.cpp
@@ -1,4 +1,4 @@
-typedef std::list<StreamedData *>::iterator   iterator;
+typedef std::list<StreamedData *>::iterator iterator;
 double foo()
 {
    if (a<bar()> c)

--- a/tests/output/cpp/34002-bug_i_793.cpp
+++ b/tests/output/cpp/34002-bug_i_793.cpp
@@ -1,0 +1,4 @@
+static void h()
+{
+   typedef int IntGroup;
+}


### PR DESCRIPTION
align_typedef_gap

The tests 00801, 02001, 30022, 30741, 30812 and 30813 are corrected.

Fix the issue #793