### PR TITLE
Fix 'mod_full_brace_if_chain' with braced statements

### DIFF
--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -352,6 +352,13 @@ static bool can_remove_braces(chunk_t *bopen)
          else if (pc->type == CT_BRACE_CLOSE)
          {
             br_count--;
+            if (pc->level == level)
+            {
+               // mean a statement in a braces { stmt; }
+               // as a statement with a semicolon { stmt; };
+               ++semi_count;
+               hit_semi = true;
+            }
          }
          else if (pc->type == CT_IF || pc->type == CT_ELSEIF)
          {

--- a/tests/input/cpp/if_chain_braces.cpp
+++ b/tests/input/cpp/if_chain_braces.cpp
@@ -25,4 +25,9 @@ int foo() {
 	if ( b ) {
 		return 9;
 	}
+
+	if ( b ) {
+		{ b = 5; }
+		return 9;
+	}
 }

--- a/tests/output/cpp/33061-if_chain_braces.cpp
+++ b/tests/output/cpp/33061-if_chain_braces.cpp
@@ -25,4 +25,9 @@ int foo() {
 	if ( b ) {
 		return 9;
 	}
+
+	if ( b ) {
+		{ b = 5; }
+		return 9;
+	}
 }

--- a/tests/output/cpp/33062-if_chain_braces.cpp
+++ b/tests/output/cpp/33062-if_chain_braces.cpp
@@ -26,4 +26,9 @@ int foo() {
 
 	if ( b )
 		return 9;
+
+	if ( b ) {
+		{ b = 5; }
+		return 9;
+	}
 }

--- a/tests/output/cpp/33063-if_chain_braces.cpp
+++ b/tests/output/cpp/33063-if_chain_braces.cpp
@@ -31,4 +31,9 @@ int foo() {
 	if ( b ) {
 		return 9;
 	}
+
+	if ( b ) {
+		{ b = 5; }
+		return 9;
+	}
 }

--- a/tests/output/cpp/33064-if_chain_braces.cpp
+++ b/tests/output/cpp/33064-if_chain_braces.cpp
@@ -30,4 +30,9 @@ int foo() {
 
 	if ( b )
 		return 9;
+
+	if ( b ) {
+		{ b = 5; }
+		return 9;
+	}
 }


### PR DESCRIPTION
The `mod_full_brace_if_chain = true` option modifies the code:
```
if ( a ) {
    {a = 5;}
    {b = 5;}
}
```
to:
```
if ( a )
    {a = 5;}
    {b = 5;}
```
which is incorrect. This PR fixes it.