### PR TITLE
Fix a couple of small bugs pointed out by gcc 7.1

### DIFF
--- a/src/backup.cpp
+++ b/src/backup.cpp
@@ -37,7 +37,7 @@ int backup_copy_file(const char *filename, const vector<UINT8> &data)
 {
    char  newpath[1024];
    char  md5_str_in[33];
-   char  md5_str[33];
+   char  md5_str[34];
    UINT8 dig[16];
 
    md5_str_in[0] = 0;

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -994,7 +994,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
          tmp = chunk_get_next_ncnl(tmp);
       }
       if (  tmp != nullptr
-         && (tmp->type == CT_BRACE_OPEN || CT_PAREN_OPEN))
+         && (tmp->type == CT_BRACE_OPEN || tmp->type == CT_PAREN_OPEN))
       {
          set_paren_parent(tmp, pc->type);
          if (ts)


### PR DESCRIPTION
The first bug has to do with the truncation of the md5_str
in backup.cpp.  snprintf was given too small of a buffer,
so it truncated the last character.  Luckily this was
the newline, so it doesn't make too much of a difference,
but this will make it more correct.

The second bug has to do with testing whether a character
is of type BRACE or PAREN.  I believe I got it right and
that we want to check if it is either a BRACE or a PAREN,
and not some logical-OR of the two.  All of the tests
pass, at least.

Signed-off-by: Chris Lalancette <clalancette@gmail.com>