### PR TITLE
Fix alignment with extra spaces after the * or &.

### DIFF
--- a/tests/config/align_var_def_thresh.cfg
+++ b/tests/config/align_var_def_thresh.cfg
@@ -1,0 +1,2 @@
+align_var_def_span   = 1
+align_var_def_thresh = 4

--- a/tests/config/align_var_def_thresh.cfg
+++ b/tests/config/align_var_def_thresh.cfg
@@ -1,2 +1,0 @@
-align_var_def_span   = 1
-align_var_def_thresh = 4

--- a/tests/config/align_var_def_thresh_1.cfg
+++ b/tests/config/align_var_def_thresh_1.cfg
@@ -1,0 +1,4 @@
+align_var_def_span       = 1
+align_var_def_thresh     = 4
+align_var_def_star_style = 0
+align_var_def_amp_style  = 0

--- a/tests/config/align_var_def_thresh_2.cfg
+++ b/tests/config/align_var_def_thresh_2.cfg
@@ -1,0 +1,4 @@
+align_var_def_span       = 1
+align_var_def_thresh     = 4
+align_var_def_star_style = 1
+align_var_def_amp_style  = 1

--- a/tests/config/align_var_def_thresh_3.cfg
+++ b/tests/config/align_var_def_thresh_3.cfg
@@ -1,0 +1,4 @@
+align_var_def_span       = 1
+align_var_def_thresh     = 4
+align_var_def_star_style = 2
+align_var_def_amp_style  = 2

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -120,6 +120,7 @@
 30258 ben.cfg                          cpp/casts.cpp
 
 30260 var_def_gap.cfg                  cpp/var_def_gap.cpp
+30261 align_var_def_thresh.cfg         cpp/align_var_def_thresh.cpp
 
 30265 long_br_cmt.cfg                  cpp/long_br_cmt.cpp
 

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -120,7 +120,9 @@
 30258 ben.cfg                          cpp/casts.cpp
 
 30260 var_def_gap.cfg                  cpp/var_def_gap.cpp
-30261 align_var_def_thresh.cfg         cpp/align_var_def_thresh.cpp
+30261 align_var_def_thresh_1.cfg       cpp/align_var_def_thresh.cpp
+30262 align_var_def_thresh_2.cfg       cpp/align_var_def_thresh.cpp
+30263 align_var_def_thresh_3.cfg       cpp/align_var_def_thresh.cpp
 
 30265 long_br_cmt.cfg                  cpp/long_br_cmt.cpp
 

--- a/tests/input/cpp/align_var_def_thresh.cpp
+++ b/tests/input/cpp/align_var_def_thresh.cpp
@@ -1,17 +1,47 @@
-void test1()
+void testShortTypes()
 {
+// No stars
 float   a;
 double       b;
 
-float & c;
-double &     d;
+// All stars
+float& a;
+double&      b;
+
+float * a;
+double    *      b;
+
+float &a;
+double       &b;
+
+// One star before
+double&       a;
+float b;
+
+double        &    a;
+float b;
+
+double            &a;
+float b;
+
+// One star after
+float b;
+double&       a;
+
+float b;
+double        &    a;
+
+float b;
+double            &a;
 }
 
-void test2()
+void testLongTypes()
 {
 int     int_var;
 int   * int_ptr_var;
+int    *int_ptr_var;
 float float_var;
+float   &float_ref_var;
 float & float_ref_var;
 double    &     double_var;
                      SomeLongNamespace::SomeLongType       long_var;
@@ -25,5 +55,9 @@ float float_var;
 float & float_ref_var;
 double    &     double_var;
                      SomeLongNamespace::SomeLongType       long_var;
-                     int *                             other_int_var;
+float float_var;
+    int *                             other_int_var;
+               int                               other_int_var;
+                     int                              *other_int_var;
+ int&                              other_int_var;
 }

--- a/tests/input/cpp/align_var_def_thresh.cpp
+++ b/tests/input/cpp/align_var_def_thresh.cpp
@@ -1,0 +1,29 @@
+void test1()
+{
+float   a;
+double       b;
+
+float & c;
+double &     d;
+}
+
+void test2()
+{
+int     int_var;
+int   * int_ptr_var;
+float float_var;
+float & float_ref_var;
+double    &     double_var;
+                     SomeLongNamespace::SomeLongType       long_var;
+   int   *  other_int_var;
+               SomeLooooongType       long_var;
+         SomeLoooooooooongType looong_var;
+                     int     int_var;
+              SomeLongNamespace::OtherLongNamespace::SomeLongType very_long_var;
+int   * int_ptr_var;
+float float_var;
+float & float_ref_var;
+double    &     double_var;
+                     SomeLongNamespace::SomeLongType       long_var;
+                     int *                             other_int_var;
+}

