### PR TITLE
Fix gen_config_combinations_uniq_output.py join digit

### DIFF
--- a/scripts/gen_config_combinations_uniq_output.py
+++ b/scripts/gen_config_combinations_uniq_output.py
@@ -285,7 +285,7 @@ def write_output_dict_pretty(out_dict, out_path):
                         combination_string = out_dict["option_settings"][
                                 out_dict["options"][combination_idx]["type"]][
                                             combination_id]
-                        combination_strings.append(combination_string)
+                        combination_strings.append(str(combination_string))
                     f.write("    (%s: %s)\n" % (file_idx,
                                                 " - ".join(combination_strings)))
             f.write("\n")


### PR DESCRIPTION
In Python digits have to be converted into strings before they are passed to join().