### PR TITLE
fix NOMINMAX

### DIFF
--- a/src/windows_compat.h
+++ b/src/windows_compat.h
@@ -9,7 +9,9 @@
 #ifndef WINDOWS_COMPAT_H_INCLUDED
 #define WINDOWS_COMPAT_H_INCLUDED
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include "windows.h"
 
 #define HAVE_SYS_STAT_H


### PR DESCRIPTION
mingw32 internally already defines NOMINMAX so a check for that has to be made

ref: #1423