### PR TITLE
Treat SIZEOF as arithmetic for check_template_arg

### DIFF
--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -1168,7 +1168,7 @@ static void check_template_arg(chunk_t *start, chunk_t *end)
       if (next->type != CT_PAREN_OPEN)
       {
          if (  chunk_is_token(pc, CT_NUMBER)
-            || (chunk_is_token(pc, CT_ARITH) && pc->type != CT_STAR))
+            || chunk_is_token(pc, CT_ARITH))
          {
             expressionIsNumeric = true;
             break;

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -1165,6 +1165,11 @@ static void check_template_arg(chunk_t *start, chunk_t *end)
       chunk_t *next = chunk_get_next_ncnl(pc, scope_e::PREPROC);
       // a test "if (next == nullptr)" is not necessary
       chunk_flags_set(pc, PCF_IN_TEMPLATE);
+      if (chunk_is_token(pc, CT_SIZEOF))
+      {
+         expressionIsNumeric = true;
+         break;
+      }
       if (next->type != CT_PAREN_OPEN)
       {
          if (  chunk_is_token(pc, CT_NUMBER)

--- a/tests/config/issue_1778.cfg
+++ b/tests/config/issue_1778.cfg
@@ -1,0 +1,3 @@
+sp_after_ptr_star               = add
+sp_after_byref                  = add
+sp_inside_sparen                = force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -312,6 +312,7 @@
 31583  empty.cfg                            cpp/sf583.cpp
 31593  indent_continue-8.cfg                cpp/sf593.cpp
 31594  issue_672.cfg                        cpp/issue_672.cpp
+31595  issue_1778.cfg                       cpp/issue_1778.cpp
 
 31600  sp_paren_ellipsis-f.cfg              cpp/parameter-packs.cpp
 31601  sp_paren_ellipsis-r.cfg              cpp/parameter-packs.cpp

--- a/tests/expected/cpp/31595-issue_1778.cpp
+++ b/tests/expected/cpp/31595-issue_1778.cpp
@@ -1,0 +1,7 @@
+using x = Foo::foo_t;
+
+using a1 = decltype( &Foo::operator() );
+using a2 = Bar<decltype( &Foo::operator() )>;
+
+using b1 = decltype( *Foo::y );
+using b2 = Bar<decltype( *Foo::y )>;

--- a/tests/input/cpp/issue_1778.cpp
+++ b/tests/input/cpp/issue_1778.cpp
@@ -1,0 +1,7 @@
+using x = Foo::foo_t;
+
+using a1 = decltype( &Foo::operator() );
+using a2 = Bar<decltype( &Foo::operator() )>;
+
+using b1 = decltype( *Foo::y );
+using b2 = Bar<decltype( *Foo::y )>;


### PR DESCRIPTION
Remove dead test in `check_template`. Tweak `check_template_arg` to treat an argument containing a `SIZEOF` (which includes `decltype`) as "arithmetic".

This fixes #1778, although it is something of a brute force approach (but one that seems plausible given the current approach to how `check_template_arg` decides whether or not to mark things as `TYPE`).