--- a/tests/output/cpp/30261-align_var_def_thresh.cpp
+++ b/tests/output/cpp/30261-align_var_def_thresh.cpp
@@ -1,0 +1,29 @@
+void test1()
+{
+	float  a;
+	double b;
+
+	float &  c;
+	double & d;
+}
+
+void test2()
+{
+	int      int_var;
+	int *    int_ptr_var;
+	float    float_var;
+	float &  float_ref_var;
+	double & double_var;
+	SomeLongNamespace::SomeLongType long_var;
+	int * other_int_var;
+	SomeLooooongType long_var;
+	SomeLoooooooooongType looong_var;
+	int int_var;
+	SomeLongNamespace::OtherLongNamespace::SomeLongType very_long_var;
+	int *    int_ptr_var;
+	float    float_var;
+	float &  float_ref_var;
+	double & double_var;
+	SomeLongNamespace::SomeLongType long_var;
+	int * other_int_var;
+}

--- a/tests/output/cpp/30262-align_var_def_thresh.cpp
+++ b/tests/output/cpp/30262-align_var_def_thresh.cpp
@@ -5,44 +5,44 @@ void testShortTypes()
 	double b;
 
 // All stars
-	float&  a;
+	float & a;
 	double& b;
 
-	float *  a;
+	float  * a;
 	double * b;
 
-	float & a;
+	float  &a;
 	double &b;
 
 // One star before
 	double& a;
-	float   b;
+	float b;
 
 	double & a;
-	float    b;
+	float  b;
 
 	double &a;
-	float   b;
+	float  b;
 
 // One star after
-	float   b;
+	float b;
 	double& a;
 
-	float    b;
+	float  b;
 	double & a;
 
-	float   b;
+	float  b;
 	double &a;
 }
 
 void testLongTypes()
 {
-	int      int_var;
-	int *    int_ptr_var;
-	int *    int_ptr_var;
-	float    float_var;
-	float &  float_ref_var;
-	float &  float_ref_var;
+	int    int_var;
+	int    * int_ptr_var;
+	int    *int_ptr_var;
+	float  float_var;
+	float  &float_ref_var;
+	float  & float_ref_var;
 	double & double_var;
 	SomeLongNamespace::SomeLongType long_var;
 	int * other_int_var;
@@ -50,14 +50,14 @@ void testLongTypes()
 	SomeLoooooooooongType looong_var;
 	int int_var;
 	SomeLongNamespace::OtherLongNamespace::SomeLongType very_long_var;
-	int *    int_ptr_var;
-	float    float_var;
-	float &  float_ref_var;
+	int    * int_ptr_var;
+	float  float_var;
+	float  & float_ref_var;
 	double & double_var;
 	SomeLongNamespace::SomeLongType long_var;
 	float float_var;
-	int * other_int_var;
+	int   * other_int_var;
 	int   other_int_var;
-	int * other_int_var;
-	int&  other_int_var;
+	int   *other_int_var;
+	int   & other_int_var;
 }

--- a/tests/output/cpp/30263-align_var_def_thresh.cpp
+++ b/tests/output/cpp/30263-align_var_def_thresh.cpp
@@ -5,13 +5,13 @@ void testShortTypes()
 	double b;
 
 // All stars
-	float&  a;
+	float & a;
 	double& b;
 
-	float *  a;
+	float  * a;
 	double * b;
 
-	float & a;
+	float  &a;
 	double &b;
 
 // One star before
@@ -38,11 +38,11 @@ void testShortTypes()
 void testLongTypes()
 {
 	int      int_var;
-	int *    int_ptr_var;
-	int *    int_ptr_var;
+	int    * int_ptr_var;
+	int     *int_ptr_var;
 	float    float_var;
-	float &  float_ref_var;
-	float &  float_ref_var;
+	float   &float_ref_var;
+	float  & float_ref_var;
 	double & double_var;
 	SomeLongNamespace::SomeLongType long_var;
 	int * other_int_var;
@@ -50,14 +50,14 @@ void testLongTypes()
 	SomeLoooooooooongType looong_var;
 	int int_var;
 	SomeLongNamespace::OtherLongNamespace::SomeLongType very_long_var;
-	int *    int_ptr_var;
+	int    * int_ptr_var;
 	float    float_var;
-	float &  float_ref_var;
+	float  & float_ref_var;
 	double & double_var;
 	SomeLongNamespace::SomeLongType long_var;
 	float float_var;
 	int * other_int_var;
 	int   other_int_var;
-	int * other_int_var;
-	int&  other_int_var;
+	int  *other_int_var;
+	int & other_int_var;
 }


### PR DESCRIPTION
Aligning does not work correctly in variable definitions with extra spaces between '*'/'&' and variable name:
```
void test()
{
float & c;
double &     d;
}
```
produce:
```
void test()
{
	float & c;
	double & d;
}
```
expected:
```
void test()
{
	float &  c;
	double & d;
}
```

Config:
```
align_var_def_span   = 1
align_var_def_thresh = 4
```

This PR is an option how to fix this issue.