### PR TITLE
Remove unnecessary else branches

### DIFF
--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -782,13 +782,15 @@ static bool check_complex_statements(parse_frame_t *frm, chunk_t *pc)
          frm->pse[frm->pse_tos].stage = brace_stage_e::PAREN1;
          return(false);
       }
-      else if (pc->type == CT_WHEN)
+
+      if (pc->type == CT_WHEN)
       {
          frm->pse[frm->pse_tos].type  = pc->type;
          frm->pse[frm->pse_tos].stage = brace_stage_e::OP_PAREN1;
          return(true);
       }
-      else if (pc->type == CT_BRACE_OPEN)
+
+      if (pc->type == CT_BRACE_OPEN)
       {
          frm->pse[frm->pse_tos].stage = brace_stage_e::BRACE2;
          return(false);
@@ -883,11 +885,9 @@ static bool handle_complex_close(parse_frame_t *frm, chunk_t *pc)
          frm->pse[frm->pse_tos].stage = brace_stage_e::CATCH_WHEN;
          return(true);
       }
-      else
-      {
-         /* PAREN1 always => BRACE2 */
-         frm->pse[frm->pse_tos].stage = brace_stage_e::BRACE2;
-      }
+
+      /* PAREN1 always => BRACE2 */
+      frm->pse[frm->pse_tos].stage = brace_stage_e::BRACE2;
    }
    else if (frm->pse[frm->pse_tos].stage == brace_stage_e::BRACE2)
    {

--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -553,7 +553,8 @@ static void convert_brace(chunk_t *br)
    {
       return;
    }
-   else if (br->type == CT_BRACE_OPEN)
+
+   if (br->type == CT_BRACE_OPEN)
    {
       set_chunk_type(br, CT_VBRACE_OPEN);
       br->str.clear();
@@ -584,7 +585,7 @@ static void convert_brace(chunk_t *br)
          }
       }
    }
-}
+} // convert_brace
 
 
 static void convert_vbrace(chunk_t *vbr)
@@ -594,7 +595,8 @@ static void convert_vbrace(chunk_t *vbr)
    {
       return;
    }
-   else if (vbr->type == CT_VBRACE_OPEN)
+
+   if (vbr->type == CT_VBRACE_OPEN)
    {
       set_chunk_type(vbr, CT_BRACE_OPEN);
       vbr->str = "{";

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2543,8 +2543,9 @@ static void fix_enum_struct_union(chunk_t *pc)
       {
          return;
       }
-      else if ((cpd.lang_flags & LANG_PAWN) &&
-               (next->type == CT_PAREN_OPEN))
+
+      if ((cpd.lang_flags & LANG_PAWN) &&
+          (next->type == CT_PAREN_OPEN))
       {
          next = set_paren_parent(next, CT_ENUM);
       }
@@ -3338,19 +3339,17 @@ static chunk_t *skip_expression(chunk_t *start)
  */
 bool go_on(chunk_t *pc, chunk_t *start)
 {
-   if ((pc == nullptr) ||
-       (pc->level != start->level))
+   if ((pc == nullptr) || (pc->level != start->level))
    {
       return(false);
    }
+
    if (pc->flags & PCF_IN_FOR)
    {
       return((!chunk_is_semicolon(pc)) && (!(pc->type == CT_COLON)));
    }
-   else
-   {
-      return(!chunk_is_semicolon(pc));
-   }
+
+   return(!chunk_is_semicolon(pc));
 } // go_on
 
 
@@ -3677,6 +3676,7 @@ static void mark_function(chunk_t *pc)
    {
       return;
    }
+
    next = skip_attribute_next(next);
    if (next == nullptr)
    {
@@ -3856,11 +3856,9 @@ static void mark_function(chunk_t *pc)
                mark_cpp_constructor(pc);
                return;
             }
-            else
-            {
-               /* Point to the item previous to the class name */
-               prev = chunk_get_prev_ncnlnp(prev);
-            }
+
+            /* Point to the item previous to the class name */
+            prev = chunk_get_prev_ncnlnp(prev);
          }
       }
    }

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -567,16 +567,14 @@ static void newline_min_after(chunk_t *ref, size_t count, UINT64 flag)
       newline_min_after(next, count, flag);
       return;
    }
