### PR TITLE
Implementation of sort includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ include(CTest)
 if(MSVC)
   add_definitions(/D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_WARNINGS /wd4267)
 elseif(CMAKE_COMPILER_IS_GNUCXX)
+  add_definitions(-std=gnu++0x)
   set(gcc_warning_flags
     -Wall
     -Wextra
@@ -30,6 +31,7 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
     -Wpointer-arith
     -Wcast-qual
     -Wcast-align
+    -Wc++11-extensions
   )
   foreach(flag ${gcc_warning_flags})
     string(REGEX REPLACE "[^a-zA-Z0-9]+" "_" flag_var "CXXFLAG_${flag}")
@@ -41,6 +43,7 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
   endforeach()
   unset(gcc_warning_flags)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_definitions(-std=gnu++0x)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 endif()
 

--- a/scripts/More_Options_to_Test/help.txt
+++ b/scripts/More_Options_to_Test/help.txt
@@ -70,6 +70,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with 
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 567 options and minimal documentation.
+There are currently 570 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1554,6 +1554,14 @@ void register_options(void)
    unc_add_option("pp_define_at_level", UO_pp_define_at_level, AT_BOOL,
                   "Whether to indent '#define' at the brace level (True) or from column 1 (false)");
 
+   unc_begin_group(UG_sort_includes, "Sort includes options");
+   unc_add_option("include_category_0", UO_include_category_0, AT_STRING,
+                  "The regex for include category with priority 0.");   
+   unc_add_option("include_category_1", UO_include_category_1, AT_STRING,
+                  "The regex for include category with priority 1.");   
+   unc_add_option("include_category_2", UO_include_category_2, AT_STRING,
+                  "The regex for include category with priority 2.");   
+
    unc_begin_group(UG_Use_Ext, "Use or Do not Use options", "G");
    unc_add_option("use_indent_func_call_param", UO_use_indent_func_call_param, AT_BOOL,
                   "True:  indent_func_call_param will be used (default)\n"

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1556,11 +1556,11 @@ void register_options(void)
 
    unc_begin_group(UG_sort_includes, "Sort includes options");
    unc_add_option("include_category_0", UO_include_category_0, AT_STRING,
-                  "The regex for include category with priority 0.");   
+                  "The regex for include category with priority 0.");
    unc_add_option("include_category_1", UO_include_category_1, AT_STRING,
-                  "The regex for include category with priority 1.");   
+                  "The regex for include category with priority 1.");
    unc_add_option("include_category_2", UO_include_category_2, AT_STRING,
-                  "The regex for include category with priority 2.");   
+                  "The regex for include category with priority 2.");
 
    unc_begin_group(UG_Use_Ext, "Use or Do not Use options", "G");
    unc_add_option("use_indent_func_call_param", UO_use_indent_func_call_param, AT_BOOL,

--- a/src/options.h
+++ b/src/options.h
@@ -814,7 +814,7 @@ enum uncrustify_options
    UO_enable_processing_cmt,    // override UNCRUSTIFY_DEFAULT_ON_TEXT
 
    UO_include_category_first,
-   UO_include_category_0 = UO_include_category_first,
+   UO_include_category_0    = UO_include_category_first,
    UO_include_category_1,
    UO_include_category_2,
    UO_include_category_last = UO_include_category_2,

--- a/src/options.h
+++ b/src/options.h
@@ -89,6 +89,7 @@ enum uncrustify_groups
    UG_comment,
    UG_preprocessor,
    UG_Use_Ext,
+   UG_sort_includes,
    UG_warnlevels,
    UG_group_count
 };
@@ -811,6 +812,12 @@ enum uncrustify_options
    UO_string_replace_tab_chars, // replace tab chars found in strings to the escape sequence \t
    UO_disable_processing_cmt,   // override UNCRUSTIFY_DEFAULT_OFF_TEXT
    UO_enable_processing_cmt,    // override UNCRUSTIFY_DEFAULT_ON_TEXT
+
+   UO_include_category_first,
+   UO_include_category_0 = UO_include_category_first,
+   UO_include_category_1,
+   UO_include_category_2,
+   UO_include_category_last = UO_include_category_2,
 
    /* Hack, add comments to the ends of namespaces */
    UO_mod_add_long_namespace_closebrace_comment,

--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -13,10 +13,10 @@
 
 struct include_category
 {
-   include_category(const char* pattern)
+   include_category(const char *pattern)
       : regex(pattern)
    {
-   };
+   }
    std::regex regex;
 };
 
@@ -25,12 +25,12 @@ enum
    kIncludeCategoriesCount = UO_include_category_last - UO_include_category_first + 1,
 };
 
