### PR TITLE
Fix 'Permission denied' during output path creation

### DIFF
--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -923,8 +923,10 @@ static void make_folders(const string &filename)
          outname[idx] = 0; // mark the end of the subpath
 
          // create subfolder if it is not the start symbol of a path
+         // and not a Windows drive letter
          if (  (strcmp(&outname[last_idx], ".") != 0)
-            && (strcmp(&outname[last_idx], "..") != 0))
+            && (strcmp(&outname[last_idx], "..") != 0)
+            && (!(last_idx == 0 && idx == 2 && outname[1] == ':')))
          {
             int status;    // Coverity CID 75999
             status = mkdir(outname, 0750);


### PR DESCRIPTION
Creating intermediate directories for the output file can sometimes lead to 'Unable to create d:: Permission denied (13)' error in Windows. This happens when Uncrustify try to create a Windows drive letter. This does not affect the creation of the path, but prints annoying messages. This patch fixes this issue.