### PR TITLE
improve parsing for a function call

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -4283,7 +4283,8 @@ static void mark_function(chunk_t *pc)
                || prev->type == CT_STRING
                || prev->type == CT_STRING_MULTI
                || prev->type == CT_NUMBER
-               || prev->type == CT_NUMBER_FP)
+               || prev->type == CT_NUMBER_FP
+               || prev->type == CT_FPAREN_OPEN) // issue #1464
             {
                isa_def = false;
             }

--- a/tests/config/i1464.cfg
+++ b/tests/config/i1464.cfg
@@ -1,0 +1,6 @@
+# auto p = std::make_pair(r * cos(a), r * sin(a));
+# type of the 'cos' token was incorrectly set to `CT_FUNC_DEF`
+# because of this the first '*' became a `CT_PTR_TYPE` instead of a `CT_ARITH`
+# type
+sp_arith                        = force
+sp_after_ptr_star               = remove

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -499,6 +499,7 @@
 34170  empty.cfg                            cpp/i1082.cpp
 34171  empty.cfg                            cpp/i1181.cpp
 34172  space_indent_columns-4.cfg           cpp/i1165.cpp
+34173  i1464.cfg                            cpp/i1464.cpp
 
 34190  bug_1003.cfg                         cpp/bug_1003.cpp
 

--- a/tests/input/cpp/i1464.cpp
+++ b/tests/input/cpp/i1464.cpp
@@ -1,0 +1,1 @@
+auto p = std::make_pair(r * cos(a), r * sin(a));

--- a/tests/output/cpp/34173-i1464.cpp
+++ b/tests/output/cpp/34173-i1464.cpp
@@ -1,0 +1,1 @@
+auto p = std::make_pair(r * cos(a), r * sin(a));


### PR DESCRIPTION
The type of the 'cos' token was incorrectly set to `CT_FUNC_DEF`,
because of this the first `*` became a `CT_PTR_TYPE` instead of a `CT_ARITH`.