-include_category* include_categories[kIncludeCategoriesCount];
+include_category *include_categories[kIncludeCategoriesCount];
 
 
 static void prepare_categories()
 {
-   for(int i=0; i<kIncludeCategoriesCount; i++)
+   for (int i = 0; i < kIncludeCategoriesCount; i++)
    {
       if (cpd.settings[UO_include_category_first + i].str != NULL)
       {
@@ -43,9 +43,10 @@ static void prepare_categories()
    }
 }
 
+
 static void cleanup_categories()
 {
-   for(int i=0; i<kIncludeCategoriesCount; i++)
+   for (int i = 0; i < kIncludeCategoriesCount; i++)
    {
       if (include_categories[i] != NULL)
       {
@@ -55,20 +56,21 @@ static void cleanup_categories()
    }
 }
 
-static int get_chunk_priority(chunk_t* pc)
+
+static int get_chunk_priority(chunk_t *pc)
 {
-   for(int i=0; i<kIncludeCategoriesCount; i++)
+   for (int i = 0; i < kIncludeCategoriesCount; i++)
    {
       if (include_categories[i] != NULL)
       {
          if (std::regex_match(pc->text(), include_categories[i]->regex))
          {
-            return i;
+            return(i);
          }
       }
    }
-   
-   return kIncludeCategoriesCount;
+
+   return(kIncludeCategoriesCount);
 }
 
 
@@ -99,12 +101,12 @@ static int compare_chunks(chunk_t *pc1, chunk_t *pc2)
    {
       int ppc1 = get_chunk_priority(pc1);
       int ppc2 = get_chunk_priority(pc2);
-      
+
       if (ppc1 != ppc2)
       {
          return(ppc1 - ppc2);
       }
-      
+
       LOG_FMT(LSORT, "text=%s, pc1->len=%zu, line=%zu, column=%zu\n", pc1->text(), pc1->len(), pc1->orig_line, pc1->orig_col);
       LOG_FMT(LSORT, "text=%s, pc2->len=%zu, line=%zu, column=%zu\n", pc2->text(), pc2->len(), pc2->orig_line, pc2->orig_col);
       size_t min_len = (pc1->len() < pc2->len()) ? pc1->len() : pc2->len();

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -6,6 +6,7 @@
  * @license GPL v2+
  */
 #include "unc_text.h"
+#include "unc_ctype.h"
 #include "unicode.h" /* encode_utf8() */
 
 
@@ -63,9 +64,24 @@ int unc_text::compare(const unc_text &ref1, const unc_text &ref2, size_t len)
 
    for (idx = 0; (idx < len1) && (idx < len2) && (idx < len); idx++)
    {
-      if (ref1.m_chars[idx] != ref2.m_chars[idx])
+      // exactly the same character ?
+      if (ref1.m_chars[idx] == ref2.m_chars[idx])
       {
-         return(ref1.m_chars[idx] - ref2.m_chars[idx]);
+         continue;
+      }
+
+      int diff = unc_tolower(ref1.m_chars[idx]) - unc_tolower(ref2.m_chars[idx]);
+      if (diff == 0)
+      {
+         // if we're comparing the same character but in different case
+         // we want to favor lowercase before uppercase (e.g. a before A)
+         // so the order is the reverse of ASCII order (we negate).
+         return -(ref1.m_chars[idx] - ref2.m_chars[idx]);
+      }
+      else
+      {
+         // return the case-insensitive diff to sort alphabetically
+         return diff;
       }
    }
    if (idx == len)

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -76,12 +76,12 @@ int unc_text::compare(const unc_text &ref1, const unc_text &ref2, size_t len)
          // if we're comparing the same character but in different case
          // we want to favor lowercase before uppercase (e.g. a before A)
          // so the order is the reverse of ASCII order (we negate).
-         return -(ref1.m_chars[idx] - ref2.m_chars[idx]);
+         return(-(ref1.m_chars[idx] - ref2.m_chars[idx]));
       }
       else
       {
          // return the case-insensitive diff to sort alphabetically
-         return diff;
+         return(diff);
       }
    }
    if (idx == len)

--- a/tests/c-sharp.test
+++ b/tests/c-sharp.test
@@ -18,6 +18,7 @@
 
 10030 sort_imports.cfg         cs/sort_using.cs
 10031 bug_i_935.cfg            cs/bug_i_935.cs
+10032 sort_using_categ.cfg     cs/sort_using_categ.cs
 
 10040 tcf.cfg                  cs/tcf.cs
 10041 tcf.cfg                  cs/gs.cs

--- a/tests/config/sort_using_categ.cfg
+++ b/tests/config/sort_using_categ.cfg
@@ -1,0 +1,5 @@
+
+mod_sort_using = true
+
+include_category_0 = System
+include_category_1 = .*

--- a/tests/input/cs/sort_using_categ.cs
+++ b/tests/input/cs/sort_using_categ.cs
@@ -1,0 +1,12 @@
+using Client.Common;
+using LeopotamGroup.Common;
+using LeopotamGroup.Serialization;
+using System;
+using UnityEngine.EventSystems;
+using UnityEngine.Events;
+using UnityEngine;
+
+using NameSpace;
+using NameSpacEveryday;
+using nameSpace;
+using Namespace;

--- a/tests/output/cs/10031-bug_i_935.cs
+++ b/tests/output/cs/10031-bug_i_935.cs
@@ -4,8 +4,8 @@ using System.Collections.Generic;
 using System2;
 
 using b;
-using b.A;
 using b.a;
+using b.A;
 using b.ddd;
 using b.ddd.A;
 using b.eee;

--- a/tests/output/cs/10032-sort_using_categ.cs
+++ b/tests/output/cs/10032-sort_using_categ.cs
@@ -1,0 +1,12 @@
+using System;
+using Client.Common;
+using LeopotamGroup.Common;
+using LeopotamGroup.Serialization;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.EventSystems;
+
+using nameSpace;
+using Namespace;
+using NameSpace;
+using NameSpacEveryday;


### PR DESCRIPTION
The implementation introduces 3 prioritised include categories defined by a configurable regex. This idea is borrowed from clang-format.

The sorting order is controlled by the priority of the category first followed by a string comparison with a higher priority on lowercase versus uppercase. We needed a different string comparison algorithm to control case sensitivity in a stable way.

