### PR TITLE
Improve indent_namespace_single_indent

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -403,7 +403,6 @@ static void indent_pse_push(parse_frame_t &frm, chunk_t *pc)
       frm.pse[frm.pse_tos].indent_tab  = frm.pse[frm.pse_tos - 1].indent_tab;
       frm.pse[frm.pse_tos].indent_cont = frm.pse[frm.pse_tos - 1].indent_cont;
       frm.pse[frm.pse_tos].non_vardef  = false;
-      frm.pse[frm.pse_tos].ns_cnt      = frm.pse[frm.pse_tos - 1].ns_cnt;
       memcpy(&frm.pse[frm.pse_tos].ip, &frm.pse[frm.pse_tos - 1].ip, sizeof(frm.pse[frm.pse_tos].ip));
    }
    else
@@ -1322,16 +1321,17 @@ void indent_text(void)
             }
             else if (pc->parent_type == CT_NAMESPACE)
             {
+               frm.pse[frm.pse_tos].ns_cnt = frm.pse[frm.pse_tos - 1].ns_cnt + 1;
                if (  cpd.settings[UO_indent_namespace].b
                   && cpd.settings[UO_indent_namespace_single_indent].b)
                {
-                  if (frm.pse[frm.pse_tos].ns_cnt)
+                  if (frm.pse[frm.pse_tos].ns_cnt >= 2)
                   {
                      // undo indent on all except the first namespace
                      frm.pse[frm.pse_tos].indent -= indent_size;
                      log_indent();
                   }
-                  indent_column_set((frm.pse_tos <= 1) ? 1 : frm.pse[frm.pse_tos - 1].brace_indent);
+                  indent_column_set(frm.pse[frm.pse_tos - frm.pse[frm.pse_tos].ns_cnt].indent);
                }
                else if (  (pc->flags & PCF_LONG_BLOCK)
                        || !cpd.settings[UO_indent_namespace].b)
@@ -1351,7 +1351,6 @@ void indent_text(void)
                      log_indent();
                   }
                }
-               frm.pse[frm.pse_tos].ns_cnt++;
             }
             else if (  (pc->parent_type == CT_EXTERN)
                     && !cpd.settings[UO_indent_extern].b)

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -113,7 +113,7 @@ struct paren_stack_entry_t
    c_token_t     parent;       //! if, for, function, etc
    brace_stage_e stage;
    bool          in_preproc;   //! whether this was created in a preprocessor
-   size_t        ns_cnt;
+   size_t        ns_cnt;       //! Number of consecutive namespace levels
    bool          non_vardef;   //! Hit a non-vardef line
    indent_ptr_t  ip;
 };

--- a/tests/config/indent_namespace_single_indent.cfg
+++ b/tests/config/indent_namespace_single_indent.cfg
@@ -1,0 +1,3 @@
+indent_extern = true
+indent_namespace = true
+indent_namespace_single_indent = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -211,6 +211,7 @@
 30911 indent_namespace-f.cfg           cpp/indent_namespace.h
 30912 long_namespace.cfg               cpp/long_namespace.cpp
 30913 indent_namespace-t.cfg           cpp/indent_namespace2.h
+30914 indent_namespace_single_indent.cfg cpp/indent_namespace_single_indent.h
 
 30920 ben.cfg                          cpp/indent-off.cpp
 30921 ben.cfg                          cpp/variadic-template.h

