### PR TITLE
set flags for enum/struct if they are preceded by a typdef

### DIFF
--- a/tests/c.test
+++ b/tests/c.test
@@ -358,6 +358,8 @@
 09612  empty.cfg                            c/bug_1041.c
 09613  empty.cfg                            c/i1413.c
 09614  empty.cfg                            c/string_prefixes.c
+09615  i1564.cfg                            c/i1564.c
+
 
 10005  empty.cfg                            c/i1270.c
 

--- a/tests/config/i1564.cfg
+++ b/tests/config/i1564.cfg
@@ -1,0 +1,2 @@
+pos_comma                       = lead
+pos_enum_comma                  = trail

--- a/tests/config/rdan.cfg
+++ b/tests/config/rdan.cfg
@@ -1,5 +1,6 @@
 sp_arith                        = force
 sp_assign                       = force
+sp_enum_assign                  = force
 sp_bool                         = force
 sp_compare                      = force
 sp_inside_paren                 = remove

--- a/tests/input/c/i1564.c
+++ b/tests/input/c/i1564.c
@@ -1,0 +1,13 @@
+void f(){
+	return f(p0,
+	         p1);
+}
+
+typedef enum
+{
+	xxx = 0x00   /* comment */
+	, yyy = 0x01 /* comment */
+	, zzz = 0x02 /* comment */
+	, ttt = 0x03 /* comment */
+	, rrr = 0x04 /* comment */
+}some_label;

--- a/tests/output/c/09615-i1564.c
+++ b/tests/output/c/09615-i1564.c
@@ -1,0 +1,13 @@
+void f(){
+	return f(p0
+	         ,p1);
+}
+
+typedef enum
+{
+	xxx = 0x00,  /* comment */
+	yyy = 0x01,  /* comment */
+	zzz = 0x02,  /* comment */
+	ttt = 0x03,  /* comment */
+	rrr = 0x04   /* comment */
+}some_label;


### PR DESCRIPTION
Some config options related to enums and structs need to right flags to be set to function properly.

The `sp_enum_assign = force` option had to be added to the `rdan.cfg` because before this commit the enum flags where missing so that `sp_assign` was applied.
With the flags in place now `sp_assign`is not used any more and `sp_enum_assign` is needed to recreate the expected formatting.

Some other misc refactoring of the code.

------

ref: #1564 