### PR TITLE
Fix alignment in 'operator' declarations.

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -1310,6 +1310,7 @@ static chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_co
 
       if (fp_active && !(pc->flags & PCF_IN_CLASS_BASE))
       {
+         // WARNING: Duplicate from the align_func_proto()
          if (  pc->type == CT_FUNC_PROTO
             || (  pc->type == CT_FUNC_DEF
                && cpd.settings[UO_align_single_line_func].b))
@@ -1317,7 +1318,17 @@ static chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_co
             LOG_FMT(LAVDB, "%s(%d): add=[%s], orig_line is %zu, orig_col is %zu, level is %zu\n",
                     __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col, pc->level);
 
-            as.Add(pc);
+            chunk_t *toadd;
+            if (  pc->parent_type == CT_OPERATOR
+               && cpd.settings[UO_align_on_operator].b)
+            {
+               toadd = chunk_get_prev_ncnl(pc);
+            }
+            else
+            {
+               toadd = pc;
+            }
+            as.Add(step_back_over_member(toadd));
             fp_look_bro = (pc->type == CT_FUNC_DEF)
                           && cpd.settings[UO_align_single_line_brace].b;
          }

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1628,8 +1628,17 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
                   || tmp->type == CT_QUALIFIER)
                {
                   set_chunk_type(prev, CT_TYPE);
-                  set_chunk_type(pc, CT_ADDR);
-                  chunk_flags_set(next, PCF_VAR_1ST);
+                  if (  next->type == CT_OPERATOR
+                     || next->type == CT_TYPE
+                     || next->type == CT_DC_MEMBER)
+                  {
+                     set_chunk_type(pc, CT_BYREF);
+                  }
+                  else
+                  {
+                     set_chunk_type(pc, CT_ADDR);
+                     chunk_flags_set(next, PCF_VAR_1ST);
+                  }
                }
                else if (tmp->type == CT_DC_MEMBER)
                {

--- a/tests/cli/Output/66.txt
+++ b/tests/cli/Output/66.txt
@@ -244,7 +244,7 @@ space_col_align(): orig_line is , orig_col is , [QUALIFIER/NONE] 'const' <==> or
 do_space(): orig_line is , orig_col is , first->text() 'const', type is QUALIFIER
 log_rule(): Spacing: first->orig_line is , first->text() is 'const', [QUALIFIER/NONE] <===>
    second->text() 'char', [TYPE/NONE] : rule sp_after_type[line ]
-space_col_align(): av is force
+ <force between 'const' and 'char'>space_col_align(): av is force
    len is 
    => coldiff is 
 space_col_align(): orig_line is , orig_col is , [TYPE/NONE] 'char' <==> orig_line is , orig_col is  [PTR_TYPE/NONE] '*' [CallStack:-DEBUG NOT SET-]
@@ -279,14 +279,14 @@ space_col_align(): orig_line is , orig_col is , [TYPE/NONE] 'unsigned' <==> orig
 do_space(): orig_line is , orig_col is , first->text() 'unsigned', type is TYPE
 log_rule(): Spacing: first->orig_line is , first->text() is 'unsigned', [TYPE/NONE] <===>
    second->text() 'long', [TYPE/NONE] : rule sp_after_type[line ]
-space_col_align(): av is force
+ <force between 'unsigned' and 'long'>space_col_align(): av is force
    len is 
    => coldiff is 
 space_col_align(): orig_line is , orig_col is , [TYPE/NONE] 'long' <==> orig_line is , orig_col is  [WORD/NONE] 'nI' [CallStack:-DEBUG NOT SET-]
 do_space(): orig_line is , orig_col is , first->text() 'long', type is TYPE
 log_rule(): Spacing: first->orig_line is , first->text() is 'long', [TYPE/NONE] <===>
    second->text() 'nI', [WORD/NONE] : rule sp_after_type[line ]
-space_col_align(): av is force
+ <force between 'long' and 'nI'>space_col_align(): av is force
    len is 
    => coldiff is 
 space_col_align(): orig_line is , orig_col is , [WORD/NONE] 'nI' <==> orig_line is , orig_col is  [FPAREN_CLOSE/FUNC_CLASS_DEF] ')' [CallStack:-DEBUG NOT SET-]
@@ -417,7 +417,7 @@ space_col_align(): orig_line is , orig_col is , [QUALIFIER/NONE] 'const' <==> or
 do_space(): orig_line is , orig_col is , first->text() 'const', type is QUALIFIER
 log_rule(): Spacing: first->orig_line is , first->text() is 'const', [QUALIFIER/NONE] <===>
    second->text() 'char', [TYPE/NONE] : rule sp_after_type[line ]
-space_col_align(): av is force
+ <force between 'const' and 'char'>space_col_align(): av is force
    len is 
    => coldiff is 
 space_col_align(): orig_line is , orig_col is , [TYPE/NONE] 'char' <==> orig_line is , orig_col is  [PTR_TYPE/NONE] '*' [CallStack:-DEBUG NOT SET-]
@@ -438,7 +438,7 @@ space_col_align(): orig_line is , orig_col is , [QUALIFIER/NONE] 'const' <==> or
 do_space(): orig_line is , orig_col is , first->text() 'const', type is QUALIFIER
 log_rule(): Spacing: first->orig_line is , first->text() is 'const', [QUALIFIER/NONE] <===>
    second->text() 'pTelName', [WORD/NONE] : rule sp_after_type[line ]
-space_col_align(): av is force
+ <force between 'const' and 'pTelName'>space_col_align(): av is force
    len is 
    => coldiff is 
 space_col_align(): orig_line is , orig_col is , [WORD/NONE] 'pTelName' <==> orig_line is , orig_col is  [SEMICOLON/NONE] ';' [CallStack:-DEBUG NOT SET-]
@@ -457,14 +457,14 @@ space_col_align(): orig_line is , orig_col is , [TYPE/NONE] 'unsigned' <==> orig
 do_space(): orig_line is , orig_col is , first->text() 'unsigned', type is TYPE
 log_rule(): Spacing: first->orig_line is , first->text() is 'unsigned', [TYPE/NONE] <===>
    second->text() 'long', [TYPE/NONE] : rule sp_after_type[line ]
-space_col_align(): av is force
+ <force between 'unsigned' and 'long'>space_col_align(): av is force
    len is 
    => coldiff is 
 space_col_align(): orig_line is , orig_col is , [TYPE/NONE] 'long' <==> orig_line is , orig_col is  [WORD/NONE] 'nTelIndex' [CallStack:-DEBUG NOT SET-]
 do_space(): orig_line is , orig_col is , first->text() 'long', type is TYPE
 log_rule(): Spacing: first->orig_line is , first->text() is 'long', [TYPE/NONE] <===>
    second->text() 'nTelIndex', [WORD/NONE] : rule sp_after_type[line ]
-space_col_align(): av is force
+ <force between 'long' and 'nTelIndex'>space_col_align(): av is force
    len is 
    => coldiff is 
 space_col_align(): orig_line is , orig_col is , [WORD/NONE] 'nTelIndex' <==> orig_line is , orig_col is  [SEMICOLON/NONE] ';' [CallStack:-DEBUG NOT SET-]

--- a/tests/config/op-space-remove-align-1.cfg
+++ b/tests/config/op-space-remove-align-1.cfg
@@ -1,0 +1,21 @@
+#
+# Removes a space after an operator
+#
+
+indent_columns		= 3
+
+sp_before_byref		= remove
+sp_after_byref		= force
+
+indent_class		= True
+
+sp_func_def_paren	= remove
+sp_func_proto_paren	= remove
+sp_after_operator	= remove
+sp_after_operator_sym   = remove
+
+align_right_cmt_span = 2
+
+align_var_class_span = 2
+align_var_def_span   = 2
+align_mix_var_proto  = true

--- a/tests/config/op-space-remove-align-2.cfg
+++ b/tests/config/op-space-remove-align-2.cfg
@@ -1,0 +1,22 @@
+#
+# Removes a space after an operator
+#
+
+indent_columns		= 3
+
+sp_before_byref		= remove
+sp_after_byref		= force
+
+indent_class		= True
+
+sp_func_def_paren	= remove
+sp_func_proto_paren	= remove
+sp_after_operator	= remove
+sp_after_operator_sym   = remove
+
+align_right_cmt_span = 2
+
+align_var_class_span = 2
+align_var_def_span   = 2
+align_mix_var_proto  = true
+align_on_operator    = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -40,6 +40,10 @@
 30033 op-space-remove.cfg              cpp/operator.cpp
 30034 op-space-force.cfg               cpp/operator_proto.cpp
 30035 op-space-remove.cfg              cpp/operator_proto.cpp
+30036 op-space-remove-align-1.cfg      cpp/operator.cpp
+30037 op-space-remove-align-1.cfg      cpp/operator_proto.cpp
+30038 op-space-remove-align-2.cfg      cpp/operator.cpp
+30039 op-space-remove-align-2.cfg      cpp/operator_proto.cpp
 
 30040 nl_class-r.cfg                   cpp/nl-class.h
 30041 nl_class-a.cfg                   cpp/nl-class.h

--- a/tests/output/cpp/30023-templates.cpp
+++ b/tests/output/cpp/30023-templates.cpp
@@ -163,8 +163,8 @@ void g(X<>& x);
 typedef std::vector<std::vector<int> >    Table; // OK
 typedef std::vector<std::vector<bool> >   Flags; // Error
 
-void func(List<B>       =default_val1);
-void func(List<List<B> >=default_val2);
+void func(List<B>        =default_val1);
+void func(List<List<B> > =default_val2);
 
 BLAH<(3.14 >= 42)> blah;
 bool               X = j<3> > 1;

--- a/tests/output/cpp/30036-operator.cpp
+++ b/tests/output/cpp/30036-operator.cpp
@@ -1,0 +1,87 @@
+
+struct bar;
+struct foo
+{
+   operator bar*();
+};
+
+class Foo {
+   Foo operator       +(const Foo& rhs) const;
+
+   const Foo& operator==(Foo& me);
+
+   bool operator      >(const Foo& rhs) const;
+
+   InStream& operator <<(InStream& in);
+}
+
+const Foo& Foo::operator==(Foo& me)
+{
+}
+
+Foo Foo::operator+(const Foo& rhs) const
+{
+}
+
+bool Foo::operator>(const Foo& rhs) const
+{
+}
+
+class Example
+{
+   char                  m_array[256];
+
+   Example& operator     =(const Example& rhs);
+   Example& operator     +=(const Example& rhs);
+   const Example operator+(const Example& other) const;
+   bool operator         ==(const Example& other) const;
+   bool operator         !=(const Example& other) const;
+   Example operator      +(const Example& x, const Example& y);
+   Example operator      *(const Example& x, const Example& y);
+
+   double& operator      ()(int row, int col);
+   double operator       ()(int row, int col) const;
+   void operator         ++();
+   int& operator         *();
+   Example& operator     ++();    // prefix ++
+   Example operator      ++(int); // postfix ++
+
+   bool operator         <(const Example& lhs, const Example& rhs) const;
+
+   int operator()(int index)
+   {
+      i = ~~3;
+      return index + 1;
+   }
+
+   char& operator[](unsigned i)
+   {
+      return m_array[i & 0xff];
+   }
+}
+bool Example::operator==(const Example& other) const
+{
+   /*TODO: compare something? */
+   return false;
+}
+bool Example::operator!=(const Example& other) const
+{
+   return !operator==(other);
+}
+
+
+void a() {
+   Op op = &X::operator==;
+   if (!A)
+      if (op != &X::operator==)
+	 A(1) = a;
+   if (!A) {
+      if (op != &X::operator==)
+	 A(1) = a;
+   }
+}
+
+void *operator new(std::size_t) throw(std::bad_alloc);
+void *operator new[](std::size_t) throw(std::bad_alloc);
+void operator  delete(void *) throw();
+void operator  delete[](void *) throw();

--- a/tests/output/cpp/30037-operator_proto.cpp
+++ b/tests/output/cpp/30037-operator_proto.cpp
@@ -1,0 +1,64 @@
+/* A collection of all the different known operator prototypes in C++ */
+
+// arithmetic operators
+Type1 operator +(const Type1& a);                          // +a
+Type1 operator +(const Type1& a, const Type2& b);          // a + b
+Type1& operator++(Type1& a);                               // ++a
+Type1 operator ++(Type1& a, int);                          // a++
+Type1& operator+=(Type1& a, const Type1& b);               // a += b
+Type1 operator -(const Type1& a);                          // -a
+Type1& operator--(Type1& a);                               // --a
+Type1 operator --(Type1& a, int);                          // a--
+Type1& operator-=(Type1& a, const Type1& b);               // a -= b
+Type1 operator *(const Type1& a, const Type1& b);          // a * b
+Type1& operator*=(Type1& a, const Type1& b);               // a *= b
+Type1 operator /(const Type1& a, const Type1& b);          // a / b
+Type1& operator/=(Type1& a, const Type1& b);               // a /= b
+Type1 operator %(const Type1& a, const Type1& b);          // a % b
+Type1& operator%=(Type1& a, const Type1& b);               // a %= b
+
+// comparison operators
+bool operator<(const Type1& a, const Type1& b);            // a < b
+bool operator<=(const Type1& a, const Type1& b);           // a <= b
+bool operator>(const Type1& a, const Type1& b);            // a > b
+bool operator>=(const Type1& a, const Type1& b);           // a >= b
+bool operator!=(const Type1& a, const Type1& b);           // a != b
+bool operator==(const Type1& a, const Type1& b);           // a == b
+
+// logical operators
+bool operator!(const Type1& a);                            // !a
+bool operator&&(const Type1& a, const Type1& b);           // a && b
+bool operator||(const Type1& a, const Type1& b);           // a || b
+
+// bitwise operators
+Type1 operator <<(const Type1& a, const Type1& b);         // a << b
+Type1& operator<<=(Type1& a, const Type1& b);              // a <<= b
+Type1 operator >>(const Type1& a, const Type1& b);         // a >> b
+Type1& operator>>=(Type1& a, const Type1& b);              // a >>= b
+Type1 operator ~(const Type1& a);                          // ~a
+Type1 operator &(const Type1& a, const Type1& b);          // a & b
+Type1& operator&=(Type1& a, const Type1& b);               // a &= b
+Type1 operator |(const Type1& a, const Type1& b);          // a | b
+Type1& operator|=(Type1& a, const Type1& b);               // a |= b
+Type1 operator ^(const Type1& a, const Type1& b);          // a ^ b
+Type1& operator^=(Type1& a, const Type1& b);               // a ^= b
+
+// other operators
+Type1& Type1::operator=(const Type1& b);                   // a = b
+void operator         ()(Type1& a);                        // a()
+const Type2& operator [](const Type1& a, const Type1& b);  // a[b]
+Type2& operator       *(const Type1& a);                   // *a
+Type2* operator       &(const Type1& a);                   // &a
+Type2* Type1::operator->();                                // a->b
+Type1::operator       type();                              // (type)a
+Type2& operator       ,(const Type1& a, Type2& b);         // a, b
+void *Type1::operator new(size_t x);                       // new Type1
+void *Type1::operator new[](size_t x);                     // new Type1[n]
+void *Type1::operator delete(size_t x);                    // delete a
+void *Type1::operator delete[](size_t x);                  // delete [] a
+
+// Misc examples
+int& operator *();
+Foo::operator const char *();
+Foo::operator const Bar&();
+

--- a/tests/output/cpp/30038-operator.cpp
+++ b/tests/output/cpp/30038-operator.cpp
@@ -1,0 +1,87 @@
+
+struct bar;
+struct foo
+{
+   operator bar*();
+};
+
+class Foo {
+   Foo        operator+(const Foo& rhs) const;
+
+   const Foo& operator==(Foo& me);
+
+   bool       operator>(const Foo& rhs) const;
+
+   InStream&  operator<<(InStream& in);
+}
+
+const Foo& Foo::operator==(Foo& me)
+{
+}
+
+Foo Foo::operator+(const Foo& rhs) const
+{
+}
+
+bool Foo::operator>(const Foo& rhs) const
+{
+}
+
+class Example
+{
+   char          m_array[256];
+
+   Example&      operator=(const Example& rhs);
+   Example&      operator+=(const Example& rhs);
+   const Example operator+(const Example& other) const;
+   bool          operator==(const Example& other) const;
+   bool          operator!=(const Example& other) const;
+   Example       operator+(const Example& x, const Example& y);
+   Example       operator*(const Example& x, const Example& y);
+
+   double&       operator()(int row, int col);
+   double        operator()(int row, int col) const;
+   void          operator++();
+   int&          operator*();
+   Example&      operator++();    // prefix ++
+   Example       operator++(int); // postfix ++
+
+   bool          operator<(const Example& lhs, const Example& rhs) const;
+
+   int operator()(int index)
+   {
+      i = ~~3;
+      return index + 1;
+   }
+
+   char& operator[](unsigned i)
+   {
+      return m_array[i & 0xff];
+   }
+}
+bool Example::operator==(const Example& other) const
+{
+   /*TODO: compare something? */
+   return false;
+}
+bool Example::operator!=(const Example& other) const
+{
+   return !operator==(other);
+}
+
+
+void a() {
+   Op op = &X::operator==;
+   if (!A)
+      if (op != &X::operator==)
+	 A(1) = a;
+   if (!A) {
+      if (op != &X::operator==)
+	 A(1) = a;
+   }
+}
+
+void *operator new(std::size_t) throw(std::bad_alloc);
+void *operator new[](std::size_t) throw(std::bad_alloc);
+void  operator delete(void *) throw();
+void  operator delete[](void *) throw();

--- a/tests/output/cpp/30039-operator_proto.cpp
+++ b/tests/output/cpp/30039-operator_proto.cpp
@@ -1,0 +1,64 @@
+/* A collection of all the different known operator prototypes in C++ */
+
+// arithmetic operators
+Type1  operator+(const Type1& a);                          // +a
+Type1  operator+(const Type1& a, const Type2& b);          // a + b
+Type1& operator++(Type1& a);                               // ++a
+Type1  operator++(Type1& a, int);                          // a++
+Type1& operator+=(Type1& a, const Type1& b);               // a += b
+Type1  operator-(const Type1& a);                          // -a
+Type1& operator--(Type1& a);                               // --a
+Type1  operator--(Type1& a, int);                          // a--
+Type1& operator-=(Type1& a, const Type1& b);               // a -= b
+Type1  operator*(const Type1& a, const Type1& b);          // a * b
+Type1& operator*=(Type1& a, const Type1& b);               // a *= b
+Type1  operator/(const Type1& a, const Type1& b);          // a / b
+Type1& operator/=(Type1& a, const Type1& b);               // a /= b
+Type1  operator%(const Type1& a, const Type1& b);          // a % b
+Type1& operator%=(Type1& a, const Type1& b);               // a %= b
+
+// comparison operators
+bool operator<(const Type1& a, const Type1& b);            // a < b
+bool operator<=(const Type1& a, const Type1& b);           // a <= b
+bool operator>(const Type1& a, const Type1& b);            // a > b
+bool operator>=(const Type1& a, const Type1& b);           // a >= b
+bool operator!=(const Type1& a, const Type1& b);           // a != b
+bool operator==(const Type1& a, const Type1& b);           // a == b
+
+// logical operators
+bool operator!(const Type1& a);                            // !a
+bool operator&&(const Type1& a, const Type1& b);           // a && b
+bool operator||(const Type1& a, const Type1& b);           // a || b
+
+// bitwise operators
+Type1  operator<<(const Type1& a, const Type1& b);         // a << b
+Type1& operator<<=(Type1& a, const Type1& b);              // a <<= b
+Type1  operator>>(const Type1& a, const Type1& b);         // a >> b
+Type1& operator>>=(Type1& a, const Type1& b);              // a >>= b
+Type1  operator~(const Type1& a);                          // ~a
+Type1  operator&(const Type1& a, const Type1& b);          // a & b
+Type1& operator&=(Type1& a, const Type1& b);               // a &= b
+Type1  operator|(const Type1& a, const Type1& b);          // a | b
+Type1& operator|=(Type1& a, const Type1& b);               // a |= b
+Type1  operator^(const Type1& a, const Type1& b);          // a ^ b
+Type1& operator^=(Type1& a, const Type1& b);               // a ^= b
+
+// other operators
+Type1&       Type1::operator=(const Type1& b);             // a = b
+void         operator()(Type1& a);                         // a()
+const Type2& operator[](const Type1& a, const Type1& b);   // a[b]
+Type2&       operator*(const Type1& a);                    // *a
+Type2*       operator&(const Type1& a);                    // &a
+Type2*       Type1::operator->();                          // a->b
+             Type1::operator type();                       // (type)a
+Type2&       operator,(const Type1& a, Type2& b);          // a, b
+void *       Type1::operator new(size_t x);                // new Type1
+void *       Type1::operator new[](size_t x);              // new Type1[n]
+void *       Type1::operator delete(size_t x);             // delete a
+void *       Type1::operator delete[](size_t x);           // delete [] a
+
+// Misc examples
+int& operator*();
+     Foo::operator const char *();
+     Foo::operator const Bar&();
+


### PR DESCRIPTION
It fixes some incorrect alignments in the `operator` declarations.

Config:
```
indent_columns = 4

sp_after_operator = remove

align_func_proto_span = 2
align_var_def_span    = 2
align_mix_var_proto   = true
align_on_operator     = true
```

Source:
```
// 'sp_after_operator = remove' eats the space
Foo& Foo::operator =(const Foo& a);
void *Foo::operator new(size_t x);

// 'align_on_operator = true' invalid alignment
bool operator==(const FooBar& a);
FooBar& operator =(const FooBar& a);
```

Invalid result:
```
// 'sp_after_operator = remove' eats the space
Foo& Foo::operator =(const Foo& a);
void *Foo::operatornew(size_t x);

// 'align_on_operator = true' invalid alignment
bool operator   ==(const FooBar& a);
FooBar&         operator=(const FooBar& a);
```

Valid result:
```
// 'sp_after_operator = remove' eats the space
Foo&  Foo::operator=(const Foo& a);
void *Foo::operator new(size_t x);

// 'align_on_operator = true' invalid alignment
bool    operator==(const FooBar& a);
FooBar& operator=(const FooBar& a);
```
