### PR TITLE
Add unit test for issue 1607

### DIFF
--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -532,6 +532,8 @@
 # TODO: Find relevant test cases for 'override'.
 34210  empty.cfg                            cpp/override_virtual.cpp
 
+34250  empty.cfg                            cpp/bug_1607.cpp
+
 # __asm__
 34300  bug_1236.cfg                         cpp/bug_1236.cpp
 

--- a/tests/input/cpp/bug_1607.cpp
+++ b/tests/input/cpp/bug_1607.cpp
@@ -1,0 +1,2 @@
+decltype(i * d) prod = i * d;
+decltype(i + d) sum;

--- a/tests/output/cpp/34250-bug_1607.cpp
+++ b/tests/output/cpp/34250-bug_1607.cpp
@@ -1,0 +1,2 @@
+decltype(i * d) prod = i * d;
+decltype(i + d) sum;


### PR DESCRIPTION
Ensure that spaces after decltype(expression) are not removed when
using an empty config