### PR TITLE
Fix some initializer list issues

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1388,6 +1388,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
          || chunk_is_token(pc, CT_ANGLE_CLOSE)
          || chunk_is_token(pc, CT_SQUARE_CLOSE)
          || chunk_is_token(pc, CT_TSQUARE)
+         || chunk_is_token(pc, CT_FPAREN_OPEN)
          || (  chunk_is_token(pc, CT_BRACE_OPEN)
             && (  pc->parent_type == CT_NONE
                || pc->parent_type == CT_BRACED_INIT_LIST)))

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1161,9 +1161,12 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
       return(cpd.settings[UO_sp_inside_braces_empty].a);
    }
 
-   if (chunk_is_token(second, CT_BRACE_OPEN) && second->parent_type == CT_BRACED_INIT_LIST)
+   if ( !chunk_is_token(first, CT_BRACE_OPEN)
+      && chunk_is_token(second, CT_BRACE_OPEN)
+      && second->parent_type == CT_BRACED_INIT_LIST)
    {
       // 'int{9}' vs 'int {9}'
+      log_rule("sp_type_brace_init_lst");
       return(cpd.settings[UO_sp_type_brace_init_lst].a);
    }
 

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1161,7 +1161,8 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
       return(cpd.settings[UO_sp_inside_braces_empty].a);
    }
 
