### PR TITLE
use error codes from sysexists.h (implements #857)

### DIFF
--- a/src/backup.cpp
+++ b/src/backup.cpp
@@ -79,7 +79,7 @@ int backup_copy_file(const char *filename, const vector<UINT8> &data)
    if (memcmp(md5_str, md5_str_in, 32) == 0)
    {
       LOG_FMT(LNOTE, "%s: MD5 match for %s\n", __func__, filename);
-      return(SUCCESS);
+      return(EX_OK);
    }
 
    LOG_FMT(LNOTE, "%s: MD5 mismatch - backing up %s\n", __func__, filename);
@@ -97,7 +97,7 @@ int backup_copy_file(const char *filename, const vector<UINT8> &data)
 
       if (retval == 1)
       {
-         return(SUCCESS);
+         return(EX_OK);
       }
       LOG_FMT(LERR, "fwrite(%s) failed: %s (%d)\n",
               newpath, strerror(my_errno), my_errno);
@@ -109,7 +109,7 @@ int backup_copy_file(const char *filename, const vector<UINT8> &data)
               newpath, strerror(errno), errno);
       cpd.error_count++;
    }
-   return(FAILURE);
+   return(EX_IOERR);
 } // backup_copy_file
 
 

--- a/src/backup.h
+++ b/src/backup.h
@@ -38,7 +38,8 @@
  * @param filename   The file that was read (full path)
  * @param file_data  The file data
  * @param file_len   The file length
- * @return           SUCCESS or FAILURE
+ * @retval           EX_OK    - successfully created backup file
+ * @retval           EX_IOERR - could not create backup file
  */
 int backup_copy_file(const char *filename, const vector<UINT8> &data);
 

--- a/src/base_types.h
+++ b/src/base_types.h
@@ -9,6 +9,8 @@
 #ifndef BASE_TYPES_H_INCLUDED
 #define BASE_TYPES_H_INCLUDED
 
+#include "error_types.h"
+
 #ifdef WIN32
 
 #include "windows_compat.h"
@@ -42,14 +44,8 @@ typedef uint32_t   UINT32;
 typedef uint64_t   UINT64;
 #endif   /* ifdef WIN32 */
 
-/* and the good old SUCCESS/FAILURE */
-
-#define SUCCESS    0
-#define FAILURE    -1
-
 
 /* and a nice macro to keep SlickEdit happy */
-
 #define static_inline    static inline
 
 /* and the ever-so-important array size macro */

--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -102,7 +102,7 @@ chunk_t *chunk_dup(const chunk_t *pc_in)
    pc = new chunk_t;
    if (pc == NULL)
    {
-      exit(1);
+      exit(EXIT_FAILURE);
    }
 
    /* Copy all fields and then init the entry */

--- a/src/defines.cpp
+++ b/src/defines.cpp
@@ -58,7 +58,7 @@ int load_define_file(const char *filename)
       LOG_FMT(LERR, "%s: fopen(%s) failed: %s (%d)\n",
               __func__, filename, strerror(errno), errno);
       cpd.error_count++;
-      return(FAILURE);
+      return(EX_IOERR);
    }
 
    char   buf[160];
@@ -95,7 +95,7 @@ int load_define_file(const char *filename)
    }
 
    fclose(pf);
-   return(SUCCESS);
+   return(EX_OK);
 } // load_define_file
 
 

--- a/src/defines.h
+++ b/src/defines.h
@@ -15,7 +15,8 @@
  * Loads the defines from a file
  *
  * @param filename   The path to the file to load
- * @return           SUCCESS or FAILURE
+ * @retval           EX_OK    - defines successfully loaded from file
+ * @retval           EX_IOERR - reading defines file failed
  */
 int load_define_file(const char *filename);
 

