### PR TITLE
fix compiler warnings

### DIFF
--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -507,7 +507,7 @@ chunk_t *chunk_get_prev_type(chunk_t *cur, c_token_t type,
       pc = chunk_get_prev(pc, nav);
       if (pc != NULL)
       {
-         LOG_FMT(LCHUNK, "%s(%d): pc: %s, type is %s, orig_line=%d, orig_col=%d\n",
+         LOG_FMT(LCHUNK, "%s(%d): pc: %s, type is %s, orig_line=%zd, orig_col=%zd\n",
                  __func__, __LINE__, pc->text(), get_token_name(pc->type), pc->orig_line, pc->orig_col);
       }
       if ((pc == NULL) ||

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -407,7 +407,7 @@ static void indent_pse_pop(struct parse_frame &frm, chunk_t *pc)
    {
       /* fatal error */
       fprintf(stderr, "the stack index is already zero\n");
-      fprintf(stderr, "at line=%d, type is %s\n",
+      fprintf(stderr, "at line=%zd, type is %s\n",
               pc->orig_line, get_token_name(pc->type));
       exit(EXIT_FAILURE);
    }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2126,7 +2126,7 @@ int save_option_file_kernel(FILE *pfile, bool withDoc, bool only_not_default)
 
    if (withDoc)
    {
-      fprintf(pfile, DOC_TEXT_END);
+      fprintf(pfile, "%s", DOC_TEXT_END);
    }
 
    /* Print custom keywords */
@@ -2198,7 +2198,7 @@ void print_options(FILE *pfile)
          fputs("\n\n", pfile);
       }
    }
-   fprintf(pfile, DOC_TEXT_END);
+   fprintf(pfile, "%s", DOC_TEXT_END);
 } // print_options
 
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -251,7 +251,7 @@ void output_parsed(FILE *pfile)
    fprintf(pfile, "# Line              Tag           Parent          Columns Br/Lvl/pp     Flag   Nl  Text");
    for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
    {
-      fprintf(pfile, "\n# %3d> %16.16s[%16.16s][%3d/%3lu/%3d/%3d][%lu/%lu/%lu][%10" PRIx64 "][%lu-%d]",
+      fprintf(pfile, "\n# %3zd> %16.16s[%16.16s][%3d/%3lu/%3d/%3d][%lu/%lu/%lu][%10" PRIx64 "][%lu-%d]",
               pc->orig_line, get_token_name(pc->type),
               get_token_name(pc->parent_type),
               pc->column, pc->orig_col, pc->orig_col_end, pc->orig_prev_sp,

--- a/src/unc_tools.cpp
+++ b/src/unc_tools.cpp
@@ -47,7 +47,7 @@ void prot_the_line(int theLine, unsigned int actual_line)
          }
          else
          {
-            LOG_FMT(LGUY, "(%d) orig_line=%d, text() %s, type %s, col=%d\n",
+            LOG_FMT(LGUY, "(%d) orig_line=%d, text() %s, type %s, col=%zd\n",
                     theLine, actual_line, pc->text(), get_token_name(pc->type), pc->orig_col);
          }
       }


### PR DESCRIPTION
With the change to use size_t the format specification (%d) may produce warnings and should be updated to specify a length modifier. I have used (%zd) per C99 standard. Also *printf functions without a string literal format string are considered a "potentially insecure" as the compiler warns. The remedy is to use "%s" as the format string and pass the string as the argument.