### PR TITLE
Transfer oc-tests from imported to oc

### DIFF
--- a/tests/imported.test
+++ b/tests/imported.test
@@ -3,6 +3,3 @@
 #
 # this suite is not an ordinary language test suite.
 #
-# adopt tests from UT
-10018  empty.cfg                            oc/delete-space-oc.mm
-10019  empty.cfg                            oc/func-param-wrap-oc.mm

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -115,3 +115,9 @@
 
 50800  obj-c-properties.cfg                 oc/properties.m
 50801  empty.cfg                            oc/i1213.m
+
+
+#
+# adopt tests from UT
+10018  empty.cfg                            oc/delete-space-oc.mm
+10019  empty.cfg                            oc/func-param-wrap-oc.mm


### PR DESCRIPTION
The list imported.test is let empty.
It can be used for any other test(s).