### PR TITLE
restrict closebrace comment options to consider the appropriate scopes

### DIFF
--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -887,7 +887,7 @@ void add_long_closebrace_comment(void)
       size_t  nl_count = 0;
 
       chunk_t *tmp = pc;
-      while ((tmp = chunk_get_next(tmp)) != nullptr)
+      while ((tmp = chunk_get_next(tmp, scope_e::PREPROC)) != nullptr)
       {
          if (chunk_is_newline(tmp))
          {

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -36,7 +36,7 @@
 enum class scope_e : unsigned int
 {
    ALL,      //! search in all kind of chunks
-   PREPROC,  //! search only in preprocessor chunks
+   PREPROC
 };
 
 

--- a/tests/config/mod_add_long_namespace_closebrace_comment-1.cfg
+++ b/tests/config/mod_add_long_namespace_closebrace_comment-1.cfg
@@ -1,0 +1,1 @@
+mod_add_long_namespace_closebrace_comment = 1

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -524,7 +524,7 @@
 34199  empty.cfg                            cpp/not_lambda.cpp
 
 34200  i1536.cfg                            cpp/i1536.cpp
-
+34201  mod_add_long_namespace_closebrace_comment-1.cfg  cpp/i1565.cpp
 
 
 # TODO: Find relevant test cases for 'override'.

--- a/tests/input/cpp/i1565.cpp
+++ b/tests/input/cpp/i1565.cpp
@@ -1,0 +1,9 @@
+namespace ns1 {
+namespace ns2 {
+
+  #define SOME_MACRO() \
+	if(true) { \
+	}
+
+}
+}

--- a/tests/output/cpp/34201-i1565.cpp
+++ b/tests/output/cpp/34201-i1565.cpp
@@ -1,0 +1,9 @@
+namespace ns1 {
+namespace ns2 {
+
+  #define SOME_MACRO() \
+	if(true) { \
+	}
+
+} // namespace ns2
+} // namespace ns1


### PR DESCRIPTION
opening and closing braces should be in the same scope of blocks (preproc,
non preproc)

<table>
<tr>
<td>Input</td><td>Output (prev)</td><td>Output (now), Expected</td>
</tr>

<tr>

<td>
<pre lang="cpp"><code>
namespace ns1 {
namespace ns2 {

  #define SOME_MACRO() \
	if(true) { \
	}

}
}
</code></pre>
</td>
<td>
<pre lang="cpp"><code>
namespace ns1 {
namespace ns2 {

  #define SOME_MACRO() \
	if(true) { \
	}  // namespace ns2

}
}  // namespace ns1
</code></pre>
</td>
<td>
<pre lang="cpp"><code>
namespace ns1 {
namespace ns2 {

  #define SOME_MACRO() \
	if(true) { \
	}

}  // namespace ns2
}  // namespace ns1
</code></pre>
</td>

</tr>
</table>



Because the the opening brace of ns2 had the same level (1) as the if closing
brace the comment text was appended thereafter.

This commit fix this behaviour by adding a check for the scopes.

Additionally removes wrong comment, see the comment above scope_e enum.

----------

ref #1565 