### PR TITLE
 make unc_text::c_str const 

### DIFF
--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -774,8 +774,8 @@ void tokenize_cleanup(void)
       // Detect "pragma region" and "pragma endregion"
       if (pc->type == CT_PP_PRAGMA && next->type == CT_PREPROC_BODY)
       {
-         if (  (memcmp(next->str.c_str(), "region", 6) == 0)
-            || (memcmp(next->str.c_str(), "endregion", 9) == 0))
+         if (  (strncmp(next->str.c_str(), "region", 6) == 0)
+            || (strncmp(next->str.c_str(), "endregion", 9) == 0))
          // TODO: probably better use strncmp
          {
             set_chunk_type(pc, (*next->str.c_str() == 'r') ? CT_PP_REGION : CT_PP_ENDREGION);

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -8,28 +8,100 @@
 #include "unc_text.h"
 #include "unc_ctype.h"
 #include "unicode.h" // encode_utf8()
+#include <stdexcept>
 #include <algorithm>
 
+
 using namespace std;
+
+
+static constexpr const int_fast8_t UTF8_BLOCKS = 6;  // 6 -> max utf8 blocks per char
 
 
 static size_t fix_len_idx(size_t size, size_t idx, size_t len);
 
 //! converts \n and \r chars are into NL and CR UTF8 symbols before encode_utf8 is called
-static void toLogTextUtf8(int m_char, vector<UINT8> &container);
+static void toLogTextUtf8(int c, unc_text::log_type &container);
+
+/**
+ * calculates the size a 'log_type' container needs to have in order to take
+ * in values of a 'unc_text::value_type' up to idx
+ * (without \0, with symbols for the converted \n and \r chars)
+ *
+ * throws if char is greater than 0x7fffffff
+ */
+static int getLogTextUtf8Len(unc_text::value_type &c0, size_t end);
+
+static int getLogTextUtf8Len(unc_text::value_type &c0, size_t start, size_t end);
 
 
-static void toLogTextUtf8(int m_char, vector<UINT8> &container)
+static int getLogTextUtf8Len(unc_text::value_type &c0, size_t start, size_t end)
 {
-   if (m_char == '\n')
+   size_t c1_idx = 0;
+
+   for (size_t i = start; i < end; ++i)
    {
-      m_char = 0x2424; // NL symbol
+      auto ch = c0[i];
+      if (ch == '\n')
+      {
+         ch = 0x2424;  // NL symbol
+      }
+      else if (ch == '\r')
+      {
+         ch = 0x240d;  // CR symbol
+      }
+
+      if (ch < 0x80)              // 1-byte sequence
+      {
+         c1_idx += 1;
+      }
+      else if (ch < 0x0800)       // 2-byte sequence
+      {
+         c1_idx += 2;
+      }
+      else if (ch < 0x10000)      // 3-byte sequence
+      {
+         c1_idx += 3;
+      }
+      else if (ch < 0x200000)     // 4-byte sequence
+      {
+         c1_idx += 4;
+      }
+      else if (ch < 0x4000000)    // 5-byte sequence
+      {
+         c1_idx += 5;
+      }
+      else if (ch <= 0x7fffffff)  // 6-byte sequence
+      {
+         c1_idx += 6;
+      }
+      else
+      {
+         throw out_of_range(string(__func__) + ":" + to_string(__LINE__)
+                            + " - ch value too big, can't convert to utf8");
+      }
    }
-   else if (m_char == '\r')
+   return(c1_idx);
+} // getLogTextUTF8Len
+
+
+static int getLogTextUtf8Len(unc_text::value_type &c0, size_t end)
+{
+   return(getLogTextUtf8Len(c0, 0, end));
+}
+
+
+static void toLogTextUtf8(int c, unc_text::log_type &container)
+{
+   if (c == '\n')
    {
-      m_char = 0x240d; // CR symbol
+      c = 0x2424; // NL symbol
    }
-   encode_utf8(m_char, container);
+   else if (c == '\r')
+   {
+      c = 0x240d; // CR symbol
+   }
+   encode_utf8(c, container);
 }
 
 
@@ -46,8 +118,8 @@ static size_t fix_len_idx(size_t size, size_t idx, size_t len)
 
 
 unc_text::unc_text()
-   : m_logok(false)
 {
+   m_logtext = log_type{ '\0' };
 }
 
 
@@ -143,13 +215,6 @@ unc_text &unc_text::operator +=(const char *ascii_text)
 }
 
 
-unc_text::value_type &unc_text::get()
-{
-   m_logok = false;
-   return(m_chars);
-}
-
-
 const unc_text::value_type &unc_text::get() const
 {
    return(m_chars);
@@ -162,12 +227,6 @@ int unc_text::operator[](size_t idx) const
 }
 
 
-int &unc_text::at(size_t idx)
-{
-   return(m_chars.at(idx));
-}
-
-
 const int &unc_text::at(size_t idx) const
 {
    return(m_chars.at(idx));
@@ -176,13 +235,6 @@ const int &unc_text::at(size_t idx) const
 
 const int &unc_text::back() const
 {
-   return(m_chars.back());
-}
-
-
-int &unc_text::back()
-{
-   // TODO: returning a temporary via a reference this has to be checked and probably changed
    return(m_chars.back());
 }
 
@@ -219,11 +271,6 @@ void unc_text::pop_front()
 
 void unc_text::update_logtext()
 {
-   if (m_logok)
-   {
-      return;
-   }
-
    // make a pessimistic guess at the size
    m_logtext.clear();
    m_logtext.reserve(m_chars.size() * 3);
@@ -232,7 +279,6 @@ void unc_text::update_logtext()
       toLogTextUtf8(m_char, m_logtext);
    }
    m_logtext.push_back(0);
-   m_logok = true;
 }
 
 
@@ -296,37 +342,39 @@ bool unc_text::equals(const unc_text &ref) const
 }
 
 
