### PR TITLE
sun.cfg: nl_func_var_def_blk = 1

### DIFF
--- a/etc/sun.cfg
+++ b/etc/sun.cfg
@@ -1046,7 +1046,7 @@ nl_after_square_assign                    = remove   # ignore/add/remove/force
 
 # The number of blank lines after a block of variable definitions at the top of a function body
 # 0 = No change (default)
-nl_func_var_def_blk                       = 2        # number
+nl_func_var_def_blk                       = 1        # number
 
 # The number of newlines before a block of typedefs
 # 0 = No change (default)


### PR DESCRIPTION
Fix error: "The option 'nl_func_var_def_blk' is too big against the option 'nl_max'"

Per: http://www.oracle.com/technetwork/java/codeconventions-150003.pdf page 14
"One blank line should always be used in the following circumstances:
Between the local variables in a method and its first statement"