### PR TITLE
Revert const chunk_list PRs

### DIFF
--- a/src/ListManager.h
+++ b/src/ListManager.h
@@ -45,7 +45,7 @@ public:
     *
     * @return pointer to first element or nullptr if list is empty
     */
-   T *GetHead() const
+   T *GetHead()
    {
       return(first);
    }
@@ -56,7 +56,7 @@ public:
     *
     * @return pointer to last element or nullptr if list is empty
     */
-   T *GetTail() const
+   T *GetTail()
    {
       return(last);
    }
@@ -69,7 +69,7 @@ public:
     *
     * @return pointer to next element or nullptr if no next element exists
     */
-   T *GetNext(const T *ref)
+   T *GetNext(T *ref)
    {
       return((ref != NULL) ? ref->next : NULL);
    }
@@ -82,7 +82,7 @@ public:
     *
     * @return pointer to previous element or nullptr if no previous element exists
     */
-   T *GetPrev(const T *ref)
+   T *GetPrev(T *ref)
    {
       return((ref != NULL) ? ref->prev : NULL);
    }

--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -37,7 +37,7 @@ enum class direction_e : unsigned int
  * for a function pointer of type
  * bool function(chunk_t *pc)
  */
-typedef bool (*check_t)(const chunk_t *pc);
+typedef bool (*check_t)(chunk_t *pc);
 
 
 /**
@@ -47,7 +47,7 @@ typedef bool (*check_t)(const chunk_t *pc);
  * for a function pointer of type
  * chunk_t *function(chunk_t *cur, nav_t scope)
  */
-typedef chunk_t * (*search_t)(const chunk_t *cur, scope_e scope);
+typedef chunk_t * (*search_t)(chunk_t *cur, scope_e scope);
 
 
 /**
@@ -74,10 +74,10 @@ typedef chunk_t * (*search_t)(const chunk_t *cur, scope_e scope);
  * @retval nullptr  no requested chunk was found or invalid parameters provided
  * @retval chunk_t  pointer to the found chunk
  */
-static chunk_t *chunk_search(const chunk_t *cur, const check_t check_fct, const scope_e scope = scope_e::ALL, const direction_e dir = direction_e::FORWARD, const bool cond = true);
+static chunk_t *chunk_search(chunk_t *cur, const check_t check_fct, const scope_e scope = scope_e::ALL, const direction_e dir = direction_e::FORWARD, const bool cond = true);
 
 
-static void chunk_log(const chunk_t *pc, const char *text);
+static void chunk_log(chunk_t *pc, const char *text);
 
 
 /*
@@ -101,7 +101,7 @@ static void chunk_log(const chunk_t *pc, const char *text);
  * @retval nullptr  no chunk found or invalid parameters provided
  * @retval chunk_t  pointer to the found chunk
  */
-static chunk_t *chunk_search_type(const chunk_t *cur, const c_token_t type, const scope_e scope = scope_e::ALL, const direction_e dir = direction_e::FORWARD);
+static chunk_t *chunk_search_type(chunk_t *cur, const c_token_t type, const scope_e scope = scope_e::ALL, const direction_e dir = direction_e::FORWARD);
 
 
 /**
@@ -121,7 +121,7 @@ static chunk_t *chunk_search_type(const chunk_t *cur, const c_token_t type, cons
  * @retval nullptr  no chunk found or invalid parameters provided
  * @retval chunk_t  pointer to the found chunk
  */
-static chunk_t *chunk_search_typelevel(const chunk_t *cur, c_token_t type, scope_e scope = scope_e::ALL, direction_e dir = direction_e::FORWARD, int level = -1);
+static chunk_t *chunk_search_typelevel(chunk_t *cur, c_token_t type, scope_e scope = scope_e::ALL, direction_e dir = direction_e::FORWARD, int level = -1);
 
 
 /**
@@ -137,10 +137,10 @@ static chunk_t *chunk_search_typelevel(const chunk_t *cur, c_token_t type, scope
  * @retval nullptr  no chunk found or invalid parameters provided
  * @retval chunk_t  pointer to the found chunk
  */
-static chunk_t *chunk_get_ncnlnp(const chunk_t *cur, const scope_e scope = scope_e::ALL, const direction_e dir = direction_e::FORWARD);
+static chunk_t *chunk_get_ncnlnp(chunk_t *cur, const scope_e scope = scope_e::ALL, const direction_e dir = direction_e::FORWARD);
 
 
-static chunk_t *chunk_get_ncnlnpnd(const chunk_t *cur, const scope_e scope = scope_e::ALL, const direction_e dir = direction_e::FORWARD);
+static chunk_t *chunk_get_ncnlnpnd(chunk_t *cur, const scope_e scope = scope_e::ALL, const direction_e dir = direction_e::FORWARD);
 
 
 /**
@@ -160,7 +160,7 @@ static chunk_t *chunk_get_ncnlnpnd(const chunk_t *cur, const scope_e scope = sco
  * @retval NULL     no chunk found or invalid parameters provided
  * @retval chunk_t  pointer to the found chunk
  */
