### PR TITLE
allow scoped variable types in variable definition blocks

### DIFF
--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -881,3 +881,42 @@ chunk_t *chunk_get_prev_ssq(chunk_t *cur)
    }
    return(cur);
 }
+
+
+//! skip to the final word/type in a :: chain
+static chunk_t *chunk_skip_dc_member(chunk_t *start, scope_e scope, direction_e dir)
+{
+   LOG_FUNC_ENTRY();
+   if (start == nullptr)
+   {
+      return(nullptr);
+   }
+
+   const auto step_fcn = (dir == direction_e::FORWARD)
+                         ? chunk_get_next_ncnl : chunk_get_prev_ncnl;
+
+   chunk_t *pc   = start;
+   chunk_t *next = (pc->type == CT_DC_MEMBER) ? pc : step_fcn(pc, scope);
+   while (chunk_is_token(next, CT_DC_MEMBER))
+   {
+      pc = step_fcn(next, scope);
+      if (pc == nullptr)
+      {
+         return(nullptr);
+      }
+      next = step_fcn(pc, scope);
+   }
+   return(pc);
+}
+
+
+chunk_t *chunk_skip_dc_member(chunk_t *start, scope_e scope)
+{
+   return(chunk_skip_dc_member(start, scope, direction_e::FORWARD));
+}
+
+
+chunk_t *chunk_skip_dc_member_rev(chunk_t *start, scope_e scope)
+{
+   return(chunk_skip_dc_member(start, scope, direction_e::BACKWARD));
+}

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -509,6 +509,11 @@ static_inline chunk_t *chunk_skip_to_match_rev(chunk_t *cur, scope_e scope = sco
 }
 
 
+//! skip to the final word/type in a :: chain
+chunk_t *chunk_skip_dc_member(chunk_t *start, scope_e scope = scope_e::ALL);
+chunk_t *chunk_skip_dc_member_rev(chunk_t *start, scope_e scope = scope_e::ALL);
+
+
 /**
  * checks if a chunk is valid and is a comment
  *

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -50,13 +50,6 @@ static void flag_asm(chunk_t *pc);
 static bool chunk_ends_type(chunk_t *start);
 
 
-/**
- * skip to the final word/type in a :: chain
- * pc is either a word or a ::
- */
-static chunk_t *skip_dc_member(chunk_t *start);
-
-
 //! Skips to the start of the next statement.
 static chunk_t *skip_to_next_statement(chunk_t *pc);
 
@@ -737,29 +730,6 @@ static bool chunk_ends_type(chunk_t *start)
 
    return(ret);
 } // chunk_ends_type
-
-
-static chunk_t *skip_dc_member(chunk_t *start)
-{
-   LOG_FUNC_ENTRY();
-   if (!start)
-   {
-      return(nullptr);
-   }
-
-   chunk_t *pc   = start;
-   chunk_t *next = (pc->type == CT_DC_MEMBER) ? pc : chunk_get_next_ncnl(pc);
-   while (chunk_is_token(next, CT_DC_MEMBER))
-   {
-      pc = chunk_get_next_ncnl(next);
-      if (pc == nullptr)
-      {
-         return(nullptr);
-      }
-      next = chunk_get_next_ncnl(pc);
-   }
-   return(pc);
-}
 
 
 void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
