### PR TITLE
Test_more_Options.sh Changes

### DIFF
--- a/scripts/More_Options_to_Test/show_config.txt
+++ b/scripts/More_Options_to_Test/show_config.txt
@@ -1,4 +1,4 @@
-# Uncrustify 0.64
+
 #
 # General options
 #

--- a/scripts/Output/mini_d_uc.txt
+++ b/scripts/Output/mini_d_uc.txt
@@ -1,5 +1,5 @@
 scripts/Config/mini_d.cfg:2 Unknown symbol 'not_existing_option'
-# Uncrustify 0.64
+
 newlines                        = auto
 input_tab_size                  = 8
 output_tab_size                 = 8

--- a/scripts/Output/mini_d_ucwd.txt
+++ b/scripts/Output/mini_d_ucwd.txt
@@ -1,5 +1,5 @@
 scripts/Config/mini_d.cfg:2 Unknown symbol 'not_existing_option'
-# Uncrustify 0.64
+
 
 #
 # General options

--- a/scripts/Output/mini_nd_uc.txt
+++ b/scripts/Output/mini_nd_uc.txt
@@ -1,5 +1,5 @@
 scripts/Config/mini_d.cfg:2 Unknown symbol 'not_existing_option'
-# Uncrustify 0.64
+
 newlines                        = crlf
 input_tab_size                  = 8
 output_tab_size                 = 8

--- a/scripts/Output/mini_nd_ucwd.txt
+++ b/scripts/Output/mini_nd_ucwd.txt
@@ -1,5 +1,5 @@
 scripts/Config/mini_d.cfg:2 Unknown symbol 'not_existing_option'
-# Uncrustify 0.64
+
 
 #
 # General options

