### PR TITLE
 Fix 'if constexpr' C++17 feature

### DIFF
--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -884,6 +884,15 @@ static bool check_complex_statements(parse_frame_t *frm, chunk_t *pc)
       }
    }
 
+   // Check for "constexpr" after CT_IF or CT_ELSEIF
+   if (  frm->pse[frm->pse_tos].stage == brace_stage_e::PAREN1
+      && (  frm->pse[frm->pse_tos].type == CT_IF
+         || frm->pse[frm->pse_tos].type == CT_ELSEIF)
+      && pc->str.equals("constexpr")) // FIXME: Take care of the "constexpr" const string.
+   {
+      return(false);
+   }
+
    // Verify open parenthesis in complex statement
    if (  pc->type != CT_PAREN_OPEN
       && (  (frm->pse[frm->pse_tos].stage == brace_stage_e::PAREN1)

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -374,6 +374,7 @@
 33057  bug_1349.cfg                         cpp/bug_1349.cpp
 #33058  sp_arith-a.cfg                       cpp/stdcall.cpp
 
+33060  empty.cfg                            cpp/if_constexpr.cpp
 33061  empty.cfg                            cpp/if_chain_braces.cpp
 33062  mod_full_brace_if_chain-t.cfg        cpp/if_chain_braces.cpp
 33063  mod_full_brace_if_chain_only-t.cfg   cpp/if_chain_braces.cpp

--- a/tests/input/cpp/if_constexpr.cpp
+++ b/tests/input/cpp/if_constexpr.cpp
@@ -1,0 +1,8 @@
+static constexpr int test{
+	if constexpr (condition_1)
+		return 1;
+	else if constexpr (condition_2)
+		return 2;
+	else
+		return 3;
+};

--- a/tests/output/cpp/33060-if_constexpr.cpp
+++ b/tests/output/cpp/33060-if_constexpr.cpp
@@ -1,0 +1,8 @@
+static constexpr int test{
+	if constexpr (condition_1)
+		return 1;
+	else if constexpr (condition_2)
+		return 2;
+	else
+		return 3;
+};


### PR DESCRIPTION
'if constexpr' and 'else if constexpr' are marked as valid statements.