### PR TITLE
Refactor enums

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -1980,7 +1980,7 @@ static void align_oc_msg_colon(chunk_t *so)
    cas.Start(span);
 
    size_t  level = so->level;
-   chunk_t *pc   = chunk_get_next_ncnl(so, CNAV_PREPROC);
+   chunk_t *pc   = chunk_get_next_ncnl(so, scope_e::PREPROC);
 
    bool    did_line  = false;
    bool    has_colon = false;
@@ -2015,7 +2015,7 @@ static void align_oc_msg_colon(chunk_t *so)
          }
          did_line = true;
       }
-      pc = chunk_get_next(pc, CNAV_PREPROC);
+      pc = chunk_get_next(pc, scope_e::PREPROC);
    }
 
    nas.m_skip_first = !cpd.settings[UO_align_oc_msg_colon_first].b;
@@ -2120,7 +2120,7 @@ static void align_oc_decl_colon(void)
       cas.Reset();
 
       size_t level = pc->level;
-      pc = chunk_get_next_ncnl(pc, CNAV_PREPROC);
+      pc = chunk_get_next_ncnl(pc, scope_e::PREPROC);
 
       did_line = false;
 
@@ -2142,8 +2142,8 @@ static void align_oc_decl_colon(void)
          {
             cas.Add(pc);
 
-            chunk_t *tmp  = chunk_get_prev(pc, CNAV_PREPROC);
-            chunk_t *tmp2 = chunk_get_prev_ncnl(tmp, CNAV_PREPROC);
+            chunk_t *tmp  = chunk_get_prev(pc, scope_e::PREPROC);
+            chunk_t *tmp2 = chunk_get_prev_ncnl(tmp, scope_e::PREPROC);
 
             /* Check for an un-labeled parameter */
             if ((tmp != NULL) &&
@@ -2162,7 +2162,7 @@ static void align_oc_decl_colon(void)
             }
             did_line = true;
          }
-         pc = chunk_get_next(pc, CNAV_PREPROC);
+         pc = chunk_get_next(pc, scope_e::PREPROC);
       }
       nas.End();
       cas.End();
@@ -2189,7 +2189,7 @@ static void align_asm_colon(void)
 
       cas.Reset();
 
-      pc = chunk_get_next_ncnl(pc, CNAV_PREPROC);
+      pc = chunk_get_next_ncnl(pc, scope_e::PREPROC);
       size_t level = pc ? pc->level : 0;
       did_nl = true;
       while (pc && (pc->level >= level))
@@ -2209,7 +2209,7 @@ static void align_asm_colon(void)
             did_nl = false;
             cas.Add(pc);
          }
-         pc = chunk_get_next_nc(pc, CNAV_PREPROC);
+         pc = chunk_get_next_nc(pc, scope_e::PREPROC);
       }
       cas.End();
    }

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -1413,18 +1413,18 @@ chunk_t *align_nl_cont(chunk_t *start)
 }
 
 
-enum CmtAlignType
+enum class comment_align_e : unsigned int
 {
-   CAT_REGULAR,
-   CAT_BRACE,
-   CAT_ENDIF,
+   REGULAR,
+   BRACE,
+   ENDIF,
 };
 
 
-static CmtAlignType get_comment_align_type(chunk_t *cmt)
+static comment_align_e get_comment_align_type(chunk_t *cmt)
 {
-   chunk_t      *prev;
-   CmtAlignType cmt_type = CAT_REGULAR;
+   chunk_t         *prev;
+   comment_align_e cmt_type = comment_align_e::REGULAR;
 
    if (!cpd.settings[UO_align_right_cmt_mix].b &&
        ((prev = chunk_get_prev(cmt)) != NULL))
@@ -1437,7 +1437,7 @@ static CmtAlignType get_comment_align_type(chunk_t *cmt)
          /* REVISIT: someone may want this configurable */
          if ((cmt->column - (prev->column + prev->len())) < 3)
          {
-            cmt_type = (prev->type == CT_PP_ENDIF) ? CAT_ENDIF : CAT_BRACE;
+            cmt_type = (prev->type == CT_PP_ENDIF) ? comment_align_e::ENDIF : comment_align_e::BRACE;
          }
       }
    }
@@ -1448,15 +1448,15 @@ static CmtAlignType get_comment_align_type(chunk_t *cmt)
 chunk_t *align_trailing_comments(chunk_t *start)
 {
    LOG_FUNC_ENTRY();
-   size_t       min_col  = 0;
-   size_t       min_orig = 0;
-   chunk_t      *pc      = start;
-   size_t       nl_count = 0;
-   ChunkStack   cs;
-   size_t       col;
-   size_t       intended_col = cpd.settings[UO_align_right_cmt_at_col].u;
-   CmtAlignType cmt_type_cur;
-   CmtAlignType cmt_type_start = get_comment_align_type(pc);
+   size_t          min_col  = 0;
+   size_t          min_orig = 0;
+   chunk_t         *pc      = start;
+   size_t          nl_count = 0;
+   ChunkStack      cs;
+   size_t          col;
+   size_t          intended_col = cpd.settings[UO_align_right_cmt_at_col].u;
+   comment_align_e cmt_type_cur;
+   comment_align_e cmt_type_start = get_comment_align_type(pc);
 
    LOG_FMT(LALADD, "%s: start on line=%zu\n",
            __func__, pc->orig_line);

--- a/src/align_stack.cpp
+++ b/src/align_stack.cpp
@@ -186,7 +186,7 @@ void AlignStack::Add(chunk_t *start, size_t seqnum)
             prev = chunk_get_prev(ali);
             // this is correct, even Coverity says:
             // CID 76021 (#1 of 1): Unused value (UNUSED_VALUE)returned_pointer: Assigning value from
-            // chunk_get_prev(ali, CNAV_ALL) to prev here, but that stored value is overwritten before it can be used.
+            // chunk_get_prev(ali, nav_e::ALL) to prev here, but that stored value is overwritten before it can be used.
          }
       }
       if (m_amp_style != SS_IGNORE)

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -100,7 +100,7 @@ static size_t preproc_start(parse_frame_t *frm, chunk_t *pc)
          /*TODO: not sure about the next 3 lines */
          frm->pse_tos                 = 1;
          frm->pse[frm->pse_tos].type  = CT_PP_DEFINE;
