### PR TITLE
Temp. fix for --show-config crash

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2220,6 +2220,7 @@ int save_option_file(FILE *pfile, bool withDoc)
 
 void print_options(FILE *pfile)
 {
+   // TODO refactor to be undependent of type positioning
    const char *names[] =
    {
       "{ False, True }",
@@ -2228,6 +2229,7 @@ void print_options(FILE *pfile)
       "{ Auto, LF, CR, CRLF }",
       "{ Ignore, Lead, Trail }",
       "String",
+      "Unsigned Number",
    };
 
 #if defined (DEBUG) || defined (_DEBUG)


### PR DESCRIPTION
Adds name for the new AT_UNUM type.

This does not solve the actual problem, we need to be able to either iterate those enum values or generate tests for the `--show-config` option output if we want to be sure that this does not happen every time another option type is introduced.

------------------
ref: #1080, #1046 