### PR TITLE
Less warnings for space.*

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -629,7 +629,7 @@ void register_options(void)
                   "Controls the spaces between new and '(' in 'new()'");
    unc_add_option("sp_before_tr_emb_cmt", UO_sp_before_tr_emb_cmt, AT_IARF,
                   "Controls the spaces before a trailing or embedded comment");
-   unc_add_option("sp_num_before_tr_emb_cmt", UO_sp_num_before_tr_emb_cmt, AT_NUM,
+   unc_add_option("sp_num_before_tr_emb_cmt", UO_sp_num_before_tr_emb_cmt, AT_UNUM,
                   "Number of spaces before a trailing or embedded comment");
    unc_add_option("sp_annotation_paren", UO_sp_annotation_paren, AT_IARF,
                   "Control space between a Java annotation and the open paren.");

--- a/src/options_for_QT.cpp
+++ b/src/options_for_QT.cpp
@@ -13,7 +13,7 @@
 
 // for the modification of options within the SIGNAL/SLOT call. guy 2015-09-22
 bool     QT_SIGNAL_SLOT_found      = false;
-int      QT_SIGNAL_SLOT_level      = 0;
+size_t   QT_SIGNAL_SLOT_level      = 0;
 bool     restoreValues             = false;
 argval_t SaveUO_sp_inside_fparen_A = AV_NOT_DEFINED;
 // Issue #481
@@ -29,11 +29,11 @@ argval_t SaveUO_sp_before_unnamed_byref_A = AV_NOT_DEFINED;
 argval_t SaveUO_sp_after_type_A           = AV_NOT_DEFINED;
 
 
-void save_set_options_for_QT(int level)
+void save_set_options_for_QT(size_t level)
 {
    assert(cpd.settings[UO_use_options_overriding_for_qt_macros].b);
 
-   LOG_FMT(LGUY, "save values, level=%d\n", level);
+   LOG_FMT(LGUY, "save values, level=%zu\n", level);
    // save the values
    QT_SIGNAL_SLOT_level             = level;
    SaveUO_sp_inside_fparen_A        = cpd.settings[UO_sp_inside_fparen].a;

--- a/src/options_for_QT.h
+++ b/src/options_for_QT.h
@@ -14,11 +14,11 @@
 
 #include "uncrustify_types.h"
 
-extern bool QT_SIGNAL_SLOT_found;
-extern int  QT_SIGNAL_SLOT_level;
-extern bool restoreValues;
+extern bool   QT_SIGNAL_SLOT_found;
+extern size_t QT_SIGNAL_SLOT_level;
+extern bool   restoreValues;
 
-void save_set_options_for_QT(int level);
+void save_set_options_for_QT(size_t level);
 void restore_options_for_QT(void);
 
 #endif /* OPTIONS_FOR_QT_H_INCLUDED */

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -31,7 +31,7 @@
 #include "uncrustify.h"
 
 
-static void log_rule2(int line, const char *rule, chunk_t *first, chunk_t *second, bool complete);
+static void log_rule2(size_t line, const char *rule, chunk_t *first, chunk_t *second, bool complete);
 
 
 /**
@@ -100,12 +100,12 @@ const no_space_table_t no_space_table[] =
    } while (0)
 
 
-static void log_rule2(int line, const char *rule, chunk_t *first, chunk_t *second, bool complete)
+static void log_rule2(size_t line, const char *rule, chunk_t *first, chunk_t *second, bool complete)
 {
    LOG_FUNC_ENTRY();
    if (second->type != CT_NEWLINE)
    {
-      LOG_FMT(LSPACE, "Spacing: line %zu [%s/%s] '%s' <===> [%s/%s] '%s' : %s[%d]%s",
+      LOG_FMT(LSPACE, "Spacing: line %zu [%s/%s] '%s' <===> [%s/%s] '%s' : %s[%zu]%s",
               first->orig_line,
               get_token_name(first->type), get_token_name(first->parent_type),
               first->text(),
@@ -349,7 +349,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
         (second->parent_type == CT_COMMENT_EMBED)))
    {
       log_rule("sp_before_tr_emb_cmt");
-      min_sp = cpd.settings[UO_sp_num_before_tr_emb_cmt].n;
+      min_sp = cpd.settings[UO_sp_num_before_tr_emb_cmt].u;
       return(cpd.settings[UO_sp_before_tr_emb_cmt].a);
    }
 
@@ -519,7 +519,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
           ((second->type == CT_FPAREN_CLOSE) ||
            (second->type == CT_COMMA)))
       {
-         if (second->level == (QT_SIGNAL_SLOT_level))
+         if (second->level == QT_SIGNAL_SLOT_level)
          {
             restoreValues = true;
          }
@@ -1352,7 +1352,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
    if ((cpd.settings[UO_sp_after_constr_colon].a != AV_IGNORE) &&
        (first->type == CT_CONSTR_COLON))
    {
-      min_sp = cpd.settings[UO_indent_ctor_init_leading].n - 1; // default indent is 1 space
+      min_sp = cpd.settings[UO_indent_ctor_init_leading].u - 1; // default indent is 1 space
 
       log_rule("sp_after_constr_colon");
       return(cpd.settings[UO_sp_after_constr_colon].a);
@@ -1772,7 +1772,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
 
    // this table lists out all combos where a space should NOT be present
    // CT_UNKNOWN is a wildcard.
-   for (int idx = 0; idx < (int)ARRAY_SIZE(no_space_table); idx++)
+   for (size_t idx = 0; idx < ARRAY_SIZE(no_space_table); idx++)
    {
       if (((no_space_table[idx].first == CT_UNKNOWN) ||
            (no_space_table[idx].first == first->type))
@@ -1817,8 +1817,8 @@ void space_text(void)
    }
 
    chunk_t *next;
-   int     prev_column;
-   int     column = pc->column;
+   size_t  prev_column;
+   size_t  column = pc->column;
    while (pc != NULL)
    {
 #ifdef DEBUG
@@ -2013,7 +2013,7 @@ void space_text(void)
 
          if (chunk_is_comment(next) &&
              chunk_is_newline(chunk_get_next(next)) &&
-             (column < (int)next->orig_col))
+             (column < next->orig_col))
          {
             /* do some comment adjustments if sp_before_tr_emb_cmt and
              * sp_endif_cmt did not apply.
@@ -2035,7 +2035,7 @@ void space_text(void)
                {
                   /* If there was a space, we need to force one, otherwise
                    * try to keep the comment in the same column. */
-                  int col_min = pc->column + pc->len() + ((next->orig_prev_sp > 0) ? 1 : 0);
+                  size_t col_min = pc->column + pc->len() + ((next->orig_prev_sp > 0) ? 1 : 0);
                   column = next->orig_col;
                   if (column < col_min)
                   {
@@ -2047,7 +2047,7 @@ void space_text(void)
          }
          next->column = column;
 
-         LOG_FMT(LSPACE, " = %s @ %d => %zu\n",
+         LOG_FMT(LSPACE, " = %s @ %zu => %zu\n",
                  (av == AV_IGNORE) ? "IGNORE" :
                  (av == AV_ADD) ? "ADD" :
                  (av == AV_REMOVE) ? "REMOVE" : "FORCE",
@@ -2126,7 +2126,7 @@ void space_text_balance_nested_parens(void)
 } // space_text_balance_nested_parens
 
 
-int space_needed(chunk_t *first, chunk_t *second)
+size_t space_needed(chunk_t *first, chunk_t *second)
 {
    LOG_FUNC_ENTRY();
    LOG_FMT(LSPACE, "%s\n", __func__);
@@ -2165,7 +2165,7 @@ int space_col_align(chunk_t *first, chunk_t *second)
    argval_t av = do_space(first, second, min_sp);
 
    LOG_FMT(LSPACE, "%s: av=%d, ", __func__, av);
-   int coldiff;
+   size_t coldiff;
    if (first->nl_count)
    {
       LOG_FMT(LSPACE, "nl_count=%zu, orig_col_end=%d", first->nl_count, first->orig_col_end);
@@ -2196,7 +2196,7 @@ int space_col_align(chunk_t *first, chunk_t *second)
    case AV_NOT_DEFINED:
       break;
    }
-   LOG_FMT(LSPACE, " => %d\n", coldiff);
+   LOG_FMT(LSPACE, " => %zu\n", coldiff);
    return(coldiff);
 } // space_col_align
 

--- a/src/space.h
+++ b/src/space.h
@@ -39,7 +39,7 @@ int space_col_align(chunk_t *first, chunk_t *second);
 /**
  * Determines if a space is required between two chunks
  */
-int space_needed(chunk_t *first, chunk_t *second);
+size_t space_needed(chunk_t *first, chunk_t *second);
 
 
 void space_add_after(chunk_t *pc, size_t count);

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -429,7 +429,7 @@ void tokenize_cleanup(void)
                }
                /* Change tmp into a type so that space_needed() works right */
                make_type(tmp);
-               int num_sp = space_needed(tmp2, tmp);
+               size_t num_sp = space_needed(tmp2, tmp);
                while (num_sp-- > 0)
                {
                   next->str.append(" ");


### PR DESCRIPTION
Use settings[UO_xxxxx].u instead of .n
Change some int-declarations to size_t