### PR TITLE
fix template for nl_before options

### DIFF
--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -447,6 +447,7 @@
 34112  sp_after_cast-r.cfg                  cpp/bug_i_889.cpp
 34113! nl_before_func_body_def-1.cfg        cpp/bug_902.cpp
 34114  nl_before_func_body_def-2.cfg        cpp/bug_902.cpp
+34115  nl_before_func_body_def-2.cfg        cpp/nl_before_func_body_def.cpp
 
 34120  align_assign_span-1.cfg              cpp/bug_i_999.cpp
 

--- a/tests/input/cpp/nl_before_func_body_def.cpp
+++ b/tests/input/cpp/nl_before_func_body_def.cpp
@@ -1,0 +1,60 @@
+lass A
+{
+	void f0(void);
+	template<typename T, typename U>
+	void g(T s, U t)
+	{
+		return;
+	}
+	void f1(void);
+	template
+	<typename T,
+	 typename U>
+	void h(T s, U t)
+	{
+		return;
+	}
+	void f2(void);
+	template
+	<typename T,
+	 typename U>
+	void
+	i(T s, U t)
+	{
+		return;
+	}
+	void f3(void);
+	template
+	<typename T,
+	 typename U>
+	void
+	j
+	        (T s, U t)
+	{
+		return;
+	}
+	void f4(void);
+	template
+	<typename T,
+	 typename U>
+	void
+	k
+	(
+		T s, U t)
+	{
+		return;
+	}
+	void f5(void);
+	template
+	<typename T,
+	 typename U>
+	void
+	l
+	(
+		T s,
+		U t
+	)
+	{
+		return;
+	}
+}

--- a/tests/output/cpp/34115-nl_before_func_body_def.cpp
+++ b/tests/output/cpp/34115-nl_before_func_body_def.cpp
@@ -1,0 +1,66 @@
+lass A
+{
+	void f0(void);
+
+	template<typename T, typename U>
+	void g(T s, U t)
+	{
+		return;
+	}
+	void f1(void);
+
+	template
+	<typename T,
+	 typename U>
+	void h(T s, U t)
+	{
+		return;
+	}
+	void f2(void);
+
+	template
+	<typename T,
+	 typename U>
+	void
+	i(T s, U t)
+	{
+		return;
+	}
+	void f3(void);
+
+	template
+	<typename T,
+	 typename U>
+	void
+	j
+	        (T s, U t)
+	{
+		return;
+	}
+	void f4(void);
+
+	template
+	<typename T,
+	 typename U>
+	void
+	k
+	(
+		T s, U t)
+	{
+		return;
+	}
+	void f5(void);
+
+	template
+	<typename T,
+	 typename U>
+	void
+	l
+	(
+		T s,
+		U t
+	)
+	{
+		return;
+	}
+}


### PR DESCRIPTION
let `nl_before_*` options add newlines before the template syntax, not after it