### PR TITLE
Add indent_ternary_operator to forUncrustifySources.cfg

### DIFF
--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -6,6 +6,7 @@ indent_columns                  = 3
 indent_with_tabs                = 0
 indent_class                    = true
 indent_member                   = 3
+indent_ternary_operator         = 2
 sp_arith                        = force
 sp_assign                       = force
 sp_assign_default               = force

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -2068,8 +2068,10 @@ void add_long_preprocessor_conditional_block_comment(void)
             tmp = chunk_get_next(tmp);
 
             LOG_FMT(LPPIF, "next item type %d (is %s)\n",
-                    (tmp ? tmp->type : -1), (tmp ? chunk_is_newline(tmp) ? "newline"
-                                             : chunk_is_comment(tmp) ? "comment" : "other" : "---"));
+                    (tmp ? tmp->type : -1),
+                    (tmp ? chunk_is_newline(tmp) ? "newline"
+                                                 : chunk_is_comment(tmp) ? "comment"
+                                                                         : "other" : "---"));
             if ((tmp == nullptr) || (tmp->type == CT_NEWLINE) /* chunk_is_newline(tmp) */)
             {
                size_t nl_min;


### PR DESCRIPTION
This option is intended to be used to format future PRs.

------------------

E: I just noticed that it unfortunately does not work properly:
```cpp 
                    (tmp ? chunk_is_newline(tmp) ? "newline"
                                                 : chunk_is_comment(tmp) ? "comment"
                                                                         : "other" 
                                                                         : "---"));
```
sould be 
```cpp
                    (tmp ? chunk_is_newline(tmp) ? "newline"
                                                 : chunk_is_comment(tmp) ? "comment"
                                                                         : "other" 
                         : "---"));
```