### PR TITLE
newline_func_def_or_call - don't use func def/decl options for funcalls

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -2385,6 +2385,11 @@ static void newline_func_def_or_call(chunk_t *start)
          {
             pc = tmp;
          }
+
+         if (is_call)
+         {
+            continue;
+         } // else:
          newline_iarf(pc, cpd.settings[(  start->parent_type == CT_FUNC_DEF
                                        || start->parent_type == CT_FUNC_CLASS_DEF) ?
                                        UO_nl_func_def_args :
@@ -2410,13 +2415,16 @@ static void newline_func_def_or_call(chunk_t *start)
          ae = atmp;
       }
    }
-   newline_iarf(start, as);
+   if (!is_call)
+   {
+      newline_iarf(start, as);
+   }
 
    // and fix up the close parenthesis
    if (chunk_is_token(pc, CT_FPAREN_CLOSE))
    {
       prev = chunk_get_prev_nnl(pc);
-      if (prev != nullptr && prev->type != CT_FPAREN_OPEN)
+      if (prev != nullptr && prev->type != CT_FPAREN_OPEN && !is_call)
       {
          newline_iarf(prev, ae);
       }

--- a/tests/config/i1768.cfg
+++ b/tests/config/i1768.cfg
@@ -1,0 +1,2 @@
+nl_func_call_paren              = remove
+nl_func_decl_start              = force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -566,6 +566,8 @@
 34294  sp_after_type_brace_init_lst_open-f.cfg  cpp/brace_brace_init_lst.cpp
 34295  sp_after_type_brace_init_lst_open-r.cfg  cpp/brace_brace_init_lst.cpp
 
+34296  i1768.cfg                            cpp/i1768.cpp
+
 # __asm__
 34300  bug_1236.cfg                         cpp/bug_1236.cpp
 
@@ -626,3 +628,4 @@
 60038  UNI-30088.cfg                        cpp/UNI-30088.cpp
 60039  U36-Cpp.cfg                          cpp/UNI-30628.cpp
 60042  UNI-18777.cfg                        cpp/UNI-18777.cpp
+

--- a/tests/input/cpp/i1768.cpp
+++ b/tests/input/cpp/i1768.cpp
@@ -1,0 +1,6 @@
+void f(int a, int b);
+
+void g()
+{
+	f(1, 2);
+}

--- a/tests/output/cpp/34296-i1768.cpp
+++ b/tests/output/cpp/34296-i1768.cpp
@@ -1,0 +1,7 @@
+void f(
+	int a, int b);
+
+void g()
+{
+	f(1, 2);
+}


### PR DESCRIPTION
ref #1768