### PR TITLE
Fix align_assign to work at brace level 0

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -686,7 +686,7 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
    size_t  equ_count   = 0;
    size_t  tmp;
    chunk_t *pc = first;
-   while ((pc != nullptr) && ((pc->level >= my_level) || (pc->level == 0)))
+   while (pc != nullptr)
    {
       /* Don't check inside PAREN or SQUARE groups */
       if ((pc->type == CT_SPAREN_OPEN) ||
@@ -735,6 +735,14 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
             }
          }
          continue;
+      }
+
+      /* Done with this brace set? */
+      if ((pc->type == CT_BRACE_CLOSE) ||
+          (pc->type == CT_VBRACE_CLOSE))
+      {
+         pc = chunk_get_next(pc);
+         break;
       }
 
       if (chunk_is_newline(pc))

--- a/src/align.h
+++ b/src/align.h
@@ -53,7 +53,7 @@ chunk_t *align_nl_cont(chunk_t *start);
  * For variable definitions, only consider the '=' for the first variable.
  * Otherwise, only look at the first '=' on the line.
  */
-chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh);
+chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_count);
 
 
 void quick_align_again(void);

--- a/tests/output/d/40024-tst03.d
+++ b/tests/output/d/40024-tst03.d
@@ -126,9 +126,9 @@ int[3] c = [ black:3, green:2, red:5 ];
 char[]  file        = `c:\root\file.c`;
 char[]  quoteString = \"  r"[^\\]*(\\.[^\\]*)*"  \";
 
-char[]  hello       = "hello world" \n;
-char[]  foo_ascii   = "hello";     // string is taken to be ascii
-wchar[] foo_wchar   = "hello";     // string is taken to be wchar
+char[]  hello     = "hello world" \n;
+char[]  foo_ascii = "hello";       // string is taken to be ascii
+wchar[] foo_wchar = "hello";       // string is taken to be wchar
 
 enum COLORS { red, blue, green };
 

--- a/tests/output/d/40025-tst03.d
+++ b/tests/output/d/40025-tst03.d
@@ -126,9 +126,9 @@ int[ 3 ] c = [ black:3, green:2, red:5 ];
 char[]  file        = `c:\root\file.c`;
 char[]  quoteString = \"  r"[^\\]*(\\.[^\\]*)*"  \";
 
-char[]  hello       = "hello world" \n;
-char[]  foo_ascii   = "hello";     // string is taken to be ascii
-wchar[] foo_wchar   = "hello";     // string is taken to be wchar
+char[]  hello     = "hello world" \n;
+char[]  foo_ascii = "hello";       // string is taken to be ascii
+wchar[] foo_wchar = "hello";       // string is taken to be wchar
 
 enum COLORS { red, blue, green };
 

--- a/tests/output/oc/50007-misc.m
+++ b/tests/output/oc/50007-misc.m
@@ -2,7 +2,7 @@
 {
    GLfloat wc[3][3] = { { 0.6, 0.6, 0.0 }, { 1.0, 0.7, 0.1 }, { 0.5, 0.7, 0.2 }, };
    GLfloat cc[3][3] = { { 0.0, 0.0, 0.6 }, { 0.3, 0.1, 0.5 }, { 0.0, 0.0, 0.5 }, };
-   GLfloat sc[3] = { 0.75, 0.75, 0.75 };
+   GLfloat sc[3]    = { 0.75, 0.75, 0.75 };
 
    return [self initWithWarmColors: (float *)&wc
                         coolColors: (float *)&cc


### PR DESCRIPTION
To determine how many new lines have spanned, use the count from the
NEWLINE token.  Before, this span was determined from the difference
of the original line numbers.  Since other functions might insert or
remove new lines, it would generate different output depending on the
input.  This made test 50007 unstable.

This new method was ported from align_var_def_brace.