### PR TITLE
Coverity: Add a travis.yml file and script to push code to coverity

### DIFF
--- a/coverity.sh
+++ b/coverity.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+#
+# ARGS: 1:remote
+#
+
+BRANCH=coverity_scan
+
+if [ -z "$1" ] ; then
+	cat <<EOF
+Usage: $0 REMOTE
+
+This script triggers a coverity build by pushing the current code to
+the '$BRANCH' branch.
+
+It copies the current (master) branch over the '$BRANCH' branch,
+then copies 'coverity.travis.yml' over '.travis.yml' and force-pushes
+the new branch.
+
+You obviously must have commit rights on the repository, so this is
+a maintainer-only script, unless you are pushing to your own fork.
+
+Example:
+  $0 origin
+EOF
+	exit 1
+fi
+REMOTE=$1
+
+set -e
+
+if [ -z "$NOTIFICATION_EMAIL" ] ; then
+	NOTIFICATION_EMAIL=$(git config user.email)
+	if [ -z "$NOTIFICATION_EMAIL" ] ; then
+		echo "No notification email address set."
+	fi
+fi
+
+if [ $(git rev-parse --abbrev-ref HEAD) != 'master' ] ; then
+	cat <<EOF
+Please switch to the master branch before running this script.
+EOF
+	exit 1
+fi
+
+if git describe --dirty | grep -q dirty ; then
+	cat <<EOF
+Please clean up your dirty workspace before running this script.
+EOF
+	exit 1
+fi
+
+echo "NOTIFICATION_EMAIL: $NOTIFICATION_EMAIL"
+
+if git branch | grep $BRANCH ; then
+	echo "Deleting local coverity_scan branch..."
+	git branch -D $BRANCH
+fi
+
+git branch $BRANCH $REMOTE/master
+git checkout -f $BRANCH
+
+sed "s|{NOTIFICATION_EMAIL}|$NOTIFICATION_EMAIL|" coverity.travis.yml > .travis.yml
+
+git add .travis.yml
+git commit -m 'Copy coverity.travis.yml -> .travis.yml for coverity build.'
+git push -f $REMOTE $BRANCH
+git checkout master
+
+echo 'Finished.'

--- a/coverity.sh
+++ b/coverity.sh
@@ -32,6 +32,7 @@ if [ -z "$NOTIFICATION_EMAIL" ] ; then
 	NOTIFICATION_EMAIL=$(git config user.email)
 	if [ -z "$NOTIFICATION_EMAIL" ] ; then
 		echo "No notification email address set."
+		exit 1
 	fi
 fi
 

--- a/coverity.travis.yml
+++ b/coverity.travis.yml
@@ -1,0 +1,29 @@
+language: cpp
+sudo: required
+
+branches:
+  only:
+    - coverity_scan
+
+# Coverity stuff
+env:
+  global:
+    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
+    #   via the "travis encrypt" command using the project repo's public key
+    - secure: "rHg6I3iGS/u7+sWDD0misaVVrmVy6sjTuTGp1NK5nxuoDBjZgJkXC61yIzhbbDywwt5lCTYhC1J08ljrfVl4OSblrQIy9ihSrOs2mA/SrPiKh5sB1B661Pd20GDK+hkLByrSyWR2UusgHxYly9KPykbo0wX7R0qdLJouv86Irx09SS+YggkQTiAxVD7dvxHagiZa609zau5sZvDDtmFs73nS+JAjRwj5iweSPO00ApHZSgIrhWMDCSoWXPEnOn8+Ruw02Eza0ArvceipuMtY5ju6kejQvgZ7l7y7nu4LwXUFxWE2z4C7lSTIjIk9cKGcEoSHAvTCAJor75AQY7NcMWq0MYNXj55e+CPzELBT5XCcR14CKirgOHaG7L9H7McvFdMTsmujkd61Qbxs9p2lro8nliFAvpG7yduuaF/XTCugzS8JwrPfq98mWgqhVO0ysowEsesOn0Bjo9XmjBUtjVJxg8hdq50XoVyWHnXLoEXgXLcRv4JFFfquvM5+nvd2pNxopTboO//KPsGIz1A1qCQ0g9ktaVM+be7wZzB6Lb3L2hnOdmTiNNirJXnNupwQF64ZUxmajyh3QF+SIcYEnoug+2X1bftC+qLKf2DkR4DwjCvWWVXAk0/Nn3ndfuKyGy8ZzUkHGw+BGjq5Z/SVC0l+AJ+y5UWtu8PNj+Bdtsw="
+
+before_install:
+  - mkdir $TRAVIS_BUILD_DIR/build
+  - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
+
+script: true
+
+addons:
+  coverity_scan:
+    project:
+      name: "uncrustify/uncrustify"
+      description: "Build submitted via Travis CI"
+    notification_email: {NOTIFICATION_EMAIL}
+    build_command_prepend: "(rm -rf $TRAVIS_BUILD_DIR/build ; mkdir $TRAVIS_BUILD_DIR/build ; cd $TRAVIS_BUILD_DIR/build ; cmake -DCMAKE_BUILD_TYPE=Release $TRAVIS_BUILD_DIR)"
+    build_command:   "make -C $TRAVIS_BUILD_DIR/build"
+    branch_pattern: coverity_scan


### PR DESCRIPTION
This is an attempt to integrate travis-ci and coverity.

To trigger a coverity build, run "./coverity.sh REMOTE" in a clean workspace.
This creates a branch named 'coverity_scan', copies 'coverity.travis.yml' over '.travis.yml', and pushes the result to REMOTE.

Guy - REMOTE might be either 'upstream' or 'origin', depending on how you have your workspace set up.

I couldn't come up with a cleaner solution.  Integrating the coverity stuff into the existing .travis.yml and only doing the coverity build on the 'coverity_build' branch should be possible, but I couldn't figure it out quickly.