--- a/scripts/Output/p.txt
+++ b/scripts/Output/p.txt
@@ -1,0 +1,64 @@
+
+newlines                        = crlf
+# option(s) with 'not default' value: 1
+#
+# -=====-
+# Line              Tag           Parent          Columns Br/Lvl/pp     Flag   Nl  Text
+#   1>           STRUCT[            NONE][  1/  1/  7/  0][0/0/0][     70002][0-0] struct
+#   1>             TYPE[          STRUCT][  8/  8/ 21/  1][0/0/0][         2][0-0]        TelegramIndex
+#   1>          NEWLINE[            NONE][ 21/ 21/  1/  0][0/0/0][         2][1-0]
+#   2>       BRACE_OPEN[          STRUCT][  1/  1/  2/  0][0/0/0][ 100000002][0-0] {
+#   2>          NEWLINE[            NONE][  2/  2/  1/  0][1/1/0][         2][1-0]
+#   3>   FUNC_CLASS_DEF[            NONE][  9/  1/ 14/  0][1/1/0][     60402][0-0]         TelegramIndex
+#   3>      FPAREN_OPEN[  FUNC_CLASS_DEF][ 22/ 14/ 15/  0][1/1/0][ 100000502][0-0]                      (
+#   3>        QUALIFIER[            NONE][ 23/ 15/ 20/  0][1/2/0][     50512][0-0]                       const
+#   3>             TYPE[            NONE][ 29/ 21/ 25/  1][1/2/0][    400512][0-0]                             char
+#   3>         PTR_TYPE[            NONE][ 33/ 25/ 26/  0][1/2/0][ 100000512][0-0]                                 *
+#   3>             WORD[            NONE][ 35/ 27/ 29/  1][1/2/0][    800512][0-0]                                   pN
+#   3>            COMMA[            NONE][ 37/ 29/ 30/  0][1/2/0][ 100000512][0-0]                                     ,
+#   3>             TYPE[            NONE][ 39/ 31/ 39/  1][1/2/0][    450512][0-0]                                       unsigned
+#   3>             TYPE[            NONE][ 48/ 40/ 44/  1][1/2/0][    410512][0-0]                                                long
+#   3>             WORD[            NONE][ 53/ 45/ 47/  1][1/2/0][    800512][0-0]                                                     nI
+#   3>     FPAREN_CLOSE[  FUNC_CLASS_DEF][ 55/ 47/ 48/  0][1/1/0][ 100000502][0-0]                                                       )
+#   3>     CONSTR_COLON[            NONE][ 57/ 49/ 50/  1][1/1/0][ 100000502][0-0]                                                         :
+#   3>          NEWLINE[            NONE][ 58/ 50/  1/  0][1/1/0][         2][1-0]
+#   4>    FUNC_CTOR_VAR[            NONE][ 17/  1/  9/  0][1/1/0][     60502][0-0]                 pTelName
+#   4>      FPAREN_OPEN[   FUNC_CTOR_VAR][ 25/  9/ 10/  0][1/1/0][ 100000502][0-0]                         (
+#   4>             WORD[            NONE][ 26/ 10/ 12/  0][1/2/0][     40512][0-0]                          pN
+#   4>     FPAREN_CLOSE[   FUNC_CTOR_VAR][ 28/ 12/ 13/  0][1/1/0][ 100000502][0-0]                            )
+#   4>            COMMA[            NONE][ 29/ 13/ 14/  0][1/1/0][ 100000502][0-0]                             ,
+#   4>          NEWLINE[            NONE][ 30/ 14/  1/  0][1/1/0][         2][1-0]
+#   5>    FUNC_CTOR_VAR[            NONE][ 17/  1/ 10/  0][1/1/0][     40502][0-0]                 nTelIndex
+#   5>      FPAREN_OPEN[   FUNC_CTOR_VAR][ 26/ 10/ 11/  0][1/1/0][ 100000502][0-0]                          (
+#   5>             WORD[            NONE][ 27/ 11/ 12/  0][1/2/0][     40512][0-0]                           n
+#   5>     FPAREN_CLOSE[   FUNC_CTOR_VAR][ 28/ 12/ 13/  0][1/1/0][ 100000502][0-0]                            )
+#   5>          NEWLINE[            NONE][ 29/ 13/  1/  0][1/1/0][         2][1-0]
+#   6>       BRACE_OPEN[  FUNC_CLASS_DEF][  9/  1/  2/  0][1/1/0][ 140000402][0-0]         {
+#   6>          NEWLINE[            NONE][ 10/  2/  1/  0][2/2/0][         2][1-0]
+#   7>      BRACE_CLOSE[  FUNC_CLASS_DEF][  9/  1/  2/  0][1/1/0][ 140000402][0-0]         }
+#   7>          NEWLINE[            NONE][ 10/  2/  1/  0][1/1/0][         2][2-0]
+#   9>       DESTRUCTOR[            NONE][  9/  1/  2/  0][1/1/0][ 100060402][0-0]         ~
+#   9>   FUNC_CLASS_DEF[      DESTRUCTOR][ 10/  2/ 15/  0][1/1/0][     40402][0-0]          TelegramIndex
+#   9>      FPAREN_OPEN[  FUNC_CLASS_DEF][ 23/ 15/ 16/  0][1/1/0][ 100000502][0-0]                       (
+#   9>     FPAREN_CLOSE[  FUNC_CLASS_DEF][ 24/ 16/ 17/  0][1/1/0][ 100000502][0-0]                        )
+#   9>          NEWLINE[            NONE][ 25/ 17/  1/  0][1/1/0][         2][1-0]
+#  10>       BRACE_OPEN[  FUNC_CLASS_DEF][  9/  1/  2/  0][1/1/0][ 140000402][0-0]         {
+#  10>          NEWLINE[            NONE][ 10/  2/  1/  0][2/2/0][         2][1-0]
+#  11>      BRACE_CLOSE[  FUNC_CLASS_DEF][  9/  1/  2/  0][1/1/0][ 140000402][0-0]         }
+#  11>          NEWLINE[            NONE][ 10/  2/  1/  0][1/1/0][         2][2-0]
+#  13>        QUALIFIER[            NONE][  9/  1/  6/  0][1/1/0][    470402][0-0]         const
+#  13>             TYPE[            NONE][ 15/  7/ 11/  1][1/1/0][    400402][0-0]               char
+#  13>         PTR_TYPE[            NONE][ 19/ 11/ 12/  0][1/1/0][ 100400402][0-0]                   *
+#  13>        QUALIFIER[            NONE][ 21/ 13/ 18/  1][1/1/0][    410402][0-0]                     const
+#  13>             WORD[            NONE][ 27/ 19/ 27/  1][1/1/0][   1800402][0-0]                           pTelName
+#  13>        SEMICOLON[            NONE][ 35/ 27/ 28/  0][1/1/0][ 100000402][0-0]                                   ;
+#  13>          NEWLINE[            NONE][ 36/ 28/  1/  0][1/1/0][         2][1-0]
+#  14>             TYPE[            NONE][  9/  1/  9/  0][1/1/0][    470402][0-0]         unsigned
+#  14>             TYPE[            NONE][ 18/ 10/ 14/  1][1/1/0][    410402][0-0]                  long
+#  14>             WORD[            NONE][ 23/ 15/ 24/  1][1/1/0][   1800402][0-0]                       nTelIndex
+#  14>        SEMICOLON[            NONE][ 32/ 24/ 25/  0][1/1/0][ 100000402][0-0]                                ;
+#  14>          NEWLINE[            NONE][ 33/ 25/  1/  0][1/1/0][         2][1-0]
+#  15>      BRACE_CLOSE[          STRUCT][  1/  1/  2/  0][0/0/0][ 100000400][0-0] }
+#  15>        SEMICOLON[          STRUCT][  2/  2/  3/  0][0/0/0][ 100000000][0-0]  ;
+#  15>          NEWLINE[            NONE][  3/  3/  1/  0][0/0/0][         0][2-0]
+# -=====-

