### PR TITLE
Fix align_assign and an unstable test

### DIFF
--- a/src/align.h
+++ b/src/align.h
@@ -53,7 +53,7 @@ chunk_t *align_nl_cont(chunk_t *start);
  * For variable definitions, only consider the '=' for the first variable.
  * Otherwise, only look at the first '=' on the line.
  */
-chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh);
+chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_count);
 
 
 void quick_align_again(void);

--- a/tests/output/oc/50007-misc.m
+++ b/tests/output/oc/50007-misc.m
@@ -2,7 +2,7 @@
 {
    GLfloat wc[3][3] = { { 0.6, 0.6, 0.0 }, { 1.0, 0.7, 0.1 }, { 0.5, 0.7, 0.2 }, };
    GLfloat cc[3][3] = { { 0.0, 0.0, 0.6 }, { 0.3, 0.1, 0.5 }, { 0.0, 0.0, 0.5 }, };
-   GLfloat sc[3] = { 0.75, 0.75, 0.75 };
+   GLfloat sc[3]    = { 0.75, 0.75, 0.75 };
 
    return [self initWithWarmColors: (float *)&wc
                         coolColors: (float *)&cc


### PR DESCRIPTION
To determine how many new lines have spanned, use the count from the
NEWLINE token.  Before, this span was determined from the difference
of the original line numbers.  Since other functions might insert or
remove new lines, it would generate different output depending on the
input.  This made test 50007 unstable.

This new method was ported from align_var_def_brace.