### PR TITLE
nl_before_func_body_def checks now comment and func line delta (i_902)

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -747,13 +747,21 @@ static void newlines_func_pre_blank_lines(chunk_t *start)
       else if (chunk_is_comment(pc))
       {
          LOG_FMT(LNLFUNCT, "   <chunk_is_comment> found at line=%zu column=%zu\n", pc->orig_line, pc->orig_col);
-         if (last_comment)
+         if ((pc->orig_line < start->orig_line
+              && ((start->orig_line - pc->orig_line
+                   - (pc->type == CT_COMMENT_MULTI ? pc->nl_count : 0))) < 2) ||
+             (last_comment != NULL
+              && pc->type == CT_COMMENT_CPP     // combine only cpp comments
+              && last_comment->type == pc->type // don't mix comment types
+              && last_comment->orig_line > pc->orig_line
+              && (last_comment->orig_line - pc->orig_line) < 2))
          {
-            do_it = true;
-            break;
+            last_comment = pc;
+            continue;
          }
-         last_comment = pc;
-         continue;
+
+         do_it = true;
+         break;
       }
       else if (pc->type == CT_DESTRUCTOR)
       {

--- a/tests/config/bug_902-1.cfg
+++ b/tests/config/bug_902-1.cfg
@@ -1,0 +1,1 @@
+nl_before_func_body_def         = 1

--- a/tests/config/bug_902-2.cfg
+++ b/tests/config/bug_902-2.cfg
@@ -1,0 +1,1 @@
+nl_before_func_body_def         = 2

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -368,4 +368,5 @@
 34105 bug_i_663.cfg                    cpp/bug_i_663.cpp
 34108 bug_i_666.cfg                    cpp/bug_i_666.cpp
 34112 empty.cfg                        cpp/bug_i_889.cpp
-
+34113 bug_902-1.cfg                    cpp/bug_902.cpp
+34114 bug_902-2.cfg                    cpp/bug_902.cpp

--- a/tests/input/cpp/bug_902.cpp
+++ b/tests/input/cpp/bug_902.cpp
@@ -1,0 +1,65 @@
+// unc_add_option("sp_cond_colon", UO_sp_cond_colon, AT_IARF,
+//                "Add or remove space around the ':' in 'b ? t : f'");
+// unc_add_option("sp_cond_question", UO_sp_cond_question, AT_IARF,
+//                "Add or remove space around the '?' in 'b ? t : f'");
+
+
+void detect_options(void)
+{
+	detect_space_options();
+}
+
+int i = 0;
+
+//a
+void a(){ return 0; }
+
+//0
+/*b*/
+void b(){ return 0; }
+
+/*0*/
+//c
+void c(){ return 0; }
+
+
+//d
+//d
+//d
+void d(){ return 0; }
+
+//0
+
+//h
+//h
+void h(){ return 0; }
+
+/*0*/
+/*e*/
+void e(){ return 0; }
+
+void f(){ return 0; }
+
+int i = 0;
+void g(){ return 0; }
+
+void i(){ return 0; }
+void j(){ return 0; }
+void k(){ return 0; }
+
+//0
+
+void l(){ return 0; }
+
+/*
+ * 0
+ */
+
+void m(){ return 0; }
+
+/*
+ * n
+ * n
+ * n
+ */
+void n(){ return 0; }

--- a/tests/output/cpp/34113-bug_902.cpp
+++ b/tests/output/cpp/34113-bug_902.cpp
@@ -1,0 +1,82 @@
+// unc_add_option("sp_cond_colon", UO_sp_cond_colon, AT_IARF,
+//                "Add or remove space around the ':' in 'b ? t : f'");
+// unc_add_option("sp_cond_question", UO_sp_cond_question, AT_IARF,
+//                "Add or remove space around the '?' in 'b ? t : f'");
+void detect_options(void)
+{
+	detect_space_options();
+}
+
+int i = 0;
+//a
+void a(){
+	return 0;
+}
+
+//0
+/*b*/
+void b(){
+	return 0;
+}
+
+/*0*/
+//c
+void c(){
+	return 0;
+}
+//d
+//d
+//d
+void d(){
+	return 0;
+}
+
+//0
+//h
+//h
+void h(){
+	return 0;
+}
+
+/*0*/
+/*e*/
+void e(){
+	return 0;
+}
+void f(){
+	return 0;
+}
+
+int i = 0;
+void g(){
+	return 0;
+}
+void i(){
+	return 0;
+}
+void j(){
+	return 0;
+}
+void k(){
+	return 0;
+}
+
+//0
+void l(){
+	return 0;
+}
+
+/*
+ * 0
+ */
+void m(){
+	return 0;
+}
+/*
+ * n
+ * n
+ * n
+ */
+void n(){
+	return 0;
+}

--- a/tests/output/cpp/34114-bug_902.cpp
+++ b/tests/output/cpp/34114-bug_902.cpp
@@ -1,0 +1,97 @@
+// unc_add_option("sp_cond_colon", UO_sp_cond_colon, AT_IARF,
+//                "Add or remove space around the ':' in 'b ? t : f'");
+// unc_add_option("sp_cond_question", UO_sp_cond_question, AT_IARF,
+//                "Add or remove space around the '?' in 'b ? t : f'");
+
+void detect_options(void)
+{
+	detect_space_options();
+}
+
+int i = 0;
+
+//a
+void a(){
+	return 0;
+}
+
+//0
+
+/*b*/
+void b(){
+	return 0;
+}
+
+/*0*/
+
+//c
+void c(){
+	return 0;
+}
+
+//d
+//d
+//d
+void d(){
+	return 0;
+}
+
+//0
+
+//h
+//h
+void h(){
+	return 0;
+}
+
+/*0*/
+
+/*e*/
+void e(){
+	return 0;
+}
+
+void f(){
+	return 0;
+}
+
+int i = 0;
+
+void g(){
+	return 0;
+}
+
+void i(){
+	return 0;
+}
+
+void j(){
+	return 0;
+}
+
+void k(){
+	return 0;
+}
+
+//0
+
+void l(){
+	return 0;
+}
+
+/*
+ * 0
+ */
+
+void m(){
+	return 0;
+}
+
+/*
+ * n
+ * n
+ * n
+ */
+void n(){
+	return 0;
+}


### PR DESCRIPTION
The previous behaviour was to insert newlines between two comments tokens.
Now newlines are inserted after a comment if it is not directly behind a func_body_def or does not belong to the set of cpp comments that is directly behind a func_body_def.

ref: #902 