### PR TITLE
Add options for new Operator function

### DIFF
--- a/scripts/More_Options_to_Test/help.txt
+++ b/scripts/More_Options_to_Test/help.txt
@@ -70,6 +70,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with 
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 576 options and minimal documentation.
+There are currently 580 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -996,7 +996,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
          ts  = tmp;
          tmp = chunk_get_next_ncnl(tmp);
       }
-      if (tmp && (tmp->type == CT_BRACE_OPEN))
+      if (tmp && (tmp->type == CT_BRACE_OPEN || CT_PAREN_OPEN))
       {
          set_paren_parent(tmp, pc->type);
          if (ts)

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -664,6 +664,8 @@ void register_options(void)
                   "Controls the spaces after 'new', 'delete' and 'delete[]'");
    unc_add_option("sp_between_new_paren", UO_sp_between_new_paren, AT_IARF,
                   "Controls the spaces between new and '(' in 'new()'");
+   unc_add_option("sp_after_newop_paren", UO_sp_after_newop_paren, AT_IARF,
+                  "Controls the spaces between ')' and 'type' in 'new(foo) BAR'");
    unc_add_option("sp_before_tr_emb_cmt", UO_sp_before_tr_emb_cmt, AT_IARF,
                   "Controls the spaces before a trailing or embedded comment");
    unc_add_option("sp_num_before_tr_emb_cmt", UO_sp_num_before_tr_emb_cmt, AT_UNUM,

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -666,6 +666,8 @@ void register_options(void)
                   "Controls the spaces between new and '(' in 'new()'");
    unc_add_option("sp_after_newop_paren", UO_sp_after_newop_paren, AT_IARF,
                   "Controls the spaces between ')' and 'type' in 'new(foo) BAR'");
+   unc_add_option("sp_inside_newop_paren", UO_sp_inside_newop_paren, AT_IARF,
+                  "Controls the spaces inside paren of the new operator: 'new(foo) BAR'");
    unc_add_option("sp_before_tr_emb_cmt", UO_sp_before_tr_emb_cmt, AT_IARF,
                   "Controls the spaces before a trailing or embedded comment");
    unc_add_option("sp_num_before_tr_emb_cmt", UO_sp_num_before_tr_emb_cmt, AT_UNUM,

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -668,6 +668,10 @@ void register_options(void)
                   "Controls the spaces between ')' and 'type' in 'new(foo) BAR'");
    unc_add_option("sp_inside_newop_paren", UO_sp_inside_newop_paren, AT_IARF,
                   "Controls the spaces inside paren of the new operator: 'new(foo) BAR'");
+   unc_add_option("sp_inside_newop_paren_open", UO_sp_inside_newop_paren_open, AT_IARF,
+                  "Controls the space after open paren of the new operator: 'new(foo) BAR'");
+   unc_add_option("sp_inside_newop_paren_close", UO_sp_inside_newop_paren_close, AT_IARF,
+                  "Controls the space before close paren of the new operator: 'new(foo) BAR'");
    unc_add_option("sp_before_tr_emb_cmt", UO_sp_before_tr_emb_cmt, AT_IARF,
                   "Controls the spaces before a trailing or embedded comment");
    unc_add_option("sp_num_before_tr_emb_cmt", UO_sp_num_before_tr_emb_cmt, AT_UNUM,

--- a/src/options.h
+++ b/src/options.h
@@ -302,6 +302,7 @@ enum uncrustify_options
    UO_sp_endif_cmt,                //
    UO_sp_after_new,                //
    UO_sp_between_new_paren,        //
+   UO_sp_after_newop_paren,        //
    UO_sp_before_tr_emb_cmt,        // treatment of spaces before comments following code
    UO_sp_num_before_tr_emb_cmt,    // number of spaces before comments following code
    UO_sp_annotation_paren,         //

--- a/src/options.h
+++ b/src/options.h
@@ -303,6 +303,7 @@ enum uncrustify_options
    UO_sp_after_new,                //
    UO_sp_between_new_paren,        //
    UO_sp_after_newop_paren,        //
+   UO_sp_inside_newop_paren,       //
    UO_sp_before_tr_emb_cmt,        // treatment of spaces before comments following code
    UO_sp_num_before_tr_emb_cmt,    // number of spaces before comments following code
    UO_sp_annotation_paren,         //

--- a/src/options.h
+++ b/src/options.h
@@ -304,6 +304,8 @@ enum uncrustify_options
    UO_sp_between_new_paren,        //
    UO_sp_after_newop_paren,        //
    UO_sp_inside_newop_paren,       //
+   UO_sp_inside_newop_paren_open,  //
+   UO_sp_inside_newop_paren_close, //
    UO_sp_before_tr_emb_cmt,        // treatment of spaces before comments following code
    UO_sp_num_before_tr_emb_cmt,    // number of spaces before comments following code
    UO_sp_annotation_paren,         //

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1314,6 +1314,14 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
          log_rule("sp_inside_paren_cast");
          return(cpd.settings[UO_sp_inside_paren_cast].a);
       }
