### PR TITLE
fix nl_func_type_name

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -2339,7 +2339,12 @@ static void newline_func_def_or_call(chunk_t *start)
                   && prev->type != CT_VBRACE_CLOSE
                   && prev->type != CT_BRACE_OPEN
                   && prev->type != CT_SEMICOLON
-                  && prev->type != CT_PRIVATE_COLON)
+                  && prev->type != CT_PRIVATE_COLON
+                     // #1008: if we landed on an operator check that it is having
+                     // a type before it, in order to not apply nl_func_type_name
+                     // on conversion operators as they don't have a normal
+                     // return type syntax
+                  && (tmp_next->type != CT_OPERATOR ? true : chunk_is_type(prev)))
                {
                   newline_iarf(prev, a);
                }

--- a/tests/config/nl_func_type_name-r.cfg
+++ b/tests/config/nl_func_type_name-r.cfg
@@ -1,0 +1,1 @@
+nl_func_type_name               = remove                                       #

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -569,6 +569,8 @@
 34206  indent_semicolon_for_paren-t.cfg     cpp/for_loop_head.cpp
 34207  indent_first_for_expr-t.cfg          cpp/for_loop_head.cpp
 
+34208  nl_func_type_name-r.cfg              cpp/conversion_operator.cpp
+
 
 # TODO: Find relevant test cases for 'override'.
 34210  empty.cfg                            cpp/override_virtual.cpp

--- a/tests/input/cpp/conversion_operator.cpp
+++ b/tests/input/cpp/conversion_operator.cpp
@@ -1,0 +1,5 @@
+template< class T >
+operator T*() const
+{
+	return 0;
+}

--- a/tests/output/cpp/34208-conversion_operator.cpp
+++ b/tests/output/cpp/34208-conversion_operator.cpp
@@ -1,0 +1,5 @@
+template< class T >
+operator T*() const
+{
+	return 0;
+}


### PR DESCRIPTION
prevent `nl_func_type_name` from being applied onto user-defined conversion
operators which do not follow the conventional function syntax:

_returnType memberFunctionName() ..._

but

_[explicit] operator int() ..._

where the _returnType_ is the _memberFunctionName_


----
ref: #1008 