-   else
+
+   chunk_flags_set(pc, flag);
+   if (chunk_is_newline(pc) && can_increase_nl(pc))
    {
-      chunk_flags_set(pc, flag);
-      if (chunk_is_newline(pc) && can_increase_nl(pc))
+      if (pc->nl_count < count)
       {
-         if (pc->nl_count < count)
-         {
-            pc->nl_count = count;
-            MARK_CHANGE();
-         }
+         pc->nl_count = count;
+         MARK_CHANGE();
       }
    }
 } // newline_min_after
@@ -1350,10 +1348,9 @@ static void newlines_do_else(chunk_t *start, argval_t nl_opt)
          LOG_FMT(LNL1LINE, "a new line may NOT be added\n");
          return;
       }
-      else
-      {
-         LOG_FMT(LNL1LINE, "a new line may be added\n");
-      }
+
+      LOG_FMT(LNL1LINE, "a new line may be added\n");
+
       if (next->type == CT_VBRACE_OPEN)
       {
          /* Can only add - we don't want to create a one-line here */
@@ -1602,10 +1599,8 @@ static void newlines_brace_pair(chunk_t *br_open)
       LOG_FMT(LNL1LINE, "a new line may NOT be added\n");
       return;
    }
-   else
-   {
-      LOG_FMT(LNL1LINE, "a new line may be added\n");
-   }
+
+   LOG_FMT(LNL1LINE, "a new line may be added\n");
 
    next = chunk_get_next_nc(br_open);
    chunk_t *prev;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1688,14 +1688,12 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
    }
 
    const option_map_value *tmp;
