### PR TITLE
must look for the opening parenthesis.

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -29,8 +29,11 @@ using namespace std;
 /**
  * Flags everything from the open paren to the close paren.
  *
- * @param po     Pointer to the open parenthesis
- * @param flags  flags to add
+ * @param po          Pointer to the open parenthesis
+ * @param flags       flags to add
+ * @param opentype
+ * @param parenttype
+ * @param parent_all
  *
  * @return The token after the close paren
  */
@@ -1720,7 +1723,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
                }
             }
             // Issue #322 STDMETHOD(GetValues)(BSTR bsName, REFDATA** pData);
-            if (  (pc->next->next)
+            if (  (pc->next->next != nullptr)
                && pc->next->next->type == CT_STAR
                && ((pc->flags & PCF_IN_CONST_ARGS) != 0))
             {
@@ -1729,11 +1732,18 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
                set_chunk_type(pc->next->next, CT_PTR_TYPE);
             }
             // Issue #222 whatever3 *(func_ptr)( whatever4 *foo2, ...
-            if (  (pc->next->next)
+            if (  (pc->next->next != nullptr)
                && pc->next->next->type == CT_WORD
                && (pc->flags & PCF_IN_FCN_DEF))
             {
-               set_chunk_type(pc->next, CT_PTR_TYPE);
+               // look for the opening parenthesis
+               // Issue 1403
+               tmp = chunk_get_prev_type(pc, CT_FPAREN_OPEN, pc->level - 1);
+               if (  tmp != nullptr
+                  && tmp->parent_type != CT_FUNC_CTOR_VAR)
+               {
+                  set_chunk_type(pc->next, CT_PTR_TYPE);
+               }
             }
          }
       }
@@ -4621,7 +4631,7 @@ static void mark_function(chunk_t *pc)
       {
          set_chunk_type(pc, CT_FUNC_CTOR_VAR);
          D_LOG_FMT(LFCN, "%s(%d): ", __func__, __LINE__);
-         LOG_FMT(LFCN, "  3) Marked [%s] as FUNC_CTOR_VAR on line %zu col %zu\n",
+         LOG_FMT(LFCN, "  3) Marked text() '%s' as FUNC_CTOR_VAR on orig_line %zu, orig_col %zu\n",
                  pc->text(), pc->orig_line, pc->orig_col);
       }
       else if (pc->brace_level > 0)
@@ -4657,7 +4667,9 @@ static void mark_function(chunk_t *pc)
       set_chunk_parent(semi, pc->type);
    }
 
+   // Issue # 1403
    flag_parens(paren_open, PCF_IN_FCN_DEF, CT_FPAREN_OPEN, pc->type, false);
+   //flag_parens(paren_open, PCF_IN_FCN_DEF, CT_FPAREN_OPEN, pc->type, true);
 
    if (pc->type == CT_FUNC_CTOR_VAR)
    {

--- a/tests/config/bug_1403.cfg
+++ b/tests/config/bug_1403.cfg
@@ -1,0 +1,1 @@
+sp_arith = force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -203,6 +203,7 @@
 30800  star_pos-0.cfg                       cpp/align-star-amp-pos.cpp
 30801  star_pos-1.cfg                       cpp/align-star-amp-pos.cpp
 30802  star_pos-2.cfg                       cpp/align-star-amp-pos.cpp
+30803  bug_1403.cfg                         cpp/bug_1403.cpp
 
 30804  block_pointer.cfg                    cpp/block_pointer.cpp
 30805  ptr_star-1.cfg                       cpp/ptr-star.cpp

--- a/tests/input/cpp/bug_1403.cpp
+++ b/tests/input/cpp/bug_1403.cpp
@@ -1,0 +1,6 @@
+int main()
+{
+float x;
+float y;
+float result(1 + x*y);
+}

--- a/tests/output/cpp/30803-bug_1403.cpp
+++ b/tests/output/cpp/30803-bug_1403.cpp
@@ -1,0 +1,6 @@
+int main()
+{
+	float x;
+	float y;
+	float result(1 + x * y);
+}


### PR DESCRIPTION
If parent_type == CT_FUNC_CTOR_VAR, do
not change to pointer

Ref. #1403