### PR TITLE
distinguish "indent" vs. "ident" vs. "identifier"

### DIFF
--- a/documentation/htdocs/index.html
+++ b/documentation/htdocs/index.html
@@ -44,7 +44,7 @@ Create a highly configurable, easily modifiable source code beautifier.</p>
 
 <h2>Features</h2>
 <ul>
-   <li>Ident code, aligning on parens, assignments, etc</li>
+   <li>Indent code, aligning on parens, assignments, etc</li>
    <li>Align on '=' and variable definitions</li>
    <li>Align structure initializers</li>
    <li>Align #define stuff</li>

--- a/documentation/htdocs/uncrustify.html
+++ b/documentation/htdocs/uncrustify.html
@@ -12,7 +12,7 @@ web site</A>
 Uncrustify 0.0.3</A></P>
 <B>What it does:</B>
 <UL>
-	<LI>Ident code
+	<LI>Indent code
 	<LI>Align code on '=' and variable definitions
 	<LI>Align #define stuff
 	<LI>Align backslash-newline stuff

--- a/scripts/pclint/co-gcc.lnt
+++ b/scripts/pclint/co-gcc.lnt
@@ -93,7 +93,7 @@
 
 // =========================================================
 // +rw and -d options to cope with GNU syntax:
-+ppw(ident)                 // Tolerate #ident
++ppw(ident)                 // Tolerate #ident keyword definitions for SCCS/RCS
 +ppw(warning)
 
 // GCC provides alternative spellings of certain keywords:

--- a/scripts/pclint/co-gcc.lnt
+++ b/scripts/pclint/co-gcc.lnt
@@ -78,10 +78,10 @@
 
 // Begin: System Dependent Options
 // -------------------------------
