### PR TITLE
 Clean up and "modernize" .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,45 +1,17 @@
-# Generated uncrustify files
-src/config.h
-src/token_names.h
-src/uncrustify_version.h
+# "Default" build tree
+/build/
 
-# Testing framework
+# Compiled Python code
+*.pyc
+
+# Testing framework (if run_tests.py is run from the source tree)
 results/
-tests/results/
-tests/results_2/
-tests/usage.txt
-tests/pclint/
-*.sh.trs
-*.sh.log
-test-suite.log
+results_2/
 
-# Testing with gcov
+# Static analysis and code coverage
+/tests/pclint/
+/cov-int
 gcov_test/
-
-# UNIX build artifacts
-*.[oadisS]
-src/uncrustify
-
-# Gnu autotools
-Makefile
-Makefile.in
-/autom4te.cache
-/autoscan.log
-/autoscan-*.log
-/aclocal.m4
-/autotools/compile
-/config.h.in
-/configure
-/configure.scan
-/depcomp
-/autotools/install-sh
-/autotools/missing
-/autotools/test-driver
-/stamp-h1
-/src/stamp-h1
-config.log
-config.status
-man/uncrustify.1
 
 # SlickEdit workspace history and tag files
 *.vtg
@@ -50,16 +22,9 @@ man/uncrustify.1
 .lock*
 waf*
 
-# Visual Studio temporary files, build results, etc
-win32/Intermediate
-win32/Release
-win32/Debug
-win32/*.*sdf
-win32/*.suo
-win32/*.user
-win32/**/*.VC.db
-win32/**/*.obj
-win32/**/*.exe
+# KDevelop
+*.kdev4
+.kdev4/
 
 # XCode
 *.xcodeproj/*.pbxuser
@@ -70,19 +35,13 @@ win32/**/*.exe
 *.xcworkspace
 xcuserdata
 
-# Windows mingw build
-uncrustify-*-win32
-
 # Sublime
 *.sublime-workspace
 
-# Coverity
-/cov-int
-
-# TRIAGE: To clasify or remove
-.svn
-.*
-build*
+# Eclipse Configuration
+.cproject
+.project
+.settings
 
 # backup files
 #   texteditor (kate, etc.)
@@ -92,13 +51,3 @@ build*
 
 # uncrustified files
 *.uncrustify
-
-# Eclipse Build Directories
-Debug/
-Release/
-build/
-
-# Eclipse Configuration
-.cproject
-.project
-.settings

--- a/src/.kateconfig
+++ b/src/.kateconfig
@@ -1,0 +1,1 @@
+kate: indent-width 3;


### PR DESCRIPTION
This removes a bunch of cruft from `.gitignore` (e.g. autotools build artifacts) and adds `*.pyc` and [KDevelop](https://www.kdevelop.org/) project files. It also adds a `.kateconfig` so users of katepart-based editors (e.g. the aforementioned KDevelop) will automatically pick up the correct indent width without having to reconfigure their editors. (Because, seriously, 3 is weird :wink:. Not many developers are likely using that as their global default.)

While axing the old cruft is useful in its own right, this is related to #1821, in that that PR starts generating a bunch of `.pyc`s, eliminates `tests/usage.txt`, and risks creating `/results_2/` if `run_tests.py` is run from the top of the checkout. (Also, as I'm sure is obvious, the kate-friendly stuff is for my own convenience :smile:, but I'll claim existing precedent given the existing bits for sublime, slickedit, etc.)

I left the lint/coverage entries, though I wonder if these would not be in the build tree?

If I dropped anything that should stay, please let me know.