+      if (first->parent_type == CT_NEW)
+      {
+         if(cpd.settings[UO_sp_inside_newop_paren].a != AV_IGNORE)
+         {
+            log_rule("sp_inside_newop_paren");
+            return(cpd.settings[UO_sp_inside_newop_paren].a);
+         }
+      }
       log_rule("sp_inside_paren");
       return(cpd.settings[UO_sp_inside_paren].a);
    }
@@ -1326,6 +1334,14 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
       {
          log_rule("sp_inside_paren_cast");
          return(cpd.settings[UO_sp_inside_paren_cast].a);
+      }
+      if (second->parent_type == CT_NEW)
+      {
+         if(cpd.settings[UO_sp_inside_newop_paren].a != AV_IGNORE)
+         {
+            log_rule("sp_inside_newop_paren");
+            return(cpd.settings[UO_sp_inside_newop_paren].a);
+         }
       }
       log_rule("sp_inside_paren");
       return(cpd.settings[UO_sp_inside_paren].a);

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1228,6 +1228,13 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
          log_rule("ADD");
          return(AV_ADD);
       }
+
+      /* C++ new operator: new(bar) Foo */
+      if (first->parent_type == CT_NEW)
+      {
+         log_rule("sp_after_newop_paren");
+         return(cpd.settings[UO_sp_after_newop_paren].a);
+      }
    }
 
    /* "foo(...)" vs "foo( ... )" */
@@ -1761,6 +1768,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
 
    if ((first->type == CT_NEW) && (second->type == CT_PAREN_OPEN))
    {
+      // c# new Constraint, c++ new operator
       log_rule("sp_between_new_paren");
       return(cpd.settings[UO_sp_between_new_paren].a);
    }

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -583,14 +583,6 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
       return(AV_REMOVE);
    }
 
