### PR TITLE
fix regression of nl_func_type_name / nl_func_proto_type_name when return type is a reference

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3305,10 +3305,6 @@ void newlines_cleanup_braces(bool first)
       {
          newline_iarf(pc, AV_REMOVE);
       }
-      else if (pc->type == CT_BYREF)
-      {
-         newline_iarf(pc, AV_REMOVE);
-      }
       else
       {
          // ignore it


### PR DESCRIPTION
Fixes #1360 which is a regression of #1226.