### PR TITLE
set :: punctuator to LANG_ALLC for Java8 :: operator

### DIFF
--- a/src/punctuators.cpp
+++ b/src/punctuators.cpp
@@ -97,7 +97,7 @@ static const chunk_tag_t symbols2[] =
    { "..",      CT_RANGE,        LANG_D                                                     },
    { "?.",      CT_NULLCOND,     LANG_CS                                                    }, // null conditional operator
    { "/=",      CT_ASSIGN,       LANG_ALL                                                   },
-   { "::",      CT_DC_MEMBER,    LANG_C | LANG_CPP | LANG_OC | LANG_CS | LANG_D | LANG_VALA },
+   { "::",      CT_DC_MEMBER,    LANG_ALLC                                                  },
    { "<<",      CT_ARITH,        LANG_ALL                                                   },
    { "<=",      CT_COMPARE,      LANG_ALL                                                   },
    { "<>",      CT_COMPARE,      LANG_D                                                     },

--- a/src/punctuators.cpp
+++ b/src/punctuators.cpp
@@ -78,45 +78,45 @@ static const chunk_tag_t symbols3[] =
 // 2-char symbols
 static const chunk_tag_t symbols2[] =
 {
-   { "!<",      CT_COMPARE,      LANG_D                                                     },
-   { "!=",      CT_COMPARE,      LANG_ALL                                                   },
-   { "!>",      CT_COMPARE,      LANG_D                                                     },
-   { "!~",      CT_COMPARE,      LANG_D                                                     },
-   { "##",      CT_PP,           LANG_C | LANG_CPP | LANG_OC                                },
-   { "#@",      CT_POUND,        LANG_C | LANG_CPP | LANG_OC                                }, // MS extension
-   { "%=",      CT_ASSIGN,       LANG_ALL                                                   },
-   { "&&",      CT_BOOL,         LANG_ALL                                                   },
-   { "&=",      CT_ASSIGN,       LANG_ALL                                                   },
-   { "*=",      CT_ASSIGN,       LANG_ALL                                                   },
-   { "++",      CT_INCDEC_AFTER, LANG_ALL                                                   },
-   { "+=",      CT_ASSIGN,       LANG_ALL                                                   },
-   { "--",      CT_INCDEC_AFTER, LANG_ALL                                                   },
-   { "-=",      CT_ASSIGN,       LANG_ALL                                                   },
-   { "->",      CT_MEMBER,       LANG_ALLC                                                  },
-   { ".*",      CT_MEMBER,       LANG_C | LANG_CPP | LANG_OC | LANG_D                       },
-   { "..",      CT_RANGE,        LANG_D                                                     },
-   { "?.",      CT_NULLCOND,     LANG_CS                                                    }, // null conditional operator
-   { "/=",      CT_ASSIGN,       LANG_ALL                                                   },
-   { "::",      CT_DC_MEMBER,    LANG_ALLC                                                  },
-   { "<<",      CT_ARITH,        LANG_ALL                                                   },
-   { "<=",      CT_COMPARE,      LANG_ALL                                                   },
-   { "<>",      CT_COMPARE,      LANG_D                                                     },
-   { "==",      CT_COMPARE,      LANG_ALL                                                   },
-   { ">=",      CT_COMPARE,      LANG_ALL                                                   },
-   { ">>",      CT_ARITH,        LANG_ALL                                                   },
-   { "[]",      CT_TSQUARE,      LANG_ALL                                                   },
-   { "^=",      CT_ASSIGN,       LANG_ALL                                                   },
-   { "|=",      CT_ASSIGN,       LANG_ALL                                                   },
-   { "||",      CT_BOOL,         LANG_ALL                                                   },
-   { "~=",      CT_COMPARE,      LANG_D                                                     },
-   { "~~",      CT_COMPARE,      LANG_D                                                     },
-   { "=>",      CT_LAMBDA,       LANG_VALA | LANG_CS | LANG_D                               },
-   { "??",      CT_COMPARE,      LANG_CS | LANG_VALA                                        },
-   { R"_(<%)_", CT_BRACE_OPEN,   LANG_C | LANG_CPP | LANG_OC | FLAG_DIG                     }, // digraph {
-   { R"_(%>)_", CT_BRACE_CLOSE,  LANG_C | LANG_CPP | LANG_OC | FLAG_DIG                     }, // digraph }
-   { R"_(<:)_", CT_SQUARE_OPEN,  LANG_C | LANG_CPP | LANG_OC | FLAG_DIG                     }, // digraph [
-   { R"_(:>)_", CT_SQUARE_CLOSE, LANG_C | LANG_CPP | LANG_OC | FLAG_DIG                     }, // digraph ]
-   { R"_(%:)_", CT_POUND,        LANG_C | LANG_CPP | LANG_OC | FLAG_DIG                     }, // digraph #
+   { "!<",      CT_COMPARE,      LANG_D                                 },
+   { "!=",      CT_COMPARE,      LANG_ALL                               },
+   { "!>",      CT_COMPARE,      LANG_D                                 },
+   { "!~",      CT_COMPARE,      LANG_D                                 },
+   { "##",      CT_PP,           LANG_C | LANG_CPP | LANG_OC            },
+   { "#@",      CT_POUND,        LANG_C | LANG_CPP | LANG_OC            },                     // MS extension
+   { "%=",      CT_ASSIGN,       LANG_ALL                               },
+   { "&&",      CT_BOOL,         LANG_ALL                               },
+   { "&=",      CT_ASSIGN,       LANG_ALL                               },
+   { "*=",      CT_ASSIGN,       LANG_ALL                               },
+   { "++",      CT_INCDEC_AFTER, LANG_ALL                               },
+   { "+=",      CT_ASSIGN,       LANG_ALL                               },
+   { "--",      CT_INCDEC_AFTER, LANG_ALL                               },
+   { "-=",      CT_ASSIGN,       LANG_ALL                               },
+   { "->",      CT_MEMBER,       LANG_ALLC                              },
+   { ".*",      CT_MEMBER,       LANG_C | LANG_CPP | LANG_OC | LANG_D   },
+   { "..",      CT_RANGE,        LANG_D                                 },
+   { "?.",      CT_NULLCOND,     LANG_CS                                },                     // null conditional operator
+   { "/=",      CT_ASSIGN,       LANG_ALL                               },
+   { "::",      CT_DC_MEMBER,    LANG_ALLC                              },
+   { "<<",      CT_ARITH,        LANG_ALL                               },
+   { "<=",      CT_COMPARE,      LANG_ALL                               },
+   { "<>",      CT_COMPARE,      LANG_D                                 },
+   { "==",      CT_COMPARE,      LANG_ALL                               },
+   { ">=",      CT_COMPARE,      LANG_ALL                               },
+   { ">>",      CT_ARITH,        LANG_ALL                               },
+   { "[]",      CT_TSQUARE,      LANG_ALL                               },
+   { "^=",      CT_ASSIGN,       LANG_ALL                               },
+   { "|=",      CT_ASSIGN,       LANG_ALL                               },
+   { "||",      CT_BOOL,         LANG_ALL                               },
+   { "~=",      CT_COMPARE,      LANG_D                                 },
+   { "~~",      CT_COMPARE,      LANG_D                                 },
+   { "=>",      CT_LAMBDA,       LANG_VALA | LANG_CS | LANG_D           },
+   { "??",      CT_COMPARE,      LANG_CS | LANG_VALA                    },
+   { R"_(<%)_", CT_BRACE_OPEN,   LANG_C | LANG_CPP | LANG_OC | FLAG_DIG },                     // digraph {
+   { R"_(%>)_", CT_BRACE_CLOSE,  LANG_C | LANG_CPP | LANG_OC | FLAG_DIG },                     // digraph }
+   { R"_(<:)_", CT_SQUARE_OPEN,  LANG_C | LANG_CPP | LANG_OC | FLAG_DIG },                     // digraph [
+   { R"_(:>)_", CT_SQUARE_CLOSE, LANG_C | LANG_CPP | LANG_OC | FLAG_DIG },                     // digraph ]
+   { R"_(%:)_", CT_POUND,        LANG_C | LANG_CPP | LANG_OC | FLAG_DIG },                     // digraph #
 };
 
 // 1-char symbols

