### PR TITLE
Standardize option descriptions to "override"

### DIFF
--- a/scripts/More_Options_to_Test/show_config.txt
+++ b/scripts/More_Options_to_Test/show_config.txt
@@ -288,9 +288,7 @@ sp_after_operator_sym           { Ignore, Add, Remove, Force }
   Add or remove space between the operator symbol and the open paren, as in 'operator ++('.
 
 sp_after_operator_sym_empty     { Ignore, Add, Remove, Force }
-  Add or remove space between the operator symbol and the open paren when the operator
-  has no arguments, as in 'operator *()'.
-  Have precedence of sp_after_operator_sym.
+  Overrides sp_after_operator_sym when the operator has no arguments, as in 'operator *()'.
 
 sp_after_cast                   { Ignore, Add, Remove, Force }
   Add or remove space after C/D cast, i.e. 'cast(int)a' vs 'cast(int) a' or '(int)a' vs '(int) a'.
@@ -618,11 +616,11 @@ sp_inside_newop_paren           { Ignore, Add, Remove, Force }
 
 sp_inside_newop_paren_open      { Ignore, Add, Remove, Force }
   Controls the space after open paren of the new operator: 'new(foo) BAR'.
-  Have precedence of sp_inside_newop_paren.
+  Overrides sp_inside_newop_paren.
 
 sp_inside_newop_paren_close     { Ignore, Add, Remove, Force }
   Controls the space before close paren of the new operator: 'new(foo) BAR'.
-  Have precedence of sp_inside_newop_paren.
+  Overrides sp_inside_newop_paren.
 
 sp_before_tr_emb_cmt            { Ignore, Add, Remove, Force }
   Controls the spaces before a trailing or embedded comment.
@@ -976,7 +974,7 @@ nl_func_var_def_blk             Unsigned Number
 nl_typedef_blk_start            Unsigned Number
   The number of newlines before a block of typedefs
   0 = No change (default)
-  the option 'nl_after_access_spec' takes preference over 'nl_typedef_blk_start'.
+  is overridden by the option 'nl_after_access_spec'.
 
 nl_typedef_blk_end              Unsigned Number
   The number of newlines after a block of typedefs
@@ -989,7 +987,7 @@ nl_typedef_blk_in               Unsigned Number
 nl_var_def_blk_start            Unsigned Number
   The number of newlines before a block of variable definitions not at the top of a function body
   0 = No change (default)
-  the option 'nl_after_access_spec' takes preference over 'nl_var_def_blk_start'.
+  is overridden by the option 'nl_after_access_spec'.
 
 nl_var_def_blk_end              Unsigned Number
   The number of newlines after a block of variable definitions not at the top of a function body
@@ -1455,7 +1453,7 @@ nl_before_access_spec           Unsigned Number
 nl_after_access_spec            Unsigned Number
   The number of newlines after a 'private:', 'public:', 'protected:', 'signals:' or 'slots:' label.
   0 = No change.
-  the option 'nl_after_access_spec' takes preference over 'nl_typedef_blk_start' and 'nl_var_def_blk_start'.
+  Overrides 'nl_typedef_blk_start' and 'nl_var_def_blk_start'.
 
 nl_comment_func_def             Unsigned Number
   The number of newlines between a function def and the function comment.

--- a/scripts/Output/mini_d_ucwd.txt
+++ b/scripts/Output/mini_d_ucwd.txt
@@ -289,9 +289,7 @@ sp_after_operator               = ignore   # ignore/add/remove/force
 # Add or remove space between the operator symbol and the open paren, as in 'operator ++('.
 sp_after_operator_sym           = ignore   # ignore/add/remove/force
 
-# Add or remove space between the operator symbol and the open paren when the operator
-# has no arguments, as in 'operator *()'.
-# Have precedence of sp_after_operator_sym.
+# Overrides sp_after_operator_sym when the operator has no arguments, as in 'operator *()'.
 sp_after_operator_sym_empty     = ignore   # ignore/add/remove/force
 
 # Add or remove space after C/D cast, i.e. 'cast(int)a' vs 'cast(int) a' or '(int)a' vs '(int) a'.
@@ -619,11 +617,11 @@ sp_after_newop_paren            = ignore   # ignore/add/remove/force
 sp_inside_newop_paren           = ignore   # ignore/add/remove/force
 
 # Controls the space after open paren of the new operator: 'new(foo) BAR'.
-# Have precedence of sp_inside_newop_paren.
+# Overrides sp_inside_newop_paren.
 sp_inside_newop_paren_open      = ignore   # ignore/add/remove/force
 
 # Controls the space before close paren of the new operator: 'new(foo) BAR'.
