### PR TITLE
Allow align_func_param to align params proceeded by a leading comma

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -878,7 +878,11 @@ static chunk_t *align_func_param(chunk_t *start)
       }
       else if (pc->type == CT_COMMA)
       {
-         comma_count++;
+         chunk_t *tmp_prev = chunk_get_prev_nc(pc);
+         if (!chunk_is_newline(tmp_prev))  // don't count leading commas
+         {
+            comma_count++;
+         }
       }
    }
 

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -527,7 +527,7 @@
 34201  mod_add_long_namespace_closebrace_comment-1.cfg  cpp/i1565.cpp
 
 34203  i1516.cfg                            cpp/i1516.cpp
-
+34204  align_func_params_span-1.cfg         cpp/func_param_indent_leading_comma.cpp
 
 # TODO: Find relevant test cases for 'override'.
 34210  empty.cfg                            cpp/override_virtual.cpp

--- a/tests/input/cpp/func_param_indent_leading_comma.cpp
+++ b/tests/input/cpp/func_param_indent_leading_comma.cpp
@@ -1,0 +1,7 @@
+uint32_t foo ( uint8_t param1
+               , some_datatype param2
+               , datatype param3
+               , another_datatype *param4
+               , uint16_t param5
+               , uint32_t *param6
+               );

--- a/tests/output/cpp/34204-func_param_indent_leading_comma.cpp
+++ b/tests/output/cpp/34204-func_param_indent_leading_comma.cpp
@@ -1,0 +1,7 @@
+uint32_t foo ( uint8_t             param1
+               , some_datatype     param2
+               , datatype          param3
+               , another_datatype *param4
+               , uint16_t          param5
+               , uint32_t *        param6
+               );


### PR DESCRIPTION
ref: #1596