### PR TITLE
Add feature to indent lines which contain only single newline

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1084,6 +1084,12 @@ void indent_text(void)
       indent_column_set(frm.top().indent_tmp);
       log_indent_tmp();
 
+      if (  pc->type == CT_NEWLINE
+         && cpd.settings[UO_indent_single_newlines].b)
+      {
+         pc->nl_column = indent_column;
+      }
+
       if (  !chunk_is_newline(pc)
          && !chunk_is_comment(pc)
          && log_sev_on(LINDPC))

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -760,6 +760,8 @@ void register_options(void)
    unc_add_option("indent_continue", UO_indent_continue, AT_NUM,
                   "The continuation indent. If non-zero, this overrides the indent of '(' and '=' continuation indents.\n"
                   "For FreeBSD, this is set to 4. Negative value is absolute and not increased for each '(' level.");
+   unc_add_option("indent_single_newlines", UO_indent_single_newlines, AT_BOOL,
+                  "Indent empty lines - lines which contain only spaces before newline character");
    unc_add_option("indent_param", UO_indent_param, AT_UNUM,
                   "The continuation indent for func_*_param if they are true.\n"
                   "If non-zero, this overrides the indent.");

--- a/src/options.h
+++ b/src/options.h
@@ -357,6 +357,7 @@ enum uncrustify_options
    // group: UG_indent, "Indenting"                                                                2
    UO_indent_columns,                       // ie 3 or 8
    UO_indent_continue,                      //
+   UO_indent_single_newlines,               //
    UO_indent_param,                         // indent value of indent_*_param
    UO_indent_with_tabs,                     // 1=only to the 'level' indent, 2=use tabs for indenting
    UO_indent_cmt_with_tabs,                 //

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -242,6 +242,7 @@ struct chunk_t
       column        = 0;
       column_indent = 0;
       nl_count      = 0;
+      nl_column     = 0;
       level         = 0;
       brace_level   = 0;
       pp_level      = 0;
@@ -279,6 +280,7 @@ struct chunk_t
                                    * column, which may be less than the real
                                    * column used to indent with tabs          */
    size_t       nl_count;         //! number of newlines in CT_NEWLINE
+   size_t       nl_column;        //! column of the subsequent newline entries(all of them should have the same column)
    size_t       level;            //! nest level in {, (, or [
    size_t       brace_level;      //! nest level in braces only
    size_t       pp_level;         //! nest level in preprocessor

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 631 options and minimal documentation.
+There are currently 632 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -213,6 +213,7 @@ sp_skip_vbrace_tokens           = false
 force_tab_after_define          = false
 indent_columns                  = 8
 indent_continue                 = 0
+indent_single_newlines          = false
 indent_param                    = 0
 indent_with_tabs                = 1
 indent_cmt_with_tabs            = false

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -695,6 +695,9 @@ indent_columns                  = 8        # unsigned number
 # For FreeBSD, this is set to 4. Negative value is absolute and not increased for each '(' level.
 indent_continue                 = 0        # number
 
+# Indent empty lines - lines which contain only spaces before newline character
+indent_single_newlines          = false    # false/true
+
 # The continuation indent for func_*_param if they are true.
 # If non-zero, this overrides the indent.
 indent_param                    = 0        # unsigned number

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -213,6 +213,7 @@ sp_skip_vbrace_tokens           = false
 force_tab_after_define          = false
 indent_columns                  = 8
 indent_continue                 = 0
+indent_single_newlines          = false
 indent_param                    = 0
 indent_with_tabs                = 1
 indent_cmt_with_tabs            = false

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -695,6 +695,9 @@ indent_columns                  = 8        # unsigned number
 # For FreeBSD, this is set to 4. Negative value is absolute and not increased for each '(' level.
 indent_continue                 = 0        # number
 
+# Indent empty lines - lines which contain only spaces before newline character
+indent_single_newlines          = false    # false/true
+
 # The continuation indent for func_*_param if they are true.
 # If non-zero, this overrides the indent.
 indent_param                    = 0        # unsigned number

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -694,6 +694,9 @@ indent_continue                 Number
   The continuation indent. If non-zero, this overrides the indent of '(' and '=' continuation indents.
   For FreeBSD, this is set to 4. Negative value is absolute and not increased for each '(' level.
 
+indent_single_newlines          { False, True }
+  Indent empty lines - lines which contain only spaces before newline character
+
 indent_param                    Unsigned Number
   The continuation indent for func_*_param if they are true.
   If non-zero, this overrides the indent.

--- a/tests/config/indent_single_newline.cfg
+++ b/tests/config/indent_single_newline.cfg
@@ -1,0 +1,3 @@
+indent_single_newlines = true
+indent_columns                          = 4             # number
+indent_with_tabs                        = 0             # number

--- a/tests/input/oc/indent_single_newline.m
+++ b/tests/input/oc/indent_single_newline.m
@@ -1,0 +1,15 @@
+
+- (BOOL)isSomethingTrue:(BOOL) something{
+    
+    if (something){
+        //Yes it's true
+
+        return YES;
+    }
+    else {
+        //No it's false
+        
+        return NO;
+    }
+    
+}

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -126,6 +126,7 @@
 50800  obj-c-properties.cfg                 oc/properties.m
 50801  empty.cfg                            oc/i1213.m
 50802  obj-c-available.cfg                  oc/available.m
+50803  indent_single_newline.cfg            oc/indent_single_newline.m
 
 50810  bug_841.cfg                          oc/bug_841.m
 

--- a/tests/output/oc/50803-indent_single_newline.m
+++ b/tests/output/oc/50803-indent_single_newline.m
@@ -1,0 +1,15 @@
+
+- (BOOL)isSomethingTrue:(BOOL) something {
+    
+    if (something) {
+        //Yes it's true
+        
+        return YES;
+    }
+    else {
+        //No it's false
+        
+        return NO;
+    }
+    
+}


### PR DESCRIPTION
Solution to #1641 (Recreated https://github.com/uncrustify/uncrustify/pull/1660, sorry for duplicating )

Added config parameter indent_single_newlines
Enabling this parameter will allow indenting single newline lines in the same way as normal lines.