### PR TITLE
prevent underflow in parse_number on check for Hex, Octal, or Binary

### DIFF
--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -671,7 +671,7 @@ static bool parse_number(tok_ctx &ctx, chunk_t &pc)
    {
       int     ch;
       chunk_t pc_temp;
-      int     pc_length;
+      size_t  pc_length;
 
       pc.str.append(ctx.get());  /* store the '0' */
       // MS constant might have an "h" at the end. Look for it
@@ -682,7 +682,7 @@ static bool parse_number(tok_ctx &ctx, chunk_t &pc)
          pc_temp.str.append(ch);
       }
       pc_length = pc_temp.len();
-      ch        = pc_temp.str[pc_length - 1];
+      ch        = (pc_length > 0) ? pc_temp.str[pc_length - 1] : -1;
       ctx.restore();
       LOG_FMT(LGUY98, "%s:(%d)pc_temp:%s\n", __func__, __LINE__, pc_temp.text());
       if (ch == 'h')

--- a/src/unc_text.h
+++ b/src/unc_text.h
@@ -67,7 +67,7 @@ public:
 
 
    /* grab the number of characters */
-   size_t size() const
+   value_type::size_type size() const
    {
       return(m_chars.size());
    }

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -263,7 +263,7 @@ struct chunk_t
    }
 
 
-   int len()
+   size_t len()
    {
       return(str.size());
    }


### PR DESCRIPTION
pc_length = pc_temp.len(); ---> 0
ch        = pc_temp.str[pc_length - 1];

changes some length return types to size_t

--------------------------------------------

While figuring out if the [operator[]](https://github.com/uncrustify/uncrustify/blob/7f268aff6c652be6088fd619d5fccb05bb04f509/src/unc_text.h#L164) function in unc_text.h actually should or should not take in negative param values I set up a conditional breakpoint that triggers when [pc_length](https://github.com/uncrustify/uncrustify/blob/e4e0cc7515b26d464dc11f4d42e85aa88f9ce9e9/src/tokenize.cpp#L684) == 0 in parse_number in _tokenize.cpp_ while uncrustifying _uncrustify.cpp_. 

In `ch        = pc_temp.str[pc_length - 1];` 
`pc_length - 1` becomes -1 and underfloats the _size_t_ of [operator[]](https://github.com/uncrustify/uncrustify/blob/7f268aff6c652be6088fd619d5fccb05bb04f509/src/unc_text.h#L164) and the (idx < m_chars.size()) check returns false.

If the input type param of [operator[]](https://github.com/uncrustify/uncrustify/blob/7f268aff6c652be6088fd619d5fccb05bb04f509/src/unc_text.h#L164) is not _size_t_ but _int_ ( as it was before 7f268aff6c652be6088fd619d5fccb05bb04f509) the comparison of int(-1) and ulong(m_chars.size()) also returns false.

Seeing the comment 

> /* either just 0 or 0.1 or 0UL, etc */

 further down below in the parse_number function I get the feeling that the comparison of negative _int_ and _ulong_ was actually intended to return false, i.e. it was not a mere coincidence.

Still I think _size_t_ should be used here as it makes more clear what values are appropriate.