### PR TITLE
add sp_cpp_before_struct_binding to support C++17 structured binding declarations

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -450,6 +450,8 @@ void register_options(void)
                   "Add or remove space before '[' (except '[]').");
    unc_add_option("sp_before_squares", UO_sp_before_squares, AT_IARF,
                   "Add or remove space before '[]'.");
+   unc_add_option("sp_cpp_before_struct_binding", UO_sp_cpp_before_struct_binding, AT_IARF,
+                  "Add or remove space before structured bindings. Only for C++17.");
    unc_add_option("sp_inside_square", UO_sp_inside_square, AT_IARF,
                   "Add or remove space inside a non-empty '[' and ']'.");
    unc_add_option("sp_after_comma", UO_sp_after_comma, AT_IARF,

--- a/src/options.h
+++ b/src/options.h
@@ -216,6 +216,7 @@ enum uncrustify_options
    UO_sp_after_semi_for_empty,     // space after final ';' in empty for statement
    UO_sp_before_square,            // space before single '['
    UO_sp_before_squares,           // space before '[]', as in 'byte []'
+   UO_sp_cpp_before_struct_binding, // space before structured binding declaration
    UO_sp_inside_square,            // space inside 'byte[ 5 ]' vs 'byte[5]'
    UO_sp_after_comma,              // space after ','
    UO_sp_before_comma,             // space before ','

--- a/src/options.h
+++ b/src/options.h
@@ -147,99 +147,99 @@ enum uncrustify_options
    UO_utf8_force,
 
    // group: UG_space, "Spacing options"                                                        1
-   UO_sp_arith,                    // space around + - / * etc
-                                   // also ">>>" "<<" ">>" "%" "|"
-   UO_sp_arith_additive,           // space around + or -
-   UO_sp_assign,                   // space around =, +=, etc
-   UO_sp_cpp_lambda_assign,        // space around the capture spec [=](...){...}
-   UO_sp_cpp_lambda_paren,         // space after the capture spec [] (...){...}
-   UO_sp_assign_default,           // space around '=' in prototype
-   UO_sp_before_assign,            // space before =, +=, etc
-   UO_sp_after_assign,             // space after =, +=, etc
-   UO_sp_enum_paren,               // space in 'NS_ENUM ('"
-   UO_sp_enum_assign,              // space around = in enum
-   UO_sp_enum_before_assign,       // space before = in enum
-   UO_sp_enum_after_assign,        // space after = in enum
-   UO_sp_enum_colon,               // space around ':' in enum
-   UO_sp_pp_concat,                // space around ##
-   UO_sp_pp_stringify,             // space after #
-   UO_sp_before_pp_stringify,      // space before # in a #define x(y) L#y
-   UO_sp_bool,                     // space around || &&
-   UO_sp_compare,                  // space around < > ==, etc
-   UO_sp_inside_paren,             // space inside '+ ( xxx )' vs '+ (xxx)'
-   UO_sp_paren_paren,              // space between nested parens - '( (' vs '(('
-   UO_sp_cparen_oparen,            // space between nested parens - ') (' vs ')('
-   UO_sp_balance_nested_parens,    // balance spaces inside nested parens
-   UO_sp_paren_brace,              // space between ')' and '{'
-   UO_sp_before_ptr_star,          // space before a '*' that is part of a type
-   UO_sp_before_unnamed_ptr_star,  //
-   UO_sp_between_ptr_star,         // space between two '*' that are part of a type
-   UO_sp_after_ptr_star,           // space after a '*' that is part of a type
-   UO_sp_after_ptr_star_qualifier, // space after a '*' next to a qualifier
-   UO_sp_after_ptr_star_func,      // space between a '*' and a function proto/def
-   UO_sp_ptr_star_paren,           //
-   UO_sp_before_ptr_star_func,     //
-   UO_sp_before_byref,             // space before '&' of 'fcn(int& idx)'
-   UO_sp_before_unnamed_byref,     //
-   UO_sp_after_byref,              // space after a '&'  as in 'int& var'
-   UO_sp_after_byref_func,         //
-   UO_sp_before_byref_func,        //
-   UO_sp_after_type,               // space between type and word
-   UO_sp_before_template_paren,    // D: 'template Foo('
-   UO_sp_template_angle,           //
-   UO_sp_before_angle,             // space before '<>', as in '<class T>'
-   UO_sp_inside_angle,             // space inside '<>', as in '<class T>'
-   UO_sp_angle_colon,              // space between '<>' and ':'
-   UO_sp_after_angle,              // space after  '<>', as in '<class T>'
-   UO_sp_angle_paren,              // space between '<>' and '(' in 'a = new List<byte>(foo);'
-   UO_sp_angle_paren_empty,        // space between '<>' and '()' in 'a = new List<byte>();'
-   UO_sp_angle_word,               // space between '<>' and a word in 'List<byte> a;
-                                   // or template <typename T> static ...'
-   UO_sp_angle_shift,              // '> >' vs '>>'
-   UO_sp_permit_cpp11_shift,       // '>>' vs '> >' for C++11 code
-   UO_sp_before_sparen,            // space before '(' of 'if/for/while/switch/etc'
-   UO_sp_inside_sparen,            // space inside 'if( xxx )' vs 'if(xxx)'
-   UO_sp_inside_sparen_close,      //
-   UO_sp_inside_sparen_open,       //
-   UO_sp_after_sparen,             // space after  ')' of 'if/for/while/switch/etc'
-                                   // the do-while does not get set here
-   UO_sp_sparen_brace,             // space between ')' and '{' of if, while, etc
-   UO_sp_invariant_paren,          //
-   UO_sp_after_invariant_paren,    //
-   UO_sp_special_semi,             // space empty stmt ';' on while, if, for
-                                   //   example 'while (*p++ = ' ') ;'
-   UO_sp_before_semi,              // space before all ';'
-   UO_sp_before_semi_for,          // space before the two ';' in a for() - non-empty
-   UO_sp_before_semi_for_empty,    // space before ';' in empty for statement
-   UO_sp_after_semi,               //
-   UO_sp_after_semi_for,           //
-   UO_sp_after_semi_for_empty,     // space after final ';' in empty for statement
-   UO_sp_before_square,            // space before single '['
-   UO_sp_before_squares,           // space before '[]', as in 'byte []'
+   UO_sp_arith,                     // space around + - / * etc
+                                    // also ">>>" "<<" ">>" "%" "|"
+   UO_sp_arith_additive,            // space around + or -
+   UO_sp_assign,                    // space around =, +=, etc
+   UO_sp_cpp_lambda_assign,         // space around the capture spec [=](...){...}
+   UO_sp_cpp_lambda_paren,          // space after the capture spec [] (...){...}
+   UO_sp_assign_default,            // space around '=' in prototype
+   UO_sp_before_assign,             // space before =, +=, etc
+   UO_sp_after_assign,              // space after =, +=, etc
+   UO_sp_enum_paren,                // space in 'NS_ENUM ('"
+   UO_sp_enum_assign,               // space around = in enum
+   UO_sp_enum_before_assign,        // space before = in enum
+   UO_sp_enum_after_assign,         // space after = in enum
+   UO_sp_enum_colon,                // space around ':' in enum
+   UO_sp_pp_concat,                 // space around ##
+   UO_sp_pp_stringify,              // space after #
+   UO_sp_before_pp_stringify,       // space before # in a #define x(y) L#y
+   UO_sp_bool,                      // space around || &&
+   UO_sp_compare,                   // space around < > ==, etc
+   UO_sp_inside_paren,              // space inside '+ ( xxx )' vs '+ (xxx)'
+   UO_sp_paren_paren,               // space between nested parens - '( (' vs '(('
+   UO_sp_cparen_oparen,             // space between nested parens - ') (' vs ')('
+   UO_sp_balance_nested_parens,     // balance spaces inside nested parens
+   UO_sp_paren_brace,               // space between ')' and '{'
+   UO_sp_before_ptr_star,           // space before a '*' that is part of a type
+   UO_sp_before_unnamed_ptr_star,   //
+   UO_sp_between_ptr_star,          // space between two '*' that are part of a type
+   UO_sp_after_ptr_star,            // space after a '*' that is part of a type
+   UO_sp_after_ptr_star_qualifier,  // space after a '*' next to a qualifier
+   UO_sp_after_ptr_star_func,       // space between a '*' and a function proto/def
+   UO_sp_ptr_star_paren,            //
+   UO_sp_before_ptr_star_func,      //
+   UO_sp_before_byref,              // space before '&' of 'fcn(int& idx)'
+   UO_sp_before_unnamed_byref,      //
+   UO_sp_after_byref,               // space after a '&'  as in 'int& var'
+   UO_sp_after_byref_func,          //
+   UO_sp_before_byref_func,         //
+   UO_sp_after_type,                // space between type and word
+   UO_sp_before_template_paren,     // D: 'template Foo('
+   UO_sp_template_angle,            //
+   UO_sp_before_angle,              // space before '<>', as in '<class T>'
+   UO_sp_inside_angle,              // space inside '<>', as in '<class T>'
+   UO_sp_angle_colon,               // space between '<>' and ':'
+   UO_sp_after_angle,               // space after  '<>', as in '<class T>'
+   UO_sp_angle_paren,               // space between '<>' and '(' in 'a = new List<byte>(foo);'
+   UO_sp_angle_paren_empty,         // space between '<>' and '()' in 'a = new List<byte>();'
+   UO_sp_angle_word,                // space between '<>' and a word in 'List<byte> a;
+                                    // or template <typename T> static ...'
+   UO_sp_angle_shift,               // '> >' vs '>>'
+   UO_sp_permit_cpp11_shift,        // '>>' vs '> >' for C++11 code
+   UO_sp_before_sparen,             // space before '(' of 'if/for/while/switch/etc'
+   UO_sp_inside_sparen,             // space inside 'if( xxx )' vs 'if(xxx)'
+   UO_sp_inside_sparen_close,       //
+   UO_sp_inside_sparen_open,        //
+   UO_sp_after_sparen,              // space after  ')' of 'if/for/while/switch/etc'
+                                    // the do-while does not get set here
+   UO_sp_sparen_brace,              // space between ')' and '{' of if, while, etc
+   UO_sp_invariant_paren,           //
+   UO_sp_after_invariant_paren,     //
+   UO_sp_special_semi,              // space empty stmt ';' on while, if, for
+                                    //   example 'while (*p++ = ' ') ;'
+   UO_sp_before_semi,               // space before all ';'
+   UO_sp_before_semi_for,           // space before the two ';' in a for() - non-empty
+   UO_sp_before_semi_for_empty,     // space before ';' in empty for statement
+   UO_sp_after_semi,                //
+   UO_sp_after_semi_for,            //
+   UO_sp_after_semi_for_empty,      // space after final ';' in empty for statement
+   UO_sp_before_square,             // space before single '['
+   UO_sp_before_squares,            // space before '[]', as in 'byte []'
    UO_sp_cpp_before_struct_binding, // space before structured binding declaration
-   UO_sp_inside_square,            // space inside 'byte[ 5 ]' vs 'byte[5]'
-   UO_sp_after_comma,              // space after ','
-   UO_sp_before_comma,             // space before ','
-   UO_sp_after_mdatype_commas,     //
-   UO_sp_before_mdatype_commas,    //
-   UO_sp_between_mdatype_commas,   //
-   UO_sp_paren_comma,              //
-   UO_sp_before_ellipsis,          // space before '...'
-   UO_sp_after_class_colon,        // space after class ':'
-   UO_sp_before_class_colon,       // space before class ':'
-   UO_sp_after_constr_colon,       // space after class constructor ':'
-   UO_sp_before_constr_colon,      // space before class constructor ':'
-   UO_sp_before_case_colon,        // space before case ':'
-   UO_sp_after_operator,           // space after operator when followed by a punctuator
-   UO_sp_after_operator_sym,       // space after operator when followed by a punctuator
-   UO_sp_after_operator_sym_empty, // space after operator sign when the operator has no arguments
-   UO_sp_after_cast,               // space after C & D cast - '(int) a' vs '(int)a'
-   UO_sp_inside_paren_cast,        // spaces inside the parens of a cast
-   UO_sp_cpp_cast_paren,           //
-   UO_sp_sizeof_paren,             // space between 'sizeof' and '('
-   UO_sp_after_tag,                // pawn: space after a tag colon
-   UO_sp_inside_braces_enum,       // space inside enum '{' and '}' - '{ a, b, c }'
-   UO_sp_inside_braces_struct,     // space inside struct/union '{' and '}'
+   UO_sp_inside_square,             // space inside 'byte[ 5 ]' vs 'byte[5]'
+   UO_sp_after_comma,               // space after ','
+   UO_sp_before_comma,              // space before ','
+   UO_sp_after_mdatype_commas,      //
+   UO_sp_before_mdatype_commas,     //
+   UO_sp_between_mdatype_commas,    //
+   UO_sp_paren_comma,               //
+   UO_sp_before_ellipsis,           // space before '...'
+   UO_sp_after_class_colon,         // space after class ':'
+   UO_sp_before_class_colon,        // space before class ':'
+   UO_sp_after_constr_colon,        // space after class constructor ':'
+   UO_sp_before_constr_colon,       // space before class constructor ':'
+   UO_sp_before_case_colon,         // space before case ':'
+   UO_sp_after_operator,            // space after operator when followed by a punctuator
+   UO_sp_after_operator_sym,        // space after operator when followed by a punctuator
+   UO_sp_after_operator_sym_empty,  // space after operator sign when the operator has no arguments
+   UO_sp_after_cast,                // space after C & D cast - '(int) a' vs '(int)a'
+   UO_sp_inside_paren_cast,         // spaces inside the parens of a cast
+   UO_sp_cpp_cast_paren,            //
+   UO_sp_sizeof_paren,              // space between 'sizeof' and '('
+   UO_sp_after_tag,                 // pawn: space after a tag colon
+   UO_sp_inside_braces_enum,        // space inside enum '{' and '}' - '{ a, b, c }'
+   UO_sp_inside_braces_struct,      // space inside struct/union '{' and '}'
    UO_sp_after_type_brace_init_lst_open,
    UO_sp_before_type_brace_init_lst_close,
    UO_sp_inside_type_brace_init_lst,

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -809,6 +809,19 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
       return(cpd.settings[UO_sp_after_oc_msg_receiver].a);
    }
 
