### PR TITLE
guard current AT_STRING options against empty strings

### DIFF
--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -52,9 +52,11 @@ static void prepare_categories()
 {
    for (int i = 0; i < kIncludeCategoriesCount; i++)
    {
-      if (cpd.settings[UO_include_category_first + i].str != nullptr)
+      const auto *cat_pattern = cpd.settings[UO_include_category_first + i].str;
+
+      if (cat_pattern != nullptr && cat_pattern[0] != '\0')
       {
-         include_categories[i] = new include_category(cpd.settings[UO_include_category_first + i].str);
+         include_categories[i] = new include_category(cat_pattern);
       }
       else
       {

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -657,7 +657,7 @@ static bool parse_comment(tok_ctx &ctx, chunk_t &pc)
    if (cpd.unc_off)
    {
       const char *ontext = cpd.settings[UO_enable_processing_cmt].str;
-      if (ontext == nullptr || !ontext[0])
+      if (ontext == nullptr || ontext[0] == '\0')
       {
          ontext = UNCRUSTIFY_ON_TEXT;
       }
@@ -1571,7 +1571,7 @@ static bool parse_ignored(tok_ctx &ctx, chunk_t &pc)
    }
    // Note that we aren't actually making sure this is in a comment, yet
    const char *ontext = cpd.settings[UO_enable_processing_cmt].str;
-   if (ontext == nullptr)
+   if (ontext == nullptr || ontext[0] == '\0')
    {
       ontext = UNCRUSTIFY_ON_TEXT;
    }

--- a/tests/c.test
+++ b/tests/c.test
@@ -322,3 +322,5 @@
 09610 bug_i_876.cfg             c/bug_i_876.c
 09611 bug_i_222.cfg             c/bug_i_222.c
 09612 bug_1041.cfg              c/bug_1041.c
+
+10005  enable_processing_cmt-empty.cfg    c/i1270.c

--- a/tests/config/enable_processing_cmt-empty.cfg
+++ b/tests/config/enable_processing_cmt-empty.cfg
@@ -1,0 +1,1 @@
+enable_processing_cmt           = ""

--- a/tests/input/c/i1270.c
+++ b/tests/input/c/i1270.c
@@ -1,0 +1,3 @@
+#ifdef asm
+#endif
+/* comment should stay */

--- a/tests/output/c/10005-i1270.c
+++ b/tests/output/c/10005-i1270.c
@@ -1,0 +1,3 @@
+#ifdef asm
+#endif
+/* comment should stay */


### PR DESCRIPTION
Some AT_STRING options where missing checks for empty strings.

------

ref: #1270