-static chunk_t *chunk_search_str(const chunk_t *cur, const char *str, size_t len, scope_e scope, direction_e dir, int level);
+static chunk_t *chunk_search_str(chunk_t *cur, const char *str, size_t len, scope_e scope, direction_e dir, int level);
 
 
 /**
@@ -211,19 +211,19 @@ static search_t select_search_fct(const direction_e dir)
 }
 
 
-chunk_t *chunk_search_prev_cat(const chunk_t *pc, const c_token_t cat)
+chunk_t *chunk_search_prev_cat(chunk_t *pc, const c_token_t cat)
 {
    return(chunk_search_type(pc, cat, scope_e::ALL, direction_e::BACKWARD));
 }
 
 
-chunk_t *chunk_search_next_cat(const chunk_t *pc, const c_token_t cat)
+chunk_t *chunk_search_next_cat(chunk_t *pc, const c_token_t cat)
 {
    return(chunk_search_type(pc, cat, scope_e::ALL, direction_e::FORWARD));
 }
 
 
-static chunk_t *chunk_search_type(const chunk_t *cur, const c_token_t type,
+static chunk_t *chunk_search_type(chunk_t *cur, const c_token_t type,
                                   const scope_e scope, const direction_e dir)
 {
    /*
@@ -231,37 +231,29 @@ static chunk_t *chunk_search_type(const chunk_t *cur, const c_token_t type,
     * in forward or backward direction
     */
    search_t search_function = select_search_fct(dir);
+   chunk_t  *pc             = cur;
 
-   // loop over the chunk list
-   chunk_t *pc = search_function(cur, scope);
-
-   while (  pc != nullptr           // the end of the list was not reached
-         && pc->type != type)       // and the demanded chunk was not found
+   do                                  // loop over the chunk list
    {
-      pc = search_function(pc, scope);
-   }
-
-   return(pc);  // the latest chunk is the searched one or nullptr
+      pc = search_function(pc, scope); // in either direction while
+   } while (  pc != nullptr            // the end of the list was not reached yet
+           && pc->type != type);       // and the demanded chunk was not found either
+   return(pc);                         // the latest chunk is the searched one
 }
 
 
-static chunk_t *chunk_search_typelevel(const chunk_t *cur, c_token_t type,
-                                       scope_e scope, direction_e dir, int level)
+static chunk_t *chunk_search_typelevel(chunk_t *cur, c_token_t type, scope_e scope, direction_e dir, int level)
 {
    /*
     * Depending on the parameter dir the search function searches
     * in forward or backward direction
     */
    search_t search_function = select_search_fct(dir);
+   chunk_t  *pc             = cur;
 
-
-   // loop over the chunk list
-   chunk_t *pc = search_function(cur, scope);
-
-   while (  pc != nullptr        // the end of the list was not reached
-         && !is_expected_type_and_level(pc, type, level))
+   do                                  // loop over the chunk list
    {
-      pc = search_function(pc, scope);
+      pc = search_function(pc, scope); // in either direction while
 #if DEBUG
       if (pc != nullptr)
       {
@@ -277,48 +269,44 @@ static chunk_t *chunk_search_typelevel(const chunk_t *cur, c_token_t type,
          }
       }
 #endif
-   }
-   return(pc);  // the latest chunk is the searched one or nullptr
+   } while (  pc != nullptr        // the end of the list was not reached yet
+           && (is_expected_type_and_level(pc, type, level) == false));
+   return(pc);                     // the latest chunk is the searched one
 }
 
 
-static chunk_t *chunk_search_str(const chunk_t *cur, const char *str, size_t len, scope_e scope, direction_e dir, int level)
+static chunk_t *chunk_search_str(chunk_t *cur, const char *str, size_t len, scope_e scope, direction_e dir, int level)
 {
    /*
     * Depending on the parameter dir the search function searches
     * in forward or backward direction */
    search_t search_function = select_search_fct(dir);
+   chunk_t  *pc             = cur;
 
-   // loop over the chunk list
-   chunk_t *pc = search_function(cur, scope);
-
-   while (  pc != nullptr            // the end of the list was not reached yet
-         && (is_expected_string_and_level(pc, str, level, len) == false))
+   do                                  // loop over the chunk list
    {
-      pc = search_function(pc, scope);
-   }
-   return(pc);  // the latest chunk is the searched one or nullptr
+      pc = search_function(pc, scope); // in either direction while
+   } while (  pc != nullptr            // the end of the list was not reached yet
+           && (is_expected_string_and_level(pc, str, level, len) == false));
+   return(pc);                         // the latest chunk is the searched one
 }
 
 
-static chunk_t *chunk_search(const chunk_t *cur, const check_t check_fct,
-                             const scope_e scope, const direction_e dir,
-                             const bool cond)
+static chunk_t *chunk_search(chunk_t *cur, const check_t check_fct, const scope_e scope,
+                             const direction_e dir, const bool cond)
 {
    /*
     * Depending on the parameter dir the search function searches
     * in forward or backward direction */
    search_t search_function = select_search_fct(dir);
+   chunk_t  *pc             = cur;
 
-   // loop over the chunk list
-   chunk_t *pc = search_function(cur, scope);
-
-   while (  pc != nullptr            // end of the list was not reached yet
-         && (check_fct(pc) != cond)) // and the demanded chunk was not found
+   do                                   // loop over the chunk list
    {
-      pc = search_function(pc, scope);
-   }
-   return(pc);                       // the latest chunk is the searched one
+      pc = search_function(pc, scope);  // in either direction while
+   } while (  pc != nullptr             // the end of the list was not reached yet
+           && (check_fct(pc) != cond)); // and the demanded chunk was not found either
+   return(pc);                          // the latest chunk is the searched one
 }
 
 