-   if ((entry->type == AT_NUM) ||
-       (entry->type == AT_UNUM))
+   if ((entry->type == AT_NUM) || (entry->type == AT_UNUM))
    {
-      if (unc_isdigit(*val) ||
-          (unc_isdigit(val[1]) && ((*val == '-') || (*val == '+'))))
+      if (unc_isdigit(*val)
+          || (unc_isdigit(val[1]) && ((*val == '-') || (*val == '+'))))
       {
-         if ((entry->type == AT_UNUM) &&
-             (*val == '-'))
+         if ((entry->type == AT_UNUM) && (*val == '-'))
          {
             fprintf(stderr, "%s:%d\n  for the option '%s' is a negative value not possible: %s",
                     cpd.filename, cpd.line_number, entry->name, val);
@@ -1705,50 +1703,42 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
          // is the same as dest->u
          return;
       }
-      else
-      {
-         /* Try to see if it is a variable */
-         int mult = 1;
-         if (*val == '-')
-         {
-            mult = -1;
-            val++;
-         }
 
-         tmp = unc_find_option(val);
-         if (tmp == nullptr)
-         {
-            fprintf(stderr, "%s:%d\n  for the assigment: unknown option '%s':",
-                    cpd.filename, cpd.line_number, val);
-            exit(EX_CONFIG);
-         }
-         // indent_case_brace = -indent_columns
-         LOG_FMT(LNOTE, "line_number=%d, entry(%s) %s, tmp(%s) %s\n",
-                 cpd.line_number,
-                 get_argtype_name(entry->type), entry->name,
-                 get_argtype_name(tmp->type), tmp->name);
-         if ((tmp->type == entry->type) ||
-             ((tmp->type == AT_UNUM) && (entry->type == AT_NUM)) ||
-             ((tmp->type == AT_NUM) && (entry->type == AT_UNUM) && (cpd.settings[tmp->id].n * mult) > 0))
-         {
-            dest->n = cpd.settings[tmp->id].n * mult;
-            // is the same as dest->u
-            return;
-         }
-         else
-         {
-            fprintf(stderr, "%s:%d\n  for the assigment: expected type for %s is %s, got %s\n",
-                    cpd.filename, cpd.line_number,
-                    entry->name, get_argtype_name(entry->type), get_argtype_name(tmp->type));
-            exit(EX_CONFIG);
-         }
+      /* Try to see if it is a variable */
+      int mult = 1;
+      if (*val == '-')
+      {
+         mult = -1;
+         val++;
       }
-      fprintf(stderr, "%s:%d Expected a number for %s, got %s\n",
-              cpd.filename, cpd.line_number, entry->name, val);
-      cpd.error_count++;
-      dest->n = 0;
-      // is the same as dest->u
-      return;
+
+      tmp = unc_find_option(val);
+      if (tmp == nullptr)
+      {
+         fprintf(stderr, "%s:%d\n  for the assigment: unknown option '%s':",
+                 cpd.filename, cpd.line_number, val);
+         exit(EX_CONFIG);
+      }
+
+      // indent_case_brace = -indent_columns
+      LOG_FMT(LNOTE, "line_number=%d, entry(%s) %s, tmp(%s) %s\n",
+              cpd.line_number, get_argtype_name(entry->type),
+              entry->name, get_argtype_name(tmp->type), tmp->name);
+
+      if ((tmp->type == entry->type)
+          || ((tmp->type == AT_UNUM) && (entry->type == AT_NUM))
+          || ((tmp->type == AT_NUM) && (entry->type == AT_UNUM)
+              && (cpd.settings[tmp->id].n * mult) > 0))
+      {
+         dest->n = cpd.settings[tmp->id].n * mult;
+         // is the same as dest->u
+         return;
+      }
+
+      fprintf(stderr, "%s:%d\n  for the assigment: expected type for %s is %s, got %s\n",
+              cpd.filename, cpd.line_number,
+              entry->name, get_argtype_name(entry->type), get_argtype_name(tmp->type));
+      exit(EX_CONFIG);
    }
 
    if (entry->type == AT_BOOL)
@@ -1781,6 +1771,7 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
          dest->b = cpd.settings[tmp->id].b ? btrue : !btrue;
          return;
       }
+
       fprintf(stderr, "%s:%d Expected 'True' or 'False' for %s, got %s\n",
               cpd.filename, cpd.line_number, entry->name, val);
       cpd.error_count++;
@@ -2353,10 +2344,8 @@ string bool_to_string(bool val)
    {
       return("true");
    }
-   else
-   {
-      return("false");
-   }
+
+   return("false");
 }
 
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -93,7 +93,8 @@ static void add_char(UINT32 ch)
          }
          return;
       }
-      else if ((ch == ' ') && !cpd.output_trailspace)
+
+      if ((ch == ' ') && !cpd.output_trailspace)
       {
          cpd.spaces++;
          cpd.column++;

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -500,11 +500,9 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
             log_rule("sp_between_mdatype_commas");
             return(cpd.settings[UO_sp_between_mdatype_commas].a);
          }
-         else
-         {
-            log_rule("sp_after_mdatype_commas");
-            return(cpd.settings[UO_sp_after_mdatype_commas].a);
-         }
+
+         log_rule("sp_after_mdatype_commas");
+         return(cpd.settings[UO_sp_after_mdatype_commas].a);
       }
       else
       {
@@ -1239,14 +1237,14 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
          log_rule("sp_after_oc_return_type");
          return(cpd.settings[UO_sp_after_oc_return_type].a);
       }
-      else if ((first->parent_type == CT_OC_MSG_SPEC) ||
-               (first->parent_type == CT_OC_MSG_DECL))
+
+      if ((first->parent_type == CT_OC_MSG_SPEC) || (first->parent_type == CT_OC_MSG_DECL))
       {
          log_rule("sp_after_oc_type");
          return(cpd.settings[UO_sp_after_oc_type].a);
       }