@@ -1467,7 +1437,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
          || pc->type == CT_CLASS
          || pc->type == CT_ENUM))
    {
-      tmp = skip_dc_member(next);
+      tmp = chunk_skip_dc_member(next);
       if (  tmp
          && (tmp->type == CT_TYPE || tmp->type == CT_WORD))
       {

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -1645,12 +1645,11 @@ static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
             var_blk       = false;
          }
          else if (  chunk_is_type(pc)
-                 && ((  chunk_is_type(next)
-                     || next->type == CT_WORD
-                     || next->type == CT_FUNC_CTOR_VAR))
-                 && !(next->type == CT_DC_MEMBER))  // DbConfig::configuredDatabase()->apply(db);
-                                                    // is NOT a declaration of a variable
-                                                    // guy 2015-09-22
+                 && (  next->type != CT_DC_MEMBER  // proceed if not CT_DC_MEMBER else skip it
+                    || (next = chunk_skip_dc_member(next)) != nullptr)
+                 && (  chunk_is_type(next)
+                    || next->type == CT_WORD
+                    || next->type == CT_FUNC_CTOR_VAR))
          {
             // set newlines before var def block
             if (  !var_blk
@@ -1695,7 +1694,7 @@ static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
                && fn_top
                && (cpd.settings[UO_nl_func_var_def_blk].u > 0))
             {
-               newline_min_after(prev, 1 + cpd.settings[UO_nl_func_var_def_blk].u, PCF_VAR_DEF);
+               newline_min_after(prev, 1 + cpd.settings[UO_nl_func_var_def_blk].u, PCF_VAR_DEF); // TODO: why +1 ?
             }
             // set newlines after var def block
             else if (var_blk && (cpd.settings[UO_nl_var_def_blk_end].u > 0))

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -1529,7 +1529,6 @@ static void newlines_do_else(chunk_t *start, argval_t nl_opt)
 static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *pc;
    bool    did_this_line = false;
    bool    first_var_blk = true;
    bool    typedef_blk   = false;
@@ -1539,10 +1538,11 @@ static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
    // can't be any variable definitions in a "= {" block
    if (chunk_is_token(prev, CT_ASSIGN))
    {
-      pc = chunk_get_next_type(start, CT_BRACE_CLOSE, start->level);
-      return(chunk_get_next_ncnl(pc));
+      chunk_t *tmp = chunk_get_next_type(start, CT_BRACE_CLOSE, start->level);
+      return(chunk_get_next_ncnl(tmp));
    }
-   pc = chunk_get_next(start);
+
+   chunk_t *pc = chunk_get_next(start);
    while (  pc != nullptr
          && (pc->level >= start->level || pc->level == 0))
    {
@@ -1570,10 +1570,7 @@ static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
       if (pc->type == CT_VBRACE_OPEN)
       {
          pc = chunk_get_next_type(pc, CT_VBRACE_CLOSE, pc->level);
-         if (pc != nullptr)
-         {
-            pc = chunk_get_next(pc);
-         }
+         pc = chunk_get_next(pc);
          continue;
       }
 
@@ -1602,13 +1599,14 @@ static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
          {
             break;
          }
+
          prev = chunk_get_prev_ncnl(pc);
          if (pc->type == CT_TYPEDEF)
          {
             // set newlines before typedef block
             if (  !typedef_blk
                && prev != nullptr
-               && (cpd.settings[UO_nl_typedef_blk_start].u > 0))
+               && cpd.settings[UO_nl_typedef_blk_start].u > 0)
             {
                newline_min_after(prev, cpd.settings[UO_nl_typedef_blk_start].u, PCF_VAR_DEF);
             }
@@ -1636,10 +1634,11 @@ static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
             }
             // set newlines after var def block
             else if (  var_blk
-                    && (cpd.settings[UO_nl_var_def_blk_end].u > 0))
+                    && cpd.settings[UO_nl_var_def_blk_end].u > 0)
             {
                newline_min_after(prev, cpd.settings[UO_nl_var_def_blk_end].u, PCF_VAR_DEF);
             }
+
             pc            = chunk_get_next_type(pc, CT_SEMICOLON, pc->level);
             typedef_blk   = true;
             first_var_blk = false;
@@ -1656,7 +1655,7 @@ static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
             // set newlines before var def block
             if (  !var_blk
                && !first_var_blk
-               && (cpd.settings[UO_nl_var_def_blk_start].u > 0))
+               && cpd.settings[UO_nl_var_def_blk_start].u > 0)
             {
                newline_min_after(prev, cpd.settings[UO_nl_var_def_blk_start].u, PCF_VAR_DEF);
             }

--- a/tests/config/i1516.cfg
+++ b/tests/config/i1516.cfg
@@ -1,0 +1,4 @@
+nl_func_var_def_blk             = 2
+nl_var_def_blk_start            = 2
+nl_var_def_blk_end              = 2
+nl_var_def_blk_in               = 1

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -526,6 +526,8 @@
 34200  i1536.cfg                            cpp/i1536.cpp
 34201  mod_add_long_namespace_closebrace_comment-1.cfg  cpp/i1565.cpp
 
+34203  i1516.cfg                            cpp/i1516.cpp
+
 
 # TODO: Find relevant test cases for 'override'.
 34210  empty.cfg                            cpp/override_virtual.cpp

--- a/tests/input/cpp/i1516.cpp
+++ b/tests/input/cpp/i1516.cpp
@@ -1,0 +1,15 @@
+void myClass::foo() {
+	int bar;
+	std::string str;
+	DbConfig::configuredDatabase()->apply(db);
+	std::string str2;
+
+	std::string str2;
+	f();
+	DbConfig::configuredDatabase()->apply(db);
+	int bar;
+	std::string str;
+
+	std::string str2;
+	f();
+}

--- a/tests/output/cpp/34203-i1516.cpp
+++ b/tests/output/cpp/34203-i1516.cpp
@@ -1,0 +1,19 @@
+void myClass::foo() {
+	int bar;
+	std::string str;
+
+
+	DbConfig::configuredDatabase()->apply(db);
+
+	std::string str2;
+	std::string str2;
+
+	f();
+	DbConfig::configuredDatabase()->apply(db);
+
+	int bar;
+	std::string str;
+	std::string str2;
+
+	f();
+}


### PR DESCRIPTION
Prior to this commit variable definitions that used a scope resolution operator (rop) in the type (i.e. std::string) were not considered as such to mitigate miss handling of function calls.

This commit jumps 'next', if it is a CT_DC_MEMBER (rop), ahead to the last chunk preceded by the last CT_DC_MEMBER so that the following checks correctly throw out function calls while allowing scoped variable definitions.

----------

ref: #1516