### PR TITLE
Replace size zero check with empty()

### DIFF
--- a/src/ChunkStack.cpp
+++ b/src/ChunkStack.cpp
@@ -24,7 +24,7 @@ void ChunkStack::Set(const ChunkStack &cs)
 
 const ChunkStack::Entry *ChunkStack::Top() const
 {
-   if (m_cse.size() > 0)
+   if (!m_cse.empty())
    {
       return(&m_cse[m_cse.size() - 1]);
    }
@@ -56,7 +56,7 @@ chunk_t *ChunkStack::Pop_Front()
 {
    chunk_t *pc = NULL;
 
-   if (m_cse.size() > 0)
+   if (!m_cse.empty())
    {
       pc = m_cse[0].m_pc;
       m_cse.pop_front();
@@ -69,7 +69,7 @@ chunk_t *ChunkStack::Pop_Back()
 {
    chunk_t *pc = NULL;
 
-   if (m_cse.size() > 0)
+   if (!m_cse.empty())
    {
       pc = m_cse[m_cse.size() - 1].m_pc;
       m_cse.pop_back();

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1610,13 +1610,13 @@ static void uncrustify_start(const deque<int> &data)
    }
 
    /* Add the file header */
-   if (cpd.file_hdr.data.size() > 0)
+   if (!cpd.file_hdr.data.empty())
    {
       add_file_header();
    }
 
    /* Add the file footer */
-   if (cpd.file_ftr.data.size() > 0)
+   if (!cpd.file_ftr.data.empty())
    {
       add_file_footer();
    }
@@ -1721,7 +1721,7 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
       /**
        * Add comments before function defs and classes
        */
-      if (cpd.func_hdr.data.size() > 0)
+      if (!cpd.func_hdr.data.empty())
       {
          add_func_header(CT_FUNC_DEF, cpd.func_hdr);
          if (cpd.settings[UO_cmt_insert_before_ctor_dtor].b)
@@ -1729,11 +1729,11 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
             add_func_header(CT_FUNC_CLASS_DEF, cpd.func_hdr);
          }
       }
-      if (cpd.class_hdr.data.size() > 0)
+      if (!cpd.class_hdr.data.empty())
       {
          add_func_header(CT_CLASS, cpd.class_hdr);
       }
-      if (cpd.oc_msg_hdr.data.size() > 0)
+      if (!cpd.oc_msg_hdr.data.empty())
       {
          add_msg_header(CT_OC_MSG_DECL, cpd.oc_msg_hdr);
       }


### PR DESCRIPTION
This change is only visual.
Both std::deque size() and empty() on stl containers are O(1).

clang-tidy -fix -checks="-*, readability-container-size-empty"