-const char *unc_text::c_str()
+const char *unc_text::c_str() const
 {
-   update_logtext();
    return(reinterpret_cast<const char *>(&m_logtext[0]));
 }
 
 
 void unc_text::set(int ch)
 {
+   m_logtext.clear();
+   toLogTextUtf8(ch, m_logtext);
+   m_logtext.push_back('\0');
+
+
    m_chars.clear();
    m_chars.push_back(ch);
-   m_logok = false;
 }
 
 
 void unc_text::set(const unc_text &ref)
 {
-   m_chars = ref.m_chars;
-   m_logok = false;
+   m_chars   = ref.m_chars;
+   m_logtext = ref.m_logtext;
 }
 
 
 void unc_text::set(const unc_text &ref, size_t idx, size_t len)
 {
-   m_logok = false;
-
    const auto ref_size = ref.size();
 
    if (len == ref_size)
    {
       m_chars = ref.m_chars;
+      update_logtext();
       return;
    }
 
@@ -339,6 +387,9 @@ void unc_text::set(const unc_text &ref, size_t idx, size_t len)
    {
       m_chars[di] = ref.m_chars[idx];
    }
+
+
+   update_logtext();
 }
 
 
@@ -351,7 +402,9 @@ void unc_text::set(const string &ascii_text)
    {
       m_chars[idx] = ascii_text[idx];
    }
-   m_logok = false;
+
+
+   update_logtext();
 }
 
 
@@ -364,7 +417,9 @@ void unc_text::set(const char *ascii_text)
    {
       m_chars[idx] = *ascii_text++;
    }
-   m_logok = false;
+
+
+   update_logtext();
 }
 
 
@@ -380,7 +435,8 @@ void unc_text::set(const value_type &data, size_t idx, size_t len)
       m_chars[di] = data[idx];
    }
 
-   m_logok = false;
+
+   update_logtext();
 }
 
 
@@ -391,43 +447,111 @@ void unc_text::resize(size_t new_size)
       return;
    }
 
+   const auto log_new_size = getLogTextUtf8Len(m_chars, new_size);
+   m_logtext.resize(log_new_size + 1); // one extra for \0
+   m_logtext[log_new_size] = '\0';
+
+
    m_chars.resize(new_size);
