### PR TITLE
Squelch ignored-qualifiers warning

### DIFF
--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -42,8 +42,11 @@ class ParseFrame;
 //! returns type (with removed reference) of a variable
 #define noref_decl_t(X)              std::remove_reference<decltype((X))>::type
 
+//! returns type (with removed const and reference) of a variable
+#define nocref_decl_t(X)             std::remove_const<noref_decl_t((X))>::type
+
 //! static casts Y to the type (with removed reference) of X
-#define s_cast_noref_decl_t(X, Y)    static_cast<noref_decl_t(X)>(Y)
+#define s_cast_noref_decl_t(X, Y)    static_cast<nocref_decl_t(X)>(Y)
 
 //! performs abs on Y after static casting it to the type (with removed reference) of X
 #define cast_abs(X, Y)               s_cast_noref_decl_t(X, abs(Y))


### PR DESCRIPTION
Modify `cast_abs` helper to remove `const` from the cast type. This avoids tripping -Wignored-qualifiers, and is almost certainly safe since the value being casted is the result of `abs()` and is almost certainly a scalar type. (In actual use, it is always an integer type...)

...because I like to build with -Werror=ignored-qualifiers :slightly_smiling_face:.