### PR TITLE
add languages Ecma and Java to '->' punctuator

### DIFF
--- a/src/punctuators.cpp
+++ b/src/punctuators.cpp
@@ -74,45 +74,45 @@ static const chunk_tag_t symbols3[] =
 /* 2-char symbols */
 static const chunk_tag_t symbols2[] =
 {
-   { "!<",      CT_COMPARE,      LANG_D                                                     },
-   { "!=",      CT_COMPARE,      LANG_ALL                                                   },
-   { "!>",      CT_COMPARE,      LANG_D                                                     },
-   { "!~",      CT_COMPARE,      LANG_D                                                     },
-   { "##",      CT_PP,           LANG_C | LANG_CPP | LANG_OC                                },
-   { "#@",      CT_POUND,        LANG_C | LANG_CPP | LANG_OC                                }, /* MS extension */
-   { "%=",      CT_ASSIGN,       LANG_ALL                                                   },
-   { "&&",      CT_BOOL,         LANG_ALL                                                   },
-   { "&=",      CT_ASSIGN,       LANG_ALL                                                   },
-   { "*=",      CT_ASSIGN,       LANG_ALL                                                   },
-   { "++",      CT_INCDEC_AFTER, LANG_ALL                                                   },
-   { "+=",      CT_ASSIGN,       LANG_ALL                                                   },
-   { "--",      CT_INCDEC_AFTER, LANG_ALL                                                   },
-   { "-=",      CT_ASSIGN,       LANG_ALL                                                   },
-   { "->",      CT_MEMBER,       LANG_C | LANG_CPP | LANG_CS | LANG_OC | LANG_D | LANG_VALA },
-   { ".*",      CT_MEMBER,       LANG_C | LANG_CPP | LANG_D                                 },
-   { "..",      CT_RANGE,        LANG_D                                                     },
-   { "?.",      CT_NULLCOND,     LANG_CS                                                    }, // null conditional operator
-   { "/=",      CT_ASSIGN,       LANG_ALL                                                   },
-   { "::",      CT_DC_MEMBER,    LANG_C | LANG_CPP | LANG_CS | LANG_D | LANG_VALA           },
-   { "<<",      CT_ARITH,        LANG_ALL                                                   },
-   { "<=",      CT_COMPARE,      LANG_ALL                                                   },
-   { "<>",      CT_COMPARE,      LANG_D                                                     },
-   { "==",      CT_COMPARE,      LANG_ALL                                                   },
-   { ">=",      CT_COMPARE,      LANG_ALL                                                   },
-   { ">>",      CT_ARITH,        LANG_ALL                                                   },
-   { "[]",      CT_TSQUARE,      LANG_ALL                                                   },
-   { "^=",      CT_ASSIGN,       LANG_ALL                                                   },
-   { "|=",      CT_ASSIGN,       LANG_ALL                                                   },
-   { "||",      CT_BOOL,         LANG_ALL                                                   },
-   { "~=",      CT_COMPARE,      LANG_D                                                     },
-   { "~~",      CT_COMPARE,      LANG_D                                                     },
-   { "=>",      CT_LAMBDA,       LANG_VALA | LANG_CS | LANG_D                               },
-   { "??",      CT_COMPARE,      LANG_CS | LANG_VALA                                        },
-   { R"_(<%)_", CT_BRACE_OPEN,   LANG_C | LANG_CPP | FLAG_DIG                               }, // digraph {
-   { R"_(%>)_", CT_BRACE_CLOSE,  LANG_C | LANG_CPP | FLAG_DIG                               }, // digraph }
-   { R"_(<:)_", CT_SQUARE_OPEN,  LANG_C | LANG_CPP | FLAG_DIG                               }, // digraph [
-   { R"_(:>)_", CT_SQUARE_CLOSE, LANG_C | LANG_CPP | FLAG_DIG                               }, // digraph ]
-   { R"_(%:)_", CT_POUND,        LANG_C | LANG_CPP | FLAG_DIG                               }, // digraph #
+   { "!<",      CT_COMPARE,      LANG_D                                           },
+   { "!=",      CT_COMPARE,      LANG_ALL                                         },
+   { "!>",      CT_COMPARE,      LANG_D                                           },
+   { "!~",      CT_COMPARE,      LANG_D                                           },
+   { "##",      CT_PP,           LANG_C | LANG_CPP | LANG_OC                      },
+   { "#@",      CT_POUND,        LANG_C | LANG_CPP | LANG_OC                      },           /* MS extension */
+   { "%=",      CT_ASSIGN,       LANG_ALL                                         },
+   { "&&",      CT_BOOL,         LANG_ALL                                         },
+   { "&=",      CT_ASSIGN,       LANG_ALL                                         },
+   { "*=",      CT_ASSIGN,       LANG_ALL                                         },
+   { "++",      CT_INCDEC_AFTER, LANG_ALL                                         },
+   { "+=",      CT_ASSIGN,       LANG_ALL                                         },
+   { "--",      CT_INCDEC_AFTER, LANG_ALL                                         },
+   { "-=",      CT_ASSIGN,       LANG_ALL                                         },
+   { "->",      CT_MEMBER,       LANG_ALLC                                        },
+   { ".*",      CT_MEMBER,       LANG_C | LANG_CPP | LANG_D                       },
+   { "..",      CT_RANGE,        LANG_D                                           },
+   { "?.",      CT_NULLCOND,     LANG_CS                                          },           // null conditional operator
+   { "/=",      CT_ASSIGN,       LANG_ALL                                         },
+   { "::",      CT_DC_MEMBER,    LANG_C | LANG_CPP | LANG_CS | LANG_D | LANG_VALA },
+   { "<<",      CT_ARITH,        LANG_ALL                                         },
+   { "<=",      CT_COMPARE,      LANG_ALL                                         },
+   { "<>",      CT_COMPARE,      LANG_D                                           },
+   { "==",      CT_COMPARE,      LANG_ALL                                         },
+   { ">=",      CT_COMPARE,      LANG_ALL                                         },
+   { ">>",      CT_ARITH,        LANG_ALL                                         },
+   { "[]",      CT_TSQUARE,      LANG_ALL                                         },
+   { "^=",      CT_ASSIGN,       LANG_ALL                                         },
+   { "|=",      CT_ASSIGN,       LANG_ALL                                         },
+   { "||",      CT_BOOL,         LANG_ALL                                         },
+   { "~=",      CT_COMPARE,      LANG_D                                           },
+   { "~~",      CT_COMPARE,      LANG_D                                           },
+   { "=>",      CT_LAMBDA,       LANG_VALA | LANG_CS | LANG_D                     },
+   { "??",      CT_COMPARE,      LANG_CS | LANG_VALA                              },
+   { R"_(<%)_", CT_BRACE_OPEN,   LANG_C | LANG_CPP | FLAG_DIG                     },           // digraph {
+   { R"_(%>)_", CT_BRACE_CLOSE,  LANG_C | LANG_CPP | FLAG_DIG                     },           // digraph }
+   { R"_(<:)_", CT_SQUARE_OPEN,  LANG_C | LANG_CPP | FLAG_DIG                     },           // digraph [
+   { R"_(:>)_", CT_SQUARE_CLOSE, LANG_C | LANG_CPP | FLAG_DIG                     },           // digraph ]
+   { R"_(%:)_", CT_POUND,        LANG_C | LANG_CPP | FLAG_DIG                     },           // digraph #
 };
 
 /* 1-char symbols */

