### PR TITLE
Fix include guards

### DIFF
--- a/src/ListManager.h
+++ b/src/ListManager.h
@@ -7,8 +7,8 @@
  * @license GPL v2+
  */
 
-#ifndef _LIST_MANAGER_H_
-#define _LIST_MANAGER_H_
+#ifndef LIST_MANAGER_H_INCLUDED
+#define LIST_MANAGER_H_INCLUDED
 
 /**
  * A simple list manager for a double-linked list.
@@ -203,4 +203,4 @@ public:
    }
 };
 
-#endif /* _LIST_MANAGER_H_ */
+#endif /* LIST_MANAGER_H_INCLUDED */

--- a/src/align_stack.h
+++ b/src/align_stack.h
@@ -7,8 +7,8 @@
  * @license GPL v2+
  */
 
-#ifndef _ALIGN_STACK_H
-#define _ALIGN_STACK_H
+#ifndef ALIGN_STACK_H_INCLUDED
+#define ALIGN_STACK_H_INCLUDED
 
 #include "ChunkStack.h"
 
@@ -92,5 +92,5 @@ protected:
    ChunkStack m_scratch; /* used in ReAddSkipped() */
 };
 
-#endif /* _ALIGN_STACK_H */
+#endif /* ALIGN_STACK_H_INCLUDED */
 

--- a/src/error_types.h
+++ b/src/error_types.h
@@ -5,8 +5,8 @@
  *
  * @license GPL v2+
  */
-#ifndef _ERROR_TYPES_H_
-#define _ERROR_TYPES_H_
+#ifndef ERROR_TYPES_H_INCLUDED
+#define ERROR_TYPES_H_INCLUDED
 
 #if 1
 #include <stdlib.h>      /* provides EXIT_SUCCESS and EXIT FAILURE */
@@ -51,4 +51,4 @@
 #include "sysexits.h"      /* comes from BSD */
 #endif
 
-#endif /* _ERROR_TYPES_H_ */
+#endif /* ERROR_TYPES_H_INCLUDED */

--- a/src/punctuators.h
+++ b/src/punctuators.h
@@ -3,8 +3,8 @@
  * Automatically generated
  */
 
-#ifndef _PUNCTUATORS_H_
-#define _PUNCTUATORS_H_
+#ifndef PUNCTUATORS_H_INCLUDED
+#define PUNCTUATORS_H_INCLUDED
 
 static const lookup_entry_t punc_table[] =
 {
@@ -91,4 +91,4 @@ static const lookup_entry_t punc_table[] =
    { '~',  0,  0, &symbols2[31] },   //  80: '~~'
 };
 
-#endif /* _PUNCTUATORS_H_ */
+#endif /* PUNCTUATORS_H_INCLUDED */


### PR DESCRIPTION
Names starting with an underscore followed by an uppercase letter are reserved.