### PR TITLE
Add option mod_full_brace_nl_block_rem_mlcond

### DIFF
--- a/scripts/More_Options_to_Test/help.txt
+++ b/scripts/More_Options_to_Test/help.txt
@@ -70,6 +70,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with 
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 580 options and minimal documentation.
+There are currently 581 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -4227,3 +4227,22 @@ void annotations_newlines(void)
       }
    }
 } // annotations_newlines
+
+
+int newlines_between(chunk_t *pcS, chunk_t *pcE, scope_e scope)
+{
+   if (pcS == nullptr || pcE == nullptr)
+   {
+      return(-1);
+   }
+
+   auto nl_count = 0;
+
+   auto it = pcS;
+   for ( ; it != pcE; it = chunk_get_next(it, scope))
+   {
+      nl_count += it->nl_count;
+   }
+
+   return((it == chunk_get_tail()) ? -1 : nl_count);
+}

--- a/src/newlines.h
+++ b/src/newlines.h
@@ -9,7 +9,7 @@
 #define NEWLINES_H_INCLUDED
 
 #include "uncrustify_types.h"
-
+#include "chunk_list.h"
 
 void newlines_remove_newlines(void);
 void newlines_cleanup_braces(bool first);
@@ -34,5 +34,7 @@ chunk_t *newline_add_after(chunk_t *pc);
 chunk_t *newline_force_after(chunk_t *pc);
 void newline_del_between(chunk_t *start, chunk_t *end);
 chunk_t *newline_add_between(chunk_t *start, chunk_t *end);
+
+int newlines_between(chunk_t *pcS, chunk_t *pcE, scope_e scope = scope_e::ALL);
 
 #endif /* NEWLINES_H_INCLUDED */

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1528,6 +1528,12 @@ void register_options(void)
                   "and simple 'if' statements will lose them (if possible).\n");
    unc_add_option("mod_full_brace_nl", UO_mod_full_brace_nl, AT_UNUM,
                   "Don't remove braces around statements that span N newlines", "", 0, 5000);
+   unc_add_option("mod_full_brace_nl_block_rem_mlcond", UO_mod_full_brace_nl_block_rem_mlcond, AT_BOOL,
+                  "Blocks removal of braces if the parenthesis of if/for/while/.. span multiple lines.",
+                  "Affected options:"
+                  "mod_full_brace_for, mod_full_brace_if, mod_full_brace_if_chain, mod_full_brace_if_chain_only, mod_full_brace_while,mod_full_brace_using"
+                  "Not affected options:"
+                  "mod_full_brace_do, mod_full_brace_function");
    unc_add_option("mod_full_brace_while", UO_mod_full_brace_while, AT_IARF,
                   "Add or remove braces on single-line 'while' statement");
    unc_add_option("mod_full_brace_using", UO_mod_full_brace_using, AT_IARF,

--- a/src/options.h
+++ b/src/options.h
@@ -759,6 +759,7 @@ enum uncrustify_options
    UO_mod_full_brace_if_chain_only,              // make all if/elseif/else statements in a chain with at least
                                                  // one 'else' or 'else if' fully braced
    UO_mod_full_brace_nl,                         // max number of newlines to span w/o braces
+   UO_mod_full_brace_nl_block_rem_mlcond,        // block brace removal on multiline condition
    UO_mod_full_brace_while,                      // add or remove braces on single-line while
    UO_mod_full_brace_using,                      // add or remove braces on using
    UO_mod_paren_on_return,                       // add or remove paren on return

--- a/tests/c-sharp.test
+++ b/tests/c-sharp.test
@@ -61,3 +61,6 @@
 12004 verbatim_strings.cfg     cs/verbatim_strings.cs
 
 12101 bug_i_679.cfg            cs/bug_i_679.cs
+
+12102 mod_full_brace_nl_block_rem_mlcond-0.cfg cs/mod_full_brace_nl_block_rem_mlcond.cs
+12103 mod_full_brace_nl_block_rem_mlcond-1.cfg cs/mod_full_brace_nl_block_rem_mlcond.cs

--- a/tests/config/mod_full_brace_nl_block_rem_mlcond-0.cfg
+++ b/tests/config/mod_full_brace_nl_block_rem_mlcond-0.cfg
@@ -1,0 +1,6 @@
+mod_full_brace_nl_block_rem_mlcond = True
+
+mod_full_brace_for                 = remove
+mod_full_brace_if                  = remove
+mod_full_brace_while               = remove
+mod_full_brace_using               = remove

--- a/tests/config/mod_full_brace_nl_block_rem_mlcond-1.cfg
+++ b/tests/config/mod_full_brace_nl_block_rem_mlcond-1.cfg
@@ -1,0 +1,3 @@
+mod_full_brace_nl_block_rem_mlcond = True
+
+mod_full_brace_if_chain            = True

--- a/tests/input/cs/mod_full_brace_nl_block_rem_mlcond.cs
+++ b/tests/input/cs/mod_full_brace_nl_block_rem_mlcond.cs
@@ -1,0 +1,42 @@
+if( a == true
+    && b == false )
+{
+	return 1;
+}
+else if( a == true
+         && b == false)
+{
+	return 2;
+}
+else
+{
+	return 3;
+}
+
+
+if( a == true;
+    b == true;
+    c == true)
+{
+	return 1;
+}
+
+for( a = true;
+     a < 9;
+     a++)
+{
+	return 1;
+}
+
+while( a == true
+       && b == true
+       && c == true)
+{
+	return 1;
+}
+
+using (Foo bar =
+	       new Foo())
+{
+	return 1;
+}

--- a/tests/output/cs/12102-mod_full_brace_nl_block_rem_mlcond.cs
+++ b/tests/output/cs/12102-mod_full_brace_nl_block_rem_mlcond.cs
@@ -1,0 +1,40 @@
+if( a == true
+    && b == false )
+{
+	return 1;
+}
+else if( a == true
+         && b == false)
+{
+	return 2;
+}
+else
+	return 3;
+
+
+if( a == true;
+    b == true;
+    c == true)
+{
+	return 1;
+}
+
+for( a = true;
+     a < 9;
+     a++)
+{
+	return 1;
+}
+
+while( a == true
+       && b == true
+       && c == true)
+{
+	return 1;
+}
+
+using (Foo bar =
+	       new Foo())
+{
+	return 1;
+}

--- a/tests/output/cs/12103-mod_full_brace_nl_block_rem_mlcond.cs
+++ b/tests/output/cs/12103-mod_full_brace_nl_block_rem_mlcond.cs
@@ -1,0 +1,40 @@
+if( a == true
+    && b == false )
+{
+	return 1;
+}
+else if( a == true
+         && b == false)
+{
+	return 2;
+}
+else
+	return 3;
+
+
+if( a == true;
+    b == true;
+    c == true)
+{
+	return 1;
+}
+
+for( a = true;
+     a < 9;
+     a++)
+{
+	return 1;
+}
+
+while( a == true
+       && b == true
+       && c == true)
+{
+	return 1;
+}
+
+using (Foo bar =
+	       new Foo())
+{
+	return 1;
+}


### PR DESCRIPTION
Blocks removal of braces if the parenthesis of if/for/while/.. span multiple lines.

Affected options:
- mod_full_brace_for
- mod_full_brace_if
- mod_full_brace_if_chain
- mod_full_brace_if_chain_only
- mod_full_brace_while
- mod_full_brace_using

Not affected options:
- mod_full_brace_do
- mod_full_brace_function

ref: #1070