-   if ( !chunk_is_token(first, CT_BRACE_OPEN)
+   if (  !chunk_is_token(first, CT_BRACE_OPEN)
+      && !chunk_is_token(first, CT_FPAREN_OPEN)
       && chunk_is_token(second, CT_BRACE_OPEN)
       && second->parent_type == CT_BRACED_INIT_LIST)
    {

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -556,6 +556,15 @@
 
 34280  UNI-29935.cfg                        cpp/UNI-29935.cpp
 
+34290  sp_type_brace_init_lst-f.cfg         cpp/brace_brace_init_lst.cpp
+34291  sp_type_brace_init_lst-r.cfg         cpp/brace_brace_init_lst.cpp
+
+34292  sp_inside_type_brace_init_lst-f.cfg  cpp/brace_brace_init_lst.cpp
+34293  sp_inside_type_brace_init_lst-r.cfg  cpp/brace_brace_init_lst.cpp
+
+34294  sp_after_type_brace_init_lst_open-f.cfg  cpp/brace_brace_init_lst.cpp
+34295  sp_after_type_brace_init_lst_open-r.cfg  cpp/brace_brace_init_lst.cpp
+
 # __asm__
 34300  bug_1236.cfg                         cpp/bug_1236.cpp
 

--- a/tests/input/cpp/brace_brace_init_lst.cpp
+++ b/tests/input/cpp/brace_brace_init_lst.cpp
@@ -1,0 +1,22 @@
+int main()
+{
+	int a0[][] = {{  1  }};
+	unknown_type b0 = {{  2  }};
+	auto c0 = unknown_type  {{  3  }};
+	auto d0 = func( {{  3  }}  );
+	auto e0 = func( unknown_type  {{  3  }}  );
+
+	int a1[][] = {  {1}  };
+	unknown_type b1 = {  {2}  };
+	auto c1 = unknown_type{  {3}  };
+	auto d1 = func({  {3}  });
+	auto e1 = func(unknown_type{  {3}  });
+
+	int a2[][] = {{1}};
+	unknown_type b2 = {{2}};
+	auto c2 = unknown_type{{3}};
+	auto d2 = func({{3}});
+	auto e2 = func(unknown_type{{3}});
+
+	return 1;
+}

--- a/tests/output/cpp/34290-brace_brace_init_lst.cpp
+++ b/tests/output/cpp/34290-brace_brace_init_lst.cpp
@@ -1,0 +1,22 @@
+int main()
+{
+	int a0[][] = {{  1  }};
+	unknown_type b0 = {{  2  }};
+	auto c0 = unknown_type {{  3  }};
+	auto d0 = func( {{  3  }}  );
+	auto e0 = func( unknown_type {{  3  }}  );
+
+	int a1[][] = {  {1}  };
+	unknown_type b1 = {  {2}  };
+	auto c1 = unknown_type {  {3}  };
+	auto d1 = func({  {3}  });
+	auto e1 = func(unknown_type {  {3}  });
+
+	int a2[][] = {{1}};
+	unknown_type b2 = {{2}};
+	auto c2 = unknown_type {{3}};
+	auto d2 = func({{3}});
+	auto e2 = func(unknown_type {{3}});
+
+	return 1;
+}

--- a/tests/output/cpp/34291-brace_brace_init_lst.cpp
+++ b/tests/output/cpp/34291-brace_brace_init_lst.cpp
@@ -1,0 +1,22 @@
+int main()
+{
+	int a0[][] = {{  1  }};
+	unknown_type b0 = {{  2  }};
+	auto c0 = unknown_type{{  3  }};
+	auto d0 = func( {{  3  }}  );
+	auto e0 = func( unknown_type{{  3  }}  );
+
+	int a1[][] = {  {1}  };
+	unknown_type b1 = {  {2}  };
+	auto c1 = unknown_type{  {3}  };
+	auto d1 = func({  {3}  });
+	auto e1 = func(unknown_type{  {3}  });
+
+	int a2[][] = {{1}};
+	unknown_type b2 = {{2}};
+	auto c2 = unknown_type{{3}};
+	auto d2 = func({{3}});
+	auto e2 = func(unknown_type{{3}});
+
+	return 1;
+}

--- a/tests/output/cpp/34292-brace_brace_init_lst.cpp
+++ b/tests/output/cpp/34292-brace_brace_init_lst.cpp
@@ -1,0 +1,22 @@
+int main()
+{
+	int a0[][] = { { 1 } };
+	unknown_type b0 = { { 2 } };
+	auto c0 = unknown_type  { { 3 } };
+	auto d0 = func( { { 3 } }  );
+	auto e0 = func( unknown_type  { { 3 } }  );
+
+	int a1[][] = { { 1 } };
+	unknown_type b1 = { { 2 } };
+	auto c1 = unknown_type{ { 3 } };
+	auto d1 = func({ { 3 } });
+	auto e1 = func(unknown_type{ { 3 } });
+
+	int a2[][] = { { 1 } };
+	unknown_type b2 = { { 2 } };
+	auto c2 = unknown_type{ { 3 } };
+	auto d2 = func({ { 3 } });
+	auto e2 = func(unknown_type{ { 3 } });
+
+	return 1;
+}

--- a/tests/output/cpp/34293-brace_brace_init_lst.cpp
+++ b/tests/output/cpp/34293-brace_brace_init_lst.cpp
@@ -1,0 +1,22 @@
+int main()
+{
+	int a0[][] = {{1}};
+	unknown_type b0 = {{2}};
+	auto c0 = unknown_type  {{3}};
+	auto d0 = func( {{3}}  );
+	auto e0 = func( unknown_type  {{3}}  );
+
+	int a1[][] = {{1}};
+	unknown_type b1 = {{2}};
+	auto c1 = unknown_type{{3}};
+	auto d1 = func({{3}});
+	auto e1 = func(unknown_type{{3}});
+
+	int a2[][] = {{1}};
+	unknown_type b2 = {{2}};
+	auto c2 = unknown_type{{3}};
+	auto d2 = func({{3}});
+	auto e2 = func(unknown_type{{3}});
+
+	return 1;
+}

--- a/tests/output/cpp/34294-brace_brace_init_lst.cpp
+++ b/tests/output/cpp/34294-brace_brace_init_lst.cpp
@@ -1,0 +1,22 @@
+int main()
+{
+	int a0[][] = { { 1  }};
+	unknown_type b0 = { { 2  }};
+	auto c0 = unknown_type  { { 3  }};
+	auto d0 = func( { { 3  }}  );
+	auto e0 = func( unknown_type  { { 3  }}  );
+
+	int a1[][] = { { 1}  };
+	unknown_type b1 = { { 2}  };
+	auto c1 = unknown_type{ { 3}  };
+	auto d1 = func({ { 3}  });
+	auto e1 = func(unknown_type{ { 3}  });
+
+	int a2[][] = { { 1}};
+	unknown_type b2 = { { 2}};
+	auto c2 = unknown_type{ { 3}};
+	auto d2 = func({ { 3}});
+	auto e2 = func(unknown_type{ { 3}});
+
+	return 1;
+}

--- a/tests/output/cpp/34295-brace_brace_init_lst.cpp
+++ b/tests/output/cpp/34295-brace_brace_init_lst.cpp
@@ -1,0 +1,22 @@
+int main()
+{
+	int a0[][] = {{1  }};
+	unknown_type b0 = {{2  }};
+	auto c0 = unknown_type  {{3  }};
+	auto d0 = func( {{3  }}  );
+	auto e0 = func( unknown_type  {{3  }}  );
+
+	int a1[][] = {{1}  };
+	unknown_type b1 = {{2}  };
+	auto c1 = unknown_type{{3}  };
+	auto d1 = func({{3}  });
+	auto e1 = func(unknown_type{{3}  });
+
+	int a2[][] = {{1}};
+	unknown_type b2 = {{2}};
+	auto c2 = unknown_type{{3}};
+	auto d2 = func({{3}});
+	auto e2 = func(unknown_type{{3}});
+
+	return 1;
+}


### PR DESCRIPTION
Fix incorrect handling (and missing logging) of `sp_type_brace_init_lst`, which was tripping between opening braces of an explicit or nested initializer list with no type name, and for anonymous initializer lists inside of a function call. Modify combining rules to recognize an initializer list in a function (like `foo({0})`).

Add tests for the above.

This fixes #1786.