### PR TITLE
adds checks for Null pointers and some more code clean up

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -16,7 +16,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cerrno>
 #include "unc_ctype.h"
 #include "uncrustify.h"
 #include "indent.h"
@@ -503,9 +502,9 @@ void align_right_comments(void)
           (pc->type == CT_COMMENT_CPP) ||
           (pc->type == CT_COMMENT_MULTI))
       {
-         bool skip = false;
          if (pc->parent_type == CT_COMMENT_END)
          {
+            bool    skip  = false;
             chunk_t *prev = chunk_get_prev(pc);
             if (pc->orig_col < (prev->orig_col_end + cpd.settings[UO_align_right_cmt_gap].n))
             {
@@ -518,7 +517,7 @@ void align_right_comments(void)
                        pc->orig_col, prev->orig_col_end, cpd.settings[UO_align_right_cmt_gap].n);
                skip = true;
             }
-            if (!skip)
+            if (skip == false)
             {
                LOG_FMT(LALTC, "Changing END comment on line %zu into a RIGHT-comment\n",
                        pc->orig_line);
@@ -1446,7 +1445,7 @@ static CmtAlignType get_comment_align_type(chunk_t *cmt)
 }
 
 
-chunk_t *align_trailing_comments(chunk_t *start)
+static chunk_t *align_trailing_comments(chunk_t *start)
 {
    LOG_FUNC_ENTRY();
    size_t       min_col  = 0;
@@ -1523,12 +1522,6 @@ chunk_t *align_trailing_comments(chunk_t *start)
 } // align_trailing_comments
 
 
-/**
- * Shifts out all columns by a certain amount.
- *
- * @param idx  The index to start shifting
- * @param num  The number of columns to shift
- */
 void ib_shift_out(size_t idx, size_t num)
 {
    while (idx < cpd.al_cnt)
@@ -1539,10 +1532,6 @@ void ib_shift_out(size_t idx, size_t num)
 }
 
 
-/**
- * If sq_open is CT_SQUARE_OPEN and the matching close is followed by '=',
- * then return the chunk after the '='.  Otherwise, return NULL.
- */
 static chunk_t *skip_c99_array(chunk_t *sq_open)
 {
    if (chunk_is_token(sq_open, CT_SQUARE_OPEN))
@@ -1566,7 +1555,7 @@ static chunk_t *skip_c99_array(chunk_t *sq_open)
  */
 static chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
 {
-   (void)first_pass;
+   UNUSED(first_pass);
    LOG_FUNC_ENTRY();
    chunk_t *prev_match = NULL;
    size_t  idx         = 0;

--- a/src/align.h
+++ b/src/align.h
@@ -56,6 +56,24 @@ chunk_t *align_nl_cont(chunk_t *start);
 chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh);
 
 
+/**
+ * Shifts out all columns by a certain amount.
+ *
+ * @param idx  The index to start shifting
+ * @param num  The number of columns to shift
+ */
+void ib_shift_out(size_t idx, size_t num);
+
+
+/**
+ * If sq_open is CT_SQUARE_OPEN and the matching close is followed by '=',
+ * then return the chunk after the '='.  Otherwise, return NULL.
+ */
+static chunk_t *skip_c99_array(chunk_t *sq_open);
+
+
+chunk_t *step_back_over_member(chunk_t *pc);
+
 void quick_align_again(void);
 
 

--- a/src/align_stack.cpp
+++ b/src/align_stack.cpp
@@ -73,6 +73,12 @@ void AlignStack::ReAddSkipped()
 void AlignStack::Add(chunk_t *start, size_t seqnum)
 {
    LOG_FUNC_ENTRY();
+
+   if (start == NULL)
+   {
+      return;
+   }
+
    /* Assign a seqnum if needed */
    if (seqnum == 0)
    {

--- a/src/args.h
+++ b/src/args.h
@@ -63,7 +63,7 @@ public:
    const char *Param(const char *token);
 
    /**
-    * Similiar to arg_param, but can iterate over all matches.
+    * Similar to arg_param, but can iterate over all matches.
     * Set index to 0 before the first call.
     *
     * @param token   The token string to match

--- a/src/backup.cpp
+++ b/src/backup.cpp
@@ -63,7 +63,7 @@ int backup_copy_file(const char *filename, const vector<UINT8> &data)
          {
             if (unc_isxdigit(buffer[i]))
             {
-               md5_str_in[i] = unc_tolower(buffer[i]);
+               md5_str_in[i] = (char)unc_tolower(buffer[i]);
             }
             else
             {

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -10,13 +10,11 @@
 
 #include "brace_cleanup.h"
 #include "uncrustify_types.h"
-#include "char_table.h"
 #include "prototypes.h"
 #include "chunk_list.h"
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cerrno>
 #include "unc_ctype.h"
 #include "uncrustify.h"
 #include "lang_pawn.h"
@@ -36,7 +34,6 @@ static chunk_t *insert_vbrace(chunk_t *pc, bool after, parse_frame_t *frm);
 
 static void parse_cleanup(parse_frame_t *frm, chunk_t *pc);
 
-static bool close_statement(parse_frame_t *frm, chunk_t *pc);
 
 /**
  * Called when a statement was just closed and the pse_tos was just
@@ -118,7 +115,7 @@ static size_t preproc_start(parse_frame_t *frm, chunk_t *pc)
 static void print_stack(log_sev_t logsev, const char *str,
                         parse_frame_t *frm, chunk_t *pc)
 {
-   (void)pc;
+   UNUSED(pc);
    LOG_FUNC_ENTRY();
    if (log_sev_on(logsev))
    {
@@ -327,7 +324,6 @@ static void push_fmr_pse(parse_frame_t *frm, chunk_t *pc,
 static void parse_cleanup(parse_frame_t *frm, chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
-   c_token_t parent = CT_NONE;
 
    LOG_FMT(LTOK, "%s:%zu] %16s - tos:%zu/%16s stg:%d\n",
            __func__, pc->orig_line, get_token_name(pc->type),
@@ -510,7 +506,7 @@ static void parse_cleanup(parse_frame_t *frm, chunk_t *pc)
    }
 
    /* Get the parent type for brace and paren open */
-   parent = pc->parent_type;
+   c_token_t parent = pc->parent_type;
    if ((pc->type == CT_PAREN_OPEN) ||
        (pc->type == CT_FPAREN_OPEN) ||
        (pc->type == CT_SPAREN_OPEN) ||
@@ -1039,7 +1035,7 @@ static chunk_t *insert_vbrace(chunk_t *pc, bool after, parse_frame_t *frm)
 } // insert_vbrace
 
 
-bool close_statement(parse_frame_t *frm, chunk_t *pc)
+static bool close_statement(parse_frame_t *frm, chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
    chunk_t *vbc = pc;

--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -12,7 +12,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cerrno>
 #include "unc_ctype.h"
 #include "uncrustify.h"
 #include "combine.h"
@@ -742,6 +741,12 @@ chunk_t *insert_comment_after(chunk_t *ref, c_token_t cmt_type,
 static void append_tag_name(unc_text &txt, chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
+
+   if (pc == NULL)
+   {
+      return;
+   }
+
    chunk_t *tmp = pc;
 
    /* step backwards over all a::b stuff */
@@ -858,7 +863,7 @@ void add_long_closebrace_comment(void)
                {
                   nl_min = cpd.settings[UO_mod_add_long_switch_closebrace_comment].u;
                   tag_pc = sw_pc;
-                  xstr   = sw_pc ? sw_pc->str : NULL;
+                  xstr   = sw_pc ? sw_pc->str : NULL; /* \todo NULL is no unc_text structure */
                }
                else if ((br_open->parent_type == CT_FUNC_DEF) ||
                         (br_open->parent_type == CT_OC_MSG_DECL))
@@ -1093,6 +1098,12 @@ static void mod_case_brace(void)
 static void process_if_chain(chunk_t *br_start)
 {
    LOG_FUNC_ENTRY();
+
+   if (br_start == NULL)
+   {
+      return;
+   }
+
    chunk_t *braces[256];
    int     br_cnt           = 0;
    bool    must_have_braces = false;

--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -279,9 +279,6 @@ chunk_t *chunk_get_prev_nnl(chunk_t *cur, chunk_nav_t nav)
 }
 
 
-/**
- * Gets the next non-NEWLINE and non-comment chunk
- */
 chunk_t *chunk_get_next_ncnl(chunk_t *cur, chunk_nav_t nav)
 {
    chunk_t *pc = cur;

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -51,7 +51,14 @@ chunk_t *chunk_first_on_line(chunk_t *pc);
 chunk_t *chunk_get_next_nl(chunk_t *cur, chunk_nav_t nav = CNAV_ALL);
 chunk_t *chunk_get_next_nc(chunk_t *cur, chunk_nav_t nav = CNAV_ALL);
 chunk_t *chunk_get_next_nnl(chunk_t *cur, chunk_nav_t nav = CNAV_ALL);
+
+
+/**
+ * Gets the next non-NEWLINE and non-comment chunk
+ */
 chunk_t *chunk_get_next_ncnl(chunk_t *cur, chunk_nav_t nav = CNAV_ALL);
+
+
 chunk_t *chunk_get_next_ncnlnp(chunk_t *cur, chunk_nav_t nav = CNAV_ALL);
 chunk_t *chunk_get_next_nisq(chunk_t *cur, chunk_nav_t nav = CNAV_ALL);
 
@@ -189,7 +196,12 @@ bool chunk_is_token(chunk_t *pc, c_token_t c_token)
 static_inline
 bool chunk_is_str(chunk_t *pc, const char *str, size_t len)
 {
-   return((pc != NULL) && (pc->len() == len) && (memcmp(pc->text(), str, len) == 0));
+   return((pc != NULL) &&                       /* valid pc pointer */
+          (pc->len() == len) &&                 /* token size equals size parameter */
+          (memcmp(pc->text(), str, len) == 0)); /* token name is the same as str parameter */
+
+   /* \todo possible access beyond array for memcmp, check this
+    * why not use strncmp here?  */
 }
 
 

--- a/src/combine.h
+++ b/src/combine.h
@@ -39,6 +39,35 @@ void combine_labels(void);
 
 
 /**
+ * This is called on every chunk.
+ * First on all non-preprocessor chunks and then on each preprocessor chunk.
+ * It does all the detection and classifying.
+ * This is only called by fix_symbols.
+ * The three parameters never get the value NULL.
+ * it is not necessary to test.
+ */
+void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next);
+
+
+/**
+ * help function for mark_variable_definition...
+ */
+bool go_on(chunk_t *pc, chunk_t *start);
+
+
+/**
+ * Sets the parent of the open paren/brace/square/angle and the closing.
+ * Note - it is assumed that pc really does point to an open item and the
+ * close must be open + 1.
+ *
+ * @param start   The open paren
+ * @param parent  The type to assign as the parent
+ * @return        The chunk after the close paren
+ */
+chunk_t *set_paren_parent(chunk_t *start, c_token_t parent);
+
+
+/**
  * Sets the parent for comments.
  */
 void mark_comments(void);

--- a/src/detect.cpp
+++ b/src/detect.cpp
@@ -9,12 +9,10 @@
 #include "uncrustify_types.h"
 #include "chunk_list.h"
 #include "ChunkStack.h"
-#include "align_stack.h"
 #include "prototypes.h"
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cerrno>
 #include "unc_ctype.h"
 
 

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -15,7 +15,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cerrno>
 #include "unc_ctype.h"
 #include "uncrustify.h"
 #include "align.h"
@@ -162,7 +161,7 @@ static void indent_comment(chunk_t *pc, int col);
  * @param frm  The parse frame
  * @param pc   The chunk causing the push
  */
-static void indent_pse_push(struct parse_frame &frm, chunk_t *pc);
+static void indent_pse_push(parse_frame_t &frm, chunk_t *pc);
 
 
 /**
@@ -171,13 +170,13 @@ static void indent_pse_push(struct parse_frame &frm, chunk_t *pc);
  * @param frm  The parse frame
  * @param pc   The chunk causing the push
  */
-static void indent_pse_pop(struct parse_frame &frm, chunk_t *pc);
+static void indent_pse_pop(parse_frame_t &frm, chunk_t *pc);
 
 
 static int token_indent(c_token_t type);
 
 
-static int calc_indent_continue(struct parse_frame &frm, int pse_tos);
+static int calc_indent_continue(parse_frame_t &frm, int pse_tos);
 
 
 /**

--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -302,7 +302,7 @@ static const chunk_tag_t keywords[] =
 };
 
 
-void init_keywords()
+void init_keywords(void)
 {
 }
 
@@ -420,6 +420,10 @@ c_token_t find_keyword_type(const char *word, int len)
 
 int load_keyword_file(const char *filename)
 {
+   if (filename == NULL)
+   {
+      return(EX_CONFIG);
+   }
    FILE *pf = fopen(filename, "r");
 
    if (pf == NULL)
@@ -430,8 +434,7 @@ int load_keyword_file(const char *filename)
       return(EX_IOERR);
    }
 
-   char buf[256];
-   char *args[3];
+   char buf[256];       /* \todo what is the meaning of 256 ? */
    int  line_no = 0;
    while (fgets(buf, sizeof(buf), pf) != NULL)
    {
@@ -444,8 +447,9 @@ int load_keyword_file(const char *filename)
          *ptr = 0;
       }
 
-      int argc = Args::SplitLine(buf, args, ARRAY_SIZE(args) - 1);
-      args[argc] = 0;
+      char *args[3];    /* \todo what is the meaning of 3 ? */
+      int  argc = Args::SplitLine(buf, args, ARRAY_SIZE(args) - 1);
+      args[argc] = 0;   /* \todo what is this used for? can this write beyond args? */
 
       if (argc > 0)
       {

--- a/src/keywords.h
+++ b/src/keywords.h
@@ -11,6 +11,9 @@
 #include "uncrustify_types.h"
 
 
+void init_keywords(void);
+
+
 /**
  * Loads the dynamic keywords from a file
  *

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -10,7 +10,7 @@
  * @license GPL v2+
  */
 #include "logger.h"
-
+#include "uncrustify_types.h"
 #include <cstdio>
 #include <deque>
 #include <stdarg.h>
@@ -360,7 +360,7 @@ void log_hex_blk(log_sev_t sev, const void *data, size_t len)
       buf[str_idx + 1] = to_hex_char(tmp);
       str_idx         += 3;
 
-      buf[chr_idx++] = unc_isprint(tmp) ? tmp : '.';
+      buf[chr_idx++] = (char)(unc_isprint(tmp) ? tmp : '.');
 
       total++;
       count++;
@@ -416,6 +416,8 @@ void log_func_call(int line)
 
 void log_func_stack(log_sev_t sev, const char *prefix, const char *suffix, size_t skip_cnt)
 {
+   UNUSED(skip_cnt);
+
    if (prefix)
    {
       LOG_FMT(sev, "%s", prefix);

--- a/src/logger.h
+++ b/src/logger.h
@@ -89,7 +89,7 @@ void log_str(log_sev_t sev, const char *str, size_t len);
 
 
 /**
- * Logs a formatted string -- similiar to printf()
+ * Logs a formatted string -- similar to printf()
  *
  * @param sev     The severity
  * @param fmt     The format string

--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -149,12 +149,12 @@ void MD5::Update(const void *data, UINT32 len)
          reverse_u32(m_in, 16);
       }
       Transform(m_buf, (UINT32 *)m_in);
-      buf += 64;
+      buf += 64;        /* \todo possible creation of out-of-bounds pointer 64 beyond end of data */
       len -= 64;
    }
 
    /* Save off any remaining bytes of data */
-   memcpy(m_in, buf, len);
+   memcpy(m_in, buf, len);      /* \todo possible access beyond array */
 } // MD5::Update
 
 
@@ -223,7 +223,7 @@ void MD5::Final(UINT8 digest[16])
 
 /* This is the central step in the MD5 algorithm. */
 #define MD5STEP(f, w, x, y, z, data, s) \
-   (w += f(x, y, z) + data, w = w << s | w >> (32 - s), w += x)
+   ((w) += f((x), (y), (z)) + (data), (w) = (w) << (s) | (w) >> (32 - (s)), (w) += (x))
 
 
 /*

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -25,7 +25,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <algorithm>
-#include <cerrno>
 #include "unc_ctype.h"
 #include "unc_tools.h"
 #include "uncrustify.h"
@@ -1114,7 +1113,6 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, argval
    chunk_t *pc;
    chunk_t *next;
    chunk_t *prev;
-   bool    have_pre_vbrace_nl = false;
 
    if ((nl_opt == AV_IGNORE) ||
        ((start->flags & PCF_IN_PREPROC) &&
@@ -1166,7 +1164,7 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, argval
       return;
    }
 
-   have_pre_vbrace_nl = isVBrace && chunk_is_newline(prev);
+   bool have_pre_vbrace_nl = isVBrace && chunk_is_newline(prev);
    if (nl_opt & AV_REMOVE)
    {
       /* if vbrace, have to check before and after */

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -112,9 +112,9 @@ void unc_begin_group(uncrustify_groups id, const char *short_desc,
 }
 
 
-void unc_add_option(const char *name, uncrustify_options id, argtype_e type,
-                    const char *short_desc, const char *long_desc,
-                    int min_val, int max_val)
+static void unc_add_option(const char *name, uncrustify_options id, argtype_e type,
+                           const char *short_desc, const char *long_desc,
+                           int min_val, int max_val)
 {
 #define OptionMaxLength    60
    int lengthOfTheOption = strlen(name);
@@ -1622,7 +1622,7 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
       }
       if (strcasecmp(val, "AUTO") != 0)
       {
-         fprintf(stderr, "%s:%d Expected AUTO, LF, CRLF, or CR for %s, got %s\n",
+         fprintf(stderr, "%s:%u Expected AUTO, LF, CRLF, or CR for %s, got %s\n",
                  cpd.filename, cpd.line_number, entry->name, val);
          cpd.error_count++;
       }
@@ -1669,7 +1669,7 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
       }
       if (strcasecmp(val, "IGNORE") != 0)
       {
-         fprintf(stderr, "%s:%d Expected IGNORE, JOIN, LEAD, LEAD_BREAK, LEAD_FORCE, "
+         fprintf(stderr, "%s:%u Expected IGNORE, JOIN, LEAD, LEAD_BREAK, LEAD_FORCE, "
                  "TRAIL, TRAIL_BREAK, TRAIL_FORCE for %s, got %s\n",
                  cpd.filename, cpd.line_number, entry->name, val);
          cpd.error_count++;
@@ -1688,7 +1688,7 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
          if ((entry->type == AT_UNUM) &&
              (*val == '-'))
          {
-            fprintf(stderr, "%s:%d\n  for the option '%s' is a negative value not possible: %s",
+            fprintf(stderr, "%s:%u\n  for the option '%s' is a negative value not possible: %s",
                     cpd.filename, cpd.line_number, entry->name, val);
             exit(EX_CONFIG);
          }
@@ -1709,7 +1709,7 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
          tmp = unc_find_option(val);
          if (tmp == NULL)
          {
-            fprintf(stderr, "%s:%d\n  for the assigment: unknown option '%s':",
+            fprintf(stderr, "%s:%u\n  for the assigment: unknown option '%s':",
                     cpd.filename, cpd.line_number, val);
             exit(EX_CONFIG);
          }
@@ -1721,13 +1721,13 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
          }
          else
          {
-            fprintf(stderr, "%s:%d\n  for the assigment: expected type for %s is %s, got %s\n",
+            fprintf(stderr, "%s:%u\n  for the assigment: expected type for %s is %s, got %s\n",
                     cpd.filename, cpd.line_number,
                     entry->name, get_argtype_name(entry->type), get_argtype_name(tmp->type));
             exit(EX_CONFIG);
          }
       }
-      fprintf(stderr, "%s:%d Expected a number for %s, got %s\n",
+      fprintf(stderr, "%s:%u Expected a number for %s, got %s\n",
               cpd.filename, cpd.line_number, entry->name, val);
       cpd.error_count++;
       dest->n = 0;
@@ -1765,7 +1765,7 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
          dest->b = cpd.settings[tmp->id].b ? btrue : !btrue;
          return;
       }
-      fprintf(stderr, "%s:%d Expected 'True' or 'False' for %s, got %s\n",
+      fprintf(stderr, "%s:%u Expected 'True' or 'False' for %s, got %s\n",
               cpd.filename, cpd.line_number, entry->name, val);
       cpd.error_count++;
       dest->b = false;
@@ -1805,7 +1805,7 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
       dest->a = cpd.settings[tmp->id].a;
       return;
    }
-   fprintf(stderr, "%s:%d Expected 'Add', 'Remove', 'Force', or 'Ignore' for %s, got %s\n",
+   fprintf(stderr, "%s:%u Expected 'Add', 'Remove', 'Force', or 'Ignore' for %s, got %s\n",
            cpd.filename, cpd.line_number, entry->name, val);
    cpd.error_count++;
    dest->a = AV_IGNORE;
@@ -1885,7 +1885,7 @@ void process_option_line(char *configLine, const char *filename)
    {
       if (argc > 0)
       {
-         fprintf(stderr, "%s:%d Wrong number of arguments: %s...\n",
+         fprintf(stderr, "%s:%u Wrong number of arguments: %s...\n",
                  filename, cpd.line_number, configLine);
          cpd.error_count++;
       }
@@ -1920,7 +1920,7 @@ void process_option_line(char *configLine, const char *filename)
    {
       if (argc < 3)
       {
-         fprintf(stderr, "%s:%d 'set' requires at least three arguments\n",
+         fprintf(stderr, "%s:%u 'set' requires at least three arguments\n",
                  filename, cpd.line_number);
       }
       else
@@ -1938,7 +1938,7 @@ void process_option_line(char *configLine, const char *filename)
          }
          else
          {
-            fprintf(stderr, "%s:%d unknown type '%s':", filename, cpd.line_number, args[1]);
+            fprintf(stderr, "%s:%u unknown type '%s':", filename, cpd.line_number, args[1]);
          }
       }
    }
@@ -1968,7 +1968,7 @@ void process_option_line(char *configLine, const char *filename)
    {
       if (argc < 3)
       {
-         fprintf(stderr, "%s:%d 'file_ext' requires at least three arguments\n",
+         fprintf(stderr, "%s:%u 'file_ext' requires at least three arguments\n",
                  filename, cpd.line_number);
       }
       else
@@ -1978,12 +1978,12 @@ void process_option_line(char *configLine, const char *filename)
             const char *lang_name = extension_add(args[idx], args[1]);
             if (lang_name)
             {
-               LOG_FMT(LNOTE, "%s:%d file_ext '%s' => '%s'\n",
+               LOG_FMT(LNOTE, "%s:%u file_ext '%s' => '%s'\n",
                        filename, cpd.line_number, args[idx], lang_name);
             }
             else
             {
-               fprintf(stderr, "%s:%d file_ext has unknown language '%s'\n",
+               fprintf(stderr, "%s:%u file_ext has unknown language '%s'\n",
                        filename, cpd.line_number, args[1]);
             }
          }
@@ -1995,7 +1995,7 @@ void process_option_line(char *configLine, const char *filename)
       const int id = set_option_value(args[0], args[1]);
       if (id < 0)
       {
-         fprintf(stderr, "%s:%d Unknown symbol '%s'\n",
+         fprintf(stderr, "%s:%u Unknown symbol '%s'\n",
                  filename, cpd.line_number, args[0]);
          cpd.error_count++;
       }

--- a/src/options.h
+++ b/src/options.h
@@ -871,6 +871,8 @@ string number_to_string(int number);
 string lineends_to_string(lineends_e linends);
 string tokenpos_to_string(tokenpos_e tokenpos);
 string op_val_to_string(argtype_e argtype, op_val_t op_val);
+bool is_path_relative(const char *path);
+const option_map_value *unc_find_option(const char *name);
 
 typedef map<uncrustify_options, option_map_value>::iterator   option_name_map_it;
 typedef map<uncrustify_groups, group_map_value>::iterator     group_map_it;

--- a/src/options_for_QT.h
+++ b/src/options_for_QT.h
@@ -14,11 +14,9 @@
 
 #include "uncrustify_types.h"
 
-extern cp_data_t cpd;
-
-extern bool      QT_SIGNAL_SLOT_found;
-extern int       QT_SIGNAL_SLOT_level;
-extern bool      restoreValues;
+extern bool QT_SIGNAL_SLOT_found;
+extern int  QT_SIGNAL_SLOT_level;
+extern bool restoreValues;
 
 void save_set_options_for_QT(int level);
 void restore_options_for_QT(void);

--- a/src/output.h
+++ b/src/output.h
@@ -9,6 +9,20 @@
 #define OUTPUT_H_INCLUDED
 
 #include <stdio.h>
+#include "unc_text.h"
+
+/**
+ * All output text is sent here, one char at a time.
+ */
+static void add_char(UINT32 ch);
+
+/**
+ * Advance to a specific column
+ * cpd.column is the current column
+ *
+ * @param column  The column to advance to
+ */
+static void output_to_column(size_t column, bool allow_tabs);
 
 
 /**
@@ -35,5 +49,27 @@ void output_parsed(FILE *pfile);
  * things a little bit, but not much.
  */
 void add_long_preprocessor_conditional_block_comment(void);
+
+
+/**
+ * Count the number of characters to the end of the next chunk of text.
+ * If it exceeds the limit, return true.
+ */
+static bool next_word_exceeds_limit(const unc_text &text, int idx);
+
+
+/**
+ * Output a comment to the column using indent_with_tabs and
+ * indent_cmt_with_tabs as the rules.
+ * base_col is the indent of the first line of the comment.
+ * On the first line, column == base_col.
+ * On subsequent lines, column >= base_col.
+ *
+ * @param brace_col the brace-level indent of the comment
+ * @param base_col  the indent of the start of the comment (multiline)
+ * @param column    the column that we should end up in
+ */
+static void cmt_output_indent(int brace_col, int base_col, int column);
+
 
 #endif /* OUTPUT_H_INCLUDED */

--- a/src/parens.cpp
+++ b/src/parens.cpp
@@ -11,7 +11,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cerrno>
 #include "unc_ctype.h"
 #include "uncrustify.h"
 
@@ -75,6 +74,12 @@ void do_parens(void)
 static void add_parens_between(chunk_t *first, chunk_t *last)
 {
    LOG_FUNC_ENTRY();
+
+   if ((first == NULL) ||
+       (last == NULL))
+   {
+      return;
+   }
 
    LOG_FMT(LPARADD, "%s: line %zu between %s [lvl=%zu] and %s [lvl=%zu]\n",
            __func__, first->orig_line,

--- a/src/parse_frame.cpp
+++ b/src/parse_frame.cpp
@@ -27,9 +27,6 @@ static void pf_log_frms(log_sev_t logsev, const char *txt, struct parse_frame *p
 static void pf_copy_2nd_tos(struct parse_frame *pf);
 
 
-/**
- * Logs one parse frame
- */
 void pf_log(log_sev_t logsev, parse_frame_t *pf)
 {
    LOG_FMT(logsev, "[%s] BrLevel=%d Level=%d PseTos=%zu\n",
@@ -60,9 +57,6 @@ static void pf_log_frms(log_sev_t logsev, const char *txt, parse_frame_t *pf)
 }
 
 
-/**
- * Logs the entire parse frame stack
- */
 void pf_log_all(log_sev_t logsev)
 {
    LOG_FMT(logsev, "##=- Parse Frame : %d entries\n", cpd.frame_count);
@@ -77,19 +71,12 @@ void pf_log_all(log_sev_t logsev)
 }
 
 
-/**
- * Copies src to dst.
- */
 void pf_copy(parse_frame_t *dst, const parse_frame_t *src)
 {
    memcpy(dst, src, sizeof(parse_frame_t));
 }
 
 
-/**
- * Push a copy of the parse frame onto the stack.
- * This is called on #if and #ifdef.
- */
 void pf_push(parse_frame_t *pf)
 {
    static int ref_no = 1;

--- a/src/parse_frame.h
+++ b/src/parse_frame.h
@@ -10,13 +10,34 @@
 
 #include "uncrustify_types.h"
 
+/**
+ * Logs the entire parse frame stack
+ */
+void pf_log_all(log_sev_t logsev);
 
+
+/**
+ * Copies src to dst.
+ */
 void pf_copy(parse_frame_t *dst, const parse_frame_t *src);
+
+
+/**
+ * Push a copy of the parse frame onto the stack.
+ * This is called on #if and #ifdef.
+ */
 void pf_push(parse_frame_t *pf);
 void pf_push_under(parse_frame_t *pf);
 void pf_copy_tos(parse_frame_t *pf);
 void pf_trash_tos(void);
 void pf_pop(parse_frame_t *pf);
 int pf_check(parse_frame_t *frm, chunk_t *pc);
+
+
+/**
+ * Logs one parse frame
+ */
+void pf_log(log_sev_t logsev, parse_frame_t *pf);
+
 
 #endif /* PARSE_FRAME_H_INCLUDED */

--- a/src/punctuators.cpp
+++ b/src/punctuators.cpp
@@ -6,7 +6,7 @@
  * @license GPL v2+
  */
 #include "uncrustify_types.h"
-#include <cstring>
+#include "prototypes.h"
 
 
 /**

--- a/src/semicolons.cpp
+++ b/src/semicolons.cpp
@@ -15,9 +15,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cerrno>
 #include "unc_ctype.h"
-#include <cassert>
 
 
 static void remove_semicolon(chunk_t *pc);

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -26,7 +26,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cerrno>
 #include <algorithm>
 #include "unc_ctype.h"
 #include "uncrustify.h"

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -15,7 +15,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cerrno>
 #include "unc_ctype.h"
 #include "uncrustify.h"
 #include "keywords.h"
@@ -139,6 +138,16 @@ struct tok_ctx
    tok_info          c; /* current */
    tok_info          s; /* saved */
 };
+
+
+/**
+ * Count the number of characters in a word.
+ * The first character is already valid for a keyword
+ *
+ * @param pc   The structure to update, str is an input.
+ * @return     Whether a word was parsed (always true)
+ */
+static bool parse_word(tok_ctx &ctx, chunk_t &pc, bool skipcheck);
 
 
 /**
@@ -965,8 +974,8 @@ static bool parse_number(tok_ctx &ctx, chunk_t &pc)
 
 static bool parse_string(tok_ctx &ctx, chunk_t &pc, int quote_idx, bool allow_escape)
 {
-   char escape_char        = cpd.settings[UO_string_escape_char].n;
-   char escape_char2       = cpd.settings[UO_string_escape_char2].n;
+   char escape_char        = (char)cpd.settings[UO_string_escape_char].n;
+   char escape_char2       = (char)cpd.settings[UO_string_escape_char2].n;
    bool should_escape_tabs = cpd.settings[UO_string_replace_tab_chars].b && (cpd.lang_flags & LANG_ALLC);
 
    pc.str.clear();
@@ -1253,14 +1262,7 @@ static bool parse_cr_string(tok_ctx &ctx, chunk_t &pc, int q_idx)
 } // parse_cr_string
 
 
-/**
- * Count the number of characters in a word.
- * The first character is already valid for a keyword
- *
- * @param pc   The structure to update, str is an input.
- * @return     Whether a word was parsed (always true)
- */
-bool parse_word(tok_ctx &ctx, chunk_t &pc, bool skipcheck)
+static bool parse_word(tok_ctx &ctx, chunk_t &pc, bool skipcheck)
 {
    static unc_text intr_txt("@interface");
 
@@ -1821,10 +1823,10 @@ static bool parse_next(tok_ctx &ctx, chunk_t &pc)
 
    /* see if we have a punctuator */
    char punc_txt[4];
-   punc_txt[0] = ctx.peek();
-   punc_txt[1] = ctx.peek(1);
-   punc_txt[2] = ctx.peek(2);
-   punc_txt[3] = ctx.peek(3);
+   punc_txt[0] = (char)ctx.peek();
+   punc_txt[1] = (char)ctx.peek(1);
+   punc_txt[2] = (char)ctx.peek(2);
+   punc_txt[3] = (char)ctx.peek(3);
    const chunk_tag_t *punc;
    if ((punc = find_punctuator(punc_txt, cpd.lang_flags)) != NULL)
    {

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -93,7 +93,6 @@ void tokenize_cleanup(void)
 {
    LOG_FUNC_ENTRY();
 
-   chunk_t *pc   = chunk_get_head();
    chunk_t *prev = NULL;
    chunk_t *next;
    bool    in_type_cast = false;
@@ -103,6 +102,7 @@ void tokenize_cleanup(void)
    /* Since [] is expected to be TSQUARE for the 'operator', we need to make
     * this change in the first pass.
     */
+   chunk_t *pc;
    for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next_ncnl(pc))
    {
       if (pc->type == CT_SQUARE_OPEN)
@@ -738,6 +738,7 @@ void tokenize_cleanup(void)
       {
          if ((memcmp(next->str.c_str(), "region", 6) == 0) ||
              (memcmp(next->str.c_str(), "endregion", 9) == 0))
+         /* \todo probably better use strncmp */
          {
             set_chunk_type(pc, (*next->str.c_str() == 'r') ? CT_PP_REGION : CT_PP_ENDREGION);
 

--- a/src/unc_text.h
+++ b/src/unc_text.h
@@ -179,6 +179,8 @@ public:
 
    int &back()
    {
+      /* \todo returning a temporary via a reference
+       * this has to be checked and probably changed */
       return(m_chars.back());
    }
 

--- a/src/unc_tools.cpp
+++ b/src/unc_tools.cpp
@@ -56,6 +56,7 @@ void prot_the_line(int theLine, unsigned int actual_line)
 }
 
 
+/* \todo examine_ Data seems not to be used, is it still required? */
 void examine_Data(const char *func_name, int theLine, int what)
 {
    LOG_FMT(LGUY, "\n%s:", func_name);
@@ -125,6 +126,9 @@ void examine_Data(const char *func_name, int theLine, int what)
             }
          }
       }
+      break;
+
+   default:
       break;
    } // switch
 }    // examine_Data

--- a/src/unc_tools.h
+++ b/src/unc_tools.h
@@ -13,7 +13,11 @@
 #include "uncrustify_types.h"
 #include "chunk_list.h"
 
+
 void prot_the_line(int theLine, unsigned int actual_line);
+
+
 void examine_Data(const char *func_name, int theLine, int what);
+
 
 #endif /* UNC_TOOLS_H_INCLUDED */

--- a/src/uncrustify.h
+++ b/src/uncrustify.h
@@ -61,6 +61,9 @@ const char *get_file_extension(int &idx);
 void print_extensions(FILE *pfile);
 
 
+void usage_exit(const char *msg, const char *argv0, int code);
+
+
 const char *extension_add(const char *ext_text, const char *lang_text);
 
 #endif /* UNCRUSTIFY_H_INCLUDED */

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -28,6 +28,16 @@ using namespace std;
 #define UNCRUSTIFY_OFF_TEXT    " *INDENT-OFF*"
 #define UNCRUSTIFY_ON_TEXT     " *INDENT-ON*"
 
+
+/**
+ * @brief Macro to inform the compiler that a variable is intentionally
+ * not in use.
+ *
+ * @param [in] variableName: The unused variable.
+ */
+#define UNUSED(variableName)    ((void)variableName)
+
+
 /**
  * Brace stage enum used in brace_cleanup
  */
@@ -459,6 +469,6 @@ struct cp_data_t
    op_val_t       defaults[UO_option_count];
 };
 
-extern cp_data_t cpd;
+extern cp_data_t cpd;   /* \todo can we avoid this external variable? */
 
 #endif /* UNCRUSTIFY_TYPES_H_INCLUDED */

--- a/src/universalindentgui.cpp
+++ b/src/universalindentgui.cpp
@@ -100,7 +100,7 @@ void print_universal_indent_cfg(FILE *pfile)
             }
             else if (was_space)
             {
-               *character = unc_toupper(*character);
+               *character = (char)unc_toupper(*character);
                was_space  = false;
             }
          }
@@ -260,8 +260,8 @@ void print_universal_indent_cfg(FILE *pfile)
                val_string = op_val_to_string(option->type, cpd.settings[option->id]);
                val_str    = val_string.c_str();
                fprintf(pfile, "ValueDefault=%s\n", val_str);
+               break;
             }
-            break;
 
             default:
                break;

--- a/src/width.cpp
+++ b/src/width.cpp
@@ -441,9 +441,7 @@ static bool split_line(chunk_t *start)
 static void split_for_stmt(chunk_t *start)
 {
    LOG_FUNC_ENTRY();
-   int     count   = 0;
-   int     max_cnt = cpd.settings[UO_ls_for_split_full].b ? 2 : 1;
-   chunk_t *st[2];
+   int     max_cnt     = cpd.settings[UO_ls_for_split_full].b ? 2 : 1;
    chunk_t *open_paren = NULL;
    int     nl_cnt      = 0;
 
@@ -471,6 +469,8 @@ static void split_for_stmt(chunk_t *start)
    }
 
    /* see if we started on the semicolon */
+   int     count = 0;
+   chunk_t *st[2];
    pc = start;
    if ((pc->type == CT_SEMICOLON) && (pc->parent_type == CT_FOR))
    {
@@ -500,6 +500,7 @@ static void split_for_stmt(chunk_t *start)
 
    while (--count >= 0)
    {
+      /* \todo st[0] may be uninitialized here */
       LOG_FMT(LSPLIT, "%s: split before %s\n", __func__, st[count]->text());
       split_before_chunk(chunk_get_next(st[count]));
    }

--- a/src/windows_compat.h
+++ b/src/windows_compat.h
@@ -13,7 +13,7 @@
 
 #define HAVE_SYS_STAT_H
 
-#define NO_MACRO_VARARG
+#define NO_MACRO_VARARG    /* variable parameter numbers don't work on windows */
 
 typedef char                 CHAR;
 


### PR DESCRIPTION
implements #940 

This PR aims to make the code more robust against unexpected situations. Hopefully it will prevent some crashes of uncrustify.

* added some Null pointer checks
* some variable types changed
* some implicit casts with loss of precision made explicit
* added a few \todos for review

To make the code clearer
* removed unused header includes
* a few unused assignments deleted

I kindly ask you to review not only my changes but especially the instructions I have marked with \todo.