### PR TITLE
A bugfix for #666 and #1068

### DIFF
--- a/scripts/More_Options_to_Test/show_config.txt
+++ b/scripts/More_Options_to_Test/show_config.txt
@@ -1255,7 +1255,8 @@ nl_before_if                    { Ignore, Add, Remove, Force }
   Add or remove blank line before 'if'
 
 nl_after_if                     { Ignore, Add, Remove, Force }
-  Add or remove blank line after 'if' statement
+  Add or remove blank line after 'if' statement.
+  Add/Force work only if the next token is not a closing brace
 
 nl_before_for                   { Ignore, Add, Remove, Force }
   Add or remove blank line before 'for'

--- a/scripts/Output/25.txt
+++ b/scripts/Output/25.txt
@@ -1,6 +1,50 @@
 Newline loop start: 
-newline_add_between: ';'[SEMICOLON] line : and '}' line : : [CallStack:-DEBUG NOT SET-]
-newline_add_between: '{'[BRACE_OPEN] line : and '}' line : : [CallStack:-DEBUG NOT SET-]
-newline_add_between: '{'[BRACE_OPEN] line : and '}' line : : [CallStack:-DEBUG NOT SET-]
-newline_add_between: '{'[BRACE_OPEN] line : and '}' line : : [CallStack:-DEBUG NOT SET-]
-newline_add_between: '{'[BRACE_OPEN] line : and '}' line : : [CallStack:-DEBUG NOT SET-]
+newline_add_between:: ';'[SEMICOLON] line : and '}' line : : [CallStack:-DEBUG NOT SET-]
+newline_add_between:: '{'[BRACE_OPEN] line : and '}' line : : [CallStack:-DEBUG NOT SET-]
+newline_add_between:: '{'[BRACE_OPEN] line : and '}' line : : [CallStack:-DEBUG NOT SET-]
+newline_add_between:: '{'[BRACE_OPEN] line : and '}' line : : [CallStack:-DEBUG NOT SET-]
+newline_add_between:: '{'[BRACE_OPEN] line : and '}' line : : [CallStack:-DEBUG NOT SET-]
+newlines_insert_blank_lines:: for-loop: line , column , struct type STRUCT
+newlines_insert_blank_lines:: for-loop: line , column , TelegramIndex type TYPE
+newlines_insert_blank_lines:: for-loop: line , column , { type BRACE_OPEN
+newlines_insert_blank_lines:: for-loop: line , column , TelegramIndex type FUNC_CLASS_DEF
+newlines_insert_blank_lines:: for-loop: line , column , ( type FPAREN_OPEN
+newlines_insert_blank_lines:: for-loop: line , column , const type QUALIFIER
+newlines_insert_blank_lines:: for-loop: line , column , char type TYPE
+newlines_insert_blank_lines:: for-loop: line , column , * type PTR_TYPE
+newlines_insert_blank_lines:: for-loop: line , column , pN type WORD
+newlines_insert_blank_lines:: for-loop: line , column , , type COMMA
+newlines_insert_blank_lines:: for-loop: line , column , unsigned type TYPE
+newlines_insert_blank_lines:: for-loop: line , column , long type TYPE
+newlines_insert_blank_lines:: for-loop: line , column , nI type WORD
+newlines_insert_blank_lines:: for-loop: line , column , ) type FPAREN_CLOSE
+newlines_insert_blank_lines:: for-loop: line , column , : type CONSTR_COLON
+newlines_insert_blank_lines:: for-loop: line , column , pTelName type FUNC_CTOR_VAR
+newlines_insert_blank_lines:: for-loop: line , column , ( type FPAREN_OPEN
+newlines_insert_blank_lines:: for-loop: line , column , pN type WORD
+newlines_insert_blank_lines:: for-loop: line , column , ) type FPAREN_CLOSE
+newlines_insert_blank_lines:: for-loop: line , column , , type COMMA
+newlines_insert_blank_lines:: for-loop: line , column , nTelIndex type FUNC_CTOR_VAR
+newlines_insert_blank_lines:: for-loop: line , column , ( type FPAREN_OPEN
+newlines_insert_blank_lines:: for-loop: line , column , n type WORD
+newlines_insert_blank_lines:: for-loop: line , column , ) type FPAREN_CLOSE
+newlines_insert_blank_lines:: for-loop: line , column , { type BRACE_OPEN
+newlines_insert_blank_lines:: for-loop: line , column , } type BRACE_CLOSE
+newlines_insert_blank_lines:: for-loop: line , column , ~ type DESTRUCTOR
+newlines_insert_blank_lines:: for-loop: line , column , TelegramIndex type FUNC_CLASS_DEF
+newlines_insert_blank_lines:: for-loop: line , column , ( type FPAREN_OPEN
+newlines_insert_blank_lines:: for-loop: line , column , ) type FPAREN_CLOSE
+newlines_insert_blank_lines:: for-loop: line , column , { type BRACE_OPEN
+newlines_insert_blank_lines:: for-loop: line , column , } type BRACE_CLOSE
+newlines_insert_blank_lines:: for-loop: line , column , const type QUALIFIER
+newlines_insert_blank_lines:: for-loop: line , column , char type TYPE
+newlines_insert_blank_lines:: for-loop: line , column , * type PTR_TYPE
+newlines_insert_blank_lines:: for-loop: line , column , const type QUALIFIER
+newlines_insert_blank_lines:: for-loop: line , column , pTelName type WORD
+newlines_insert_blank_lines:: for-loop: line , column , ; type SEMICOLON
+newlines_insert_blank_lines:: for-loop: line , column , unsigned type TYPE
+newlines_insert_blank_lines:: for-loop: line , column , long type TYPE
+newlines_insert_blank_lines:: for-loop: line , column , nTelIndex type WORD
+newlines_insert_blank_lines:: for-loop: line , column , ; type SEMICOLON
+newlines_insert_blank_lines:: for-loop: line , column , } type BRACE_CLOSE
+newlines_insert_blank_lines:: for-loop: line , column , ; type SEMICOLON

