### PR TITLE
Improve integration of test_cli_options.py

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,34 +123,32 @@ endif()
 # FIXME: the version number should be automatically integrated
 set(CURRENT_VERSION "Uncrustify-0.67_f")
 
-find_package(PythonInterp)
+find_package(PythonInterp REQUIRED)
 option(NoGitVersionString "Do not use make_version.py and git to build a version string" OFF)
 if(NOT NoGitVersionString)
-    if(PythonInterp_FOUND)
-        set(version_debug_flag "")
-        STRING(REGEX MATCH "-g[0-3]?" version_debug_flag ${CMAKE_CXX_FLAGS})
+  set(version_debug_flag "")
+  STRING(REGEX MATCH "-g[0-3]?" version_debug_flag ${CMAKE_CXX_FLAGS})
 
-        # checking for build type and passing it to make_version.py
-        # FIXME: does not work with VS .sln projects
-        if(NOT "${version_debug_flag}" STREQUAL "" OR "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" )
-            set(version_debug_flag "Debug")
-        endif()
+  # checking for build type and passing it to make_version.py
+  # FIXME: does not work with VS .sln projects
+  if(NOT "${version_debug_flag}" STREQUAL "" OR "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" )
+    set(version_debug_flag "Debug")
+  endif()
 
-        execute_process(
-            COMMAND ${PYTHON_EXECUTABLE} scripts/make_version.py ${version_debug_flag}
-            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-            RESULT_VARIABLE make_version_error
-            OUTPUT_VARIABLE make_version_output
-        )
+  execute_process(
+    COMMAND ${PYTHON_EXECUTABLE} scripts/make_version.py ${version_debug_flag}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    RESULT_VARIABLE make_version_error
+    OUTPUT_VARIABLE make_version_output
+  )
 
