### PR TITLE
Coverity finds some bug:

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -5856,6 +5856,10 @@ static void handle_oc_property_decl(chunk_t *os)
                      next = chunk_get_next(next);
                   } while (next && next->type != CT_COMMA && next->type != CT_PAREN_CLOSE);
                   next = next->prev;
+                  if (next == NULL)
+                  {
+                     break;
+                  }
                   getter_chunks.push_back(chunkGroup);
                }
                else if (chunk_is_str(next, "setter", 6))
@@ -5867,6 +5871,10 @@ static void handle_oc_property_decl(chunk_t *os)
                      next = chunk_get_next(next);
                   } while (next && next->type != CT_COMMA && next->type != CT_PAREN_CLOSE);
                   next = next->prev;
+                  if (next == NULL)
+                  {
+                     break;
+                  }
                   setter_chunks.push_back(chunkGroup);
                }
                else if (chunk_is_str(next, "nullable", 8))


### PR DESCRIPTION
CID 160946:    (FORWARD_NULL)
Dereferencing null pointer "next"
Add a test to prevent it.