### PR TITLE
Don't force CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,11 +117,6 @@ endif()
 # Generate uncrustify_version.h
 #
 
-# FIXME: checking for CMAKE_BUILD_TYPE and passing it to make_version.py
-# does not work with VS .sln projects
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
 # FIXME: the version number should be automatically integrated
 set(FALLBACK_VERSION "Uncrustify-0.65_f")
 


### PR DESCRIPTION
If build type is not set, it should not be forced. For example, it should remain unset for FreeBSD port which is required to respect systemwide C/C++ compiler flags passed via CMAKE_C/CXX_FLAGS, and adding extra flags (which setting build type does) is allowed.