### PR TITLE
Fix indent_func_const.

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2412,7 +2412,7 @@ void indent_text(void)
                     || next->type == CT_VBRACE_OPEN))
          {
             // indent const - void GetFoo(void)\n const\n { return (m_Foo); }
-            indent_column_set(cpd.settings[UO_indent_func_const].u);
+            indent_column_set(frm.pse[frm.pse_tos].indent + cpd.settings[UO_indent_func_const].u);
             LOG_FMT(LINDENT, "%s(%d): %zu] const => %zu [%s]\n",
                     __func__, __LINE__, pc->orig_line, indent_column, pc->text());
             reindent_line(pc, indent_column);

--- a/tests/config/const_throw.cfg
+++ b/tests/config/const_throw.cfg
@@ -6,3 +6,6 @@ indent_func_const = 69 # number
 # e.g., int GetFoo(void)\n throw (std::bad_alloc)\n { return (m_Foo); }
 indent_func_throw = 41 # number
 
+#indent class memeber function declarations. This is to test
+#that a 'const' qualifier is continuation indented
+indent_class = true

--- a/tests/input/cpp/const_throw.cpp
+++ b/tests/input/cpp/const_throw.cpp
@@ -6,3 +6,8 @@ int GetFoo(void)
  throw (std::bad_alloc)
  { return (m_Foo); }
 
+class foo{
+  void bar(void)
+    const;
+};
+

--- a/tests/output/cpp/30270-const_throw.cpp
+++ b/tests/output/cpp/30270-const_throw.cpp
@@ -1,5 +1,5 @@
 void GetFoo(void)
-                                                                    const
+                                                                     const
 {
 	return (m_Foo);
 }
@@ -9,4 +9,9 @@ int GetFoo(void)
 {
 	return (m_Foo);
 }
+
+class foo {
+	void bar(void)
+	                                                                     const;
+};
 


### PR DESCRIPTION
Without this fix, the 'indent_func_const' configuration is used
as an absolute value, not as a relative to the current indentation
level.

The C++ test 30270 has in its configuration
'indent_func_const = 69',
yet the outputs 'const' started on column 69, i.e. 68 spaces indent.
The error is even more noticable when the 'const' is part of a class
member function, already indented. This appends the 30270 test case
with such an example.