--a#machine(i386)  	// #assert's machine(i386)  (SVR4 facility).
-+fdi              	// Use the directory of the including file
--si4           		// size of int
--sp4				// size of pointer
+-a#machine(i386)  // #assert's machine(i386)  (SVR4 facility).
++fdi              // Use the directory of the including file
+-si4              // size of int
+-sp4              // size of pointer
 
 // -----------------------------
 // End: System Dependent Options

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2432,8 +2432,8 @@ void indent_text(void)
          }
          else
          {
-            bool   use_ident = true;
-            size_t ttidx     = frm.pse_tos;
+            bool   use_indent = true;
+            size_t ttidx      = frm.pse_tos;
             if (ttidx > 0)
             {
                //if (strcasecmp(get_token_name(frm.pse[ttidx].pc->parent_type), "FUNC_CALL") == 0)
@@ -2447,13 +2447,13 @@ void indent_text(void)
                   else
                   {
                      LOG_FMT(LINDPC, "use is false [%d]\n", __LINE__);
-                     use_ident = false;
+                     use_indent = false;
                   }
                }
             }
             if (pc->column != indent_column)
             {
-               if (use_ident && pc->type != CT_PP_IGNORE) // Leave indentation alone for PP_IGNORE tokens
+               if (use_indent && pc->type != CT_PP_IGNORE) // Leave indentation alone for PP_IGNORE tokens
                {
                   LOG_FMT(LINDENT, "%s(%d): orig_line is %zu, indent set to %zu, for '%s'\n",
                           __func__, __LINE__, pc->orig_line, indent_column, pc->text());

--- a/tests/input/cpp/gh555.cpp
+++ b/tests/input/cpp/gh555.cpp
@@ -4,5 +4,5 @@ class \u005FClass // underscore character
 
 int main()
 {
-   string IdentContainingTwoUCNCharacters\u1234\U00001234 = "\u005FClass";
+   string IdentifierContainingTwoUCNCharacters\u1234\U00001234 = "\u005FClass";
 }

--- a/tests/input/d/Lexer.d
+++ b/tests/input/d/Lexer.d
@@ -353,7 +353,7 @@ class Lexer
 			    case 'r':
 //					debug writefln( "    wysiwyg" );
 					if( p[1] != '"')
-					    goto case_ident;
+					    goto case_identifier;
 					p++;
 				    case '`':
 					t.value = wysiwygStringConstant(t, *p);
@@ -362,7 +362,7 @@ class Lexer
 			    case 'x':
 //					debug writefln( "    hex string" );
 					if( p[1] != '"')
-					    goto case_ident;
+					    goto case_identifier;
 					p++;
 					t.value = hexStringConstant(t);
 					return;
@@ -409,7 +409,7 @@ class Lexer
 			    case 'U':  	case 'V':   case 'W':   case 'X':   case 'Y':
 			    case 'Z':
 			    case '_':
-			    case_ident:
+			    case_identifier:
 			    {
 //					debug writefln( "    identifier" );
 					ubyte c;
@@ -435,7 +435,7 @@ class Lexer
 						stringtable[tmp] = id;
 					}
 
-					t.ident = id;
+					t.identifier = id;
 					t.value = cast(TOK) id.value;
 					anyToken = 1;
 
@@ -467,7 +467,7 @@ class Lexer
 							if( loc.filename.length )
 								t.ustring = loc.filename;
 							else
-								t.ustring = mod.ident.toChars();
+								t.ustring = mod.identifier.toChars();
 							goto Llen;
 					    }
 					    else if( mod && id == Id.LINE )
@@ -952,7 +952,7 @@ class Lexer
 						uint u = decodeUTF();
 					    // Check for start of unicode identifier
 					    if( isUniAlpha(u) )
-							goto case_ident;
+							goto case_identifier;
 
 					    if( u == PS || u == LS )
 					    {
@@ -2035,7 +2035,7 @@ class Lexer
 
 	    scan(&tok);
 
-	    if( tok.value != TOK.TOKidentifier || tok.ident != Id.line )
+	    if( tok.value != TOK.TOKidentifier || tok.identifier != Id.line )
 			goto Lerr;
 
 	    scan(&tok);
@@ -2076,7 +2076,7 @@ class Lexer
 					if( mod && memcmp(p, cast(char*)"__FILE__", 8) == 0)
 					{
 					    p += 8;
-//!					    filespec = mem.strdup(loc.filename ? loc.filename : mod.ident.toChars());
+//!					    filespec = mem.strdup(loc.filename ? loc.filename : mod.identifier.toChars());
 					}
 					continue;
 

--- a/tests/output/cpp/33090-gh555.cpp
+++ b/tests/output/cpp/33090-gh555.cpp
@@ -4,5 +4,5 @@ class \u005FClass // underscore character
 
 int main()
 {
-	string IdentContainingTwoUCNCharacters\u1234\U00001234 = "\u005FClass";
+	string IdentifierContainingTwoUCNCharacters\u1234\U00001234 = "\u005FClass";
 }

--- a/tests/output/d/40006-Lexer.d
+++ b/tests/output/d/40006-Lexer.d
@@ -361,7 +361,7 @@ class Lexer
             case 'r':
 //					debug writefln( "    wysiwyg" );
                 if (p[1] != '"')
-                    goto case_ident;
+                    goto case_identifier;
                 p++;
 
             case '`':
@@ -371,7 +371,7 @@ class Lexer
             case 'x':
 //					debug writefln( "    hex string" );
                 if (p[1] != '"')
-                    goto case_ident;
+                    goto case_identifier;
                 p++;
                 t.value = hexStringConstant(t);
                 return;
@@ -454,7 +454,7 @@ class Lexer
             case 'Y':
             case 'Z':
             case '_':
- case_ident:
+ case_identifier:
                 {
 //					debug writefln( "    identifier" );
                     ubyte c;
@@ -480,9 +480,9 @@ class Lexer
                         stringtable[tmp] = id;
                     }
 
-                    t.ident  = id;
-                    t.value  = cast(TOK)id.value;
-                    anyToken = 1;
+                    t.identifier = id;
+                    t.value      = cast(TOK)id.value;
+                    anyToken     = 1;
 
                     // if special identifier token
                     if (*t.ptr == '_')
@@ -512,7 +512,7 @@ class Lexer
                             if (loc.filename.length)
                                 t.ustring = loc.filename;
                             else
-                                t.ustring = mod.ident.toChars();
+                                t.ustring = mod.identifier.toChars();
                             goto Llen;
                         }
                         else if (mod && id == Id.LINE)
@@ -1048,7 +1048,7 @@ class Lexer
                         uint u = decodeUTF();
                         // Check for start of unicode identifier
                         if (isUniAlpha(u))
-                            goto case_ident;
+                            goto case_identifier;
 
                         if (u == PS || u == LS)
                         {
@@ -2161,7 +2161,7 @@ class Lexer
 
         scan(&tok);
 
-        if (tok.value != TOK.TOKidentifier || tok.ident != Id.line)
+        if (tok.value != TOK.TOKidentifier || tok.identifier != Id.line)
             goto Lerr;
 
         scan(&tok);
@@ -2203,7 +2203,7 @@ class Lexer
                 if (mod && memcmp(p, cast(char *)"__FILE__", 8) == 0)
                 {
                     p += 8;
-//!					    filespec = mem.strdup(loc.filename ? loc.filename : mod.ident.toChars());
+//!					    filespec = mem.strdup(loc.filename ? loc.filename : mod.identifier.toChars());
                 }
                 continue;
 

--- a/tests/output/d/40007-Lexer.d
+++ b/tests/output/d/40007-Lexer.d
@@ -346,7 +346,7 @@ class Lexer
             case 'r':
 //					debug writefln( "    wysiwyg" );
                 if (p[1] != '"') {
-                    goto case_ident;
+                    goto case_identifier;
                 }
                 p++;
 
@@ -357,7 +357,7 @@ class Lexer
             case 'x':
 //					debug writefln( "    hex string" );
                 if (p[1] != '"') {
-                    goto case_ident;
+                    goto case_identifier;
                 }
                 p++;
                 t.value = hexStringConstant(t);
@@ -440,7 +440,7 @@ class Lexer
             case 'Y':
             case 'Z':
             case '_':
-case_ident:
+case_identifier:
                 {
 //					debug writefln( "    identifier" );
                     ubyte c;
@@ -463,9 +463,9 @@ case_ident:
                         stringtable[tmp] = id;
                     }
 
-                    t.ident  = id;
-                    t.value  = cast(TOK)id.value;
-                    anyToken = 1;
+                    t.identifier = id;
+                    t.value      = cast(TOK)id.value;
+                    anyToken     = 1;
 
                     // if special identifier token
                     if (*t.ptr == '_') {
@@ -493,7 +493,7 @@ case_ident:
                                 t.ustring = loc.filename;
                             }
                             else {
-                                t.ustring = mod.ident.toChars();
+                                t.ustring = mod.identifier.toChars();
                             }
                             goto Llen;
                         }
@@ -1001,7 +1001,7 @@ Llen:
                         uint u = decodeUTF();
                         // Check for start of unicode identifier
                         if (isUniAlpha(u)) {
-                            goto case_ident;
+                            goto case_identifier;
                         }
 
                         if (u == PS || u == LS) {
@@ -2104,7 +2104,7 @@ done:
 
         scan(&tok);
 
-        if (tok.value != TOK.TOKidentifier || tok.ident != Id.line) {
+        if (tok.value != TOK.TOKidentifier || tok.identifier != Id.line) {
             goto Lerr;
         }
 
@@ -2146,7 +2146,7 @@ Lnewline:
             case '_':
                 if (mod && memcmp(p, cast(char*)"__FILE__", 8) == 0) {
                     p += 8;
-//!					    filespec = mem.strdup(loc.filename ? loc.filename : mod.ident.toChars());
+//!					    filespec = mem.strdup(loc.filename ? loc.filename : mod.identifier.toChars());
                 }
                 continue;
 


### PR DESCRIPTION
There were a few typos where "ident" was used where "indent" was intended; additionally, there was a use of "ident" as an actual token that differed from other instances of the term, which were abbreviations of "identifier". These changes hopefully clarify the distinctions among these three cases.

I ran the tests locally (especially to confirm that the files `tests/output/d/*-Lexer.d` remained valid), and they succeeded (`100% tests passed, 0 tests failed out of 794`). I don't know D, though, so I'd appreciate if someone versed in the language could confirm the validity of the changes in the `*.d` test files.