### PR TITLE
removes operator const char*() to prevent ambiguities

### DIFF
--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -167,7 +167,7 @@ void brace_cleanup(void)
       {
          cpd.consumed = false;
          parse_cleanup(&frm, pc);
-         print_stack(LBCSAFTER, (pc->type == CT_VBRACE_CLOSE) ? "Virt-}" : pc->str, &frm, pc);
+         print_stack(LBCSAFTER, (pc->type == CT_VBRACE_CLOSE) ? "Virt-}" : pc->str.c_str(), &frm, pc);
       }
       pc = chunk_get_next(pc);
    }

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1670,7 +1670,7 @@ static bool mark_function_type(chunk_t *pc)
               get_token_name(tmp->type), tmp->text(),
               tmp->orig_line, tmp->orig_col);
 
-      if (*tmp->str == '(')
+      if (*tmp->str.c_str() == '(')
       {
          if ((pc->flags & PCF_IN_TYPEDEF) == 0)
          {
@@ -2342,7 +2342,7 @@ static void fix_typedef(chunk_t *start)
             the_type = next;
          }
          chunk_flags_clr(next, PCF_VAR_1ST_DEF);
-         if (*next->str == '(')
+         if (*next->str.c_str() == '(')
          {
             last_op = next;
          }

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -471,12 +471,12 @@ void tokenize_cleanup(void)
 
       /* Look for <newline> 'EXEC' 'SQL' */
       if ((chunk_is_str(pc, "EXEC", 4) && chunk_is_str(next, "SQL", 3)) ||
-          ((*pc->str == '$') && (pc->type != CT_SQL_WORD)))
+          ((*pc->str.c_str() == '$') && (pc->type != CT_SQL_WORD)))
       {
          tmp = chunk_get_prev(pc);
          if (chunk_is_newline(tmp))
          {
-            if (*pc->str == '$')
+            if (*pc->str.c_str() == '$')
             {
                set_chunk_type(pc, CT_SQL_EXEC);
                if (pc->len() > 1)
@@ -518,7 +518,7 @@ void tokenize_cleanup(void)
                {
                   break;
                }
-               if ((tmp->len() > 0) && (unc_isalpha(*tmp->str) || (*tmp->str == '$')))
+               if ((tmp->len() > 0) && (unc_isalpha(*tmp->str.c_str()) || (*tmp->str.c_str() == '$')))
                {
                   set_chunk_type(tmp, CT_SQL_WORD);
                }
@@ -725,10 +725,10 @@ void tokenize_cleanup(void)
       /* Detect "pragma region" and "pragma endregion" */
       if ((pc->type == CT_PP_PRAGMA) && (next->type == CT_PREPROC_BODY))
       {
-         if ((memcmp(next->str, "region", 6) == 0) ||
-             (memcmp(next->str, "endregion", 9) == 0))
+         if ((memcmp(next->str.c_str(), "region", 6) == 0) ||
+             (memcmp(next->str.c_str(), "endregion", 9) == 0))
          {
-            set_chunk_type(pc, (*next->str == 'r') ? CT_PP_REGION : CT_PP_ENDREGION);
+            set_chunk_type(pc, (*next->str.c_str() == 'r') ? CT_PP_REGION : CT_PP_ENDREGION);
 
             set_chunk_parent(prev, pc->type);
          }

--- a/src/unc_text.h
+++ b/src/unc_text.h
@@ -141,11 +141,6 @@ public:
    /* get the UTF-8 string for logging */
    const char *c_str();
 
-   operator const char *()
-   {
-      return(c_str());
-   }
-
    static int compare(const unc_text &ref1, const unc_text &ref2, size_t len = 0);
    bool equals(const unc_text &ref) const;
 


### PR DESCRIPTION
Please merge only either this PR or PR #830 

-------------------

operator const char*() causes problems when combined with `operator[](size_t)`