### PR TITLE
Split travis build status badge for linux and osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,18 @@ matrix:
   include:
     - os: linux
       dist: trusty
-      env: BUILD_TYPE=debug
+      env: BADGE=linux BUILD_TYPE=debug
     - os: linux
       dist: trusty
-      env: BUILD_TYPE=release
+      env: BADGE=linux BUILD_TYPE=release
     - os: linux
       dist: trusty
-      env: BUILD_TYPE=release NO_MACRO_VARARG=1
+      env: BADGE=linux BUILD_TYPE=release NO_MACRO_VARARG=1
 
     # GCC 6
     - os: linux
       dist: trusty 
-      env: C_COMPILER=gcc-6 CXX_COMPILER=g++-6
+      env: BADGE=linux C_COMPILER=gcc-6 CXX_COMPILER=g++-6
       addons:
         apt:
           update: true
@@ -29,7 +29,7 @@ matrix:
     # Clang 3.8 address sanitizer
     - os: linux
       dist: trusty
-      env: BUILD_TYPE=asan C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8
+      env: BADGE=linux BUILD_TYPE=asan C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8
       addons:
         apt:
           sources:
@@ -41,7 +41,7 @@ matrix:
     # mingw-w64 Win64 cross-compile
     - os: linux
       dist: trusty
-      env: BUILD_TYPE=cross C_COMPILER=x86_64-w64-mingw32-gcc CXX_COMPILER=x86_64-w64-mingw32-g++
+      env: BADGE=linux BUILD_TYPE=cross C_COMPILER=x86_64-w64-mingw32-gcc CXX_COMPILER=x86_64-w64-mingw32-g++
       addons:
         apt:
           packages:
@@ -58,9 +58,9 @@ matrix:
 
     # OSX
     - os: osx
-      env: BUILD_TYPE=debug
+      env: BADGE=osx BUILD_TYPE=debug
     - os: osx
-      env: BUILD_TYPE=release
+      env: BADGE=osx BUILD_TYPE=release
 
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Travis CI](https://img.shields.io/travis/uncrustify/uncrustify/master.svg?style=flat-square&label=Linux&env=BADGE=linux&branch=master)](https://travis-ci.org/uncrustify/uncrustify)
-[![Travis CI](https://img.shields.io/travis/uncrustify/uncrustify/master.svg?style=flat-square&label=OSX&env=BADGE=osx&branch=master)](https://travis-ci.org/uncrustify/uncrustify)
+[![Travis CI](http://badges.herokuapp.com/travis/uncrustify/uncrustify?style=flat-square&env=BADGE=linux&label=build&branch=master)](https://travis-ci.org/uncrustify/uncrustify)
+[![Travis CI](http://badges.herokuapp.com/travis/uncrustify/uncrustify?style=flat-square&env=BADGE=osx&label=build&branch=master)](https://travis-ci.org/uncrustify/uncrustify)
 [![AppVeyor](https://img.shields.io/appveyor/ci/uncrustify/uncrustify/master.svg?style=flat-square&label=Windows)](https://ci.appveyor.com/project/uncrustify/uncrustify)
 [![Coverity](https://scan.coverity.com/projects/8264/badge.svg)](https://scan.coverity.com/projects/uncrustify)
 <a href="#"><img src="https://img.shields.io/badge/C++-11-blue.svg?style=flat-square"></a>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Travis CI](https://img.shields.io/travis/uncrustify/uncrustify/master.svg?style=flat-square&label=Linux)](https://travis-ci.org/uncrustify/uncrustify)
+[![Travis CI](https://img.shields.io/travis/uncrustify/uncrustify/master.svg?style=flat-square&label=Linux&env=BADGE=linux&branch=master)](https://travis-ci.org/uncrustify/uncrustify)
+[![Travis CI](https://img.shields.io/travis/uncrustify/uncrustify/master.svg?style=flat-square&label=OSX&env=BADGE=osx&branch=master)](https://travis-ci.org/uncrustify/uncrustify)
 [![AppVeyor](https://img.shields.io/appveyor/ci/uncrustify/uncrustify/master.svg?style=flat-square&label=Windows)](https://ci.appveyor.com/project/uncrustify/uncrustify)
 [![Coverity](https://scan.coverity.com/projects/8264/badge.svg)](https://scan.coverity.com/projects/uncrustify)
 <a href="#"><img src="https://img.shields.io/badge/C++-11-blue.svg?style=flat-square"></a>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Travis CI](http://badges.herokuapp.com/travis/uncrustify/uncrustify?style=flat-square&env=BADGE=linux&label=build&branch=master)](https://travis-ci.org/uncrustify/uncrustify)
-[![Travis CI](http://badges.herokuapp.com/travis/uncrustify/uncrustify?style=flat-square&env=BADGE=osx&label=build&branch=master)](https://travis-ci.org/uncrustify/uncrustify)
+[![Travis CI](http://badges.herokuapp.com/travis/uncrustify/uncrustify?style=flat-square&env=BADGE=linux&label=Linux&branch=master)](https://travis-ci.org/uncrustify/uncrustify)
+[![Travis CI](http://badges.herokuapp.com/travis/uncrustify/uncrustify?style=flat-square&env=BADGE=osx&label=OSX&branch=master)](https://travis-ci.org/uncrustify/uncrustify)
 [![AppVeyor](https://img.shields.io/appveyor/ci/uncrustify/uncrustify/master.svg?style=flat-square&label=Windows)](https://ci.appveyor.com/project/uncrustify/uncrustify)
 [![Coverity](https://scan.coverity.com/projects/8264/badge.svg)](https://scan.coverity.com/projects/uncrustify)
 <a href="#"><img src="https://img.shields.io/badge/C++-11-blue.svg?style=flat-square"></a>


### PR DESCRIPTION
We can actually split the badge when our travis build matrix is targeting multiple operating systems using an environment variable as mentioned here https://github.com/travis-ci/travis-ci/issues/9579 and in the docs here https://github.com/exogen/badge-matrix\#travisuserrepo.