### PR TITLE
Fix out-of-bounds memory write

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -216,7 +216,7 @@ void log_fmt(log_sev_t sev, const char *fmt, ...)
    char         buf[BUFFERLENGTH];
    // it MUST be a 'unsigned int' variable to be runable under windows
    unsigned int length = strlen(fmt);
-   if (length > BUFFERLENGTH)
+   if (length >= BUFFERLENGTH)
    {
       fprintf(stderr, "FATAL: The variable 'buf' is not big enought:\n");
       fprintf(stderr, "   it should be bigger as = %u\n", length);


### PR DESCRIPTION
The following code merely checks length greater than 200:

   ` if (length > BUFFERLENGTH)`

that means the `length `may equal to 200. so it will overrun
array "`buf`" of 200 bytes at byte offset 200 for the following
code when `length `is 200 and results in unexpected issue:

```
    memcpy(buf, fmt, length);
    buf[length] = 0;

```
Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>