-   m_logok = false;
 }
 
 
 void unc_text::clear()
 {
+   m_logtext.clear();
+   m_logtext.push_back('\0');
+
+
    m_chars.clear();
-   m_logok = false;
 }
 
 
 void unc_text::insert(size_t idx, int ch)
 {
-   m_chars.insert(m_chars.begin() + idx, ch);
-   m_logok = false;
+   if (idx >= m_chars.size())
+   {
+      throw out_of_range(string(__func__) + ":" + to_string(__LINE__)
+                         + " - idx >= m_chars.size()");
+   }
+
+   log_type utf8converted;
+   utf8converted.reserve(UTF8_BLOCKS);
+   toLogTextUtf8(ch, utf8converted);
+
+   const auto utf8_idx = getLogTextUtf8Len(m_chars, idx);
+   m_logtext.pop_back(); // remove '\0'
+   m_logtext.insert(std::next(std::begin(m_logtext), utf8_idx),
+                    std::begin(utf8converted), std::end(utf8converted));
+   m_logtext.push_back('\0');
+
+
+   m_chars.insert(std::next(std::begin(m_chars), idx), ch);
 }
 
 
 void unc_text::insert(size_t idx, const unc_text &ref)
 {
-   m_chars.insert(m_chars.begin() + idx, ref.m_chars.begin(), ref.m_chars.end());
-   m_logok = false;
+   if (ref.size() == 0)
+   {
+      return;
+   }
+   if (idx >= m_chars.size())
+   {
+      throw out_of_range(string(__func__) + ":" + to_string(__LINE__)
+                         + " - idx >= m_chars.size()");
+   }
+
+   const auto utf8_idx = getLogTextUtf8Len(m_chars, idx);
+   // (A+B) remove \0 from both containers, add back a single at the end
+   m_logtext.pop_back(); // A
+   m_logtext.insert(std::next(std::begin(m_logtext), utf8_idx),
+                    std::begin(ref.m_logtext),
+                    std::prev(std::end(ref.m_logtext))); // B
+   m_logtext.push_back('\0');
+
+
+   m_chars.insert(std::next(std::begin(m_chars), idx),
+                  std::begin(ref.m_chars), std::end(ref.m_chars));
 }
 
 
 void unc_text::append(int ch)
 {
+   m_logtext.pop_back();
+   if (ch < 0x80 && ch != '\n' && ch != '\r')
+   {
+      m_logtext.push_back(ch);
+   }
+   else
+   {
+      log_type utf8converted;
+      utf8converted.reserve(UTF8_BLOCKS);
+      toLogTextUtf8(ch, utf8converted);
+
+      m_logtext.insert(std::end(m_logtext),
+                       std::begin(utf8converted), std::end(utf8converted));
+   }
+   m_logtext.push_back('\0');
+
+
    m_chars.push_back(ch);
-   m_logok = false;
 }
 
 
 void unc_text::append(const unc_text &ref)
 {
+   if (ref.size() == 0)
+   {
+      return;
+   }
+
+   m_logtext.pop_back();
+   m_logtext.insert(std::end(m_logtext),
+                    std::begin(ref.m_logtext), std::end(ref.m_logtext));
+   m_logtext.push_back('\0');
+
+
    m_chars.insert(m_chars.end(), ref.m_chars.begin(), ref.m_chars.end());
-   m_logok = false;
 }
 
 
@@ -555,6 +679,20 @@ void unc_text::erase(size_t idx, size_t len)
    {
       return;
    }
+   if (idx + len >= m_chars.size())
+   {
+      throw out_of_range(string(__func__) + ":" + to_string(__LINE__)
+                         + " - idx + len >= m_chars.size()");
+   }
+
+   const auto pos_s = getLogTextUtf8Len(m_chars, idx);
+   const auto pos_e = pos_s + getLogTextUtf8Len(m_chars, idx, idx + len);
+
+   m_logtext.pop_back();
+   m_logtext.erase(std::next(std::begin(m_logtext), pos_s),
+                   std::next(std::begin(m_logtext), pos_e));
+   m_logtext.push_back('\0');
+
 
    m_chars.erase(m_chars.begin() + idx, m_chars.begin() + idx + len);
 }
