### PR TITLE
Allow align_enum_equ* without align_assign_span

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -404,10 +404,14 @@ void align_all(void)
    }
 
    /* Align assignments */
-   align_assign(chunk_get_head(),
-                cpd.settings[UO_align_assign_span].u,
-                cpd.settings[UO_align_assign_thresh].u,
-                nullptr);
+   if ((cpd.settings[UO_align_enum_equ_span].u > 0) ||
+       (cpd.settings[UO_align_assign_span].u > 0))
+   {
+      align_assign(chunk_get_head(),
+                   cpd.settings[UO_align_assign_span].u,
+                   cpd.settings[UO_align_assign_thresh].u,
+                   nullptr);
+   }
 
    /* Align structure initializers */
    if (cpd.settings[UO_align_struct_init_span].u > 0)
@@ -664,11 +668,6 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
       return(nullptr);
    }
    size_t my_level = first->level;
-
-   if (span == 0)
-   {
-      return(chunk_get_next(first));
-   }
 
    LOG_FMT(LALASS, "%s[%zu]: checking %s on line %zu - span=%zu thresh=%zu\n",
            __func__, my_level, first->text(), first->orig_line, span, thresh);

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -686,7 +686,7 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
    size_t  equ_count   = 0;
    size_t  tmp;
    chunk_t *pc = first;
-   while ((pc != nullptr) && ((pc->level >= my_level) || (pc->level == 0)))
+   while (pc != nullptr)
    {
       /* Don't check inside PAREN or SQUARE groups */
       if ((pc->type == CT_SPAREN_OPEN) ||
@@ -735,6 +735,14 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
             }
          }
          continue;
+      }
+
+      /* Done with this brace set? */
+      if ((pc->type == CT_BRACE_CLOSE) ||
+          (pc->type == CT_VBRACE_CLOSE))
+      {
+         pc = chunk_get_next(pc);
+         break;
       }
 
       if (chunk_is_newline(pc))

--- a/src/align.h
+++ b/src/align.h
@@ -53,7 +53,7 @@ chunk_t *align_nl_cont(chunk_t *start);
  * For variable definitions, only consider the '=' for the first variable.
  * Otherwise, only look at the first '=' on the line.
  */
-chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh);
+chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_count);
 
 
 void quick_align_again(void);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1348,8 +1348,7 @@ void register_options(void)
    unc_add_option("align_assign_thresh", UO_align_assign_thresh, AT_UNUM,
                   "The threshold for aligning on '=' in assignments (0=no limit)", "", 0, 5000);
    unc_add_option("align_enum_equ_span", UO_align_enum_equ_span, AT_UNUM,
-                  "The span for aligning on '=' in enums (0=don't align)\n"
-                  "Note: align_assign_span must be set also.", "", 0, 5000);
+                  "The span for aligning on '=' in enums (0=don't align)", "", 0, 5000);
    unc_add_option("align_enum_equ_thresh", UO_align_enum_equ_thresh, AT_UNUM,
                   "The threshold for aligning on '=' in enums (0=no limit)", "", 0, 5000);
    unc_add_option("align_var_class_span", UO_align_var_class_span, AT_UNUM,

--- a/tests/config/enum.cfg
+++ b/tests/config/enum.cfg
@@ -1,6 +1,5 @@
 indent_columns                = 3
 
-align_assign_span             = 1
 align_enum_equ_span           = 4
 align_enum_equ_thresh         = 8
 align_right_cmt_span          = 3

--- a/tests/output/d/40024-tst03.d
+++ b/tests/output/d/40024-tst03.d
@@ -126,9 +126,9 @@ int[3] c = [ black:3, green:2, red:5 ];
 char[]  file        = `c:\root\file.c`;
 char[]  quoteString = \"  r"[^\\]*(\\.[^\\]*)*"  \";
 
-char[]  hello       = "hello world" \n;
-char[]  foo_ascii   = "hello";     // string is taken to be ascii
-wchar[] foo_wchar   = "hello";     // string is taken to be wchar
+char[]  hello     = "hello world" \n;
+char[]  foo_ascii = "hello";       // string is taken to be ascii
+wchar[] foo_wchar = "hello";       // string is taken to be wchar
 
 enum COLORS { red, blue, green };
 

--- a/tests/output/d/40025-tst03.d
+++ b/tests/output/d/40025-tst03.d
@@ -126,9 +126,9 @@ int[ 3 ] c = [ black:3, green:2, red:5 ];
 char[]  file        = `c:\root\file.c`;
 char[]  quoteString = \"  r"[^\\]*(\\.[^\\]*)*"  \";
 
-char[]  hello       = "hello world" \n;
-char[]  foo_ascii   = "hello";     // string is taken to be ascii
-wchar[] foo_wchar   = "hello";     // string is taken to be wchar
+char[]  hello     = "hello world" \n;
+char[]  foo_ascii = "hello";       // string is taken to be ascii
+wchar[] foo_wchar = "hello";       // string is taken to be wchar
 
 enum COLORS { red, blue, green };
 

--- a/tests/output/oc/50007-misc.m
+++ b/tests/output/oc/50007-misc.m
@@ -2,7 +2,7 @@
 {
    GLfloat wc[3][3] = { { 0.6, 0.6, 0.0 }, { 1.0, 0.7, 0.1 }, { 0.5, 0.7, 0.2 }, };
    GLfloat cc[3][3] = { { 0.0, 0.0, 0.6 }, { 0.3, 0.1, 0.5 }, { 0.0, 0.0, 0.5 }, };
-   GLfloat sc[3] = { 0.75, 0.75, 0.75 };
+   GLfloat sc[3]    = { 0.75, 0.75, 0.75 };
 
    return [self initWithWarmColors: (float *)&wc
                         coolColors: (float *)&cc


### PR DESCRIPTION
Fix issue #1030 to allow align_enum_equ_span and
align_enum_equ_threshold to be set without setting align_assign_span.

Remove align_assign_span from enum.cfg to effectively make 33110 a
regression test.