### PR TITLE
Correct handling of C++ nested scopes for function definitions

### DIFF
--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -140,9 +140,6 @@ static chunk_t *chunk_search_typelevel(chunk_t *cur, c_token_t type, scope_e sco
 static chunk_t *chunk_get_ncnlnp(chunk_t *cur, const scope_e scope = scope_e::ALL, const direction_e dir = direction_e::FORWARD);
 
 
-static chunk_t *chunk_get_ncnlnpnd(chunk_t *cur, const scope_e scope = scope_e::ALL, const direction_e dir = direction_e::FORWARD);
-
-
 /**
  * @brief searches a chunk that holds a specific string
  *
@@ -529,12 +526,6 @@ chunk_t *chunk_get_prev_ncnlnp(chunk_t *cur, scope_e scope)
 }
 
 
-chunk_t *chunk_get_prev_ncnlnpnd(chunk_t *cur, scope_e scope)
-{
-   return(chunk_get_ncnlnpnd(cur, scope, direction_e::BACKWARD));
-}
-
-
 chunk_t *chunk_get_next_nblank(chunk_t *cur, scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment_newline_or_blank, scope, direction_e::FORWARD, false));
@@ -824,22 +815,6 @@ static chunk_t *chunk_get_ncnlnp(chunk_t *cur, const scope_e scope, const direct
    pc = (chunk_is_preproc(pc) == true) ?
         chunk_search(pc, chunk_is_comment_or_newline_in_preproc, scope, dir, false) :
         chunk_search(pc, chunk_is_comment_newline_or_preproc, scope, dir, false);
-   return(pc);
-}
-
-
-static chunk_t *chunk_get_ncnlnpnd(chunk_t *cur, const scope_e scope, const direction_e dir)
-{
-   search_t search_function = select_search_fct(dir);
-   chunk_t  *pc             = cur;
-
-   do                                   // loop over the chunk list
-   {
-      pc = search_function(pc, scope);  // in either direction while
-   } while (  pc != nullptr             // the end of the list was not reached yet
-           && !chunk_is_comment_or_newline(pc)
-           && !chunk_is_preproc(pc)
-           && chunk_is_token(pc, CT_DC_MEMBER));
    return(pc);
 }
 

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -292,15 +292,6 @@ chunk_t *chunk_get_prev_ncnlnp(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
- * Gets the prev non-NEWLINE and non-comment chunk, non-preprocessor chunk, non-DC_MEMBER chunk
- *
- * @param cur    chunk to use as start point
- * @param scope  code region to search in
- */
-chunk_t *chunk_get_prev_ncnlnpnd(chunk_t *cur, scope_e scope = scope_e::ALL);
-
-
-/**
  * Grabs the next chunk of the given type at the level.
  *
  * @param cur    chunk to use as start point

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -517,6 +517,7 @@
 34173  arith-vs-ptr.cfg                     cpp/i1464.cpp
 34174  arith-vs-ptr.cfg                     cpp/i1466.cpp
 34175  align_assign_span-1.cfg              cpp/i1509.cpp
+34176  align_assign_span-1.cfg              cpp/i1509_bug_1112_correction.cpp
 
 34180  bug_1402.cfg                         cpp/bug_1402.cpp
 

--- a/tests/input/cpp/i1509_bug_1112_correction.cpp
+++ b/tests/input/cpp/i1509_bug_1112_correction.cpp
@@ -1,0 +1,26 @@
+void f()
+{
+int i = A::B::C::bar();
+int ii = A::B::C::bar();
+}
+
+int A::foo()
+{
+return 1;
+}
+int A::B::foo()
+{
+return A::foo();
+}
+int A::B::C::foo()
+{
+return A::B::foo();
+}
+int A::B::C::D::foo()
+{
+return A::B::C::foo();
+}
+int A::B::C::D::E::foo()
+{
+return A::B::C::D::foo();
+}

--- a/tests/output/cpp/34176-i1509_bug_1112_correction.cpp
+++ b/tests/output/cpp/34176-i1509_bug_1112_correction.cpp
@@ -1,0 +1,26 @@
+void f()
+{
+	int i  = A::B::C::bar();
+	int ii = A::B::C::bar();
+}
+
+int A::foo()
+{
+	return 1;
+}
+int A::B::foo()
+{
+	return A::foo();
+}
+int A::B::C::foo()
+{
+	return A::B::foo();
+}
+int A::B::C::D::foo()
+{
+	return A::B::C::foo();
+}
+int A::B::C::D::E::foo()
+{
+	return A::B::C::D::foo();
+}


### PR DESCRIPTION
This change fixes problems introduced by bug #1112 and made worse with issue #1509 with respect to nested scopes and names being identified as function calls not function declarations because the return type was getting skipped. Specifically
```
int A::B::C::foo()
{
}
```
Was marked as a function call (CT_FUNC_CALL) rather than a function definition (CT_FUNC_DEF) resulting in output formatting not producing the correct results. This change properly identifies foo as a function definition. I have also added a test that checks up to 5 levels of nesting.