### PR TITLE
Fix invalid alignment of the right comments

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -1538,17 +1538,12 @@ chunk_t *align_trailing_comments(chunk_t *start)
 
          if (cmt_type_cur == cmt_type_start)
          {
-            col = 1 + (pc->brace_level * cpd.settings[UO_indent_columns].u);
-            LOG_FMT(LALADD, "%s(%d): line=%zu col=%zu min_col=%zu pc->col=%zu pc->len=%zu %s\n",
-                    __func__, __LINE__, pc->orig_line, col, min_col, pc->column, pc->len(),
+            LOG_FMT(LALADD, "%s(%d): line=%zu min_col=%zu pc->col=%zu pc->len=%zu %s\n",
+                    __func__, __LINE__, pc->orig_line, min_col, pc->column, pc->len(),
                     get_token_name(pc->type));
             if (min_orig == 0 || min_orig > pc->column)
             {
                min_orig = pc->column;
-            }
-            if (pc->column < col)
-            {
-               pc->column = col;
             }
             align_add(cs, pc, min_col, 1, true); // (intended_col < col));
             nl_count = 0;

--- a/tests/config/align_right_comment.cfg
+++ b/tests/config/align_right_comment.cfg
@@ -1,0 +1,1 @@
+align_right_cmt_span = 3

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -119,6 +119,7 @@
 30210  empty.cfg                            cpp/bug_1338.cpp
 30211  space_indent_class-t_columns-4.cfg   cpp/indent_comment_align_thresh.cpp
 30212  indent_comment_align_thresh_2.cfg    cpp/indent_comment_align_thresh.cpp
+30213  align_right_comment.cfg              cpp/align_right_comment.cpp
 
 30220  bug_1340.cfg                         cpp/bug_1340.cpp
 

--- a/tests/input/cpp/align_right_comment.cpp
+++ b/tests/input/cpp/align_right_comment.cpp
@@ -1,0 +1,29 @@
+namespace A
+{
+namespace B
+{
+namespace C
+{
+
+
+struct D
+{
+	int a; // a.
+	int b;
+	int c;
+}; // struct D
+
+
+} // namespace C
+
+
+struct E {};
+
+
+} // namespace B
+
+
+struct F {};
+
+
+} // namespace C

--- a/tests/output/c/00054-if_chain.c
+++ b/tests/output/c/00054-if_chain.c
@@ -63,7 +63,7 @@ void bar(void)
 #ifdef SOME_DEFINE
 				hw_priv->Counter[ port - 1 ].time + HZ * 2;
 
-#else                   /* ifdef SOME_DEFINE */
+#else /* ifdef SOME_DEFINE */
 				hw_priv->Counter[ MAIN_PORT ].time + HZ * 2;
 #endif /* ifdef SOME_DEFINE */
 	}

--- a/tests/output/cpp/30213-align_right_comment.cpp
+++ b/tests/output/cpp/30213-align_right_comment.cpp
@@ -1,0 +1,29 @@
+namespace A
+{
+namespace B
+{
+namespace C
+{
+
+
+struct D
+{
+	int a; // a.
+	int b;
+	int c;
+}; // struct D
+
+
+} // namespace C
+
+
+struct E {};
+
+
+} // namespace B
+
+
+struct F {};
+
+
+} // namespace C


### PR DESCRIPTION
The align_right_cmt_span option adds extra spaces before the right comments at a large level of nested braces.

Config:
`align_right_cmt_span = 3`

Source:
```
namespace A
{
namespace B
{
namespace C
{


struct D
{
	int a; // a.
	int b;
	int c;
}; // struct D


} // namespace C


struct E {};


} // namespace B


struct F {};


} // namespace C
```
Result:
```
namespace A
{
namespace B
{
namespace C
{


struct D
{
	int a;                  // a.
	int b;
	int c;
};                      // struct D


}               // namespace C


struct E {};


}       // namespace B


struct F {};


} // namespace C
```
Expected:
```
namespace A
{
namespace B
{
namespace C
{


struct D
{
	int a; // a.
	int b;
	int c;
}; // struct D


} // namespace C


struct E {};


} // namespace B


struct F {};


} // namespace C
```
