### PR TITLE
Hang on multi-line comments fixed.

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1492,7 +1492,12 @@ static void output_comment_multi(chunk_t *pc)
              * This is not the first line, so we need to indent to the
              * correct column. Each line is indented 0 or more spaces.
              */
-            ccol -= col_diff;
+            // Ensure ccol is not negative
+            if (static_cast<int>(ccol) >= col_diff)
+            {
+               ccol -= col_diff;
+            }
+
             if (ccol < (cmt_col + 3))
             {
                ccol = cmt_col + 3;

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -438,3 +438,5 @@
 34171  i1181.cfg                       cpp/i1181.cpp
 
 34190 bug_1003.cfg                     cpp/bug_1003.cpp
+
+34191 empty.cfg                        cpp/comment-align-multiline.cpp

--- a/tests/input/cpp/comment-align-multiline.cpp
+++ b/tests/input/cpp/comment-align-multiline.cpp
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+void function()
+{
+    printf( "Hello World\n" );
+        /*
+ //test
+        /// Another comment
+//end test
+*/
+}

--- a/tests/output/cpp/34191-comment-align-multiline.cpp
+++ b/tests/output/cpp/34191-comment-align-multiline.cpp
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+void function()
+{
+	printf( "Hello World\n" );
+	/*
+	   //test
+	   /// Another comment
+	   //end test
+	 */
+}


### PR DESCRIPTION
Uncrustify hangs when indenting bad formatted multi-line comments like in
```.cpp
void function()
{
    printf( "Hello World\n" );
        /*
 //test
        /// Another comment
//end test
*/
}
```

This was caused by a subtraction without boundary check, so that the unsigned variable `ccol` actually got huge values. By ensuring the subtraction will not result in negative values this problem was fixed.

A test was added which shows the original problem.