### PR TITLE
mark_function step back the whole function name chain

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -4201,35 +4201,50 @@ static void mark_function(chunk_t *pc)
             isa_def = false;
          }
 
-         // Skip the word/type before the '.' or '::'
+         // get first chunk before: A::B::pc | this.B.pc | this->B->pc
          if (prev->type == CT_DC_MEMBER || prev->type == CT_MEMBER)
          {
-            prev = chunk_get_prev_ncnlnp(prev);
-            if (  prev == nullptr
-               || (  prev->type != CT_WORD
-                  && prev->type != CT_TYPE
-                  && prev->type != CT_THIS))
+            bool do_break = false;
+            while (  prev != nullptr
+                  && (  prev->type == CT_TYPE
+                     || prev->type == CT_DC_MEMBER
+                     || prev->type == CT_MEMBER))
             {
+               prev = chunk_get_prev_ncnlnp(prev);
+               if (  prev == nullptr
+                  || (  prev->type != CT_WORD
+                     && prev->type != CT_TYPE
+                     && prev->type != CT_THIS))
+               {
+                  D_LOG_FMT(LFCN, "%s(%d):", __func__, __LINE__);
+                  LOG_FMT(LFCN, " --? skipped MEMBER and landed on %s\n",
+                          (prev == NULL) ? "<null>" : get_token_name(prev->type));
+
+                  set_chunk_type(pc, CT_FUNC_CALL);
+                  isa_def  = false;
+                  do_break = true;
+                  break;
+               }
+
                D_LOG_FMT(LFCN, "%s(%d):", __func__, __LINE__);
-               LOG_FMT(LFCN, " --? Skipped MEMBER and landed on %s\n",
-                       (prev == NULL) ? "<null>" : get_token_name(prev->type));
-               set_chunk_type(pc, CT_FUNC_CALL);
-               isa_def = false;
+               LOG_FMT(LFCN, " <skip '%s'>", prev->text());
+               D_LOG_FMT(LFCN, "\n");
+
+               // Issue #1112
+               prev = chunk_get_prev_ncnlnpnd(prev);
+               if (prev == nullptr)
+               {
+                  LOG_FMT(LFCN, "nullptr\n");
+               }
+               else
+               {
+                  LOG_FMT(LFCN, "orig_line is %zu, orig_col is %zu, text() '%s'\n",
+                          prev->orig_line, prev->orig_col, prev->text());
+               }
+            }
+            if (do_break)
+            {
                break;
-            }
-            D_LOG_FMT(LFCN, "%s(%d):", __func__, __LINE__);
-            LOG_FMT(LFCN, " <skip '%s'>", prev->text());
-            D_LOG_FMT(LFCN, "\n");
-            // Issue #1112
-            prev = chunk_get_prev_ncnlnpnd(prev);
-            if (prev == nullptr)
-            {
-               LOG_FMT(LFCN, "nullptr\n");
-            }
-            else
-            {
-               LOG_FMT(LFCN, "orig_line is %zu, orig_col is %zu, text() '%s'\n",
-                       prev->orig_line, prev->orig_col, prev->text());
             }
             continue;
          }

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -504,6 +504,7 @@
 34172  space_indent_columns-4.cfg           cpp/i1165.cpp
 34173  arith-vs-ptr.cfg                     cpp/i1464.cpp
 34174  arith-vs-ptr.cfg                     cpp/i1466.cpp
+34175  align_assign_span-1.cfg              cpp/i1509.cpp
 
 34190  bug_1003.cfg                         cpp/bug_1003.cpp
 

--- a/tests/input/cpp/i1509.cpp
+++ b/tests/input/cpp/i1509.cpp
@@ -1,0 +1,5 @@
+void f()
+{
+	int i = A::B::C::bar();
+	int ii = A::B::C::bar();
+}

--- a/tests/output/cpp/34175-i1509.cpp
+++ b/tests/output/cpp/34175-i1509.cpp
@@ -1,0 +1,5 @@
+void f()
+{
+	int i  = A::B::C::bar();
+	int ii = A::B::C::bar();
+}


### PR DESCRIPTION
Prior to this commit on this input:

int i = A::B::C::bar();

when `pc` was pointing at the token for 'bar' and the '::' before it was
pointed by `prev` the edited region only jumped back `prev` to 'B' instead
of '='.

This caused that `pc` in the end had the wrong flags assigned (PCF_VAR_1ST_DEF)
which in turn lead to a prematurely clearing of the align stack while aligning.