### PR TITLE
Fix #1196 unmatched extern "C" brace

### DIFF
--- a/scripts/Input/unmatched_close_pp.cpp
+++ b/scripts/Input/unmatched_close_pp.cpp
@@ -1,0 +1,12 @@
+#ifndef _Include_H
+#define _Include_H
+namespace Namespace
+{
+	// class Class {
+		public void foo()
+		{
+
+		}
+	}
+}
+#endif

--- a/scripts/Output/unmatched_close_pp.txt
+++ b/scripts/Output/unmatched_close_pp.txt
@@ -1,0 +1,2 @@
+Unmatched BRACE_CLOSE
+at line=11, column=1

--- a/scripts/Test_more_Options.sh
+++ b/scripts/Test_more_Options.sh
@@ -173,7 +173,7 @@ do
   fi
 done
 
-Liste_of_Error_Tests="I-842"
+Liste_of_Error_Tests="I-842 unmatched_close_pp"
 for Error_T in ${Liste_of_Error_Tests}
 do
   ConfigFile="${CONFIG}/${Error_T}.cfg"

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -22,6 +22,7 @@
 #include "keywords.h"
 #include "logger.h"
 #include "helper_for_print.h"
+#include "indent.h"
 
 
 /*
@@ -691,11 +692,12 @@ static void parse_cleanup(parse_frame_t *frm, chunk_t *pc)
       LOG_FMT(LSTMT, "%s(%d): %zu> reset expr on %s\n",
               __func__, __LINE__, pc->orig_line, pc->text());
    }
-   else if (pc->type == CT_BRACE_CLOSE && pc->pp_level == 0)
+   else if (pc->type == CT_BRACE_CLOSE)
    {
       if (!cpd.consumed)
       {
-         if (!cpd.unc_off_used)
+         size_t file_pp_level = ifdef_over_whole_file() ? 1 : 0;
+         if (!cpd.unc_off_used && pc->pp_level == file_pp_level)
          {
             // fatal error
             char *outputMessage;

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -691,7 +691,7 @@ static void parse_cleanup(parse_frame_t *frm, chunk_t *pc)
       LOG_FMT(LSTMT, "%s(%d): %zu> reset expr on %s\n",
               __func__, __LINE__, pc->orig_line, pc->text());
    }
-   else if (pc->type == CT_BRACE_CLOSE)
+   else if (pc->type == CT_BRACE_CLOSE && pc->pp_level == 0)
    {
       if (!cpd.consumed)
       {

--- a/tests/c.test
+++ b/tests/c.test
@@ -236,6 +236,8 @@
 01070  label_colon_nl_1.cfg    c/various_colons.c
 01071  label_colon_nl_2.cfg    c/various_colons.c
 
+01080  empty.cfg               c/bug_1196.c
+
 # big general tests
 02000 ben.cfg                  c/i2c-core.c
 02001 preproc-cleanup.cfg      c/directfb.h

--- a/tests/input/c/bug_1196.c
+++ b/tests/input/c/bug_1196.c
@@ -1,0 +1,9 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void foo(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/output/c/01080-bug_1196.c
+++ b/tests/output/c/01080-bug_1196.c
@@ -1,0 +1,9 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void foo(void);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
A common pattern for headers that are used in both C and C++ sources
is to conditionally wrap declarations that need C linkage in an
extern C block, but guarded by preprocessor. Since uncrustify's
parser doesn't yet match braces across preprocessor blocks, the brace
close for this "extern C" was incorrectly seen as unmatched, resulting
in fatal error.

This patch suppresses this fatal error when inside a PP block, until
the parser can be improved.