### PR TITLE
#870 reduced the scope of many variables, no functional change

### DIFF
--- a/src/ChunkStack.cpp
+++ b/src/ChunkStack.cpp
@@ -108,9 +108,8 @@ void ChunkStack::Zap(size_t idx)
 void ChunkStack::Collapse()
 {
    size_t wr_idx = 0;
-   size_t rd_idx;
 
-   for (rd_idx = 0; rd_idx < m_cse.size(); rd_idx++)
+   for (size_t rd_idx = 0; rd_idx < (int)m_cse.size(); rd_idx++)
    {
       if (m_cse[rd_idx].m_pc != NULL)
       {

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -805,13 +805,11 @@ static void align_func_params(void)
 static void align_params(chunk_t *start, deque<chunk_t *> &chunks)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc       = start;
-   bool    hit_comma = true;
+   bool hit_comma = true;
 
    chunks.clear();
 
-   pc = chunk_get_next_type(start, CT_FPAREN_OPEN, start->level);
-
+   chunk_t *pc = chunk_get_next_type(start, CT_FPAREN_OPEN, start->level);
    while ((pc = chunk_get_next(pc)) != NULL)
    {
       if (chunk_is_newline(pc) ||
@@ -1639,8 +1637,7 @@ static void align_log_al(log_sev_t sev, size_t line)
    if (log_sev_on(sev))
    {
       log_fmt(sev, "%s: line %lu, %lu)", __func__, line, cpd.al_cnt);
-      size_t idx;
-      for (idx = 0; idx < cpd.al_cnt; idx++)
+      for (size_t idx = 0; idx < cpd.al_cnt; idx++)
       {
          log_fmt(sev, " %lu/%lu=%s", cpd.al[idx].col, cpd.al[idx].len,
                  get_token_name(cpd.al[idx].type));

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -205,15 +205,12 @@ static void align_add(ChunkStack &cs, chunk_t *pc, size_t &max_col, size_t min_p
 void quick_align_again(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t    *pc;
-   chunk_t    *tmp;
-   AlignStack as;
-
    LOG_FMT(LALAGAIN, "%s:\n", __func__);
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
    {
       if ((pc->align.next != NULL) && (pc->flags & PCF_ALIGN_START))
       {
+         AlignStack as;
          as.Start(100, 0);
          as.m_right_align = pc->align.right_align;
          as.m_star_style  = (AlignStack::StarStyle)pc->align.star_style;
@@ -223,7 +220,7 @@ void quick_align_again(void)
          LOG_FMT(LALAGAIN, "   [%s:%lu]", pc->text(), pc->orig_line);
          as.Add(pc->align.start);
          chunk_flags_set(pc, PCF_WAS_ALIGNED);
-         for (tmp = pc->align.next; tmp != NULL; tmp = tmp->align.next)
+         for (chunk_t *tmp = pc->align.next; tmp != NULL; tmp = tmp->align.next)
          {
             chunk_flags_set(tmp, PCF_WAS_ALIGNED);
             as.Add(tmp->align.start);
@@ -239,14 +236,12 @@ void quick_align_again(void)
 void quick_indent_again(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
-   chunk_t *tmp;
 
-   for (pc = chunk_get_head(); pc; pc = chunk_get_next(pc))
+   for (chunk_t *pc = chunk_get_head(); pc; pc = chunk_get_next(pc))
    {
       if (pc->indent.ref)
       {
-         tmp = chunk_get_prev(pc);
+         chunk_t *tmp = chunk_get_prev(pc);
          if (chunk_is_newline(tmp))
          {
             int col = pc->indent.ref->column + pc->indent.delta;
@@ -344,13 +339,12 @@ void align_all(void)
 static void align_oc_msg_spec(int span)
 {
    LOG_FUNC_ENTRY();
-   chunk_t    *pc;
-   AlignStack as;
-
    LOG_FMT(LALIGN, "%s\n", __func__);
+
+   AlignStack as;
    as.Start(span, 0);
 
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
    {
       if (chunk_is_newline(pc))
       {
@@ -372,9 +366,7 @@ static void align_oc_msg_spec(int span)
 void align_backslash_newline(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
-
-   pc = chunk_get_head();
+   chunk_t *pc = chunk_get_head();
    while (pc != NULL)
    {
       if (pc->type != CT_NL_CONT)
@@ -390,11 +382,9 @@ void align_backslash_newline(void)
 void align_right_comments(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
-   chunk_t *prev;
-   bool    skip;
+   bool skip;
 
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
    {
       if ((pc->type == CT_COMMENT) ||
           (pc->type == CT_COMMENT_CPP) ||
@@ -403,7 +393,7 @@ void align_right_comments(void)
          skip = false;
          if (pc->parent_type == CT_COMMENT_END)
          {
-            prev = chunk_get_prev(pc);
+            chunk_t *prev = chunk_get_prev(pc);
             if (pc->orig_col < (prev->orig_col_end + cpd.settings[UO_align_right_cmt_gap].n))
             {
                LOG_FMT(LALTC, "NOT changing END comment on line %lu (%lu <= %d + %d)\n",
@@ -436,7 +426,7 @@ void align_right_comments(void)
       }
    }
 
-   pc = chunk_get_head();
+   chunk_t *pc = chunk_get_head();
    while (pc != NULL)
    {
       if (pc->flags & PCF_RIGHT_COMMENT)
@@ -457,9 +447,7 @@ void align_right_comments(void)
 void align_struct_initializers(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
-
-   pc = chunk_get_head();
+   chunk_t *pc = chunk_get_head();
    while (pc != NULL)
    {
       chunk_t *prev = chunk_get_prev_ncnl(pc);
@@ -480,18 +468,18 @@ void align_struct_initializers(void)
 void align_preprocessor(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t    *pc;
+
    AlignStack as;    // value macros
-   AlignStack asf;   // function macros
    AlignStack *cur_as = &as;
 
    as.Start(cpd.settings[UO_align_pp_define_span].n);
    as.m_gap = cpd.settings[UO_align_pp_define_gap].n;
 
+   AlignStack asf;   // function macros
    asf.Start(cpd.settings[UO_align_pp_define_span].n);
    asf.m_gap = cpd.settings[UO_align_pp_define_gap].n;
 
-   pc = chunk_get_head();
+   chunk_t *pc = chunk_get_head();
    while (pc != NULL)
    {
       /* Note: not counting back-slash newline combos */
@@ -567,11 +555,10 @@ void align_preprocessor(void)
 chunk_t *align_assign(chunk_t *first, int span, int thresh)
 {
    LOG_FUNC_ENTRY();
-   size_t  my_level;
-   chunk_t *pc;
-   size_t  tmp;
-   int     var_def_cnt = 0;
-   int     equ_count   = 0;
+   size_t my_level;
+   size_t tmp;
+   int    var_def_cnt = 0;
+   int    equ_count   = 0;
 
    if (first == NULL)
    {
@@ -597,7 +584,7 @@ chunk_t *align_assign(chunk_t *first, int span, int thresh)
    vdas.Start(span, thresh);
    vdas.m_right_align = as.m_right_align;
 
-   pc = first;
+   chunk_t *pc = first;
    while ((pc != NULL) && ((pc->level >= my_level) || (pc->level == 0)))
    {
       /* Don't check inside PAREN or SQUARE groups */
@@ -722,18 +709,18 @@ int count_prev_ptr_type(chunk_t *pc)
 static chunk_t *align_func_param(chunk_t *start)
 {
    LOG_FUNC_ENTRY();
-   AlignStack as;
-   chunk_t    *pc = start;
 
+   AlignStack as;
    as.Start(2, 0);
 
    as.m_star_style = (AlignStack::StarStyle)cpd.settings[UO_align_var_def_star_style].n;
    as.m_amp_style  = (AlignStack::StarStyle)cpd.settings[UO_align_var_def_amp_style].n;
 
-   bool did_this_line = false;
-   int  comma_count   = 0;
-   int  chunk_count   = 0;
+   bool    did_this_line = false;
+   int     comma_count   = 0;
+   int     chunk_count   = 0;
 
+   chunk_t *pc = start;
    while ((pc = chunk_get_next(pc)) != NULL)
    {
       chunk_count++;
@@ -781,9 +768,7 @@ static chunk_t *align_func_param(chunk_t *start)
 static void align_func_params(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
-
-   pc = chunk_get_head();
+   chunk_t *pc = chunk_get_head();
    while ((pc = chunk_get_next(pc)) != NULL)
    {
       if ((pc->type != CT_FPAREN_OPEN) ||
@@ -848,7 +833,6 @@ static void align_same_func_call_params()
    deque<chunk_t *>  chunks;
    deque<AlignStack> as;
    AlignStack        fcn_as;
-   size_t            idx;
    const char        *add_str;
 
    fcn_as.Start(3);
@@ -859,7 +843,7 @@ static void align_same_func_call_params()
       {
          if (chunk_is_newline(pc))
          {
-            for (idx = 0; idx < as.size(); idx++)
+            for (size_t idx = 0; idx < as.size(); idx++)
             {
                as[idx].NewLines(pc->nl_count);
             }
@@ -874,7 +858,7 @@ static void align_same_func_call_params()
 
                /* Flush it all! */
                fcn_as.Flush();
-               for (idx = 0; idx < as.size(); idx++)
+               for (size_t idx = 0; idx < as.size(); idx++)
                {
                   as[idx].Flush();
                }
@@ -938,7 +922,7 @@ static void align_same_func_call_params()
 
             /* Flush it all! */
             fcn_as.Flush();
-            for (idx = 0; idx < as.size(); idx++)
+            for (size_t idx = 0; idx < as.size(); idx++)
             {
                as[idx].Flush();
             }
@@ -963,7 +947,7 @@ static void align_same_func_call_params()
          align_params(pc, chunks);
          LOG_FMT(LASFCP, " %d items:", (int)chunks.size());
 
-         for (idx = 0; idx < chunks.size(); idx++)
+         for (size_t idx = 0; idx < chunks.size(); idx++)
          {
             LOG_FMT(LASFCP, " [%s]", chunks[idx]->text());
             if (idx >= as.size())
@@ -991,7 +975,7 @@ static void align_same_func_call_params()
    {
       LOG_FMT(LASFCP, "  ++ Ended with %d fcns\n", align_len);
       fcn_as.End();
-      for (idx = 0; idx < as.size(); idx++)
+      for (size_t idx = 0; idx < as.size(); idx++)
       {
          as[idx].End();
       }
@@ -1020,22 +1004,22 @@ chunk_t *step_back_over_member(chunk_t *pc)
 static void align_func_proto(int span)
 {
    LOG_FUNC_ENTRY();
-   chunk_t    *pc;
-   chunk_t    *toadd;
-   bool       look_bro = false;
-   AlignStack as;
-   AlignStack as_br;
+   chunk_t *toadd;
+   bool    look_bro = false;
 
    LOG_FMT(LALIGN, "%s\n", __func__);
+
+   AlignStack as;
    as.Start(span, 0);
    as.m_gap        = cpd.settings[UO_align_func_proto_gap].n;
    as.m_star_style = (AlignStack::StarStyle)cpd.settings[UO_align_var_def_star_style].n;
    as.m_amp_style  = (AlignStack::StarStyle)cpd.settings[UO_align_var_def_amp_style].n;
 
+   AlignStack as_br;
    as_br.Start(span, 0);
    as_br.m_gap = cpd.settings[UO_align_single_line_brace_gap].n;
 
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
    {
       if (chunk_is_newline(pc))
       {
@@ -1081,19 +1065,14 @@ static void align_func_proto(int span)
 static chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
 {
    LOG_FUNC_ENTRY();
-   chunk_t    *pc;
-   chunk_t    *next;
-   chunk_t    *prev;
-   UINT64     align_mask = PCF_IN_FCN_DEF | PCF_VAR_1ST;
-   int        myspan     = span;
-   int        mythresh   = 0;
-   int        mygap      = 0;
-   AlignStack as;    /* var/proto/def */
-   AlignStack as_bc; /* bit-colon */
-   AlignStack as_at; /* attribute */
-   AlignStack as_br; /* one-liner brace open */
-   bool       fp_active   = cpd.settings[UO_align_mix_var_proto].b;
-   bool       fp_look_bro = false;
+   chunk_t *next;
+   chunk_t *prev;
+   UINT64  align_mask  = PCF_IN_FCN_DEF | PCF_VAR_1ST;
+   int     myspan      = span;
+   int     mythresh    = 0;
+   int     mygap       = 0;
+   bool    fp_active   = cpd.settings[UO_align_mix_var_proto].b;
+   bool    fp_look_bro = false;
 
 
    if (start == NULL)
@@ -1128,7 +1107,7 @@ static chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_co
       LOG_FMT(LAVDB, "%s: start=%s [%s] on line %lu (abort due to assign)\n", __func__,
               start->text(), get_token_name(start->type), start->orig_line);
 
-      pc = chunk_get_next_type(start, CT_BRACE_CLOSE, start->level);
+      chunk_t *pc = chunk_get_next_type(start, CT_BRACE_CLOSE, start->level);
       return(chunk_get_next_ncnl(pc));
    }
 
@@ -1141,23 +1120,27 @@ static chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_co
    }
 
    /* Set up the var/proto/def aligner */
+   AlignStack as;
    as.Start(myspan, mythresh);
    as.m_gap        = mygap;
    as.m_star_style = (AlignStack::StarStyle)cpd.settings[UO_align_var_def_star_style].n;
    as.m_amp_style  = (AlignStack::StarStyle)cpd.settings[UO_align_var_def_amp_style].n;
 
    /* Set up the bit colon aligner */
+   AlignStack as_bc;
    as_bc.Start(myspan, 0);
    as_bc.m_gap = cpd.settings[UO_align_var_def_colon_gap].n;
 
+   AlignStack as_at; /* attribute */
    as_at.Start(myspan, 0);
 
    /* Set up the brace open aligner */
+   AlignStack as_br;
    as_br.Start(myspan, mythresh);
    as_br.m_gap = cpd.settings[UO_align_single_line_brace_gap].n;
 
-   bool did_this_line = false;
-   pc = chunk_get_next(start);
+   bool    did_this_line = false;
+   chunk_t *pc           = chunk_get_next(start);
    while ((pc != NULL) && ((pc->level >= start->level) || (pc->level == 0)))
    {
       LOG_FMT(LGUY, "%s: pc->text()=%s, pc->orig_line=%lu, pc->orig_col=%lu\n",
@@ -1335,14 +1318,13 @@ chunk_t *align_nl_cont(chunk_t *start)
 {
    LOG_FUNC_ENTRY();
    size_t     max_col = 0;
-   chunk_t    *pc     = start;
-   chunk_t    *tmp;
    ChunkStack cs;
 
    LOG_FMT(LALNLC, "%s: start on [%s] on line %lu\n", __func__,
            get_token_name(start->type), start->orig_line);
 
    /* Find the max column */
+   chunk_t *pc = start;
    while ((pc != NULL) &&
           (pc->type != CT_NEWLINE) &&
           (pc->type != CT_COMMENT_MULTI))
@@ -1355,6 +1337,7 @@ chunk_t *align_nl_cont(chunk_t *start)
    }
 
    /* NL_CONT is always the last thing on a line */
+   chunk_t *tmp;
    while ((tmp = cs.Pop_Back()) != NULL)
    {
       chunk_flags_set(tmp, PCF_WAS_ALIGNED);
@@ -1426,8 +1409,7 @@ chunk_t *align_trailing_comments(chunk_t *start)
 
    cmt_type_start = get_comment_align_type(pc);
 
-   LOG_FMT(LALADD, "%s: start on line=%lu\n",
-           __func__, pc->orig_line);
+   LOG_FMT(LALADD, "%s: start on line=%lu\n", __func__, pc->orig_line);
 
    /* Find the max column */
    while ((pc != NULL) && (nl_count < cpd.settings[UO_align_right_cmt_span].u))
@@ -1537,12 +1519,11 @@ static chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
    LOG_FUNC_ENTRY();
    chunk_t *pc;
    chunk_t *prev_match = NULL;
-   chunk_t *tmp;
    size_t  token_width;
    size_t  idx = 0;
 
    /* Skip past C99 "[xx] =" stuff */
-   tmp = skip_c99_array(start);
+   chunk_t *tmp = skip_c99_array(start);
    if (tmp)
    {
       set_chunk_parent(start, CT_TSQUARE);
@@ -1683,7 +1664,6 @@ static void align_init_brace(chunk_t *start)
 {
    LOG_FUNC_ENTRY();
    size_t  idx;
-   chunk_t *pc;
    chunk_t *next;
    chunk_t *prev;
    chunk_t *tmp;
@@ -1694,7 +1674,7 @@ static void align_init_brace(chunk_t *start)
 
    LOG_FMT(LALBR, "%s: start @ %lu:%lu\n", __func__, start->orig_line, start->orig_col);
 
-   pc = chunk_get_next_ncnl(start);
+   chunk_t *pc = chunk_get_next_ncnl(start);
    pc = scan_ib_line(pc, true);
    if ((pc == NULL) || ((pc->type == CT_BRACE_CLOSE) &&
                         (pc->parent_type == CT_ASSIGN)))
@@ -1846,16 +1826,15 @@ static void align_init_brace(chunk_t *start)
 static void align_typedefs(size_t span)
 {
    LOG_FUNC_ENTRY();
-   chunk_t    *pc;
-   chunk_t    *c_typedef = NULL;
-   AlignStack as;
 
+   AlignStack as;
    as.Start(span);
    as.m_gap        = cpd.settings[UO_align_typedef_gap].u;
    as.m_star_style = (AlignStack::StarStyle)cpd.settings[UO_align_typedef_star_style].u;
    as.m_amp_style  = (AlignStack::StarStyle)cpd.settings[UO_align_typedef_amp_style].u;
 
-   pc = chunk_get_head();
+   chunk_t *c_typedef = NULL;
+   chunk_t *pc        = chunk_get_head();
    while (pc != NULL)
    {
       if (chunk_is_newline(pc))
@@ -1895,13 +1874,11 @@ static void align_typedefs(size_t span)
 static void align_left_shift(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t    *pc;
    chunk_t    *start = NULL;
    AlignStack as;
-
    as.Start(255);
 
-   pc = chunk_get_head();
+   chunk_t *pc = chunk_get_head();
    while (pc != NULL)
    {
       if ((start != NULL) &&
@@ -1994,28 +1971,21 @@ static void align_left_shift(void)
 static void align_oc_msg_colon(chunk_t *so)
 {
    LOG_FUNC_ENTRY();
-   int        span = cpd.settings[UO_align_oc_msg_colon_span].n;
-   chunk_t    *pc;
-   chunk_t    *tmp;
-   AlignStack cas;   /* for the colons */
+
    AlignStack nas;   /* for the parameter tag */
-   size_t     level;
-   bool       did_line;
-   int        lcnt;  /* line count with no colon for span */
-   bool       has_colon;
-
-
    nas.Reset();
    nas.m_right_align = !cpd.settings[UO_align_on_tabstop].b;
 
+   AlignStack cas;   /* for the colons */
+   int        span = cpd.settings[UO_align_oc_msg_colon_span].n;
    cas.Start(span);
 
-   level = so->level;
-   pc    = chunk_get_next_ncnl(so, CNAV_PREPROC);
+   size_t  level = so->level;
+   chunk_t *pc   = chunk_get_next_ncnl(so, CNAV_PREPROC);
 
-   did_line  = false;
-   has_colon = false;
-   lcnt      = 0;
+   bool    did_line  = false;
+   bool    has_colon = false;
+   int     lcnt      = 0; /* line count with no colon for span */
 
    while ((pc != NULL) && (pc->level > level))
    {
@@ -2036,7 +2006,7 @@ static void align_oc_msg_colon(chunk_t *so)
       {
          has_colon = true;
          cas.Add(pc);
-         tmp = chunk_get_prev(pc);
+         chunk_t *tmp = chunk_get_prev(pc);
          if ((tmp != NULL) &&
              ((tmp->type == CT_OC_MSG_FUNC) ||
               (tmp->type == CT_OC_MSG_NAME)))
@@ -2053,19 +2023,16 @@ static void align_oc_msg_colon(chunk_t *so)
    cas.m_skip_first = !cpd.settings[UO_align_oc_msg_colon_first].b;
 
    /* find the longest args that isn't the first one */
-   int     idx;
-   int     len;
    int     first_len = 0;
-   int     len_diff;
-   int     mlen        = 0;
-   int     indent_size = cpd.settings[UO_indent_columns].n;
-   chunk_t *longest    = NULL;
+   int     mlen      = 0;
+   chunk_t *longest  = NULL;
 
-   for (idx = 0, len = nas.m_aligned.Len(); idx < len; idx++)
+   size_t  len = nas.m_aligned.Len();
+   for (size_t idx = 0; idx < len; idx++)
    {
-      tmp = nas.m_aligned.GetChunk(idx);
+      chunk_t *tmp = nas.m_aligned.GetChunk(idx);
 
-      int tlen = tmp->str.size();
+      int     tlen = tmp->str.size();
       if (tlen > mlen)
       {
          mlen = tlen;
@@ -2081,8 +2048,9 @@ static void align_oc_msg_colon(chunk_t *so)
    }
 
    /* add spaces before the longest arg */
-   len      = cpd.settings[UO_indent_oc_msg_colon].n;
-   len_diff = mlen - first_len;
+   len = cpd.settings[UO_indent_oc_msg_colon].n;
+   int len_diff    = mlen - first_len;
+   int indent_size = cpd.settings[UO_indent_columns].n;
    /* Align with first colon if possible by removing spaces */
    if (longest &&
        cpd.settings[UO_indent_oc_msg_prioritize_first_colon].b &&
@@ -2103,7 +2071,7 @@ static void align_oc_msg_colon(chunk_t *so)
       chunk.flags       = longest->flags & PCF_COPY_FLAGS;
 
       /* start at one since we already indent for the '[' */
-      for (idx = 1; idx < len; idx++)
+      for (int idx = 1; idx < len; idx++)
       {
          chunk.str.append(' ');
       }
@@ -2121,9 +2089,8 @@ static void align_oc_msg_colon(chunk_t *so)
 static void align_oc_msg_colons(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
 
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
    {
       if ((pc->type == CT_SQUARE_OPEN) && (pc->parent_type == CT_OC_MSG))
       {
@@ -2141,18 +2108,15 @@ static void align_oc_msg_colons(void)
 static void align_oc_decl_colon(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t    *pc = chunk_get_head();
-   chunk_t    *tmp;
-   chunk_t    *tmp2;
-   AlignStack cas;   /* for the colons */
-   AlignStack nas;   /* for the parameter label */
-   size_t     level;
    bool       did_line;
 
+   AlignStack cas;   /* for the colons */
+   AlignStack nas;   /* for the parameter label */
    cas.Start(4);
    nas.Start(4);
    nas.m_right_align = !cpd.settings[UO_align_on_tabstop].b;
 
+   chunk_t *pc = chunk_get_head();
    while (pc != NULL)
    {
       if (pc->type != CT_OC_SCOPE)
@@ -2164,8 +2128,8 @@ static void align_oc_decl_colon(void)
       nas.Reset();
       cas.Reset();
 
-      level = pc->level;
-      pc    = chunk_get_next_ncnl(pc, CNAV_PREPROC);
+      size_t level = pc->level;
+      pc = chunk_get_next_ncnl(pc, CNAV_PREPROC);
 
       did_line = false;
 
@@ -2187,8 +2151,8 @@ static void align_oc_decl_colon(void)
          {
             cas.Add(pc);
 
-            tmp  = chunk_get_prev(pc, CNAV_PREPROC);
-            tmp2 = chunk_get_prev_ncnl(tmp, CNAV_PREPROC);
+            chunk_t *tmp  = chunk_get_prev(pc, CNAV_PREPROC);
+            chunk_t *tmp2 = chunk_get_prev_ncnl(tmp, CNAV_PREPROC);
 
             /* Check for an un-labeled parameter */
             if ((tmp != NULL) &&
@@ -2227,13 +2191,12 @@ static void align_oc_decl_colon(void)
 static void align_asm_colon(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t    *pc = chunk_get_head();
-   AlignStack cas;   /* for the colons */
-   size_t     level;
    bool       did_nl;
 
+   AlignStack cas;   /* for the colons */
    cas.Start(4);
 
+   chunk_t *pc = chunk_get_head();
    while (pc != NULL)
    {
       if (pc->type != CT_ASM_COLON)
@@ -2244,8 +2207,8 @@ static void align_asm_colon(void)
 
       cas.Reset();
 
-      pc     = chunk_get_next_ncnl(pc, CNAV_PREPROC);
-      level  = pc ? pc->level : 0;
+      pc = chunk_get_next_ncnl(pc, CNAV_PREPROC);
+      size_t level = pc ? pc->level : 0;
       did_nl = true;
       while (pc && (pc->level >= level))
       {

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -123,7 +123,6 @@ static void align_asm_colon(void);
 static void align_stack(ChunkStack &cs, int col, bool align_single, log_sev_t sev)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
 
    if (cpd.settings[UO_align_on_tabstop].b)
    {
@@ -133,6 +132,7 @@ static void align_stack(ChunkStack &cs, int col, bool align_single, log_sev_t se
    if ((cs.Len() > 1) || (align_single && (cs.Len() == 1)))
    {
       LOG_FMT(sev, "%s: max_col=%d\n", __func__, col);
+      chunk_t *pc;
       while ((pc = cs.Pop_Back()) != NULL)
       {
          align_to_column(pc, col);
@@ -458,12 +458,11 @@ void align_struct_initializers(void)
 {
    LOG_FUNC_ENTRY();
    chunk_t *pc;
-   chunk_t *prev;
 
    pc = chunk_get_head();
    while (pc != NULL)
    {
-      prev = chunk_get_prev_ncnl(pc);
+      chunk_t *prev = chunk_get_prev_ncnl(pc);
       if ((prev != NULL) && (prev->type == CT_ASSIGN) &&
           ((pc->type == CT_BRACE_OPEN) ||
            ((cpd.lang_flags & LANG_D) && (pc->type == CT_SQUARE_OPEN))))
@@ -1539,7 +1538,6 @@ static chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
    (void)first_pass;
    LOG_FUNC_ENTRY();
    chunk_t *pc;
-   chunk_t *next;
    chunk_t *prev_match = NULL;
    chunk_t *tmp;
    size_t  token_width;
@@ -1567,7 +1565,7 @@ static chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
       //LOG_FMT(LSIB, "%s:     '%s'   col %d/%d line %lu\n", __func__,
       //        pc->text(), pc->column, pc->orig_col, pc->orig_line);
 
-      next = chunk_get_next(pc);
+      chunk_t *next = chunk_get_next(pc);
       if ((next == NULL) || chunk_is_comment(next))
       {
          /* do nothing */
@@ -1638,12 +1636,10 @@ static chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
 
 static void align_log_al(log_sev_t sev, size_t line)
 {
-   size_t idx;
-
    if (log_sev_on(sev))
    {
-      log_fmt(sev, "%s: line %lu, %lu)",
-              __func__, line, cpd.al_cnt);
+      log_fmt(sev, "%s: line %lu, %lu)", __func__, line, cpd.al_cnt);
+      size_t idx;
       for (idx = 0; idx < cpd.al_cnt; idx++)
       {
          log_fmt(sev, " %lu/%lu=%s", cpd.al[idx].col, cpd.al[idx].len,
@@ -2064,7 +2060,6 @@ static void align_oc_msg_colon(chunk_t *so)
    int     len;
    int     first_len = 0;
    int     len_diff;
-   int     tlen;
    int     mlen        = 0;
    int     indent_size = cpd.settings[UO_indent_columns].n;
    chunk_t *longest    = NULL;
@@ -2073,7 +2068,7 @@ static void align_oc_msg_colon(chunk_t *so)
    {
       tmp = nas.m_aligned.GetChunk(idx);
 
-      tlen = tmp->str.size();
+      int tlen = tmp->str.size();
       if (tlen > mlen)
       {
          mlen = tlen;

--- a/src/align_stack.cpp
+++ b/src/align_stack.cpp
@@ -334,8 +334,7 @@ void AlignStack::NewLines(size_t cnt)
 void AlignStack::Flush()
 {
    size_t                  last_seqnum = 0;
-   size_t                  idx;
-   const ChunkStack::Entry *ce = NULL;
+   const ChunkStack::Entry *ce         = NULL;
    chunk_t                 *pc;
 
    LOG_FMT(LAS, "%s: m_aligned.Len()=%lu\n", __func__, m_aligned.Len());
@@ -359,7 +358,7 @@ void AlignStack::Flush()
    m_max_col    = 0;
 
    /* Recalculate the max_col - it may have shifted since the last Add() */
-   for (idx = 0; idx < m_aligned.Len(); idx++)
+   for (size_t idx = 0; idx < m_aligned.Len(); idx++)
    {
       pc = m_aligned.Get(idx)->m_pc;
 
@@ -416,7 +415,7 @@ void AlignStack::Flush()
 
    LOG_FMT(LAS, "%s: m_aligned.Len()=%lu\n",
            __func__, m_aligned.Len());
-   for (idx = 0; idx < m_aligned.Len(); idx++)
+   for (size_t idx = 0; idx < m_aligned.Len(); idx++)
    {
       ce = m_aligned.Get(idx);
       pc = ce->m_pc;
@@ -465,7 +464,7 @@ void AlignStack::Flush()
    else
    {
       /* Remove all items with seqnum < last_seqnum */
-      for (idx = 0; idx < m_skipped.Len(); idx++)
+      for (size_t idx = 0; idx < m_skipped.Len(); idx++)
       {
          if (m_skipped.Get(idx)->m_seqnum < last_seqnum)
          {

--- a/src/align_stack.cpp
+++ b/src/align_stack.cpp
@@ -48,12 +48,10 @@ void AlignStack::ReAddSkipped()
       m_scratch.Set(m_skipped);
       m_skipped.Reset();
 
-      const ChunkStack::Entry *ce;
-
       /* Need to add them in order so that m_nl_seqnum is correct */
       for (size_t idx = 0; idx < m_scratch.Len(); idx++)
       {
-         ce = m_scratch.Get(idx);
+         const ChunkStack::Entry *ce = m_scratch.Get(idx);
          LOG_FMT(LAS, "ReAddSkipped [%lu] - ", ce->m_seqnum);
          Add(ce->m_pc, ce->m_seqnum);
       }
@@ -81,14 +79,8 @@ void AlignStack::Add(chunk_t *start, size_t seqnum)
 
    chunk_t *ali;
    chunk_t *ref;
-   chunk_t *tmp;
    chunk_t *prev;
    chunk_t *next;
-
-   size_t  col_adj = 0; /* Amount the column is shifted for 'dangle' mode */
-   size_t  tmp_col;
-   size_t  endcol;
-   size_t  gap;
 
    m_last_added = 0;
 
@@ -210,11 +202,12 @@ void AlignStack::Add(chunk_t *start, size_t seqnum)
          }
       }
 
+      chunk_t *tmp;
       /* Tighten down the spacing between ref and start */
       if (!cpd.settings[UO_align_keep_extra_space].b)
       {
-         tmp_col = ref->column;
-         tmp     = ref;
+         size_t tmp_col = ref->column;
+         tmp = ref;
          while (tmp != start)
          {
             next     = chunk_get_next(tmp);
@@ -228,8 +221,8 @@ void AlignStack::Add(chunk_t *start, size_t seqnum)
       }
 
       /* Set the column adjust and gap */
-      col_adj = 0;
-      gap     = 0;
+      size_t col_adj = 0; /* Amount the column is shifted for 'dangle' mode */
+      size_t gap     = 0;
       if (ref != ali)
       {
          gap = ali->column - (ref->column + ref->len());
@@ -248,7 +241,7 @@ void AlignStack::Add(chunk_t *start, size_t seqnum)
       }
 
       /* See if this pushes out the max_col */
-      endcol = ali->column + col_adj;
+      size_t endcol = ali->column + col_adj;
       if (gap < m_gap)
       {
          endcol += m_gap - gap;
@@ -342,7 +335,6 @@ void AlignStack::Flush()
 {
    size_t                  last_seqnum = 0;
    size_t                  idx;
-   size_t                  tmp_col;
    const ChunkStack::Entry *ce = NULL;
    chunk_t                 *pc;
 
@@ -429,7 +421,7 @@ void AlignStack::Flush()
       ce = m_aligned.Get(idx);
       pc = ce->m_pc;
 
-      tmp_col = m_max_col - pc->align.col_adj;
+      size_t tmp_col = m_max_col - pc->align.col_adj;
       if (idx == 0)
       {
          if (m_skip_first && (pc->column != tmp_col))

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -50,8 +50,7 @@ bool Args::Present(const char *token)
 {
    if (token != NULL)
    {
-      int idx;
-      for (idx = 0; idx < m_count; idx++)
+      for (int idx = 0; idx < m_count; idx++)
       {
          if (strcmp(token, m_values[idx]) == 0)
          {
@@ -93,8 +92,7 @@ const char *Args::Params(const char *token, int &index)
 
    int token_len = (int)strlen(token);
 
-   int idx;
-   for (idx = index; idx < m_count; idx++)
+   for (int idx = index; idx < m_count; idx++)
    {
       int arg_len = (int)strlen(m_values[idx]);
 
@@ -165,14 +163,12 @@ void Args::SetUsed(int idx)
  */
 const char *Args::Unused(int &index)
 {
-   int idx;
-
    if (m_used == NULL)
    {
       return(NULL);
    }
 
-   for (idx = index; idx < m_count; idx++)
+   for (int idx = index; idx < m_count; idx++)
    {
       if (!GetUsed(idx))
       {

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -48,10 +48,9 @@ Args::~Args()
  */
 bool Args::Present(const char *token)
 {
-   int idx;
-
    if (token != NULL)
    {
+      int idx;
       for (idx = 0; idx < m_count; idx++)
       {
          if (strcmp(token, m_values[idx]) == 0)
@@ -61,7 +60,6 @@ bool Args::Present(const char *token)
          }
       }
    }
-
    return(false);
 }
 
@@ -88,20 +86,17 @@ const char *Args::Param(const char *token)
  */
 const char *Args::Params(const char *token, int &index)
 {
-   int idx;
-   int token_len;
-   int arg_len;
-
    if (token == NULL)
    {
       return(NULL);
    }
 
-   token_len = (int)strlen(token);
+   int token_len = (int)strlen(token);
 
+   int idx;
    for (idx = index; idx < m_count; idx++)
    {
-      arg_len = (int)strlen(m_values[idx]);
+      int arg_len = (int)strlen(m_values[idx]);
 
       if ((arg_len >= token_len) &&
           (memcmp(token, m_values[idx], token_len) == 0))

--- a/src/backup.cpp
+++ b/src/backup.cpp
@@ -38,7 +38,6 @@
 int backup_copy_file(const char *filename, const vector<UINT8> &data)
 {
    char  newpath[1024];
-   char  buffer[128];
    char  md5_str_in[33];
    char  md5_str[33];
    UINT8 dig[16];
@@ -59,6 +58,7 @@ int backup_copy_file(const char *filename, const vector<UINT8> &data)
    FILE *thefile = fopen(newpath, "rb");
    if (thefile != NULL)
    {
+      char buffer[128];
       if (fgets(buffer, sizeof(buffer), thefile) != NULL)
       {
          for (int i = 0; buffer[i] != 0; i++)

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -110,7 +110,6 @@ void brace_cleanup(void)
    LOG_FUNC_ENTRY();
    chunk_t            *pc;
    struct parse_frame frm;
-   int                pp_level;
 
    cpd.unc_stage = US_BRACE_CLEANUP;
 
@@ -136,7 +135,7 @@ void brace_cleanup(void)
       }
 
       /* Check for a preprocessor start */
-      pp_level = cpd.pp_level;
+      int pp_level = cpd.pp_level;
       if (pc->type == CT_PREPROC)
       {
          pp_level = preproc_start(&frm, pc);
@@ -287,7 +286,6 @@ static void parse_cleanup(struct parse_frame *frm, chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
    c_token_t parent = CT_NONE;
-   chunk_t   *prev;
 
    LOG_FMT(LTOK, "%s:%lu] %16s - tos:%d/%16s stg:%d\n",
            __func__, pc->orig_line, get_token_name(pc->type),
@@ -478,7 +476,7 @@ static void parse_cleanup(struct parse_frame *frm, chunk_t *pc)
        (pc->type == CT_SPAREN_OPEN) ||
        (pc->type == CT_BRACE_OPEN))
    {
-      prev = chunk_get_prev_ncnl(pc);
+      chunk_t *prev = chunk_get_prev_ncnl(pc);
       if (prev != NULL)
       {
          if ((pc->type == CT_PAREN_OPEN) ||
@@ -680,7 +678,6 @@ static bool check_complex_statements(struct parse_frame *frm, chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
    c_token_t parent;
-   chunk_t   *vbrace;
 
    /* Turn an optional paren into either a real paren or a brace */
    if (frm->pse[frm->pse_tos].stage == BS_OP_PAREN1)
@@ -807,7 +804,7 @@ static bool check_complex_statements(struct parse_frame *frm, chunk_t *pc)
       {
          parent = frm->pse[frm->pse_tos].type;
 
-         vbrace = insert_vbrace_open_before(pc, frm);
+         chunk_t *vbrace = insert_vbrace_open_before(pc, frm);
          set_chunk_parent(vbrace, parent);
 
          frm->level++;

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -78,11 +78,9 @@ static void print_stack(log_sev_t logsev, const char *str,
    LOG_FUNC_ENTRY();
    if (log_sev_on(logsev))
    {
-      int idx;
-
       log_fmt(logsev, "%8.8s", str);
 
-      for (idx = 1; idx <= frm->pse_tos; idx++)
+      for (int idx = 1; idx <= frm->pse_tos; idx++)
       {
          if (frm->pse[idx].stage != BS_NONE)
          {
@@ -310,12 +308,10 @@ static void parse_cleanup(struct parse_frame *frm, chunk_t *pc)
 
    if (frm->sparen_count > 0)
    {
-      int tmp;
-
       chunk_flags_set(pc, PCF_IN_SPAREN);
 
       /* Mark everything in the a for statement */
-      for (tmp = frm->pse_tos - 1; tmp >= 0; tmp--)
+      for (int tmp = frm->pse_tos - 1; tmp >= 0; tmp--)
       {
          if (frm->pse[tmp].type == CT_FOR)
          {

--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -1046,11 +1046,10 @@ static void mod_case_brace(void)
 {
    LOG_FUNC_ENTRY();
    chunk_t *pc = chunk_get_head();
-   chunk_t *next;
 
    while (pc != NULL)
    {
-      next = chunk_get_next_ncnl(pc, CNAV_PREPROC);
+      chunk_t *next = chunk_get_next_ncnl(pc, CNAV_PREPROC);
       if (next == NULL)
       {
          return;

--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -598,13 +598,12 @@ static void convert_vbrace(chunk_t *vbr)
 static void convert_vbrace_to_brace(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
    chunk_t *tmp;
    chunk_t *vbc;
    bool    in_preproc;
 
    /* Find every vbrace open */
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next_ncnl(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next_ncnl(pc))
    {
       if (pc->type != CT_VBRACE_OPEN)
       {
@@ -889,10 +888,9 @@ void add_long_closebrace_comment(void)
 static void move_case_break(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
    chunk_t *prev = NULL;
 
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next_ncnl(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next_ncnl(pc))
    {
       if ((pc->type == CT_BREAK) &&
           (prev != NULL) &&
@@ -1205,9 +1203,8 @@ static void process_if_chain(chunk_t *br_start)
 static void mod_full_brace_if_chain(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
 
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
    {
       if (((pc->type == CT_BRACE_OPEN) || (pc->type == CT_VBRACE_OPEN)) &&
           (pc->parent_type == CT_IF))

--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -155,16 +155,15 @@ static void examine_braces(void)
 static bool should_add_braces(chunk_t *vbopen)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
-   int     nl_max   = cpd.settings[UO_mod_full_brace_nl].n;
-   int     nl_count = 0;
-
+   int nl_max = cpd.settings[UO_mod_full_brace_nl].n;
    if (nl_max == 0)
    {
       return(false);
    }
 
    LOG_FMT(LBRDEL, "%s: start on %lu : ", __func__, vbopen->orig_line);
+   chunk_t *pc;
+   int     nl_count = 0;
    for (pc = chunk_get_next_nc(vbopen, CNAV_PREPROC);
         (pc != NULL) && (pc->level > vbopen->level);
         pc = chunk_get_next_nc(pc, CNAV_PREPROC))
@@ -332,7 +331,6 @@ static bool can_remove_braces(chunk_t *bopen)
 static void examine_brace(chunk_t *bopen)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
    chunk_t *next;
    chunk_t *prev      = NULL;
    int     semi_count = 0;
@@ -346,7 +344,7 @@ static void examine_brace(chunk_t *bopen)
 
    LOG_FMT(LBRDEL, "%s: start on %lu : ", __func__, bopen->orig_line);
 
-   pc = chunk_get_next_nc(bopen);
+   chunk_t *pc = chunk_get_next_nc(bopen);
    while ((pc != NULL) && (pc->level >= level))
    {
       if (pc->flags & PCF_IN_PREPROC)
@@ -598,7 +596,6 @@ static void convert_vbrace(chunk_t *vbr)
 static void convert_vbrace_to_brace(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *tmp;
    chunk_t *vbc;
    bool    in_preproc;
 
@@ -635,7 +632,7 @@ static void convert_vbrace_to_brace(void)
       {
          /* Find the matching vbrace close */
          vbc = NULL;
-         tmp = pc;
+         chunk_t *tmp = pc;
          while ((tmp = chunk_get_next(tmp)) != NULL)
          {
             if (in_preproc && ((tmp->flags & PCF_IN_PREPROC) == 0))
@@ -672,9 +669,8 @@ chunk_t *insert_comment_after(chunk_t *ref, c_token_t cmt_type,
                               const unc_text &cmt_text)
 {
    LOG_FUNC_ENTRY();
-   chunk_t new_cmt;
+   chunk_t new_cmt = *ref;
 
-   new_cmt      = *ref;
    new_cmt.prev = NULL;
    new_cmt.next = NULL;
 
@@ -755,9 +751,6 @@ static void append_tag_name(unc_text &txt, chunk_t *pc)
 void add_long_closebrace_comment(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t  *pc;
-   chunk_t  *tmp;
-   chunk_t  *br_open;
    chunk_t  *br_close;
    chunk_t  *fcn_pc     = NULL;
    chunk_t  *sw_pc      = NULL;
@@ -767,7 +760,7 @@ void add_long_closebrace_comment(void)
    unc_text xstr;
    int      nl_count;
 
-   for (pc = chunk_get_head(); pc; pc = chunk_get_next_ncnl(pc))
+   for (chunk_t *pc = chunk_get_head(); pc; pc = chunk_get_next_ncnl(pc))
    {
       if ((pc->type == CT_FUNC_DEF) ||
           (pc->type == CT_OC_MSG_DECL))
@@ -792,10 +785,10 @@ void add_long_closebrace_comment(void)
          continue;
       }
 
-      br_open  = pc;
+      chunk_t *br_open = pc;
       nl_count = 0;
 
-      tmp = pc;
+      chunk_t *tmp = pc;
       while ((tmp = chunk_get_next(tmp)) != NULL)
       {
          if (chunk_is_newline(tmp))
@@ -914,14 +907,12 @@ static void move_case_break(void)
 static chunk_t *mod_case_brace_remove(chunk_t *br_open)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
-   chunk_t *br_close;
    chunk_t *next = chunk_get_next_ncnl(br_open, CNAV_PREPROC);
 
    LOG_FMT(LMCB, "%s: line %lu", __func__, br_open->orig_line);
 
    /* Find the matching brace close */
-   br_close = chunk_get_next_type(br_open, CT_BRACE_CLOSE, br_open->level, CNAV_PREPROC);
+   chunk_t *br_close = chunk_get_next_type(br_open, CT_BRACE_CLOSE, br_open->level, CNAV_PREPROC);
    if (br_close == NULL)
    {
       LOG_FMT(LMCB, " - no close\n");
@@ -929,7 +920,7 @@ static chunk_t *mod_case_brace_remove(chunk_t *br_open)
    }
 
    /* Make sure 'break', 'return', 'goto', 'case' or '}' is after the close brace */
-   pc = chunk_get_next_ncnl(br_close, CNAV_PREPROC);
+   chunk_t *pc = chunk_get_next_ncnl(br_close, CNAV_PREPROC);
    if ((pc == NULL) ||
        ((pc->type != CT_BREAK) &&
         (pc->type != CT_RETURN) &&
@@ -975,9 +966,6 @@ static chunk_t *mod_case_brace_add(chunk_t *cl_colon)
    chunk_t *pc   = cl_colon;
    chunk_t *last = NULL;
    chunk_t *next = chunk_get_next_ncnl(cl_colon, CNAV_PREPROC);
-   chunk_t *br_open;
-   chunk_t *br_close;
-   chunk_t chunk;
 
    LOG_FMT(LMCB, "%s: line %lu", __func__, pc->orig_line);
 
@@ -1011,6 +999,7 @@ static chunk_t *mod_case_brace_add(chunk_t *cl_colon)
 
    LOG_FMT(LMCB, " - adding before '%s' on line %lu\n", last->text(), last->orig_line);
 
+   chunk_t chunk;
    chunk.type        = CT_BRACE_OPEN;
    chunk.orig_line   = cl_colon->orig_line;
    chunk.parent_type = CT_CASE;
@@ -1019,13 +1008,13 @@ static chunk_t *mod_case_brace_add(chunk_t *cl_colon)
    chunk.flags       = pc->flags & PCF_COPY_FLAGS;
    chunk.str         = "{";
 
-   br_open = chunk_add_after(&chunk, cl_colon);
+   chunk_t *br_open = chunk_add_after(&chunk, cl_colon);
 
    chunk.type      = CT_BRACE_CLOSE;
    chunk.orig_line = last->orig_line;
    chunk.str       = "}";
 
-   br_close = chunk_add_before(&chunk, last);
+   chunk_t *br_close = chunk_add_before(&chunk, last);
    newline_add_before(last);
 
    for (pc = chunk_get_next(br_open, CNAV_PREPROC);
@@ -1043,8 +1032,8 @@ static chunk_t *mod_case_brace_add(chunk_t *cl_colon)
 static void mod_case_brace(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc = chunk_get_head();
 
+   chunk_t *pc = chunk_get_head();
    while (pc != NULL)
    {
       chunk_t *next = chunk_get_next_ncnl(pc, CNAV_PREPROC);
@@ -1086,7 +1075,6 @@ static void process_if_chain(chunk_t *br_start)
    int     br_cnt = 0;
    chunk_t *pc;
    bool    must_have_braces = false;
-   bool    tmp;
 
    pc = br_start;
 
@@ -1096,7 +1084,7 @@ static void process_if_chain(chunk_t *br_start)
    {
       if (pc->type == CT_BRACE_OPEN)
       {
-         tmp = can_remove_braces(pc);
+         bool tmp = can_remove_braces(pc);
          LOG_FMT(LBRCH, "  [%d] line %lu - can%s remove %s\n",
                  br_cnt, pc->orig_line, tmp ? "" : "not",
                  get_token_name(pc->type));
@@ -1107,7 +1095,7 @@ static void process_if_chain(chunk_t *br_start)
       }
       else
       {
-         tmp = should_add_braces(pc);
+         bool tmp = should_add_braces(pc);
          if (tmp)
          {
             must_have_braces = true;

--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -544,9 +544,7 @@ chunk_t *chunk_get_prev_str(chunk_t *cur, const char *str, size_t len, int level
  */
 bool chunk_is_newline_between(chunk_t *start, chunk_t *end)
 {
-   chunk_t *pc;
-
-   for (pc = start; pc != end; pc = chunk_get_next(pc))
+   for (chunk_t *pc = start; pc != end; pc = chunk_get_next(pc))
    {
       if (chunk_is_newline(pc))
       {

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -200,25 +200,25 @@ chunk_t *set_paren_parent(chunk_t *start, c_token_t parent)
 static void flag_asm(chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *po;
-   chunk_t *tmp;
-   chunk_t *end;
 
-   tmp = chunk_get_next_ncnl(pc, CNAV_PREPROC);
+   chunk_t *tmp = chunk_get_next_ncnl(pc, CNAV_PREPROC);
    if (!chunk_is_token(tmp, CT_QUALIFIER))
    {
       return;
    }
-   po = chunk_get_next_ncnl(tmp, CNAV_PREPROC);
+
+   chunk_t *po = chunk_get_next_ncnl(tmp, CNAV_PREPROC);
    if (!chunk_is_paren_open(po))
    {
       return;
    }
-   end = chunk_skip_to_match(po, CNAV_PREPROC);
+
+   chunk_t *end = chunk_skip_to_match(po, CNAV_PREPROC);
    if (!end)
    {
       return;
    }
+
    set_chunk_parent(po, CT_ASM);
    set_chunk_parent(end, CT_ASM);
    for (tmp = chunk_get_next_ncnl(po, CNAV_PREPROC);
@@ -4559,9 +4559,8 @@ static chunk_t *get_d_template_types(ChunkStack &cs, chunk_t *open_paren)
 
 static bool chunkstack_match(ChunkStack &cs, chunk_t *pc)
 {
-   int idx;
+   for (int idx = 0; idx < cs.Len(); idx++)
 
-   for (idx = 0; idx < cs.Len(); idx++)
    {
       chunk_t *tmp = cs.GetChunk(idx);
       if (pc->str.equals(tmp->str))

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -110,7 +110,6 @@ static chunk_t *flag_parens(chunk_t *po, UINT64 flags,
 {
    LOG_FUNC_ENTRY();
    chunk_t *paren_close;
-   chunk_t *pc;
 
    paren_close = chunk_skip_to_match(po, CNAV_PREPROC);
    if (paren_close == NULL)
@@ -134,6 +133,7 @@ static chunk_t *flag_parens(chunk_t *po, UINT64 flags,
       if ((flags != 0) ||
           (parent_all && (parenttype != CT_NONE)))
       {
+         chunk_t *pc;
          for (pc = chunk_get_next(po, CNAV_PREPROC);
               pc != paren_close;
               pc = chunk_get_next(pc, CNAV_PREPROC))
@@ -1307,8 +1307,6 @@ void fix_symbols(void)
 {
    LOG_FUNC_ENTRY();
    chunk_t *pc;
-   chunk_t *next;
-   chunk_t *prev;
    chunk_t dummy;
 
    cpd.unc_stage = US_FIX_SYMBOLS;
@@ -1342,12 +1340,12 @@ void fix_symbols(void)
    }
    while (pc != NULL)
    {
-      prev = chunk_get_prev_ncnl(pc, CNAV_PREPROC);
+      chunk_t *prev = chunk_get_prev_ncnl(pc, CNAV_PREPROC);
       if (prev == NULL)
       {
          prev = &dummy;
       }
-      next = chunk_get_next_ncnl(pc, CNAV_PREPROC);
+      chunk_t *next = chunk_get_next_ncnl(pc, CNAV_PREPROC);
       if (next == NULL)
       {
          next = &dummy;
@@ -2714,12 +2712,9 @@ static void mark_variable_stack(ChunkStack &cs, log_sev_t sev)
 {
    (void)sev;
    LOG_FUNC_ENTRY();
-   chunk_t *var_name;
-   chunk_t *word_type;
-   int     word_cnt = 0;
 
    /* throw out the last word and mark the rest */
-   var_name = cs.Pop_Back();
+   chunk_t *var_name = cs.Pop_Back();
    if (var_name && (var_name->prev->type == CT_DC_MEMBER))
    {
       cs.Push_Back(var_name);
@@ -2730,6 +2725,8 @@ static void mark_variable_stack(ChunkStack &cs, log_sev_t sev)
       LOG_FMT(LFCNP, "%s: parameter on line %lu :",
               __func__, var_name->orig_line);
 
+      int     word_cnt = 0;
+      chunk_t *word_type;
       while ((word_type = cs.Pop_Back()) != NULL)
       {
          if ((word_type->type == CT_WORD) || (word_type->type == CT_TYPE))
@@ -3290,7 +3287,6 @@ static void mark_function(chunk_t *pc)
    chunk_t *semi = NULL;
    chunk_t *paren_open;
    chunk_t *paren_close;
-   chunk_t *pc_op = NULL;
 
    prev = chunk_get_prev_ncnlnp(pc);
    next = chunk_get_next_ncnlnp(pc);
@@ -3302,7 +3298,7 @@ static void mark_function(chunk_t *pc)
    /* Find out what is before the operator */
    if (pc->parent_type == CT_OPERATOR)
    {
-      pc_op = chunk_get_prev_type(pc, CT_OPERATOR, pc->level);
+      chunk_t *pc_op = chunk_get_prev_type(pc, CT_OPERATOR, pc->level);
       if ((pc_op != NULL) && (pc_op->flags & PCF_EXPR_START))
       {
          set_chunk_type(pc, CT_FUNC_CALL);
@@ -4258,7 +4254,6 @@ void mark_comments(void)
    chunk_t *cur;
    chunk_t *next;
    bool    prev_nl = true;
-   bool    next_nl;
 
    cpd.unc_stage = US_MARK_COMMENTS;
 
@@ -4266,8 +4261,8 @@ void mark_comments(void)
 
    while (cur != NULL)
    {
-      next    = chunk_get_next_nvb(cur);
-      next_nl = (next == NULL) || chunk_is_newline(next);
+      next = chunk_get_next_nvb(cur);
+      bool next_nl = (next == NULL) || chunk_is_newline(next);
 
       if (chunk_is_comment(cur))
       {
@@ -4564,12 +4559,11 @@ static chunk_t *get_d_template_types(ChunkStack &cs, chunk_t *open_paren)
 
 static bool chunkstack_match(ChunkStack &cs, chunk_t *pc)
 {
-   chunk_t *tmp;
-   int     idx;
+   int idx;
 
    for (idx = 0; idx < cs.Len(); idx++)
    {
-      tmp = cs.GetChunk(idx);
+      chunk_t *tmp = cs.GetChunk(idx);
       if (pc->str.equals(tmp->str))
       {
          return(true);
@@ -4999,7 +4993,6 @@ static void handle_oc_block_literal(chunk_t *pc)
    }
 
    chunk_t *apo;  /* arg paren open */
-   chunk_t *apc;  /* arg paren close */
    chunk_t *bbo;  /* block brace open */
    chunk_t *bbc;  /* block brace close */
 
@@ -5053,7 +5046,7 @@ static void handle_oc_block_literal(chunk_t *pc)
    chunk_t *lbp; /* last before paren - end of return type, if any */
    if (apo)
    {
-      apc = chunk_skip_to_match(apo);
+      chunk_t *apc = chunk_skip_to_match(apo);  /* arg paren close */
       if (chunk_is_paren_close(apc))
       {
          LOG_FMT(LOCBLK, " -- marking parens @ %lu:%lu and %lu:%lu\n",
@@ -5110,23 +5103,17 @@ static void handle_oc_block_type(chunk_t *pc)
       return;
    }
 
-   chunk_t *tpo;  /* type paren open */
-   chunk_t *tpc;  /* type paren close */
-   chunk_t *nam;  /* name (if any) of '^' */
-   chunk_t *apo;  /* arg paren open */
-   chunk_t *apc;  /* arg paren close */
-
    /* make sure we have '( ^' */
-   tpo = chunk_get_prev_ncnl(pc);
+   chunk_t *tpo = chunk_get_prev_ncnl(pc); /* type paren open */
    if (chunk_is_paren_open(tpo))
    {
       /* block type: 'RTYPE (^LABEL)(ARGS)'
        * LABEL is optional.
        */
-      tpc = chunk_skip_to_match(tpo);  /* type close paren (after '^') */
-      nam = chunk_get_prev_ncnl(tpc);  /* name (if any) or '^' */
-      apo = chunk_get_next_ncnl(tpc);  /* arg open paren */
-      apc = chunk_skip_to_match(apo);  /* arg close paren */
+      chunk_t *tpc = chunk_skip_to_match(tpo);  /* type close paren (after '^') */
+      chunk_t *nam = chunk_get_prev_ncnl(tpc);  /* name (if any) or '^' */
+      chunk_t *apo = chunk_get_next_ncnl(tpc);  /* arg open paren */
+      chunk_t *apc = chunk_skip_to_match(apo);  /* arg close paren */
 
       // If this is a block literal instead of a block type, 'nam' will actually
       // be the closing bracket of the block.

--- a/src/defines.cpp
+++ b/src/defines.cpp
@@ -64,9 +64,7 @@ int load_define_file(const char *filename)
 {
    FILE *pf;
    char buf[160];
-   char *ptr;
    char *args[3];
-   int  argc;
    int  line_no = 0;
 
    pf = fopen(filename, "r");
@@ -83,12 +81,13 @@ int load_define_file(const char *filename)
       line_no++;
 
       /* remove comments */
+      char *ptr;
       if ((ptr = strchr(buf, '#')) != NULL)
       {
          *ptr = 0;
       }
 
-      argc       = Args::SplitLine(buf, args, ARRAY_SIZE(args) - 1);
+      int argc = Args::SplitLine(buf, args, ARRAY_SIZE(args) - 1);
       args[argc] = 0;
 
       if (argc > 0)

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2417,7 +2417,6 @@ static void indent_comment(chunk_t *pc, int col)
 bool ifdef_over_whole_file(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
    chunk_t *next;
    chunk_t *end_pp = NULL;
 
@@ -2429,7 +2428,7 @@ bool ifdef_over_whole_file(void)
       return(cpd.ifdef_over_whole_file > 0);
    }
 
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
    {
       if (chunk_is_comment(pc) || chunk_is_newline(pc))
       {
@@ -2492,7 +2491,6 @@ bool ifdef_over_whole_file(void)
 void indent_preproc(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
    chunk_t *next;
    int     pp_level;
    int     pp_level_sub = 0;
@@ -2503,7 +2501,7 @@ void indent_preproc(void)
       pp_level_sub = 1;
    }
 
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
    {
       if (pc->type != CT_PREPROC)
       {

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -156,7 +156,6 @@ void align_to_column(chunk_t *pc, int column)
 
    int col_delta = column - pc->column;
    int min_col   = column;
-   int min_delta;
 
    pc->column = column;
    do
@@ -169,10 +168,10 @@ void align_to_column(chunk_t *pc, int column)
       {
          break;
       }
-      min_delta = space_col_align(pc, next);
-      min_col  += min_delta;
-      prev      = pc;
-      pc        = next;
+      int min_delta = space_col_align(pc, next);
+      min_col += min_delta;
+      prev     = pc;
+      pc       = next;
 
       if (chunk_is_comment(pc) && (pc->parent_type != CT_COMMENT_EMBED))
       {

--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -365,10 +365,9 @@ static const chunk_tag_t *kw_static_first(const chunk_tag_t *tag)
 
 static const chunk_tag_t *kw_static_match(const chunk_tag_t *tag)
 {
-   bool              in_pp = ((cpd.in_preproc != CT_NONE) && (cpd.in_preproc != CT_PP_DEFINE));
-   const chunk_tag_t *iter;
+   bool in_pp = ((cpd.in_preproc != CT_NONE) && (cpd.in_preproc != CT_PP_DEFINE));
 
-   for (iter = kw_static_first(tag);
+   for (const chunk_tag_t *iter = kw_static_first(tag);
         iter < &keywords[ARRAY_SIZE(keywords)];
         iter++)
    {

--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -366,7 +366,6 @@ static const chunk_tag_t *kw_static_first(const chunk_tag_t *tag)
 static const chunk_tag_t *kw_static_match(const chunk_tag_t *tag)
 {
    bool              in_pp = ((cpd.in_preproc != CT_NONE) && (cpd.in_preproc != CT_PP_DEFINE));
-   bool              pp_iter;
    const chunk_tag_t *iter;
 
    for (iter = kw_static_first(tag);
@@ -374,7 +373,7 @@ static const chunk_tag_t *kw_static_match(const chunk_tag_t *tag)
         iter++)
    {
       //fprintf(stderr, " check:%s", iter->tag);
-      pp_iter = (iter->lang_flags & FLAG_PP) != 0;    // forcing value to bool
+      bool pp_iter = (iter->lang_flags & FLAG_PP) != 0; // forcing value to bool
       if ((strcmp(iter->tag, tag->tag) == 0) &&
           (cpd.lang_flags & iter->lang_flags) &&
           (in_pp == pp_iter))
@@ -435,9 +434,7 @@ int load_keyword_file(const char *filename)
 {
    FILE *pf;
    char buf[256];
-   char *ptr;
    char *args[3];
-   int  argc;
    int  line_no = 0;
 
    pf = fopen(filename, "r");
@@ -454,12 +451,13 @@ int load_keyword_file(const char *filename)
       line_no++;
 
       /* remove comments */
+      char *ptr;
       if ((ptr = strchr(buf, '#')) != NULL)
       {
          *ptr = 0;
       }
 
-      argc       = Args::SplitLine(buf, args, ARRAY_SIZE(args) - 1);
+      int argc = Args::SplitLine(buf, args, ARRAY_SIZE(args) - 1);
       args[argc] = 0;
 
       if (argc > 0)

--- a/src/lang_pawn.cpp
+++ b/src/lang_pawn.cpp
@@ -60,16 +60,13 @@ void pawn_scrub_vsemi(void)
       return;
    }
 
-   chunk_t *pc;
-   chunk_t *prev;
-
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
    {
       if (pc->type != CT_VSEMICOLON)
       {
          continue;
       }
-      prev = chunk_get_prev_ncnl(pc);
+      chunk_t *prev = chunk_get_prev_ncnl(pc);
       if ((prev != NULL) && (prev->type == CT_BRACE_CLOSE))
       {
          if ((prev->parent_type == CT_IF) ||

--- a/src/lang_pawn.cpp
+++ b/src/lang_pawn.cpp
@@ -325,12 +325,11 @@ void pawn_add_virtual_semicolons(void)
 static chunk_t *pawn_mark_function0(chunk_t *start, chunk_t *fcn)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *last;
 
    /* handle prototypes */
    if (start == fcn)
    {
-      last = chunk_get_next_type(fcn, CT_PAREN_CLOSE, fcn->level);
+      chunk_t *last = chunk_get_next_type(fcn, CT_PAREN_CLOSE, fcn->level);
       last = chunk_get_next(last);
       if ((last != NULL) && (last->type == CT_SEMICOLON))
       {
@@ -365,7 +364,6 @@ static chunk_t *pawn_process_func_def(chunk_t *pc)
    /* We are on a function definition */
    chunk_t *clp;
    chunk_t *last;
-   chunk_t *next;
 
    set_chunk_type(pc, CT_FUNC_DEF);
 
@@ -449,7 +447,7 @@ static chunk_t *pawn_process_func_def(chunk_t *pc)
          if ((prev->type == CT_NEWLINE) &&
              (prev->level == 0))
          {
-            next = chunk_get_next_ncnl(prev);
+            chunk_t *next = chunk_get_next_ncnl(prev);
             if ((next != NULL) &&
                 (next->type != CT_ELSE) &&
                 (next->type != CT_WHILE_OF_DO))

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -321,7 +321,6 @@ void log_hex_blk(log_sev_t sev, const void *data, size_t len)
 {
    static char buf[80] = "nnn | XX XX XX XX XX XX XX XX XX XX XX XX XX XX XX XX | cccccccccccccccc\n";
    const UINT8 *dat    = (const UINT8 *)data;
-   size_t      idx;
    int         count;
    int         str_idx = 0;
    int         chr_idx = 0;
@@ -340,7 +339,7 @@ void log_hex_blk(log_sev_t sev, const void *data, size_t len)
    /* Loop through the data of the current iov */
    count = 0;
    total = 0;
-   for (idx = 0; idx < len; idx++)
+   for (size_t idx = 0; idx < len; idx++)
    {
       if (count == 0)
       {

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -325,7 +325,6 @@ void log_hex_blk(log_sev_t sev, const void *data, size_t len)
    int         count;
    int         str_idx = 0;
    int         chr_idx = 0;
-   int         tmp;
    int         total;
 
    if ((data == NULL) || !log_sev_on(sev))
@@ -353,7 +352,7 @@ void log_hex_blk(log_sev_t sev, const void *data, size_t len)
          buf[2] = to_hex_char(total >> 4);
       }
 
-      tmp = dat[idx];
+      int tmp = dat[idx];
 
       buf[str_idx]     = to_hex_char(tmp >> 4);
       buf[str_idx + 1] = to_hex_char(tmp);

--- a/src/logmask.cpp
+++ b/src/logmask.cpp
@@ -24,15 +24,14 @@ char *logmask_to_str(const log_mask_t &mask, char *buf, int size)
 {
    int  last_sev = -1;
    bool is_range = false;
-   int  sev;
-   int  len = 0;
+   int  len      = 0;
 
    if ((buf == NULL) || (size <= 0))
    {
       return(buf);
    }
 
-   for (sev = 0; sev < 256; sev++)
+   for (int sev = 0; sev < 256; sev++)
    {
       if (logmask_test(mask, (log_sev_t)sev))
       {
@@ -91,7 +90,6 @@ void logmask_from_string(const char *str, log_mask_t &mask)
    bool was_dash   = false;
    int  last_level = -1;
    int  level;
-   int  idx;
 
    if (str == NULL)
    {
@@ -124,7 +122,7 @@ void logmask_from_string(const char *str, log_mask_t &mask)
          logmask_set_sev(mask, (log_sev_t)level, true);
          if (was_dash)
          {
-            for (idx = last_level + 1; idx < level; idx++)
+            for (int idx = last_level + 1; idx < level; idx++)
             {
                logmask_set_sev(mask, (log_sev_t)idx, true);
             }

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -524,8 +524,6 @@ static bool newlines_if_for_while_switch(chunk_t *start, argval_t nl_opt)
 {
    LOG_FUNC_ENTRY();
    chunk_t *pc;
-   chunk_t *close_paren;
-   chunk_t *brace_open;
    bool    retval = false;
 
    if ((nl_opt == AV_IGNORE) ||
@@ -538,8 +536,8 @@ static bool newlines_if_for_while_switch(chunk_t *start, argval_t nl_opt)
    pc = chunk_get_next_ncnl(start);
    if ((pc != NULL) && (pc->type == CT_SPAREN_OPEN))
    {
-      close_paren = chunk_get_next_type(pc, CT_SPAREN_CLOSE, pc->level);
-      brace_open  = chunk_get_next_ncnl(close_paren);
+      chunk_t *close_paren = chunk_get_next_type(pc, CT_SPAREN_CLOSE, pc->level);
+      chunk_t *brace_open  = chunk_get_next_ncnl(close_paren);
 
       if ((brace_open != NULL) &&
           ((brace_open->type == CT_BRACE_OPEN) ||
@@ -919,7 +917,6 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, argval
    chunk_t *next;
    chunk_t *prev;
    bool    have_pre_vbrace_nl = false;
-   int     nl_count;
 
    if ((nl_opt == AV_IGNORE) ||
        ((start->flags & PCF_IN_PREPROC) &&
@@ -1011,7 +1008,7 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, argval
       {
          /* if vbrace, have to check before and after */
          /* if chunk before vbrace, check its count */
-         nl_count = have_pre_vbrace_nl ? prev->nl_count : 0;
+         int nl_count = have_pre_vbrace_nl ? prev->nl_count : 0;
          if (chunk_is_newline(next = chunk_get_next_nvb(pc)))
          {
             nl_count += next->nl_count;
@@ -1078,7 +1075,6 @@ static void newlines_struct_enum_union(chunk_t *start, argval_t nl_opt, bool lea
 {
    LOG_FUNC_ENTRY();
    chunk_t *pc;
-   chunk_t *next;
 
    if ((nl_opt == AV_IGNORE) ||
        ((start->flags & PCF_IN_PREPROC) &&
@@ -1108,7 +1104,7 @@ static void newlines_struct_enum_union(chunk_t *start, argval_t nl_opt, bool lea
    if ((pc != NULL) && (pc->type == CT_BRACE_OPEN))
    {
       /* Skip over embedded C comments */
-      next = chunk_get_next(pc);
+      chunk_t *next = chunk_get_next(pc);
       while ((next != NULL) && (next->type == CT_COMMENT))
       {
          next = chunk_get_next(next);
@@ -1160,7 +1156,6 @@ static void newlines_do_else(chunk_t *start, argval_t nl_opt)
 {
    LOG_FUNC_ENTRY();
    chunk_t *next;
-   chunk_t *tmp;
 
    if ((nl_opt == AV_IGNORE) ||
        ((start->flags & PCF_IN_PREPROC) &&
@@ -1189,7 +1184,7 @@ static void newlines_do_else(chunk_t *start, argval_t nl_opt)
          if (nl_opt & AV_ADD)
          {
             newline_iarf_pair(start, chunk_get_next_ncnl(next), nl_opt);
-            tmp = chunk_get_next_type(next, CT_VBRACE_CLOSE, next->level);
+            chunk_t *tmp = chunk_get_next_type(next, CT_VBRACE_CLOSE, next->level);
             if (!chunk_is_newline(chunk_get_next_nc(tmp)) &&
                 !chunk_is_newline(chunk_get_prev_nc(tmp)))
             {
@@ -2217,7 +2212,6 @@ static bool one_liner_nl_ok(chunk_t *pc)
 void undo_one_liner(chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *tmp;
 
    if (pc && (pc->flags & PCF_ONE_LINER))
    {
@@ -2225,7 +2219,7 @@ void undo_one_liner(chunk_t *pc)
       chunk_flags_clr(pc, PCF_ONE_LINER);
 
       /* scan backward */
-      tmp = pc;
+      chunk_t *tmp = pc;
       while ((tmp = chunk_get_prev(tmp)) != NULL)
       {
          if (!(tmp->flags & PCF_ONE_LINER))

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -401,8 +401,7 @@ chunk_t *newline_add_between(chunk_t *start, chunk_t *end)
    }
 
    /* Scan for a line break */
-   chunk_t *pc;
-   for (pc = start; pc != end; pc = chunk_get_next(pc))
+   for (chunk_t *pc = start; pc != end; pc = chunk_get_next(pc))
    {
       if (chunk_is_newline(pc))
       {
@@ -415,7 +414,7 @@ chunk_t *newline_add_between(chunk_t *start, chunk_t *end)
     */
    if (end->type == CT_BRACE_OPEN)
    {
-      pc = chunk_get_next(end);
+      chunk_t *pc = chunk_get_next(end);
       if (chunk_is_comment(pc))
       {
          pc = chunk_get_next(pc);

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -382,7 +382,6 @@ static void newline_min_after(chunk_t *ref, INT32 count, UINT64 flag)
 chunk_t *newline_add_between(chunk_t *start, chunk_t *end)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
 
    if ((start == NULL) || (end == NULL))
    {
@@ -402,6 +401,7 @@ chunk_t *newline_add_between(chunk_t *start, chunk_t *end)
    }
 
    /* Scan for a line break */
+   chunk_t *pc;
    for (pc = start; pc != end; pc = chunk_get_next(pc))
    {
       if (chunk_is_newline(pc))
@@ -597,7 +597,6 @@ static bool newlines_if_for_while_switch(chunk_t *start, argval_t nl_opt)
 static void newlines_if_for_while_switch_pre_blank_lines(chunk_t *start, argval_t nl_opt)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
    chunk_t *prev;
    chunk_t *next;
    chunk_t *last_nl = NULL;
@@ -617,7 +616,7 @@ static void newlines_if_for_while_switch_pre_blank_lines(chunk_t *start, argval_
     *  2 newlines in a row (don't add)
     *  something else (don't remove)
     */
-   for (pc = chunk_get_prev(start); pc != NULL; pc = chunk_get_prev(pc))
+   for (chunk_t *pc = chunk_get_prev(start); pc != NULL; pc = chunk_get_prev(pc))
    {
       if (chunk_is_newline(pc))
       {
@@ -2670,14 +2669,13 @@ void newlines_cleanup_braces(bool first)
             if (pc->flags & PCF_ONE_LINER)
             {
                // split one-liner
-               chunk_t *temp;
                chunk_t *end = chunk_get_next(chunk_get_next_type(pc->next, CT_SEMICOLON, -1));
                /* Scan for clear flag */
 #ifdef DEBUG
                LOG_FMT(LGUY, "(%d) ", __LINE__);
 #endif
                LOG_FMT(LGUY, "\n");
-               for (temp = pc; temp != end; temp = chunk_get_next(temp))
+               for (chunk_t *temp = pc; temp != end; temp = chunk_get_next(temp))
                {
                   LOG_FMT(LGUY, "%s type=%s , level=%lu", temp->text(), get_token_name(temp->type), temp->level);
                   log_pcf_flags(LGUY, temp->flags);
@@ -2982,10 +2980,9 @@ static void nl_handle_define(chunk_t *pc)
 void newline_after_multiline_comment(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
    chunk_t *tmp;
 
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
    {
       if (pc->type != CT_COMMENT_MULTI)
       {
@@ -3011,9 +3008,8 @@ void newline_after_multiline_comment(void)
 void newline_after_label_colon(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
 
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
    {
       if (pc->type != CT_LABEL_COLON)
       {
@@ -3031,9 +3027,8 @@ void newline_after_label_colon(void)
 void newlines_insert_blank_lines(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
 
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next_ncnl(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next_ncnl(pc))
    {
       if (pc->type == CT_IF)
       {
@@ -3289,7 +3284,6 @@ void newlines_eat_start_end(void)
 void newlines_chunk_pos(c_token_t chunk_type, tokenpos_e mode)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
    chunk_t *next;
    chunk_t *prev;
    int     nl_flag;
@@ -3299,7 +3293,7 @@ void newlines_chunk_pos(c_token_t chunk_type, tokenpos_e mode)
       return;
    }
 
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next_ncnl(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next_ncnl(pc))
    {
       if (pc->type == chunk_type)
       {
@@ -3444,7 +3438,6 @@ void newlines_chunk_pos(c_token_t chunk_type, tokenpos_e mode)
 void newlines_class_colon_pos(c_token_t tok)
 {
    LOG_FUNC_ENTRY();
-   chunk_t    *pc;
    chunk_t    *next;
    chunk_t    *prev;
    chunk_t    *ccolon = NULL;
@@ -3466,7 +3459,7 @@ void newlines_class_colon_pos(c_token_t tok)
       pcc  = cpd.settings[UO_pos_constr_comma].tp;
    }
 
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next_ncnl(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next_ncnl(pc))
    {
       if (!ccolon && (pc->type != tok))
       {
@@ -3609,13 +3602,12 @@ static void _blank_line_max(chunk_t *pc, const char *text, uncrustify_options uo
 void do_blank_lines(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
    chunk_t *next;
    chunk_t *prev;
    chunk_t *pcmt;
    int     old_nl;
 
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
    {
       bool line_added = false;
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1613,8 +1613,6 @@ const option_map_value *get_option_name(uncrustify_options option)
 static void convert_value(const option_map_value *entry, const char *val, op_val_t *dest)
 {
    const option_map_value *tmp;
-   bool                   btrue;
-   int                    mult;
 
    if (entry->type == AT_LINE)
    {
@@ -1704,7 +1702,7 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
       else
       {
          /* Try to see if it is a variable */
-         mult = 1;
+         int mult = 1;
          if (*val == '-')
          {
             mult = -1;
@@ -1744,7 +1742,7 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
          return;
       }
 
-      btrue = true;
+      bool btrue = true;
       if ((*val == '-') || (*val == '~'))
       {
          btrue = false;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -178,12 +178,11 @@ static bool next_word_exceeds_limit(const unc_text &text, int idx)
  */
 static void output_to_column(int column, bool allow_tabs)
 {
-   int nc;
-
    cpd.did_newline = 0;
    if (allow_tabs)
    {
       /* tab out as far as possible and then use spaces */
+      int nc;
       while ((nc = next_tab_column(cpd.column)) <= column)
       {
          add_text("\t");
@@ -1201,7 +1200,6 @@ static void output_comment_multi(chunk_t *pc)
 {
    int        cmt_col;
    int        cmt_idx;
-   int        ch;
    unc_text   line;
    int        line_count = 0;
    int        ccol; /* the col of subsequent comment lines */
@@ -1231,7 +1229,7 @@ static void output_comment_multi(chunk_t *pc)
    line.clear();
    while (cmt_idx < pc->len())
    {
-      ch = pc->str[cmt_idx++];
+      int ch = pc->str[cmt_idx++];
 
       /* handle the CRLF and CR endings. convert both to LF */
       if (ch == '\r')
@@ -1654,7 +1652,6 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text &out_txt)
 
    chunk_t *fpo;
    chunk_t *fpc;
-   chunk_t *prev;
    bool    has_param = true;
    bool    need_nl   = false;
 
@@ -1723,8 +1720,8 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text &out_txt)
 
    if (has_param)
    {
-      tmp  = fpo;
-      prev = NULL;
+      chunk_t *prev = NULL;
+      tmp = fpo;
       while ((tmp = chunk_get_next(tmp)) != NULL)
       {
          if ((tmp->type == CT_COMMA) || (tmp == fpc))
@@ -1891,7 +1888,6 @@ static void output_comment_multi_simple(chunk_t *pc, bool kw_subst)
 {
    (void)kw_subst;
    int        cmt_idx;
-   int        ch;
    int        line_count = 0;
    int        ccol;
    int        col_diff = 0;
@@ -1917,7 +1913,7 @@ static void output_comment_multi_simple(chunk_t *pc, bool kw_subst)
    line.clear();
    while (cmt_idx < pc->len())
    {
-      ch = pc->str[cmt_idx++];
+      int ch = pc->str[cmt_idx++];
 
       /* handle the CRLF and CR endings. convert both to LF */
       if (ch == '\r')

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -240,15 +240,12 @@ static void cmt_output_indent(int brace_col, int base_col, int column)
 
 void output_parsed(FILE *pfile)
 {
-   chunk_t *pc;
-   int     cnt;
-
    // save_option_file(pfile, false);
    save_option_file_kernel(pfile, false, true);
 
    fprintf(pfile, "# -=====-\n");
    fprintf(pfile, "# Line              Tag           Parent          Columns Br/Lvl/pp     Flag   Nl  Text");
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
    {
       fprintf(pfile, "\n# %3zd> %16.16s[%16.16s][%3d/%3lu/%3d/%3d][%lu/%lu/%lu][%10" PRIx64 "][%lu-%d]",
               pc->orig_line, get_token_name(pc->type),
@@ -259,7 +256,7 @@ void output_parsed(FILE *pfile)
 
       if ((pc->type != CT_NEWLINE) && (pc->len() != 0))
       {
-         for (cnt = 0; cnt < pc->column; cnt++)
+         for (int cnt = 0; cnt < pc->column; cnt++)
          {
             fprintf(pfile, " ");
          }
@@ -285,7 +282,6 @@ void output_text(FILE *pfile)
 {
    chunk_t *pc;
    chunk_t *prev;
-   int     cnt;
    int     lvlcol;
    bool    allow_tabs;
 
@@ -317,7 +313,7 @@ void output_text(FILE *pfile)
                                  chunk_is_comment(pc));
       if (pc->type == CT_NEWLINE)
       {
-         for (cnt = 0; cnt < pc->nl_count; cnt++)
+         for (int cnt = 0; cnt < pc->nl_count; cnt++)
          {
             add_char('\n');
          }
@@ -1269,7 +1265,6 @@ static void output_comment_multi(chunk_t *pc)
           (ch == '\n') &&
           (cmt_idx < pc->len()))
       {
-         int  nxt_len            = 0;
          int  next_nonempty_line = -1;
          int  prev_nonempty_line = -1;
          int  nwidx              = line.size();
@@ -1293,7 +1288,7 @@ static void output_comment_multi(chunk_t *pc)
          }
 
          int remaining = pc->len() - cmt_idx;
-         for (nxt_len = 0;
+         for (int nxt_len = 0;
               (nxt_len <= remaining) &&
               (pc->str[nxt_len] != 'r') &&
               (pc->str[nxt_len] != '\n');
@@ -1990,11 +1985,10 @@ static void output_comment_multi_simple(chunk_t *pc, bool kw_subst)
  */
 static void generate_if_conditional_as_text(unc_text &dst, chunk_t *ifdef)
 {
-   chunk_t *pc;
-   int     column = -1;
+   int column = -1;
 
    dst.clear();
-   for (pc = ifdef; pc != NULL; pc = chunk_get_next(pc))
+   for (chunk_t *pc = ifdef; pc != NULL; pc = chunk_get_next(pc))
    {
       if (column == -1)
       {
@@ -2017,9 +2011,7 @@ static void generate_if_conditional_as_text(unc_text &dst, chunk_t *ifdef)
       }
       else // if (pc->type == CT_JUNK) || else
       {
-         int spacing;
-
-         for (spacing = pc->column - column; spacing > 0; spacing--)
+         for (int spacing = pc->column - column; spacing > 0; spacing--)
          {
             dst += ' ';
             column++;
@@ -2047,7 +2039,6 @@ static void generate_if_conditional_as_text(unc_text &dst, chunk_t *ifdef)
  */
 void add_long_preprocessor_conditional_block_comment(void)
 {
-   chunk_t *pc;
    chunk_t *tmp;
    chunk_t *br_open;
    chunk_t *br_close;
@@ -2055,7 +2046,7 @@ void add_long_preprocessor_conditional_block_comment(void)
    chunk_t *pp_end   = NULL;
    int     nl_count;
 
-   for (pc = chunk_get_head(); pc; pc = chunk_get_next_ncnl(pc))
+   for (chunk_t *pc = chunk_get_head(); pc; pc = chunk_get_next_ncnl(pc))
    {
       /* just track the preproc level: */
       if (pc->type == CT_PREPROC)

--- a/src/parens.cpp
+++ b/src/parens.cpp
@@ -58,7 +58,6 @@ static void add_parens_between(chunk_t *first, chunk_t *last)
    chunk_t pc;
    chunk_t *first_n;
    chunk_t *last_p;
-   chunk_t *tmp;
 
    LOG_FMT(LPARADD, "%s: line %lu between %s [lvl=%lu] and %s [lvl=%lu]\n",
            __func__, first->orig_line,
@@ -91,7 +90,7 @@ static void add_parens_between(chunk_t *first, chunk_t *last)
 
    chunk_add_after(&pc, last_p);
 
-   for (tmp = first_n;
+   for (chunk_t *tmp = first_n;
         tmp != last_p;
         tmp = chunk_get_next_ncnl(tmp))
    {

--- a/src/parens.cpp
+++ b/src/parens.cpp
@@ -22,12 +22,11 @@ static void check_bool_parens(chunk_t *popen, chunk_t *pclose, int nest);
 void do_parens(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
    chunk_t *pclose;
 
    if (cpd.settings[UO_mod_full_paren_if_bool].b)
    {
-      pc = chunk_get_head();
+      chunk_t *pc = chunk_get_head();
       while ((pc = chunk_get_next_ncnl(pc)) != NULL)
       {
          if ((pc->type != CT_SPAREN_OPEN) ||

--- a/src/parse_frame.cpp
+++ b/src/parse_frame.cpp
@@ -90,6 +90,7 @@ void pf_push(struct parse_frame *pf)
    {
       pf_copy(&cpd.frames[cpd.frame_count], pf);
       cpd.frame_count++;
+
       pf->ref_no = ref_no++;
    }
    LOG_FMT(LPF, "%s(%d): count = %d\n", __func__, __LINE__, cpd.frame_count);
@@ -103,16 +104,13 @@ void pf_push(struct parse_frame *pf)
  */
 void pf_push_under(struct parse_frame *pf)
 {
-   struct parse_frame *npf1;
-   struct parse_frame *npf2;
-
    LOG_FMT(LPF, "%s(%d): before count = %d\n", __func__, __LINE__, cpd.frame_count);
 
    if ((cpd.frame_count < (int)ARRAY_SIZE(cpd.frames)) &&
        (cpd.frame_count >= 1))
    {
-      npf1 = &cpd.frames[cpd.frame_count - 1];
-      npf2 = &cpd.frames[cpd.frame_count];
+      struct parse_frame *npf1 = &cpd.frames[cpd.frame_count - 1];
+      struct parse_frame *npf2 = &cpd.frames[cpd.frame_count];
       pf_copy(npf2, npf1);
       pf_copy(npf1, pf);
       cpd.frame_count++;

--- a/src/parse_frame.cpp
+++ b/src/parse_frame.cpp
@@ -18,14 +18,12 @@
  */
 void pf_log(log_sev_t logsev, struct parse_frame *pf)
 {
-   int idx;
-
    LOG_FMT(logsev, "[%s] BrLevel=%d Level=%d PseTos=%d\n",
            get_token_name(pf->in_ifdef),
            pf->brace_level, pf->level, pf->pse_tos);
 
    LOG_FMT(logsev, " *");
-   for (idx = 1; idx <= pf->pse_tos; idx++)
+   for (int idx = 1; idx <= pf->pse_tos; idx++)
    {
       LOG_FMT(logsev, " [%s-%d]",
               get_token_name(pf->pse[idx].type),
@@ -37,10 +35,8 @@ void pf_log(log_sev_t logsev, struct parse_frame *pf)
 
 static void pf_log_frms(log_sev_t logsev, const char *txt, struct parse_frame *pf)
 {
-   int idx;
-
    LOG_FMT(logsev, "%s Parse Frames(%d):", txt, cpd.frame_count);
-   for (idx = 0; idx < cpd.frame_count; idx++)
+   for (int idx = 0; idx < cpd.frame_count; idx++)
    {
       LOG_FMT(logsev, " [%s-%d]",
               get_token_name(cpd.frames[idx].in_ifdef),
@@ -55,11 +51,9 @@ static void pf_log_frms(log_sev_t logsev, const char *txt, struct parse_frame *p
  */
 void pf_log_all(log_sev_t logsev)
 {
-   int idx;
-
    LOG_FMT(logsev, "##=- Parse Frame : %d entries\n", cpd.frame_count);
 
-   for (idx = 0; idx < cpd.frame_count; idx++)
+   for (int idx = 0; idx < cpd.frame_count; idx++)
    {
       LOG_FMT(logsev, "##  <%d> ", idx);
 

--- a/src/semicolons.cpp
+++ b/src/semicolons.cpp
@@ -45,13 +45,13 @@ void remove_extra_semicolons(void)
    LOG_FUNC_ENTRY();
    chunk_t *pc;
    chunk_t *next;
-   chunk_t *prev;
 
    pc = chunk_get_head();
    while (pc != NULL)
    {
       next = chunk_get_next_ncnl(pc);
 
+      chunk_t *prev;
       if ((pc->type == CT_SEMICOLON) && !(pc->flags & PCF_IN_PREPROC) &&
           ((prev = chunk_get_prev_ncnl(pc)) != NULL))
       {

--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -67,7 +67,8 @@ static int compare_chunks(chunk_t *pc1, chunk_t *pc2)
 static void do_the_sort(chunk_t **chunks, int num_chunks)
 {
    LOG_FUNC_ENTRY();
-   int start_idx, min_idx, idx;
+   int min_idx;
+   int idx;
 
    LOG_FMT(LSORT, "%s: %d chunks:", __func__, num_chunks);
    for (idx = 0; idx < num_chunks; idx++)
@@ -76,6 +77,7 @@ static void do_the_sort(chunk_t **chunks, int num_chunks)
    }
    LOG_FMT(LSORT, "\n");
 
+   int start_idx;
    for (start_idx = 0; start_idx < (num_chunks - 1); start_idx++)
    {
       /* Find the index of the minimum value */

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -119,7 +119,6 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
    int      idx;
    argval_t arg;
    chunk_t  *next;
-   chunk_t  *prev;
 
    min_sp = 1;
 
@@ -1434,7 +1433,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
 
    if ((first->type == CT_PTR_TYPE) && CharTable::IsKw1(second->str[0]))
    {
-      prev = chunk_get_prev(first);
+      chunk_t *prev = chunk_get_prev(first);
       if ((prev != NULL) && (prev->type == CT_IN))
       {
          log_rule("sp_deref");

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -299,7 +299,6 @@ static bool parse_comment(tok_ctx &ctx, chunk_t &pc)
    bool is_d    = (cpd.lang_flags & LANG_D) != 0;          // forcing value to bool
    bool is_cs   = (cpd.lang_flags & LANG_CS) != 0;         // forcing value to bool
    int  d_level = 0;
-   int  bs_cnt;
 
    /* does this start with '/ /' or '/ *' or '/ +' (d) */
    if ((ctx.peek() != '/') ||
@@ -321,7 +320,7 @@ static bool parse_comment(tok_ctx &ctx, chunk_t &pc)
       pc.type = CT_COMMENT_CPP;
       while (true)
       {
-         bs_cnt = 0;
+         int bs_cnt = 0;
          while (ctx.more())
          {
             ch = ctx.peek();
@@ -511,7 +510,7 @@ static bool parse_comment(tok_ctx &ctx, chunk_t &pc)
  */
 static bool parse_code_placeholder(tok_ctx &ctx, chunk_t &pc)
 {
-   int last2 = 0, last1 = 0;
+   int last1 = 0;
 
    if ((ctx.peek() != '<') || (ctx.peek(1) != '#'))
    {
@@ -527,7 +526,7 @@ static bool parse_code_placeholder(tok_ctx &ctx, chunk_t &pc)
    /* grab everything until '#>', fail if not found. */
    while (ctx.more())
    {
-      last2 = last1;
+      int last2 = last1;
       last1 = ctx.get();
       pc.str.append(last1);
 
@@ -1167,7 +1166,6 @@ static bool parse_cr_string(tok_ctx &ctx, chunk_t &pc, int q_idx)
  */
 bool parse_word(tok_ctx &ctx, chunk_t &pc, bool skipcheck)
 {
-   int             ch;
    static unc_text intr_txt("@interface");
 
    /* The first character is already valid */
@@ -1176,7 +1174,7 @@ bool parse_word(tok_ctx &ctx, chunk_t &pc, bool skipcheck)
 
    while (ctx.more())
    {
-      ch = ctx.peek();
+      int ch = ctx.peek();
       if (CharTable::IsKw2(ch))
       {
          pc.str.append(ctx.get());
@@ -1476,7 +1474,6 @@ static bool parse_ignored(tok_ctx &ctx, chunk_t &pc)
 static bool parse_next(tok_ctx &ctx, chunk_t &pc)
 {
    const chunk_tag_t *punc;
-   int               ch1;
 
    //chunk_t           pc_temp;
 
@@ -1714,8 +1711,8 @@ static bool parse_next(tok_ctx &ctx, chunk_t &pc)
       /* Not D stuff */
 
       /* Check for L'a', L"abc", 'a', "abc", <abc> strings */
-      ch  = ctx.peek();
-      ch1 = ctx.peek(1);
+      ch = ctx.peek();
+      int ch1 = ctx.peek(1);
       if ((((ch == 'L') || (ch == 'S')) &&
            ((ch1 == '"') || (ch1 == '\''))) ||
           (ch == '"') ||

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -1979,9 +1979,7 @@ void tokenize(const deque<int> &data, chunk_t *ref)
 // int str_find(const char *needle, int needle_len,
 //              const char *haystack, int haystack_len)
 // {
-//    int idx;
-//
-//    for (idx = 0; idx < (haystack_len - needle_len); idx++)
+//    for (int idx = 0; idx < (haystack_len - needle_len); idx++)
 //    {
 //       if (memcmp(needle, haystack + idx, needle_len) == 0)
 //       {

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -841,7 +841,6 @@ static void check_template(chunk_t *start)
    chunk_t *end;
    chunk_t *prev;
    chunk_t *next;
-   bool    in_if = false;
 
    LOG_FMT(LTEMPL, "%s: Line %lu, col %lu:", __func__, start->orig_line, start->orig_col);
 
@@ -909,6 +908,7 @@ static void check_template(chunk_t *start)
       LOG_FMT(LTEMPL, " - prev %s -", get_token_name(prev->type));
 
       /* Scan back and make sure we aren't inside square parens */
+      bool in_if = false;
       pc = start;
       while ((pc = chunk_get_prev_ncnl(pc, CNAV_PREPROC)) != NULL)
       {

--- a/src/unc_tools.cpp
+++ b/src/unc_tools.cpp
@@ -18,10 +18,8 @@
 // protocol of the line
 void prot_the_line(int theLine, unsigned int actual_line)
 {
-   chunk_t *pc;
-
    LOG_FMT(LGUY, "Prot_the_line:(%d) \n", theLine);
-   for (pc = chunk_get_head(); pc != NULL; pc = pc->next)
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = pc->next)
    {
       if (pc->orig_line == actual_line)
       {

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -768,7 +768,6 @@ static bool read_stdin(file_mem &fm)
 {
    deque<UINT8> dq;
    char         buf[4096];
-   int          idx;
 
    fm.raw.clear();
    fm.data.clear();
@@ -777,7 +776,7 @@ static bool read_stdin(file_mem &fm)
    while (!feof(stdin))
    {
       int len = fread(buf, 1, sizeof(buf), stdin);
-      for (idx = 0; idx < len; idx++)
+      for (int idx = 0; idx < len; idx++)
       {
          dq.push_back(buf[idx]);
       }
@@ -791,13 +790,12 @@ static bool read_stdin(file_mem &fm)
 
 static void make_folders(const string &filename)
 {
-   int  idx;
    int  last_idx = 0;
    char outname[4096];
 
    snprintf(outname, sizeof(outname), "%s", filename.c_str());
 
-   for (idx = 0; outname[idx] != 0; idx++)
+   for (int idx = 0; outname[idx] != 0; idx++)
    {
       if ((outname[idx] == '/') || (outname[idx] == '\\'))
       {
@@ -1919,8 +1917,7 @@ c_token_t find_token_name(const char *text)
 {
    if ((text != NULL) && (*text != 0))
    {
-      int idx;
-      for (idx = 1; idx < (int)ARRAY_SIZE(token_names); idx++)
+      for (int idx = 1; idx < (int)ARRAY_SIZE(token_names); idx++)
       {
          if (strcasecmp(text, token_names[idx]) == 0)
          {
@@ -1966,9 +1963,7 @@ static lang_name_t language_names[] =
 
 int language_flags_from_name(const char *name)
 {
-   int i;
-
-   for (i = 0; i < (int)ARRAY_SIZE(language_names); i++)
+   for (int i = 0; i < (int)ARRAY_SIZE(language_names); i++)
    {
       if (strcasecmp(name, language_names[i].name) == 0)
       {

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -721,15 +721,13 @@ static void process_source_list(const char *source_list,
    }
 
    char linebuf[256];
-   char *fname;
    int  line = 0;
-   int  len;
 
    while (fgets(linebuf, sizeof(linebuf), p_file) != NULL)
    {
       line++;
-      fname = linebuf;
-      len   = strlen(fname);
+      char *fname = linebuf;
+      int  len    = strlen(fname);
       while ((len > 0) && unc_isspace(*fname))
       {
          fname++;
@@ -770,7 +768,6 @@ static bool read_stdin(file_mem &fm)
 {
    deque<UINT8> dq;
    char         buf[4096];
-   int          len;
    int          idx;
 
    fm.raw.clear();
@@ -779,7 +776,7 @@ static bool read_stdin(file_mem &fm)
 
    while (!feof(stdin))
    {
-      len = fread(buf, 1, sizeof(buf), stdin);
+      int len = fread(buf, 1, sizeof(buf), stdin);
       for (idx = 0; idx < len; idx++)
       {
          dq.push_back(buf[idx]);
@@ -999,7 +996,6 @@ static bool file_content_matches(const string &filename1, const string &filename
    int         fd1, fd2;
    UINT8       buf1[1024], buf2[1024];
    int         len1 = 0, len2 = 0;
-   int         minlen;
 
    /* Check the sizes first */
    if ((stat(filename1.c_str(), &st1) != 0) ||
@@ -1033,7 +1029,7 @@ static bool file_content_matches(const string &filename1, const string &filename
       {
          break;
       }
-      minlen = (len1 < len2) ? len1 : len2;
+      int minlen = (len1 < len2) ? len1 : len2;
       if (memcmp(buf1, buf2, minlen) != 0)
       {
          break;
@@ -1921,10 +1917,9 @@ const char *get_token_name(c_token_t token)
  */
 c_token_t find_token_name(const char *text)
 {
-   int idx;
-
    if ((text != NULL) && (*text != 0))
    {
+      int idx;
       for (idx = 1; idx < (int)ARRAY_SIZE(token_names); idx++)
       {
          if (strcasecmp(text, token_names[idx]) == 0)

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -108,7 +108,8 @@ void encode_utf8(int ch, vector<UINT8> &res)
 static bool decode_utf8(const vector<UINT8> &in_data, deque<int> &out_data)
 {
    int idx = 0;
-   int ch, tmp, cnt;
+   int tmp;
+   int cnt;
 
    out_data.clear();
 
@@ -126,7 +127,7 @@ static bool decode_utf8(const vector<UINT8> &in_data, deque<int> &out_data)
 
    while (idx < (int)in_data.size())
    {
-      ch = in_data[idx++];
+      int ch = in_data[idx++];
       if (ch < 0x80)                   /* 1-byte sequence */
       {
          out_data.push_back(ch);

--- a/src/width.cpp
+++ b/src/width.cpp
@@ -51,11 +51,10 @@ static void split_before_chunk(chunk_t *pc)
 void do_code_width(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
 
    LOG_FMT(LSPLIT, "%s\n", __func__);
 
-   for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
    {
       if (!chunk_is_newline(pc) &&
           !chunk_is_comment(pc) &&
@@ -112,9 +111,7 @@ static const token_pri pri_table[] =
 
 static int get_split_pri(c_token_t tok)
 {
-   int idx;
-
-   for (idx = 0; idx < (int)ARRAY_SIZE(pri_table); idx++)
+   for (int idx = 0; idx < (int)ARRAY_SIZE(pri_table); idx++)
    {
       if (pri_table[idx].tok == tok)
       {


### PR DESCRIPTION
This is a fixed version of PR #871

> The intention of this commit was to reduce the scope of the variables as much as possible.
> Thus all variables are as close as possible to the place where they are used.
> 
> The actual functionality was not changed. Or at least it was not my intention.

Things that I changed:
* moved all static ints back at their original position ([indent.cpp:325](https://github.com/uncrustify/uncrustify/pull/871/commits/a1591201f25929f5025739d9ab65ca4f19ff17b6#diff-c5ce1a11bc44c523945fd2542a4ec137L325), [parse_frame.cpp:87](https://github.com/uncrustify/uncrustify/pull/871/commits/a1591201f25929f5025739d9ab65ca4f19ff17b6#diff-a4e6abd47800d30ec297e2d256210542L87)) 
* integrated / squashed the fixup commits f4d738d5b66d4eaf7f0542755934c92c094f8033 and ae409f84b7e9cc067c12aacbff72b2f030a217db
* removed already merged content ([options.cpp:24](https://github.com/uncrustify/uncrustify/pull/871/commits/a1591201f25929f5025739d9ab65ca4f19ff17b6#diff-8fc678ba06a385b9b43fa2afc72e840cR23), [options.cpp:2067](https://github.com/uncrustify/uncrustify/pull/871/commits/a1591201f25929f5025739d9ab65ca4f19ff17b6#diff-8fc678ba06a385b9b43fa2afc72e840cL2067))
* removed merge conflicts