### PR TITLE
Semicolon removal fix

### DIFF
--- a/src/semicolons.cpp
+++ b/src/semicolons.cpp
@@ -119,12 +119,13 @@ static void check_unknown_brace_close(chunk_t *semi, chunk_t *brace_close)
    LOG_FUNC_ENTRY();
    chunk_t *pc = chunk_get_prev_type(brace_close, CT_BRACE_OPEN, brace_close->level);
    pc = chunk_get_prev_ncnl(pc);
-   if (  (pc != nullptr)
-      && (pc->type != CT_RETURN)
-      && (pc->type != CT_WORD)
-      && (pc->type != CT_TYPE)
-      && (pc->type != CT_SQUARE_CLOSE)
-      && (pc->type != CT_TSQUARE)
+   if (  pc != nullptr
+      && pc->type != CT_RETURN
+      && pc->type != CT_WORD
+      && pc->type != CT_TYPE
+      && pc->type != CT_SQUARE_CLOSE
+      && pc->type != CT_ANGLE_CLOSE
+      && pc->type != CT_TSQUARE
       && !chunk_is_paren_close(pc))
    {
       remove_semicolon(semi);

--- a/tests/config/mod_remove_extra_semicolon-t.cfg
+++ b/tests/config/mod_remove_extra_semicolon-t.cfg
@@ -1,0 +1,1 @@
+mod_remove_extra_semicolon      = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -442,3 +442,4 @@
 34190 bug_1003.cfg                     cpp/bug_1003.cpp
 
 34191 empty.cfg                        cpp/comment-align-multiline.cpp
+34192  mod_remove_extra_semicolon-t.cfg    cpp/i1207.cpp

--- a/tests/input/cpp/i1207.cpp
+++ b/tests/input/cpp/i1207.cpp
@@ -1,0 +1,10 @@
+#include <vector>
+std::vector<int> f()
+{;
+return std::vector<int>{1};
+};
+
+int main()
+{;
+    return f()[0];;;;;
+};

--- a/tests/output/cpp/34192-i1207.cpp
+++ b/tests/output/cpp/34192-i1207.cpp
@@ -1,0 +1,10 @@
+#include <vector>
+std::vector<int> f()
+{
+	return std::vector<int>{1};
+}
+
+int main()
+{
+	return f()[0];
+}


### PR DESCRIPTION
`return vector<int>{1};` <- Semicolon was removed.

The check_unknown_brace_close() function did not check for _template type argument-list angle brackets_ which lead to the faulty removal.

---------

ref: #1207

---------

<s>Will be closed temporarily until an other issue is fixed.</s>