### PR TITLE
options.cpp: Copy from defaults to settins whole union, not first field.

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2523,7 +2523,7 @@ void set_option_defaults(void)
    // copy all the default values to settings array
    for (unsigned int count = 0; count < UO_option_count; count++)
    {
-      cpd.settings[count].a = cpd.defaults[count].a;
+      cpd.settings[count] = cpd.defaults[count];
    }
 } // set_option_defaults
 


### PR DESCRIPTION
Otherwise size_t was not copied correctly on s390x arch.

This is followup to #1229 and #1231.

Before this patch on s390x we have
    63% tests passed, 283 tests failed out of 763
after
    100% tests passed, 0 tests failed out of 763

Signed-off-by: Alexander GQ Gerasiov <gq@cs.msu.su>