### PR TITLE
using void for functions without parameters

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -21,13 +21,13 @@
 static chunk_t *align_var_def_brace(chunk_t *pc, size_t span, size_t *nl_count);
 static chunk_t *align_trailing_comments(chunk_t *start);
 static void align_init_brace(chunk_t *start);
-static void align_func_params();
+static void align_func_params(void);
 static void align_same_func_call_params();
 static void align_func_proto(int span);
 static void align_oc_msg_spec(int span);
 static void align_typedefs(int span);
 static void align_left_shift(void);
-static void align_oc_msg_colons();
+static void align_oc_msg_colons(void);
 static void align_oc_msg_colon(chunk_t *so);
 static void align_oc_decl_colon(void);
 static void align_asm_colon(void);
@@ -779,7 +779,7 @@ static chunk_t *align_func_param(chunk_t *start)
 } // align_func_param
 
 
-static void align_func_params()
+static void align_func_params(void)
 {
    LOG_FUNC_ENTRY();
    chunk_t *pc;
@@ -2125,7 +2125,7 @@ static void align_oc_msg_colon(chunk_t *so)
 /**
  * Aligns OC messages
  */
-static void align_oc_msg_colons()
+static void align_oc_msg_colons(void)
 {
    LOG_FUNC_ENTRY();
    chunk_t *pc;

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -5861,7 +5861,7 @@ static void handle_cs_array_type(chunk_t *pc)
 /**
  * Remove 'return;' that appears as the last statement in a function
  */
-void remove_extra_returns()
+void remove_extra_returns(void)
 {
    LOG_FUNC_ENTRY();
    chunk_t *pc;

--- a/src/detect.cpp
+++ b/src/detect.cpp
@@ -481,7 +481,7 @@ static void detect_space_options()
 /**
  * Call all the detect_xxxx() functions
  */
-void detect_options()
+void detect_options(void)
 {
    detect_space_options();
 }

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2407,7 +2407,7 @@ static void indent_comment(chunk_t *pc, int col)
 /**
  * Scan to see if the whole file is covered by one #ifdef
  */
-bool ifdef_over_whole_file()
+bool ifdef_over_whole_file(void)
 {
    LOG_FUNC_ENTRY();
    chunk_t *pc;

--- a/src/options_for_QT.cpp
+++ b/src/options_for_QT.cpp
@@ -57,7 +57,7 @@ void save_set_options_for_QT(int level)
 }
 
 
-void restore_options_for_QT()
+void restore_options_for_QT(void)
 {
    assert(cpd.settings[UO_use_options_overriding_for_qt_macros].b);
 

--- a/src/options_for_QT.h
+++ b/src/options_for_QT.h
@@ -21,6 +21,6 @@ extern int            QT_SIGNAL_SLOT_level;
 extern bool           restoreValues;
 
 void save_set_options_for_QT(int level);
-void restore_options_for_QT();
+void restore_options_for_QT(void);
 
 #endif /* OPTIONS_FOR_QT_H_INCLUDED */

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -31,7 +31,7 @@ const char *extension_add(const char *ext_text, const char *lang_text);
 /*
  * detect.cpp
  */
-void detect_options();
+void detect_options(void);
 
 
 /*
@@ -72,7 +72,7 @@ void indent_text(void);
 void indent_preproc(void);
 void indent_to_column(chunk_t *pc, int column);
 void align_to_column(chunk_t *pc, int column);
-bool ifdef_over_whole_file();
+bool ifdef_over_whole_file(void);
 void reindent_line(chunk_t *pc, int column);
 void quick_indent_again(void);
 
@@ -138,7 +138,7 @@ chunk_t *skip_tsquare_next(chunk_t *ary_def);
 chunk_t *skip_attribute_next(chunk_t *attr);
 chunk_t *skip_attribute_prev(chunk_t *fp_close);
 
-void remove_extra_returns();
+void remove_extra_returns(void);
 
 
 /*
@@ -236,7 +236,7 @@ void do_code_width(void);
  * lang_pawn.cpp
  */
 void pawn_prescan(void);
-void pawn_add_virtual_semicolons();
+void pawn_add_virtual_semicolons(void);
 chunk_t *pawn_check_vsemicolon(chunk_t *pc);
 void pawn_scrub_vsemi(void);
 chunk_t *pawn_add_vsemi_after(chunk_t *pc);
@@ -251,7 +251,7 @@ void print_universal_indent_cfg(FILE *pfile);
 /*
  * unicode.cpp
  */
-void write_bom();
+void write_bom(void);
 void write_char(int ch);
 void write_string(const unc_text &text);
 bool decode_unicode(const vector<UINT8> &in_data, deque<int> &out_data, CharEncoding &enc, bool &has_bom);

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -50,11 +50,11 @@ static int language_flags_from_filename(const char *filename);
 const char *language_name_from_flags(int lang);
 static bool read_stdin(file_mem &fm);
 static void uncrustify_start(const deque<int> &data);
-static void uncrustify_end();
+static void uncrustify_end(void);
 void uncrustify_file(const file_mem &fm, FILE *pfout, const char *parsed_file, bool defer_uncrustify_end = false);
 static void do_source_file(const char *filename_in, const char *filename_out, const char *parsed_file, bool no_backup, bool keep_mtime);
 static void process_source_list(const char *source_list, const char *prefix, const char *suffix, bool no_backup, bool keep_mtime);
-int load_header_files();
+int load_header_files(void);
 
 static const char *make_output_filename(char *buf, int buf_size, const char *filename, const char *prefix, const char *suffix);
 

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -460,7 +460,7 @@ static void write_utf16(int ch, bool be)
 }
 
 
-void write_bom()
+void write_bom(void)
 {
    switch (cpd.enc)
    {


### PR DESCRIPTION
A few functions that use no parameters had an empty paramter list.
I have made this explicitely by adding void. This makes the code more consistent.

For C++ this makes no functional difference. But for people like me who program in C for ages it makes a difference as an empty parameter list in C means the function accepts any number of parameters.
