### PR TITLE
Improve execution of unit tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
+find_package(Git QUIET)
+
 function(add_uncrustify_test name lang config rerun_config input result result_2 output rerun_output)
   add_test(NAME ${name}
     COMMAND ${CMAKE_COMMAND}
@@ -13,6 +15,7 @@ function(add_uncrustify_test name lang config rerun_config input result result_2
       -DTEST_OUTPUT=${output}
       -DTEST_RERUN_OUTPUT=${rerun_output}
       -DTEST_DIR=${PROJECT_SOURCE_DIR}/tests
+      -DGIT_EXECUTABLE=${GIT_EXECUTABLE}
       -P ${PROJECT_SOURCE_DIR}/tests/run_test.cmake
   )
   set_tests_properties(${name}

--- a/tests/run_test.cmake
+++ b/tests/run_test.cmake
@@ -1,113 +1,91 @@
 #
-# This is a wrapper cmake script to run one uncrustify test because cmake add_test
-# can't launch multiple processes and so it doesn't allow a complex test scenario.
+# This is a wrapper CMake script to run one uncrustify test because CMake
+# add_test can't launch multiple processes on its own, and so doesn't directly
+# allow a complex test scenario.
 #
 
 cmake_minimum_required(VERSION 2.8)
 
+function(require)
+  foreach(var IN LISTS ARGN)
+    if(NOT ${var})
+      message(FATAL_ERROR "Variable ${var} not defined")
+    endif()
+  endforeach()
+endfunction()
 
-if(NOT TEST_PROGRAM)
-  message(FATAL_ERROR "Variable TEST_PROGRAM not defined")
-endif()
-if(NOT TEST_LANG)
-  message(FATAL_ERROR "Variable TEST_LANG not defined")
-endif()
-if(NOT TEST_CONFIG)
-  message(FATAL_ERROR "Variable TEST_CONFIG not defined")
-endif()
-if(NOT TEST_RERUN_CONFIG)
-  message(FATAL_ERROR "Variable TEST_RERUN_CONFIG not defined")
-endif()
-if(NOT TEST_INPUT)
-  message(FATAL_ERROR "Variable TEST_INPUT not defined")
-endif()
-if(NOT TEST_OUTPUT)
-  message(FATAL_ERROR "Variable TEST_OUTPUT not defined")
-endif()
-if(NOT TEST_RESULT)
-  message(FATAL_ERROR "Variable TEST_RESULT not defined")
-endif()
-if(NOT TEST_RESULT_2)
-  message(FATAL_ERROR "Variable TEST_RESULT_2 not defined")
-endif()
-if(NOT TEST_DIR)
-  message(FATAL_ERROR "Variable TEST_DIR not defined")
-endif()
-if(NOT TEST_RERUN_OUTPUT)
-  message(FATAL_ERROR "Variable TEST_RERUN_OUTPUT not defined")
-endif()
-
-
-# first pass
-execute_process(
-  COMMAND ${TEST_PROGRAM} -l ${TEST_LANG} -c ${TEST_CONFIG} -f ${TEST_INPUT} -o ${TEST_RESULT}
+function(run_test name config input output result)
+  execute_process(
+    COMMAND ${TEST_PROGRAM}
+      -l ${TEST_LANG}
+      -c ${config}
+      -f ${input}
+      -o ${result}
     WORKING_DIRECTORY ${TEST_DIR}
     RESULT_VARIABLE uncrustify_error_code
     OUTPUT_QUIET
-    ERROR_VARIABLE uncrustify_error
-    ERROR_FILE ${TEST_DIR}/ERR-1.txt
+  )
+
+  if(uncrustify_error_code)
+    message(SEND_ERROR
+      "Uncrustify error_code ${uncrustify_error_code} (${name})"
+    )
+  else()
+    execute_process(
+      COMMAND ${CMAKE_COMMAND} -E compare_files ${result} ${output}
+      RESULT_VARIABLE files_are_different
+    )
+    if(files_are_different)
+      message(WARNING
+        "MISMATCH (${name}): ${result} does not match ${output}"
+      )
+      if(GIT_EXECUTABLE)
+        execute_process(
+          COMMAND ${GIT_EXECUTABLE}
+            diff --no-index
+            ${output}
+            ${result}
+        )
+      else()
+        execute_process(
+          COMMAND ${CMAKE_COMMAND} -E echo "the result file:"
+        )
+        execute_process(
+          COMMAND ${CMAKE_COMMAND} -E copy ${result} /dev/stderr
+        )
+      endif()
+      message(SEND_ERROR "Uncrustify MISMATCH (${name})")
+    endif()
+  endif()
+endfunction()
+
+require(
+  TEST_PROGRAM
+  TEST_LANG
+  TEST_CONFIG
+  TEST_RERUN_CONFIG
+  TEST_INPUT
+  TEST_OUTPUT
+  TEST_RESULT
+  TEST_RESULT_2
+  TEST_DIR
+  TEST_RERUN_OUTPUT
 )
 
-if(uncrustify_error_code)
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -E echo "Uncrustify error. The ERR-1.txt file is:"
-  )
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -E copy ${TEST_DIR}/ERR-1.txt /dev/stderr
-  )
-  message(SEND_ERROR "Uncrustify error_code (Pass 1)")
-else(uncrustify_error_code)
-  # Unfortunately I had to pull cmake out of the previous execute_process due to instability issues.
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -E compare_files ${TEST_DIR}/${TEST_RESULT} ${TEST_DIR}/${TEST_OUTPUT}
-      RESULT_VARIABLE files_are_different
-  )
-  if(files_are_different)
-    message(WARNING "MISSMATCH (Pass 1): ${TEST_RESULT} does not match ${TEST_OUTPUT}")
-    execute_process(
-      COMMAND ${CMAKE_COMMAND} -E echo "the result file:"
-    )
-    execute_process(
-      COMMAND ${CMAKE_COMMAND} -E copy ${TEST_DIR}/${TEST_RESULT} /dev/stderr
-    )
-    message(SEND_ERROR "Uncrustify MISSMATCH (Pass 1)")
-  endif()
-endif(uncrustify_error_code)
-file(REMOVE ${TEST_DIR}/ERR-1.txt)
-
-
-# Re-run with the output file as the input to check stability.
-execute_process(
-  COMMAND ${TEST_PROGRAM} -l ${TEST_LANG} -c ${TEST_RERUN_CONFIG} -f ${TEST_RERUN_OUTPUT} -o ${TEST_RESULT_2}
-    WORKING_DIRECTORY ${TEST_DIR}
-    RESULT_VARIABLE uncrustify_error_code
-    OUTPUT_QUIET
-    ERROR_VARIABLE uncrustify_error
-    ERROR_FILE ${TEST_DIR}/ERR-2.txt
+# Run first pass
+run_test(
+  "Pass 1"
+  ${TEST_CONFIG}
+  ${TEST_DIR}/${TEST_INPUT}
+  ${TEST_DIR}/${TEST_OUTPUT}
+  ${TEST_DIR}/${TEST_RESULT}
 )
 
-if(uncrustify_error_code)
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -E echo "Uncrustify error. The ERR-2.txt file is:"
-  )
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -E copy ${TEST_DIR}/ERR-2.txt /dev/stderr
-  )
-  message(SEND_ERROR "Uncrustify error_code (Pass 2)")
-else(uncrustify_error_code)
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -E compare_files ${TEST_DIR}/${TEST_RESULT_2} ${TEST_DIR}/${TEST_RERUN_OUTPUT}
-      RESULT_VARIABLE files_are_different
-  )
-  if(files_are_different)
-    message(WARNING "UNSTABLE (Pass 2): ${TEST_RESULT_2} does not match ${TEST_RERUN_OUTPUT}")
-    execute_process(
-      COMMAND ${CMAKE_COMMAND} -E echo "the result file:"
-    )
-    execute_process(
-      COMMAND ${CMAKE_COMMAND} -E copy ${TEST_DIR}/${TEST_RESULT_2} /dev/stderr
-    )
-    message(SEND_ERROR "Uncrustify UNSTABLE (Pass 2)")
-  endif()
-endif()
-file(REMOVE ${TEST_DIR}/ERR-2.txt)
+# Re-run with the output file as the input to check stability
+run_test(
+  "Pass 2"
+  ${TEST_RERUN_CONFIG}
+  ${TEST_DIR}/${TEST_RERUN_OUTPUT}
+  ${TEST_DIR}/${TEST_RERUN_OUTPUT}
+  ${TEST_DIR}/${TEST_RESULT_2}
+)


### PR DESCRIPTION
Refactor and tweak the unit test execution script for a couple of improvements:

- Refactor each "pass" into a function to reduce code duplication.

- Remove use of temporary file to capture stderr; we don't need it (the output was just being dumped back into the test's stderr anyway), and since every test was writing to the same file, parallel tests would trample on each other if anything actually went wrong.

- Pass along `GITCOMMAND` if available, and use to show diffs of the expected and actual output, falling back to just dumping the actual output otherwise.