### PR TITLE
Consider errors when using the --check option

### DIFF
--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -689,12 +689,16 @@ int main(int argc, char *argv[])
    clear_keyword_file();
    clear_defines();
 
-   if (cpd.do_check)
+   if (cpd.error_count != 0)
    {
-      return(cpd.check_fail_cnt ? EXIT_FAILURE : EXIT_SUCCESS);
+      return(EXIT_FAILURE);
+   }
+   if (cpd.do_check && (cpd.check_fail_cnt != 0))
+   {
+      return(EXIT_FAILURE);
    }
 
-   return((cpd.error_count != 0) ? EXIT_FAILURE : EXIT_SUCCESS);
+   return(EXIT_SUCCESS);
 } // main
 
 


### PR DESCRIPTION
If an error occurs when using the `--check` option, ensure that the return code
indicates a failure. This is important when uncrustify is run in a test that
inspects the return code to determine the test result.

For example, if the file passed to `-F` can't be read, or a file listed in that
file can't be read, then the return code should indicate a failure.