-        if (make_version_error)
-            message(STATUS "scripts/make_version.py exited with code ${make_version_error}: ${make_version_output}\n"
-                           "As a fallback, version '${CURRENT_VERSION}' will be used.")
-        else()
-            string(STRIP ${make_version_output} CURRENT_VERSION)
-            message(STATUS "Version: '${CURRENT_VERSION}'")
-        endif()
-    endif()
+  if (make_version_error)
+    message(STATUS "scripts/make_version.py exited with code ${make_version_error}: ${make_version_output}\n"
+                   "As a fallback, version '${CURRENT_VERSION}' will be used.")
+  else()
+    string(STRIP ${make_version_output} CURRENT_VERSION)
+    message(STATUS "Version: '${CURRENT_VERSION}'")
+  endif()
 endif()
 
 configure_file(src/uncrustify_version.h.in uncrustify_version.h @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,9 +123,9 @@ endif()
 # FIXME: the version number should be automatically integrated
 set(CURRENT_VERSION "Uncrustify-0.67_f")
 
+find_package(PythonInterp)
 option(NoGitVersionString "Do not use make_version.py and git to build a version string" OFF)
 if(NOT NoGitVersionString)
-    find_package(PythonInterp)
     if(PythonInterp_FOUND)
         set(version_debug_flag "")
         STRING(REGEX MATCH "-g[0-3]?" version_debug_flag ${CMAKE_CXX_FLAGS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,39 +61,37 @@ foreach(test_lang c-sharp c cpp d java pawn objective-c vala ecma imported)
   endforeach()
 endforeach()
 
-if(PythonInterp_FOUND)
-  if (CMAKE_CONFIGURATION_TYPES)
-    # Not really, but just to make the following if() true
-    set(_build_type release)
-    set(_configs CONFIGURATIONS Release RelWithDebInfo MinSizeRel)
-  else()
-    string(TOLOWER "${CMAKE_BUILD_TYPE}" _build_type)
-    set(_configs)
-  endif()
+if (CMAKE_CONFIGURATION_TYPES)
+  # Not really, but just to make the following if() true
+  set(_build_type release)
+  set(_configs CONFIGURATIONS Release RelWithDebInfo MinSizeRel)
+else()
+  string(TOLOWER "${CMAKE_BUILD_TYPE}" _build_type)
+  set(_configs)
+endif()
 
-  # Only enable test_cli_options stuff if building a release configuration,
-  # or using a multi-configuration generator (note: in the latter case, these
-  # will fail if a release configuration has not been built)
-  if (_build_type MATCHES "release|relwithdebinfo|minsizerel")
-    add_test(
-      NAME cli_options
-      COMMAND ${PYTHON_EXECUTABLE}
-        test_cli_options.py
-        --build ${uncrustify_BINARY_DIR}
-        --cache ${CMAKE_BINARY_DIR}/CMakeCache.txt
-        --diff
-      ${_configs}
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cli
-    )
+# Only enable test_cli_options stuff if building a release configuration,
+# or using a multi-configuration generator (note: in the latter case, these
+# will fail if a release configuration has not been built)
+if (_build_type MATCHES "release|relwithdebinfo|minsizerel")
+  add_test(
+    NAME cli_options
+    COMMAND ${PYTHON_EXECUTABLE}
+      test_cli_options.py
+      --build ${uncrustify_BINARY_DIR}
+      --cache ${CMAKE_BINARY_DIR}/CMakeCache.txt
+      --diff
+    ${_configs}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cli
+  )
 
-    add_custom_target(update_cli_options
-      COMMAND ${PYTHON_EXECUTABLE}
-        test_cli_options.py
-        --build ${uncrustify_BINARY_DIR}
-        --cache ${CMAKE_BINARY_DIR}/CMakeCache.txt
-        --apply
-      DEPENDS uncrustify
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cli
-    )
-  endif()
+  add_custom_target(update_cli_options
+    COMMAND ${PYTHON_EXECUTABLE}
+      test_cli_options.py
+      --build ${uncrustify_BINARY_DIR}
+      --cache ${CMAKE_BINARY_DIR}/CMakeCache.txt
+      --apply
+    DEPENDS uncrustify
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cli
+  )
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,3 +60,37 @@ foreach(test_lang c-sharp c cpp d java pawn objective-c vala ecma imported)
     endif()
   endforeach()
 endforeach()
+
+if(PythonInterp_FOUND)
+  if (CMAKE_CONFIGURATION_TYPES)
+    # Not really, but just to make the following if() true
+    set(_build_type release)
+  else()
+    string(TOLOWER "${CMAKE_BUILD_TYPE}" _build_type)
+  endif()
+
+  # Only enable test_cli_options stuff if building a release configuration,
+  # or using a multi-configuration generator (note: in the latter case, these
+  # will fail if a release configuration has not been built)
+  if (_build_type MATCHES "release|relwithdebinfo|minsizerel")
+    add_test(
+      NAME cli_options
+      COMMAND ${PYTHON_EXECUTABLE}
+        test_cli_options.py
+        --build ${uncrustify_BINARY_DIR}
+        --cache ${CMAKE_BINARY_DIR}/CMakeCache.txt
+        --diff
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cli
+    )
+
+    add_custom_target(update_cli_options
+      COMMAND ${PYTHON_EXECUTABLE}
+        test_cli_options.py
+        --build ${uncrustify_BINARY_DIR}
+        --cache ${CMAKE_BINARY_DIR}/CMakeCache.txt
+        --apply
+      DEPENDS uncrustify
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cli
+    )
+  endif()
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,8 +65,10 @@ if(PythonInterp_FOUND)
   if (CMAKE_CONFIGURATION_TYPES)
     # Not really, but just to make the following if() true
     set(_build_type release)
+    set(_configs CONFIGURATIONS Release RelWithDebInfo MinSizeRel)
   else()
     string(TOLOWER "${CMAKE_BUILD_TYPE}" _build_type)
+    set(_configs)
   endif()
 
   # Only enable test_cli_options stuff if building a release configuration,
@@ -80,6 +82,7 @@ if(PythonInterp_FOUND)
         --build ${uncrustify_BINARY_DIR}
         --cache ${CMAKE_BINARY_DIR}/CMakeCache.txt
         --diff
+      ${_configs}
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cli
     )
 

--- a/tests/cli/test_cli_options.py
+++ b/tests/cli/test_cli_options.py
@@ -422,15 +422,15 @@ def file_find_string(search_string, file_path):
     return False
 
 
-def check_build_type(build_type, cmake_cache_path):
+def check_build_type(build_types, cmake_cache_path):
     """
     checks if a cmake build was of a certain single-configuration type
 
 
     Parameters:
     ----------------------------------------------------------------------------
-    :param build_type: string
-        the build type that is going to be expected
+    :param build_types: list/tuple
+        list of acceptable build types
 
     :param cmake_cache_path: string
         the path of the to be checked CMakeCache.txt file
@@ -442,12 +442,13 @@ def check_build_type(build_type, cmake_cache_path):
 
     """
 
-    check_string = "CMAKE_BUILD_TYPE:STRING=%s" % build_type
+    for build_type in build_types:
+        check_string = "CMAKE_BUILD_TYPE:STRING=%s" % build_type
 
-    if file_find_string(check_string, cmake_cache_path):
-        return True
+        if file_find_string(check_string, cmake_cache_path):
+            return True
 
-    eprint("CMAKE_BUILD_TYPE must be '%s'" % build_type)
+    eprint("CMAKE_BUILD_TYPE must be one of %r" % build_types)
     return False
 
 
@@ -533,7 +534,11 @@ def main(args):
     bd_dir = parsed_args.build
     bin_paths = [s_path_join(bd_dir, 'uncrustify'),
                  s_path_join(bd_dir, 'Release/uncrustify'),
-                 s_path_join(bd_dir, 'Release/uncrustify.exe')]
+                 s_path_join(bd_dir, 'Release/uncrustify.exe'),
+                 s_path_join(bd_dir, 'RelWithDebInfo/uncrustify'),
+                 s_path_join(bd_dir, 'RelWithDebInfo/uncrustify.exe'),
+                 s_path_join(bd_dir, 'MinSizeRel/uncrustify'),
+                 s_path_join(bd_dir, 'MinSizeRel/uncrustify.exe')]
     for uncr_bin in bin_paths:
         if not isfile(uncr_bin):
             eprint("is not a file: %s" % uncr_bin)
@@ -548,11 +553,11 @@ def main(args):
     '''
     Check if the binary was build as Release-type
     
-    TODO: find a check for Windows,
-          for now rely on the ../../build/Release/ location
+    TODO: fix this for multi-configuration generators
     '''
     if os_name != 'nt' and not check_build_type(
-            'release', s_path_join(bd_dir, 'CMakeCache.txt')):
+            ['release', 'relwithdebinfo', 'minsizerel'],
+            s_path_join(bd_dir, 'CMakeCache.txt')):
         sys_exit(EX_USAGE)
 
     clear_dir(s_path_join(sc_dir, "./results"))

