### PR TITLE
Adding additional exclusion patterns to .gitignore (implements #917)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 # Generated uncrustify files
-#src/config.h
-#src/token_names.h
-#src/uncrustify_version.h
+src/config.h
+src/token_names.h
+src/uncrustify_version.h
 
 # Testing framework
+results/
 tests/results
 tests/usage.txt
 *.sh.trs
@@ -11,7 +12,7 @@ tests/usage.txt
 test-suite.log
 
 # UNIX build artifacts
-#*.o
+*.[oaisS]
 src/uncrustify
 
 # Gnu autotools
@@ -77,5 +78,14 @@ uncrustify-*-win32
 .svn
 *~
 .*
-Debug
 build*
+
+
+# Eclipse Build Directories
+Debug/
+Release/
+
+# Eclipse Configuration
+.cproject
+.project
+.settings


### PR DESCRIPTION
This pull request adds a few more exclusion patterns to the `.gitignore` file.
This helps people that do not rely on the cmake build procedure. Specifically it helps people that use eclipse.
The exclusion of additional UNIX/GCC build artefacts `*.[oaisS]` is helpful during debugging when working with changed compiler flags. 

I expect that the additional exclusion will not disturb the exisiting build process. 