--- a/src/error_types.h
+++ b/src/error_types.h
@@ -1,0 +1,54 @@
+/**
+ * @file error_types.h
+ *
+ * Defines the error codes that are used throughout uncrustify
+ *
+ * @license GPL v2+
+ */
+#ifndef _ERROR_TYPES_H_
+#define _ERROR_TYPES_H_
+
+#if 1
+#include <stdlib.h>      /* provides EXIT_SUCCESS and EXIT FAILURE */
+
+/* \todo if we decided to only use EX_OK and EX_xxx we can
+ * avoid including stdlib.h here */
+
+#else
+/* \todo I left this to show my modifications
+ *       remove it after the PR was reviewed     */
+
+/* the good old SUCCESS/FAILURE */
+#define SUCCESS    0      /* same as EX_OK */
+#define FAILURE    -1     /* incompatible to EXIT_FAILURE */
+#endif
+
+
+#ifdef WIN32
+/* Windows does not know sysexists.h. Thus define the error codes */
+
+#define EX_OK             0    /* successful termination */
+#define EX__BASE          64   /* base value for error messages */
+#define EX_USAGE          64   /* command line usage error */
+#define EX_DATAERR        65   /* data format error */
+#define EX_NOINPUT        66   /* cannot open input */
+#define EX_NOUSER         67   /* addressee unknown */
+#define EX_NOHOST         68   /* host name unknown */
+#define EX_UNAVAILABLE    69   /* service unavailable */
+#define EX_SOFTWARE       70   /* internal software error */
+#define EX_OSERR          71   /* system error (e.g., can't fork) */
+#define EX_OSFILE         72   /* critical OS file missing */
+#define EX_CANTCREAT      73   /* can't create (user) output file */
+#define EX_IOERR          74   /* input/output error */
+#define EX_TEMPFAIL       75   /* temp failure; user is invited to retry */
+#define EX_PROTOCOL       76   /* remote error in protocol */
+#define EX_NOPERM         77   /* permission denied */
+#define EX_CONFIG         78   /* configuration error */
+#define EX__MAX           78   /* maximum listed value */
+
+#else /* not WIN32 */
+/* \todo do all non windows systems know sysexits.h, Linux probably not? */
+#include "sysexits.h"      /* comes from BSD */
+#endif
+
+#endif /* _ERROR_TYPES_H_ */

--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -427,7 +427,7 @@ int load_keyword_file(const char *filename)
       LOG_FMT(LERR, "%s: fopen(%s) failed: %s (%d)\n",
               __func__, filename, strerror(errno), errno);
       cpd.error_count++;
-      return(FAILURE);
+      return(EX_IOERR);
    }
 
    char buf[256];
@@ -463,7 +463,7 @@ int load_keyword_file(const char *filename)
    }
 
    fclose(pf);
-   return(SUCCESS);
+   return(EX_OK);
 } // load_keyword_file
 
 

--- a/src/keywords.h
+++ b/src/keywords.h
@@ -15,7 +15,8 @@
  * Loads the dynamic keywords from a file
  *
  * @param filename   The path to the file to load
- * @return           SUCCESS or FAILURE
+ * @retval           EX_OK    - successfully read keywords from file
+ * @retval           EX_IOERR - reading keywords file failed
  */
 int load_keyword_file(const char *filename);
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1690,7 +1690,7 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
          {
             fprintf(stderr, "%s:%d\n  for the option '%s' is a negative value not possible: %s",
                     cpd.filename, cpd.line_number, entry->name, val);
-            exit(2);
+            exit(EX_CONFIG);
          }
          dest->n = strtol(val, NULL, 0);
          // is the same as dest->u
@@ -1711,7 +1711,7 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
          {
             fprintf(stderr, "%s:%d\n  for the assigment: unknown option '%s':",
                     cpd.filename, cpd.line_number, val);
-            exit(2);
+            exit(EX_CONFIG);
          }
          if (tmp->type == entry->type)
          {
@@ -1724,7 +1724,7 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
             fprintf(stderr, "%s:%d\n  for the assigment: expected type for %s is %s, got %s\n",
                     cpd.filename, cpd.line_number,
                     entry->name, get_argtype_name(entry->type), get_argtype_name(tmp->type));
-            exit(2);
+            exit(EX_CONFIG);
          }
       }
       fprintf(stderr, "%s:%d Expected a number for %s, got %s\n",

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -307,7 +307,7 @@ void usage_exit(const char *msg, const char *argv0, int code)
 static void version_exit(void)
 {
    printf("uncrustify %s\n", UNCRUSTIFY_VERSION);
-   exit(0);
+   exit(EX_OK);
 }
 
 
@@ -324,7 +324,7 @@ static void redir_stdout(const char *output_file)
          LOG_FMT(LERR, "Unable to open %s for write: %s (%d)\n",
                  output_file, strerror(errno), errno);
          cpd.error_count++;
-         usage_exit(NULL, NULL, 56);
+         usage_exit(NULL, NULL, EX_IOERR);
       }
       LOG_FMT(LNOTE, "Redirecting output to %s\n", output_file);
    }
