### PR TITLE
fix sp_before_byref=remove on Java if statements with &&

### DIFF
--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -843,7 +843,9 @@ void tokenize_cleanup(void)
       }
 
       // Add minimal support for C++0x rvalue references
-      if (pc->type == CT_BOOL && chunk_is_str(pc, "&&", 2))
+      if (  pc->type == CT_BOOL
+         && (cpd.lang_flags & LANG_CPP)
+         && chunk_is_str(pc, "&&", 2))
       {
          if (prev->type == CT_TYPE)
          {

--- a/tests/input/java/sp_before_byref.java
+++ b/tests/input/java/sp_before_byref.java
@@ -1,0 +1,5 @@
+public static void method() {
+	if (argA != null && argB != null) {
+	}
+	return (argA != null && argB != null);
+}

--- a/tests/java.test
+++ b/tests/java.test
@@ -22,4 +22,5 @@
 
 80100  align_same_func_call_params-t.cfg    java/sf567.java
 
+80200  sp_before_byref-r.cfg                java/sp_before_byref.java
 80201  template_angles.cfg                  java/generics.java

--- a/tests/output/java/80200-sp_before_byref.java
+++ b/tests/output/java/80200-sp_before_byref.java
@@ -1,0 +1,5 @@
+public static void method() {
+	if (argA != null && argB != null) {
+	}
+	return (argA != null && argB != null);
+}


### PR DESCRIPTION
In some languages (java, cs, ...) 'null' is handled as type.
Prior to this commit, in cases where a 'null' `CT_TYPE` chunk was followed by an '&&' operator, caused that the insufficient rvalue references check to passed and transformed the operator into a byref.
This in turn enabled the use of sp_before_byref.

For C++ the rvalue references check works as intended because 'null' is not handled as `CT_TYPE`.

To fix the issue an additional condition was added to the rvalue references check that only passes if the  current language is C++.

Example failure from the diff file:
<code>

```diff
 public class JavaClass {
     public static void method() {
-        if (argA != null && argB != null) {
+        if (argA != null&& argB != null) {
         }
     }
 }
```

</code>

original commit: 4130602b1343fc412e5a16e9c09fc3f29e990a6b