--- a/tests/cli/test_cli_options.py
+++ b/tests/cli/test_cli_options.py
@@ -525,6 +525,8 @@ def main(args):
     parser.add_argument('--build',
                         default=s_path_join(sc_dir, '../../build'),
                         help='specify location of the build directory')
+    parser.add_argument('--cache',
+                        help='specify location of CMake cache')
 
     parsed_args = parser.parse_args()
 
@@ -557,7 +559,7 @@ def main(args):
     '''
     if os_name != 'nt' and not check_build_type(
             ['release', 'relwithdebinfo', 'minsizerel'],
-            s_path_join(bd_dir, 'CMakeCache.txt')):
+            parsed_args.cache or s_path_join(bd_dir, 'CMakeCache.txt')):
         sys_exit(EX_USAGE)
 
     clear_dir(s_path_join(sc_dir, "./results"))

--- a/tests/cli/test_cli_options.py
+++ b/tests/cli/test_cli_options.py
@@ -521,15 +521,19 @@ def main(args):
                         help='show diffs when there is a test mismatch')
     parser.add_argument('--apply', action='store_true',
                         help='auto apply the changes from the results folder to the output folder')
+    parser.add_argument('--build',
+                        default=s_path_join(sc_dir, '../../build'),
+                        help='specify location of the build directory')
 
     parsed_args = parser.parse_args()
 
     # find the uncrustify binary (keep Debug dir excluded)
     bin_found = False
     uncr_bin = ''
-    bin_paths = [s_path_join(sc_dir, '../../build/uncrustify'),
-                 s_path_join(sc_dir, '../../build/Release/uncrustify'),
-                 s_path_join(sc_dir, '../../build/Release/uncrustify.exe')]
+    bd_dir = parsed_args.build
+    bin_paths = [s_path_join(bd_dir, 'uncrustify'),
+                 s_path_join(bd_dir, 'Release/uncrustify'),
+                 s_path_join(bd_dir, 'Release/uncrustify.exe')]
     for uncr_bin in bin_paths:
         if not isfile(uncr_bin):
             eprint("is not a file: %s" % uncr_bin)
@@ -548,7 +552,7 @@ def main(args):
           for now rely on the ../../build/Release/ location
     '''
     if os_name != 'nt' and not check_build_type(
-            'release', s_path_join(sc_dir, '../../build/CMakeCache.txt')):
+            'release', s_path_join(bd_dir, 'CMakeCache.txt')):
         sys_exit(EX_USAGE)
 
     clear_dir(s_path_join(sc_dir, "./results"))


### PR DESCRIPTION
Modify `test_cli_options.py` to work if the build directory is not `${CMAKE_SOURCE_DIR}/build`, and also (at least in theory) to work if uncrustify is being build via `add_subdirectory` as part of a larger project. Add a CTest test to run the script as part of the suite of CTest tests, and also a custom target to run the script in `--apply` mode; both of these make it *much* easier for contributors to run the script, and also increase the chances that they will actually do so.