### PR TITLE
Unum fixup

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -553,9 +553,9 @@ void align_right_comments(void)
 
             if (pc->orig_col < prev->orig_col_end + cpd.settings[UO_align_right_cmt_gap].u)
             {
-               LOG_FMT(LALTC, "NOT changing END comment on line %zu (%zu <= %zu + %d)\n",
+               LOG_FMT(LALTC, "NOT changing END comment on line %zu (%zu <= %zu + %zu)\n",
                        pc->orig_line, pc->orig_col, prev->orig_col_end,
-                       cpd.settings[UO_align_right_cmt_gap].n);
+                       cpd.settings[UO_align_right_cmt_gap].u);
             }
             else
             {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2450,7 +2450,7 @@ void set_option_defaults(void)
       {
          int min_value     = value.min_val;
          int max_value     = value.max_val;
-         int default_value = cpd.defaults[id.first].u;
+         int default_value = cpd.defaults[id.first].n;
          if (default_value > max_value)
          {
             fprintf(stderr, "option '%s' is not correctly set:\n", id.second.name);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1838,7 +1838,7 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
       tmp = unc_find_option(val);
       if (tmp == nullptr)
       {
-         fprintf(stderr, "%s:%d\n  for the assigment: unknown option '%s':",
+         fprintf(stderr, "%s:%d\n  for the assignment: unknown option '%s':",
                  cpd.filename, cpd.line_number, val);
          log_flush(true);
          exit(EX_CONFIG);
@@ -1860,7 +1860,7 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
          return;
       }
 
-      fprintf(stderr, "%s:%d\n  for the assigment: expected type for %s is %s, got %s\n",
+      fprintf(stderr, "%s:%d\n  for the assignment: expected type for %s is %s, got %s\n",
               cpd.filename, cpd.line_number,
               entry->name, get_argtype_name(entry->type), get_argtype_name(tmp->type));
       log_flush(true);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2349,12 +2349,12 @@ void set_option_defaults(void)
    cpd.defaults[UO_cmt_indent_multi].b                                  = true;
    cpd.defaults[UO_cmt_insert_before_inlines].b                         = true;
    cpd.defaults[UO_cmt_multi_check_last].b                              = true;
-   cpd.defaults[UO_cmt_multi_first_len_minimum].n                       = 4;
+   cpd.defaults[UO_cmt_multi_first_len_minimum].u                       = 4;
    cpd.defaults[UO_indent_access_spec].n                                = 1;
    cpd.defaults[UO_indent_align_assign].b                               = true;
    cpd.defaults[UO_indent_columns].u                                    = 8;
    cpd.defaults[UO_indent_cpp_lambda_body].b                            = false;
-   cpd.defaults[UO_indent_ctor_init_leading].n                          = 2;
+   cpd.defaults[UO_indent_ctor_init_leading].u                          = 2;
    cpd.defaults[UO_indent_label].n                                      = 1;
    cpd.defaults[UO_indent_oc_msg_prioritize_first_colon].b              = true;
    cpd.defaults[UO_indent_token_after_brace].b                          = true;
@@ -2364,7 +2364,7 @@ void set_option_defaults(void)
    cpd.defaults[UO_input_tab_size].u                                    = 8;
    cpd.defaults[UO_newlines].le                                         = LE_AUTO;
    cpd.defaults[UO_output_tab_size].u                                   = 8;
-   cpd.defaults[UO_pp_indent_count].n                                   = 1;
+   cpd.defaults[UO_pp_indent_count].u                                   = 1;
    cpd.defaults[UO_sp_addr].a                                           = AV_REMOVE;
    cpd.defaults[UO_sp_after_semi].a                                     = AV_ADD;
    cpd.defaults[UO_sp_after_semi_for].a                                 = AV_FORCE;
@@ -2386,10 +2386,10 @@ void set_option_defaults(void)
    cpd.defaults[UO_sp_this_paren].a                                     = AV_REMOVE;
    cpd.defaults[UO_sp_word_brace].a                                     = AV_ADD;
    cpd.defaults[UO_sp_word_brace_ns].a                                  = AV_ADD;
-   cpd.defaults[UO_string_escape_char].n                                = '\\';
+   cpd.defaults[UO_string_escape_char].u                                = '\\';
    cpd.defaults[UO_use_indent_func_call_param].b                        = true;
    cpd.defaults[UO_use_options_overriding_for_qt_macros].b              = true;
-   cpd.defaults[UO_warn_level_tabs_found_in_verbatim_string_literals].n = LWARN;
+   cpd.defaults[UO_warn_level_tabs_found_in_verbatim_string_literals].u = LWARN;
    cpd.defaults[UO_pp_indent_case].b                                    = true;
    cpd.defaults[UO_pp_indent_func_def].b                                = true;
    cpd.defaults[UO_pp_indent_extern].b                                  = true;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -545,7 +545,7 @@ void output_text(FILE *pfile)
          }
          else
          {
-            output_to_column(pc->column, (cpd.settings[UO_indent_with_tabs].n == 2));
+            output_to_column(pc->column, (cpd.settings[UO_indent_with_tabs].u == 2));
          }
          add_char('\\');
          add_char('\n');
@@ -597,7 +597,7 @@ void output_text(FILE *pfile)
          // indent to the 'level' first
          if (cpd.did_newline)
          {
-            if (cpd.settings[UO_indent_with_tabs].n == 1)
+            if (cpd.settings[UO_indent_with_tabs].u == 1)
             {
                size_t lvlcol;
                /*
@@ -624,9 +624,9 @@ void output_text(FILE *pfile)
                   output_to_column(lvlcol, true);
                }
             }
-            allow_tabs = (cpd.settings[UO_indent_with_tabs].n == 2)
+            allow_tabs = (cpd.settings[UO_indent_with_tabs].u == 2)
                          || (  chunk_is_comment(pc)
-                            && cpd.settings[UO_indent_with_tabs].n != 0);
+                            && cpd.settings[UO_indent_with_tabs].u != 0);
 
             LOG_FMT(LOUTIND, "  %zu> col %zu/%zu/%zu - ", pc->orig_line, pc->column, pc->column_indent, cpd.column);
          }


### PR DESCRIPTION
Error on arch s390x (and some others): wrong assumption that sizeof(int)==sizeof(size_t)

I'm packaging uncrustify for Debian and found the following serious issue:
uncrustify 0.64 builds and passes all tests without problem
uncrustify 0.65 builds and passes tests on all architectures but ppc64, sparc64, s390x.

See also #1229 and https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=867376

The problem came from commits 3f1565c312e95b0ac05f0265dead6d38e0a184cf and 62958075351d74f9e9d2ea47107905d50d277493.

You made wrong assumption that sizeof(int)==sizeof(size_t), but unfortunately there are platforms where this is wrong. Thus you could not handle AT_UNUM and AT_NUM the same way.

What the problem looks like:
Current master, build type Debug, every test fails with

> 36:   Uncrustify error: option
>36:   'warn_level_tabs_found_in_verbatim_string_literals' is not correctly set:
>36: 
>36:   The default value '8589934592' is more than the max value '3'.

After debugging a little bit, I found 3 errors in code:
1. Default initialization of AT_UNUM should be done with .u field, not .n (fixed in 71ca57b5)
2. In convert_value() AT_NUM and AT_UNUM should be handled differently (fixed in 5469dd1c)
3. In convert_value() assignment should be processed a little bit more complex (also fixed in 5469dd1c)

After I fixed this errors, there are only 287 failed tests left.

I looked through code a little bit more and found some more wrong usages of the union. (fixed in 5587cb3 and c6888e8)
This reduces number of failed tests to 268.

So this branch fixes some, but not all of the errors, more research is needed. But these changes are atomic, looks correct and could already be merged into master.