--- a/scripts/Output/mini_d_ucwd.txt
+++ b/scripts/Output/mini_d_ucwd.txt
@@ -1256,7 +1256,8 @@ nl_squeeze_ifdef_top_level      = false    # false/true
 # Add or remove blank line before 'if'
 nl_before_if                    = ignore   # ignore/add/remove/force
 
-# Add or remove blank line after 'if' statement
+# Add or remove blank line after 'if' statement.
+# Add/Force work only if the next token is not a closing brace
 nl_after_if                     = ignore   # ignore/add/remove/force
 
 # Add or remove blank line before 'for'

--- a/scripts/Output/mini_nd_ucwd.txt
+++ b/scripts/Output/mini_nd_ucwd.txt
@@ -1256,7 +1256,8 @@ nl_squeeze_ifdef_top_level      = false    # false/true
 # Add or remove blank line before 'if'
 nl_before_if                    = ignore   # ignore/add/remove/force
 
-# Add or remove blank line after 'if' statement
+# Add or remove blank line after 'if' statement.
+# Add/Force work only if the next token is not a closing brace
 nl_after_if                     = ignore   # ignore/add/remove/force
 
 # Add or remove blank line before 'for'

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -371,7 +371,7 @@ static void double_newline(chunk_t *nl)
    LOG_FMT(LNEWLINE, "%s:%d: add newline after ", __func__, __LINE__);
    if (prev->type == CT_VBRACE_CLOSE)
    {
-       LOG_FMT(LNEWLINE, "VBRACE_CLOSE ");
+      LOG_FMT(LNEWLINE, "VBRACE_CLOSE ");
    }
    else
    {
@@ -1302,7 +1302,7 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, argval
                prev = chunk_get_prev_nnl(next);
                LOG_FMT(LNEWLINE, "   %d:prev->... , type %s, line %zu, column %zu,\n",
                        __LINE__, get_token_name(prev->type), prev->orig_line, prev->orig_col);
-               pc   = chunk_get_next_nl(next);
+               pc = chunk_get_next_nl(next);
                LOG_FMT(LNEWLINE, "   %d:pc->...   , type %s, line %zu, column %zu,\n",
                        __LINE__, get_token_name(pc->type), pc->orig_line, pc->orig_col);
                chunk_t *pc2 = chunk_get_next(pc);

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -364,9 +364,20 @@ static void double_newline(chunk_t *nl)
 {
    LOG_FUNC_ENTRY();
    chunk_t *prev = chunk_get_prev(nl);
-
-   LOG_FMT(LNEWLINE, "%s: add newline after %s on line %zu",
-           __func__, prev->text(), prev->orig_line);
+   if (prev == nullptr)
+   {
+      return;
+   }
+   LOG_FMT(LNEWLINE, "%s:%d: add newline after ", __func__, __LINE__);
+   if (prev->type == CT_VBRACE_CLOSE)
+   {
+       LOG_FMT(LNEWLINE, "VBRACE_CLOSE ");
+   }
+   else
+   {
+      LOG_FMT(LNEWLINE, "%s ", prev->text());
+   }
+   LOG_FMT(LNEWLINE, "on line %zu", prev->orig_line);
 
    if (!can_increase_nl(nl))
    {
@@ -607,8 +618,8 @@ chunk_t *newline_add_between(chunk_t *start, chunk_t *end)
       return(nullptr);
    }
 
-   LOG_FMT(LNEWLINE, "%s: '%s'[%s] line %zu:%zu and '%s' line %zu:%zu :",
-           __func__, start->text(), get_token_name(start->type),
+   LOG_FMT(LNEWLINE, "%s:%d: '%s'[%s] line %zu:%zu and '%s' line %zu:%zu :",
+           __func__, __LINE__, start->text(), get_token_name(start->type),
            start->orig_line, start->orig_col,
            end->text(), end->orig_line, end->orig_col);
    log_func_stack_inline(LNEWLINE);
@@ -1115,6 +1126,8 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, argval
    chunk_t *next;
    chunk_t *prev;
 
+   LOG_FMT(LNEWLINE, "%s:\n   %d:start->..., type %s, line %zu, column %zu,\n",
+           __func__, __LINE__, get_token_name(start->type), start->orig_line, start->orig_col);
    if ((nl_opt == AV_IGNORE) ||
        ((start->flags & PCF_IN_PREPROC) &&
         !cpd.settings[UO_nl_define_macro].b))
@@ -1127,6 +1140,8 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, argval
    {
       return;
    }
+   LOG_FMT(LNEWLINE, "   %d:pc->...   , type %s, line %zu, column %zu,\n",
+           __LINE__, get_token_name(pc->type), pc->orig_line, pc->orig_col);
 
    /* if we're dealing with an if, we actually want to add or remove blank lines after any elses */
    if (start->type == CT_IF)
@@ -1141,6 +1156,8 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, argval
             {
                return;
             }
+            LOG_FMT(LNEWLINE, "   %d:pc->...   , type %s, line %zu, column %zu,\n",
+                    __LINE__, get_token_name(pc->type), pc->orig_line, pc->orig_col);
          }
          else
          {
@@ -1157,15 +1174,34 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, argval
       {
          return;
       }
+      LOG_FMT(LNEWLINE, "   %d:pc->...   , type %s, line %zu, column %zu,\n",
+              __LINE__, get_token_name(pc->type), pc->orig_line, pc->orig_col);
    }
 
-   bool isVBrace = pc->type == CT_VBRACE_CLOSE;
+   bool isVBrace = (pc->type == CT_VBRACE_CLOSE);
+   if (isVBrace)
+   {
+      LOG_FMT(LNEWLINE, "   %d: isVBrace is TRUE\n", __LINE__);
+   }
+   else
+   {
+      LOG_FMT(LNEWLINE, "   %d: isVBrace is FALSE\n", __LINE__);
+   }
+
    if ((prev = chunk_get_prev_nvb(pc)) == nullptr)
    {
       return;
    }
 
    bool have_pre_vbrace_nl = isVBrace && chunk_is_newline(prev);
+   if (have_pre_vbrace_nl)
+   {
+      LOG_FMT(LNEWLINE, "   %d: have_pre_vbrace_nl is TRUE\n", __LINE__);
+   }
+   else
+   {
+      LOG_FMT(LNEWLINE, "   %d: have_pre_vbrace_nl is FALSE\n", __LINE__);
+   }
    if (nl_opt & AV_REMOVE)
    {
       /* if vbrace, have to check before and after */
@@ -1196,51 +1232,90 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, argval
    /* don't do anything with it if the next non nl chunk is a closing brace */
    if (nl_opt & AV_ADD)
    {
-      if ((next = chunk_get_next_nnl(pc)) == nullptr)
+      chunk_t *nextNNL = chunk_get_next_nnl(pc);
+      do
       {
-         return;
-      }
+         if (nextNNL == nullptr)
+         {
+            return;
+         }
+         if (nextNNL->type != CT_VBRACE_CLOSE)
+         {
+            next = nextNNL;
+            break;
+         }
+         nextNNL = chunk_get_next_nnl(nextNNL);
+      } while (true);
 
+      LOG_FMT(LNEWLINE, "   %d:next->... , type %s, line %zu, column %zu,\n",
+              __LINE__, get_token_name(next->type), next->orig_line, next->orig_col);
       if (next->type != CT_BRACE_CLOSE)
       {
          /* if vbrace, have to check before and after */
          /* if chunk before vbrace, check its count */
          size_t nl_count = have_pre_vbrace_nl ? prev->nl_count : 0;
+         LOG_FMT(LNEWLINE, "   %d:nl_count %zu\n", __LINE__, nl_count);
          if (chunk_is_newline(next = chunk_get_next_nvb(pc)))
          {
+            LOG_FMT(LNEWLINE, "   %d:next->... , type %s, line %zu, column %zu,\n",
+                    __LINE__, get_token_name(next->type), next->orig_line, next->orig_col);
             nl_count += next->nl_count;
+            LOG_FMT(LNEWLINE, "   %d:nl_count %zu\n", __LINE__, nl_count);
          }
 
          /* if we have no newlines, add one and make it double */
          if (nl_count == 0)
          {
+            LOG_FMT(LNEWLINE, "   %d: nl_count is 0\n", __LINE__);
             if (((next = chunk_get_next(pc)) != nullptr) &&
                 chunk_is_comment(next))
             {
+               LOG_FMT(LNEWLINE, "   %d:next->... , type %s, line %zu, column %zu,\n",
+                       __LINE__, get_token_name(next->type), next->orig_line, next->orig_col);
                pc = next;
+               LOG_FMT(LNEWLINE, "   %d:pc->...   , type %s, line %zu, column %zu,\n",
+                       __LINE__, get_token_name(pc->type), pc->orig_line, pc->orig_col);
             }
 
             if ((next = newline_add_after(pc)) == nullptr)
             {
                return;
             }
+            LOG_FMT(LNEWLINE, "   %d:next->... , type %s, line %zu, column %zu,\n",
+                    __LINE__, get_token_name(next->type), next->orig_line, next->orig_col);
             double_newline(next);
          }
          else if (nl_count == 1) /* if we don't have enough newlines */
          {
+            LOG_FMT(LNEWLINE, "   %d: nl_count is 1\n", __LINE__);
             /* if we have one before vbrace, need to add one after */
             if (have_pre_vbrace_nl)
             {
+               LOG_FMT(LNEWLINE, "   %d: have_pre_vbrace_nl is TRUE\n", __LINE__);
                next = newline_add_after(pc);
+               LOG_FMT(LNEWLINE, "   %d:next->... , type %s, line %zu, column %zu,\n",
+                       __LINE__, get_token_name(next->type), next->orig_line, next->orig_col);
             }
             else
             {
+               LOG_FMT(LNEWLINE, "   %d: have_pre_vbrace_nl is FALSE\n", __LINE__);
                prev = chunk_get_prev_nnl(next);
+               LOG_FMT(LNEWLINE, "   %d:prev->... , type %s, line %zu, column %zu,\n",
+                       __LINE__, get_token_name(prev->type), prev->orig_line, prev->orig_col);
                pc   = chunk_get_next_nl(next);
-               //LOG_FMT(LSYS, "  -- pc1=%s [%s]\n", pc->text(), get_token_name(pc->type));
-
-               pc = chunk_get_next(pc);
-               //LOG_FMT(LSYS, "  -- pc2=%s [%s]\n", pc->text(), get_token_name(pc->type));
+               LOG_FMT(LNEWLINE, "   %d:pc->...   , type %s, line %zu, column %zu,\n",
+                       __LINE__, get_token_name(pc->type), pc->orig_line, pc->orig_col);
+               chunk_t *pc2 = chunk_get_next(pc);
+               if (pc2 != nullptr)
+               {
+                  pc = pc2;
+                  LOG_FMT(LNEWLINE, "   %d:pc->...   , type %s, line %zu, column %zu,\n",
+                          __LINE__, get_token_name(pc->type), pc->orig_line, pc->orig_col);
+               }
+               else
+               {
+                  LOG_FMT(LNEWLINE, "   %d: no next found: <EOF>\n", __LINE__);
+               }
                if ((pc != nullptr) && (pc->type == CT_PREPROC) &&
                    (pc->parent_type == CT_PP_ENDIF) &&
                    cpd.settings[UO_nl_squeeze_ifdef].b)
@@ -1251,6 +1326,7 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, argval
                else
                {
                   /* make nl after double */
+                  LOG_FMT(LNEWLINE, "   %d: call double_newline\n", __LINE__);
                   double_newline(next);
                }
             }
@@ -2875,13 +2951,13 @@ void newlines_cleanup_braces(bool first)
                chunk_t *end = chunk_get_next(chunk_get_next_type(pc->next, CT_SEMICOLON, -1));
                /* Scan for clear flag */
 #ifdef DEBUG
-               LOG_FMT(LGUY, "(%d) ", __LINE__);
+               LOG_FMT(LNEWLINE, "(%d) ", __LINE__);
 #endif
-               LOG_FMT(LGUY, "\n");
+               LOG_FMT(LNEWLINE, "\n");
                for (chunk_t *temp = pc; temp != end; temp = chunk_get_next(temp))
                {
-                  LOG_FMT(LGUY, "%s type=%s , level=%zu", temp->text(), get_token_name(temp->type), temp->level);
-                  log_pcf_flags(LGUY, temp->flags);
+                  LOG_FMT(LNEWLINE, "%s type=%s , level=%zu", temp->text(), get_token_name(temp->type), temp->level);
+                  log_pcf_flags(LNEWLINE, temp->flags);
                   chunk_flags_clr(temp, PCF_ONE_LINER);
                }
                // split
@@ -3229,6 +3305,9 @@ void newlines_insert_blank_lines(void)
 
    for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnl(pc))
    {
+      LOG_FMT(LNEWLINE, "%s:%d: for-loop: line %zu, column %zu, %s type %s\n",
+              __func__, __LINE__, pc->orig_line, pc->orig_col,
+              pc->text(), get_token_name(pc->type));
       if (pc->type == CT_IF)
       {
          newlines_if_for_while_switch_pre_blank_lines(pc, cpd.settings[UO_nl_before_if].a);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1132,7 +1132,8 @@ void register_options(void)
    unc_add_option("nl_before_if", UO_nl_before_if, AT_IARF,
                   "Add or remove blank line before 'if'");
    unc_add_option("nl_after_if", UO_nl_after_if, AT_IARF,
-                  "Add or remove blank line after 'if' statement");
+                  "Add or remove blank line after 'if' statement.\n"
+                  "Add/Force work only if the next token is not a closing brace");
    unc_add_option("nl_before_for", UO_nl_before_for, AT_IARF,
                   "Add or remove blank line before 'for'");
    unc_add_option("nl_after_for", UO_nl_after_for, AT_IARF,

--- a/tests/config/bug_1068.cfg
+++ b/tests/config/bug_1068.cfg
@@ -1,0 +1,2 @@
+nl_after_if = force
+#nl_after_if = remove

--- a/tests/config/bug_666.cfg
+++ b/tests/config/bug_666.cfg
@@ -1,0 +1,2 @@
+indent_else_if       = true
+nl_after_brace_close = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -397,3 +397,5 @@
 34144 i683.cfg                         cpp/i683.cpp
 
 34150 bug_1032.cfg                     cpp/bug_1032.cpp
+34151 bug_666.cfg                      cpp/bug_666.cpp
+34152 bug_1068.cfg                     cpp/bug_1068.cpp

--- a/tests/input/cpp/bug_1068.cpp
+++ b/tests/input/cpp/bug_1068.cpp
@@ -1,0 +1,55 @@
+// No extra line added
+void test1()
+{
+	if ( i == 10 )
+		i++;
+}
+
+// No extra line added
+void test2()
+{
+	if ( i == 10 )
+	{
+		i++;
+	}
+}
+
+// No extra line added
+void test3()
+{
+	if ( i == 10 )
+	{
+		if ( j == 10 )
+		{
+			i++;
+		}
+	}
+}
+
+// No extra line added
+void test4()
+{
+	if ( i == 10 )
+	{
+		if ( j == 10 )
+			i++;
+	}
+}
+
+// Extra line added (after Uncrustify)
+void test5()
+{
+	if ( i == 10 )
+		if ( j == 10 )
+		{
+			i++;
+		}
+}
+
+// Extra line added (after Uncrustify)
+void test6()
+{
+	if ( i == 10 )
+		if ( j == 10 )
+			i++;
+}

--- a/tests/input/cpp/bug_666.cpp
+++ b/tests/input/cpp/bug_666.cpp
@@ -1,0 +1,12 @@
+bool test()
+{
+    if ( true )
+    {
+        i = 10;
+    }
+    else
+        if ( true )
+        {
+            i = 10;
+        }
+}

--- a/tests/output/c/02100-i2c-core.c
+++ b/tests/output/c/02100-i2c-core.c
@@ -250,7 +250,6 @@ int i2c_del_adapter(struct i2c_adapter *adap)
                 "for driver [%s]\n", driver->name);
         goto out_unlock;
         }
-
     }
 
   /* detach any active clients. This must be done first, because

--- a/tests/output/cpp/34151-bug_666.cpp
+++ b/tests/output/cpp/34151-bug_666.cpp
@@ -1,0 +1,12 @@
+bool test()
+{
+	if ( true )
+	{
+		i = 10;
+	}
+	else
+		if ( true )
+		{
+			i = 10;
+		}
+}

--- a/tests/output/cpp/34152-bug_1068.cpp
+++ b/tests/output/cpp/34152-bug_1068.cpp
@@ -1,0 +1,55 @@
+// No extra line added
+void test1()
+{
+	if ( i == 10 )
+		i++;
+}
+
+// No extra line added
+void test2()
+{
+	if ( i == 10 )
+	{
+		i++;
+	}
+}
+
+// No extra line added
+void test3()
+{
+	if ( i == 10 )
+	{
+		if ( j == 10 )
+		{
+			i++;
+		}
+	}
+}
+
+// No extra line added
+void test4()
+{
+	if ( i == 10 )
+	{
+		if ( j == 10 )
+			i++;
+	}
+}
+
+// Extra line added (after Uncrustify)
+void test5()
+{
+	if ( i == 10 )
+		if ( j == 10 )
+		{
+			i++;
+		}
+}
+
+// Extra line added (after Uncrustify)
+void test6()
+{
+	if ( i == 10 )
+		if ( j == 10 )
+			i++;
+}


### PR DESCRIPTION
if more than one token ```CT_VBRACE_CLOSE``` are present, 
```newlines_if_for_while_switch_post_blank_lines``` must go on to look for ```CT_BRACE_CLOSE```