### PR TITLE
removes code redundancy of function get_next_class()

### DIFF
--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -18,6 +18,21 @@
 typedef ListManager<chunk_t> ChunkList;
 
 
+/**
+ * \brief search a chunk of a given category in a chunk list
+ *
+ * follows a chunk list until it finds a chunk of a given category.
+ * The search direction is determined by parameter dir.
+ *
+ * @retval NULL    - no object found, or invalid parameters provided
+ * @retval chunk_t - pointer to the found object
+ */
+static chunk_t *search_chunk(chunk_t         *pc, /**< [in] chunk list to search in */
+                             const c_token_t cat, /**< [in] category to search for */
+                             const bool      dir  /**< [in] search forward=true, backward=false */
+                             );
+
+
 static void chunk_log(chunk_t *pc, const char *text);
 
 
@@ -33,6 +48,32 @@ chunk_t *chunk_get_head(void)
 chunk_t *chunk_get_tail(void)
 {
    return(g_cl.GetTail());
+}
+
+
+chunk_t *search_prev_chunk(chunk_t *pc, const c_token_t cat)
+{
+   return(search_chunk(pc, cat, false));
+}
+
+
+chunk_t *search_next_chunk(chunk_t *pc, const c_token_t cat)
+{
+   return(search_chunk(pc, cat, true));
+}
+
+
+static chunk_t *search_chunk(chunk_t *pc, const c_token_t cat, const bool dir)
+{
+   /* no need to check if pc != NULL as this is done in chunk_get_next/prev */
+   while ((pc = (dir == true) ? chunk_get_next(pc) : chunk_get_prev(pc)) != NULL)
+   {
+      if (pc->type == cat)
+      {
+         return(pc);
+      }
+   }
+   return(NULL);
 }
 
 

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -75,6 +75,28 @@ chunk_t *chunk_get_prev_nvb(chunk_t *cur, chunk_nav_t nav = CNAV_ALL);
 
 
 /**
+ * \brief reverse search a chunk of a given category in a chunk list
+ *
+ * @retval NULL    - no object found, or invalid parameters provided
+ * @retval chunk_t - pointer to the found object
+ */
+chunk_t *search_prev_chunk(chunk_t         *pc, /**< [in] chunk list to search in */
+                           const c_token_t cat  /**< [in] category to search for */
+                           );
+
+
+/**
+ * \brief forward search a chunk of a given category in a chunk list
+ *
+ * @retval NULL    - no object found, or invalid parameters provided
+ * @retval chunk_t - pointer to the found object
+ */
+chunk_t *search_next_chunk(chunk_t         *pc, /**< [in] chunk list to search in */
+                           const c_token_t cat  /**< [in] category to search for */
+                           );
+
+
+/**
  * Skips to the closing match for the current paren/brace/square.
  *
  * @param cur  The opening or closing paren/brace/square

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -660,6 +660,7 @@ static void calculate_comment_body_indent(cmt_reflow &cmt, const unc_text &str)
 } // calculate_comment_body_indent
 
 
+/* \todo can we use search_next_chunk here? */
 static chunk_t *get_next_function(chunk_t *pc)
 {
    while ((pc = chunk_get_next(pc)) != NULL)
@@ -677,60 +678,27 @@ static chunk_t *get_next_function(chunk_t *pc)
 }
 
 
-/* \todo better use generic functions for the following functions
- *
- * static chunk_t *check_prev_category(chunk_t *pc, c_token_t* cat)
- * static chunk_t *check_next_category(chunk_t *pc, c_token_t* cat)
- */
+static chunk_t *get_next_class(chunk_t *pc)
+{
+   return(chunk_get_next(search_next_chunk(pc, CT_CLASS)));
+}
+
+
 static chunk_t *get_prev_category(chunk_t *pc)
 {
-   while ((pc = chunk_get_prev(pc)) != NULL)
-   {
-      if (pc->type == CT_OC_CATEGORY)
-      {
-         return(pc);
-      }
-   }
-   return(NULL);
+   return(search_prev_chunk(pc, CT_OC_CATEGORY));
 }
 
 
 static chunk_t *get_next_scope(chunk_t *pc)
 {
-   while ((pc = chunk_get_next(pc)) != NULL)
-   {
-      if (pc->type == CT_OC_SCOPE)
-      {
-         return(pc);
-      }
-   }
-   return(NULL);
-}
-
-
-static chunk_t *get_next_class(chunk_t *pc)
-{
-   while ((pc = chunk_get_next(pc)) != NULL)
-   {
-      if (pc->type == CT_CLASS)
-      {
-         return(chunk_get_next(pc));
-      }
-   }
-   return(NULL);
+   return(search_next_chunk(pc, CT_OC_SCOPE));
 }
 
 
 static chunk_t *get_prev_oc_class(chunk_t *pc)
 {
-   while ((pc = chunk_get_prev(pc)) != NULL)
-   {
-      if (pc->type == CT_OC_CLASS)
-      {
-         return(pc);
-      }
-   }
-   return(NULL);
+   return(search_prev_chunk(pc, CT_OC_CLASS));
 }
 
 

--- a/src/token_enum.h
+++ b/src/token_enum.h
@@ -326,7 +326,7 @@ typedef enum
    CT_FOR_COLON,    /* colon in "for ( TYPE var: EXPR ) { ... }" */
    CT_DOUBLE_BRACE, /* parent for double brace */
 
-   /* extentions for Qt macros */
+   /* extensions for Qt macros */
    CT_Q_EMIT,       // guy 2015-10-16
    CT_Q_FOREACH,    // guy 2015-09-23
    CT_Q_FOREVER,    // guy 2015-10-18


### PR DESCRIPTION
The four functions get_next_class(), get_prev_category(), get_next_scope() and get_prev_oc_class() did almost the same thing. They have been merged into a common function search_chunk().