+   // c++17 structured bindings e.g., "auto [x, y, z]" vs a[x, y, z]" or "auto const [x, y, z]" vs "auto const[x, y, z]"
+   if (  cpd.lang_flags & LANG_CPP
+      && (  first->type == CT_BYREF
+         || first->type == CT_QUALIFIER
+         || first->type == CT_TYPE)
+      && second->type == CT_SQUARE_OPEN
+      && second->parent_type != CT_OC_MSG
+      && second->parent_type != CT_CS_SQ_STMT)
+   {
+      log_rule("UO_sp_cpp_before_struct_binding");
+      return(cpd.settings[UO_sp_cpp_before_struct_binding].a);
+   }
+
    // "a [x]" vs "a[x]"
    if (  second->type == CT_SQUARE_OPEN
       && (  second->parent_type != CT_OC_MSG

--- a/tests/cli/Output/help.txt
+++ b/tests/cli/Output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 614 options and minimal documentation.
+There are currently 615 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/tests/cli/Output/mini_d_uc.txt
+++ b/tests/cli/Output/mini_d_uc.txt
@@ -77,6 +77,7 @@ sp_after_semi_for               = force
 sp_after_semi_for_empty         = ignore
 sp_before_square                = ignore
 sp_before_squares               = ignore
+sp_cpp_before_struct_binding    = ignore
 sp_inside_square                = ignore
 sp_after_comma                  = ignore
 sp_before_comma                 = remove

--- a/tests/cli/Output/mini_d_ucwd.txt
+++ b/tests/cli/Output/mini_d_ucwd.txt
@@ -249,6 +249,9 @@ sp_before_square                = ignore   # ignore/add/remove/force
 # Add or remove space before '[]'.
 sp_before_squares               = ignore   # ignore/add/remove/force
 
+# Add or remove space before structured bindings. Only for C++17.
+sp_cpp_before_struct_binding    = ignore   # ignore/add/remove/force
+
 # Add or remove space inside a non-empty '[' and ']'.
 sp_inside_square                = ignore   # ignore/add/remove/force
 

--- a/tests/cli/Output/mini_nd_uc.txt
+++ b/tests/cli/Output/mini_nd_uc.txt
@@ -77,6 +77,7 @@ sp_after_semi_for               = force
 sp_after_semi_for_empty         = ignore
 sp_before_square                = ignore
 sp_before_squares               = ignore
+sp_cpp_before_struct_binding    = ignore
 sp_inside_square                = ignore
 sp_after_comma                  = ignore
 sp_before_comma                 = remove

--- a/tests/cli/Output/mini_nd_ucwd.txt
+++ b/tests/cli/Output/mini_nd_ucwd.txt
@@ -249,6 +249,9 @@ sp_before_square                = ignore   # ignore/add/remove/force
 # Add or remove space before '[]'.
 sp_before_squares               = ignore   # ignore/add/remove/force
 
+# Add or remove space before structured bindings. Only for C++17.
+sp_cpp_before_struct_binding    = ignore   # ignore/add/remove/force
+
 # Add or remove space inside a non-empty '[' and ']'.
 sp_inside_square                = ignore   # ignore/add/remove/force
 

--- a/tests/cli/Output/show_config.txt
+++ b/tests/cli/Output/show_config.txt
@@ -248,6 +248,9 @@ sp_before_square                { Ignore, Add, Remove, Force }
 sp_before_squares               { Ignore, Add, Remove, Force }
   Add or remove space before '[]'.
 
+sp_cpp_before_struct_binding    { Ignore, Add, Remove, Force }
+  Add or remove space before structured bindings. Only for C++17.
+
 sp_inside_square                { Ignore, Add, Remove, Force }
   Add or remove space inside a non-empty '[' and ']'.
 

--- a/tests/config/cpp17.cfg
+++ b/tests/config/cpp17.cfg
@@ -1,0 +1,1 @@
+sp_cpp_before_struct_binding    = force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -316,6 +316,8 @@
 32005  align_var_class_span-1.cfg           cpp/issue_633_typename.cpp
 32006  space_indent_columns-4.cfg           cpp/bug_i_687.cpp
 
+32100  cpp17.cfg                            cpp/cpp17.cpp
+
 33000  tab-0-11.cfg                         cpp/tab-0.cpp
 33001  indent_columns-11.cfg                cpp/tab-1.cpp
 33002  empty.cfg                            cpp/cmt_convert_tab_to_spaces.cpp

--- a/tests/input/cpp/cpp17.cpp
+++ b/tests/input/cpp/cpp17.cpp
@@ -1,0 +1,8 @@
+bool CompareGenomeByFeatureResults::clickOnLink(std::string const& inLink) {
+   auto const[sequence, type, firstPosition, lastPosition] = parseLink(inLink);
+   if (sequence.empty()) {
+      return true;
+   }
+   return showFeature(statistics.nameDocumentA, type, firstPosition, lastPosition);
+}
+

--- a/tests/output/cpp/32100-cpp17.cpp
+++ b/tests/output/cpp/32100-cpp17.cpp
@@ -1,0 +1,8 @@
+bool CompareGenomeByFeatureResults::clickOnLink(std::string const& inLink) {
+	auto const [sequence, type, firstPosition, lastPosition] = parseLink(inLink);
+	if (sequence.empty()) {
+		return true;
+	}
+	return showFeature(statistics.nameDocumentA, type, firstPosition, lastPosition);
+}
+


### PR DESCRIPTION
C++17 structured binding declarations use square brackets. The option allows

`auto [x, y, z] = f();`

to be formatted with a space following the variable and before the space. This also works for

`auto& [x, y, z] = f();`
`auto const [x, y, z] = f();`
`auto const& [x, y, z] = f();`

----------

original: #1547