@@ -464,7 +464,7 @@ int main(int argc, char *argv[])
    while ((p_arg = arg.Params("-d", idx)) != NULL)
    {
       int return_code = load_define_file(p_arg);
-      if (return_code != SUCCESS)
+      if (return_code != EX_OK)
       {
          return(return_code);
       }
@@ -537,7 +537,7 @@ int main(int argc, char *argv[])
        (output_file || replace || no_backup || keep_mtime || update_config ||
         update_config_wd || detect || prefix || suffix || cpd.if_changed))
    {
-      usage_exit("Cannot use --check with output options.", argv[0], 67);
+      usage_exit("Cannot use --check with output options.", argv[0], EX_NOUSER);
    }
 
    if (!cpd.do_check)
@@ -546,11 +546,11 @@ int main(int argc, char *argv[])
       {
          if ((prefix != NULL) || (suffix != NULL))
          {
-            usage_exit("Cannot use --replace with --prefix or --suffix", argv[0], 66);
+            usage_exit("Cannot use --replace with --prefix or --suffix", argv[0], EX_NOINPUT);
          }
          if ((source_file != NULL) || (output_file != NULL))
          {
-            usage_exit("Cannot use --replace or --no-backup with -f or -o", argv[0], 66);
+            usage_exit("Cannot use --replace or --no-backup with -f or -o", argv[0], EX_NOINPUT);
          }
       }
       else
@@ -571,7 +571,7 @@ int main(int argc, char *argv[])
       cpd.filename = cfg_file.c_str();
       if (load_option_file(cpd.filename) < 0)
       {
-         usage_exit("Unable to load the config file", argv[0], 56);
+         usage_exit("Unable to load the config file", argv[0], EX_IOERR);
       }
       // test if all options are compatible to each other
       if (cpd.settings[UO_nl_max].n > 0)
@@ -580,7 +580,7 @@ int main(int argc, char *argv[])
          if (cpd.settings[UO_nl_func_var_def_blk].n >= cpd.settings[UO_nl_max].n)
          {
             fprintf(stderr, "The option 'nl_func_var_def_blk' is too big against the option 'nl_max'\n");
-            exit(2);
+            exit(EX_CONFIG);
          }
       }
    }
@@ -610,7 +610,7 @@ int main(int argc, char *argv[])
       else
       {
          /* TODO: consider using defines like EX_USAGE from sysexits.h */
-         usage_exit("Error while parsing --set", argv[0], 64);
+         usage_exit("Error while parsing --set", argv[0], EX_USAGE);
       }
    }
 
@@ -682,7 +682,7 @@ int main(int argc, char *argv[])
    if (cfg_file.empty())
    {
       usage_exit("Specify the config file with '-c file' or set UNCRUSTIFY_CONFIG",
-                 argv[0], 58);
+                 argv[0], EX_IOERR);
    }
 
    /*
@@ -699,13 +699,13 @@ int main(int argc, char *argv[])
       if (source_file != NULL)
       {
          usage_exit("Cannot specify both the single file option and a multi-file option.",
-                    argv[0], 67);
+                    argv[0], EX_NOUSER);
       }
 
       if (output_file != NULL)
       {
          usage_exit("Cannot specify -o with a multi-file option.",
-                    argv[0], 68);
+                    argv[0], EX_NOHOST);
       }
    }
 
@@ -1256,7 +1256,7 @@ static void do_source_file(const char *filename_in,
 
             if (!no_backup)
             {
-               if (backup_copy_file(filename_in, fm.raw) != SUCCESS)
+               if (backup_copy_file(filename_in, fm.raw) != EX_OK)
                {
                   LOG_FMT(LERR, "%s: Failed to create backup file for %s\n",
                           __func__, filename_in);


### PR DESCRIPTION
This PR aims at providing consistent return codes for uncrustify.
Implements #857 

So far we used various exit codes:
SUCCESS 0 		defined in base_types.h	
FAILURE -1		defined in base_types.h
EXIT_FAILURE 1	from stdlib.h
EXIT_SUCCESS 0	from stdlib.h
some hardcoded numbers 56, 57, etc.

This was a bad idea, especially because FAILURE and EXIT_FAILURE had different values.
Generally speaking it was a bad idea to have error codes that are positive and negative.
This makes checking for error codes very error prone. Thus I propose only to use
positive error codes and 0 as success code.

I left EXIT_FAILURE and EXIT_SUCCESS as they are conform with sysexit.h. I have replaced FAILURE and SUCCESS and the hardcoded numbers to use exit codes from sysexit.h I have tried to keep the values of the hardcoded error codes unchanged as I do not know if someone relys on their specific values. For the future I would rather recommend to use the return codes that correspond to the actual error condition.