### PR TITLE
add debug log macro

### DIFF
--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -444,7 +444,7 @@ static void chunk_log(chunk_t *pc, const char *text)
       {
          chunk_log_msg(prev, log, " @ after");
       }
-      LOG_FMT(log, " stage is %d", cpd.unc_stage);
+      LOG_FMT(log, " stage is %u", static_cast<unsigned int>(cpd.unc_stage));
       log_func_stack_inline(log);
    }
 }

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1942,9 +1942,7 @@ static void mark_function_return_type(chunk_t *fname, chunk_t *start, c_token_t 
       // Step backwards from pc and mark the parent of the return type
       LOG_FMT(LFCNR, "%s(%d): (backwards) return type for '%s' @ orig_line is %zu, orig_col is %zu",
               __func__, __LINE__, fname->text(), fname->orig_line, fname->orig_col);
-#ifdef DEBUG
-      LOG_FMT(LFCN, "\n");
-#endif
+      D_LOG_FMT(LFCN, "\n");
 
       chunk_t *first = pc;
       chunk_t *save;
@@ -3154,9 +3152,7 @@ void combine_labels(void)
                {
                   return;
                }
-#ifdef DEBUG
-               LOG_FMT(LGUY, "(%d) ", __LINE__);
-#endif
+               D_LOG_FMT(LGUY, "(%d) ", __LINE__);
                LOG_FMT(LGUY, "%s: %zu:%zu, tmp '%s'\n",
                        __func__, tmp->orig_line, tmp->orig_col, (tmp->type == CT_NEWLINE) ? "<Newline>" : tmp->text());
                log_pcf_flags(LGUY, tmp->flags);
@@ -3902,9 +3898,7 @@ static void mark_function(chunk_t *pc)
    if (pc->flags & PCF_IN_CONST_ARGS)
    {
       set_chunk_type(pc, CT_FUNC_CTOR_VAR);
-#ifdef DEBUG
-      LOG_FMT(LFCN, "(%d) ", __LINE__);
-#endif
+      D_LOG_FMT(LFCN, "(%d) ", __LINE__);
       LOG_FMT(LFCN, "  1) Marked [%s] as FUNC_CTOR_VAR on line %zu col %zu\n",
               pc->text(), pc->orig_line, pc->orig_col);
       next = skip_template_next(next);
@@ -3935,9 +3929,7 @@ static void mark_function(chunk_t *pc)
 
    if (paren_open == nullptr || paren_close == nullptr)
    {
-#ifdef DEBUG
-      LOG_FMT(LFCN, "%s(%d) ", __func__, __LINE__);
-#endif
+      D_LOG_FMT(LFCN, "%s(%d) ", __func__, __LINE__);
       LOG_FMT(LFCN, "No parens found for [%s] on orig_line %zu, orig_col %zu\n",
               pc->text(), pc->orig_line, pc->orig_col);
       return;
@@ -3991,25 +3983,19 @@ static void mark_function(chunk_t *pc)
       {
          if (tmp2)
          {
-#ifdef DEBUG
-            LOG_FMT(LFCN, "%s(%d): ", __func__, __LINE__);
-#endif
+            D_LOG_FMT(LFCN, "%s(%d): ", __func__, __LINE__);
             LOG_FMT(LFCN, "[%zu/%zu] function variable [%s], changing [%s] into a type\n",
                     pc->orig_line, pc->orig_col, tmp2->text(), pc->text());
             set_chunk_type(tmp2, CT_FUNC_VAR);
             flag_parens(paren_open, 0, CT_PAREN_OPEN, CT_FUNC_VAR, false);
 
-#ifdef DEBUG
-            LOG_FMT(LFCN, "%s(%d): ", __func__, __LINE__);
-#endif
+            D_LOG_FMT(LFCN, "%s(%d): ", __func__, __LINE__);
             LOG_FMT(LFCN, "paren open @ %zu:%zu\n",
                     paren_open->orig_line, paren_open->orig_col);
          }
          else
          {
-#ifdef DEBUG
-            LOG_FMT(LFCN, "%s(%d): ", __func__, __LINE__);
-#endif
+            D_LOG_FMT(LFCN, "%s(%d): ", __func__, __LINE__);
             LOG_FMT(LFCN, "[%zu/%zu] function type, changing [%s] into a type\n",
                     pc->orig_line, pc->orig_col, pc->text());
             if (tmp2)
@@ -4031,9 +4017,7 @@ static void mark_function(chunk_t *pc)
          return;
       }
 
-#ifdef DEBUG
-      LOG_FMT(LFCN, "%s(%d): ", __func__, __LINE__);
-#endif
+      D_LOG_FMT(LFCN, "%s(%d): ", __func__, __LINE__);
       LOG_FMT(LFCN, "chained function calls? [%zu.%zu] [%s]\n",
               pc->orig_line, pc->orig_col, pc->text());
    }
@@ -4118,9 +4102,7 @@ static void mark_function(chunk_t *pc)
    {
       bool isa_def  = false;
       bool hit_star = false;
-#ifdef DEBUG
-      LOG_FMT(LFCN, "%s(%d):", __func__, __LINE__);
-#endif
+      D_LOG_FMT(LFCN, "%s(%d):", __func__, __LINE__);
       if (prev == NULL)
       {
          LOG_FMT(LFCN, "  Checking func call: prev->type is NULL");
@@ -4130,9 +4112,7 @@ static void mark_function(chunk_t *pc)
          LOG_FMT(LFCN, "  Checking func call: prev->text() '%s', prev->type is %s",
                  prev->text(), get_token_name(prev->type));
       }
-#ifdef DEBUG
-      LOG_FMT(LFCN, "\n");
-#endif
+      D_LOG_FMT(LFCN, "\n");
 
       // if (!chunk_ends_type(prev))
       // {
@@ -4159,9 +4139,7 @@ static void mark_function(chunk_t *pc)
        */
       while (prev != nullptr)
       {
-#ifdef DEBUG
-         LOG_FMT(LFCN, "%s(%d): next step with: ", __func__, __LINE__);
-#endif
+         D_LOG_FMT(LFCN, "%s(%d): next step with: ", __func__, __LINE__);
          LOG_FMT(LFCN, "orig_line is %zu, orig_col is %zu, text() '%s'\n",
                  prev->orig_line, prev->orig_col, prev->text());
          if (prev->flags & PCF_IN_PREPROC)
@@ -4181,9 +4159,7 @@ static void mark_function(chunk_t *pc)
          // skip const(TYPE)
          if (prev->type == CT_PAREN_CLOSE && prev->parent_type == CT_D_CAST)
          {
-#ifdef DEBUG
-            LOG_FMT(LFCN, "%s(%d):", __func__, __LINE__);
-#endif
+            D_LOG_FMT(LFCN, "%s(%d):", __func__, __LINE__);
             LOG_FMT(LFCN, " --> For sure a prototype or definition\n");
             isa_def = true;
             break;
@@ -4209,22 +4185,16 @@ static void mark_function(chunk_t *pc)
                   && prev->type != CT_TYPE
                   && prev->type != CT_THIS))
             {
-#ifdef DEBUG
-               LOG_FMT(LFCN, "%s(%d):", __func__, __LINE__);
-#endif
+               D_LOG_FMT(LFCN, "%s(%d):", __func__, __LINE__);
                LOG_FMT(LFCN, " --? Skipped MEMBER and landed on %s\n",
                        (prev == NULL) ? "<null>" : get_token_name(prev->type));
                set_chunk_type(pc, CT_FUNC_CALL);
                isa_def = false;
                break;
             }
-#ifdef DEBUG
-            LOG_FMT(LFCN, "%s(%d):", __func__, __LINE__);
-#endif
+            D_LOG_FMT(LFCN, "%s(%d):", __func__, __LINE__);
             LOG_FMT(LFCN, " <skip '%s'>", prev->text());
-#ifdef DEBUG
-            LOG_FMT(LFCN, "\n");
-#endif
+            D_LOG_FMT(LFCN, "\n");
             // Issue #1112
             prev = chunk_get_prev_ncnlnpnd(prev);
             if (prev == nullptr)
@@ -4244,16 +4214,12 @@ static void mark_function(chunk_t *pc)
          {
             if (!hit_star)
             {
-#ifdef DEBUG
-               LOG_FMT(LFCN, "%s(%d) ", __func__, __LINE__);
-#endif
+               D_LOG_FMT(LFCN, "%s(%d) ", __func__, __LINE__);
                LOG_FMT(LFCN, " --> For sure a prototype or definition\n");
                isa_def = true;
                break;
             }
-#ifdef DEBUG
-            LOG_FMT(LFCN, "%s(%d) ", __func__, __LINE__);
-#endif
+            D_LOG_FMT(LFCN, "%s(%d) ", __func__, __LINE__);
             LOG_FMT(LFCN, " --> maybe a proto/def\n");
             isa_def = true;
          }
@@ -4271,9 +4237,7 @@ static void mark_function(chunk_t *pc)
             && prev->type != CT_WORD
             && !chunk_is_ptr_operator(prev))
          {
-#ifdef DEBUG
-            LOG_FMT(LFCN, "%s(%d) ", __func__, __LINE__);
-#endif
+            D_LOG_FMT(LFCN, "%s(%d) ", __func__, __LINE__);
             LOG_FMT(LFCN, " --> Stopping on %s [%s]\n",
                     prev->text(), get_token_name(prev->type));
             // certain tokens are unlikely to precede a prototype or definition
@@ -4311,9 +4275,7 @@ static void mark_function(chunk_t *pc)
             || prev->type == CT_ASSIGN
             || prev->type == CT_RETURN))
       {
-#ifdef DEBUG
-         LOG_FMT(LFCN, "%s(%d):", __func__, __LINE__);
-#endif
+         D_LOG_FMT(LFCN, "%s(%d):", __func__, __LINE__);
          LOG_FMT(LFCN, " -- overriding DEF due to %s [%s]\n",
                  prev->text(), get_token_name(prev->type));
          isa_def = false;
@@ -4321,9 +4283,7 @@ static void mark_function(chunk_t *pc)
       if (isa_def)
       {
          set_chunk_type(pc, CT_FUNC_DEF);
-#ifdef DEBUG
-         LOG_FMT(LFCN, "%s(%d):", __func__, __LINE__);
-#endif
+         D_LOG_FMT(LFCN, "%s(%d):", __func__, __LINE__);
          LOG_FMT(LFCN, " '%s' is FCN_DEF:", pc->text());
          if (prev == nullptr)
          {
@@ -4342,9 +4302,7 @@ static void mark_function(chunk_t *pc)
 
    if (pc->type != CT_FUNC_DEF)
    {
-#ifdef DEBUG
-      LOG_FMT(LFCN, "%s(%d): ", __func__, __LINE__);
-#endif
+      D_LOG_FMT(LFCN, "%s(%d): ", __func__, __LINE__);
       LOG_FMT(LFCN, "  Detected %s '%s' on line %zu col %zu\n",
               get_token_name(pc->type),
               pc->text(), pc->orig_line, pc->orig_col);
@@ -4392,9 +4350,7 @@ static void mark_function(chunk_t *pc)
             // Set the parent for the semicolon for later
             semi = tmp;
             set_chunk_type(pc, CT_FUNC_PROTO);
-#ifdef DEBUG
-            LOG_FMT(LFCN, "%s(%d): ", __func__, __LINE__);
-#endif
+            D_LOG_FMT(LFCN, "%s(%d): ", __func__, __LINE__);
             LOG_FMT(LFCN, "  2) Marked [%s] as FUNC_PROTO on line %zu col %zu\n",
                     pc->text(), pc->orig_line, pc->orig_col);
             break;
@@ -4402,9 +4358,7 @@ static void mark_function(chunk_t *pc)
          else if (pc->type == CT_COMMA)
          {
             set_chunk_type(pc, CT_FUNC_CTOR_VAR);
-#ifdef DEBUG
-            LOG_FMT(LFCN, "%s(%d): ", __func__, __LINE__);
-#endif
+            D_LOG_FMT(LFCN, "%s(%d): ", __func__, __LINE__);
             LOG_FMT(LFCN, "  2) Marked [%s] as FUNC_CTOR_VAR on line %zu col %zu\n",
                     pc->text(), pc->orig_line, pc->orig_col);
             break;
@@ -4425,9 +4379,7 @@ static void mark_function(chunk_t *pc)
       && pc->type == CT_FUNC_PROTO
       && pc->parent_type != CT_OPERATOR)
    {
-#ifdef DEBUG
-      LOG_FMT(LFPARAM, "%s(%d):", __func__, __LINE__);
-#endif
+      D_LOG_FMT(LFPARAM, "%s(%d):", __func__, __LINE__);
       LOG_FMT(LFPARAM, "  checking '%s' for constructor variable %s %s\n",
               pc->text(),
               get_token_name(paren_open->type),
@@ -4468,9 +4420,7 @@ static void mark_function(chunk_t *pc)
       if (!is_param)
       {
          set_chunk_type(pc, CT_FUNC_CTOR_VAR);
-#ifdef DEBUG
-         LOG_FMT(LFCN, "%s(%d): ", __func__, __LINE__);
-#endif
+         D_LOG_FMT(LFCN, "%s(%d): ", __func__, __LINE__);
          LOG_FMT(LFCN, "  3) Marked [%s] as FUNC_CTOR_VAR on line %zu col %zu\n",
                  pc->text(), pc->orig_line, pc->orig_col);
       }
@@ -4493,9 +4443,7 @@ static void mark_function(chunk_t *pc)
                   && p_op->parent_type != CT_NAMESPACE)
                {
                   set_chunk_type(pc, CT_FUNC_CTOR_VAR);
-#ifdef DEBUG
-                  LOG_FMT(LFCN, "%s(%d) ", __func__, __LINE__);
-#endif
+                  D_LOG_FMT(LFCN, "%s(%d) ", __func__, __LINE__);
                   LOG_FMT(LFCN, "  4) Marked [%s] as FUNC_CTOR_VAR on line %zu col %zu\n",
                           pc->text(), pc->orig_line, pc->orig_col);
                }

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -299,9 +299,7 @@ void reindent_line(chunk_t *pc, size_t column)
            __func__, __LINE__, pc->orig_line, pc->column, pc->text(),
            get_token_name(pc->type), get_token_name(pc->parent_type),
            column);
-#ifdef DEBUG
-   LOG_FMT(LINDLINE, "\n");
-#endif
+   D_LOG_FMT(LINDLINE, "\n");
    log_func_stack_inline(LINDLINE);
 
    if (column == pc->column)
@@ -2740,9 +2738,7 @@ static void indent_comment(chunk_t *pc, size_t col)
 
    LOG_FMT(LCMTIND, "%s(%d): orig_line %zu, orig_col %zu, level %zu: ",
            __func__, __LINE__, pc->orig_line, pc->orig_col, pc->level);
-#ifdef DEBUG
-   LOG_FMT(LCMTIND, "\n");
-#endif
+   D_LOG_FMT(LCMTIND, "\n");
 
    // force column 1 comment to column 1 if not changing them
    if (  pc->orig_col == 1

--- a/src/logger.h
+++ b/src/logger.h
@@ -129,6 +129,13 @@ void log_flush(bool force_nl);
 #endif
 
 
+#ifdef DEBUG
+#define D_LOG_FMT    LOG_FMT
+#else
+#define D_LOG_FMT(sev, ...)    ((void)0) //forces semicolon after macro
+#endif
+
+
 /**
  * Dumps hex characters inline, no newlines inserted
  *

--- a/src/logger.h
+++ b/src/logger.h
@@ -123,8 +123,8 @@ void log_flush(bool force_nl);
 #define LOG_FMT    log_fmt
 // TODO during debugging add source file and line number
 #else
-#define LOG_FMT(sev, args...)                           \
-   do { if (log_sev_on(sev)) { log_fmt(sev, ## args); } \
+#define LOG_FMT(sev, ...)                                   \
+   do { if (log_sev_on(sev)) { log_fmt(sev, __VA_ARGS__); } \
    } while (0)
 #endif
 

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3076,9 +3076,7 @@ void newlines_cleanup_braces(bool first)
                // split one-liner
                chunk_t *end = chunk_get_next(chunk_get_next_type(pc->next, CT_SEMICOLON, -1));
                // Scan for clear flag
-#ifdef DEBUG
-               LOG_FMT(LNEWLINE, "(%d) ", __LINE__);
-#endif
+               D_LOG_FMT(LNEWLINE, "(%d) ", __LINE__);
                LOG_FMT(LNEWLINE, "\n");
                for (chunk_t *temp = pc; temp != end; temp = chunk_get_next(temp))
                {

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1946,15 +1946,14 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
       return(AV_REMOVE);
    }
 
-#ifdef DEBUG
    // these lines are only useful for debugging uncrustify itself
-   LOG_FMT(LSPACE, "\n\n%s(%d): WARNING: unrecognize do_space:\n",
-           __func__, __LINE__);
-   LOG_FMT(LSPACE, "   first->orig_line  is %zu, first->orig_col  is %zu, first->text()  '%s', first->type is  %s\n",
-           first->orig_line, first->orig_col, first->text(), get_token_name(first->type));
-   LOG_FMT(LSPACE, "   second->orig_line is %zu, second->orig_col is %zu, second->text() '%s', second->type is %s\n",
-           second->orig_line, second->orig_col, second->text(), get_token_name(second->type));
-#endif
+   D_LOG_FMT(LSPACE, "\n\n%s(%d): WARNING: unrecognize do_space:\n",
+             __func__, __LINE__);
+   D_LOG_FMT(LSPACE, "   first->orig_line  is %zu, first->orig_col  is %zu, first->text()  '%s', first->type is  %s\n",
+             first->orig_line, first->orig_col, first->text(), get_token_name(first->type));
+   D_LOG_FMT(LSPACE, "   second->orig_line is %zu, second->orig_col is %zu, second->text() '%s', second->type is %s\n",
+             second->orig_line, second->orig_col, second->text(), get_token_name(second->type));
+
    log_rule("ADD as default value");
    return(AV_ADD);
 } // do_space

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -893,9 +893,7 @@ static void check_template(chunk_t *start)
 {
    LOG_FMT(LTEMPL, "%s(%d): orig_line %zu, orig_col %zu:",
            __func__, __LINE__, start->orig_line, start->orig_col);
-#ifdef DEBUG
-   LOG_FMT(LTEMPL, "\n");
-#endif // DEBUG
+   D_LOG_FMT(LTEMPL, "\n");
 
    chunk_t *prev = chunk_get_prev_ncnl(start, scope_e::PREPROC);
    if (prev == nullptr)
@@ -907,13 +905,9 @@ static void check_template(chunk_t *start)
    chunk_t *pc;
    if (prev->type == CT_TEMPLATE)
    {
-#ifdef DEBUG
-      LOG_FMT(LTEMPL, "%s(%d):", __func__, __LINE__);
-#endif
+      D_LOG_FMT(LTEMPL, "%s(%d):", __func__, __LINE__);
       LOG_FMT(LTEMPL, " CT_TEMPLATE:");
-#ifdef DEBUG
-      LOG_FMT(LTEMPL, "\n");
-#endif
+      D_LOG_FMT(LTEMPL, "\n");
 
       // We have: "template< ... >", which is a template declaration
       size_t level = 1;
@@ -923,17 +917,13 @@ static void check_template(chunk_t *start)
       {
          LOG_FMT(LTEMPL, "%s(%d): [%s,%zu]",
                  __func__, __LINE__, get_token_name(pc->type), level);
-#ifdef DEBUG
-         LOG_FMT(LTEMPL, "\n");
-#endif
+         D_LOG_FMT(LTEMPL, "\n");
 
          if ((pc->str[0] == '>') && (pc->len() > 1))
          {
             LOG_FMT(LTEMPL, "%s(%d): {split '%s' at orig_line %zu, orig_col %zu}",
                     __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col);
-#ifdef DEBUG
-            LOG_FMT(LTEMPL, "\n");
-#endif
+            D_LOG_FMT(LTEMPL, "\n");
             split_off_angle_close(pc);
          }
 
@@ -971,18 +961,14 @@ static void check_template(chunk_t *start)
       {
          LOG_FMT(LTEMPL, "%s(%d): - after %s + ( - Not a template\n",
                  __func__, __LINE__, get_token_name(prev->type));
-#ifdef DEBUG
-         LOG_FMT(LTEMPL, "\n");
-#endif
+         D_LOG_FMT(LTEMPL, "\n");
          set_chunk_type(start, CT_COMPARE);
          return;
       }
 
       LOG_FMT(LTEMPL, "%s(%d): - prev %s -",
               __func__, __LINE__, get_token_name(prev->type));
-#ifdef DEBUG
-      LOG_FMT(LTEMPL, "\n");
-#endif
+      D_LOG_FMT(LTEMPL, "\n");
 
       // Scan back and make sure we aren't inside square parenthesis
       bool in_if = false;
@@ -1018,9 +1004,7 @@ static void check_template(chunk_t *start)
       {
          LOG_FMT(LTEMPL, "%s(%d): [%s,%zu]",
                  __func__, __LINE__, get_token_name(pc->type), num_tokens);
-#ifdef DEBUG
-         LOG_FMT(LTEMPL, "\n");
-#endif
+         D_LOG_FMT(LTEMPL, "\n");
 
          if (  (tokens[num_tokens - 1] == CT_ANGLE_OPEN)
             && (pc->str[0] == '>')
@@ -1030,9 +1014,8 @@ static void check_template(chunk_t *start)
          {
             LOG_FMT(LTEMPL, "%s(%d): {split '%s' at orig_line %zu, orig_col %zu}",
                     __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col);
-#ifdef DEBUG
-            LOG_FMT(LTEMPL, "\n");
-#endif
+            D_LOG_FMT(LTEMPL, "\n");
+
             split_off_angle_close(pc);
          }
 
@@ -1093,18 +1076,12 @@ static void check_template(chunk_t *start)
       pc = chunk_get_next_ncnl(end, scope_e::PREPROC);
       if (pc == nullptr || pc->type != CT_NUMBER)
       {
-#ifdef DEBUG
-         LOG_FMT(LTEMPL, "%s(%d):", __func__, __LINE__);
-#endif
+         D_LOG_FMT(LTEMPL, "%s(%d):", __func__, __LINE__);
          LOG_FMT(LTEMPL, " - Template Detected\n");
-#ifdef DEBUG
-         LOG_FMT(LTEMPL, "%s(%d):", __func__, __LINE__);
-#endif
+         D_LOG_FMT(LTEMPL, "%s(%d):", __func__, __LINE__);
          LOG_FMT(LTEMPL, "     from orig_line %zu, orig_col %zu\n",
                  start->orig_line, start->orig_col);
-#ifdef DEBUG
-         LOG_FMT(LTEMPL, "%s(%d):", __func__, __LINE__);
-#endif
+         D_LOG_FMT(LTEMPL, "%s(%d):", __func__, __LINE__);
          LOG_FMT(LTEMPL, "     to   orig_line %zu, orig_col %zu\n",
                  end->orig_line, end->orig_col);
 


### PR DESCRIPTION
adds `D_LOG_FMT` macro to replace the nasty `#ifdef DEBUG` checks