### PR TITLE
Fix 1683 - Don't put newline after brace close in @ OC declarations

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3106,10 +3106,11 @@ void newlines_cleanup_braces(bool first)
                newline_iarf(pc, cpd.settings[UO_nl_brace_struct_var].a);
             }
          }
-         else if (  cpd.settings[UO_nl_after_brace_close].b
-                 || pc->parent_type == CT_FUNC_CLASS_DEF
-                 || pc->parent_type == CT_FUNC_DEF
-                 || pc->parent_type == CT_OC_MSG_DECL)
+         else if (  pc->parent_type != CT_OC_AT
+                 && (  cpd.settings[UO_nl_after_brace_close].b
+                    || pc->parent_type == CT_FUNC_CLASS_DEF
+                    || pc->parent_type == CT_FUNC_DEF
+                    || pc->parent_type == CT_OC_MSG_DECL))
          {
             next = chunk_get_next(pc);
             if (  next != nullptr

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 632 options and minimal documentation.
+There are currently 634 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/tests/config/oc_bug_1683.cfg
+++ b/tests/config/oc_bug_1683.cfg
@@ -1,0 +1,1 @@
+nl_after_brace_close                    = true          # boolean (false/true)

--- a/tests/input/oc/bug_1683.m
+++ b/tests/input/oc/bug_1683.m
@@ -1,0 +1,1 @@
+[mutString addAttributes:@{ NSParagraphStyleAttributeName : style } range:range];

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -130,6 +130,7 @@
 
 50810  bug_841.cfg                          oc/bug_841.m
 50811  oc_bug_1674.cfg                      oc/bug_1674.m
+50812  oc_bug_1683.cfg                      oc/bug_1683.m
 
 
 #

--- a/tests/output/oc/50812-bug_1683.m
+++ b/tests/output/oc/50812-bug_1683.m
@@ -1,0 +1,1 @@
+[mutString addAttributes:@{ NSParagraphStyleAttributeName : style } range:range];


### PR DESCRIPTION
Fix for https://github.com/uncrustify/uncrustify/issues/1683

I don't think we ever need to put a newline after closing brace in @{} OC dictionary declarations