### PR TITLE
Minor CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ script:
   # test if all the sources are conform to the forUncrustifySources.cfg config file
   - if [ "x${BUILD_TYPE}" == "xrelease" ]; then cd ../ && ./scripts/Run_uncrustify_for_sources.sh; cd -; fi
   # run all tests
-  - if [ "x${BUILD_TYPE}" != "xcross" ]; then ctest -V; fi
+  - if [ "x${BUILD_TYPE}" != "xcross" ]; then ctest --output-on-failure; fi
 
   # DO NOT REMOVE (debugging purposes)
   #- /home/travis/build/uncrustify/uncrustify/build/uncrustify -l cs -c /home/travis/build/uncrustify/uncrustify/tests/config/U10-Cpp.cfg -f /home/travis/build/uncrustify/uncrustify/tests/input/cs/newlines.mm -L A

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,8 +113,6 @@ script:
   - make VERBOSE=1
   # test if all the sources are conform to the forUncrustifySources.cfg config file
   - if [ "x${BUILD_TYPE}" == "xrelease" ]; then cd ../ && ./scripts/Run_uncrustify_for_sources.sh; cd -; fi
-  # test if uncrustify runs for (some) command line options
-  - if [ "x${BUILD_TYPE}" == "xrelease" ]; then cd ../tests/cli && ./test_cli_options.py; cd -; fi
   # run all tests
   - if [ "x${BUILD_TYPE}" != "xcross" ]; then ctest -V; fi
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,5 +31,5 @@ build_script:
 test_script:
 #  - echo This is for test only
 #  - C:/projects/uncrustify/build/Debug/uncrustify.exe -c C:/projects/uncrustify/tests/config/mono.cfg -f C:/projects/uncrustify/tests/input/cs/simple.cs -L 66
-  - ctest -C %CONFIGURATION% -V
+  - ctest -C %CONFIGURATION% --output-on-failure
 deploy: off


### PR DESCRIPTION
Remove redundant run of `test_cli_options.sh`; this is now covered by a CTest test. Only show verbose output from tests that failed; this should make the logs easier to read.