-      else if ((first->parent_type == CT_OC_SEL) &&
-               (second->type != CT_SQUARE_CLOSE))
+
+      if ((first->parent_type == CT_OC_SEL) && (second->type != CT_SQUARE_CLOSE))
       {
          log_rule("sp_after_oc_at_sel_parens");
          return(cpd.settings[UO_sp_after_oc_at_sel_parens].a);
@@ -1453,13 +1451,15 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
          log_rule("sp_deref");
          return(cpd.settings[UO_sp_deref].a);
       }
+
       if ((second->type == CT_QUALIFIER) &&
           (cpd.settings[UO_sp_after_ptr_star_qualifier].a != AV_IGNORE))
       {
          log_rule("sp_after_ptr_star_qualifier");
          return(cpd.settings[UO_sp_after_ptr_star_qualifier].a);
       }
-      else if (cpd.settings[UO_sp_after_ptr_star].a != AV_IGNORE)
+
+      if (cpd.settings[UO_sp_after_ptr_star].a != AV_IGNORE)
       {
          log_rule("sp_after_ptr_star");
          return(cpd.settings[UO_sp_after_ptr_star].a);
@@ -1538,12 +1538,14 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
          log_rule("sp_brace_else");
          return(cpd.settings[UO_sp_brace_else].a);
       }
-      else if (second->type == CT_CATCH)
+
+      if (second->type == CT_CATCH)
       {
          log_rule("sp_brace_catch");
          return(cpd.settings[UO_sp_brace_catch].a);
       }
-      else if (second->type == CT_FINALLY)
+
+      if (second->type == CT_FINALLY)
       {
          log_rule("sp_brace_finally");
          return(cpd.settings[UO_sp_brace_finally].a);
@@ -1557,13 +1559,14 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
          log_rule("sp_inside_braces_enum");
          return(cpd.settings[UO_sp_inside_braces_enum].a);
       }
-      else if ((first->parent_type == CT_UNION) ||
-               (first->parent_type == CT_STRUCT))
+
+      if ((first->parent_type == CT_UNION) || (first->parent_type == CT_STRUCT))
       {
          log_rule("sp_inside_braces_struct");
          return(cpd.settings[UO_sp_inside_braces_struct].a);
       }
-      else if (!chunk_is_comment(second))
+
+      if (!chunk_is_comment(second))
       {
          log_rule("sp_inside_braces");
          return(cpd.settings[UO_sp_inside_braces].a);
@@ -1577,12 +1580,13 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
          log_rule("sp_inside_braces_enum");
          return(cpd.settings[UO_sp_inside_braces_enum].a);
       }
-      else if ((second->parent_type == CT_UNION) ||
-               (second->parent_type == CT_STRUCT))
+
+      if ((second->parent_type == CT_UNION) || (second->parent_type == CT_STRUCT))
       {
          log_rule("sp_inside_braces_struct");
          return(cpd.settings[UO_sp_inside_braces_struct].a);
       }
+
       log_rule("sp_inside_braces");
       return(cpd.settings[UO_sp_inside_braces].a);
    }
@@ -1699,26 +1703,21 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
          log_rule("sp_after_send_oc_colon");
          return(cpd.settings[UO_sp_after_send_oc_colon].a);
       }
