### PR TITLE
Adopt UT 20011

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -4559,6 +4559,31 @@ static void mark_function(chunk_t *pc)
       //LOG_FMT(LFCN, " -- stopped on %s [%s]\n",
       //        prev->text(), get_token_name(prev->type));
 
+      // Fixes issue #1634
+      if (chunk_is_paren_close(prev))
+      {
+         chunk_t *preproc = chunk_get_next_ncnl(prev);
+         if (chunk_is_token(preproc, CT_PREPROC))
+         {
+            size_t pp_level = preproc->pp_level;
+            if (chunk_is_token(chunk_get_next_ncnl(preproc), CT_PP_ELSE))
+            {
+               do
+               {
+                  preproc = chunk_get_prev_ncnl(preproc);
+                  if (chunk_is_token(preproc, CT_PP_IF))
+                  {
+                     preproc = chunk_get_prev_ncnl(preproc);
+                     if (preproc->pp_level == pp_level)
+                     {
+                        prev = chunk_get_prev_ncnlnp(preproc);
+                        break;
+                     }
+                  }
+               } while (preproc != nullptr);
+            }
+         }
+      }
       if (  isa_def
          && prev != nullptr
          && (  (chunk_is_paren_close(prev) && prev->parent_type != CT_D_CAST)

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -606,6 +606,7 @@
 10566  empty.cfg                            cpp/issue_1752.cpp
 11000  UNI-12046.cfg                        cpp/UNI-12046.cpp
 20002  UNI-32657.cfg                        cpp/UNI-32657.cpp
+20011  empty.cfg                            cpp/UNI-38381.cpp
 60001  UNI-2650.cfg                         cpp/UNI-2650.cpp
 60002  U25-Cpp.cfg                          cpp/UNI-16283.cpp
 60003  U26-Cpp.cfg                          cpp/UNI-1288.cpp

--- a/tests/input/cpp/UNI-38381.cpp
+++ b/tests/input/cpp/UNI-38381.cpp
@@ -1,0 +1,5 @@
+#if UNITY_DEFER_GRAPHICS_JOBS_SCHEDULE
+void GfxDevice::ScheduleAsyncJob(AsyncCommandJobFunc* jobFunc, GfxDeviceAsyncCommand* cmd, const JobFence& depends, JobBatchDispatcher& dispatcher)
+#else
+JobFence& GfxDevice::ScheduleAsyncJob(AsyncCommandJobFunc* jobFunc, GfxDeviceAsyncCommand* cmd, const JobFence& depends, JobBatchDispatcher& dispatcher)
+#endif // #if UNITY_DEFER_GRAPHICS_JOBS_SCHEDULE

--- a/tests/output/cpp/20011-UNI-38381.cpp
+++ b/tests/output/cpp/20011-UNI-38381.cpp
@@ -1,0 +1,5 @@
+#if UNITY_DEFER_GRAPHICS_JOBS_SCHEDULE
+void GfxDevice::ScheduleAsyncJob(AsyncCommandJobFunc* jobFunc, GfxDeviceAsyncCommand* cmd, const JobFence& depends, JobBatchDispatcher& dispatcher)
+#else
+JobFence& GfxDevice::ScheduleAsyncJob(AsyncCommandJobFunc* jobFunc, GfxDeviceAsyncCommand* cmd, const JobFence& depends, JobBatchDispatcher& dispatcher)
+#endif // #if UNITY_DEFER_GRAPHICS_JOBS_SCHEDULE


### PR DESCRIPTION
Another example where `CT_STAR` is tokenised as `CT_ARITH` and not as pointer type
Ref. #1634
Thanks to Kalyana Chakravarthi