-# Have precedence of sp_inside_newop_paren.
+# Overrides sp_inside_newop_paren.
 sp_inside_newop_paren_close     = ignore   # ignore/add/remove/force
 
 # Controls the spaces before a trailing or embedded comment.
@@ -977,7 +975,7 @@ nl_func_var_def_blk             = 0        # unsigned number
 
 # The number of newlines before a block of typedefs
 # 0 = No change (default)
-# the option 'nl_after_access_spec' takes preference over 'nl_typedef_blk_start'.
+# is overridden by the option 'nl_after_access_spec'.
 nl_typedef_blk_start            = 0        # unsigned number
 
 # The number of newlines after a block of typedefs
@@ -990,7 +988,7 @@ nl_typedef_blk_in               = 0        # unsigned number
 
 # The number of newlines before a block of variable definitions not at the top of a function body
 # 0 = No change (default)
-# the option 'nl_after_access_spec' takes preference over 'nl_var_def_blk_start'.
+# is overridden by the option 'nl_after_access_spec'.
 nl_var_def_blk_start            = 0        # unsigned number
 
 # The number of newlines after a block of variable definitions not at the top of a function body
@@ -1456,7 +1454,7 @@ nl_before_access_spec           = 0        # unsigned number
 
 # The number of newlines after a 'private:', 'public:', 'protected:', 'signals:' or 'slots:' label.
 # 0 = No change.
-# the option 'nl_after_access_spec' takes preference over 'nl_typedef_blk_start' and 'nl_var_def_blk_start'.
+# Overrides 'nl_typedef_blk_start' and 'nl_var_def_blk_start'.
 nl_after_access_spec            = 0        # unsigned number
 
 # The number of newlines between a function def and the function comment.

--- a/scripts/Output/mini_nd_ucwd.txt
+++ b/scripts/Output/mini_nd_ucwd.txt
@@ -289,9 +289,7 @@ sp_after_operator               = ignore   # ignore/add/remove/force
 # Add or remove space between the operator symbol and the open paren, as in 'operator ++('.
 sp_after_operator_sym           = ignore   # ignore/add/remove/force
 
-# Add or remove space between the operator symbol and the open paren when the operator
-# has no arguments, as in 'operator *()'.
-# Have precedence of sp_after_operator_sym.
+# Overrides sp_after_operator_sym when the operator has no arguments, as in 'operator *()'.
 sp_after_operator_sym_empty     = ignore   # ignore/add/remove/force
 
 # Add or remove space after C/D cast, i.e. 'cast(int)a' vs 'cast(int) a' or '(int)a' vs '(int) a'.
@@ -619,11 +617,11 @@ sp_after_newop_paren            = ignore   # ignore/add/remove/force
 sp_inside_newop_paren           = ignore   # ignore/add/remove/force
 
 # Controls the space after open paren of the new operator: 'new(foo) BAR'.
-# Have precedence of sp_inside_newop_paren.
+# Overrides sp_inside_newop_paren.
 sp_inside_newop_paren_open      = ignore   # ignore/add/remove/force
 
 # Controls the space before close paren of the new operator: 'new(foo) BAR'.
-# Have precedence of sp_inside_newop_paren.
+# Overrides sp_inside_newop_paren.
 sp_inside_newop_paren_close     = ignore   # ignore/add/remove/force
 
 # Controls the spaces before a trailing or embedded comment.
@@ -977,7 +975,7 @@ nl_func_var_def_blk             = 0        # unsigned number
 
 # The number of newlines before a block of typedefs
 # 0 = No change (default)
-# the option 'nl_after_access_spec' takes preference over 'nl_typedef_blk_start'.
+# is overridden by the option 'nl_after_access_spec'.
 nl_typedef_blk_start            = 0        # unsigned number
 
 # The number of newlines after a block of typedefs
@@ -990,7 +988,7 @@ nl_typedef_blk_in               = 0        # unsigned number
 
 # The number of newlines before a block of variable definitions not at the top of a function body
 # 0 = No change (default)
-# the option 'nl_after_access_spec' takes preference over 'nl_var_def_blk_start'.
+# is overridden by the option 'nl_after_access_spec'.
 nl_var_def_blk_start            = 0        # unsigned number
 
 # The number of newlines after a block of variable definitions not at the top of a function body
@@ -1456,7 +1454,7 @@ nl_before_access_spec           = 0        # unsigned number
 
 # The number of newlines after a 'private:', 'public:', 'protected:', 'signals:' or 'slots:' label.
 # 0 = No change.
