### PR TITLE
Add contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,19 +3,34 @@
 ## How to contribute
 
 There are lots of ways to contribute to Uncrustify:
-- Reporting Bugs
-- Suggesting Enhancements
+- Report Issues
+- Propose Features or Improvements
 - Submit Pull Requests
 
 ## Making changes
 
-Best practices:
-- Branches should be named after _what_ the change is about
-- Branches should not be named after the issue number, developer name, etc.
-- Branch name should contain keywords like `fix`, `feature`, etc.
-- It is recommended to do only one thing at a time and get that to master, splitting your work in multiple PRs if necessary
-- The PR title should represent _what_ is being changed (could be a rephrasing of the branch name if set correctly)
-- The PR description should document the _why_ the change needed to be done and not _what_ which should be obvious by doing the code review
-- Try to avoid merges, always rebase your work on top of master before creating a PR. This will reduce the likelihood of conflicts and test failures
-- No PR should be approved to be merged in master if the work is incomplete (no fix-up commits). That's why core reviews are for, not for automatic testing by a CI server. As a reviewer be very critical but not try to over-engineer things
-- The changes should always be accompanied by regression tests (if not possible, state why not ?)
+* Pull latest _master_ and create a new branch:
+    - Branch name _should_ use lowercase, using `-` to separate words and not `_`. Other special characters _should_ be avoided.
+    - A hierarchical structure _can_ be designated using `/` (e.g. `area/topic`). The last part of the name can be keywords like `bugfix`, `feature`, `optim`, `docs`, `refactor`, `test`, etc.
+    - Branches _should_ be named after _what_ the change is about
+    - Branches _should not_ be named after the issue number, developer name, etc.
+* Organize your work:
+    - Specialize your branch to target only one thing. Split your work in multiple branches if necessary
+    - Make commits of logical units
+    - Try to write a quality commit message:
+        + Separate subject line from body with a blank line
+        + Limit subject line to 50 characters
+        + Capitalize the subject line
+        + Do not end the subject line with a period
+        + Use imperative present tense in the subject line. A proper subject can complete the sentence _If applied, this commit will, [subject]_.
+        + Wrap the body at 72 characters
+        + Include motivation for the change and contrast its implementation with previous behavior. Explain the _what_ and _why_ instead of _how_.
+* Definition of done:
+    - The code is clean and documented where needed
+    - The change has to be complete (no upcoming fix-up commits)
+    - The change should always be accompanied by regression tests (explain why if not possible)
+* Preparing a Pull Request (PR):
+    - To reduce the likelihood of conflicts and test failures, try to avoid merges, rebasing your work on top of latest master before creating a PR 
+    - Verify that your code is properly formatted by running `scripts/Run_uncrustify_for_sources`
+    - The PR title should represent _what_ is being changed (a rephrasing of the branch name if set correctly)
+    - The PR description should document the _why_ the change needed to be done and _not how_ which should be obvious by doing the code review

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to Uncrustify
+
+## How to contribute
+
+There are lots of ways to contribute to Uncrustify:
+- Reporting Bugs
+- Suggesting Enhancements
+- Submit Pull Requests
+
+## Making changes
+
+Best practices:
+- Branches should be named after _what_ the change is about
+- Branches should not be named after the issue number, developer name, etc.
+- Branch name should contain keywords like `fix`, `feature`, etc.
+- It is recommended to do only one thing at a time and get that to master, splitting your work in multiple PRs if necessary
+- The PR title should represent _what_ is being changed (could be a rephrasing of the branch name if set correctly)
+- The PR description should document the _why_ the change needed to be done and not _what_ which should be obvious by doing the code review
+- Try to avoid merges, always rebase your work on top of master before creating a PR. This will reduce the likelihood of conflicts and test failures
+- No PR should be approved to be merged in master if the work is incomplete (no fix-up commits). That's why core reviews are for, not for automatic testing by a CI server. As a reviewer be very critical but not try to over-engineer things
+- The changes should always be accompanied by regression tests (if not possible, state why not ?)


### PR DESCRIPTION
The main motivation is to help define a common working framework for uncrustify contributors.
The need of a contributing file was also mentioned in #898 but the main discussion happened in the comments for issue #899.