### PR TITLE
Fix expected output for test objective-c:50410

### DIFF
--- a/tests/output/oc/50410-oc_cond_colon.m
+++ b/tests/output/oc/50410-oc_cond_colon.m
@@ -6,4 +6,4 @@ x = path[0] == '/' ? path:"abc";
 x = path[0] == '/' ? [NSString str : path]:[NSString strFormat : @"Data/%s", path];
 
 id<MTLBuffer> buf = data ? [metal::g_Device newBufferWithBytes : data length : len options : MTLResourceOptionCPUCacheModeDefault]
-		    :[metal::g_Device newBufferWithLength : len options : MTLResourceOptionCPUCacheModeDefault];
+                    :[metal::g_Device newBufferWithLength : len options : MTLResourceOptionCPUCacheModeDefault];


### PR DESCRIPTION
Replace tabs with spaces in the expected output for Objective C test 50410. This results in a passing test, which was previously failing, and seems to be correct since there is nothing in the test's config to indicate that tabs are expected in the output.

Some digging points to 0fc6091f1710 as the cause of failure, indicating that the change in output was intentional. However, at that point (and still as of this commit), CTest is not running this test, so almost certainly it just got overlooked.
