### PR TITLE
Fix newline between function name and open paren

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -2253,7 +2253,7 @@ static void newline_func_def(chunk_t *start)
       atmp = cpd.settings[is_def ? UO_nl_func_def_paren_empty : UO_nl_func_paren_empty].a;
       if (atmp != AV_IGNORE)
       {
-         prev = chunk_get_prev_ncnl(pc);
+         prev = chunk_get_prev_ncnl(start);
          if (prev != NULL)
          {
             newline_iarf(prev, atmp);

--- a/tests/config/nl_func_def_paren_empty.cfg
+++ b/tests/config/nl_func_def_paren_empty.cfg
@@ -1,1 +1,4 @@
+# The option that is being overridden by nl_func_def_paren_empty
+nl_func_def_paren = force
+
 nl_func_def_paren_empty = remove

--- a/tests/config/nl_func_paren_empty.cfg
+++ b/tests/config/nl_func_paren_empty.cfg
@@ -1,1 +1,4 @@
+# The option that is being overridden by nl_func_paren_empty
+nl_func_paren = force
+
 nl_func_paren_empty = remove

--- a/tests/input/cpp/nl_func_def_paren_empty.cpp
+++ b/tests/input/cpp/nl_func_def_paren_empty.cpp
@@ -1,7 +1,20 @@
 void LocalClass::LocalClass()
 {
+	int Function
+		(
+		)
+	{
+		return 0;
+	}
+
 	int Function(
 		)
+	{
+		return 0;
+	}
+
+	int Function
+		()
 	{
 		return 0;
 	}

--- a/tests/input/cpp/nl_func_paren_empty.cpp
+++ b/tests/input/cpp/nl_func_paren_empty.cpp
@@ -1,2 +1,9 @@
+int Function
+	(
+	);
+
 int Function(
 	);
+
+int Function
+	();

--- a/tests/output/cpp/30047-nl_func_paren_empty.cpp
+++ b/tests/output/cpp/30047-nl_func_paren_empty.cpp
@@ -1,1 +1,7 @@
+int Function(
+	);
+
+int Function(
+	);
+
 int Function();

--- a/tests/output/cpp/30048-nl_func_def_paren_empty.cpp
+++ b/tests/output/cpp/30048-nl_func_def_paren_empty.cpp
@@ -1,5 +1,17 @@
 void LocalClass::LocalClass()
 {
+	int Function(
+		)
+	{
+		return 0;
+	}
+
+	int Function(
+		)
+	{
+		return 0;
+	}
+
 	int Function()
 	{
 		return 0;


### PR DESCRIPTION
The current test cases don't accurately test what these
options are supposed to do, and the current implementation
doesn't work correctly either. This fixes both the
implementation and test cases so that they correctly format
the newline between the function name and open paren. Also 
adds the options that these override, to prove they do in 
fact override them.