### PR TITLE
improve parsing for a function call

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -4201,6 +4201,13 @@ static void mark_function(chunk_t *pc)
             }
          }
 
+         // if it was determined that this could be a function definition
+         // but one of the preceding tokens is a CT_MEMBER than this is not a
+         // fcn def, issue #1466
+         if (isa_def && prev->type == CT_MEMBER)
+         {
+            isa_def = false;
+         }
 
          // Skip the word/type before the '.' or '::'
          if (prev->type == CT_DC_MEMBER || prev->type == CT_MEMBER)
@@ -4235,7 +4242,7 @@ static void mark_function(chunk_t *pc)
             continue;
          }
 
-         // If we are on a TYPE or WORD, then we must be on a proto or def
+         // If we are on a TYPE or WORD, then this could be a proto or def
          if (prev->type == CT_TYPE || prev->type == CT_WORD)
          {
             if (!hit_star)

--- a/tests/config/arith-vs-ptr.cfg
+++ b/tests/config/arith-vs-ptr.cfg
@@ -1,0 +1,14 @@
+sp_arith                        = force
+sp_after_ptr_star               = remove
+
+# issue 1464
+# ------------------------------------------------------------------------------
+# auto p = std::make_pair(r * cos(a), r * sin(a));
+# type of the 'cos' token was incorrectly set to `CT_FUNC_DEF`
+# because of this the first '*' became a `CT_PTR_TYPE` instead of a `CT_ARITH`
+# type
+
+# issue 1466
+# ------------------------------------------------------------------------------
+# A a = {this->r * cos(b)};
+# similar to 1464

--- a/tests/config/i1464.cfg
+++ b/tests/config/i1464.cfg
@@ -1,6 +1,0 @@
-# auto p = std::make_pair(r * cos(a), r * sin(a));
-# type of the 'cos' token was incorrectly set to `CT_FUNC_DEF`
-# because of this the first '*' became a `CT_PTR_TYPE` instead of a `CT_ARITH`
-# type
-sp_arith                        = force
-sp_after_ptr_star               = remove

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -501,7 +501,8 @@
 34170  empty.cfg                            cpp/i1082.cpp
 34171  empty.cfg                            cpp/i1181.cpp
 34172  space_indent_columns-4.cfg           cpp/i1165.cpp
-34173  i1464.cfg                            cpp/i1464.cpp
+34173  arith-vs-ptr.cfg                     cpp/i1464.cpp
+34174  arith-vs-ptr.cfg                     cpp/i1466.cpp
 
 34190  bug_1003.cfg                         cpp/bug_1003.cpp
 

--- a/tests/input/cpp/i1466.cpp
+++ b/tests/input/cpp/i1466.cpp
@@ -1,0 +1,1 @@
+A a = {this->r * cos(b)};

--- a/tests/output/cpp/34174-i1466.cpp
+++ b/tests/output/cpp/34174-i1466.cpp
@@ -1,0 +1,1 @@
+A a = {this->r * cos(b)};


### PR DESCRIPTION
The type of the `cos` token was incorrectly set to `FUNC_CTOR_VAR`,
because of this the first `*` became a `CT_PTR_TYPE` instead of a `CT_ARITH`.