--- a/scripts/Test_more_Options.sh
+++ b/scripts/Test_more_Options.sh
@@ -120,8 +120,30 @@ do
   fi
 done
 
+#
+# Test -p
+#
+ResultsFile="${RESULTS}/p.txt"
+InputFile="${INPUT}/28.cpp"
+OutputFile="${OUTPUT}/p.txt"
+ConfigFile="${CONFIG}/mini_nd.cfg"
+
+./build/uncrustify -c "${ConfigFile}" -f "${InputFile}" -p "${ResultsFile}" &> /dev/null
+sed 's/# Uncrustify.*//g' "${ResultsFile}" > "${ResultsFile}.sed"
+cmp -s "${ResultsFile}.sed" "${OutputFile}"
+how_different=${?}
+if [ ${how_different} != "0" ] ;
+then
+  echo "Problem with ${ResultsFile}.sed"
+  echo "use: diff ${ResultsFile}.sed ${OutputFile} to find why"
+  diff "${ResultsFile}.sed" "${OutputFile}"
+else
+  rm "${ResultsFile}"
+  rm "${ResultsFile}.sed"
+fi
+
+
 # Debug Options:
-#   -p TODO
 #   -L
 # look at src/log_levels.h
 

--- a/scripts/Test_more_Options.sh
+++ b/scripts/Test_more_Options.sh
@@ -34,36 +34,41 @@ CONFIG="scripts/Config"
 #
 # Test help
 #   -h -? --help --usage
-  file="help.txt"
-  ./build/uncrustify > "${RESULTS}/${file}"
-  cmp -s "${RESULTS}/${file}" "${SCRIPTS}/More_Options_to_Test/${file}"
-  how_different=${?}
-  if [ ${how_different} != "0" ] ;
-  then
-    echo
-    echo "Problem with "${file}
-    echo "use: diff ${RESULTS}/${file} ${SCRIPTS}/More_Options_to_Test/${file} to find why"
-    diff "${RESULTS}/${file}" "${SCRIPTS}/More_Options_to_Test/${file}"
-  else
-    rm "results/${file}"
-  fi
+file="help.txt"
+
+./build/uncrustify > "${RESULTS}/${file}"
+cmp -s "${RESULTS}/${file}" "${SCRIPTS}/More_Options_to_Test/${file}"
+how_different=${?}
+if [ ${how_different} != "0" ] ;
+then
+  echo
+  echo "Problem with "${file}
+  echo "use: diff ${RESULTS}/${file} ${SCRIPTS}/More_Options_to_Test/${file} to find why"
+  diff "${RESULTS}/${file}" "${SCRIPTS}/More_Options_to_Test/${file}"
+else
+  rm "results/${file}"
+fi
 
 #
 # Test --show-config
 #
