### PR TITLE
A bugfix proposal for #672

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2964,7 +2964,7 @@ void indent_text(void)
       // Issue #672
       if (  chunk_is_token(pc, CT_CLASS)
          && language_is_set(LANG_CPP | LANG_JAVA)
-         && cpd.settings[UO_indent_continue].u != 0
+         && cpd.settings[UO_indent_continue_class_head].u != 0
          && !classFound)
       {
          LOG_FMT(LINDENT, "%s(%d): orig_line is %zu, CT_CLASS found and UO_indent_continue != 0, OPEN IT\n",

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -567,7 +567,8 @@ void indent_text(void)
 
    ParseFrame frm{};
 
-   chunk_t    *pc = chunk_get_head();
+   chunk_t    *pc        = chunk_get_head();
+   bool       classFound = false; // Issue #672
    while (pc != nullptr)
    {
       //  forces string literal to column-1 [Fix for 1246]
@@ -931,7 +932,7 @@ void indent_text(void)
             {
                frm.pop();
                pc = chunk_get_next(pc);
-               if (!pc)
+               if (pc == nullptr)
                {
                   // need to break out of both the do and while loops
                   goto null_pc;
@@ -1138,6 +1139,20 @@ void indent_text(void)
                     frm.at(ttidx).level,
                     frm.at(ttidx).pc->brace_level);
          }
+      }
+
+      // Issue #672
+      if (  chunk_is_token(pc, CT_BRACE_OPEN)
+         && classFound)
+      {
+         LOG_FMT(LINDENT, "%s(%d): orig_line is %zu, CT_BRACE_OPEN found, CLOSE IT\n",
+                 __func__, __LINE__, pc->orig_line);
+         frm.pop();
+         frm.top().indent_tmp = 1;
+         frm.top().indent     = 1;
+         frm.top().indent_tab = 1;
+         log_indent();
+         classFound = false;
       }
 
       /*
@@ -1805,7 +1820,8 @@ void indent_text(void)
             }
          }
       }
-      else if (chunk_is_token(pc, CT_CLASS_COLON) || chunk_is_token(pc, CT_CONSTR_COLON))
+      else if (  chunk_is_token(pc, CT_CLASS_COLON)
+              || chunk_is_token(pc, CT_CONSTR_COLON))
       {
          // just indent one level
          frm.push(*pc);
@@ -2324,10 +2340,11 @@ void indent_text(void)
             log_indent();
          }
       }
-      else if (chunk_is_token(pc, CT_OC_SCOPE) || chunk_is_token(pc, CT_TYPEDEF))
+      else if (  chunk_is_token(pc, CT_OC_SCOPE)
+              || chunk_is_token(pc, CT_TYPEDEF))
       {
          frm.push(*pc);
-         // Issue # 405
+         // Issue #405
          frm.top().indent = frm.prev().indent;
          log_indent();
 
@@ -2506,8 +2523,6 @@ void indent_text(void)
       {
          if (cpd.settings[UO_indent_continue].n != 0)
          {
-            //vardefcol = frm.top().indent +
-            //            abs(cpd.settings[UO_indent_continue].n);
             vardefcol = calc_indent_continue(frm);
             frm.top().indent_cont = true;
          }
@@ -2944,6 +2959,24 @@ void indent_text(void)
             xml_indent = pc->column;
          }
          xml_indent += cpd.settings[UO_indent_xml_string].u;
+      }
+
+      // Issue #672
+      if (  chunk_is_token(pc, CT_CLASS)
+         && language_is_set(LANG_CPP | LANG_JAVA)
+         && cpd.settings[UO_indent_continue].u != 0
+         && !classFound)
+      {
+         LOG_FMT(LINDENT, "%s(%d): orig_line is %zu, CT_CLASS found and UO_indent_continue != 0, OPEN IT\n",
+                 __func__, __LINE__, pc->orig_line);
+         frm.push(*pc);
+         frm.top().indent = cpd.settings[UO_indent_continue].u + 1;
+         log_indent();
+
+         frm.top().indent_tmp = frm.top().indent;
+         frm.top().indent_tab = frm.top().indent;
+         log_indent_tmp();
+         classFound = true;
       }
 
       pc = chunk_get_next(pc);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -766,6 +766,9 @@ void register_options(void)
                   "The continuation indent. If non-zero, this overrides the indent of '(' and '=' continuation indents.\n"
                   "For FreeBSD, this is set to 4. Negative value is absolute and not increased for each '(' level.\n"
                   "negative value are OK.", "", -16, 16);
+   unc_add_option("indent_continue_class_head", UO_indent_continue_class_head, AT_UNUM,
+                  "The continuation indent, only for class header line(s).\n"
+                  "If non-zero, this overrides the indent of 'class' continuation indents.\n", "", 0, 16);
    unc_add_option("indent_single_newlines", UO_indent_single_newlines, AT_BOOL,
                   "Indent empty lines - lines which contain only spaces before newline character");
    unc_add_option("indent_param", UO_indent_param, AT_UNUM,

--- a/src/options.h
+++ b/src/options.h
@@ -358,6 +358,7 @@ enum uncrustify_options
    // group: UG_indent, "Indenting"                                                                2
    UO_indent_columns,                       // ie 3 or 8
    UO_indent_continue,                      //
+   UO_indent_continue_class_head,           // only for class header line(s)
    UO_indent_single_newlines,               //
    UO_indent_param,                         // indent value of indent_*_param
    UO_indent_with_tabs,                     // 1=only to the 'level' indent, 2=use tabs for indenting

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 639 options and minimal documentation.
+There are currently 640 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -214,6 +214,7 @@ sp_after_noexcept               = ignore
 force_tab_after_define          = false
 indent_columns                  = 8
 indent_continue                 = 0
+indent_continue_class_head      = 0
 indent_single_newlines          = false
 indent_param                    = 0
 indent_with_tabs                = 1

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -699,6 +699,10 @@ indent_columns                  = 8        # unsigned number
 # negative value are OK.
 indent_continue                 = 0        # number
 
+# The continuation indent, only for class header line(s).
+# If non-zero, this overrides the indent of 'class' continuation indents.
+indent_continue_class_head      = 0        # unsigned number
+
 # Indent empty lines - lines which contain only spaces before newline character
 indent_single_newlines          = false    # false/true
 

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -214,6 +214,7 @@ sp_after_noexcept               = ignore
 force_tab_after_define          = false
 indent_columns                  = 8
 indent_continue                 = 0
+indent_continue_class_head      = 0
 indent_single_newlines          = false
 indent_param                    = 0
 indent_with_tabs                = 1

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -699,6 +699,10 @@ indent_columns                  = 8        # unsigned number
 # negative value are OK.
 indent_continue                 = 0        # number
 
+# The continuation indent, only for class header line(s).
+# If non-zero, this overrides the indent of 'class' continuation indents.
+indent_continue_class_head      = 0        # unsigned number
+
 # Indent empty lines - lines which contain only spaces before newline character
 indent_single_newlines          = false    # false/true
 

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -698,6 +698,11 @@ indent_continue                 Number
   For FreeBSD, this is set to 4. Negative value is absolute and not increased for each '(' level.
   negative value are OK.
 
+indent_continue_class_head      Unsigned Number
+  The continuation indent, only for class header line(s).
+  If non-zero, this overrides the indent of 'class' continuation indents.
+  
+
 indent_single_newlines          { False, True }
   Indent empty lines - lines which contain only spaces before newline character
 

--- a/tests/config/issue_672.cfg
+++ b/tests/config/issue_672.cfg
@@ -1,0 +1,4 @@
+indent_columns  = 4
+indent_continue = 16
+indent_class    = true
+code_width = 80

--- a/tests/config/issue_672.cfg
+++ b/tests/config/issue_672.cfg
@@ -1,4 +1,5 @@
-indent_columns  = 4
-indent_continue = 16
-indent_class    = true
-code_width = 80
+indent_columns             = 4
+indent_continue            = 16
+indent_continue_class_head = 16
+indent_class               = true
+code_width                 = 80

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -307,6 +307,7 @@
 31567  align_same_func_call_params-t.cfg    cpp/sf567.cpp
 31583  empty.cfg                            cpp/sf583.cpp
 31593  indent_continue-8.cfg                cpp/sf593.cpp
+31594  issue_672.cfg                        cpp/issue_672.cpp
 
 31700  toggle_processing_cmt.cfg            cpp/toggle_processing_cmt.cpp
 31701  toggle_processing_cmt2.cfg           cpp/toggle_processing_cmt2.cpp

--- a/tests/input/cpp/issue_672.cpp
+++ b/tests/input/cpp/issue_672.cpp
@@ -1,0 +1,8 @@
+class
+MyClass
+{
+public:
+   void f123(MyType1 AAAAAAAAAAAAAA, MyType2 BBBBBBBBBBBB, int XXXXXXXXXXXXXXX);
+   void foo(::some::very::looong::_and::complicated::name::MyType& a, ::some::very::looong::_and::complicated::name::MyType& b,
+      some::very::looong::_and::complicated::name::MyType& c);
+};

--- a/tests/input/java/issue_672.java
+++ b/tests/input/java/issue_672.java
@@ -1,0 +1,2 @@
+public abstract class KeyValueItemWriter<K, V> implements ItemWriter<V>, InitializingBean {}
+//3456789=123456789=12

--- a/tests/java.test
+++ b/tests/java.test
@@ -31,3 +31,5 @@
 80204  aet.cfg                              java/cast.java
 80205  aet.cfg                              java/sp_after_angle.java
 80206  aet.cfg                              java/annotation3.java
+
+80301  issue_672.cfg                        java/issue_672.java

--- a/tests/output/cpp/31594-issue_672.cpp
+++ b/tests/output/cpp/31594-issue_672.cpp
@@ -1,0 +1,10 @@
+class
+		MyClass
+{
+public:
+    void f123(MyType1 AAAAAAAAAAAAAA, MyType2 BBBBBBBBBBBB,
+                    int XXXXXXXXXXXXXXX);
+    void foo(::some::very::looong::_and::complicated::name::MyType& a,
+                    ::some::very::looong::_and::complicated::name::MyType& b,
+                    some::very::looong::_and::complicated::name::MyType& c);
+};

--- a/tests/output/java/80301-issue_672.java
+++ b/tests/output/java/80301-issue_672.java
@@ -1,0 +1,3 @@
+public abstract class KeyValueItemWriter<K, V> implements ItemWriter<V>,
+		InitializingBean {}
+//3456789=123456789=12


### PR DESCRIPTION
We introduce a new frame after **class**.
The indentation is set to the value of the option **indent_continue**, if not zero.
We close it before the opening **brace**, if opened.
The indentation is reset to 1.