-# the option 'nl_after_access_spec' takes preference over 'nl_typedef_blk_start' and 'nl_var_def_blk_start'.
+# Overrides 'nl_typedef_blk_start' and 'nl_var_def_blk_start'.
 nl_after_access_spec            = 0        # unsigned number
 
 # The number of newlines between a function def and the function comment.

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -473,9 +473,7 @@ void register_options(void)
    unc_add_option("sp_after_operator_sym", UO_sp_after_operator_sym, AT_IARF,
                   "Add or remove space between the operator symbol and the open paren, as in 'operator ++('.");
    unc_add_option("sp_after_operator_sym_empty", UO_sp_after_operator_sym_empty, AT_IARF,
-                  "Add or remove space between the operator symbol and the open paren when the operator\n"
-                  "has no arguments, as in 'operator *()'.\n"
-                  "Have precedence of sp_after_operator_sym.");
+                  "Overrides sp_after_operator_sym when the operator has no arguments, as in 'operator *()'.");
    unc_add_option("sp_after_cast", UO_sp_after_cast, AT_IARF,
                   "Add or remove space after C/D cast, i.e. 'cast(int)a' vs 'cast(int) a' or '(int)a' vs '(int) a'.");
    unc_add_option("sp_inside_paren_cast", UO_sp_inside_paren_cast, AT_IARF,
@@ -702,10 +700,10 @@ void register_options(void)
                   "Controls the spaces inside paren of the new operator: 'new(foo) BAR'.");
    unc_add_option("sp_inside_newop_paren_open", UO_sp_inside_newop_paren_open, AT_IARF,
                   "Controls the space after open paren of the new operator: 'new(foo) BAR'.\n"
-                  "Have precedence of sp_inside_newop_paren.");
+                  "Overrides sp_inside_newop_paren.");
    unc_add_option("sp_inside_newop_paren_close", UO_sp_inside_newop_paren_close, AT_IARF,
                   "Controls the space before close paren of the new operator: 'new(foo) BAR'.\n"
-                  "Have precedence of sp_inside_newop_paren.");
+                  "Overrides sp_inside_newop_paren.");
    unc_add_option("sp_before_tr_emb_cmt", UO_sp_before_tr_emb_cmt, AT_IARF,
                   "Controls the spaces before a trailing or embedded comment.");
    unc_add_option("sp_num_before_tr_emb_cmt", UO_sp_num_before_tr_emb_cmt, AT_UNUM,
@@ -963,7 +961,7 @@ void register_options(void)
    unc_add_option("nl_typedef_blk_start", UO_nl_typedef_blk_start, AT_UNUM,
                   "The number of newlines before a block of typedefs\n"
                   "0 = No change (default)\n"
-                  "the option 'nl_after_access_spec' takes preference over 'nl_typedef_blk_start'.");
+                  "is overridden by the option 'nl_after_access_spec'.");
    unc_add_option("nl_typedef_blk_end", UO_nl_typedef_blk_end, AT_UNUM,
                   "The number of newlines after a block of typedefs\n"
                   "0 = No change (default).");
@@ -973,7 +971,7 @@ void register_options(void)
    unc_add_option("nl_var_def_blk_start", UO_nl_var_def_blk_start, AT_UNUM,
                   "The number of newlines before a block of variable definitions not at the top of a function body\n"
                   "0 = No change (default)\n"
-                  "the option 'nl_after_access_spec' takes preference over 'nl_var_def_blk_start'.");
+                  "is overridden by the option 'nl_after_access_spec'.");
    unc_add_option("nl_var_def_blk_end", UO_nl_var_def_blk_end, AT_UNUM,
                   "The number of newlines after a block of variable definitions not at the top of a function body\n"
                   "0 = No change (default).");
@@ -1299,7 +1297,7 @@ void register_options(void)
    unc_add_option("nl_after_access_spec", UO_nl_after_access_spec, AT_UNUM,
                   "The number of newlines after a 'private:', 'public:', 'protected:', 'signals:' or 'slots:' label.\n"
                   "0 = No change.\n"
-                  "the option 'nl_after_access_spec' takes preference over 'nl_typedef_blk_start' and 'nl_var_def_blk_start'.");
+                  "Overrides 'nl_typedef_blk_start' and 'nl_var_def_blk_start'.");
    unc_add_option("nl_comment_func_def", UO_nl_comment_func_def, AT_UNUM,
                   "The number of newlines between a function def and the function comment.\n"
                   "0 = No change.");


### PR DESCRIPTION
These options have similar descriptions:
*sp_after_operator_sym_empty - Have precedence of...
*nl_typedef_blk_start - takes preference over...
*nl_func_paren_empty - Overrides...

This change modifies these descriptions to use the
"override" wording. This doesn't make any changes to
the options like sp_before_unnamed_ptr_star, where if it's
set to ignore, another options is used, and isn't really
overridden.