### PR TITLE
fix issue #1439: incorrect implication of ‘nl_after_struct’ option

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2692,18 +2692,13 @@ static void fix_enum_struct_union(chunk_t *pc)
       set_chunk_parent(next, pc->type);
       prev = next;  // save xyz
       next = chunk_get_next_ncnl(next);
-      if (next == nullptr)
+      if (next == nullptr || next->type == CT_SEMICOLON/*c++ forward declaration*/)
       {
          return;
       }
       set_chunk_parent(next, pc->type);
 
       // next up is either a colon, open brace, or open parenthesis (pawn)
-      if (!next)
-      {
-         return;
-      }
-
       if ((cpd.lang_flags & LANG_PAWN) && next->type == CT_PAREN_OPEN)
       {
          next = set_paren_parent(next, CT_ENUM);


### PR DESCRIPTION
fix issue #1439: incorrect implication of ‘nl_after_struct’ option for forward declarations of structs