-      else
-      {
-         log_rule("sp_after_oc_colon");
-         return(cpd.settings[UO_sp_after_oc_colon].a);
-      }
+
+      log_rule("sp_after_oc_colon");
+      return(cpd.settings[UO_sp_after_oc_colon].a);
    }
    if (second->type == CT_OC_COLON)
    {
-      if ((first->flags & PCF_IN_OC_MSG) &&
-          ((first->type == CT_OC_MSG_FUNC) ||
-           (first->type == CT_OC_MSG_NAME)))
+      if ((first->flags & PCF_IN_OC_MSG)
+          && ((first->type == CT_OC_MSG_FUNC) || (first->type == CT_OC_MSG_NAME)))
       {
          log_rule("sp_before_send_oc_colon");
          return(cpd.settings[UO_sp_before_send_oc_colon].a);
       }
-      else
-      {
-         log_rule("sp_before_oc_colon");
-         return(cpd.settings[UO_sp_before_oc_colon].a);
-      }
+
+      log_rule("sp_before_oc_colon");
+      return(cpd.settings[UO_sp_before_oc_colon].a);
    }
 
    if ((second->type == CT_COMMENT) && (second->parent_type == CT_COMMENT_EMBED))

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -335,7 +335,8 @@ static bool d_parse_string(tok_ctx &ctx, chunk_t &pc)
    {
       return(parse_string(ctx, pc, 0, true));
    }
-   else if (ch == '\\')
+
+   if (ch == '\\')
    {
       ctx.save();
       int cnt;
@@ -1722,8 +1723,9 @@ static bool parse_next(tok_ctx &ctx, chunk_t &pc)
             parse_string(ctx, pc, 1, (ctx.peek() == '!'));
             return(true);
          }
-         else if (((ctx.peek(1) == '\\') || (ctx.peek(1) == '!')) &&
-                  (ctx.peek(2) == '"'))
+
+         if (((ctx.peek(1) == '\\') || (ctx.peek(1) == '!'))
+             && (ctx.peek(2) == '"'))
          {
             parse_string(ctx, pc, 2, false);
             return(true);
@@ -1800,7 +1802,8 @@ static bool parse_next(tok_ctx &ctx, chunk_t &pc)
          parse_string(ctx, pc, 1, true);
          return(true);
       }
-      else if ((nc >= '0') && (nc <= '9'))
+
+      if ((nc >= '0') && (nc <= '9'))
       {
          /* literal number */
          pc.str.append(ctx.get());  /* store the '@' */

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -77,16 +77,16 @@ int unc_text::compare(const unc_text &ref1, const unc_text &ref2, size_t len)
          // so the order is the reverse of ASCII order (we negate).
          return(-(ref1.m_chars[idx] - ref2.m_chars[idx]));
       }
-      else
-      {
-         // return the case-insensitive diff to sort alphabetically
-         return(diff);
-      }
+
+      // return the case-insensitive diff to sort alphabetically
+      return(diff);
    }
+
    if (idx == len)
    {
       return(0);
    }
+
    return(len1 - len2);
 }
 

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -344,15 +344,15 @@ static bool decode_bom(const vector<UINT8> &in_data, char_encoding_e &enc)
          enc = char_encoding_e::UTF16_BE;
          return(true);
       }
-      else if ((in_data[0] == 0xff) && (in_data[1] == 0xfe))
+
+      if ((in_data[0] == 0xff) && (in_data[1] == 0xfe))
       {
          enc = char_encoding_e::UTF16_LE;
          return(true);
       }
-      else if ((in_data.size() >= 3) &&
-               (in_data[0] == 0xef) &&
-               (in_data[1] == 0xbb) &&
-               (in_data[2] == 0xbf))
+
+      if ((in_data.size() >= 3) && (in_data[0] == 0xef) && (in_data[1] == 0xbb)
+          && (in_data[2] == 0xbf))
       {
          enc = char_encoding_e::UTF8;
          return(true);
@@ -372,10 +372,8 @@ bool decode_unicode(const vector<UINT8> &in_data, deque<int> &out_data, char_enc
       {
          return(decode_utf8(in_data, out_data));
       }
-      else
-      {
-         return(decode_utf16(in_data, out_data, enc));
-      }
+
+      return(decode_utf16(in_data, out_data, enc));
    }
    has_bom = false;
 


### PR DESCRIPTION
clang-tidy -fix -checks="-*, readability-else-after-return"

Also removes unreachable code in options.cpp convert_value()