### PR TITLE
In the above scenario "<"  &  ">"  are tokenized as template.

### DIFF
--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -969,18 +969,27 @@ static void check_template(chunk_t *start)
               __func__, __LINE__, get_token_name(prev->type));
 
       // Scan back and make sure we aren't inside square parenthesis
-      bool in_if = false;
+      bool in_if         = false;
+      bool hit_semicolon = false;
       pc = start;
       while ((pc = chunk_get_prev_ncnl(pc, scope_e::PREPROC)) != nullptr)
       {
-         if (  pc->type == CT_SEMICOLON
+         if (  (pc->type == CT_SEMICOLON && hit_semicolon)
             || pc->type == CT_BRACE_OPEN
             || pc->type == CT_BRACE_CLOSE
             || pc->type == CT_SQUARE_CLOSE)
          {
             break;
          }
-         if (pc->type == CT_IF || pc->type == CT_RETURN)
+         if (pc->type == CT_SEMICOLON && !hit_semicolon)
+         {
+            hit_semicolon = true;
+         }
+         if (  ((  pc->type == CT_IF
+                || pc->type == CT_RETURN
+                || pc->type == CT_WHILE
+                || pc->type == CT_WHILE_OF_DO) && hit_semicolon == false)
+            || (pc->type == CT_FOR && hit_semicolon == true))
          {
             in_if = true;
             break;

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -177,6 +177,7 @@
 
 30711  del_semicolon.cfg                    cpp/semicolons.cpp
 30712  empty.cfg                            cpp/bug_1158.cpp
+30713  empty.cfg                            cpp/fix_for_relational_operators.cpp
 
 30720  wessex.cfg                           cpp/custom-open-2.cpp
 

--- a/tests/input/cpp/fix_for_relational_operators.cpp
+++ b/tests/input/cpp/fix_for_relational_operators.cpp
@@ -1,0 +1,8 @@
+void foo()
+{
+while (a < b && c > d)
+i++;
+
+for  (  ;a < b && c > d; )
+i++;
+}

--- a/tests/output/cpp/30713-fix_for_relational_operators.cpp
+++ b/tests/output/cpp/30713-fix_for_relational_operators.cpp
@@ -1,0 +1,8 @@
+void foo()
+{
+	while (a < b && c > d)
+		i++;
+
+	for  (; a < b && c > d; )
+		i++;
+}


### PR DESCRIPTION
hit semicolon was introduced to solve the same problem in case of for loop.
making sure that they are present in condition. Because initialization may contain <> for
such as maps or sets iterations.

Thanks to Kalyana Chakravarthi