### PR TITLE
improve nested generics

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -412,7 +412,7 @@ void register_options(void)
    unc_add_option("sp_angle_word", UO_sp_angle_word, AT_IARF,
                   "Add or remove space between '<>' and a word as in 'List<byte> m;' or 'template <typename T> static ...'.");
    unc_add_option("sp_angle_shift", UO_sp_angle_shift, AT_IARF,
-                  "Add or remove space between '>' and '>' in '>>' (template stuff C++/C# only). Default=Add.");
+                  "Add or remove space between '>' and '>' in '>>' (template stuff). Default=Add.");
    unc_add_option("sp_permit_cpp11_shift", UO_sp_permit_cpp11_shift, AT_BOOL,
                   "Permit removal of the space between '>>' in 'foo<bar<int> >' (C++11 only). Default=False.\n"
                   "sp_angle_shift cannot remove the space without this option.");

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -1005,7 +1005,8 @@ static void check_template(chunk_t *start)
             && (pc->str[0] == '>')
             && (pc->len() > 1)
             && (  cpd.settings[UO_tok_split_gte].b
-               || (chunk_is_str(pc, ">>", 2) && num_tokens >= 2)))
+               || (  (chunk_is_str(pc, ">>", 2) || chunk_is_str(pc, ">>>", 3))
+                  && num_tokens >= 2)))
          {
             LOG_FMT(LTEMPL, "%s(%d): {split '%s' at orig_line %zu, orig_col %zu}\n",
                     __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col);

--- a/tests/cli/Output/mini_d_ucwd.txt
+++ b/tests/cli/Output/mini_d_ucwd.txt
@@ -191,7 +191,7 @@ sp_angle_paren_empty            = ignore   # ignore/add/remove/force
 # Add or remove space between '<>' and a word as in 'List<byte> m;' or 'template <typename T> static ...'.
 sp_angle_word                   = ignore   # ignore/add/remove/force
 
-# Add or remove space between '>' and '>' in '>>' (template stuff C++/C# only). Default=Add.
+# Add or remove space between '>' and '>' in '>>' (template stuff). Default=Add.
 sp_angle_shift                  = add      # ignore/add/remove/force
 
 # Permit removal of the space between '>>' in 'foo<bar<int> >' (C++11 only). Default=False.

--- a/tests/cli/Output/mini_nd_ucwd.txt
+++ b/tests/cli/Output/mini_nd_ucwd.txt
@@ -191,7 +191,7 @@ sp_angle_paren_empty            = ignore   # ignore/add/remove/force
 # Add or remove space between '<>' and a word as in 'List<byte> m;' or 'template <typename T> static ...'.
 sp_angle_word                   = ignore   # ignore/add/remove/force
 
-# Add or remove space between '>' and '>' in '>>' (template stuff C++/C# only). Default=Add.
+# Add or remove space between '>' and '>' in '>>' (template stuff). Default=Add.
 sp_angle_shift                  = add      # ignore/add/remove/force
 
 # Permit removal of the space between '>>' in 'foo<bar<int> >' (C++11 only). Default=False.

--- a/tests/cli/Output/show_config.txt
+++ b/tests/cli/Output/show_config.txt
@@ -191,7 +191,7 @@ sp_angle_word                   { Ignore, Add, Remove, Force }
   Add or remove space between '<>' and a word as in 'List<byte> m;' or 'template <typename T> static ...'.
 
 sp_angle_shift                  { Ignore, Add, Remove, Force }
-  Add or remove space between '>' and '>' in '>>' (template stuff C++/C# only). Default=Add.
+  Add or remove space between '>' and '>' in '>>' (template stuff). Default=Add.
 
 sp_permit_cpp11_shift           { False, True }
   Permit removal of the space between '>>' in 'foo<bar<int> >' (C++11 only). Default=False.

--- a/tests/config/template_angles.cfg
+++ b/tests/config/template_angles.cfg
@@ -1,0 +1,4 @@
+sp_before_angle                 = remove
+sp_inside_angle                 = remove
+sp_angle_paren_empty            = remove
+sp_angle_shift                  = remove

--- a/tests/input/java/generics.java
+++ b/tests/input/java/generics.java
@@ -1,0 +1,30 @@
+// Note: Some tests running on this _input_ file rely upon that the tripple 
+// closing '>' are not separated by spaces or anything else!
+public class TestClass {
+private static void initMap(void) {
+	HashMap < String, HashMap < String, List < Track >>> resolutionTracks = new HashMap < String, HashMap < String, List < Track >>> ();
+}
+
+private static void addTrackToMap(String resolution, Track track, HashMap < String, HashMap < String, List < Track >>> resolutionTracks) {
+	HashMap<String, List<Track> > tracks = null;
+
+	if (resolutionTracks.containsKey(resolution)) {
+		tracks = resolutionTracks.get(resolution);
+	} else {
+		tracks = new HashMap<String, List<Track> >();
+		tracks.put("soun", new LinkedList<Track>());
+		tracks.put("vide", new LinkedList<Track>());
+		resolutionTracks.put(resolution, tracks);
+	}
+
+	if (track.getHandler() != null) {
+		if (track.getHandler().equals("soun")) {
+			List<Track> audioTracks = tracks.get("soun");
+			audioTracks.add(track);
+		} else if (track.getHandler().equals("vide")) {
+			List<Track> videoTracks = tracks.get("vide");
+			videoTracks.add(track);
+		}
+	}
+}
+}

--- a/tests/java.test
+++ b/tests/java.test
@@ -21,3 +21,5 @@
 80063  empty.cfg                            java/i1121.java
 
 80100  align_same_func_call_params-t.cfg    java/sf567.java
+
+80201  template_angles.cfg                  java/generics.java

--- a/tests/output/java/80201-generics.java
+++ b/tests/output/java/80201-generics.java
@@ -1,0 +1,30 @@
+// Note: Some tests running on this _input_ file rely upon that the tripple
+// closing '>' are not separated by spaces or anything else!
+public class TestClass {
+private static void initMap(void) {
+	HashMap<String, HashMap<String, List<Track>>> resolutionTracks = new HashMap<String, HashMap<String, List<Track>>>();
+}
+
+private static void addTrackToMap(String resolution, Track track, HashMap<String, HashMap<String, List<Track>>> resolutionTracks) {
+	HashMap<String, List<Track>> tracks = null;
+
+	if (resolutionTracks.containsKey(resolution)) {
+		tracks = resolutionTracks.get(resolution);
+	} else {
+		tracks = new HashMap<String, List<Track>>();
+		tracks.put("soun", new LinkedList<Track>());
+		tracks.put("vide", new LinkedList<Track>());
+		resolutionTracks.put(resolution, tracks);
+	}
+
+	if (track.getHandler() != null) {
+		if (track.getHandler().equals("soun")) {
+			List<Track> audioTracks = tracks.get("soun");
+			audioTracks.add(track);
+		} else if (track.getHandler().equals("vide")) {
+			List<Track> videoTracks = tracks.get("vide");
+			videoTracks.add(track);
+		}
+	}
+}
+}


### PR DESCRIPTION
">>>" symbol in punctuators.cpp is conflicting
with angle/template probe, causing incorrect
whitespace formatting

workaround by checking ">>>" explicitly

Example failure from the diff file:
<code>
```diff
 public class TestClass {
     private static void initMap(void) {
-        HashMap<String, HashMap<String, List<Track>>> resolutionTracks = new HashMap<String, HashMap<String, List<Track>>>();
+        HashMap < String, HashMap < String, List < Track >>> resolutionTracks = new HashMap < String, HashMap < String, List < Track >>> ();
     }

-    private static void addTrackToMap(String resolution, Track track, HashMap<String, HashMap<String, List<Track>>> resolutionTracks) {
+    private static void addTrackToMap(String resolution, Track track, HashMap < String, HashMap < String, List < Track >>> resolutionTracks) {
         HashMap<String, List<Track>> tracks = null;
```
</code>
original commit: fde8ac83c7d5b0473a77140915b77bd6706794fa