### PR TITLE
Add basic processing of @available() syntax in objc

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -382,6 +382,8 @@ static void handle_oc_message_send(chunk_t *pc);
 //! Process @Property values and re-arrange them if necessary
 static void handle_oc_property_decl(chunk_t *pc);
 
+//! Process @available annotation
+static void handle_oc_available(chunk_t *pc);
 
 /**
  * Process a type that is enclosed in parens in message declarations.
@@ -907,6 +909,10 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       if (pc->type == CT_OC_PROPERTY)
       {
          handle_oc_property_decl(pc);
+      }
+      if (pc->type == CT_OC_AVAILABLE)
+      {
+         handle_oc_available(pc);
       }
    }
 
@@ -6333,6 +6339,22 @@ static void handle_oc_message_send(chunk_t *os)
       prev = tmp;
    }
 } // handle_oc_message_send
+
+
+static void handle_oc_available(chunk_t *os)
+{
+   os = chunk_get_next(os);
+   while (os != nullptr)
+   {
+      c_token_t origType = os->type;
+      set_chunk_type(os, CT_OC_AVAILABLE_VALUE);
+      if (origType == CT_PAREN_CLOSE)
+      {
+         break;
+      }
+      os = chunk_get_next(os);
+   }
+}
 
 
 static void handle_oc_property_decl(chunk_t *os)

--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -57,6 +57,7 @@ static const chunk_tag_t *kw_static_match(const chunk_tag_t *tag, int lang_flags
 static chunk_tag_t keywords[] =
 {
    // TODO: it might be useful if users could add there custom keywords to this list
+   { "@available",          CT_OC_AVAILABLE,     LANG_OC                                                                     },
    { "@catch",              CT_CATCH,            LANG_OC                                                                     },
    { "@dynamic",            CT_OC_DYNAMIC,       LANG_OC                                                                     },
    { "@end",                CT_OC_END,           LANG_OC                                                                     },

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -793,6 +793,11 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
       }
    }
 
+   if (first->type == CT_OC_AVAILABLE_VALUE || second->type == CT_OC_AVAILABLE_VALUE)
+   {
+      log_rule("IGNORE");
+      return(AV_IGNORE);
+   }
    if (second->type == CT_OC_BLOCK_CARET)
    {
       log_rule("sp_before_oc_block_caret");

--- a/src/token_enum.h
+++ b/src/token_enum.h
@@ -139,6 +139,8 @@ enum c_token_t
 
    CT_ASM,
    CT_ATTRIBUTE,
+   CT_OC_AVAILABLE,
+   CT_OC_AVAILABLE_VALUE,
    CT_CATCH,
    CT_WHEN,
    CT_WHERE,            // C# where clause

--- a/tests/config/obj-c-available.cfg
+++ b/tests/config/obj-c-available.cfg
@@ -1,0 +1,2 @@
+indent_columns                          = 4             # number
+indent_with_tabs                        = 0             # number

--- a/tests/input/oc/available.m
+++ b/tests/input/oc/available.m
@@ -1,0 +1,12 @@
+-(void) test{
+  if (@available(macOS 10.12.2, *)) {
+      self.automaticTextCompletionEnabled = YES;
+      self.allowsCharacterPickerTouchBarItem = NO;
+  }
+
+  if (@available( macOS 10.12,*)) {
+      self.automaticTextCompletionEnabled = YES;
+      self.allowsCharacterPickerTouchBarItem = NO;
+  }
+
+}

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -121,6 +121,7 @@
 
 50800  obj-c-properties.cfg                 oc/properties.m
 50801  empty.cfg                            oc/i1213.m
+50802  obj-c-available.cfg                  oc/available.m
 
 
 #

--- a/tests/output/oc/50802-available.m
+++ b/tests/output/oc/50802-available.m
@@ -1,0 +1,12 @@
+-(void) test {
+    if (@available(macOS 10.12.2, *)) {
+        self.automaticTextCompletionEnabled = YES;
+        self.allowsCharacterPickerTouchBarItem = NO;
+    }
+
+    if (@available( macOS 10.12,*)) {
+        self.automaticTextCompletionEnabled = YES;
+        self.allowsCharacterPickerTouchBarItem = NO;
+    }
+
+}


### PR DESCRIPTION
Implemented basic processing of the @available() syntax in objc. Just don't modify anything inside the brackets, not to break the things.