### PR TITLE
fix problem that caused newlines between function prototypes:

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1956,13 +1956,27 @@ static void mark_function_return_type(chunk_t *fname, chunk_t *start, c_token_t 
       D_LOG_FMT(LFCN, "\n");
 
       chunk_t *first = pc;
-      chunk_t *save;
       while (pc != nullptr)
       {
          LOG_FMT(LFCNR, "%s(%d): text() '%s', type is %s\n", __func__, __LINE__, pc->text(), get_token_name(pc->type));
 #ifdef DEBUG
          log_pcf_flags(LFCNR, pc->flags);
 #endif
+         if (pc->type == CT_ANGLE_CLOSE)
+         {
+            pc = skip_template_prev(pc);
+            if (pc == nullptr || pc->type == CT_TEMPLATE)
+            {
+               //either expression is not complete or this is smth like 'template<T> void func()'
+               //  - we are not interested in 'template<T>' part
+               break;
+            }
+            else
+            {
+               //this is smth like 'vector<int> func()' and 'pc' is currently on 'vector' - just proceed
+            }
+         }
+
          if (  (  !chunk_is_type(pc)
                && pc->type != CT_OPERATOR
                && pc->type != CT_WORD
@@ -1975,32 +1989,7 @@ static void mark_function_return_type(chunk_t *fname, chunk_t *start, c_token_t 
          {
             first = pc;
          }
-         save = pc; // keep a copy
-         pc   = chunk_get_prev_ncnl(pc);
-         if (pc != nullptr)
-         {
-            log_pcf_flags(LFCNR, pc->flags);
-            // Issue #1027
-            if (  (pc->flags & PCF_IN_TEMPLATE)
-               && pc->type == CT_ANGLE_CLOSE)
-            {
-               // search the opening angle
-               pc = chunk_get_prev_type(pc, CT_ANGLE_OPEN, save->level);
-               if (pc != nullptr)
-               {
-                  // get the prev
-                  pc = chunk_get_prev(pc);
-                  if (pc != nullptr)
-                  {
-                     if (pc->type == CT_TYPE)
-                     {
-                        first = save;
-                        break;
-                     }
-                  }
-               }
-            }
-         }
+         pc = chunk_get_prev_ncnl(pc);
       }
 
       // Changing words to types into tuple return types in CS.
@@ -2030,6 +2019,17 @@ static void mark_function_return_type(chunk_t *fname, chunk_t *start, c_token_t 
             break;
          }
          pc = chunk_get_next_ncnl(pc);
+
+         //template angles should keep parent type CT_TEMPLATE
+         if (pc != nullptr && pc->type == CT_ANGLE_OPEN)
+         {
+            pc = chunk_get_next_type(pc, CT_ANGLE_CLOSE, pc->level);
+            if (pc == start)
+            {
+               break;
+            }
+            pc = chunk_get_next_ncnl(pc);
+         }
       }
       LOG_FMT(LFCNR, "\n");
    }

--- a/tests/config/bug_1432.cfg
+++ b/tests/config/bug_1432.cfg
@@ -1,0 +1,2 @@
+nl_after_func_proto = 0
+nl_after_func_proto_group = 2

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -105,6 +105,7 @@
 
 30110  class-nl_func-add2.cfg               cpp/class-init.cpp
 30111  indent_columns-4.cfg                 cpp/bug_1346.h
+30112  bug_1432.cfg                         cpp/bug_1432.cpp
 
 30201  cmt_indent-1.cfg                     cpp/cmt_indent.cpp
 30202  cmt_indent-2.cfg                     cpp/cmt_indent.cpp

--- a/tests/input/cpp/bug_1432.cpp
+++ b/tests/input/cpp/bug_1432.cpp
@@ -1,0 +1,2 @@
+void set();
+vector<int> get();

--- a/tests/output/cpp/30112-bug_1432.cpp
+++ b/tests/output/cpp/30112-bug_1432.cpp
@@ -1,0 +1,2 @@
+void set();
+vector<int> get();


### PR DESCRIPTION
return type was not marked with ‘FUNC_PROTO’ parent type

Adopt the PR #1433, add a test for it
Thank to parapaul