### PR TITLE
Prevent addition of newline because of vbrace

### DIFF
--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -593,6 +593,27 @@ chunk_t *chunk_first_on_line(chunk_t *pc)
 }
 
 
+bool chunk_is_last_on_line(chunk_t &pc)  //TODO: pc should be const here
+{
+   // check if pc is the very last chunk of the file
+   const auto *end = chunk_get_tail();
+
+   if (&pc == end)
+   {
+      return(true);
+   }
+
+   // if the next chunk is a newline then pc is the last chunk on its line
+   const auto *next = chunk_get_next(&pc);
+   if (next != nullptr && next->type == CT_NEWLINE)
+   {
+      return(true);
+   }
+
+   return(false);
+}
+
+
 // TODO: this function needs some cleanup
 void chunk_swap_lines(chunk_t *pc1, chunk_t *pc2)
 {

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -165,6 +165,10 @@ void chunk_swap_lines(chunk_t *pc1, chunk_t *pc2);
 chunk_t *chunk_first_on_line(chunk_t *pc);
 
 
+//! check if a given chunk is the last on its line
+bool chunk_is_last_on_line(chunk_t &pc);
+
+
 /**
  * Gets the next NEWLINE chunk
  *

--- a/src/width.cpp
+++ b/src/width.cpp
@@ -151,6 +151,12 @@ void do_code_width(void)
          && (pc->type != CT_SPACE)
          && is_past_width(pc))
       {
+         if (  pc->type == CT_VBRACE_CLOSE // don't break if a vbrace close
+            && chunk_is_last_on_line(*pc)) // is the last chunk on its line
+         {
+            continue;
+         }
+
          bool split_OK = split_line(pc);
          if (split_OK)
          {

--- a/tests/config/code_width-25.cfg
+++ b/tests/config/code_width-25.cfg
@@ -1,0 +1,1 @@
+code_width                      = 25

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -449,3 +449,4 @@
 
 34191 empty.cfg                        cpp/comment-align-multiline.cpp
 34192  mod_remove_extra_semicolon-t.cfg    cpp/i1207.cpp
+34193  code_width-25.cfg               cpp/i1218.cpp

--- a/tests/input/cpp/i1218.cpp
+++ b/tests/input/cpp/i1218.cpp
@@ -1,0 +1,8 @@
+// Do not add a new line because of the vbrace close that is above col 25
+// after return 1;
+int main()
+{
+	if(1)
+		return 1;
+	return 0;
+}

--- a/tests/output/cpp/34193-i1218.cpp
+++ b/tests/output/cpp/34193-i1218.cpp
@@ -1,0 +1,8 @@
+// Do not add a new line because of the vbrace close that is above col 25
+// after return 1;
+int main()
+{
+	if(1)
+		return 1;
+	return 0;
+}


### PR DESCRIPTION
When the option code_width is set to M, a virtual close brace (vbrace) can
be placed at column N, N>M, this caused an unexpected insertion of a
newline.

To prevent this, the vbrace that is outside of the column range is checked
if it is the last chunk on the code line. If so no break (which causes
the newline) is made.

----------------

ref: #1218