--- a/tests/input/java/Java8DoubleColon.java
+++ b/tests/input/java/Java8DoubleColon.java
@@ -1,0 +1,10 @@
+import java.util.Objects;
+import java.util.function.Predicate;
+
+public class Java8DoubleColon {
+public static void main(String[] args) {
+	Predicate<Object> p = Objects::nonNull;
+	System.out.println(false == p.test(null));
+	System.out.println(true == p.test(p));
+}
+}

--- a/tests/java.test
+++ b/tests/java.test
@@ -20,6 +20,7 @@
 80062  sp_this_paren.cfg                    java/sp_this_paren.java
 80063  empty.cfg                            java/i1121.java
 80064  mod_add_long_class_closebrace_comment-1.cfg  java/long_cl_cmt.java
+80065  empty.cfg                            java/Java8DoubleColon.java
 
 80100  align_same_func_call_params-t.cfg    java/sf567.java
 

--- a/tests/output/java/80065-Java8DoubleColon.java
+++ b/tests/output/java/80065-Java8DoubleColon.java
@@ -1,0 +1,10 @@
+import java.util.Objects;
+import java.util.function.Predicate;
+
+public class Java8DoubleColon {
+public static void main(String[] args) {
+	Predicate<Object> p = Objects::nonNull;
+	System.out.println(false == p.test(null));
+	System.out.println(true == p.test(p));
+}
+}


### PR DESCRIPTION
Previous version would take input:
	`Predicate<Object> p = Objects::nonNull;`
and produce:
	`Predicate<Object> p = Objects: : nonNull;`

Which would not compile.

Followed fix pattern from https://github.com/uncrustify/uncrustify/pull/1133
for uncrustify#1121