### PR TITLE
removed struct from variable types (implements #869)

### DIFF
--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -19,20 +19,20 @@
 #include "unc_ctype.h"
 
 
-static chunk_t *insert_vbrace(chunk_t *pc, bool after, struct parse_frame *frm);
+static chunk_t *insert_vbrace(chunk_t *pc, bool after, parse_frame_t *frm);
 
 #define insert_vbrace_close_after(pc, frm)    insert_vbrace(pc, true, frm)
 #define insert_vbrace_open_before(pc, frm)    insert_vbrace(pc, false, frm)
 
-static void parse_cleanup(struct parse_frame *frm, chunk_t *pc);
+static void parse_cleanup(parse_frame_t *frm, chunk_t *pc);
 
-static bool close_statement(struct parse_frame *frm, chunk_t *pc);
+static bool close_statement(parse_frame_t *frm, chunk_t *pc);
 
-static bool check_complex_statements(struct parse_frame *frm, chunk_t *pc);
-static bool handle_complex_close(struct parse_frame *frm, chunk_t *pc);
+static bool check_complex_statements(parse_frame_t *frm, chunk_t *pc);
+static bool handle_complex_close(parse_frame_t *frm, chunk_t *pc);
 
 
-static size_t preproc_start(struct parse_frame *frm, chunk_t *pc)
+static size_t preproc_start(parse_frame_t *frm, chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
    chunk_t *next;
@@ -72,7 +72,7 @@ static size_t preproc_start(struct parse_frame *frm, chunk_t *pc)
 
 
 static void print_stack(log_sev_t logsev, const char *str,
-                        struct parse_frame *frm, chunk_t *pc)
+                        parse_frame_t *frm, chunk_t *pc)
 {
    (void)pc;
    LOG_FUNC_ENTRY();
@@ -106,8 +106,8 @@ static void print_stack(log_sev_t logsev, const char *str,
 void brace_cleanup(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t            *pc;
-   struct parse_frame frm;
+   chunk_t       *pc;
+   parse_frame_t frm;
 
    cpd.unc_stage = US_BRACE_CLEANUP;
 
@@ -204,7 +204,7 @@ static bool maybe_while_of_do(chunk_t *pc)
 }
 
 
-static void push_fmr_pse(struct parse_frame *frm, chunk_t *pc,
+static void push_fmr_pse(parse_frame_t *frm, chunk_t *pc,
                          brstage_e stage, const char *logtext)
 {
    LOG_FUNC_ENTRY();
@@ -280,7 +280,7 @@ static void push_fmr_pse(struct parse_frame *frm, chunk_t *pc,
  * When a #define is entered, the current frame is pushed and cleared.
  * When a #define is exited, the frame is popped.
  */
-static void parse_cleanup(struct parse_frame *frm, chunk_t *pc)
+static void parse_cleanup(parse_frame_t *frm, chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
    c_token_t parent = CT_NONE;
@@ -670,7 +670,7 @@ static void parse_cleanup(struct parse_frame *frm, chunk_t *pc)
  * @param pc   The current chunk
  * @return     true - done with this chunk, false - keep processing
  */
-static bool check_complex_statements(struct parse_frame *frm, chunk_t *pc)
+static bool check_complex_statements(parse_frame_t *frm, chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
    c_token_t parent;
@@ -850,7 +850,7 @@ static bool check_complex_statements(struct parse_frame *frm, chunk_t *pc)
  * @param pc   The current chunk
  * @return     true - done with this chunk, false - keep processing
  */
-static bool handle_complex_close(struct parse_frame *frm, chunk_t *pc)
+static bool handle_complex_close(parse_frame_t *frm, chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
    chunk_t *next;
@@ -961,8 +961,7 @@ static bool handle_complex_close(struct parse_frame *frm, chunk_t *pc)
  *   true:  insert_vbrace_close_after(pc, frm)
  *   false: insert_vbrace_open_before(pc, frm)
  */
-static chunk_t *insert_vbrace(chunk_t *pc, bool after,
-                              struct parse_frame *frm)
+static chunk_t *insert_vbrace(chunk_t *pc, bool after, parse_frame_t *frm)
 {
    LOG_FUNC_ENTRY();
    chunk_t chunk;
@@ -1030,7 +1029,7 @@ static chunk_t *insert_vbrace(chunk_t *pc, bool after,
  *
  * @return     true - done with this chunk, false - keep processing
  */
-bool close_statement(struct parse_frame *frm, chunk_t *pc)
+bool close_statement(parse_frame_t *frm, chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
    chunk_t *vbc = pc;

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -318,7 +318,7 @@ void reindent_line(chunk_t *pc, int column)
  * @param frm  The parse frame
  * @param pc   The chunk causing the push
  */
-static void indent_pse_push(struct parse_frame &frm, chunk_t *pc)
+static void indent_pse_push(parse_frame_t &frm, chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
    static int ref = 0;
@@ -363,7 +363,7 @@ static void indent_pse_push(struct parse_frame &frm, chunk_t *pc)
  * @param frm  The parse frame
  * @param pc   The chunk causing the push
  */
-static void indent_pse_pop(struct parse_frame &frm, chunk_t *pc)
+static void indent_pse_pop(parse_frame_t &frm, chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
    /* Bump up the index and initialize it */
@@ -452,7 +452,7 @@ static int token_indent(c_token_t type)
    } while (0)
 
 
-static int calc_indent_continue(struct parse_frame &frm, int pse_tos)
+static int calc_indent_continue(parse_frame_t &frm, int pse_tos)
 {
    int ic = cpd.settings[UO_indent_continue].n;
 
@@ -531,24 +531,24 @@ static chunk_t *oc_msg_prev_colon(chunk_t *pc)
 void indent_text(void)
 {
    LOG_FUNC_ENTRY();
-   chunk_t            *pc;
-   chunk_t            *next;
-   chunk_t            *prev       = NULL;
-   bool               did_newline = true;
-   int                idx;
-   int                vardefcol    = 0;
-   int                shiftcontcol = 0;
-   int                indent_size  = cpd.settings[UO_indent_columns].n;
-   struct parse_frame frm;
-   bool               in_preproc = false;
-   int                indent_column;
-   int                parent_token_indent = 0;
-   int                xml_indent          = 0;
-   bool               token_used;
-   int                sql_col      = 0;
-   int                sql_orig_col = 0;
-   bool               in_func_def  = false;
-   c_token_t          memtype;
+   chunk_t       *pc;
+   chunk_t       *next;
+   chunk_t       *prev       = NULL;
+   bool          did_newline = true;
+   int           idx;
+   int           vardefcol    = 0;
+   int           shiftcontcol = 0;
+   int           indent_size  = cpd.settings[UO_indent_columns].n;
+   parse_frame_t frm;
+   bool          in_preproc = false;
+   int           indent_column;
+   int           parent_token_indent = 0;
+   int           xml_indent          = 0;
+   bool          token_used;
+   int           sql_col      = 0;
+   int           sql_orig_col = 0;
+   bool          in_func_def  = false;
+   c_token_t     memtype;
 
    memset(&frm, 0, sizeof(frm));
    cpd.frame_count = 0;

--- a/src/options_for_QT.h
+++ b/src/options_for_QT.h
@@ -5,7 +5,7 @@
  * http://doc.qt.io/qt-4.8/qtglobal.html
  *
  * @author  Guy Maurel since version 0.62 for uncrustify4Qt
- *          Januar 2016
+ *          January 2016
  * @license GPL v2+
  */
 
@@ -14,11 +14,11 @@
 
 #include "uncrustify_types.h"
 
-extern struct cp_data cpd;
+extern cp_data_t cpd;
 
-extern bool           QT_SIGNAL_SLOT_found;
-extern int            QT_SIGNAL_SLOT_level;
-extern bool           restoreValues;
+extern bool      QT_SIGNAL_SLOT_found;
+extern int       QT_SIGNAL_SLOT_level;
+extern bool      restoreValues;
 
 void save_set_options_for_QT(int level);
 void restore_options_for_QT(void);

--- a/src/parse_frame.cpp
+++ b/src/parse_frame.cpp
@@ -16,7 +16,7 @@
 /**
  * Logs one parse frame
  */
-void pf_log(log_sev_t logsev, struct parse_frame *pf)
+void pf_log(log_sev_t logsev, parse_frame_t *pf)
 {
    LOG_FMT(logsev, "[%s] BrLevel=%d Level=%d PseTos=%zu\n",
            get_token_name(pf->in_ifdef),
@@ -33,7 +33,7 @@ void pf_log(log_sev_t logsev, struct parse_frame *pf)
 }
 
 
-static void pf_log_frms(log_sev_t logsev, const char *txt, struct parse_frame *pf)
+static void pf_log_frms(log_sev_t logsev, const char *txt, parse_frame_t *pf)
 {
    LOG_FMT(logsev, "%s Parse Frames(%d):", txt, cpd.frame_count);
    for (int idx = 0; idx < cpd.frame_count; idx++)
@@ -66,9 +66,9 @@ void pf_log_all(log_sev_t logsev)
 /**
  * Copies src to dst.
  */
-void pf_copy(struct parse_frame *dst, const struct parse_frame *src)
+void pf_copy(parse_frame_t *dst, const parse_frame_t *src)
 {
-   memcpy(dst, src, sizeof(struct parse_frame));
+   memcpy(dst, src, sizeof(parse_frame_t));
 }
 
 
@@ -76,7 +76,7 @@ void pf_copy(struct parse_frame *dst, const struct parse_frame *src)
  * Push a copy of the parse frame onto the stack.
  * This is called on #if and #ifdef.
  */
-void pf_push(struct parse_frame *pf)
+void pf_push(parse_frame_t *pf)
 {
    static int ref_no = 1;
 
@@ -96,15 +96,15 @@ void pf_push(struct parse_frame *pf)
  * If this were a linked list, just add before the last item.
  * This is called on the first #else and #elif.
  */
-void pf_push_under(struct parse_frame *pf)
+void pf_push_under(parse_frame_t *pf)
 {
    LOG_FMT(LPF, "%s(%d): before count = %d\n", __func__, __LINE__, cpd.frame_count);
 
    if ((cpd.frame_count < (int)ARRAY_SIZE(cpd.frames)) &&
        (cpd.frame_count >= 1))
    {
-      struct parse_frame *npf1 = &cpd.frames[cpd.frame_count - 1];
-      struct parse_frame *npf2 = &cpd.frames[cpd.frame_count];
+      parse_frame_t *npf1 = &cpd.frames[cpd.frame_count - 1];
+      parse_frame_t *npf2 = &cpd.frames[cpd.frame_count];
       pf_copy(npf2, npf1);
       pf_copy(npf1, pf);
       cpd.frame_count++;
@@ -118,7 +118,7 @@ void pf_push_under(struct parse_frame *pf)
  * Copy the top item off the stack into pf.
  * This is called on #else and #elif.
  */
-void pf_copy_tos(struct parse_frame *pf)
+void pf_copy_tos(parse_frame_t *pf)
 {
    if (cpd.frame_count > 0)
    {
@@ -134,7 +134,7 @@ void pf_copy_tos(struct parse_frame *pf)
  * The stack contains [...] [base] [if] at this point.
  * We want to copy [base].
  */
-static void pf_copy_2nd_tos(struct parse_frame *pf)
+static void pf_copy_2nd_tos(parse_frame_t *pf)
 {
    if (cpd.frame_count > 1)
    {
@@ -161,7 +161,7 @@ void pf_trash_tos(void)
  * Pop the top item off the stack and copy into pf.
  * This is called on #endif
  */
-void pf_pop(struct parse_frame *pf)
+void pf_pop(parse_frame_t *pf)
 {
    if (cpd.frame_count > 0)
    {
@@ -175,7 +175,7 @@ void pf_pop(struct parse_frame *pf)
 /**
  * Returns the pp_indent to use for this line
  */
-int pf_check(struct parse_frame *frm, chunk_t *pc)
+int pf_check(parse_frame_t *frm, chunk_t *pc)
 {
    int        in_ifdef = frm->in_ifdef;
    int        b4_cnt   = cpd.frame_count;

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -217,13 +217,13 @@ const chunk_tag_t *find_punctuator(const char *str, int lang_flags);
 /*
  *  parse_frame.cpp
  */
-void pf_copy(struct parse_frame *dst, const struct parse_frame *src);
-void pf_push(struct parse_frame *pf);
-void pf_push_under(struct parse_frame *pf);
-void pf_copy_tos(struct parse_frame *pf);
+void pf_copy(parse_frame_t *dst, const parse_frame_t *src);
+void pf_push(parse_frame_t *pf);
+void pf_push_under(parse_frame_t *pf);
+void pf_copy_tos(parse_frame_t *pf);
 void pf_trash_tos(void);
-void pf_pop(struct parse_frame *pf);
-int pf_check(struct parse_frame *frm, chunk_t *pc);
+void pf_pop(parse_frame_t *pf);
+int pf_check(parse_frame_t *frm, chunk_t *pc);
 
 
 /*

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -32,7 +32,7 @@
 
 static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool complete);
 
-struct no_space_table_s
+struct no_space_table_t
 {
    c_token_t first;
    c_token_t second;
@@ -43,7 +43,7 @@ struct no_space_table_s
  *
  * TODO: some of these are no longer needed.
  */
-const struct no_space_table_s no_space_table[] =
+const no_space_table_t no_space_table[] =
 {
    { CT_OC_AT,          CT_UNKNOWN       },
    { CT_INCDEC_BEFORE,  CT_WORD          },

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -1804,13 +1804,13 @@ static bool parse_next(tok_ctx &ctx, chunk_t &pc)
  */
 void tokenize(const deque<int> &data, chunk_t *ref)
 {
-   tok_ctx            ctx(data);
-   chunk_t            chunk;
-   chunk_t            *pc    = NULL;
-   chunk_t            *rprev = NULL;
-   struct parse_frame frm;
-   bool               last_was_tab = false;
-   int                prev_sp      = 0;
+   tok_ctx       ctx(data);
+   chunk_t       chunk;
+   chunk_t       *pc    = NULL;
+   chunk_t       *rprev = NULL;
+   parse_frame_t frm;
+   bool          last_was_tab = false;
+   int           prev_sp      = 0;
 
    cpd.unc_stage = US_TOKENIZE;
 

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -42,7 +42,7 @@
 #endif
 
 /* Global data */
-struct cp_data cpd;
+cp_data_t cpd;
 
 
 static int language_flags_from_name(const char *tag);

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -74,7 +74,7 @@ struct indent_ptr_t
 /**
  * Structure for counting nested level
  */
-struct paren_stack_entry
+struct paren_stack_entry_t
 {
    c_token_t    type;         /**< the type that opened the entry */
    int          level;        /**< Level of opening type */
@@ -95,25 +95,25 @@ struct paren_stack_entry
 };
 
 /* TODO: put this on a linked list */
-struct parse_frame
+struct parse_frame_t
 {
-   int                      ref_no;
-   int                      level;           // level of parens/square/angle/brace
-   int                      brace_level;     // level of brace/vbrace
-   int                      pp_level;        // level of preproc #if stuff
+   int                 ref_no;
+   int                 level;           // level of parens/square/angle/brace
+   int                 brace_level;     // level of brace/vbrace
+   int                 pp_level;        // level of preproc #if stuff
 
-   int                      sparen_count;
+   int                 sparen_count;
 
-   struct paren_stack_entry pse[128];
-   size_t                   pse_tos;
-   int                      paren_count;
+   paren_stack_entry_t pse[128];
+   size_t              pse_tos;
+   int                 paren_count;
 
-   c_token_t                in_ifdef;
-   int                      stmt_count;
-   int                      expr_count;
+   c_token_t           in_ifdef;
+   int                 stmt_count;
+   int                 expr_count;
 
-   bool                     maybe_decl;
-   bool                     maybe_cast;
+   bool                maybe_decl;
+   bool                maybe_cast;
 };
 
 #define PCF_BIT(b)    (1ULL << b)
@@ -390,75 +390,75 @@ enum unc_stage
 /* this set a limit to the name padding */
 #define MAX_OPTION_NAME_LEN    32
 
-struct cp_data
+struct cp_data_t
 {
-   deque<UINT8>       *bout;
-   FILE               *fout;
-   int                last_char;
-   bool               do_check;
-   enum unc_stage     unc_stage;
-   int                check_fail_cnt; // total failures
-   bool               if_changed;
+   deque<UINT8>   *bout;
+   FILE           *fout;
+   int            last_char;
+   bool           do_check;
+   enum unc_stage unc_stage;
+   int            check_fail_cnt;     // total failures
+   bool           if_changed;
 
-   UINT32             error_count;
-   const char         *filename;
+   UINT32         error_count;
+   const char     *filename;
 
-   file_mem           file_hdr;   // for cmt_insert_file_header
-   file_mem           file_ftr;   // for cmt_insert_file_footer
-   file_mem           func_hdr;   // for cmt_insert_func_header
-   file_mem           oc_msg_hdr; // for cmt_insert_oc_msg_header
-   file_mem           class_hdr;  // for cmt_insert_class_header
+   file_mem       file_hdr;       // for cmt_insert_file_header
+   file_mem       file_ftr;       // for cmt_insert_file_footer
+   file_mem       func_hdr;       // for cmt_insert_func_header
+   file_mem       oc_msg_hdr;     // for cmt_insert_oc_msg_header
+   file_mem       class_hdr;      // for cmt_insert_class_header
 
-   int                lang_flags; // LANG_xxx
-   bool               lang_forced;
+   int            lang_flags;     // LANG_xxx
+   bool           lang_forced;
 
-   bool               unc_off;
-   bool               unc_off_used; // to check if "unc_off" is used
-   UINT32             line_number;
-   UINT16             column;       // column for parsing
-   UINT16             spaces;       // space count on output
+   bool           unc_off;
+   bool           unc_off_used;     // to check if "unc_off" is used
+   UINT32         line_number;
+   UINT16         column;           // column for parsing
+   UINT16         spaces;           // space count on output
 
-   int                ifdef_over_whole_file;
+   int            ifdef_over_whole_file;
 
-   bool               frag;
-   UINT16             frag_cols;
+   bool           frag;
+   UINT16         frag_cols;
 
    // stuff to auto-detect line endings
-   UINT32             le_counts[LE_AUTO];
-   unc_text           newline;
+   UINT32         le_counts[LE_AUTO];
+   unc_text       newline;
 
-   bool               consumed;
+   bool           consumed;
 
-   int                did_newline;
-   c_token_t          in_preproc;
-   int                preproc_ncnl_count;
-   bool               output_trailspace;
-   bool               output_tab_as_space;
+   int            did_newline;
+   c_token_t      in_preproc;
+   int            preproc_ncnl_count;
+   bool           output_trailspace;
+   bool           output_tab_as_space;
 
-   bool               bom;
-   CharEncoding       enc;
+   bool           bom;
+   CharEncoding   enc;
 
    // bumped up when a line is split or indented
-   int                changes;
-   int                pass_count;
+   int            changes;
+   int            pass_count;
 
-   struct align_t     al[80];
-   size_t             al_cnt;
-   bool               al_c99_array;
+   align_t        al[80];
+   size_t         al_cnt;
+   bool           al_c99_array;
 
-   bool               warned_unable_string_replace_tab_chars;
+   bool           warned_unable_string_replace_tab_chars;
 
    // Here are all the settings
-   op_val_t           settings[UO_option_count];
+   op_val_t       settings[UO_option_count];
 
-   struct parse_frame frames[16];
-   int                frame_count;
-   int                pp_level;
+   parse_frame_t  frames[16];
+   int            frame_count;
+   int            pp_level;
 
    // the default values for settings
-   op_val_t           defaults[UO_option_count];
+   op_val_t       defaults[UO_option_count];
 };
 
-extern struct cp_data cpd;
+extern cp_data_t cpd;
 
 #endif /* UNCRUSTIFY_TYPES_H_INCLUDED */


### PR DESCRIPTION
Removed struct from variable definitions to make the code more compact and thus easier to read.
No functional change.