### PR TITLE
Fix the detection of lambda-expression without lambda-declarator

### DIFF
--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -186,6 +186,8 @@
 30741 al.cfg                           cpp/al.cpp
 30742 delete.cfg                       cpp/delete.cpp
 
+# TODO: Reduce the number of options, leave only those that affect lambda.
+# TODO: Add tests for nested lambdas.
 30750 ben.cfg                          cpp/lambda.cpp
 30751 lambda1.cfg                      cpp/lambda.cpp
 30752 lambda2.cfg                      cpp/lambda.cpp

--- a/tests/input/cpp/lambda.cpp
+++ b/tests/input/cpp/lambda.cpp
@@ -35,6 +35,26 @@ void f2()
            });
 }
 
+void f3a()
+{
+   auto a = [] {};
+   auto b = []{return true;};
+}
+
+void f3b()
+{
+   Invoke(a, b,
+          [&one, two]
+          {
+             std::cout << "blah: " << one << two;
+          });
+}
+
+void f3c()
+{
+   int a[]{};
+}
+
 void g1()
 {
    auto a = [ = ](int* a, Something &b) { std::cout << "blah: " << *a; };

--- a/tests/input/cpp/lambda2.cpp
+++ b/tests/input/cpp/lambda2.cpp
@@ -38,6 +38,27 @@ void f2()
     );
 }
 
+void f3a()
+{
+   auto a = [] {};
+   auto b = []{return true;};
+}
+
+void f3b()
+{
+   Invoke(a, b,
+          [&one, two]
+          {
+             std::cout << "blah: " << one << two;
+          }
+   );
+}
+
+void f3c()
+{
+   int a[]{};
+}
+
 void g1()
 {
    auto a = [ = ](int* a, Something &b) { std::cout << "blah: " << *a; };

--- a/tests/output/cpp/30750-lambda.cpp
+++ b/tests/output/cpp/30750-lambda.cpp
@@ -35,6 +35,29 @@ void f2()
    });
 }
 
+void f3a()
+{
+   auto a = [] {
+            };
+   auto b = [] {
+               return(true);
+            };
+}
+
+void f3b()
+{
+   Invoke(a, b,
+          [&one, two]
+   {
+      std::cout << "blah: " << one << two;
+   });
+}
+
+void f3c()
+{
+   int a[]{};
+}
+
 void g1()
 {
    auto a = [ = ](int *a, Something&b) {

--- a/tests/output/cpp/30751-lambda.cpp
+++ b/tests/output/cpp/30751-lambda.cpp
@@ -31,6 +31,25 @@ void f2()
    });
 }
 
+void f3a()
+{
+   auto a = [] {};
+   auto b = [] { return(true); };
+}
+
+void f3b()
+{
+   Invoke(a, b,
+          [&one, two] {
+      std::cout << "blah: " << one << two;
+   });
+}
+
+void f3c()
+{
+   int a[]{};
+}
+
 void g1()
 {
    auto a = [=] (int *a, Something&b) { std::cout << "blah: " << *a; };

--- a/tests/output/cpp/30752-lambda.cpp
+++ b/tests/output/cpp/30752-lambda.cpp
@@ -38,6 +38,32 @@ void f2()
           );
 }
 
+void f3a()
+{
+   auto a = []
+            {
+            };
+   auto b = []
+            {
+               return(true);
+            };
+}
+
+void f3b()
+{
+   Invoke(a, b,
+          [&one, two]
+   {
+      std::cout << "blah: " << one << two;
+   }
+          );
+}
+
+void f3c()
+{
+   int a[]{};
+}
+
 void g1()
 {
    auto a = [=] (int *a, Something&b)

--- a/tests/output/cpp/30753-lambda2.cpp
+++ b/tests/output/cpp/30753-lambda2.cpp
@@ -34,6 +34,26 @@ void f2()
           );
 }
 
+void f3a()
+{
+   auto a = [] {};
+   auto b = [] { return(true); };
+}
+
+void f3b()
+{
+   Invoke(a, b,
+          [&one, two] {
+             std::cout << "blah: " << one << two;
+          }
+          );
+}
+
+void f3c()
+{
+   int a[]{};
+}
+
 void g1()
 {
    auto a = [=] (int *a, Something&b) { std::cout << "blah: " << *a; };


### PR DESCRIPTION
Lambda-declarator '( params )' in the lambda-expression is optional.
The minimum lambda-expression can have the form: [captures] {body}.