--- a/tests/config/empty.cfg
+++ b/tests/config/empty.cfg
@@ -1,1 +1,5 @@
 # this is an empty config file
+
+
+# https://github.com/uncrustify/uncrustify/issues/1121
+#    do not split '->' punctuator into '- >' in JAVA

--- a/tests/input/java/i1121.java
+++ b/tests/input/java/i1121.java
@@ -1,0 +1,7 @@
+public class Test {
+public static void main() {
+	btn.addActionListener(e->{
+			System.exit(0);
+		});
+}
+}

--- a/tests/java.test
+++ b/tests/java.test
@@ -18,5 +18,8 @@
 80060 java_synchronized_1.cfg java/synchronized.java
 80061 java_synchronized_2.cfg java/synchronized.java
 80062 sp_this_paren.cfg       java/sp_this_paren.java
+80063 empty.cfg               java/i1121.java
 
 80100 sf567.cfg               java/sf567.java
+
+

--- a/tests/output/java/80063-i1121.java
+++ b/tests/output/java/80063-i1121.java
@@ -1,0 +1,7 @@
+public class Test {
+public static void main() {
+	btn.addActionListener(e->{
+			System.exit(0);
+		});
+}
+}


### PR DESCRIPTION
Prevents splitting of '->' punctuator in Java.

ref: partially solves #1121

<s>E: will be reopened after `Extend punctuators with more di/tri-graphs` is merged</s>