### PR TITLE
Fix the nested braced-init-list in the constructor

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -4598,7 +4598,7 @@ static void mark_cpp_constructor(chunk_t *pc)
    tmp = paren_open;
    bool hit_colon = false;
    while (  tmp != nullptr
-         && tmp->type != CT_BRACE_OPEN
+         && (tmp->type != CT_BRACE_OPEN || tmp->level != paren_open->level)
          && !chunk_is_semicolon(tmp))
    {
       chunk_flags_set(tmp, PCF_IN_CONST_ARGS);

--- a/tests/input/cpp/braced_init_list.cpp
+++ b/tests/input/cpp/braced_init_list.cpp
@@ -8,6 +8,15 @@ using some_type = int;
 
 class BracedInitListBase {
 public:
+BracedInitListBase()
+	: a{int{1}},
+	b(int(some_type(1))),
+	c(int{some_type(1)}),
+	d{int(some_type(1))},
+	e{some_type{some_type{a}}}
+{
+}
+
 virtual int getA() const {
 	return a;
 }


### PR DESCRIPTION
Fixes the initialization of the class member with the nested braced-init-list in the constructor:
```
class Base {
Base() : a{int{1}}{}
int a;
};
```
Issue #1405