### PR TITLE
Change some "int" to "size_t" o prevent conversion warnings.

### DIFF
--- a/src/unc_text.h
+++ b/src/unc_text.h
@@ -39,7 +39,7 @@ public:
    }
 
 
-   unc_text(const unc_text &ref, int idx, int len = -1)
+   unc_text(const unc_text &ref, size_t idx, size_t len = 0)
    {
       set(ref, idx, len);
    }
@@ -57,7 +57,7 @@ public:
    }
 
 
-   unc_text(const value_type &data, int idx = 0, int len = -1)
+   unc_text(const value_type &data, size_t idx = 0, size_t len = 0)
    {
       set(data, idx, len);
    }
@@ -67,17 +67,17 @@ public:
 
 
    /* grab the number of characters */
-   int size() const
+   size_t size() const
    {
       return(m_chars.size());
    }
 
    void set(int ch);
    void set(const unc_text &ref);
-   void set(const unc_text &ref, int idx, int len = -1);
+   void set(const unc_text &ref, size_t idx, size_t len = 0);
    void set(const string &ascii_text);
    void set(const char *ascii_text);
-   void set(const value_type &data, int idx = 0, int len = -1);
+   void set(const value_type &data, size_t idx = 0, size_t len = 0);
 
    unc_text &operator =(int ch)
    {
@@ -103,16 +103,16 @@ public:
       return(*this);
    }
 
-   void insert(int idx, int ch);
-   void insert(int idx, const unc_text &ref);
+   void insert(size_t idx, int ch);
+   void insert(size_t idx, const unc_text &ref);
 
-   void erase(int idx, int len = 1);
+   void erase(size_t idx, size_t len = 1);
 
    void append(int ch);
    void append(const unc_text &ref);
    void append(const string &ascii_text);
    void append(const char *ascii_text);
-   void append(const value_type &data, int idx = 0, int len = -1);
+   void append(const value_type &data, size_t idx = 0, size_t len = 0);
 
    unc_text &operator +=(int ch)
    {
@@ -146,7 +146,7 @@ public:
       return(c_str());
    }
 
-   static int compare(const unc_text &ref1, const unc_text &ref2, int len = 0);
+   static int compare(const unc_text &ref1, const unc_text &ref2, size_t len = 0);
    bool equals(const unc_text &ref) const;
 
    /* grab the data as a series of ints for outputting to a file */
@@ -161,18 +161,18 @@ public:
       return(m_chars);
    }
 
-   int operator[](int idx) const
+   int operator[](size_t idx) const
    {
-      return(((idx >= 0) && ((size_t)idx < m_chars.size())) ? m_chars[idx] : 0);
+      return((idx < m_chars.size()) ? m_chars[idx] : 0);
    }
 
    /* throws an exception if out of bounds */
-   int &at(int idx)
+   int &at(size_t idx)
    {
       return(m_chars.at(idx));
    }
 
-   const int &at(int idx) const
+   const int &at(size_t idx) const
    {
       return(m_chars.at(idx));
    }
@@ -213,10 +213,18 @@ public:
       }
    }
 
-   bool startswith(const unc_text &text, int idx = 0) const;
-   bool startswith(const char *text, int idx = 0) const;
-   int find(const char *text, int idx = 0) const;
-   int rfind(const char *text, int idx = -1) const;
+   bool startswith(const unc_text &text, size_t idx = 0) const;
+   bool startswith(const char *text, size_t idx = 0) const;
+
+   /*
+    * look for 'text', beginning with position 'sidx'
+    * return value:
+    *           -1: if not found
+    * the position: if found
+    */
+   int find(const char *text, size_t idx = 0) const;
+
+   int rfind(const char *text, size_t idx = 0) const;
    int replace(const char *oldtext, const unc_text &newtext);
 
 protected:


### PR DESCRIPTION
By using the compiler option -Wsign-conversion, we get many warnings such as:
... warning: conversion to ‘size_t {aka long unsigned int}’ from ‘int’ may change the sign of the result
To fix that, we need to change the type of some variables from int to size_t.
Part 1
Some more parts will follow.