-   /* "((" vs "( (" or "))" vs ") )" */
-   if ((chunk_is_str(first, "(", 1) && chunk_is_str(second, "(", 1)) ||
-       (chunk_is_str(first, ")", 1) && chunk_is_str(second, ")", 1)))
-   {
-      log_rule("sp_paren_paren");
-      return(cpd.settings[UO_sp_paren_paren].a);
-   }
-
    if ((first->type == CT_CATCH) && (second->type == CT_SPAREN_OPEN) &&
        (cpd.settings[UO_sp_catch_paren].a != AV_IGNORE))
    {
@@ -1822,6 +1814,14 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
    {
       log_rule("sp_extern_paren");
       return(cpd.settings[UO_sp_extern_paren].a);
+   }
+
+   /* "((" vs "( (" or "))" vs ") )" */
+   if ((chunk_is_str(first, "(", 1) && chunk_is_str(second, "(", 1)) ||
+       (chunk_is_str(first, ")", 1) && chunk_is_str(second, ")", 1)))
+   {
+      log_rule("sp_paren_paren");
+      return(cpd.settings[UO_sp_paren_paren].a);
    }
 
    // this table lists out all combos where a space should NOT be present

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1316,7 +1316,12 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
       }
       if (first->parent_type == CT_NEW)
       {
-         if(cpd.settings[UO_sp_inside_newop_paren].a != AV_IGNORE)
+         if (cpd.settings[UO_sp_inside_newop_paren_open].a != AV_IGNORE)
+         {
+            log_rule("sp_inside_newop_paren_open");
+            return(cpd.settings[UO_sp_inside_newop_paren_open].a);
+         }
+         if (cpd.settings[UO_sp_inside_newop_paren].a != AV_IGNORE)
          {
             log_rule("sp_inside_newop_paren");
             return(cpd.settings[UO_sp_inside_newop_paren].a);
@@ -1337,7 +1342,12 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
       }
       if (second->parent_type == CT_NEW)
       {
-         if(cpd.settings[UO_sp_inside_newop_paren].a != AV_IGNORE)
+         if (cpd.settings[UO_sp_inside_newop_paren_close].a != AV_IGNORE)
+         {
+            log_rule("sp_inside_newop_paren_close");
+            return(cpd.settings[UO_sp_inside_newop_paren_close].a);
+         }
+         if (cpd.settings[UO_sp_inside_newop_paren].a != AV_IGNORE)
          {
             log_rule("sp_inside_newop_paren");
             return(cpd.settings[UO_sp_inside_newop_paren].a);

--- a/tests/config/new_op_a.cfg
+++ b/tests/config/new_op_a.cfg
@@ -1,2 +1,3 @@
 sp_between_new_paren=add
 sp_after_newop_paren=add
+sp_inside_newop_paren=add

--- a/tests/config/new_op_a.cfg
+++ b/tests/config/new_op_a.cfg
@@ -1,0 +1,2 @@
+sp_between_new_paren=add
+sp_after_newop_paren=add

--- a/tests/config/new_op_f.cfg
+++ b/tests/config/new_op_f.cfg
@@ -1,2 +1,3 @@
 sp_between_new_paren=force
 sp_after_newop_paren=force
+sp_inside_newop_paren=force

--- a/tests/config/new_op_f.cfg
+++ b/tests/config/new_op_f.cfg
@@ -1,0 +1,2 @@
+sp_between_new_paren=force
+sp_after_newop_paren=force

--- a/tests/config/new_op_paren_open_close.cfg
+++ b/tests/config/new_op_paren_open_close.cfg
@@ -1,0 +1,2 @@
+sp_inside_newop_paren_close=remove
+sp_inside_newop_paren_open=force

--- a/tests/config/new_op_r.cfg
+++ b/tests/config/new_op_r.cfg
@@ -1,0 +1,2 @@
+sp_between_new_paren=remove
+sp_after_newop_paren=remove

--- a/tests/config/new_op_r.cfg
+++ b/tests/config/new_op_r.cfg
@@ -1,2 +1,3 @@
 sp_between_new_paren=remove
 sp_after_newop_paren=remove
+sp_inside_newop_paren=remove

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -384,3 +384,4 @@
 34132 new_op_a.cfg                     cpp/new_op.cpp
 34133 new_op_f.cfg                     cpp/new_op.cpp
 34134 new_op_r.cfg                     cpp/new_op.cpp
+34135 new_op_paren_open_close.cfg      cpp/new_op.cpp

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -380,3 +380,7 @@
 
 34130 bug_i_1000-f.cfg                 cpp/bug_i_1000.cpp
 34131 bug_i_1000-r.cfg                 cpp/bug_i_1000.cpp
+
+34132 new_op_a.cfg                     cpp/new_op.cpp
+34133 new_op_f.cfg                     cpp/new_op.cpp
+34134 new_op_r.cfg                     cpp/new_op.cpp

--- a/tests/input/cpp/new_op.cpp
+++ b/tests/input/cpp/new_op.cpp
@@ -1,0 +1,9 @@
+Foo* foo = new Foo(a,v);
+
+Foo* foo = new(ptr,std::nothrow)Foo[];
+Foo* foo = new(ptr)Foo();
+Foo* foo = new(FOO(ptr))Foo();
+
+Foo* foo = new  (  ptr,std::nothrow  )  Foo[];
+Foo* foo = new  (  ptr  )  Foo();
+Foo* foo = new  (  FOO(ptr)  )  Foo();

--- a/tests/output/cpp/30064-class-init.cpp
+++ b/tests/output/cpp/30064-class-init.cpp
@@ -6,7 +6,7 @@ class Foo
 };
 
 #define CTOR( i, _ ) \
-      : T( X()), \
+      : T( X() ), \
         y() \
    { }
 

--- a/tests/output/cpp/30066-class-init.cpp
+++ b/tests/output/cpp/30066-class-init.cpp
@@ -4,7 +4,7 @@ class Foo : public Bar
 
 };
 
-#define CTOR( i, _ ) : T( X()) \
+#define CTOR( i, _ ) : T( X() ) \
                      , y() \
 { }
 

--- a/tests/output/cpp/30924-sp_before_ellipsis.cpp
+++ b/tests/output/cpp/30924-sp_before_ellipsis.cpp
@@ -1,8 +1,8 @@
 
-void log_fmt( log_sev_t sev, const char *fmt, ... ) __attribute__(( format( printf, 2, 3 )));
+void log_fmt( log_sev_t sev, const char *fmt, ... ) __attribute__( ( format( printf, 2, 3 ) ) );
 
 #define LOG_FMT( sev, args... )                           \
-	do { if ( log_sev_on( sev )) { log_fmt( sev, ## args ); } } while ( 0 )
+	do { if ( log_sev_on( sev ) ) { log_fmt( sev, ## args ); } } while ( 0 )
 #endif
 
 void foo()

--- a/tests/output/cpp/34132-new_op.cpp
+++ b/tests/output/cpp/34132-new_op.cpp
@@ -1,0 +1,9 @@
+Foo* foo = new Foo(a,v);
+
+Foo* foo = new (ptr,std::nothrow) Foo[];
+Foo* foo = new (ptr) Foo();
+Foo* foo = new (FOO(ptr)) Foo();
+
+Foo* foo = new  (  ptr,std::nothrow  )  Foo[];
+Foo* foo = new  (  ptr  )  Foo();
+Foo* foo = new  (  FOO(ptr)  )  Foo();

--- a/tests/output/cpp/34132-new_op.cpp
+++ b/tests/output/cpp/34132-new_op.cpp
@@ -1,8 +1,8 @@
 Foo* foo = new Foo(a,v);
 
-Foo* foo = new (ptr,std::nothrow) Foo[];
-Foo* foo = new (ptr) Foo();
-Foo* foo = new (FOO(ptr)) Foo();
+Foo* foo = new ( ptr,std::nothrow ) Foo[];
+Foo* foo = new ( ptr ) Foo();
+Foo* foo = new ( FOO(ptr) ) Foo();
 
 Foo* foo = new  (  ptr,std::nothrow  )  Foo[];
 Foo* foo = new  (  ptr  )  Foo();

--- a/tests/output/cpp/34133-new_op.cpp
+++ b/tests/output/cpp/34133-new_op.cpp
@@ -1,9 +1,9 @@
 Foo* foo = new Foo(a,v);
 
-Foo* foo = new (ptr,std::nothrow) Foo[];
-Foo* foo = new (ptr) Foo();
-Foo* foo = new (FOO(ptr)) Foo();
+Foo* foo = new ( ptr,std::nothrow ) Foo[];
+Foo* foo = new ( ptr ) Foo();
+Foo* foo = new ( FOO(ptr) ) Foo();
 
-Foo* foo = new (  ptr,std::nothrow  ) Foo[];
-Foo* foo = new (  ptr  ) Foo();
-Foo* foo = new (  FOO(ptr)  ) Foo();
+Foo* foo = new ( ptr,std::nothrow ) Foo[];
+Foo* foo = new ( ptr ) Foo();
+Foo* foo = new ( FOO(ptr) ) Foo();

--- a/tests/output/cpp/34133-new_op.cpp
+++ b/tests/output/cpp/34133-new_op.cpp
@@ -1,0 +1,9 @@
+Foo* foo = new Foo(a,v);
+
+Foo* foo = new (ptr,std::nothrow) Foo[];
+Foo* foo = new (ptr) Foo();
+Foo* foo = new (FOO(ptr)) Foo();
+
+Foo* foo = new (  ptr,std::nothrow  ) Foo[];
+Foo* foo = new (  ptr  ) Foo();
+Foo* foo = new (  FOO(ptr)  ) Foo();

--- a/tests/output/cpp/34134-new_op.cpp
+++ b/tests/output/cpp/34134-new_op.cpp
@@ -1,0 +1,9 @@
+Foo* foo = new Foo(a,v);
+
+Foo* foo = new(ptr,std::nothrow)Foo[];
+Foo* foo = new(ptr)Foo();
+Foo* foo = new(FOO(ptr))Foo();
+
+Foo* foo = new(  ptr,std::nothrow  )Foo[];
+Foo* foo = new(  ptr  )Foo();
+Foo* foo = new(  FOO(ptr)  )Foo();

--- a/tests/output/cpp/34134-new_op.cpp
+++ b/tests/output/cpp/34134-new_op.cpp
@@ -4,6 +4,6 @@ Foo* foo = new(ptr,std::nothrow)Foo[];
 Foo* foo = new(ptr)Foo();
 Foo* foo = new(FOO(ptr))Foo();
 
-Foo* foo = new(  ptr,std::nothrow  )Foo[];
-Foo* foo = new(  ptr  )Foo();
-Foo* foo = new(  FOO(ptr)  )Foo();
+Foo* foo = new(ptr,std::nothrow)Foo[];
+Foo* foo = new(ptr)Foo();
+Foo* foo = new(FOO(ptr))Foo();

--- a/tests/output/cpp/34135-new_op.cpp
+++ b/tests/output/cpp/34135-new_op.cpp
@@ -1,0 +1,9 @@
+Foo* foo = new Foo(a,v);
+
+Foo* foo = new( ptr,std::nothrow)Foo[];
+Foo* foo = new( ptr)Foo();
+Foo* foo = new( FOO(ptr))Foo();
+
+Foo* foo = new  ( ptr,std::nothrow)  Foo[];
+Foo* foo = new  ( ptr)  Foo();
+Foo* foo = new  ( FOO(ptr))  Foo();


### PR DESCRIPTION
ref:#1056

About the last two commits:
I had to move the processing of the `sp_paren_paren` option because it returned before checking the new `sp_after_newop_paren` option when tested on the example that plinss provided:
```cpp
Foo* foo = new(FOO(ptr))Foo();
```

This caused that following cpp tests failed:

- 30064 ([c](https://github.com/uncrustify/uncrustify/blob/e04f5bb511960d293e16fd3001d1709a54e8664b/tests/config/class-colon-pos-sol-add.cfg), [i](https://github.com/uncrustify/uncrustify/blob/e04f5bb511960d293e16fd3001d1709a54e8664b/tests/input/cpp/class-init.cpp), [o](https://github.com/uncrustify/uncrustify/blob/e04f5bb511960d293e16fd3001d1709a54e8664b/tests/output/cpp/30064-class-init.cpp))

- 30066 ([c](https://github.com/uncrustify/uncrustify/blob/e04f5bb511960d293e16fd3001d1709a54e8664b/tests/config/class-on-colon-indent.cfg), [i](https://github.com/uncrustify/uncrustify/blob/e04f5bb511960d293e16fd3001d1709a54e8664b/tests/input/cpp/class-init.cpp), [o](https://github.com/uncrustify/uncrustify/blob/e04f5bb511960d293e16fd3001d1709a54e8664b/tests/output/cpp/30066-class-init.cpp))

- 30924 ([c](https://github.com/uncrustify/uncrustify/blob/e04f5bb511960d293e16fd3001d1709a54e8664b/tests/config/sp_before_ellipsis-r.cfg), [i](https://github.com/uncrustify/uncrustify/blob/e04f5bb511960d293e16fd3001d1709a54e8664b/tests/input/cpp/sp_before_ellipsis.cpp), [o](https://github.com/uncrustify/uncrustify/blob/e04f5bb511960d293e16fd3001d1709a54e8664b/tests/output/cpp/30924-sp_before_ellipsis.cpp))

Looking at the outputs I noticed that _apparently_ some spaces inside the parenthesis where not set correctly.