@@ -562,11 +700,11 @@ void unc_text::erase(size_t idx, size_t len)
 
 int unc_text::replace(const char *oldtext, const unc_text &newtext)
 {
-   const size_t olen         = strlen(oldtext);
+   const auto   olen         = static_cast<unsigned int>(strlen(oldtext));
    const size_t newtext_size = newtext.size();
 
-   int          fidx = find(oldtext);
    int          rcnt = 0;
+   int          fidx = find(oldtext);
 
    while (fidx >= 0)
    {

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -15,6 +15,23 @@ using namespace std;
 
 static size_t fix_len_idx(size_t size, size_t idx, size_t len);
 
+//! converts \n and \r chars are into NL and CR UTF8 symbols before encode_utf8 is called
+static void toLogTextUtf8(int m_char, vector<UINT8> &container);
+
+
+static void toLogTextUtf8(int m_char, vector<UINT8> &container)
+{
+   if (m_char == '\n')
+   {
+      m_char = 0x2424; // NL symbol
+   }
+   else if (m_char == '\r')
+   {
+      m_char = 0x240d; // CR symbol
+   }
+   encode_utf8(m_char, container);
+}
+
 
 static size_t fix_len_idx(size_t size, size_t idx, size_t len)
 {
@@ -40,15 +57,7 @@ void unc_text::update_logtext()
    m_logtext.reserve(m_chars.size() * 3);
    for (int m_char : m_chars)
    {
-      if (m_char == '\n')
-      {
-         m_char = 0x2424; // NL symbol
-      }
-      else if (m_char == '\r')
-      {
-         m_char = 0x240d; // CR symbol
-      }
-      encode_utf8(m_char, m_logtext);
+      toLogTextUtf8(m_char, m_logtext);
    }
    m_logtext.push_back(0);
    m_logok = true;

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -45,6 +45,178 @@ static size_t fix_len_idx(size_t size, size_t idx, size_t len)
 }
 
 
+unc_text::unc_text()
+   : m_logok(false)
+{
+}
+
+
+unc_text::unc_text(const unc_text &ref)
+{
+   set(ref);
+}
+
+
+unc_text::unc_text(const unc_text &ref, size_t idx, size_t len)
+{
+   set(ref, idx, len);
+}
+
+
+unc_text::unc_text(const char *ascii_text)
+{
+   set(ascii_text);
+}
+
+
+unc_text::unc_text(const std::string &ascii_text)
+{
+   set(ascii_text);
+}
+
+
+unc_text::unc_text(const value_type &data, size_t idx, size_t len)
+{
+   set(data, idx, len);
+}
+
+
+size_t unc_text::size() const
+{
+   return(m_chars.size());
+}
+
+
+unc_text &unc_text::operator =(int ch)
+{
+   set(ch);
+   return(*this);
+}
+
+
+unc_text &unc_text::operator =(const unc_text &ref)
+{
+   set(ref);
+   return(*this);
+}
+
+
+unc_text &unc_text::operator =(const std::string &ascii_text)
+{
+   set(ascii_text);
+   return(*this);
+}
+
+
+unc_text &unc_text::operator =(const char *ascii_text)
+{
+   set(ascii_text);
+   return(*this);
+}
+
+
+unc_text &unc_text::operator +=(int ch)
+{
+   append(ch);
+   return(*this);
+}
+
+
+unc_text &unc_text::operator +=(const unc_text &ref)
+{
+   append(ref);
+   return(*this);
+}
+
+
+unc_text &unc_text::operator +=(const std::string &ascii_text)
+{
+   append(ascii_text);
+   return(*this);
+}
+
+
+unc_text &unc_text::operator +=(const char *ascii_text)
+{
+   append(ascii_text);
+   return(*this);
+}
+
+
+unc_text::value_type &unc_text::get()
+{
+   m_logok = false;
+   return(m_chars);
+}
+
+
+const unc_text::value_type &unc_text::get() const
+{
+   return(m_chars);
+}
+
+
+int unc_text::operator[](size_t idx) const
+{
+   return((idx < m_chars.size()) ? m_chars[idx] : 0);
+}
+
+
+int &unc_text::at(size_t idx)
+{
+   return(m_chars.at(idx));
+}
+
+
+const int &unc_text::at(size_t idx) const
+{
+   return(m_chars.at(idx));
+}
+
+
+const int &unc_text::back() const
+{
+   return(m_chars.back());
+}
+
+
+int &unc_text::back()
+{
+   // TODO: returning a temporary via a reference this has to be checked and probably changed
+   return(m_chars.back());
+}
+
+
+void unc_text::push_back(int ch)
+{
+   append(ch);
+}
+
+
+void unc_text::pop_back()
+{
+   if (size() == 0)
+   {
+      return;
+   }
+
+   m_chars.pop_back();
+   update_logtext();
+}
+
+
+void unc_text::pop_front()
+{
+   if (size() == 0)
+   {
+      return;
+   }
+
+   m_chars.pop_front();
+   update_logtext();
+}
+
+
 void unc_text::update_logtext()
 {
    if (m_logok)

--- a/src/unc_text.h
+++ b/src/unc_text.h
@@ -23,9 +23,10 @@
 class unc_text
 {
 public:
-   typedef std::deque<int> value_type;   // double encoded list of int values
+   typedef std::deque<int>      value_type; // double encoded list of int values
+   typedef std::vector<UINT8>   log_type;
 
-public:
+
    unc_text();
 
    unc_text(const unc_text &ref);
@@ -113,7 +114,7 @@ public:
 
 
    //! Returns the UTF-8 string for logging
-   const char *c_str();
+   const char *c_str() const;
 
 
    /**
@@ -134,8 +135,6 @@ public:
 
 
    //! grab the data as a series of ints for outputting to a file
-   value_type &      get();
-
    const value_type &get() const;
 
 
@@ -143,15 +142,11 @@ public:
 
 
    // throws an exception if out of bounds
-   int &at(size_t idx);
-
    const int &at(size_t idx) const;
 
 
-   const int &back() const;
-
    //! returns the last element of the character list
-   int &back();
+   const int &back() const;
 
 
    void push_back(int ch);
@@ -189,10 +184,8 @@ public:
 protected:
    void update_logtext();
 
-
-   value_type         m_chars;   //! this contains the non-encoded 31-bit chars
-   std::vector<UINT8> m_logtext; //! logging text, utf8 encoded - updated in c_str()
-   bool               m_logok;
+   value_type m_chars;           //! this contains the non-encoded 31-bit chars
+   log_type   m_logtext;         //! logging text, utf8 encoded - updated in c_str()
 };
 
 

--- a/src/unc_text.h
+++ b/src/unc_text.h
@@ -26,45 +26,20 @@ public:
    typedef std::deque<int> value_type;   // double encoded list of int values
 
 public:
-   unc_text()
-      : m_logok(false)
-   {
-   }
+   unc_text();
+
+   unc_text(const unc_text &ref);
+
+   unc_text(const unc_text &ref, size_t idx, size_t len = 0);
+
+   unc_text(const char *ascii_text);
+
+   unc_text(const std::string &ascii_text);
+
+   unc_text(const value_type &data, size_t idx = 0, size_t len = 0);
 
 
-   ~unc_text()
-   {
-   }
-
-
-   unc_text(const unc_text &ref)
-   {
-      set(ref);
-   }
-
-
-   unc_text(const unc_text &ref, size_t idx, size_t len = 0)
-   {
-      set(ref, idx, len);
-   }
-
-
-   unc_text(const char *ascii_text)
-   {
-      set(ascii_text);
-   }
-
-
-   unc_text(const std::string &ascii_text)
-   {
-      set(ascii_text);
-   }
-
-
-   unc_text(const value_type &data, size_t idx = 0, size_t len = 0)
-   {
-      set(data, idx, len);
-   }
+   ~unc_text() = default;
 
 
    void resize(size_t new_size);
@@ -74,60 +49,32 @@ public:
 
 
    //! grab the number of characters
-   size_t size() const
-   {
-      return(m_chars.size());
-   }
+   size_t size() const;
 
 
    void set(int ch);
 
-
    void set(const unc_text &ref);
-
 
    void set(const unc_text &ref, size_t idx, size_t len = 0);
 
-
    void set(const std::string &ascii_text);
 
-
    void set(const char *ascii_text);
-
 
    void set(const value_type &data, size_t idx = 0, size_t len = 0);
 
 
-   unc_text &operator =(int ch)
-   {
-      set(ch);
-      return(*this);
-   }
+   unc_text &operator =(int ch);
 
+   unc_text &operator =(const unc_text &ref);
 
-   unc_text &operator =(const unc_text &ref)
-   {
-      set(ref);
-      return(*this);
-   }
+   unc_text &operator =(const std::string &ascii_text);
 
-
-   unc_text &operator =(const std::string &ascii_text)
-   {
-      set(ascii_text);
-      return(*this);
-   }
-
-
-   unc_text &operator =(const char *ascii_text)
-   {
-      set(ascii_text);
-      return(*this);
-   }
+   unc_text &operator =(const char *ascii_text);
 
 
    void insert(size_t idx, int ch);
-
 
    void insert(size_t idx, const unc_text &ref);
 
@@ -138,13 +85,10 @@ public:
    //! Add a unc_text character to an unc_text
    void append(int ch);
 
-
    void append(const unc_text &ref);
-
 
    //! Add a string to an unc_text
    void append(const std::string &ascii_text);
-
 
    /**
     * Add a variable length string to an unc_text.
@@ -156,36 +100,16 @@ public:
     */
    void append(const char *ascii_text);
 
-
    void append(const value_type &data, size_t idx = 0, size_t len = 0);
 
 
-   unc_text &operator +=(int ch)
-   {
-      append(ch);
-      return(*this);
-   }
+   unc_text &operator +=(int ch);
 
+   unc_text &operator +=(const unc_text &ref);
 
-   unc_text &operator +=(const unc_text &ref)
-   {
-      append(ref);
-      return(*this);
-   }
+   unc_text &operator +=(const std::string &ascii_text);
 
-
-   unc_text &operator +=(const std::string &ascii_text)
-   {
-      append(ascii_text);
-      return(*this);
-   }
-
-
-   unc_text &operator +=(const char *ascii_text)
-   {
-      append(ascii_text);
-      return(*this);
-   }
+   unc_text &operator +=(const char *ascii_text);
 
 
    //! Returns the UTF-8 string for logging
@@ -210,81 +134,39 @@ public:
 
 
    //! grab the data as a series of ints for outputting to a file
-   value_type &get()
-   {
-      m_logok = false;
-      return(m_chars);
-   }
+   value_type &      get();
+
+   const value_type &get() const;
 
 
-   const value_type &get() const
-   {
-      return(m_chars);
-   }
-
-
-   int operator[](size_t idx) const
-   {
-      return((idx < m_chars.size()) ? m_chars[idx] : 0);
-   }
+   int operator[](size_t idx) const;
 
 
    // throws an exception if out of bounds
-   int &at(size_t idx)
-   {
-      return(m_chars.at(idx));
-   }
+   int &at(size_t idx);
+
+   const int &at(size_t idx) const;
 
 
-   const int &at(size_t idx) const
-   {
-      return(m_chars.at(idx));
-   }
-
-
-   const int &back() const
-   {
-      return(m_chars.back());
-   }
+   const int &back() const;
 
    //! returns the last element of the character list
-   int &back()
-   {
-      // TODO: returning a temporary via a reference this has to be checked and probably changed
-      return(m_chars.back());
-   }
+   int &back();
 
 
-   void push_back(int ch)
-   {
-      append(ch);
-   }
+   void push_back(int ch);
 
 
-   void pop_back()
-   {
-      if (size() > 0)
-      {
-         m_chars.pop_back();
-         m_logok = false;
-      }
-   }
+   void pop_back();
 
 
-   void pop_front()
-   {
-      if (size() > 0)
-      {
-         m_chars.pop_front();
-         m_logok = false;
-      }
-   }
+   void pop_front();
 
 
    bool startswith(const unc_text &text, size_t idx = 0) const;
 
-
    bool startswith(const char *text, size_t idx = 0) const;
+
 
    /**
     * look for 'text', beginning with position 'sidx'

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -290,14 +290,14 @@ struct chunk_t
 
 
    //! provides the number of characters of string
-   size_t len()
+   size_t len() const
    {
       return(str.size());
    }
 
 
    //! provides the content of a string a zero terminated character pointer
-   const char *text()
+   const char *text() const
    {
       return(str.c_str());
    }


### PR DESCRIPTION
This PR is needed to set the `unc_text::c_str` function const. With this now m_logtext is always updated (bonus: should prevent gdb crashes when a var `c_str()` is watched and `m_logtext` is empty).
It is roughly as fast as the old implementation (tested with callgrind on `tests/input/c/directfb.h`)