### PR TITLE
Introduce a new function, 

### DIFF
--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -463,6 +463,12 @@ static_inline bool chunk_is_token(const chunk_t *pc, c_token_t c_token)
 }
 
 
+static_inline bool chunk_is_not_token(const chunk_t *pc, c_token_t c_token)
+{
+   return(pc != nullptr && pc->type != c_token);
+}
+
+
 /**
  * Skips to the closing match for the current paren/brace/square.
  *


### PR DESCRIPTION
to be use instead of:
`if (pc->type != CTXXXYYY)`

as

`if (chunk_is_not_token(pc, CT_XXXYYY))`