### PR TITLE
 refactor unc_text.cpp

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -33,6 +33,8 @@
 #include "keywords.h"
 #include "options.h"
 
+#include <algorithm>
+
 
 using namespace std;
 

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -29,6 +29,8 @@
 #include "unc_ctype.h"
 #include "uncrustify.h"
 
+#include <algorithm>
+
 
 using namespace std;
 

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -309,15 +309,15 @@ bool unc_text::startswith(const unc_text &text, size_t idx) const
 
 int unc_text::find(const char *text, size_t sidx) const
 {
-   size_t len = strlen(text); // the length of 'text' we are looking for
-   size_t si  = size();       // the length of the string we are looking in
+   const size_t len = strlen(text); // the length of 'text' we are looking for
+   const size_t si  = size();       // the length of the string we are looking in
 
-   if (si < len)              // not enough place for 'text'
+   if (si < len)                    // not enough place for 'text'
    {
       return(-1);
    }
-   size_t midx = size() - len;
 
+   const size_t midx = si - len;
    for (size_t idx = sidx; idx <= midx; idx++)
    {
       bool match = true;
@@ -392,6 +392,7 @@ int unc_text::replace(const char *oldtext, const unc_text &newtext)
       rcnt++;
       erase(static_cast<size_t>(fidx), olen);
       insert(static_cast<size_t>(fidx), newtext);
+
       fidx = find(oldtext, static_cast<size_t>(fidx) + newtext_size - olen + 1);
    }
    return(rcnt);

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -385,10 +385,11 @@ void unc_text::erase(size_t idx, size_t len)
 
 int unc_text::replace(const char *oldtext, const unc_text &newtext)
 {
-   int    fidx         = find(oldtext);
-   size_t olen         = strlen(oldtext);
-   size_t rcnt         = 0;
-   size_t newtext_size = newtext.size();
+   const size_t olen         = strlen(oldtext);
+   const size_t newtext_size = newtext.size();
+
+   int          fidx = find(oldtext);
+   int          rcnt = 0;
 
    while (fidx >= 0)
    {

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -139,33 +139,33 @@ void unc_text::set(const unc_text &ref)
 
 void unc_text::set(const unc_text &ref, size_t idx, size_t len)
 {
-   size_t ref_size = ref.size();
-
-   len = fix_len_idx(ref_size, idx, len);
    m_logok = false;
+
+   const auto ref_size = ref.size();
+
    if (len == ref_size)
    {
       m_chars = ref.m_chars;
+      return;
    }
-   else
+
+   m_chars.resize(len);
+
+   len = fix_len_idx(ref_size, idx, len);
+   for (size_t di = 0;
+        len > 0;
+        di++, idx++, len--)
    {
-      m_chars.resize(len);
-      size_t di = 0;
-      while (len-- > 0)
-      {
-         m_chars[di] = ref.m_chars[idx];
-         di++;
-         idx++;
-      }
+      m_chars[di] = ref.m_chars[idx];
    }
 }
 
 
 void unc_text::set(const string &ascii_text)
 {
-   size_t len = ascii_text.size();
+   const size_t len = ascii_text.size();
 
-   m_chars.resize((size_t)len);
+   m_chars.resize(len);
    for (size_t idx = 0; idx < len; idx++)
    {
       m_chars[idx] = ascii_text[idx];
@@ -176,9 +176,9 @@ void unc_text::set(const string &ascii_text)
 
 void unc_text::set(const char *ascii_text)
 {
-   size_t len = strlen(ascii_text);
+   const size_t len = strlen(ascii_text);
 
-   m_chars.resize((size_t)len);
+   m_chars.resize(len);
    for (size_t idx = 0; idx < len; idx++)
    {
       m_chars[idx] = *ascii_text++;
@@ -189,17 +189,16 @@ void unc_text::set(const char *ascii_text)
 
 void unc_text::set(const value_type &data, size_t idx, size_t len)
 {
-   size_t data_size = data.size();
-
-   len = fix_len_idx(data_size, idx, len);
    m_chars.resize(len);
-   size_t di = 0;
-   while (len-- > 0)
+
+   len = fix_len_idx(data.size(), idx, len);
+   for (size_t di = 0;
+        len > 0;
+        di++, idx++, len--)
    {
       m_chars[di] = data[idx];
-      di++;
-      idx++;
    }
+
    m_logok = false;
 }
 

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -205,11 +205,13 @@ void unc_text::set(const value_type &data, size_t idx, size_t len)
 
 void unc_text::resize(size_t new_size)
 {
-   if (size() != new_size)
+   if (size() == new_size)
    {
-      m_chars.resize(new_size);
-      m_logok = false;
+      return;
    }
+
+   m_chars.resize(new_size);
+   m_logok = false;
 }
 
 

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -97,12 +97,13 @@ int unc_text::compare(const unc_text &ref1, const unc_text &ref2, size_t len)
 
 bool unc_text::equals(const unc_text &ref) const
 {
-   size_t len = size();
+   const size_t len = size();
 
    if (ref.size() != len)
    {
       return(false);
    }
+
    for (size_t idx = 0; idx < len; idx++)
    {
       if (m_chars[idx] != ref.m_chars[idx])

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -30,26 +30,28 @@ static size_t fix_len_idx(size_t size, size_t idx, size_t len)
 
 void unc_text::update_logtext()
 {
-   if (!m_logok)
+   if (m_logok)
    {
-      // make a pessimistic guess at the size
-      m_logtext.clear();
-      m_logtext.reserve(m_chars.size() * 3);
-      for (int m_char : m_chars)
-      {
-         if (m_char == '\n')
-         {
-            m_char = 0x2424;
-         }
-         else if (m_char == '\r')
-         {
-            m_char = 0x240d;
-         }
-         encode_utf8(m_char, m_logtext);
-      }
-      m_logtext.push_back(0);
-      m_logok = true;
+      return;
    }
+
+   // make a pessimistic guess at the size
+   m_logtext.clear();
+   m_logtext.reserve(m_chars.size() * 3);
+   for (int m_char : m_chars)
+   {
+      if (m_char == '\n')
+      {
+         m_char = 0x2424; // NL symbol
+      }
+      else if (m_char == '\r')
+      {
+         m_char = 0x240d; // CR symbol
+      }
+      encode_utf8(m_char, m_logtext);
+   }
+   m_logtext.push_back(0);
+   m_logok = true;
 }
 
 

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -374,10 +374,12 @@ int unc_text::rfind(const char *text, size_t sidx) const
 
 void unc_text::erase(size_t idx, size_t len)
 {
-   if (len >= 1)
+   if (len == 0)
    {
-      m_chars.erase(m_chars.begin() + static_cast<int>(idx), m_chars.begin() + static_cast<int>(idx) + static_cast<int>(len));
+      return;
    }
+
+   m_chars.erase(m_chars.begin() + idx, m_chars.begin() + idx + len);
 }
 
 

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -224,14 +224,14 @@ void unc_text::clear()
 
 void unc_text::insert(size_t idx, int ch)
 {
-   m_chars.insert(m_chars.begin() + static_cast<int>(idx), ch);
+   m_chars.insert(m_chars.begin() + idx, ch);
    m_logok = false;
 }
 
 
 void unc_text::insert(size_t idx, const unc_text &ref)
 {
-   m_chars.insert(m_chars.begin() + static_cast<int>(idx), ref.m_chars.begin(), ref.m_chars.end());
+   m_chars.insert(m_chars.begin() + idx, ref.m_chars.begin(), ref.m_chars.end());
    m_logok = false;
 }
 

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -276,38 +276,34 @@ void unc_text::append(const value_type &data, size_t idx, size_t len)
 
 bool unc_text::startswith(const char *text, size_t idx) const
 {
-   bool match = false;
+   const auto orig_idx = idx;
 
-   while ((idx < size()) && *text)
+   for ( ; idx < size() && *text; idx++, text++)
    {
       if (*text != m_chars[idx])
       {
          return(false);
       }
-      idx++;
-      text++;
-      match = true;
    }
-   return(match && (*text == 0));
+
+   return(idx != orig_idx && (*text == 0));
 }
 
 
 bool unc_text::startswith(const unc_text &text, size_t idx) const
 {
-   bool   match = false;
-   size_t si    = 0;
+   size_t     si       = 0;
+   const auto orig_idx = idx;
 
-   while ((idx < size()) && (si < text.size()))
+   for ( ; idx < size() && si < text.size(); idx++, si++)
    {
       if (text.m_chars[si] != m_chars[idx])
       {
          return(false);
       }
-      idx++;
-      si++;
-      match = true;
    }
-   return(match && (si == text.size()));
+
+   return(idx != orig_idx && (si == text.size()));
 }
 
 

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -8,7 +8,7 @@
 #include "unc_text.h"
 #include "unc_ctype.h"
 #include "unicode.h" // encode_utf8()
-
+#include <algorithm>
 
 using namespace std;
 
@@ -55,15 +55,12 @@ void unc_text::update_logtext()
 
 int unc_text::compare(const unc_text &ref1, const unc_text &ref2, size_t len)
 {
-   size_t idx;
-   size_t len1 = ref1.size();
-   size_t len2 = ref2.size();
+   const size_t len1    = ref1.size();
+   const size_t len2    = ref2.size();
+   const auto   max_idx = std::min({ len, len1, len2 });
+   size_t       idx     = 0;
 
-   for (idx = 0;
-        (  idx < len1
-        && idx < len2
-        && idx < len);
-        idx++)
+   for ( ; idx < max_idx; idx++)
    {
       // exactly the same character ?
       if (ref1.m_chars[idx] == ref2.m_chars[idx])
@@ -91,7 +88,8 @@ int unc_text::compare(const unc_text &ref1, const unc_text &ref2, size_t len)
       return(0);
    }
 
-   return(len1 - len2);
+   // underflow save: return(len1 - len2);
+   return((len1 > len2) ? (len1 - len2) : -static_cast<int>(len2 - len1));
 }
 
 

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -13,23 +13,18 @@
 using namespace std;
 
 
-static void fix_len_idx(size_t size, size_t &idx, size_t &len);
+static size_t fix_len_idx(size_t size, size_t idx, size_t len);
 
 
-static void fix_len_idx(size_t size, size_t &idx, size_t &len)
+static size_t fix_len_idx(size_t size, size_t idx, size_t len)
 {
    if (idx >= size)
    {
-      len = 0;
+      return(0);
    }
-   else
-   {
-      size_t left = size - idx;
-      if (len > left)
-      {
-         len = left;
-      }
-   }
+
+   const size_t left = size - idx;
+   return((len > left) ? left : len);
 }
 
 
@@ -145,7 +140,7 @@ void unc_text::set(const unc_text &ref, size_t idx, size_t len)
 {
    size_t ref_size = ref.size();
 
-   fix_len_idx(ref_size, idx, len);
+   len = fix_len_idx(ref_size, idx, len);
    m_logok = false;
    if (len == ref_size)
    {
@@ -195,7 +190,7 @@ void unc_text::set(const value_type &data, size_t idx, size_t len)
 {
    size_t data_size = data.size();
 
-   fix_len_idx(data_size, idx, len);
+   len = fix_len_idx(data_size, idx, len);
    m_chars.resize(len);
    size_t di = 0;
    while (len-- > 0)

--- a/src/windows_compat.h
+++ b/src/windows_compat.h
@@ -9,6 +9,7 @@
 #ifndef WINDOWS_COMPAT_H_INCLUDED
 #define WINDOWS_COMPAT_H_INCLUDED
 
+#define NOMINMAX
 #include "windows.h"
 
 #define HAVE_SYS_STAT_H


### PR DESCRIPTION
The last commit disables Microsofts silly macro implementations of min / max in order to enable the use of the std implementations. This has the disadvantage that now the `algorithm` header always has to be included if min or max are used.