### PR TITLE
makes void casts self explanatory

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -1565,7 +1565,7 @@ static chunk_t *skip_c99_array(chunk_t *sq_open)
  */
 static chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
 {
-   (void)first_pass;
+   UNUSED(first_pass);
    LOG_FUNC_ENTRY();
    chunk_t *prev_match = NULL;
    size_t  idx         = 0;

--- a/src/args.h
+++ b/src/args.h
@@ -63,7 +63,7 @@ public:
    const char *Param(const char *token);
 
    /**
-    * Similiar to arg_param, but can iterate over all matches.
+    * Similar to arg_param, but can iterate over all matches.
     * Set index to 0 before the first call.
     *
     * @param token   The token string to match

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -116,7 +116,7 @@ static size_t preproc_start(parse_frame_t *frm, chunk_t *pc)
 static void print_stack(log_sev_t logsev, const char *str,
                         parse_frame_t *frm, chunk_t *pc)
 {
-   (void)pc;
+   UNUSED(pc);
    LOG_FUNC_ENTRY();
    if (log_sev_on(logsev))
    {

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -3079,7 +3079,7 @@ void combine_labels(void)
 
 static void mark_variable_stack(ChunkStack &cs, log_sev_t sev)
 {
-   (void)sev;
+   UNUSED(sev);
    LOG_FUNC_ENTRY();
 
    /* throw out the last word and mark the rest */

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -416,6 +416,8 @@ void log_func_call(int line)
 
 void log_func_stack(log_sev_t sev, const char *prefix, const char *suffix, size_t skip_cnt)
 {
+   UNUSED(skip_cnt);
+
    if (prefix)
    {
       LOG_FMT(sev, "%s", prefix);

--- a/src/logger.h
+++ b/src/logger.h
@@ -89,7 +89,7 @@ void log_str(log_sev_t sev, const char *str, size_t len);
 
 
 /**
- * Logs a formatted string -- similiar to printf()
+ * Logs a formatted string -- similar to printf()
  *
  * @param sev     The severity
  * @param fmt     The format string

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1953,12 +1953,12 @@ void process_option_line(char *configLine, const char *filename)
          unc_text ut = filename;
          ut.resize(path_dirname_len(filename));
          ut.append(args[1]);
-         (void)load_option_file(ut.c_str());
+         UNUSED(load_option_file(ut.c_str()));
       }
       else
       {
          /* include is an absolute Unix path */
-         (void)load_option_file(args[1]);
+         UNUSED(load_option_file(args[1]));
       }
 
       cpd.line_number = save_line_no;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1460,7 +1460,7 @@ static void output_comment_multi(chunk_t *pc)
 
 static bool kw_fcn_filename(chunk_t *cmt, unc_text &out_txt)
 {
-   (void)cmt;
+   UNUSED(cmt);
    out_txt.append(path_basename(cpd.filename));
    return(true);
 }
@@ -1852,7 +1852,7 @@ static void do_kw_subst(chunk_t *pc)
  */
 static void output_comment_multi_simple(chunk_t *pc, bool kw_subst)
 {
-   (void)kw_subst;
+   UNUSED(kw_subst);
    cmt_reflow cmt;
    output_cmt_start(cmt, pc);
 

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -371,7 +371,7 @@ int main(int argc, char *argv[])
 
 #ifdef WIN32
    /* tell Windows not to change what I write to stdout */
-   (void)_setmode(_fileno(stdout), _O_BINARY);
+   UNUSED(_setmode(_fileno(stdout), _O_BINARY));
 #endif
 
    /* Init logging */
@@ -1308,7 +1308,7 @@ static void do_source_file(const char *filename_in,
          if (!cpd.if_changed && file_content_matches(filename_tmp, filename_out))
          {
             /* No change - remove tmp file */
-            (void)unlink(filename_tmp.c_str());
+            UNUSED(unlink(filename_tmp.c_str()));
          }
          else
          {
@@ -1335,7 +1335,7 @@ static void do_source_file(const char *filename_in,
       {
          /* update mtime -- don't care if it fails */
          fm.utb.actime = time(NULL);
-         (void)utime(filename_in, &fm.utb);
+         UNUSED(utime(filename_in, &fm.utb));
       }
 #endif
    }

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -28,6 +28,16 @@ using namespace std;
 #define UNCRUSTIFY_OFF_TEXT    " *INDENT-OFF*"
 #define UNCRUSTIFY_ON_TEXT     " *INDENT-ON*"
 
+
+/**
+ * @brief Macro to inform the compiler that a variable is intentionally
+ * not in use.
+ *
+ * @param [in] variableName: The unused variable.
+ */
+#define UNUSED(variableName)    ((void)variableName)
+
+
 /**
  * Brace stage enum used in brace_cleanup
  */


### PR DESCRIPTION
Void casts are not self explanatory. Therefore the #define UNUSED has been added which explains why void casts are used.