### PR TITLE
Don't force-align with tabs when indenting ternary ':'

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -604,10 +604,9 @@ void output_text(FILE *pfile)
                size_t lvlcol;
                /*
                 * FIXME: it would be better to properly set column_indent in
-                * indent_text(), but this hack for '}' and ':' seems to work.
+                * indent_text(), but this hack for '}' and '#' seems to work.
                 */
                if (  pc->type == CT_BRACE_CLOSE
-                  || chunk_is_str(pc, ":", 1)
                   || pc->type == CT_PREPROC)
                {
                   lvlcol = pc->column;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -607,6 +607,7 @@ void output_text(FILE *pfile)
                 * indent_text(), but this hack for '}' and '#' seems to work.
                 */
                if (  pc->type == CT_BRACE_CLOSE
+                  || pc->type == CT_CASE_COLON
                   || pc->type == CT_PREPROC)
                {
                   lvlcol = pc->column;

--- a/tests/output/c/09604-indent_ternary-2.c
+++ b/tests/output/c/09604-indent_ternary-2.c
@@ -1,13 +1,13 @@
 void foo(void)
 {
 	int a = x ? y
-		  : z,
+	          : z,
 	    b = x ? (y)
-		  : (z),
+	          : (z),
 	    c = x ? *y
-		  : *z,
+	          : *z,
 	    d = x ? &y
-		  : &z;
+	          : &z;
 
 
 	if (x ? y


### PR DESCRIPTION
When using the following settings, a ternary operator ':' should be
aligned to '?', yet also adhering to the 'indent with tabs, align with
spaces' setting.

```
indent_with_tabs        = 1
indent_ternary_operator = 2
```

The result however is that the ':' is aligned to '?' as if
`indent_with_tabs = 2`.
(using tabs as much as it can, then aligning the last bit using spaces)

I tracked this down to a special handling of ':' in `src/output.cpp`.

Here is where I have a caveat: I don't understand what special case this
line was supposed to handle. I tried tracking it down in the git history,
but I ended up at commit fe25b6d0 ("Import r1644 from subversion"),
and then I couldn't find the old subversion repository.

No tests broke when removing this line (except for the test for
aligning of the ternary operator ':'), so it would appear to only exist
to make sure that the ternary ':' is aligned using tabs even though
`indent_with_tabs = 1` which I would argue is wrong.

I guess my only hope to understand what this line really is supposed to
do is to remove it and wait for someone to yell at me that something
would/did break when applying this commit.