--- a/tests/input/cpp/indent_namespace_single_indent.h
+++ b/tests/input/cpp/indent_namespace_single_indent.h
@@ -1,0 +1,100 @@
+namespace ns1 {
+	namespace ns2 {
+		namespace ns3 {
+			void a();
+		}
+	}
+}
+
+extern "C" {
+	namespace ns1 {
+		namespace ns2 {
+			namespace ns3 {
+				void b();
+			}
+		}
+	}
+}
+
+namespace ns1 {
+	extern "C" {
+		namespace ns2 {
+			namespace ns3 {
+				void c();
+			}
+		}
+	}
+}
+
+namespace ns1 {
+	namespace ns2 {
+		extern "C" {
+			namespace ns3 {
+				void d();
+			}
+		}
+	}
+}
+
+namespace ns1 {
+	namespace ns2 {
+		namespace ns3 {
+			extern "C" {
+				void e();
+			}
+		}
+	}
+}
+
+#define M1(ns1, ns2, ns3, f) \
+	namespace ns1 { \
+		namespace ns2 { \
+			namespace ns3 { \
+				void f(); \
+			} \
+		} \
+	}
+
+#define M2(ns1, ns2, ns3, f) \
+	extern "C" { \
+		namespace ns1 { \
+			namespace ns2 { \
+				namespace ns3 { \
+					void b(); \
+				} \
+			} \
+		} \
+	}
+
+#define M3(ns1, ns2, ns3, f) \
+	namespace ns1 { \
+		extern "C" { \
+			namespace ns2 { \
+				namespace ns3 { \
+					void c(); \
+				} \
+			} \
+		} \
+	}
+
+#define M4(ns1, ns2, ns3, f) \
+	namespace ns1 { \
+		namespace ns2 { \
+			extern "C" { \
+				namespace ns3 { \
+					void d(); \
+				} \
+			} \
+		} \
+	}
+
+#define M5(ns1, ns2, ns3, f) \
+	namespace ns1 { \
+		namespace ns2 { \
+			namespace ns3 { \
+				extern "C" { \
+					void e(); \
+				} \
+			} \
+		} \
+	}

--- a/tests/output/cpp/30914-indent_namespace_single_indent.h
+++ b/tests/output/cpp/30914-indent_namespace_single_indent.h
@@ -1,0 +1,100 @@
+namespace ns1 {
+namespace ns2 {
+namespace ns3 {
+	void a();
+}
+}
+}
+
+extern "C" {
+	namespace ns1 {
+	namespace ns2 {
+	namespace ns3 {
+		void b();
+	}
+	}
+	}
+}
+
+namespace ns1 {
+	extern "C" {
+		namespace ns2 {
+		namespace ns3 {
+			void c();
+		}
+		}
+	}
+}
+
+namespace ns1 {
+namespace ns2 {
+	extern "C" {
+		namespace ns3 {
+			void d();
+		}
+	}
+}
+}
+
+namespace ns1 {
+namespace ns2 {
+namespace ns3 {
+	extern "C" {
+		void e();
+	}
+}
+}
+}
+
+#define M1(ns1, ns2, ns3, f) \
+	namespace ns1 { \
+	namespace ns2 { \
+	namespace ns3 { \
+		void f(); \
+	} \
+	} \
+	}
+
+#define M2(ns1, ns2, ns3, f) \
+	extern "C" { \
+		namespace ns1 { \
+		namespace ns2 { \
+		namespace ns3 { \
+			void b(); \
+		} \
+		} \
+		} \
+	}
+
+#define M3(ns1, ns2, ns3, f) \
+	namespace ns1 { \
+		extern "C" { \
+			namespace ns2 { \
+			namespace ns3 { \
+				void c(); \
+			} \
+			} \
+		} \
+	}
+
+#define M4(ns1, ns2, ns3, f) \
+	namespace ns1 { \
+	namespace ns2 { \
+		extern "C" { \
+			namespace ns3 { \
+				void d(); \
+			} \
+		} \
+	} \
+	}
+
+#define M5(ns1, ns2, ns3, f) \
+	namespace ns1 { \
+	namespace ns2 { \
+	namespace ns3 { \
+		extern "C" { \
+			void e(); \
+		} \
+	} \
+	} \
+	}


### PR DESCRIPTION
indent_namespace_single_indent worked correctly only for consecutively nested namespaces at top level. With this PR, nested namespaces should be indented more reasonably when not at top level or when not nested consecutively (e.g. when sub-namespaces are contained inside an extern "C" {}).
The included tests should explain more clearly.

The idea is to count consecutive levels of namespace nesting. Every _paren_stack_entry_t_ has an _ns_cnt_ of 0 initially, which for namespaces is then set to the _ns_cnt_ of the previous _paren_stack_entry_t_ increased by 1.
Then, having an _extern "C" {}_ or _#define_ level between nested namespaces, the _ns_cnt_ would be reset to 0.