-         frm->pse[frm->pse_tos].stage = BS_NONE;
+         frm->pse[frm->pse_tos].stage = brace_stage_e::NONE;
       }
       else
       {
@@ -123,7 +123,7 @@ static void print_stack(log_sev_t logsev, const char *str,
 
       for (size_t idx = 1; idx <= frm->pse_tos; idx++)
       {
-         if (frm->pse[idx].stage != BS_NONE)
+         if (frm->pse[idx].stage != brace_stage_e::NONE)
          {
             LOG_FMT(logsev, " [%s - %d]", get_token_name(frm->pse[idx].type),
                     frm->pse[idx].stage);
@@ -246,7 +246,7 @@ static bool maybe_while_of_do(chunk_t *pc)
 
 
 static void push_fmr_pse(parse_frame_t *frm, chunk_t *pc,
-                         brstage_e stage, const char *logtext)
+                         brace_stage_e stage, const char *logtext)
 {
    LOG_FUNC_ENTRY();
    if (frm->pse_tos < ((int)ARRAY_SIZE(frm->pse) - 1))
@@ -370,7 +370,7 @@ static void parse_cleanup(parse_frame_t *frm, chunk_t *pc)
    }
 
    /* Check the progression of complex statements */
-   if (frm->pse[frm->pse_tos].stage != BS_NONE)
+   if (frm->pse[frm->pse_tos].stage != brace_stage_e::NONE)
    {
       if (check_complex_statements(frm, pc))
       {
@@ -456,7 +456,7 @@ static void parse_cleanup(parse_frame_t *frm, chunk_t *pc)
          print_stack(LBCSPOP, "-Close  ", frm, pc);
 
          /* See if we are in a complex statement */
-         if (frm->pse[frm->pse_tos].stage != BS_NONE)
+         if (frm->pse[frm->pse_tos].stage != brace_stage_e::NONE)
          {
             handle_complex_close(frm, pc);
          }
@@ -467,7 +467,7 @@ static void parse_cleanup(parse_frame_t *frm, chunk_t *pc)
     * sparen, so we need to check cpd.consumed to see if the close sparen was
     * aleady handled.
     */
-   if (frm->pse[frm->pse_tos].stage == BS_WOD_SEMI)
+   if (frm->pse[frm->pse_tos].stage == brace_stage_e::WOD_SEMI)
    {
       chunk_t *tmp = pc;
 
@@ -520,7 +520,7 @@ static void parse_cleanup(parse_frame_t *frm, chunk_t *pc)
              (pc->type == CT_SPAREN_OPEN))
          {
             /* Set the parent for parens and change paren type */
-            if (frm->pse[frm->pse_tos].stage != BS_NONE)
+            if (frm->pse[frm->pse_tos].stage != brace_stage_e::NONE)
             {
                set_chunk_type(pc, CT_SPAREN_OPEN);
                parent = frm->pse[frm->pse_tos].type;
@@ -547,7 +547,7 @@ static void parse_cleanup(parse_frame_t *frm, chunk_t *pc)
          else  /* must be CT_BRACE_OPEN */
          {
             /* Set the parent for open braces */
-            if (frm->pse[frm->pse_tos].stage != BS_NONE)
+            if (frm->pse[frm->pse_tos].stage != brace_stage_e::NONE)
             {
                parent = frm->pse[frm->pse_tos].type;
             }
@@ -592,7 +592,7 @@ static void parse_cleanup(parse_frame_t *frm, chunk_t *pc)
       {
          frm->brace_level++;
       }
-      push_fmr_pse(frm, pc, BS_NONE, "+Open   ");
+      push_fmr_pse(frm, pc, brace_stage_e::NONE, "+Open   ");
       frm->pse[frm->pse_tos].parent = parent;
       set_chunk_parent(pc, parent);
    }
@@ -604,27 +604,27 @@ static void parse_cleanup(parse_frame_t *frm, chunk_t *pc)
    if (patcls == PATCLS_BRACED)
    {
       push_fmr_pse(frm, pc,
-                   (pc->type == CT_DO) ? BS_BRACE_DO : BS_BRACE2,
+                   (pc->type == CT_DO) ? brace_stage_e::BRACE_DO : brace_stage_e::BRACE2,
                    "+ComplexBraced");
    }
    else if (patcls == PATCLS_PBRACED)
    {
-      brstage_e bs = BS_PAREN1;
+      brace_stage_e bs = brace_stage_e::PAREN1;
 
       if ((pc->type == CT_WHILE) && maybe_while_of_do(pc))
       {
          set_chunk_type(pc, CT_WHILE_OF_DO);
-         bs = BS_WOD_PAREN;
+         bs = brace_stage_e::WOD_PAREN;
       }
       push_fmr_pse(frm, pc, bs, "+ComplexParenBraced");
    }
    else if (patcls == PATCLS_OPBRACED)
    {
-      push_fmr_pse(frm, pc, BS_OP_PAREN1, "+ComplexOpParenBraced");
+      push_fmr_pse(frm, pc, brace_stage_e::OP_PAREN1, "+ComplexOpParenBraced");
    }
    else if (patcls == PATCLS_ELSE)
    {
-      push_fmr_pse(frm, pc, BS_ELSEIF, "+ComplexElse");
+      push_fmr_pse(frm, pc, brace_stage_e::ELSEIF, "+ComplexElse");
    }
 
    /* Mark simple statement/expression starts
@@ -704,19 +704,19 @@ static bool check_complex_statements(parse_frame_t *frm, chunk_t *pc)
    c_token_t parent;
 
    /* Turn an optional paren into either a real paren or a brace */
-   if (frm->pse[frm->pse_tos].stage == BS_OP_PAREN1)
+   if (frm->pse[frm->pse_tos].stage == brace_stage_e::OP_PAREN1)
    {
-      frm->pse[frm->pse_tos].stage = (pc->type != CT_PAREN_OPEN) ? BS_BRACE2 : BS_PAREN1;
+      frm->pse[frm->pse_tos].stage = (pc->type != CT_PAREN_OPEN) ? brace_stage_e::BRACE2 : brace_stage_e::PAREN1;
    }
 
    /* Check for CT_ELSE after CT_IF */
-   while (frm->pse[frm->pse_tos].stage == BS_ELSE)
+   while (frm->pse[frm->pse_tos].stage == brace_stage_e::ELSE)
    {
       if (pc->type == CT_ELSE)
       {
          /* Replace CT_IF with CT_ELSE on the stack & we are done */
          frm->pse[frm->pse_tos].type  = CT_ELSE;
-         frm->pse[frm->pse_tos].stage = BS_ELSEIF;
+         frm->pse[frm->pse_tos].stage = brace_stage_e::ELSEIF;
          print_stack(LBCSSWAP, "=Swap   ", frm, pc);
          return(true);
       }
@@ -731,7 +731,7 @@ static bool check_complex_statements(parse_frame_t *frm, chunk_t *pc)
    }
 
    /* Check for CT_IF after CT_ELSE */
-   if (frm->pse[frm->pse_tos].stage == BS_ELSEIF)
+   if (frm->pse[frm->pse_tos].stage == brace_stage_e::ELSEIF)
    {
       if (pc->type == CT_IF)
       {
@@ -741,23 +741,23 @@ static bool check_complex_statements(parse_frame_t *frm, chunk_t *pc)
             /* Replace CT_ELSE with CT_IF */
             set_chunk_type(pc, CT_ELSEIF);
             frm->pse[frm->pse_tos].type  = CT_ELSEIF;
-            frm->pse[frm->pse_tos].stage = BS_PAREN1;
+            frm->pse[frm->pse_tos].stage = brace_stage_e::PAREN1;
             return(true);
          }
       }
 
       /* Jump to the 'expecting brace' stage */
-      frm->pse[frm->pse_tos].stage = BS_BRACE2;
+      frm->pse[frm->pse_tos].stage = brace_stage_e::BRACE2;
    }
 
    /* Check for CT_CATCH or CT_FINALLY after CT_TRY or CT_CATCH */
-   while (frm->pse[frm->pse_tos].stage == BS_CATCH)
+   while (frm->pse[frm->pse_tos].stage == brace_stage_e::CATCH)
    {
       if ((pc->type == CT_CATCH) || (pc->type == CT_FINALLY))
       {
          /* Replace CT_TRY with CT_CATCH on the stack & we are done */
          frm->pse[frm->pse_tos].type  = pc->type;
-         frm->pse[frm->pse_tos].stage = (pc->type == CT_CATCH) ? BS_CATCH_WHEN : BS_BRACE2;
+         frm->pse[frm->pse_tos].stage = (pc->type == CT_CATCH) ? brace_stage_e::CATCH_WHEN : brace_stage_e::BRACE2;
          print_stack(LBCSSWAP, "=Swap   ", frm, pc);
          return(true);
       }
@@ -772,37 +772,37 @@ static bool check_complex_statements(parse_frame_t *frm, chunk_t *pc)
    }
 
    /* Check for optional paren and optional CT_WHEN after CT_CATCH */
-   if (frm->pse[frm->pse_tos].stage == BS_CATCH_WHEN)
+   if (frm->pse[frm->pse_tos].stage == brace_stage_e::CATCH_WHEN)
    {
       if (pc->type == CT_PAREN_OPEN) // this is for the paren after "catch"
       {
          /* Replace CT_PAREN_OPEN with CT_SPAREN_OPEN */
          set_chunk_type(pc, CT_SPAREN_OPEN);
          frm->pse[frm->pse_tos].type  = pc->type;
-         frm->pse[frm->pse_tos].stage = BS_PAREN1;
+         frm->pse[frm->pse_tos].stage = brace_stage_e::PAREN1;
          return(false);
       }
       else if (pc->type == CT_WHEN)
       {
          frm->pse[frm->pse_tos].type  = pc->type;
-         frm->pse[frm->pse_tos].stage = BS_OP_PAREN1;
+         frm->pse[frm->pse_tos].stage = brace_stage_e::OP_PAREN1;
          return(true);
       }
       else if (pc->type == CT_BRACE_OPEN)
       {
-         frm->pse[frm->pse_tos].stage = BS_BRACE2;
+         frm->pse[frm->pse_tos].stage = brace_stage_e::BRACE2;
          return(false);
       }
    }
 
    /* Check for CT_WHILE after the CT_DO */
-   if (frm->pse[frm->pse_tos].stage == BS_WHILE)
+   if (frm->pse[frm->pse_tos].stage == brace_stage_e::WHILE)
    {
       if (pc->type == CT_WHILE)
       {
          set_chunk_type(pc, CT_WHILE_OF_DO);
          frm->pse[frm->pse_tos].type  = CT_WHILE_OF_DO; //CT_WHILE;
-         frm->pse[frm->pse_tos].stage = BS_WOD_PAREN;
+         frm->pse[frm->pse_tos].stage = brace_stage_e::WOD_PAREN;
          return(true);
       }
 
@@ -815,8 +815,8 @@ static bool check_complex_statements(parse_frame_t *frm, chunk_t *pc)
 
    /* Insert a CT_VBRACE_OPEN, if needed */
    if ((pc->type != CT_BRACE_OPEN) &&
-       ((frm->pse[frm->pse_tos].stage == BS_BRACE2) ||
-        (frm->pse[frm->pse_tos].stage == BS_BRACE_DO)))
+       ((frm->pse[frm->pse_tos].stage == brace_stage_e::BRACE2) ||
+        (frm->pse[frm->pse_tos].stage == brace_stage_e::BRACE_DO)))
    {
       if ((cpd.lang_flags & LANG_CS) &&
           (pc->type == CT_USING_STMT) &&
@@ -834,7 +834,7 @@ static bool check_complex_statements(parse_frame_t *frm, chunk_t *pc)
          frm->level++;
          frm->brace_level++;
 
-         push_fmr_pse(frm, vbrace, BS_NONE, "+VBrace ");
+         push_fmr_pse(frm, vbrace, brace_stage_e::NONE, "+VBrace ");
          frm->pse[frm->pse_tos].parent = parent;
 
          /* update the level of pc */
@@ -853,8 +853,8 @@ static bool check_complex_statements(parse_frame_t *frm, chunk_t *pc)
 
    /* Verify open paren in complex statement */
    if ((pc->type != CT_PAREN_OPEN) &&
-       ((frm->pse[frm->pse_tos].stage == BS_PAREN1) ||
-        (frm->pse[frm->pse_tos].stage == BS_WOD_PAREN)))
+       ((frm->pse[frm->pse_tos].stage == brace_stage_e::PAREN1) ||
+        (frm->pse[frm->pse_tos].stage == brace_stage_e::WOD_PAREN)))
    {
       LOG_FMT(LWARN, "%s:%zu Error: Expected '(', got '%s' for '%s'\n",
               cpd.filename, pc->orig_line, pc->text(),
@@ -875,27 +875,27 @@ static bool handle_complex_close(parse_frame_t *frm, chunk_t *pc)
    LOG_FUNC_ENTRY();
    chunk_t *next;
 
-   if (frm->pse[frm->pse_tos].stage == BS_PAREN1)
+   if (frm->pse[frm->pse_tos].stage == brace_stage_e::PAREN1)
    {
       if ((pc->next != NULL) && (pc->next->type == CT_WHEN))
       {
          frm->pse[frm->pse_tos].type  = pc->type;
-         frm->pse[frm->pse_tos].stage = BS_CATCH_WHEN;
+         frm->pse[frm->pse_tos].stage = brace_stage_e::CATCH_WHEN;
          return(true);
       }
       else
       {
          /* PAREN1 always => BRACE2 */
-         frm->pse[frm->pse_tos].stage = BS_BRACE2;
+         frm->pse[frm->pse_tos].stage = brace_stage_e::BRACE2;
       }
    }
-   else if (frm->pse[frm->pse_tos].stage == BS_BRACE2)
+   else if (frm->pse[frm->pse_tos].stage == brace_stage_e::BRACE2)
    {
       /* BRACE2: IF => ELSE, anyting else => close */
       if ((frm->pse[frm->pse_tos].type == CT_IF) ||
           (frm->pse[frm->pse_tos].type == CT_ELSEIF))
       {
-         frm->pse[frm->pse_tos].stage = BS_ELSE;
+         frm->pse[frm->pse_tos].stage = brace_stage_e::ELSE;
 
          /* If the next chunk isn't CT_ELSE, close the statement */
          next = chunk_get_next_ncnl(pc);
@@ -912,7 +912,7 @@ static bool handle_complex_close(parse_frame_t *frm, chunk_t *pc)
       else if ((frm->pse[frm->pse_tos].type == CT_TRY) ||
                (frm->pse[frm->pse_tos].type == CT_CATCH))
       {
-         frm->pse[frm->pse_tos].stage = BS_CATCH;
+         frm->pse[frm->pse_tos].stage = brace_stage_e::CATCH;
 
          /* If the next chunk isn't CT_CATCH or CT_FINALLY, close the statement */
          next = chunk_get_next_ncnl(pc);
@@ -930,7 +930,7 @@ static bool handle_complex_close(parse_frame_t *frm, chunk_t *pc)
       }
       else
       {
-         LOG_FMT(LNOTE, "%s: close_statement on %s BS_BRACE2\n", __func__,
+         LOG_FMT(LNOTE, "%s: close_statement on %s brace_stage_e::BRACE2\n", __func__,
                  get_token_name(frm->pse[frm->pse_tos].type));
          frm->pse_tos--;
          print_stack(LBCSPOP, "-HCC B2 ", frm, pc);
@@ -940,20 +940,20 @@ static bool handle_complex_close(parse_frame_t *frm, chunk_t *pc)
          }
       }
    }
-   else if (frm->pse[frm->pse_tos].stage == BS_BRACE_DO)
+   else if (frm->pse[frm->pse_tos].stage == brace_stage_e::BRACE_DO)
    {
-      frm->pse[frm->pse_tos].stage = BS_WHILE;
+      frm->pse[frm->pse_tos].stage = brace_stage_e::WHILE;
    }
-   else if (frm->pse[frm->pse_tos].stage == BS_WOD_PAREN)
+   else if (frm->pse[frm->pse_tos].stage == brace_stage_e::WOD_PAREN)
    {
-      LOG_FMT(LNOTE, "%s: close_statement on %s BS_WOD_PAREN\n", __func__,
+      LOG_FMT(LNOTE, "%s: close_statement on %s brace_stage_e::WOD_PAREN\n", __func__,
               get_token_name(frm->pse[frm->pse_tos].type));
-      frm->pse[frm->pse_tos].stage = BS_WOD_SEMI;
+      frm->pse[frm->pse_tos].stage = brace_stage_e::WOD_SEMI;
       print_stack(LBCSPOP, "-HCC WoDP ", frm, pc);
    }
-   else if (frm->pse[frm->pse_tos].stage == BS_WOD_SEMI)
+   else if (frm->pse[frm->pse_tos].stage == brace_stage_e::WOD_SEMI)
    {
-      LOG_FMT(LNOTE, "%s: close_statement on %s BS_WOD_SEMI\n", __func__,
+      LOG_FMT(LNOTE, "%s: close_statement on %s brace_stage_e::WOD_SEMI\n", __func__,
               get_token_name(frm->pse[frm->pse_tos].type));
       frm->pse_tos--;
       print_stack(LBCSPOP, "-HCC WoDS ", frm, pc);
@@ -1089,7 +1089,7 @@ bool close_statement(parse_frame_t *frm, chunk_t *pc)
    }
 
    /* See if we are done with a complex statement */
-   if (frm->pse[frm->pse_tos].stage != BS_NONE)
+   if (frm->pse[frm->pse_tos].stage != brace_stage_e::NONE)
    {
       if (handle_complex_close(frm, vbc))
       {

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -597,17 +597,17 @@ static void parse_cleanup(parse_frame_t *frm, chunk_t *pc)
       set_chunk_parent(pc, parent);
    }
 
-   pattern_class patcls = get_token_pattern_class(pc->type);
+   pattern_class_e patcls = get_token_pattern_class(pc->type);
 
    /** Create a stack entry for complex statements: */
    /** if, elseif, switch, for, while, synchronized, using, lock, with, version, CT_D_SCOPE_IF */
-   if (patcls == PATCLS_BRACED)
+   if (patcls == pattern_class_e::BRACED)
    {
       push_fmr_pse(frm, pc,
                    (pc->type == CT_DO) ? brace_stage_e::BRACE_DO : brace_stage_e::BRACE2,
                    "+ComplexBraced");
    }
-   else if (patcls == PATCLS_PBRACED)
+   else if (patcls == pattern_class_e::PBRACED)
    {
       brace_stage_e bs = brace_stage_e::PAREN1;
 
@@ -618,11 +618,11 @@ static void parse_cleanup(parse_frame_t *frm, chunk_t *pc)
       }
       push_fmr_pse(frm, pc, bs, "+ComplexParenBraced");
    }
-   else if (patcls == PATCLS_OPBRACED)
+   else if (patcls == pattern_class_e::OPBRACED)
    {
       push_fmr_pse(frm, pc, brace_stage_e::OP_PAREN1, "+ComplexOpParenBraced");
    }
-   else if (patcls == PATCLS_ELSE)
+   else if (patcls == pattern_class_e::ELSE)
    {
       push_fmr_pse(frm, pc, brace_stage_e::ELSEIF, "+ComplexElse");
    }

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -150,7 +150,7 @@ void brace_cleanup(void)
    chunk_t       *pc;
    parse_frame_t frm;
 
-   cpd.unc_stage = US_BRACE_CLEANUP;
+   cpd.unc_stage = unc_stage_e::BRACE_CLEANUP;
 
    memset(&frm, 0, sizeof(frm));
 

--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -20,10 +20,10 @@ typedef ListManager<chunk_t> ChunkList_t;
 
 /** use this enum to define in what direction or location an
  * operation shall be performed. */
-enum loc_t
+enum class direction_e : unsigned int
 {
-   BEFORE, /**< indicates a position or direction upwards (=pref) */
-   AFTER   /**< indicates a position or direction downwards (=next) */
+   FORWARD,
+   BACKWARD
 };
 
 
@@ -70,7 +70,7 @@ typedef chunk_t * (*search_t)(chunk_t *cur, scope_e scope);
  * @retval NULL      no requested chunk was found or invalid parameters provided
  * @retval chunk_t   pointer to the found chunk
  */
-static chunk_t *chunk_search(chunk_t *cur, const check_t check_fct, const scope_e scope = scope_e::ALL, const loc_t dir = AFTER, const bool cond = true);
+static chunk_t *chunk_search(chunk_t *cur, const check_t check_fct, const scope_e scope = scope_e::ALL, const direction_e dir = direction_e::FORWARD, const bool cond = true);
 
 
 static void chunk_log(chunk_t *pc, const char *text);
@@ -94,7 +94,7 @@ static void chunk_log(chunk_t *pc, const char *text);
  * @retval NULL      no chunk found or invalid parameters provided
  * @retval chunk_t   pointer to the found chunk
  */
-static chunk_t *chunk_search_type(chunk_t *cur, const c_token_t type, const scope_e scope = scope_e::ALL, const loc_t dir = AFTER);
+static chunk_t *chunk_search_type(chunk_t *cur, const c_token_t type, const scope_e scope = scope_e::ALL, const direction_e dir = direction_e::FORWARD);
 
 
 /**
@@ -108,7 +108,7 @@ static chunk_t *chunk_search_type(chunk_t *cur, const c_token_t type, const scop
  * @retval NULL      no chunk found or invalid parameters provided
  * @retval chunk_t   pointer to the found chunk
  */
-static chunk_t *chunk_search_typelevel(chunk_t *cur, c_token_t type, scope_e scope = scope_e::ALL, loc_t dir = AFTER, int level = -1);
+static chunk_t *chunk_search_typelevel(chunk_t *cur, c_token_t type, scope_e scope = scope_e::ALL, direction_e dir = direction_e::FORWARD, int level = -1);
 
 
 /**
@@ -123,7 +123,7 @@ static chunk_t *chunk_search_typelevel(chunk_t *cur, c_token_t type, scope_e sco
  * @retval NULL      no chunk found or invalid parameters provided
  * @retval chunk_t   pointer to the found chunk
  */
-static chunk_t *chunk_get_ncnlnp(chunk_t *cur, const scope_e scope = scope_e::ALL, const loc_t dir = AFTER);
+static chunk_t *chunk_get_ncnlnp(chunk_t *cur, const scope_e scope = scope_e::ALL, const direction_e dir = direction_e::FORWARD);
 
 
 /**
@@ -142,7 +142,7 @@ static chunk_t *chunk_get_ncnlnp(chunk_t *cur, const scope_e scope = scope_e::AL
  * @retval NULL      no chunk found or invalid parameters provided
  * @retval chunk_t   pointer to the found chunk
  */
-static chunk_t *chunk_search_str(chunk_t *cur, const char *str, size_t len, scope_e scope, loc_t dir, int level);
+static chunk_t *chunk_search_str(chunk_t *cur, const char *str, size_t len, scope_e scope, direction_e dir, int level);
 
 
 /**
@@ -155,7 +155,7 @@ static chunk_t *chunk_search_str(chunk_t *cur, const char *str, size_t len, scop
  * @param  pos       insert before or after
  * @return chunk_t   pointer to the copied chunk
  */
-static chunk_t *chunk_add(const chunk_t *pc_in, chunk_t *ref, const loc_t pos = AFTER);
+static chunk_t *chunk_add(const chunk_t *pc_in, chunk_t *ref, const direction_e pos = direction_e::FORWARD);
 
 
 /**
@@ -167,7 +167,7 @@ static chunk_t *chunk_add(const chunk_t *pc_in, chunk_t *ref, const loc_t pos = 
  * @param  dir       search direction
  * @return pointer to chunk search function
  */
-static search_t select_search_fct(const loc_t dir = AFTER);
+static search_t select_search_fct(const direction_e dir = direction_e::FORWARD);
 
 
 void set_chunk_real(chunk_t *pc, c_token_t token, log_sev_t what, const char *str);
@@ -188,26 +188,26 @@ chunk_t *chunk_get_tail(void)
 }
 
 
-static search_t select_search_fct(const loc_t dir)
+static search_t select_search_fct(const direction_e dir)
 {
-   return((dir == AFTER) ? chunk_get_next : chunk_get_prev);
+   return((dir == direction_e::FORWARD) ? chunk_get_next : chunk_get_prev);
 }
 
 
 chunk_t *chunk_search_prev_cat(chunk_t *pc, const c_token_t cat)
 {
-   return(chunk_search_type(pc, cat, scope_e::ALL, BEFORE));
+   return(chunk_search_type(pc, cat, scope_e::ALL, direction_e::BACKWARD));
 }
 
 
 chunk_t *chunk_search_next_cat(chunk_t *pc, const c_token_t cat)
 {
-   return(chunk_search_type(pc, cat, scope_e::ALL, AFTER));
+   return(chunk_search_type(pc, cat, scope_e::ALL, direction_e::FORWARD));
 }
 
 
 static chunk_t *chunk_search_type(chunk_t *cur, const c_token_t type,
-                                  const scope_e scope, const loc_t dir)
+                                  const scope_e scope, const direction_e dir)
 {
    /* Depending on the parameter dir the search function searches
     * in forward or backward direction */
@@ -232,7 +232,7 @@ inline bool is_expected_type_and_level(chunk_t *pc, c_token_t type, int level)
 }
 
 
-static chunk_t *chunk_search_typelevel(chunk_t *cur, c_token_t type, scope_e scope, loc_t dir, int level)
+static chunk_t *chunk_search_typelevel(chunk_t *cur, c_token_t type, scope_e scope, direction_e dir, int level)
 {
    /* Depending on the parameter dir the search function searches
     * in forward or backward direction */
@@ -264,7 +264,7 @@ inline bool is_expected_string_and_level(chunk_t *pc, const char *str, int level
 }
 
 
-static chunk_t *chunk_search_str(chunk_t *cur, const char *str, size_t len, scope_e scope, loc_t dir, int level)
+static chunk_t *chunk_search_str(chunk_t *cur, const char *str, size_t len, scope_e scope, direction_e dir, int level)
 {
    /* Depending on the parameter dir the search function searches
     * in forward or backward direction */
@@ -281,7 +281,7 @@ static chunk_t *chunk_search_str(chunk_t *cur, const char *str, size_t len, scop
 
 
 static chunk_t *chunk_search(chunk_t *cur, const check_t check_fct, const scope_e scope,
-                             const loc_t dir, const bool cond)
+                             const direction_e dir, const bool cond)
 {
    /* Depending on the parameter dir the search function searches
     * in forward or backward direction */
@@ -417,13 +417,13 @@ static void chunk_log(chunk_t *pc, const char *text)
 
 chunk_t *chunk_add_after(const chunk_t *pc_in, chunk_t *ref)
 {
-   return(chunk_add(pc_in, ref, AFTER));
+   return(chunk_add(pc_in, ref, direction_e::FORWARD));
 }
 
 
 chunk_t *chunk_add_before(const chunk_t *pc_in, chunk_t *ref)
 {
-   return(chunk_add(pc_in, ref, BEFORE));
+   return(chunk_add(pc_in, ref, direction_e::BACKWARD));
 }
 
 
@@ -450,103 +450,103 @@ void chunk_move_after(chunk_t *pc_in, chunk_t *ref)
 
 chunk_t *chunk_get_next_nl(chunk_t *cur, scope_e scope)
 {
-   return(chunk_search(cur, chunk_is_newline, scope, AFTER, true));
+   return(chunk_search(cur, chunk_is_newline, scope, direction_e::FORWARD, true));
 }
 
 
 chunk_t *chunk_get_prev_nl(chunk_t *cur, scope_e scope)
 {
-   return(chunk_search(cur, chunk_is_newline, scope, BEFORE, true));
+   return(chunk_search(cur, chunk_is_newline, scope, direction_e::BACKWARD, true));
 }
 
 
 chunk_t *chunk_get_next_nnl(chunk_t *cur, scope_e scope)
 {
-   return(chunk_search(cur, chunk_is_newline, scope, AFTER, false));
+   return(chunk_search(cur, chunk_is_newline, scope, direction_e::FORWARD, false));
 }
 
 
 chunk_t *chunk_get_prev_nnl(chunk_t *cur, scope_e scope)
 {
-   return(chunk_search(cur, chunk_is_newline, scope, BEFORE, false));
+   return(chunk_search(cur, chunk_is_newline, scope, direction_e::BACKWARD, false));
 }
 
 
 chunk_t *chunk_get_next_ncnl(chunk_t *cur, scope_e scope)
 {
-   return(chunk_search(cur, chunk_is_comment_or_newline, scope, AFTER, false));
+   return(chunk_search(cur, chunk_is_comment_or_newline, scope, direction_e::FORWARD, false));
 }
 
 
 chunk_t *chunk_get_next_ncnlnp(chunk_t *cur, scope_e scope)
 {
-   return(chunk_get_ncnlnp(cur, scope, AFTER));
+   return(chunk_get_ncnlnp(cur, scope, direction_e::FORWARD));
 }
 
 
 chunk_t *chunk_get_prev_ncnlnp(chunk_t *cur, scope_e scope)
 {
-   return(chunk_get_ncnlnp(cur, scope, BEFORE));
+   return(chunk_get_ncnlnp(cur, scope, direction_e::BACKWARD));
 }
 
 
 chunk_t *chunk_get_next_nblank(chunk_t *cur, scope_e scope)
 {
-   return(chunk_search(cur, chunk_is_comment_newline_or_blank, scope, AFTER, false));
+   return(chunk_search(cur, chunk_is_comment_newline_or_blank, scope, direction_e::FORWARD, false));
 }
 
 
 chunk_t *chunk_get_prev_nblank(chunk_t *cur, scope_e scope)
 {
-   return(chunk_search(cur, chunk_is_comment_newline_or_blank, scope, BEFORE, false));
+   return(chunk_search(cur, chunk_is_comment_newline_or_blank, scope, direction_e::BACKWARD, false));
 }
 
 
 chunk_t *chunk_get_next_nc(chunk_t *cur, scope_e scope)
 {
-   return(chunk_search(cur, chunk_is_comment, scope, AFTER, false));
+   return(chunk_search(cur, chunk_is_comment, scope, direction_e::FORWARD, false));
 }
 
 
 chunk_t *chunk_get_next_nisq(chunk_t *cur, scope_e scope)
 {
-   return(chunk_search(cur, chunk_is_balanced_square, scope, AFTER, false));
+   return(chunk_search(cur, chunk_is_balanced_square, scope, direction_e::FORWARD, false));
 }
 
 
 chunk_t *chunk_get_prev_ncnl(chunk_t *cur, scope_e scope)
 {
-   return(chunk_search(cur, chunk_is_comment_or_newline, scope, BEFORE, false));
+   return(chunk_search(cur, chunk_is_comment_or_newline, scope, direction_e::BACKWARD, false));
 }
 
 
 chunk_t *chunk_get_prev_nc(chunk_t *cur, scope_e scope)
 {
-   return(chunk_search(cur, chunk_is_comment, scope, BEFORE, false));
+   return(chunk_search(cur, chunk_is_comment, scope, direction_e::BACKWARD, false));
 }
 
 
 chunk_t *chunk_get_next_type(chunk_t *cur, c_token_t type, int level, scope_e scope)
 {
-   return(chunk_search_typelevel(cur, type, scope, AFTER, level));
+   return(chunk_search_typelevel(cur, type, scope, direction_e::FORWARD, level));
 }
 
 
 chunk_t *chunk_get_next_str(chunk_t *cur, const char *str, size_t len, int level, scope_e scope)
 {
-   return(chunk_search_str(cur, str, len, scope, AFTER, level));
+   return(chunk_search_str(cur, str, len, scope, direction_e::FORWARD, level));
 }
 
 
 chunk_t *chunk_get_prev_type(chunk_t *cur, c_token_t type, int level, scope_e scope)
 {
-   return(chunk_search_typelevel(cur, type, scope, BEFORE, level));
+   return(chunk_search_typelevel(cur, type, scope, direction_e::BACKWARD, level));
 }
 
 
 chunk_t *chunk_get_prev_str(chunk_t *cur, const char *str, size_t len, int level, scope_e scope)
 {
-   return(chunk_search_str(cur, str, len, scope, BEFORE, level));
+   return(chunk_search_str(cur, str, len, scope, direction_e::BACKWARD, level));
 }
 
 
@@ -656,13 +656,13 @@ void chunk_swap_lines(chunk_t *pc1, chunk_t *pc2)
 
 chunk_t *chunk_get_next_nvb(chunk_t *cur, const scope_e scope)
 {
-   return(chunk_search(cur, chunk_is_vbrace, scope, AFTER, false));
+   return(chunk_search(cur, chunk_is_vbrace, scope, direction_e::FORWARD, false));
 }
 
 
 chunk_t *chunk_get_prev_nvb(chunk_t *cur, const scope_e scope)
 {
-   return(chunk_search(cur, chunk_is_vbrace, scope, BEFORE, false));
+   return(chunk_search(cur, chunk_is_vbrace, scope, direction_e::BACKWARD, false));
 }
 
 
@@ -733,7 +733,7 @@ void set_chunk_real(chunk_t *pc, c_token_t token, log_sev_t what, const char *st
 }
 
 
-static chunk_t *chunk_get_ncnlnp(chunk_t *cur, const scope_e scope, const loc_t dir)
+static chunk_t *chunk_get_ncnlnp(chunk_t *cur, const scope_e scope, const direction_e dir)
 {
    chunk_t *pc = cur;
 
@@ -744,7 +744,7 @@ static chunk_t *chunk_get_ncnlnp(chunk_t *cur, const scope_e scope, const loc_t 
 }
 
 
-static chunk_t *chunk_add(const chunk_t *pc_in, chunk_t *ref, const loc_t pos)
+static chunk_t *chunk_add(const chunk_t *pc_in, chunk_t *ref, const direction_e pos)
 {
    chunk_t *pc = chunk_dup(pc_in);
 
@@ -752,11 +752,11 @@ static chunk_t *chunk_add(const chunk_t *pc_in, chunk_t *ref, const loc_t pos)
    {
       if (ref != NULL) /* ref is a valid chunk */
       {
-         (pos == AFTER) ? g_cl.AddAfter(pc, ref) : g_cl.AddBefore(pc, ref);
+         (pos == direction_e::FORWARD) ? g_cl.AddAfter(pc, ref) : g_cl.AddBefore(pc, ref);
       }
       else /* ref == NULL */
       {
-         (pos == AFTER) ? g_cl.AddHead(pc) : g_cl.AddTail(pc);
+         (pos == direction_e::FORWARD) ? g_cl.AddHead(pc) : g_cl.AddTail(pc);
       }
       chunk_log(pc, "chunk_add");
    }

--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -388,7 +388,7 @@ static void chunk_log_msg(chunk_t *chunk, const log_sev_t log, const char *str)
 
 static void chunk_log(chunk_t *pc, const char *text)
 {
-   if ((pc != NULL) && (cpd.unc_stage != US_TOKENIZE) && (cpd.unc_stage != US_CLEANUP))
+   if ((pc != NULL) && (cpd.unc_stage != unc_stage_e::TOKENIZE) && (cpd.unc_stage != unc_stage_e::CLEANUP))
    {
       const log_sev_t log   = LCHUNK;
       chunk_t         *prev = chunk_get_prev(pc);

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -23,18 +23,18 @@
 
 
 /**
- * Specifies how to handle preprocessors.
- * CNAV_ALL (default)
+ * Specifies which chuncks should/should not be found.
+ * ALL (default)
  *  - return the true next/prev
  *
- * CNAV_PREPROC
+ * PREPROC
  *  - If not in a preprocessor, skip over any encountered preprocessor stuff
  *  - If in a preprocessor, fail to leave (return NULL)
  */
-enum nav_t
+enum class scope_e : unsigned int
 {
-   CNAV_ALL,      /**< search in all kind of chunks */
-   CNAV_PREPROC,  /**< search only in preprocessor chunks */
+   ALL,      /**< search in all kind of chunks */
+   PREPROC,  /**< search only in preprocessor chunks */
 };
 
 
@@ -84,11 +84,11 @@ chunk_t *chunk_get_tail(void);
 
 
 /** provide the next chunk in a chunk list */
-chunk_t *chunk_get_next(chunk_t *cur, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_next(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /** provide the previous chunk in a chunk list */
-chunk_t *chunk_get_prev(chunk_t *cur, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_prev(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -123,31 +123,31 @@ chunk_t *chunk_first_on_line(chunk_t *pc);
 /**
  * Gets the next NEWLINE chunk
  */
-chunk_t *chunk_get_next_nl(chunk_t *cur, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_next_nl(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
  * Gets the next non-comment chunk
  */
-chunk_t *chunk_get_next_nc(chunk_t *cur, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_next_nc(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
  * Gets the next non-NEWLINE chunk
  */
-chunk_t *chunk_get_next_nnl(chunk_t *cur, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_next_nnl(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
  * Gets the next non-NEWLINE and non-comment chunk
  */
-chunk_t *chunk_get_next_ncnl(chunk_t *cur, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_next_ncnl(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
  * Gets the next non-NEWLINE and non-comment chunk, non-preprocessor chunk
  */
-chunk_t *chunk_get_next_ncnlnp(chunk_t *cur, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_next_ncnlnp(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -156,52 +156,52 @@ chunk_t *chunk_get_next_ncnlnp(chunk_t *cur, nav_t nav = CNAV_ALL);
  * multi-dimensional array declarations
  *
  * @param  cur     Starting chunk
- * @param  nav     chunk section to consider
+ * @param  scope   chunk section to consider
  * @return         NULL or the next chunk not in or part of square brackets
  */
-chunk_t *chunk_get_next_nisq(chunk_t *cur, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_next_nisq(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
  * Gets the next non-blank chunk
  */
-chunk_t *chunk_get_next_nblank(chunk_t *cur, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_next_nblank(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
  * Gets the prev non-blank chunk
  */
-chunk_t *chunk_get_prev_nblank(chunk_t *cur, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_prev_nblank(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
  * Gets the prev NEWLINE chunk
  */
-chunk_t *chunk_get_prev_nl(chunk_t *cur, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_prev_nl(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
  * Gets the prev non-comment chunk
  */
-chunk_t *chunk_get_prev_nc(chunk_t *cur, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_prev_nc(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
  * Gets the prev non-NEWLINE chunk
  */
-chunk_t *chunk_get_prev_nnl(chunk_t *cur, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_prev_nnl(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
  * Gets the prev non-NEWLINE and non-comment chunk
  */
-chunk_t *chunk_get_prev_ncnl(chunk_t *cur, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_prev_ncnl(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
  * Gets the prev non-NEWLINE and non-comment chunk, non-preprocessor chunk
  */
-chunk_t *chunk_get_prev_ncnlnp(chunk_t *cur, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_prev_ncnlnp(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -212,7 +212,7 @@ chunk_t *chunk_get_prev_ncnlnp(chunk_t *cur, nav_t nav = CNAV_ALL);
  * @param level   -1 or ANY_LEVEL (any level) or the level to match
  * @return        NULL or the match
  */
-chunk_t *chunk_get_next_type(chunk_t *cur, c_token_t type, int level, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_next_type(chunk_t *cur, c_token_t type, int level, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -223,33 +223,33 @@ chunk_t *chunk_get_next_type(chunk_t *cur, c_token_t type, int level, nav_t nav 
  * @param level   -1 or ANY_LEVEL (any level) or the level to match
  * @return        NULL or the match
  */
-chunk_t *chunk_get_prev_type(chunk_t *cur, c_token_t type, int level, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_prev_type(chunk_t *cur, c_token_t type, int level, scope_e scope = scope_e::ALL);
 
 
-chunk_t *chunk_get_next_str(chunk_t *cur, const char *str, size_t len, int level, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_next_str(chunk_t *cur, const char *str, size_t len, int level, scope_e scope = scope_e::ALL);
 
 
-chunk_t *chunk_get_prev_str(chunk_t *cur, const char *str, size_t len, int level, nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_prev_str(chunk_t *cur, const char *str, size_t len, int level, scope_e scope = scope_e::ALL);
 
 
 /**
  * \brief Gets the next non-vbrace chunk
  *
  * @param  cur    chunk to start search
- * @param  nav    chunk section to consider
+ * @param  scope    chunk section to consider
  * @return        pointer to found chunk or NULL if no chunk was found
  */
-chunk_t *chunk_get_next_nvb(chunk_t *cur, const nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_next_nvb(chunk_t *cur, const scope_e scope = scope_e::ALL);
 
 
 /**
  * \brief Gets the previous non-vbrace chunk
  *
  * @param  cur    chunk to start search
- * @param  nav    chunk section to consider
+ * @param  scope    chunk section to consider
  * @return        pointer to found chunk or NULL if no chunk was found
  */
-chunk_t *chunk_get_prev_nvb(chunk_t *cur, const nav_t nav = CNAV_ALL);
+chunk_t *chunk_get_prev_nvb(chunk_t *cur, const scope_e scope = scope_e::ALL);
 
 
 /**
@@ -285,10 +285,10 @@ chunk_t *chunk_search_next_cat(chunk_t *pc, const c_token_t cat);
  * Skips to the closing match for the current paren/brace/square.
  *
  * @param  cur     The opening or closing paren/brace/square
- * @param  nav     chunk section to consider
+ * @param  scope   chunk section to consider
  * @return         NULL or the matching paren/brace/square
  */
-static_inline chunk_t *chunk_skip_to_match(chunk_t *cur, nav_t nav = CNAV_ALL)
+static_inline chunk_t *chunk_skip_to_match(chunk_t *cur, scope_e scope = scope_e::ALL)
 {
    if (cur &&
        ((cur->type == CT_PAREN_OPEN) ||
@@ -300,13 +300,13 @@ static_inline chunk_t *chunk_skip_to_match(chunk_t *cur, nav_t nav = CNAV_ALL)
         (cur->type == CT_ANGLE_OPEN) ||
         (cur->type == CT_SQUARE_OPEN)))
    {
-      return(chunk_get_next_type(cur, (c_token_t)(cur->type + 1), cur->level, nav));
+      return(chunk_get_next_type(cur, (c_token_t)(cur->type + 1), cur->level, scope));
    }
    return(cur);
 }
 
 
-static_inline chunk_t *chunk_skip_to_match_rev(chunk_t *cur, nav_t nav = CNAV_ALL)
+static_inline chunk_t *chunk_skip_to_match_rev(chunk_t *cur, scope_e scope = scope_e::ALL)
 {
    if (cur &&
        ((cur->type == CT_PAREN_CLOSE) ||
@@ -318,7 +318,7 @@ static_inline chunk_t *chunk_skip_to_match_rev(chunk_t *cur, nav_t nav = CNAV_AL
         (cur->type == CT_ANGLE_CLOSE) ||
         (cur->type == CT_SQUARE_CLOSE)))
    {
-      return(chunk_get_prev_type(cur, (c_token_t)(cur->type - 1), cur->level, nav));
+      return(chunk_get_prev_type(cur, (c_token_t)(cur->type - 1), cur->level, scope));
    }
    return(cur);
 }

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -521,7 +521,7 @@ void make_type(chunk_t *pc)
 }
 
 
-void flag_series(chunk_t *start, chunk_t *end, UINT64 set_flags, UINT64 clr_flags, nav_t nav)
+void flag_series(chunk_t *start, chunk_t *end, UINT64 set_flags, UINT64 clr_flags, scope_e nav)
 {
    LOG_FUNC_ENTRY();
    while (start && (start != end))
@@ -543,7 +543,7 @@ static chunk_t *flag_parens(chunk_t *po, UINT64 flags, c_token_t opentype,
    LOG_FUNC_ENTRY();
    chunk_t *paren_close;
 
-   paren_close = chunk_skip_to_match(po, CNAV_PREPROC);
+   paren_close = chunk_skip_to_match(po, scope_e::PREPROC);
    if (paren_close == NULL)
    {
       LOG_FMT(LERR, "flag_parens: no match for [%s] at [%zu:%zu]",
@@ -566,9 +566,9 @@ static chunk_t *flag_parens(chunk_t *po, UINT64 flags, c_token_t opentype,
           (parent_all && (parenttype != CT_NONE)))
       {
          chunk_t *pc;
-         for (pc = chunk_get_next(po, CNAV_PREPROC);
+         for (pc = chunk_get_next(po, scope_e::PREPROC);
               pc != paren_close;
-              pc = chunk_get_next(pc, CNAV_PREPROC))
+              pc = chunk_get_next(pc, scope_e::PREPROC))
          {
             chunk_flags_set(pc, flags);
             if (parent_all)
@@ -590,7 +590,7 @@ static chunk_t *flag_parens(chunk_t *po, UINT64 flags, c_token_t opentype,
          set_chunk_parent(paren_close, parenttype);
       }
    }
-   return(chunk_get_next_ncnl(paren_close, CNAV_PREPROC));
+   return(chunk_get_next_ncnl(paren_close, scope_e::PREPROC));
 } // flag_parens
 
 
@@ -608,7 +608,7 @@ chunk_t *set_paren_parent(chunk_t *start, c_token_t parent)
    LOG_FUNC_ENTRY();
    chunk_t *end;
 
-   end = chunk_skip_to_match(start, CNAV_PREPROC);
+   end = chunk_skip_to_match(start, scope_e::PREPROC);
    if (end != NULL)
    {
       LOG_FMT(LFLPAREN, "set_paren_parent: %zu:%zu [%s] and %zu:%zu [%s] type=%s ptype=%s",
@@ -619,7 +619,7 @@ chunk_t *set_paren_parent(chunk_t *start, c_token_t parent)
       set_chunk_parent(start, parent);
       set_chunk_parent(end, parent);
    }
-   return(chunk_get_next_ncnl(end, CNAV_PREPROC));
+   return(chunk_get_next_ncnl(end, scope_e::PREPROC));
 }
 
 
@@ -627,19 +627,19 @@ static void flag_asm(chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
 
-   chunk_t *tmp = chunk_get_next_ncnl(pc, CNAV_PREPROC);
+   chunk_t *tmp = chunk_get_next_ncnl(pc, scope_e::PREPROC);
    if (!chunk_is_token(tmp, CT_QUALIFIER))
    {
       return;
    }
 
-   chunk_t *po = chunk_get_next_ncnl(tmp, CNAV_PREPROC);
+   chunk_t *po = chunk_get_next_ncnl(tmp, scope_e::PREPROC);
    if (!chunk_is_paren_open(po))
    {
       return;
    }
 
-   chunk_t *end = chunk_skip_to_match(po, CNAV_PREPROC);
+   chunk_t *end = chunk_skip_to_match(po, scope_e::PREPROC);
    if (!end)
    {
       return;
@@ -647,9 +647,9 @@ static void flag_asm(chunk_t *pc)
 
    set_chunk_parent(po, CT_ASM);
    set_chunk_parent(end, CT_ASM);
-   for (tmp = chunk_get_next_ncnl(po, CNAV_PREPROC);
+   for (tmp = chunk_get_next_ncnl(po, scope_e::PREPROC);
         tmp != end;
-        tmp = chunk_get_next_ncnl(tmp, CNAV_PREPROC))
+        tmp = chunk_get_next_ncnl(tmp, scope_e::PREPROC))
    {
       if (tmp->type == CT_COLON)
       {
@@ -658,8 +658,8 @@ static void flag_asm(chunk_t *pc)
       else if (tmp->type == CT_DC_MEMBER)
       {
          /* if there is a string on both sides, then this is two ASM_COLONs */
-         if (chunk_is_token(chunk_get_next_ncnl(tmp, CNAV_PREPROC), CT_STRING) &&
-             chunk_is_token(chunk_get_prev_ncnl(tmp, CNAV_PREPROC), CT_STRING))
+         if (chunk_is_token(chunk_get_next_ncnl(tmp, scope_e::PREPROC), CT_STRING) &&
+             chunk_is_token(chunk_get_prev_ncnl(tmp, scope_e::PREPROC), CT_STRING))
          {
             chunk_t nc;
 
@@ -677,7 +677,7 @@ static void flag_asm(chunk_t *pc)
          }
       }
    }
-   tmp = chunk_get_next_ncnl(end, CNAV_PREPROC);
+   tmp = chunk_get_next_ncnl(end, scope_e::PREPROC);
    if (chunk_is_token(tmp, CT_SEMICOLON))
    {
       set_chunk_parent(tmp, CT_ASM);
@@ -1759,12 +1759,12 @@ void fix_symbols(void)
    }
    while (pc != NULL)
    {
-      chunk_t *prev = chunk_get_prev_ncnl(pc, CNAV_PREPROC);
+      chunk_t *prev = chunk_get_prev_ncnl(pc, scope_e::PREPROC);
       if (prev == NULL)
       {
          prev = &dummy;
       }
-      chunk_t *next = chunk_get_next_ncnl(pc, CNAV_PREPROC);
+      chunk_t *next = chunk_get_next_ncnl(pc, scope_e::PREPROC);
       if (next == NULL)
       {
          next = &dummy;
@@ -2664,7 +2664,7 @@ static void fix_typedef(chunk_t *start)
     * function type
     */
    chunk_t *next = start;
-   while (((next = chunk_get_next_ncnl(next, CNAV_PREPROC)) != NULL) &&
+   while (((next = chunk_get_next_ncnl(next, scope_e::PREPROC)) != NULL) &&
           (next->level >= start->level))
    {
       chunk_flags_set(next, PCF_IN_TYPEDEF);
@@ -2705,12 +2705,12 @@ static void fix_typedef(chunk_t *start)
       fix_fcn_def_params(last_op);
 
       open_paren = NULL;
-      the_type   = chunk_get_prev_ncnl(last_op, CNAV_PREPROC);
+      the_type   = chunk_get_prev_ncnl(last_op, scope_e::PREPROC);
       if (chunk_is_paren_close(the_type))
       {
          open_paren = chunk_skip_to_match_rev(the_type);
          mark_function_type(the_type);
-         the_type = chunk_get_prev_ncnl(the_type, CNAV_PREPROC);
+         the_type = chunk_get_prev_ncnl(the_type, scope_e::PREPROC);
       }
       else
       {
@@ -2742,7 +2742,7 @@ static void fix_typedef(chunk_t *start)
     * Skip over enum/struct/union stuff, as we know it isn't a return type
     * for a function type
     */
-   next = chunk_get_next_ncnl(start, CNAV_PREPROC);
+   next = chunk_get_next_ncnl(start, scope_e::PREPROC);
    if (next == NULL)
    {
       return;
@@ -2765,14 +2765,14 @@ static void fix_typedef(chunk_t *start)
    c_token_t tag = next->type;
 
    /* the next item should be either a type or { */
-   next = chunk_get_next_ncnl(next, CNAV_PREPROC);
+   next = chunk_get_next_ncnl(next, scope_e::PREPROC);
    if (next == NULL)
    {
       return;
    }
    if (next->type == CT_TYPE)
    {
-      next = chunk_get_next_ncnl(next, CNAV_PREPROC);
+      next = chunk_get_next_ncnl(next, scope_e::PREPROC);
    }
    if (next == NULL)
    {
@@ -2782,7 +2782,7 @@ static void fix_typedef(chunk_t *start)
    {
       set_chunk_parent(next, tag);
       /* Skip to the closing brace */
-      next = chunk_get_next_type(next, CT_BRACE_CLOSE, next->level, CNAV_PREPROC);
+      next = chunk_get_next_type(next, CT_BRACE_CLOSE, next->level, scope_e::PREPROC);
       if (next != NULL)
       {
          set_chunk_parent(next, tag);
@@ -2962,7 +2962,7 @@ void combine_labels(void)
             }
             else if (cur->type == CT_WORD)
             {
-               tmp = chunk_get_next_nc(next, CNAV_PREPROC);
+               tmp = chunk_get_next_nc(next, scope_e::PREPROC);
 #ifdef DEBUG
                LOG_FMT(LGUY, "(%d) ", __LINE__);
 #endif
@@ -3416,7 +3416,7 @@ static bool can_be_full_param(chunk_t *start, chunk_t *end)
    size_t  type_count = 0;
    chunk_t *pc;
 
-   for (pc = start; pc != end; pc = chunk_get_next_ncnl(pc, CNAV_PREPROC))
+   for (pc = start; pc != end; pc = chunk_get_next_ncnl(pc, scope_e::PREPROC))
    {
       LOG_FMT(LFPARAM, " [%s]", pc->text());
 
@@ -3469,14 +3469,14 @@ static bool can_be_full_param(chunk_t *start, chunk_t *end)
       else if ((word_cnt == 0) && (pc->type == CT_PAREN_OPEN))
       {
          /* Check for old-school func proto param '(type)' */
-         chunk_t *tmp1 = chunk_skip_to_match(pc, CNAV_PREPROC);
-         chunk_t *tmp2 = chunk_get_next_ncnl(tmp1, CNAV_PREPROC);
+         chunk_t *tmp1 = chunk_skip_to_match(pc, scope_e::PREPROC);
+         chunk_t *tmp2 = chunk_get_next_ncnl(tmp1, scope_e::PREPROC);
 
          if (chunk_is_token(tmp2, CT_COMMA) || chunk_is_paren_close(tmp2))
          {
             do
             {
-               pc = chunk_get_next_ncnl(pc, CNAV_PREPROC);
+               pc = chunk_get_next_ncnl(pc, scope_e::PREPROC);
                LOG_FMT(LFPARAM, " [%s]", pc->text());
             } while (pc != tmp1);
 
@@ -3494,9 +3494,9 @@ static bool can_be_full_param(chunk_t *start, chunk_t *end)
                (pc->type == CT_PAREN_OPEN))
       {
          /* Check for func proto param 'void (*name)' or 'void (*name)(params)' */
-         chunk_t *tmp1 = chunk_get_next_ncnl(pc, CNAV_PREPROC);
-         chunk_t *tmp2 = chunk_get_next_ncnl(tmp1, CNAV_PREPROC);
-         chunk_t *tmp3 = chunk_get_next_ncnl(tmp2, CNAV_PREPROC);
+         chunk_t *tmp1 = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+         chunk_t *tmp2 = chunk_get_next_ncnl(tmp1, scope_e::PREPROC);
+         chunk_t *tmp3 = chunk_get_next_ncnl(tmp2, scope_e::PREPROC);
 
          if (!chunk_is_str(tmp3, ")", 1) ||
              !chunk_is_str(tmp1, "*", 1) ||
@@ -3506,11 +3506,11 @@ static bool can_be_full_param(chunk_t *start, chunk_t *end)
             return(false);
          }
          LOG_FMT(LFPARAM, " <skip fcn type>");
-         tmp1 = chunk_get_next_ncnl(tmp3, CNAV_PREPROC);
-         tmp2 = chunk_get_next_ncnl(tmp1, CNAV_PREPROC); /* \todo where is tmp2 used? */
+         tmp1 = chunk_get_next_ncnl(tmp3, scope_e::PREPROC);
+         tmp2 = chunk_get_next_ncnl(tmp1, scope_e::PREPROC); /* \todo where is tmp2 used? */
          if (chunk_is_str(tmp1, "(", 1))
          {
-            tmp3 = chunk_skip_to_match(tmp1, CNAV_PREPROC);
+            tmp3 = chunk_skip_to_match(tmp1, scope_e::PREPROC);
          }
          pc = tmp3;
 
@@ -3525,12 +3525,12 @@ static bool can_be_full_param(chunk_t *start, chunk_t *end)
       else if ((word_cnt == 1) && (pc->type == CT_SQUARE_OPEN))
       {
          /* skip over any array stuff */
-         pc = chunk_skip_to_match(pc, CNAV_PREPROC);
+         pc = chunk_skip_to_match(pc, scope_e::PREPROC);
       }
       else if ((word_cnt == 2) && (pc->type == CT_SQUARE_OPEN))
       {
          /* Bug #671: is it such as: bool foo[FOO_MAX] */
-         pc = chunk_skip_to_match(pc, CNAV_PREPROC);
+         pc = chunk_skip_to_match(pc, scope_e::PREPROC);
       }
       else if ((word_cnt == 1) && (cpd.lang_flags & LANG_CPP) &&
                chunk_is_str(pc, "&&", 2))
@@ -4354,7 +4354,7 @@ static void mark_class_ctor(chunk_t *start)
 {
    LOG_FUNC_ENTRY();
 
-   chunk_t *pclass = chunk_get_next_ncnl(start, CNAV_PREPROC);
+   chunk_t *pclass = chunk_get_next_ncnl(start, scope_e::PREPROC);
    if ((pclass == NULL) ||
        ((pclass->type != CT_TYPE) &&
         (pclass->type != CT_WORD)))
@@ -4362,17 +4362,17 @@ static void mark_class_ctor(chunk_t *start)
       return;
    }
 
-   chunk_t *next = chunk_get_next_ncnl(pclass, CNAV_PREPROC);
+   chunk_t *next = chunk_get_next_ncnl(pclass, scope_e::PREPROC);
    while ((next != NULL) &&
           ((next->type == CT_TYPE) ||
            (next->type == CT_WORD) ||
            (next->type == CT_DC_MEMBER)))
    {
       pclass = next;
-      next   = chunk_get_next_ncnl(next, CNAV_PREPROC);
+      next   = chunk_get_next_ncnl(next, scope_e::PREPROC);
    }
 
-   chunk_t *pc   = chunk_get_next_ncnl(pclass, CNAV_PREPROC);
+   chunk_t *pc   = chunk_get_next_ncnl(pclass, scope_e::PREPROC);
    size_t  level = pclass->brace_level + 1;
 
    if (pc == NULL)
@@ -4425,7 +4425,7 @@ static void mark_class_ctor(chunk_t *start)
          return;
       }
       chunk_flags_set(pc, flags);
-      pc = chunk_get_next_ncnl(pc, CNAV_PREPROC);
+      pc = chunk_get_next_ncnl(pc, scope_e::PREPROC);
    }
 
    if (pc == NULL)
@@ -4436,7 +4436,7 @@ static void mark_class_ctor(chunk_t *start)
 
    set_paren_parent(pc, start->type);
 
-   pc = chunk_get_next_ncnl(pc, CNAV_PREPROC);
+   pc = chunk_get_next_ncnl(pc, scope_e::PREPROC);
    while (pc != NULL)
    {
       chunk_flags_set(pc, PCF_IN_CLASS);
@@ -4452,7 +4452,7 @@ static void mark_class_ctor(chunk_t *start)
       if ((pc->type == CT_BRACE_CLOSE) && (pc->brace_level < level))
       {
          LOG_FMT(LFTOR, "%s: %zu] Hit brace close\n", __func__, pc->orig_line);
-         pc = chunk_get_next_ncnl(pc, CNAV_PREPROC);
+         pc = chunk_get_next_ncnl(pc, scope_e::PREPROC);
          if (pc && (pc->type == CT_SEMICOLON))
          {
             set_chunk_parent(pc, start->type);
@@ -4460,7 +4460,7 @@ static void mark_class_ctor(chunk_t *start)
          return;
       }
 
-      next = chunk_get_next_ncnl(pc, CNAV_PREPROC);
+      next = chunk_get_next_ncnl(pc, scope_e::PREPROC);
       if (chunkstack_match(cs, pc))
       {
          if ((next != NULL) && (next->len() == 1) && (next->str[0] == '('))

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1728,7 +1728,7 @@ void fix_symbols(void)
    chunk_t *pc;
    chunk_t dummy;
 
-   cpd.unc_stage = US_FIX_SYMBOLS;
+   cpd.unc_stage = unc_stage_e::FIX_SYMBOLS;
 
    mark_define_expressions();
 
@@ -2816,7 +2816,7 @@ void combine_labels(void)
    bool    hit_case  = false;
    bool    hit_class = false;
 
-   cpd.unc_stage = US_COMBINE_LABELS;
+   cpd.unc_stage = unc_stage_e::COMBINE_LABELS;
 
    // need a stack to handle nesting inside of OC messages, which reset the scope
    ChunkStack cs;
@@ -4594,7 +4594,7 @@ void mark_comments(void)
 {
    LOG_FUNC_ENTRY();
 
-   cpd.unc_stage = US_MARK_COMMENTS;
+   cpd.unc_stage = unc_stage_e::MARK_COMMENTS;
 
    bool    prev_nl = true;
    chunk_t *cur    = chunk_get_head();

--- a/src/combine.h
+++ b/src/combine.h
@@ -47,7 +47,7 @@ void mark_comments(void);
 void make_type(chunk_t *pc);
 
 
-void flag_series(chunk_t *start, chunk_t *end, UINT64 set_flags, UINT64 clr_flags = 0, nav_t nav = CNAV_ALL);
+void flag_series(chunk_t *start, chunk_t *end, UINT64 set_flags, UINT64 clr_flags = 0, scope_e nav = scope_e::ALL);
 
 
 /**

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -208,11 +208,11 @@ void indent_to_column(chunk_t *pc, size_t column)
 }
 
 
-enum align_mode
+enum class align_mode_e : unsigned int
 {
-   ALMODE_SHIFT,     /* shift relative to the current column */
-   ALMODE_KEEP_ABS,  /* try to keep the original absolute column */
-   ALMODE_KEEP_REL,  /* try to keep the original gap */
+   SHIFT,     /* shift relative to the current column */
+   KEEP_ABS,  /* try to keep the original absolute column */
+   KEEP_REL,  /* try to keep the original gap */
 };
 
 
@@ -234,9 +234,9 @@ void align_to_column(chunk_t *pc, size_t column)
    pc->column = column;
    do
    {
-      chunk_t    *next = chunk_get_next(pc);
-      chunk_t    *prev;
-      align_mode almod = ALMODE_SHIFT;
+      chunk_t      *next = chunk_get_next(pc);
+      chunk_t      *prev;
+      align_mode_e almod = align_mode_e::SHIFT;
 
       if (next == NULL)
       {
@@ -251,10 +251,10 @@ void align_to_column(chunk_t *pc, size_t column)
       {
          almod = (chunk_is_single_line_comment(pc) &&
                   cpd.settings[UO_indent_relative_single_line_comments].b) ?
-                 ALMODE_KEEP_REL : ALMODE_KEEP_ABS;
+                 align_mode_e::KEEP_REL : align_mode_e::KEEP_ABS;
       }
 
-      if (almod == ALMODE_KEEP_ABS)
+      if (almod == align_mode_e::KEEP_ABS)
       {
          /* Keep same absolute column */
          pc->column = pc->orig_col;
@@ -263,7 +263,7 @@ void align_to_column(chunk_t *pc, size_t column)
             pc->column = min_col;
          }
       }
-      else if (almod == ALMODE_KEEP_REL)
+      else if (almod == align_mode_e::KEEP_REL)
       {
          /* Keep same relative column */
          int orig_delta = pc->orig_col - prev->orig_col;
@@ -273,7 +273,7 @@ void align_to_column(chunk_t *pc, size_t column)
          }
          pc->column = prev->column + orig_delta;
       }
-      else /* ALMODE_SHIFT */
+      else /* SHIFT */
       {
          /* Shift by the same amount */
          pc->column += col_delta;
@@ -283,8 +283,8 @@ void align_to_column(chunk_t *pc, size_t column)
          }
       }
       LOG_FMT(LINDLINED, "   %s set column of %s on line %zu to col %zu (orig %zu)\n",
-              (almod == ALMODE_KEEP_ABS) ? "abs" :
-              (almod == ALMODE_KEEP_REL) ? "rel" : "sft",
+              (almod == align_mode_e::KEEP_ABS) ? "abs" :
+              (almod == align_mode_e::KEEP_REL) ? "rel" : "sft",
               get_token_name(pc->type), pc->orig_line, pc->column, pc->orig_col);
    } while ((pc != NULL) && (pc->nl_count == 0));
 } // align_to_column

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -568,7 +568,7 @@ static chunk_t *oc_msg_block_indent(chunk_t *pc, bool from_brace,
 
 static chunk_t *oc_msg_prev_colon(chunk_t *pc)
 {
-   return(chunk_get_prev_type(pc, CT_OC_COLON, pc->level, CNAV_ALL));
+   return(chunk_get_prev_type(pc, CT_OC_COLON, pc->level, scope_e::ALL));
 }
 
 

--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -518,7 +518,7 @@ void clear_keyword_file(void)
 }
 
 
-pattern_class get_token_pattern_class(c_token_t tok)
+pattern_class_e get_token_pattern_class(c_token_t tok)
 {
    switch (tok)
    {
@@ -533,10 +533,10 @@ pattern_class get_token_pattern_class(c_token_t tok)
    case CT_D_WITH:
    case CT_D_VERSION_IF:
    case CT_D_SCOPE_IF:
-      return(PATCLS_PBRACED);
+      return(pattern_class_e::PBRACED);
 
    case CT_ELSE:
-      return(PATCLS_ELSE);
+      return(pattern_class_e::ELSE);
 
    case CT_DO:
    case CT_TRY:
@@ -546,23 +546,23 @@ pattern_class get_token_pattern_class(c_token_t tok)
    case CT_UNSAFE:
    case CT_VOLATILE:
    case CT_GETSET:
-      return(PATCLS_BRACED);
+      return(pattern_class_e::BRACED);
 
    case CT_CATCH:
    case CT_D_VERSION:
    case CT_DEBUG:
-      return(PATCLS_OPBRACED);
+      return(pattern_class_e::OPBRACED);
 
    case CT_NAMESPACE:
-      return(PATCLS_VBRACED);
+      return(pattern_class_e::VBRACED);
 
    case CT_WHILE_OF_DO:
-      return(PATCLS_PAREN);
+      return(pattern_class_e::PAREN);
 
    case CT_INVARIANT:
-      return(PATCLS_OPPAREN);
+      return(pattern_class_e::OPPAREN);
 
    default:
-      return(PATCLS_NONE);
+      return(pattern_class_e::NONE);
    } // switch
 }    // get_token_pattern_class

--- a/src/keywords.h
+++ b/src/keywords.h
@@ -49,7 +49,7 @@ void clear_keyword_file(void);
 /**
  * Returns the pattern that the keyword needs based on the token
  */
-pattern_class get_token_pattern_class(c_token_t tok);
+pattern_class_e get_token_pattern_class(c_token_t tok);
 
 
 bool keywords_are_sorted(void);

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -2350,7 +2350,7 @@ static void nl_create_one_liner(chunk_t *vbrace_open)
    /* See if we get a newline between the next text and the vbrace_close */
    chunk_t *tmp   = chunk_get_next_ncnl(vbrace_open);
    chunk_t *first = tmp;
-   if (!first || (get_token_pattern_class(first->type) != PATCLS_NONE))
+   if (!first || (get_token_pattern_class(first->type) != pattern_class_e::NONE))
    {
       return;
    }

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -2205,7 +2205,7 @@ static bool one_liner_nl_ok(chunk_t *pc)
    {
       br_open = chunk_get_prev_type(br_open,
                                     br_open->type == CT_BRACE_CLOSE ? CT_BRACE_OPEN : CT_VBRACE_OPEN,
-                                    br_open->level, CNAV_ALL);
+                                    br_open->level, scope_e::ALL);
    }
    else
    {
@@ -2525,7 +2525,7 @@ void newlines_cleanup_braces(bool first)
          if ((pc->parent_type == CT_DOUBLE_BRACE) &&
              (cpd.settings[UO_nl_paren_dbrace_open].a != AV_IGNORE))
          {
-            prev = chunk_get_prev_ncnl(pc, CNAV_PREPROC);
+            prev = chunk_get_prev_ncnl(pc, scope_e::PREPROC);
             if (chunk_is_paren_close(prev))
             {
                newline_iarf_pair(prev, pc, cpd.settings[UO_nl_paren_dbrace_open].a);
@@ -2534,7 +2534,7 @@ void newlines_cleanup_braces(bool first)
 
          if (cpd.settings[UO_nl_brace_brace].a != AV_IGNORE)
          {
-            next = chunk_get_next_nc(pc, CNAV_PREPROC);
+            next = chunk_get_next_nc(pc, scope_e::PREPROC);
             if ((next != NULL) && (next->type == CT_BRACE_OPEN))
             {
                newline_iarf_pair(pc, next, cpd.settings[UO_nl_brace_brace].a);
@@ -2625,7 +2625,7 @@ void newlines_cleanup_braces(bool first)
       {
          if (cpd.settings[UO_nl_brace_brace].a != AV_IGNORE)
          {
-            next = chunk_get_next_nc(pc, CNAV_PREPROC);
+            next = chunk_get_next_nc(pc, scope_e::PREPROC);
             if ((next != NULL) && (next->type == CT_BRACE_CLOSE))
             {
                newline_iarf_pair(pc, next, cpd.settings[UO_nl_brace_brace].a);
@@ -2634,7 +2634,7 @@ void newlines_cleanup_braces(bool first)
 
          if (cpd.settings[UO_nl_brace_square].a != AV_IGNORE)
          {
-            next = chunk_get_next_nc(pc, CNAV_PREPROC);
+            next = chunk_get_next_nc(pc, scope_e::PREPROC);
             if ((next != NULL) && (next->type == CT_SQUARE_CLOSE))
             {
                newline_iarf_pair(pc, next, cpd.settings[UO_nl_brace_square].a);
@@ -2643,7 +2643,7 @@ void newlines_cleanup_braces(bool first)
 
          if (cpd.settings[UO_nl_brace_fparen].a != AV_IGNORE)
          {
-            next = chunk_get_next_nc(pc, CNAV_PREPROC);
+            next = chunk_get_next_nc(pc, scope_e::PREPROC);
             if ((next != NULL) && (next->type == CT_FPAREN_CLOSE))
             {
                newline_iarf_pair(pc, next, cpd.settings[UO_nl_brace_fparen].a);
@@ -2690,7 +2690,7 @@ void newlines_cleanup_braces(bool first)
               (pc->parent_type == CT_ENUM) ||
               (pc->parent_type == CT_UNION)))
          {
-            next = chunk_get_next_ncnl(pc, CNAV_PREPROC);
+            next = chunk_get_next_ncnl(pc, scope_e::PREPROC);
             if (next &&
                 (next->type != CT_SEMICOLON) &&
                 (next->type != CT_COMMA))
@@ -2725,7 +2725,7 @@ void newlines_cleanup_braces(bool first)
          if (cpd.settings[UO_nl_after_vbrace_open].b ||
              cpd.settings[UO_nl_after_vbrace_open_empty].b)
          {
-            next = chunk_get_next(pc, CNAV_PREPROC);
+            next = chunk_get_next(pc, scope_e::PREPROC);
             bool add_it;
             if (chunk_is_semicolon(next))
             {

--- a/src/parens.cpp
+++ b/src/parens.cpp
@@ -60,7 +60,7 @@ void do_parens(void)
          }
 
          /* Grab the close sparen */
-         chunk_t *pclose = chunk_get_next_type(pc, CT_SPAREN_CLOSE, pc->level, CNAV_PREPROC);
+         chunk_t *pclose = chunk_get_next_type(pc, CT_SPAREN_CLOSE, pc->level, scope_e::PREPROC);
          if (pclose != NULL)
          {
             check_bool_parens(pc, pclose, 0);
@@ -97,7 +97,7 @@ static void add_parens_between(chunk_t *first, chunk_t *last)
 
    chunk_add_before(&pc, first_n);
 
-   chunk_t *last_p = chunk_get_prev_ncnl(last, CNAV_PREPROC);
+   chunk_t *last_p = chunk_get_prev_ncnl(last, scope_e::PREPROC);
    pc.type        = CT_PAREN_CLOSE;
    pc.str         = ")";
    pc.flags       = last_p->flags & PCF_COPY_FLAGS;

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -1869,7 +1869,7 @@ void tokenize(const deque<int> &data, chunk_t *ref)
    bool          last_was_tab = false;
    size_t        prev_sp      = 0;
 
-   cpd.unc_stage = US_TOKENIZE;
+   cpd.unc_stage = unc_stage_e::TOKENIZE;
 
    memset(&frm, 0, sizeof(frm));
 

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -621,7 +621,7 @@ void tokenize_cleanup(void)
          chunk_t *tmp = chunk_get_next_ncnl(pc, CNAV_PREPROC);
          while ((tmp != NULL) && (tmp->type != CT_OC_END))
          {
-            if (get_token_pattern_class(tmp->type) != PATCLS_NONE)
+            if (get_token_pattern_class(tmp->type) != pattern_class_e::NONE)
             {
                LOG_FMT(LOBJCWORD, "@interface %zu:%zu change '%s' (%s) to CT_WORD\n",
                        pc->orig_line, pc->orig_col, tmp->text(),

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -97,7 +97,7 @@ void tokenize_cleanup(void)
    chunk_t *next;
    bool    in_type_cast = false;
 
-   cpd.unc_stage = US_TOKENIZE_CLEANUP;
+   cpd.unc_stage = unc_stage_e::TOKENIZE_CLEANUP;
 
    /* Since [] is expected to be TSQUARE for the 'operator', we need to make
     * this change in the first pass.

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -122,7 +122,7 @@ void tokenize_cleanup(void)
       }
       if ((pc->type == CT_SEMICOLON) &&
           (pc->flags & PCF_IN_PREPROC) &&
-          !chunk_get_next_ncnl(pc, CNAV_PREPROC))
+          !chunk_get_next_ncnl(pc, scope_e::PREPROC))
       {
          LOG_FMT(LNOTE, "%s:%zu Detected a macro that ends with a semicolon. Possible failures if used.\n",
                  cpd.filename, pc->orig_line);
@@ -618,7 +618,7 @@ void tokenize_cleanup(void)
 
       if (pc->type == CT_OC_INTF)
       {
-         chunk_t *tmp = chunk_get_next_ncnl(pc, CNAV_PREPROC);
+         chunk_t *tmp = chunk_get_next_ncnl(pc, scope_e::PREPROC);
          while ((tmp != NULL) && (tmp->type != CT_OC_END))
          {
             if (get_token_pattern_class(tmp->type) != pattern_class_e::NONE)
@@ -628,7 +628,7 @@ void tokenize_cleanup(void)
                        get_token_name(tmp->type));
                set_chunk_type(tmp, CT_WORD);
             }
-            tmp = chunk_get_next_ncnl(tmp, CNAV_PREPROC);
+            tmp = chunk_get_next_ncnl(tmp, scope_e::PREPROC);
          }
       }
 
@@ -847,7 +847,7 @@ static void check_template(chunk_t *start)
 {
    LOG_FMT(LTEMPL, "%s: Line %zu, col %zu:", __func__, start->orig_line, start->orig_col);
 
-   chunk_t *prev = chunk_get_prev_ncnl(start, CNAV_PREPROC);
+   chunk_t *prev = chunk_get_prev_ncnl(start, scope_e::PREPROC);
    if (prev == NULL)
    {
       return;
@@ -861,9 +861,9 @@ static void check_template(chunk_t *start)
 
       /* We have: "template< ... >", which is a template declaration */
       size_t level = 1;
-      for (pc = chunk_get_next_ncnl(start, CNAV_PREPROC);
+      for (pc = chunk_get_next_ncnl(start, scope_e::PREPROC);
            pc != NULL;
-           pc = chunk_get_next_ncnl(pc, CNAV_PREPROC))
+           pc = chunk_get_next_ncnl(pc, scope_e::PREPROC))
       {
          LOG_FMT(LTEMPL, " [%s,%zu]", get_token_name(pc->type), level);
 
@@ -915,7 +915,7 @@ static void check_template(chunk_t *start)
       /* Scan back and make sure we aren't inside square parens */
       bool in_if = false;
       pc = start;
-      while ((pc = chunk_get_prev_ncnl(pc, CNAV_PREPROC)) != NULL)
+      while ((pc = chunk_get_prev_ncnl(pc, scope_e::PREPROC)) != NULL)
       {
          if ((pc->type == CT_SEMICOLON) ||
              (pc->type == CT_BRACE_OPEN) ||
@@ -945,9 +945,9 @@ static void check_template(chunk_t *start)
       size_t    num_tokens = 1;
 
       tokens[0] = CT_ANGLE_OPEN;
-      for (pc = chunk_get_next_ncnl(start, CNAV_PREPROC);
+      for (pc = chunk_get_next_ncnl(start, scope_e::PREPROC);
            pc != NULL;
-           pc = chunk_get_next_ncnl(pc, CNAV_PREPROC))
+           pc = chunk_get_next_ncnl(pc, scope_e::PREPROC))
       {
          LOG_FMT(LTEMPL, " [%s,%zu]", get_token_name(pc->type), num_tokens);
 
@@ -1017,7 +1017,7 @@ static void check_template(chunk_t *start)
 
    if ((end != NULL) && (end->type == CT_ANGLE_CLOSE))
    {
-      pc = chunk_get_next_ncnl(end, CNAV_PREPROC);
+      pc = chunk_get_next_ncnl(end, scope_e::PREPROC);
       if ((pc == NULL) || (pc->type != CT_NUMBER))
       {
          LOG_FMT(LTEMPL, " - Template Detected\n");
@@ -1027,7 +1027,7 @@ static void check_template(chunk_t *start)
          pc = start;
          while (pc != end)
          {
-            chunk_t *next = chunk_get_next_ncnl(pc, CNAV_PREPROC);
+            chunk_t *next = chunk_get_next_ncnl(pc, scope_e::PREPROC);
             chunk_flags_set(pc, PCF_IN_TEMPLATE);
             if (next->type != CT_PAREN_OPEN)
             {

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1461,7 +1461,7 @@ static void add_func_header(c_token_t type, file_mem &fm)
          /* If we hit an angle close, back up to the angle open */
          if (ref->type == CT_ANGLE_CLOSE)
          {
-            ref = chunk_get_prev_type(ref, CT_ANGLE_OPEN, ref->level, CNAV_PREPROC);
+            ref = chunk_get_prev_type(ref, CT_ANGLE_OPEN, ref->level, scope_e::PREPROC);
             continue;
          }
 
@@ -1542,7 +1542,7 @@ static void add_msg_header(c_token_t type, file_mem &fm)
          /* If we hit a parentheses around return type, back up to the open parentheses */
          if (ref->type == CT_PAREN_CLOSE)
          {
-            ref = chunk_get_prev_type(ref, CT_PAREN_OPEN, ref->level, CNAV_PREPROC);
+            ref = chunk_get_prev_type(ref, CT_PAREN_OPEN, ref->level, scope_e::PREPROC);
             continue;
          }
 

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -875,7 +875,7 @@ static bool read_stdin(file_mem &fm)
 
    fm.raw.clear();
    fm.data.clear();
-   fm.enc = ENC_ASCII;
+   fm.enc = char_encoding_e::ASCII;
 
    while (!feof(stdin))
    {
@@ -944,7 +944,7 @@ static int load_mem_file(const char *filename, file_mem &fm)
 
    fm.raw.clear();
    fm.data.clear();
-   fm.enc = ENC_ASCII;
+   fm.enc = char_encoding_e::ASCII;
 
    /* Grab the stat info for the file */
    if (stat(filename, &my_stat) < 0)
@@ -970,7 +970,7 @@ static int load_mem_file(const char *filename, file_mem &fm)
       /* Empty file */
       retval = 0;
       fm.bom = false;
-      fm.enc = ENC_ASCII;
+      fm.enc = char_encoding_e::ASCII;
       fm.data.clear();
    }
    else
@@ -990,11 +990,11 @@ static int load_mem_file(const char *filename, file_mem &fm)
       else
       {
          LOG_FMT(LNOTE, "%s: '%s' encoding looks like %s (%d)\n", __func__, filename,
-                 fm.enc == ENC_ASCII ? "ASCII" :
-                 fm.enc == ENC_BYTE ? "BYTES" :
-                 fm.enc == ENC_UTF8 ? "UTF-8" :
-                 fm.enc == ENC_UTF16_LE ? "UTF-16-LE" :
-                 fm.enc == ENC_UTF16_BE ? "UTF-16-BE" : "Error",
+                 fm.enc == char_encoding_e::ASCII ? "ASCII" :
+                 fm.enc == char_encoding_e::BYTE ? "BYTES" :
+                 fm.enc == char_encoding_e::UTF8 ? "UTF-8" :
+                 fm.enc == char_encoding_e::UTF16_LE ? "UTF-16-LE" :
+                 fm.enc == char_encoding_e::UTF16_BE ? "UTF-16-BE" : "Error",
                  fm.enc);
          retval = 0;
       }
@@ -1667,19 +1667,19 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
    cpd.bom = fm.bom;
    cpd.enc = fm.enc;
    if (cpd.settings[UO_utf8_force].b ||
-       ((cpd.enc == ENC_BYTE) && cpd.settings[UO_utf8_byte].b))
+       ((cpd.enc == char_encoding_e::BYTE) && cpd.settings[UO_utf8_byte].b))
    {
-      cpd.enc = ENC_UTF8;
+      cpd.enc = char_encoding_e::UTF8;
    }
    argval_t av;
    switch (cpd.enc)
    {
-   case ENC_UTF8:
+   case char_encoding_e::UTF8:
       av = cpd.settings[UO_utf8_bom].a;
       break;
 
-   case ENC_UTF16_LE:
-   case ENC_UTF16_BE:
+   case char_encoding_e::UTF16_LE:
+   case char_encoding_e::UTF16_BE:
       av = AV_FORCE;
       break;
 

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1599,7 +1599,7 @@ static void uncrustify_start(const deque<int> &data)
     */
    tokenize(data, NULL);
 
-   cpd.unc_stage = US_HEADER;
+   cpd.unc_stage = unc_stage_e::HEADER;
 
    /* Get the column for the fragment indent */
    if (cpd.frag)
@@ -1711,7 +1711,7 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
 
    uncrustify_start(data);
 
-   cpd.unc_stage = US_OTHER;
+   cpd.unc_stage = unc_stage_e::OTHER;
 
    /**
     * Done with detection. Do the rest only if the file will go somewhere.
@@ -1962,7 +1962,7 @@ static void uncrustify_end()
    /* Free all the memory */
    chunk_t *pc;
 
-   cpd.unc_stage = US_CLEANUP;
+   cpd.unc_stage = unc_stage_e::CLEANUP;
 
    while ((pc = chunk_get_head()) != NULL)
    {

--- a/src/uncrustify_emscripten.cpp
+++ b/src/uncrustify_emscripten.cpp
@@ -498,7 +498,7 @@ string uncrustify(string file, bool frag)
    file_mem fm;
    fm.raw.clear();
    fm.data.clear();
-   fm.enc = ENC_ASCII;
+   fm.enc = char_encoding_e::ASCII;
    fm.raw = vector<UINT8>(file.begin(), file.end());
 
    if (!decode_unicode(fm.raw, fm.data, fm.enc, fm.bom))

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -330,24 +330,24 @@ enum
 /**
  * Pattern classes for special keywords
  */
-enum pattern_class
+enum class pattern_class_e : unsigned int
 {
-   PATCLS_NONE,
-   PATCLS_BRACED,   // keyword + braced stmt:
-                    //    do, try, finally, body, unittest, unsafe, volatile
-                    //    add, get, remove, set
-   PATCLS_PBRACED,  // keyword + parens + braced stmt:
-                    //    if, elseif, switch, for, while, synchronized,
-                    //    using, lock, with, version, CT_D_SCOPE_IF
-   PATCLS_OPBRACED, // keyword + optional parens + braced stmt:
-                    //    catch, version, debug
-   PATCLS_VBRACED,  // keyword + value + braced stmt:
-                    //    namespace
-   PATCLS_PAREN,    // keyword + parens:
-                    //    while-of-do
-   PATCLS_OPPAREN,  // keyword + optional parens: invariant (D lang)
-   PATCLS_ELSE,     // Special case of PATCLS_BRACED for handling CT_IF
-                    //    else
+   NONE,
+   BRACED,   // keyword + braced stmt:
+             //    do, try, finally, body, unittest, unsafe, volatile
+             //    add, get, remove, set
+   PBRACED,  // keyword + parens + braced stmt:
+             //    if, elseif, switch, for, while, synchronized,
+             //    using, lock, with, version, CT_D_SCOPE_IF
+   OPBRACED, // keyword + optional parens + braced stmt:
+             //    catch, version, debug
+   VBRACED,  // keyword + value + braced stmt:
+             //    namespace
+   PAREN,    // keyword + parens:
+             //    while-of-do
+   OPPAREN,  // keyword + optional parens: invariant (D lang)
+   ELSE,     // Special case of pattern_class_e::BRACED for handling CT_IF
+             //    else
 };
 
 struct chunk_tag_t

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -41,20 +41,20 @@ using namespace std;
 /**
  * Brace stage enum used in brace_cleanup
  */
-enum brstage_e
+enum class brace_stage_e : unsigned int
 {
-   BS_NONE,
-   BS_PAREN1,     /* if/for/switch/while/synchronized */
-   BS_OP_PAREN1,  /* optional paren: catch () { */
-   BS_WOD_PAREN,  /* while of do parens */
-   BS_WOD_SEMI,   /* semicolon after while of do */
-   BS_BRACE_DO,   /* do */
-   BS_BRACE2,     /* if/else/for/switch/while */
-   BS_ELSE,       /* expecting 'else' after 'if' */
-   BS_ELSEIF,     /* expecting 'if' after 'else' */
-   BS_WHILE,      /* expecting 'while' after 'do' */
-   BS_CATCH,      /* expecting 'catch' or 'finally' after 'try' */
-   BS_CATCH_WHEN, /* optional 'when' after 'catch' */
+   NONE,
+   PAREN1,     /* if/for/switch/while/synchronized */
+   OP_PAREN1,  /* optional paren: catch () { */
+   WOD_PAREN,  /* while of do parens */
+   WOD_SEMI,   /* semicolon after while of do */
+   BRACE_DO,   /* do */
+   BRACE2,     /* if/else/for/switch/while */
+   ELSE,       /* expecting 'else' after 'if' */
+   ELSEIF,     /* expecting 'if' after 'else' */
+   WHILE,      /* expecting 'while' after 'do' */
+   CATCH,      /* expecting 'catch' or 'finally' after 'try' */
+   CATCH_WHEN, /* optional 'when' after 'catch' */
 };
 
 enum CharEncoding
@@ -86,22 +86,22 @@ struct indent_ptr_t
  */
 struct paren_stack_entry_t
 {
-   c_token_t    type;         /**< the type that opened the entry */
-   size_t       level;        /**< Level of opening type */
-   size_t       open_line;    /**< line that open symbol is on */
-   chunk_t      *pc;          /**< Chunk that opened the level */
-   int          brace_indent; /**< indent for braces - may not relate to indent */
-   size_t       indent;       /**< indent level (depends on use) */
-   size_t       indent_tmp;   /**< temporary indent level (depends on use) */
-   size_t       indent_tab;   /**< the 'tab' indent (always <= real column) */
-   bool         indent_cont;  /**< indent_continue was applied */
-   int          ref;
-   c_token_t    parent;       /**< if, for, function, etc */
-   brstage_e    stage;
-   bool         in_preproc;   /**< whether this was created in a preprocessor */
-   size_t       ns_cnt;
-   bool         non_vardef;   /**< Hit a non-vardef line */
-   indent_ptr_t ip;
+   c_token_t     type;         /**< the type that opened the entry */
+   size_t        level;        /**< Level of opening type */
+   size_t        open_line;    /**< line that open symbol is on */
+   chunk_t       *pc;          /**< Chunk that opened the level */
+   int           brace_indent; /**< indent for braces - may not relate to indent */
+   size_t        indent;       /**< indent level (depends on use) */
+   size_t        indent_tmp;   /**< temporary indent level (depends on use) */
+   size_t        indent_tab;   /**< the 'tab' indent (always <= real column) */
+   bool          indent_cont;  /**< indent_continue was applied */
+   int           ref;
+   c_token_t     parent;       /**< if, for, function, etc */
+   brace_stage_e stage;
+   bool          in_preproc;   /**< whether this was created in a preprocessor */
+   size_t        ns_cnt;
+   bool          non_vardef;   /**< Hit a non-vardef line */
+   indent_ptr_t  ip;
 };
 
 /* TODO: put this on a linked list */

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -57,13 +57,13 @@ enum class brace_stage_e : unsigned int
    CATCH_WHEN, /* optional 'when' after 'catch' */
 };
 
-enum CharEncoding
+enum class char_encoding_e : unsigned int
 {
-   ENC_ASCII,     /* 0-127 */
-   ENC_BYTE,      /* 0-255, not UTF-8 */
-   ENC_UTF8,
-   ENC_UTF16_LE,
-   ENC_UTF16_BE,
+   ASCII,     /* 0-127 */
+   BYTE,      /* 0-255, not UTF-8 */
+   UTF8,
+   UTF16_LE,
+   UTF16_BE,
 };
 
 struct chunk_t;
@@ -374,12 +374,12 @@ struct align_t
 
 struct file_mem
 {
-   vector<UINT8>  raw;
-   deque<int>     data;
-   bool           bom;
-   CharEncoding   enc;
+   vector<UINT8>   raw;
+   deque<int>      data;
+   bool            bom;
+   char_encoding_e enc;
 #ifdef HAVE_UTIME_H
-   struct utimbuf utb;
+   struct utimbuf  utb;
 #endif
 };
 
@@ -402,71 +402,71 @@ enum unc_stage
 
 struct cp_data_t
 {
-   deque<UINT8>   *bout;
-   FILE           *fout;
-   int            last_char;
-   bool           do_check;
-   enum unc_stage unc_stage;
-   int            check_fail_cnt;     // total failures
-   bool           if_changed;
+   deque<UINT8>    *bout;
+   FILE            *fout;
+   int             last_char;
+   bool            do_check;
+   enum unc_stage  unc_stage;
+   int             check_fail_cnt;    // total failures
+   bool            if_changed;
 
-   UINT32         error_count;
-   const char     *filename;
+   UINT32          error_count;
+   const char      *filename;
 
-   file_mem       file_hdr;       // for cmt_insert_file_header
-   file_mem       file_ftr;       // for cmt_insert_file_footer
-   file_mem       func_hdr;       // for cmt_insert_func_header
-   file_mem       oc_msg_hdr;     // for cmt_insert_oc_msg_header
-   file_mem       class_hdr;      // for cmt_insert_class_header
+   file_mem        file_hdr;      // for cmt_insert_file_header
+   file_mem        file_ftr;      // for cmt_insert_file_footer
+   file_mem        func_hdr;      // for cmt_insert_func_header
+   file_mem        oc_msg_hdr;    // for cmt_insert_oc_msg_header
+   file_mem        class_hdr;     // for cmt_insert_class_header
 
-   size_t         lang_flags;     // LANG_xxx
-   bool           lang_forced;
+   size_t          lang_flags;    // LANG_xxx
+   bool            lang_forced;
 
-   bool           unc_off;
-   bool           unc_off_used;     // to check if "unc_off" is used
-   UINT32         line_number;
-   UINT16         column;           // column for parsing
-   UINT16         spaces;           // space count on output
+   bool            unc_off;
+   bool            unc_off_used;    // to check if "unc_off" is used
+   UINT32          line_number;
+   UINT16          column;          // column for parsing
+   UINT16          spaces;          // space count on output
 
-   int            ifdef_over_whole_file;
+   int             ifdef_over_whole_file;
 
-   bool           frag;
-   UINT16         frag_cols;
+   bool            frag;
+   UINT16          frag_cols;
 
    // stuff to auto-detect line endings
-   UINT32         le_counts[LE_AUTO];
-   unc_text       newline;
+   UINT32          le_counts[LE_AUTO];
+   unc_text        newline;
 
-   bool           consumed;
+   bool            consumed;
 
-   int            did_newline;
-   c_token_t      in_preproc;
-   int            preproc_ncnl_count;
-   bool           output_trailspace;
-   bool           output_tab_as_space;
+   int             did_newline;
+   c_token_t       in_preproc;
+   int             preproc_ncnl_count;
+   bool            output_trailspace;
+   bool            output_tab_as_space;
 
-   bool           bom;
-   CharEncoding   enc;
+   bool            bom;
+   char_encoding_e enc;
 
    // bumped up when a line is split or indented
-   int            changes;
-   int            pass_count;
+   int             changes;
+   int             pass_count;
 
-   align_t        al[80];
-   size_t         al_cnt;
-   bool           al_c99_array;
+   align_t         al[80];
+   size_t          al_cnt;
+   bool            al_c99_array;
 
-   bool           warned_unable_string_replace_tab_chars;
+   bool            warned_unable_string_replace_tab_chars;
 
    // Here are all the settings
-   op_val_t       settings[UO_option_count];
+   op_val_t        settings[UO_option_count];
 
-   parse_frame_t  frames[16];
-   int            frame_count;
-   int            pp_level;
+   parse_frame_t   frames[16];
+   int             frame_count;
+   int             pp_level;
 
    // the default values for settings
-   op_val_t       defaults[UO_option_count];
+   op_val_t        defaults[UO_option_count];
 };
 
 extern cp_data_t cpd;   /* \todo can we avoid this external variable? */

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -383,18 +383,18 @@ struct file_mem
 #endif
 };
 
-enum unc_stage
+enum class unc_stage_e : unsigned int
 {
-   US_TOKENIZE,
-   US_HEADER,
-   US_TOKENIZE_CLEANUP,
-   US_BRACE_CLEANUP,
-   US_FIX_SYMBOLS,
-   US_MARK_COMMENTS,
-   US_COMBINE_LABELS,
-   US_OTHER,
+   TOKENIZE,
+   HEADER,
+   TOKENIZE_CLEANUP,
+   BRACE_CLEANUP,
+   FIX_SYMBOLS,
+   MARK_COMMENTS,
+   COMBINE_LABELS,
+   OTHER,
 
-   US_CLEANUP
+   CLEANUP
 };
 
 /* this set a limit to the name padding */
@@ -406,7 +406,7 @@ struct cp_data_t
    FILE            *fout;
    int             last_char;
    bool            do_check;
-   enum unc_stage  unc_stage;
+   unc_stage_e     unc_stage;
    int             check_fail_cnt;    // total failures
    bool            if_changed;
 

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -44,15 +44,15 @@ static int get_word(const vector<UINT8> &in_data, size_t &idx, bool be);
  * Sets enc based on the BOM.
  * Must have the BOM as the first two bytes.
  */
-static bool decode_utf16(const vector<UINT8> &in_data, deque<int> &out_data, CharEncoding &enc);
+static bool decode_utf16(const vector<UINT8> &in_data, deque<int> &out_data, char_encoding_e &enc);
 
 
 /**
  * Looks for the BOM of UTF-16 BE/LE and UTF-8.
  * If found, set enc and return true.
- * Sets enc to ENC_ASCII and returns false if not found.
+ * Sets enc to char_encoding_e::ASCII and returns false if not found.
  */
-static bool decode_bom(const vector<UINT8> &in_data, CharEncoding &enc);
+static bool decode_bom(const vector<UINT8> &in_data, char_encoding_e &enc);
 
 
 /**
@@ -254,7 +254,7 @@ static int get_word(const vector<UINT8> &in_data, size_t &idx, bool be)
 }
 
 
-static bool decode_utf16(const vector<UINT8> &in_data, deque<int> &out_data, CharEncoding &enc)
+static bool decode_utf16(const vector<UINT8> &in_data, deque<int> &out_data, char_encoding_e &enc)
 {
    out_data.clear();
 
@@ -273,36 +273,36 @@ static bool decode_utf16(const vector<UINT8> &in_data, deque<int> &out_data, Cha
    size_t idx = 2;
    if ((in_data[0] == 0xfe) && (in_data[1] == 0xff))
    {
-      enc = ENC_UTF16_BE;
+      enc = char_encoding_e::UTF16_BE;
    }
    else if ((in_data[0] == 0xff) && (in_data[1] == 0xfe))
    {
-      enc = ENC_UTF16_LE;
+      enc = char_encoding_e::UTF16_LE;
    }
    else
    {
       /* If we have a few words, we can take a guess, assuming the first few
        * chars are ASCII */
-      enc = ENC_ASCII;
+      enc = char_encoding_e::ASCII;
       idx = 0;
       if (in_data.size() >= 6)
       {
          if ((in_data[0] == 0) && (in_data[2] == 0) && (in_data[4] == 0))
          {
-            enc = ENC_UTF16_BE;
+            enc = char_encoding_e::UTF16_BE;
          }
          else if ((in_data[1] == 0) && (in_data[3] == 0) && (in_data[5] == 0))
          {
-            enc = ENC_UTF16_LE;
+            enc = char_encoding_e::UTF16_LE;
          }
       }
-      if (enc == ENC_ASCII)
+      if (enc == char_encoding_e::ASCII)
       {
          return(false);
       }
    }
 
-   bool be = (enc == ENC_UTF16_BE);
+   bool be = (enc == char_encoding_e::UTF16_BE);
 
    while (idx < in_data.size())
    {
@@ -334,19 +334,19 @@ static bool decode_utf16(const vector<UINT8> &in_data, deque<int> &out_data, Cha
 } // decode_utf16
 
 
-static bool decode_bom(const vector<UINT8> &in_data, CharEncoding &enc)
+static bool decode_bom(const vector<UINT8> &in_data, char_encoding_e &enc)
 {
-   enc = ENC_ASCII;
+   enc = char_encoding_e::ASCII;
    if (in_data.size() >= 2)
    {
       if ((in_data[0] == 0xfe) && (in_data[1] == 0xff))
       {
-         enc = ENC_UTF16_BE;
+         enc = char_encoding_e::UTF16_BE;
          return(true);
       }
       else if ((in_data[0] == 0xff) && (in_data[1] == 0xfe))
       {
-         enc = ENC_UTF16_LE;
+         enc = char_encoding_e::UTF16_LE;
          return(true);
       }
       else if ((in_data.size() >= 3) &&
@@ -354,7 +354,7 @@ static bool decode_bom(const vector<UINT8> &in_data, CharEncoding &enc)
                (in_data[1] == 0xbb) &&
                (in_data[2] == 0xbf))
       {
-         enc = ENC_UTF8;
+         enc = char_encoding_e::UTF8;
          return(true);
       }
    }
@@ -362,13 +362,13 @@ static bool decode_bom(const vector<UINT8> &in_data, CharEncoding &enc)
 }
 
 
-bool decode_unicode(const vector<UINT8> &in_data, deque<int> &out_data, CharEncoding &enc, bool &has_bom)
+bool decode_unicode(const vector<UINT8> &in_data, deque<int> &out_data, char_encoding_e &enc, bool &has_bom)
 {
    /* check for a BOM */
    if (decode_bom(in_data, enc))
    {
       has_bom = true;
-      if (enc == ENC_UTF8)
+      if (enc == char_encoding_e::UTF8)
       {
          return(decode_utf8(in_data, out_data));
       }
@@ -384,7 +384,7 @@ bool decode_unicode(const vector<UINT8> &in_data, deque<int> &out_data, CharEnco
    size_t zero_cnt;
    if (is_ascii(in_data, non_ascii_cnt, zero_cnt))
    {
-      enc = ENC_ASCII;
+      enc = char_encoding_e::ASCII;
       return(decode_bytes(in_data, out_data));
    }
 
@@ -401,12 +401,12 @@ bool decode_unicode(const vector<UINT8> &in_data, deque<int> &out_data, CharEnco
 
    if (decode_utf8(in_data, out_data))
    {
-      enc = ENC_UTF8;
+      enc = char_encoding_e::UTF8;
       return(true);
    }
 
    /* it is an unrecognized byte sequence */
-   enc = ENC_BYTE;
+   enc = char_encoding_e::BYTE;
    return(decode_bytes(in_data, out_data));
 } // decode_unicode
 
@@ -491,17 +491,17 @@ void write_bom(void)
 {
    switch (cpd.enc)
    {
-   case ENC_UTF8:
+   case char_encoding_e::UTF8:
       write_byte(0xef);
       write_byte(0xbb);
       write_byte(0xbf);
       break;
 
-   case ENC_UTF16_LE:
+   case char_encoding_e::UTF16_LE:
       write_utf16(0xfeff, false);
       break;
 
-   case ENC_UTF16_BE:
+   case char_encoding_e::UTF16_BE:
       write_utf16(0xfeff, true);
       break;
 
@@ -517,24 +517,24 @@ void write_char(int ch)
    {
       switch (cpd.enc)
       {
-      case ENC_BYTE:
+      case char_encoding_e::BYTE:
          write_byte(ch & 0xff);
          break;
 
-      case ENC_ASCII:
+      case char_encoding_e::ASCII:
       default:
          write_byte(ch);
          break;
 
-      case ENC_UTF8:
+      case char_encoding_e::UTF8:
          write_utf8(ch);
          break;
 
-      case ENC_UTF16_LE:
+      case char_encoding_e::UTF16_LE:
          write_utf16(ch, false);
          break;
 
-      case ENC_UTF16_BE:
+      case char_encoding_e::UTF16_BE:
          write_utf16(ch, true);
          break;
       }

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -27,7 +27,7 @@ void write_string(const unc_text &text);
 /**
  * Figure out the encoding and convert to an int sequence
  */
-bool decode_unicode(const vector<UINT8> &in_data, deque<int> &out_data, CharEncoding &enc, bool &has_bom);
+bool decode_unicode(const vector<UINT8> &in_data, deque<int> &out_data, char_encoding_e &enc, bool &has_bom);
 
 
 void encode_utf8(int ch, vector<UINT8> &res);


### PR DESCRIPTION
Now that we use C++11 I would like to refactor the enums so that they become strongly typed enums. This is also a good opportunity to rename and make them more standardized.

Tell me what you think about this. 
The ones I pushed are the easy cases. It gets more complicated when the enum values are used for calculations. For this cases the enum values need to be casted with the help of std::underlying_type.