@@ -326,7 +314,7 @@ static chunk_t *chunk_search(const chunk_t *cur, const check_t check_fct,
  * into a common function However this should be done with the preprocessor
  * to avoid addition check conditions that would be evaluated in the
  * while loop of the calling function */
-chunk_t *chunk_get_next(const chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next(chunk_t *cur, scope_e scope)
 {
    if (cur == nullptr)
    {
@@ -355,7 +343,7 @@ chunk_t *chunk_get_next(const chunk_t *cur, scope_e scope)
 }
 
 
-chunk_t *chunk_get_prev(const chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev(chunk_t *cur, scope_e scope)
 {
    if (cur == nullptr)
    {
@@ -403,7 +391,7 @@ chunk_t *chunk_dup(const chunk_t *pc_in)
 }
 
 
-static void chunk_log_msg(const chunk_t *chunk, const log_sev_t log, const char *str)
+static void chunk_log_msg(chunk_t *chunk, const log_sev_t log, const char *str)
 {
    LOG_FMT(log, "%s %zu:%zu '%s' [%s]",
            str, chunk->orig_line, chunk->orig_col, chunk->text(),
@@ -411,7 +399,7 @@ static void chunk_log_msg(const chunk_t *chunk, const log_sev_t log, const char 
 }
 
 
-static void chunk_log(const chunk_t *pc, const char *text)
+static void chunk_log(chunk_t *pc, const char *text)
 {
    if (  pc != nullptr
       && (cpd.unc_stage != unc_stage_e::TOKENIZE)
@@ -475,122 +463,117 @@ void chunk_move_after(chunk_t *pc_in, chunk_t *ref)
 }
 
 
-chunk_t *chunk_get_next_nl(const chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next_nl(chunk_t *cur, scope_e scope)
 {
    return(chunk_search(cur, chunk_is_newline, scope, direction_e::FORWARD, true));
 }
 
 
-chunk_t *chunk_get_prev_nl(const chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_nl(chunk_t *cur, scope_e scope)
 {
    return(chunk_search(cur, chunk_is_newline, scope, direction_e::BACKWARD, true));
 }
 
 
-chunk_t *chunk_get_next_nnl(const chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next_nnl(chunk_t *cur, scope_e scope)
 {
    return(chunk_search(cur, chunk_is_newline, scope, direction_e::FORWARD, false));
 }
 
 
-chunk_t *chunk_get_prev_nnl(const chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_nnl(chunk_t *cur, scope_e scope)
 {
    return(chunk_search(cur, chunk_is_newline, scope, direction_e::BACKWARD, false));
 }
 
 
-chunk_t *chunk_get_next_ncnl(const chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next_ncnl(chunk_t *cur, scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment_or_newline, scope, direction_e::FORWARD, false));
 }
 
 
-chunk_t *chunk_get_next_ncnlnp(const chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next_ncnlnp(chunk_t *cur, scope_e scope)
 {
    return(chunk_get_ncnlnp(cur, scope, direction_e::FORWARD));
 }
 
 
-chunk_t *chunk_get_prev_ncnlnp(const chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_ncnlnp(chunk_t *cur, scope_e scope)
 {
    return(chunk_get_ncnlnp(cur, scope, direction_e::BACKWARD));
 }
 
 
-chunk_t *chunk_get_prev_ncnlnpnd(const chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_ncnlnpnd(chunk_t *cur, scope_e scope)
 {
    return(chunk_get_ncnlnpnd(cur, scope, direction_e::BACKWARD));
 }
 
 
-chunk_t *chunk_get_next_nblank(const chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next_nblank(chunk_t *cur, scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment_newline_or_blank, scope, direction_e::FORWARD, false));
 }
 
 
-chunk_t *chunk_get_prev_nblank(const chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_nblank(chunk_t *cur, scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment_newline_or_blank, scope, direction_e::BACKWARD, false));
 }
 
 
-chunk_t *chunk_get_next_nc(const chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next_nc(chunk_t *cur, scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment, scope, direction_e::FORWARD, false));
 }
 
 
-chunk_t *chunk_get_next_nisq(const chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next_nisq(chunk_t *cur, scope_e scope)
 {
    return(chunk_search(cur, chunk_is_balanced_square, scope, direction_e::FORWARD, false));
 }
 
 
-chunk_t *chunk_get_prev_ncnl(const chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_ncnl(chunk_t *cur, scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment_or_newline, scope, direction_e::BACKWARD, false));
 }
 
 
-chunk_t *chunk_get_prev_nc(const chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_nc(chunk_t *cur, scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment, scope, direction_e::BACKWARD, false));
 }
 
 
-chunk_t *chunk_get_next_type(const chunk_t *cur, c_token_t type, int level, scope_e scope)
+chunk_t *chunk_get_next_type(chunk_t *cur, c_token_t type, int level, scope_e scope)
 {
    return(chunk_search_typelevel(cur, type, scope, direction_e::FORWARD, level));
 }
 
 
-chunk_t *chunk_get_next_str(const chunk_t *cur, const char *str, size_t len, int level, scope_e scope)
+chunk_t *chunk_get_next_str(chunk_t *cur, const char *str, size_t len, int level, scope_e scope)
 {
    return(chunk_search_str(cur, str, len, scope, direction_e::FORWARD, level));
 }
 
 
-chunk_t *chunk_get_prev_type(const chunk_t *cur, c_token_t type, int level, scope_e scope)
+chunk_t *chunk_get_prev_type(chunk_t *cur, c_token_t type, int level, scope_e scope)
 {
    return(chunk_search_typelevel(cur, type, scope, direction_e::BACKWARD, level));
 }
 
 
-chunk_t *chunk_get_prev_str(const chunk_t *cur, const char *str, size_t len, int level, scope_e scope)
+chunk_t *chunk_get_prev_str(chunk_t *cur, const char *str, size_t len, int level, scope_e scope)
 {
    return(chunk_search_str(cur, str, len, scope, direction_e::BACKWARD, level));
 }
 
 
-bool chunk_is_newline_between(const chunk_t *start, const chunk_t *end)
+bool chunk_is_newline_between(chunk_t *start, chunk_t *end)
 {
-   if (chunk_is_newline(start))
-   {
-      return(true);
-   }
-
-   for (chunk_t *pc = chunk_get_next(start); pc != end; pc = chunk_get_next(pc))
+   for (chunk_t *pc = start; pc != end; pc = chunk_get_next(pc))
    {
       if (chunk_is_newline(pc))
       {
@@ -608,37 +591,37 @@ void chunk_swap(chunk_t *pc1, chunk_t *pc2)
 
 
 // TODO: the following function shall be made similar to the search functions
-chunk_t *chunk_first_on_line(const chunk_t *start)
+chunk_t *chunk_first_on_line(chunk_t *pc)
 {
-   chunk_t *prev = chunk_get_prev(start);
+   chunk_t *first = pc;
 
-   if (prev == nullptr || chunk_is_newline(prev))
+   while ((pc = chunk_get_prev(pc)) != nullptr && !chunk_is_newline(pc))
    {
-      return(const_cast<chunk_t *>(start));  // can be nullptr
+      first = pc;
    }
 
-   chunk_t *out = prev;
-   while (prev != nullptr && !chunk_is_newline(prev))
-   {
-      out  = prev;
-      prev = chunk_get_prev(out);
-   }
-
-   return(out);
+   return(first);
 }
 
 
-bool chunk_is_last_on_line(const chunk_t &pc)
+bool chunk_is_last_on_line(chunk_t &pc)  //TODO: pc should be const here
 {
    // check if pc is the very last chunk of the file
-   if (&pc == chunk_get_tail())
+   const auto *end = chunk_get_tail();
+
+   if (&pc == end)
    {
       return(true);
    }
 
    // if the next chunk is a newline then pc is the last chunk on its line
    const auto *next = chunk_get_next(&pc);
-   return((next != nullptr && next->type == CT_NEWLINE) ? true : false);
+   if (next != nullptr && next->type == CT_NEWLINE)
+   {
+      return(true);
+   }
+
+   return(false);
 }
 
 
@@ -717,13 +700,13 @@ void chunk_swap_lines(chunk_t *pc1, chunk_t *pc2)
 } // chunk_swap_lines
 
 
-chunk_t *chunk_get_next_nvb(const chunk_t *cur, const scope_e scope)
+chunk_t *chunk_get_next_nvb(chunk_t *cur, const scope_e scope)
 {
    return(chunk_search(cur, chunk_is_vbrace, scope, direction_e::FORWARD, false));
 }
 
 
-chunk_t *chunk_get_prev_nvb(const chunk_t *cur, const scope_e scope)
+chunk_t *chunk_get_prev_nvb(chunk_t *cur, const scope_e scope)
 {
    return(chunk_search(cur, chunk_is_vbrace, scope, direction_e::BACKWARD, false));
 }
@@ -799,29 +782,29 @@ void set_chunk_real(chunk_t *pc, c_token_t token, log_sev_t what)
 }
 
 
-static chunk_t *chunk_get_ncnlnp(const chunk_t *cur, const scope_e scope, const direction_e dir)
+static chunk_t *chunk_get_ncnlnp(chunk_t *cur, const scope_e scope, const direction_e dir)
 {
-   return(chunk_is_preproc(cur) == true
-          ? chunk_search(cur, chunk_is_comment_or_newline_in_preproc, scope, dir, false)
-          : chunk_search(cur, chunk_is_comment_newline_or_preproc, scope, dir, false));
+   chunk_t *pc = cur;
+
+   pc = (chunk_is_preproc(pc) == true) ?
+        chunk_search(pc, chunk_is_comment_or_newline_in_preproc, scope, dir, false) :
+        chunk_search(pc, chunk_is_comment_newline_or_preproc, scope, dir, false);
+   return(pc);
 }
 
 
-static chunk_t *chunk_get_ncnlnpnd(const chunk_t *cur, const scope_e scope,
-                                   const direction_e dir)
+static chunk_t *chunk_get_ncnlnpnd(chunk_t *cur, const scope_e scope, const direction_e dir)
 {
    search_t search_function = select_search_fct(dir);
+   chunk_t  *pc             = cur;
 
-   // loop over the chunk list
-   chunk_t *pc = search_function(cur, scope);
-
-   while (  pc != nullptr            // the end of the list was not reached yet
-         && !chunk_is_comment_or_newline(pc)
-         && !chunk_is_preproc(pc)
-         && (pc->type == CT_DC_MEMBER))
+   do                                   // loop over the chunk list
    {
-      pc = search_function(pc, scope);
-   }
+      pc = search_function(pc, scope);  // in either direction while
+   } while (  pc != nullptr             // the end of the list was not reached yet
+           && !chunk_is_comment_or_newline(pc)
+           && !chunk_is_preproc(pc)
+           && (pc->type == CT_DC_MEMBER));
    return(pc);
 }
 

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -120,7 +120,7 @@ chunk_t *chunk_get_tail(void);
  *
  * @return pointer to next chunk or nullptr if no chunk was found
  */
-chunk_t *chunk_get_next(const chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_next(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -131,7 +131,7 @@ chunk_t *chunk_get_next(const chunk_t *cur, scope_e scope = scope_e::ALL);
  *
  * @return pointer to previous chunk or nullptr if no chunk was found
  */
-chunk_t *chunk_get_prev(const chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_prev(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -162,11 +162,11 @@ void chunk_swap_lines(chunk_t *pc1, chunk_t *pc2);
  *
  * @param pc  chunk to start with
  */
-chunk_t *chunk_first_on_line(const chunk_t *pc);
+chunk_t *chunk_first_on_line(chunk_t *pc);
 
 
 //! check if a given chunk is the last on its line
-bool chunk_is_last_on_line(const chunk_t &pc);
+bool chunk_is_last_on_line(chunk_t &pc);
 
 
 /**
@@ -175,7 +175,7 @@ bool chunk_is_last_on_line(const chunk_t &pc);
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_next_nl(const chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_next_nl(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -184,7 +184,7 @@ chunk_t *chunk_get_next_nl(const chunk_t *cur, scope_e scope = scope_e::ALL);
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_next_nc(const chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_next_nc(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -193,7 +193,7 @@ chunk_t *chunk_get_next_nc(const chunk_t *cur, scope_e scope = scope_e::ALL);
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_next_nnl(const chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_next_nnl(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -202,7 +202,7 @@ chunk_t *chunk_get_next_nnl(const chunk_t *cur, scope_e scope = scope_e::ALL);
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_next_ncnl(const chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_next_ncnl(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -211,7 +211,7 @@ chunk_t *chunk_get_next_ncnl(const chunk_t *cur, scope_e scope = scope_e::ALL);
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_next_ncnlnp(const chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_next_ncnlnp(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -224,7 +224,7 @@ chunk_t *chunk_get_next_ncnlnp(const chunk_t *cur, scope_e scope = scope_e::ALL)
  *
  * @return nullptr or the next chunk not in or part of square brackets
  */
-chunk_t *chunk_get_next_nisq(const chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_next_nisq(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -233,7 +233,7 @@ chunk_t *chunk_get_next_nisq(const chunk_t *cur, scope_e scope = scope_e::ALL);
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_next_nblank(const chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_next_nblank(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -242,7 +242,7 @@ chunk_t *chunk_get_next_nblank(const chunk_t *cur, scope_e scope = scope_e::ALL)
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_prev_nblank(const chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_prev_nblank(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -251,7 +251,7 @@ chunk_t *chunk_get_prev_nblank(const chunk_t *cur, scope_e scope = scope_e::ALL)
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_prev_nl(const chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_prev_nl(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -260,7 +260,7 @@ chunk_t *chunk_get_prev_nl(const chunk_t *cur, scope_e scope = scope_e::ALL);
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_prev_nc(const chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_prev_nc(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -269,7 +269,7 @@ chunk_t *chunk_get_prev_nc(const chunk_t *cur, scope_e scope = scope_e::ALL);
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_prev_nnl(const chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_prev_nnl(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -278,7 +278,7 @@ chunk_t *chunk_get_prev_nnl(const chunk_t *cur, scope_e scope = scope_e::ALL);
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_prev_ncnl(const chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_prev_ncnl(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -287,7 +287,7 @@ chunk_t *chunk_get_prev_ncnl(const chunk_t *cur, scope_e scope = scope_e::ALL);
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_prev_ncnlnp(const chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_prev_ncnlnp(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -296,7 +296,7 @@ chunk_t *chunk_get_prev_ncnlnp(const chunk_t *cur, scope_e scope = scope_e::ALL)
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_prev_ncnlnpnd(const chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_prev_ncnlnpnd(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -309,7 +309,7 @@ chunk_t *chunk_get_prev_ncnlnpnd(const chunk_t *cur, scope_e scope = scope_e::AL
  *
  * @return nullptr or the match
  */
-chunk_t *chunk_get_next_type(const chunk_t *cur, c_token_t type, int level, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_next_type(chunk_t *cur, c_token_t type, int level, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -322,7 +322,7 @@ chunk_t *chunk_get_next_type(const chunk_t *cur, c_token_t type, int level, scop
  *
  * @return nullptr or the match
  */
-chunk_t *chunk_get_prev_type(const chunk_t *cur, c_token_t type, int level, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_prev_type(chunk_t *cur, c_token_t type, int level, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -339,7 +339,7 @@ chunk_t *chunk_get_prev_type(const chunk_t *cur, c_token_t type, int level, scop
  * @retval nullptr  no chunk found or invalid parameters provided
  * @retval chunk_t  pointer to the found chunk
  */
-chunk_t *chunk_get_next_str(const chunk_t *cur, const char *str, size_t len, int level, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_next_str(chunk_t *cur, const char *str, size_t len, int level, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -356,7 +356,7 @@ chunk_t *chunk_get_next_str(const chunk_t *cur, const char *str, size_t len, int
  * @retval nullptr  no chunk found or invalid parameters provided
  * @retval chunk_t  pointer to the found chunk
  */
-chunk_t *chunk_get_prev_str(const chunk_t *cur, const char *str, size_t len, int level, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_prev_str(chunk_t *cur, const char *str, size_t len, int level, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -367,7 +367,7 @@ chunk_t *chunk_get_prev_str(const chunk_t *cur, const char *str, size_t len, int
  *
  * @return pointer to found chunk or nullptr if no chunk was found
  */
-chunk_t *chunk_get_next_nvb(const chunk_t *cur, const scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_next_nvb(chunk_t *cur, const scope_e scope = scope_e::ALL);
 
 
 /**
@@ -378,7 +378,7 @@ chunk_t *chunk_get_next_nvb(const chunk_t *cur, const scope_e scope = scope_e::A
  *
  * @return pointer to found chunk or nullptr if no chunk was found
  */
-chunk_t *chunk_get_prev_nvb(const chunk_t *cur, const scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_prev_nvb(chunk_t *cur, const scope_e scope = scope_e::ALL);
 
 
 /**
@@ -390,7 +390,7 @@ chunk_t *chunk_get_prev_nvb(const chunk_t *cur, const scope_e scope = scope_e::A
  * @retval nullptr  no object found, or invalid parameters provided
  * @retval chunk_t  pointer to the found object
  */
-chunk_t *chunk_search_prev_cat(const chunk_t *pc, const c_token_t cat);
+chunk_t *chunk_search_prev_cat(chunk_t *pc, const c_token_t cat);
 
 
 /**
@@ -402,7 +402,7 @@ chunk_t *chunk_search_prev_cat(const chunk_t *pc, const c_token_t cat);
  * @retval nullptr  no object found, or invalid parameters provided
  * @retval chunk_t  pointer to the found object
  */
-chunk_t *chunk_search_next_cat(const chunk_t *pc, const c_token_t cat);
+chunk_t *chunk_search_next_cat(chunk_t *pc, const c_token_t cat);
 
 /*
  * TODO: better move the function implementations to the source file.
@@ -415,7 +415,7 @@ chunk_t *chunk_search_next_cat(const chunk_t *pc, const c_token_t cat);
  * The compiler should know how to optimize the code itself.
  * To clarify do a profiling run with and without inline
  */
-static_inline bool is_expected_type_and_level(const chunk_t *pc, c_token_t type, int level)
+static_inline bool is_expected_type_and_level(chunk_t *pc, c_token_t type, int level)
 {
    // we don't care about the level (if it is negative) or it is as expected
    // and the type is as expected
@@ -424,7 +424,7 @@ static_inline bool is_expected_type_and_level(const chunk_t *pc, c_token_t type,
 }
 
 
-static_inline bool is_expected_string_and_level(const chunk_t *pc, const char *str, int level, size_t len)
+static_inline bool is_expected_string_and_level(chunk_t *pc, const char *str, int level, size_t len)
 {
    // we don't care about the level (if it is negative) or it is as expected
    return(  (level < 0 || pc->level == static_cast<size_t>(level))
@@ -441,9 +441,9 @@ static_inline bool is_expected_string_and_level(const chunk_t *pc, const char *s
  *
  * @return nullptr or the matching paren/brace/square
  */
-static_inline chunk_t *chunk_skip_to_match(const chunk_t *cur, scope_e scope = scope_e::ALL)
+static_inline chunk_t *chunk_skip_to_match(chunk_t *cur, scope_e scope = scope_e::ALL)
 {
-   if (  cur != nullptr
+   if (  cur
       && (  cur->type == CT_PAREN_OPEN
          || cur->type == CT_SPAREN_OPEN
          || cur->type == CT_FPAREN_OPEN
@@ -453,17 +453,15 @@ static_inline chunk_t *chunk_skip_to_match(const chunk_t *cur, scope_e scope = s
          || cur->type == CT_ANGLE_OPEN
          || cur->type == CT_SQUARE_OPEN))
    {
-      //TODO remove dirty enum value hack
-      return(chunk_get_next_type(cur, static_cast<c_token_t>(cur->type + 1),
-                                 cur->level, scope));
+      return(chunk_get_next_type(cur, (c_token_t)(cur->type + 1), cur->level, scope));
    }
-   return(const_cast<chunk_t *>(cur));
+   return(cur);
 }
 
 
-static_inline chunk_t *chunk_skip_to_match_rev(const chunk_t *cur, scope_e scope = scope_e::ALL)
+static_inline chunk_t *chunk_skip_to_match_rev(chunk_t *cur, scope_e scope = scope_e::ALL)
 {
-   if (  cur != nullptr
+   if (  cur
       && (  cur->type == CT_PAREN_CLOSE
          || cur->type == CT_SPAREN_CLOSE
          || cur->type == CT_FPAREN_CLOSE
@@ -473,11 +471,9 @@ static_inline chunk_t *chunk_skip_to_match_rev(const chunk_t *cur, scope_e scope
          || cur->type == CT_ANGLE_CLOSE
          || cur->type == CT_SQUARE_CLOSE))
    {
-      //TODO remove dirty enum value hack
-      return(chunk_get_prev_type(cur, static_cast<c_token_t>(cur->type - 1),
-                                 cur->level, scope));
+      return(chunk_get_prev_type(cur, (c_token_t)(cur->type - 1), cur->level, scope));
    }
-   return(const_cast<chunk_t *>(cur));
+   return(cur);
 }
 
 
@@ -490,7 +486,7 @@ static_inline chunk_t *chunk_skip_to_match_rev(const chunk_t *cur, scope_e scope
  * - C comment
  * - C++ comment
  */
-static_inline bool chunk_is_comment(const chunk_t *pc)
+static_inline bool chunk_is_comment(chunk_t *pc)
 {
    return(  pc != NULL
          && (  pc->type == CT_COMMENT
@@ -499,21 +495,21 @@ static_inline bool chunk_is_comment(const chunk_t *pc)
 }
 
 
-static_inline bool chunk_is_single_line_comment(const chunk_t *pc)
+static_inline bool chunk_is_single_line_comment(chunk_t *pc)
 {
    return(  pc != NULL
          && (pc->type == CT_COMMENT || pc->type == CT_COMMENT_CPP));
 }
 
 
-static_inline bool chunk_is_newline(const chunk_t *pc)
+static_inline bool chunk_is_newline(chunk_t *pc)
 {
    return(  pc != NULL
          && (pc->type == CT_NEWLINE || pc->type == CT_NL_CONT));
 }
 
 
-static_inline bool chunk_is_semicolon(const chunk_t *pc)
+static_inline bool chunk_is_semicolon(chunk_t *pc)
 {
    return(  pc != NULL
          && (pc->type == CT_SEMICOLON || pc->type == CT_VSEMICOLON));
@@ -527,20 +523,20 @@ static_inline bool chunk_is_semicolon(const chunk_t *pc)
  *
  * @todo rename function: blank is a space not an empty string
  */
-static_inline bool chunk_is_blank(const chunk_t *pc)
+static_inline bool chunk_is_blank(chunk_t *pc)
 {
    return(pc != NULL && (pc->len() == 0));
 }
 
 
 //! checks if a chunk is valid and either a comment or newline
-static_inline bool chunk_is_comment_or_newline(const chunk_t *pc)
+static_inline bool chunk_is_comment_or_newline(chunk_t *pc)
 {
    return(chunk_is_comment(pc) || chunk_is_newline(pc));
 }
 
 
-static_inline bool chunk_is_balanced_square(const chunk_t *pc)
+static_inline bool chunk_is_balanced_square(chunk_t *pc)
 {
    return(  pc != NULL
          && (  pc->type == CT_SQUARE_OPEN
@@ -549,13 +545,13 @@ static_inline bool chunk_is_balanced_square(const chunk_t *pc)
 }
 
 
-static_inline bool chunk_is_preproc(const chunk_t *pc)
+static_inline bool chunk_is_preproc(chunk_t *pc)
 {
    return(pc != NULL && (pc->flags & PCF_IN_PREPROC));
 }
 
 
-static_inline bool chunk_is_comment_or_newline_in_preproc(const chunk_t *pc)
+static_inline bool chunk_is_comment_or_newline_in_preproc(chunk_t *pc)
 {
    return(  pc != NULL
          && chunk_is_preproc(pc)
@@ -563,7 +559,7 @@ static_inline bool chunk_is_comment_or_newline_in_preproc(const chunk_t *pc)
 }
 
 
-static_inline bool chunk_is_comment_newline_or_preproc(const chunk_t *pc)
+static_inline bool chunk_is_comment_newline_or_preproc(chunk_t *pc)
 {
    return(  chunk_is_comment(pc)
          || chunk_is_newline(pc)
@@ -571,13 +567,13 @@ static_inline bool chunk_is_comment_newline_or_preproc(const chunk_t *pc)
 }
 
 
-static_inline bool chunk_is_comment_newline_or_blank(const chunk_t *pc)
+static_inline bool chunk_is_comment_newline_or_blank(chunk_t *pc)
 {
    return(chunk_is_comment_or_newline(pc) || chunk_is_blank(pc));
 }
 
 
-static_inline bool chunk_is_Doxygen_comment(const chunk_t *pc)
+static_inline bool chunk_is_Doxygen_comment(chunk_t *pc)
 {
    if (!chunk_is_comment(pc))
    {
@@ -596,7 +592,7 @@ static_inline bool chunk_is_Doxygen_comment(const chunk_t *pc)
 }
 
 
-static_inline bool chunk_is_type(const chunk_t *pc)
+static_inline bool chunk_is_type(chunk_t *pc)
 {
    return(  pc != NULL
          && (  pc->type == CT_TYPE
@@ -610,13 +606,13 @@ static_inline bool chunk_is_type(const chunk_t *pc)
 }
 
 
-static_inline bool chunk_is_token(const chunk_t *pc, c_token_t c_token)
+static_inline bool chunk_is_token(chunk_t *pc, c_token_t c_token)
 {
    return(pc != NULL && pc->type == c_token);
 }
 
 
-static_inline bool chunk_is_str(const chunk_t *pc, const char *str, size_t len)
+static_inline bool chunk_is_str(chunk_t *pc, const char *str, size_t len)
 {
    return(  pc != NULL                            // valid pc pointer
          && (pc->len() == len)                    // token size equals size parameter
@@ -629,7 +625,7 @@ static_inline bool chunk_is_str(const chunk_t *pc, const char *str, size_t len)
 }
 
 
-static_inline bool chunk_is_str_case(const chunk_t *pc, const char *str, size_t len)
+static_inline bool chunk_is_str_case(chunk_t *pc, const char *str, size_t len)
 {
    return(  pc != NULL
          && (pc->len() == len)
@@ -637,7 +633,7 @@ static_inline bool chunk_is_str_case(const chunk_t *pc, const char *str, size_t 
 }
 
 
-static_inline bool chunk_is_word(const chunk_t *pc)
+static_inline bool chunk_is_word(chunk_t *pc)
 {
    return(  pc != NULL
          && (pc->len() >= 1)
@@ -645,7 +641,7 @@ static_inline bool chunk_is_word(const chunk_t *pc)
 }
 
 
-static_inline bool chunk_is_star(const chunk_t *pc)
+static_inline bool chunk_is_star(chunk_t *pc)
 {
    return(  pc != NULL
          && (pc->len() == 1)
@@ -654,7 +650,7 @@ static_inline bool chunk_is_star(const chunk_t *pc)
 }
 
 
-static_inline bool chunk_is_addr(const chunk_t *pc)
+static_inline bool chunk_is_addr(chunk_t *pc)
 {
    if (  pc != NULL
       && (  pc->type == CT_BYREF
@@ -678,7 +674,7 @@ static_inline bool chunk_is_addr(const chunk_t *pc)
 }
 
 
-static_inline bool chunk_is_msref(const chunk_t *pc) // ms compilers for C++/CLI and WinRT use '^' instead of '*' for marking up reference types vs pointer types
+static_inline bool chunk_is_msref(chunk_t *pc) // ms compilers for C++/CLI and WinRT use '^' instead of '*' for marking up reference types vs pointer types
 {
    return(  (cpd.lang_flags & LANG_CPP)
          && (  pc != NULL
@@ -688,7 +684,7 @@ static_inline bool chunk_is_msref(const chunk_t *pc) // ms compilers for C++/CLI
 }
 
 
-static_inline bool chunk_is_ptr_operator(const chunk_t *pc)
+static_inline bool chunk_is_ptr_operator(chunk_t *pc)
 {
    return(  chunk_is_star(pc)
          || chunk_is_addr(pc)
@@ -697,31 +693,31 @@ static_inline bool chunk_is_ptr_operator(const chunk_t *pc)
 
 
 //! Check to see if there is a newline between the two chunks
-bool chunk_is_newline_between(const chunk_t *start, const chunk_t *end);
+bool chunk_is_newline_between(chunk_t *start, chunk_t *end);
 
 
-static_inline bool chunk_is_closing_brace(const chunk_t *pc)
+static_inline bool chunk_is_closing_brace(chunk_t *pc)
 {
    return(  pc != NULL
          && (pc->type == CT_BRACE_CLOSE || pc->type == CT_VBRACE_CLOSE));
 }
 
 
-static_inline bool chunk_is_opening_brace(const chunk_t *pc)
+static_inline bool chunk_is_opening_brace(chunk_t *pc)
 {
    return(  pc != NULL
          && (pc->type == CT_BRACE_OPEN || pc->type == CT_VBRACE_OPEN));
 }
 
 
-static_inline bool chunk_is_vbrace(const chunk_t *pc)
+static_inline bool chunk_is_vbrace(chunk_t *pc)
 {
    return(  pc != NULL
          && (pc->type == CT_VBRACE_CLOSE || pc->type == CT_VBRACE_OPEN));
 }
 
 
-static_inline bool chunk_is_paren_open(const chunk_t *pc)
+static_inline bool chunk_is_paren_open(chunk_t *pc)
 {
    return(  pc != NULL
          && (  pc->type == CT_PAREN_OPEN
@@ -731,7 +727,7 @@ static_inline bool chunk_is_paren_open(const chunk_t *pc)
 }
 
 
-static_inline bool chunk_is_paren_close(const chunk_t *pc)
+static_inline bool chunk_is_paren_close(chunk_t *pc)
 {
    return(  pc != NULL
          && (  pc->type == CT_PAREN_CLOSE
@@ -745,7 +741,7 @@ static_inline bool chunk_is_paren_close(const chunk_t *pc)
  * Returns true if either chunk is null or both have the same preproc flags.
  * If this is true, you can remove a newline/nl_cont between the two.
  */
-static_inline bool chunk_same_preproc(const chunk_t *pc1, chunk_t *pc2)
+static_inline bool chunk_same_preproc(chunk_t *pc1, chunk_t *pc2)
 {
    return(  pc1 == NULL
          || pc2 == NULL
@@ -758,7 +754,7 @@ static_inline bool chunk_same_preproc(const chunk_t *pc1, chunk_t *pc2)
  * The prev and next chunks must have the same PCF_IN_PREPROC flag AND
  * the newline can't be after a C++ comment.
  */
-static_inline bool chunk_safe_to_del_nl(const chunk_t *nl)
+static_inline bool chunk_safe_to_del_nl(chunk_t *nl)
 {
    chunk_t *tmp = chunk_get_prev(nl);
 
@@ -776,28 +772,29 @@ static_inline bool chunk_safe_to_del_nl(const chunk_t *nl)
  *
  * @return true  - the chunk is the opening parentheses of a for in loop
  */
-static_inline bool chunk_is_forin(const chunk_t *pc)
+static_inline bool chunk_is_forin(chunk_t *pc)
 {
-   chunk_t *prev = chunk_get_prev_ncnl(pc);
-
-   if (  !(cpd.lang_flags & LANG_OC)
-      || prev == nullptr
-      || pc == nullptr
-      || prev->type != CT_FOR
-      || pc->type != CT_SPAREN_OPEN)
+   if (  (cpd.lang_flags & LANG_OC)
+      && pc
+      && pc->type == CT_SPAREN_OPEN)
    {
-      return(false);
+      chunk_t *prev = chunk_get_prev_ncnl(pc);
+      if (prev->type == CT_FOR)
+      {
+         chunk_t *next = pc;
+         while (  next
+               && next->type != CT_SPAREN_CLOSE
+               && next->type != CT_IN)
+         {
+            next = chunk_get_next_ncnl(next);
+         }
+         if (next->type == CT_IN)
+         {
+            return(true);
+         }
+      }
    }
-
-   // search CT_IN token between the two 'for' parenthesis
-   chunk_t *next = chunk_get_next_ncnl(pc);
-   for ( ; (  next != nullptr
-           && next->type != CT_IN
-           && next->type != CT_SPAREN_CLOSE)
-         ; next = chunk_get_next_ncnl(next))
-   {
-   }
-   return((next != nullptr && next->type == CT_IN) ? true : false);
+   return(false);
 }
 
 


### PR DESCRIPTION
reverts PR #1425 and #1430

While it seemed like making the params in in the chunk_list functions const
would be a good idea, it can actually lead to catastrophic bugs.

See how this simple example circumvents the constness:

```cpp
struct chunk_t
{
    chunk_t* next;
    chunk_t* prev;
    static chunk_t* getNext(const chunk_t* e){ return e->next;}
    static chunk_t* getPrev(const chunk_t* e){ return e->prev;}

    static chunk_t* broken(const chunk_t* e)
    {
        chunk_t* m = getPrev(e);
        m = getNext(m);
        m->prev = nullptr;
        m->next = nullptr;
        return m->prev;
    }
};
```

Note: here m = e
Debugging this in a real function can easily turn into a nightmare.

Reverted commits (ordered):
dc279359cb2d4939bf2f9129652cbee5678daacc
48f8fe38d877c44ed993d292c2d179fd6b0e13c8
dbd3e672609319d1b71308cca32b3c808173baa3
035e07c88aaabd712bb26ca18eeb043cf7552561
96df76f1b06821670c960028bd2c0d42e913a5b2
1a224de706670db4cba6b5c2aacc497a30d09597
e940d89ebe259a7b0dfaebb06dc13aa8dcff0fb4
e74dee43a0130b5e8b22b8d2dbf45a97fa426800
3ca7e72d3bf4ad926a2b19a9e098cbefd77fd954
95bae3bf1e54b50ff091950aab5a7c5d94fb1e88
6e22ab4d4ab722a6f24a82b58899e4d4f787b44c
928b60c99a5d6911e3e3c058173b8332b7586f6b
88323ced8bec06a3fd34771b5e0f55c11967f647
7b0377116a305d2464b9aaeffd77e5e4f17f2f65
5d873824b9d3085dd5e1d4782bbb97a36475c785

---

ref: #1401