### PR TITLE
Fixed #1366 - Wrong indentation of the break in switch

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1547,10 +1547,17 @@ void indent_text(void)
             && prev->type == CT_BRACE_CLOSE
             && prev->parent_type == CT_CASE)
          {
-            // issue #663
-            chunk_t *temp = chunk_get_prev_type(pc, CT_BRACE_OPEN, pc->level);
-            // This only affects the 'break', so no need for a stack entry
-            indent_column_set(temp->column);
+            // issue #663 + issue #1366
+            chunk_t *prev_newline = chunk_get_prev_nl(pc);
+            if (prev_newline != nullptr)
+            {
+               chunk_t *prev_prev_newline = chunk_get_prev_nl(prev_newline);
+               if (prev_prev_newline != nullptr)
+               {
+                  // This only affects the 'break', so no need for a stack entry
+                  indent_column_set(prev_prev_newline->next->column);
+               }
+            }
          }
       }
       else if (pc->type == CT_LABEL)

--- a/tests/input/oc/bug_1366.m
+++ b/tests/input/oc/bug_1366.m
@@ -1,0 +1,14 @@
+@implementation UCTestClass
+
+- (void) test{
+    
+    switch (test) {
+        case "longlonglonglong":{
+            i = 1;
+        }
+            break;
+    }
+}
+
+@end
+

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -92,6 +92,7 @@
 50603  obj-c.cfg                                    oc/gh511.m
 50604  objc_bug_497.cfg                             oc/bug_497.m
 50605  empty.cfg                                    oc/bug_404.m
+50606  obj-c.cfg                                    oc/bug_1366.m
 
 50700  cmt_insert-0.cfg                             oc/cmt_insert.m
 

--- a/tests/output/oc/50606-bug_1366.m
+++ b/tests/output/oc/50606-bug_1366.m
@@ -1,0 +1,14 @@
+@implementation UCTestClass
+
+-(void) test
+{
+   switch (test)
+   {
+   case "longlonglonglong": {
+      i = 1;
+   }
+   break;
+   }
+}
+
+@end


### PR DESCRIPTION
Place the **break** based on the first item in the previous line