-  file="show_config.txt"
-  ./build/uncrustify --show-config > "${RESULTS}/${file}"
-  cmp -s "${RESULTS}/${file}" "${SCRIPTS}/More_Options_to_Test/${file}"
-  how_different=${?}
-  if [ ${how_different} != "0" ] ;
-  then
-    echo
-    echo "Problem with ${file}"
-    echo "use: diff ${RESULTS}/${file} ${SCRIPTS}/More_Options_to_Test/${file} to find why"
-    diff "${RESULTS}/${file}" "${SCRIPTS}/More_Options_to_Test/${file}"
-  else
-    rm "results/${file}"
-  fi
+file="show_config.txt"
+
+./build/uncrustify --show-config > "${RESULTS}/${file}"
+sed 's/# Uncrustify.*//g' "${RESULTS}/${file}" > "${RESULTS}/${file}.sed"
+cmp -s "${RESULTS}/${file}.sed" "${SCRIPTS}/More_Options_to_Test/${file}"
+how_different=${?}
+if [ ${how_different} != "0" ] ;
+then
+  echo
+  echo "Problem with ${RESULTS}/${file}.sed"
+  echo "use: diff ${RESULTS}/${file}.sed ${SCRIPTS}/More_Options_to_Test/${file} to find why"
+  diff "${RESULTS}/${file}.sed" "${SCRIPTS}/More_Options_to_Test/${file}"
+else
+  rm "results/${file}"
+  rm "results/${file}.sed"
+fi
+
 #
 # Test --update-config
 #
@@ -73,17 +78,20 @@ do
   ResultsFile="${RESULTS}/${ConfigFileName}_uc.txt"
   OutputFile="${OUTPUT}/${ConfigFileName}_uc.txt"
   ConfigFile="${CONFIG}/${ConfigFileName}.cfg"
+
   ./build/uncrustify -c "${ConfigFile}" --update-config &> "${ResultsFile}"
-  cmp -s "${ResultsFile}" "${OutputFile}"
+  sed 's/# Uncrustify.*//g' "${ResultsFile}" > "${ResultsFile}.sed"
+  cmp -s "${ResultsFile}.sed" "${OutputFile}"
   how_different=${?}
   if [ ${how_different} != "0" ] ;
   then
     echo
-    echo "Problem with ${ResultsFile}"
-    echo "use: diff ${ResultsFile} ${OutputFile} to find why"
-    diff "${ResultsFile}" "${OutputFile}"
+    echo "Problem with ${ResultsFile}.sed"
+    echo "use: diff ${ResultsFile}.sed ${OutputFile} to find why"
+    diff "${ResultsFile}.sed" "${OutputFile}"
   else
     rm "${ResultsFile}"
+    rm "${ResultsFile}.sed"
   fi
 done
 
@@ -96,16 +104,19 @@ do
   ResultsFile="${RESULTS}/${ConfigFileName}_ucwd.txt"
   OutputFile="${OUTPUT}/${ConfigFileName}_ucwd.txt"
   ConfigFile="${CONFIG}/${ConfigFileName}.cfg"
+
   ./build/uncrustify -c "${ConfigFile}" --update-config-with-doc &> "${ResultsFile}"
-  cmp -s "${ResultsFile}" "${OutputFile}"
+  sed 's/# Uncrustify.*//g' "${ResultsFile}" > "${ResultsFile}.sed"
+  cmp -s "${ResultsFile}.sed" "${OutputFile}"
   how_different=${?}
   if [ ${how_different} != "0" ] ;
   then
-    echo "Problem with "${ResultsFile}
-    echo "use: diff ${ResultsFile} ${OutputFile} to find why"
-    diff "${ResultsFile}" "${OutputFile}"
+    echo "Problem with ${ResultsFile}.sed"
+    echo "use: diff ${ResultsFile}.sed ${OutputFile} to find why"
+    diff "${ResultsFile}.sed" "${OutputFile}"
   else
     rm "${ResultsFile}"
+    rm "${ResultsFile}.sed"
   fi
 done
 


### PR DESCRIPTION
Remove version strings from Test_more_Options.sh test
If we want to have version strings like `Uncrustify-0.64-518-0dda18c9`, every new commit would need to change the version strings to successfully run Test_more_Options.sh. 
This problem is solved by removing the version string from the tests.

Also adds test for -p.