### PR TITLE
Add option for newline between paren and func name

### DIFF
--- a/scripts/More_Options_to_Test/help.txt
+++ b/scripts/More_Options_to_Test/help.txt
@@ -70,6 +70,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 600 options and minimal documentation.
+There are currently 601 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/scripts/More_Options_to_Test/show_config.txt
+++ b/scripts/More_Options_to_Test/show_config.txt
@@ -1166,6 +1166,9 @@ nl_func_def_paren               { Ignore, Add, Remove, Force }
 nl_func_def_paren_empty         { Ignore, Add, Remove, Force }
   Overrides nl_func_def_paren for functions with no parameters.
 
+nl_func_call_paren              { Ignore, Add, Remove, Force }
+  Add or remove newline between a function name and the opening '(' in the call
+
 nl_func_decl_start              { Ignore, Add, Remove, Force }
   Add or remove newline after '(' in a function declaration.
 

--- a/scripts/Output/mini_d_uc.txt
+++ b/scripts/Output/mini_d_uc.txt
@@ -355,6 +355,7 @@ nl_func_paren                   = ignore
 nl_func_paren_empty             = ignore
 nl_func_def_paren               = ignore
 nl_func_def_paren_empty         = ignore
+nl_func_call_paren              = ignore
 nl_func_decl_start              = ignore
 nl_func_def_start               = ignore
 nl_func_decl_start_single       = ignore

--- a/scripts/Output/mini_d_ucwd.txt
+++ b/scripts/Output/mini_d_ucwd.txt
@@ -1168,6 +1168,9 @@ nl_func_def_paren               = ignore   # ignore/add/remove/force
 # Overrides nl_func_def_paren for functions with no parameters.
 nl_func_def_paren_empty         = ignore   # ignore/add/remove/force
 
+# Add or remove newline between a function name and the opening '(' in the call
+nl_func_call_paren              = ignore   # ignore/add/remove/force
+
 # Add or remove newline after '(' in a function declaration.
 nl_func_decl_start              = ignore   # ignore/add/remove/force
 

--- a/scripts/Output/mini_nd_uc.txt
+++ b/scripts/Output/mini_nd_uc.txt
@@ -355,6 +355,7 @@ nl_func_paren                   = ignore
 nl_func_paren_empty             = ignore
 nl_func_def_paren               = ignore
 nl_func_def_paren_empty         = ignore
+nl_func_call_paren              = ignore
 nl_func_decl_start              = ignore
 nl_func_def_start               = ignore
 nl_func_decl_start_single       = ignore

--- a/scripts/Output/mini_nd_ucwd.txt
+++ b/scripts/Output/mini_nd_ucwd.txt
@@ -1168,6 +1168,9 @@ nl_func_def_paren               = ignore   # ignore/add/remove/force
 # Overrides nl_func_def_paren for functions with no parameters.
 nl_func_def_paren_empty         = ignore   # ignore/add/remove/force
 
+# Add or remove newline between a function name and the opening '(' in the call
+nl_func_call_paren              = ignore   # ignore/add/remove/force
+
 # Add or remove newline after '(' in a function declaration.
 nl_func_decl_start              = ignore   # ignore/add/remove/force
 

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -2152,6 +2152,16 @@ static void newline_func_def(chunk_t *start)
       }
    }
 
+   atmp = cpd.settings[UO_nl_func_call_paren].a;
+   if (atmp != AV_IGNORE)
+   {
+      prev = chunk_get_prev_ncnl(start);
+      if (prev != nullptr)
+      {
+         newline_iarf(prev, atmp);
+      }
+   }
+
    // Handle break newlines type and function
    prev = chunk_get_prev_ncnl(start);
    prev = skip_template_prev(prev);
@@ -3178,8 +3188,13 @@ void newlines_cleanup_braces(bool first)
                     || pc->parent_type == CT_FUNC_CALL_USER)
                  && (  (cpd.settings[UO_nl_func_call_start_multi_line].b)
                     || (cpd.settings[UO_nl_func_call_args_multi_line].b)
-                    || (cpd.settings[UO_nl_func_call_end_multi_line].b)))
+                    || (cpd.settings[UO_nl_func_call_end_multi_line].b)
+                    || (cpd.settings[UO_nl_func_call_paren].a != AV_IGNORE)))
          {
+            if (cpd.settings[UO_nl_func_call_paren].a != AV_IGNORE)
+            {
+               newline_func_def(pc);
+            }
             newline_func_multi_line(pc);
          }
          else if (first && (cpd.settings[UO_nl_remove_extra_newlines].u == 1))

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1093,6 +1093,8 @@ void register_options(void)
                   "Add or remove newline between a function name and the opening '(' in the definition.");
    unc_add_option("nl_func_def_paren_empty", UO_nl_func_def_paren_empty, AT_IARF,
                   "Overrides nl_func_def_paren for functions with no parameters.");
+   unc_add_option("nl_func_call_paren", UO_nl_func_call_paren, AT_IARF,
+                  "Add or remove newline between a function name and the opening '(' in the call");
    unc_add_option("nl_func_decl_start", UO_nl_func_decl_start, AT_IARF,
                   "Add or remove newline after '(' in a function declaration.");
    unc_add_option("nl_func_def_start", UO_nl_func_def_start, AT_IARF,

--- a/src/options.h
+++ b/src/options.h
@@ -520,6 +520,8 @@ enum uncrustify_options
    UO_nl_func_def_paren,              // Add or remove newline between a function name and
                                       // the opening '(' in the definition
    UO_nl_func_def_paren_empty,        // Overrides nl_func_def_paren for functions with no parameters
+   UO_nl_func_call_paren,             // Add or remove newline between a function name and
+                                      // the opening '(' in the call
    UO_nl_func_decl_start,             // newline after the '(' in a function decl
    UO_nl_func_def_start,              // newline after the '(' in a function def
    UO_nl_func_decl_start_single,      // Overrides nl_func_decl_start when there is only one parameter

--- a/tests/config/nl_func_call_paren.cfg
+++ b/tests/config/nl_func_call_paren.cfg
@@ -1,0 +1,1 @@
+nl_func_call_paren = force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -48,6 +48,7 @@
 30046 nl_func_decl_2.cfg               cpp/nl_func_decl.cpp
 30047 nl_func_paren_empty.cfg          cpp/nl_func_paren_empty.cpp
 30048 nl_func_def_paren_empty.cfg      cpp/nl_func_def_paren_empty.cpp
+30049 nl_func_call_paren.cfg           cpp/nl_func_call_paren.cpp
 
 30050 nl_namespace-r.cfg               cpp/nl-namespace.h
 30051 nl_namespace-a.cfg               cpp/nl-namespace.h

--- a/tests/input/cpp/nl_func_call_paren.cpp
+++ b/tests/input/cpp/nl_func_call_paren.cpp
@@ -1,0 +1,4 @@
+SomeFunction(
+	someVar,
+	someOtherVar,
+	);

--- a/tests/output/cpp/30049-nl_func_call_paren.cpp
+++ b/tests/output/cpp/30049-nl_func_call_paren.cpp
@@ -1,0 +1,5 @@
+SomeFunction
+(
+	someVar,
+	someOtherVar,
+);


### PR DESCRIPTION
This change adds an option that allows control of the newline between the open paren and the name of a function call.