### PR TITLE
Don't clobber tokenization of `using` RHS.

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1868,7 +1868,10 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
          // it is a Type alias, alias template
          for (temp = pc; temp != nullptr; temp = chunk_get_next_ncnl(temp))
          {
-            set_chunk_parent(temp, CT_USING_ALIAS);
+            if (temp->parent_type == CT_NONE)
+            {
+               set_chunk_parent(temp, CT_USING_ALIAS);
+            }
             if (chunk_is_token(temp, CT_SEMICOLON))
             {
                break;

--- a/tests/config/issue_1782.cfg
+++ b/tests/config/issue_1782.cfg
@@ -1,0 +1,12 @@
+sp_compare                      = force
+sp_inside_paren                 = force
+sp_paren_paren                  = force
+sp_before_angle                 = remove
+sp_inside_angle                 = force
+sp_angle_paren                  = remove
+sp_angle_paren_empty            = remove
+sp_angle_word                   = force
+sp_inside_fparens               = remove
+sp_inside_fparen                = remove
+sp_func_call_paren              = remove
+sp_func_call_paren_empty        = remove

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -313,6 +313,7 @@
 31593  indent_continue-8.cfg                cpp/sf593.cpp
 31594  issue_672.cfg                        cpp/issue_672.cpp
 31595  issue_1778.cfg                       cpp/issue_1778.cpp
+31596  issue_1782.cfg                       cpp/issue_1782.cpp
 
 31600  sp_paren_ellipsis-f.cfg              cpp/parameter-packs.cpp
 31601  sp_paren_ellipsis-r.cfg              cpp/parameter-packs.cpp

--- a/tests/expected/cpp/31596-issue_1782.cpp
+++ b/tests/expected/cpp/31596-issue_1782.cpp
@@ -1,0 +1,20 @@
+using a1 = decltype( bar() );
+using b1 = decltype( bar< int >() );
+using c1 = decltype( foo::bar< int >() );
+using d1 = decltype( *( bar< int >() ) );
+using e1 = decltype( *( foo::bar< int >() ) );
+
+using a2 = decltype( bar() );
+using b2 = decltype( bar< int >() );
+using c2 = decltype( foo::bar< int >() );
+using d2 = decltype( *( bar< int >() ) );
+using e2 = decltype( *( foo::bar< int >() ) );
+
+using a3 = decltype( bar(0) );
+using b3 = decltype( bar< int >(0) );
+using c3 = decltype( foo::bar< int >(0) );
+using d3 = decltype( *( bar< int >(0) ) );
+using e3 = decltype( *( foo::bar< int >(0) ) );
+
+using x1 = decltype( ( 0 ) );
+using x2 = decltype( ( 0 ) );

--- a/tests/input/cpp/issue_1782.cpp
+++ b/tests/input/cpp/issue_1782.cpp
@@ -1,0 +1,20 @@
+using a1 = decltype(bar());
+using b1 = decltype(bar<int>());
+using c1 = decltype(foo::bar<int>());
+using d1 = decltype(*(bar<int>()));
+using e1 = decltype(*(foo::bar<int>()));
+
+using a2 = decltype(  bar  (  )  );
+using b2 = decltype(  bar  <  int  >  (  )  );
+using c2 = decltype(  foo::bar  <  int  >  (  )  );
+using d2 = decltype(  *(  bar  <  int  >  (  )  )  );
+using e2 = decltype(  *(  foo::bar  <  int  >  (  )  )  );
+
+using a3 = decltype(  bar  (  0  )  );
+using b3 = decltype(  bar  <  int  >  (  0  )  );
+using c3 = decltype(  foo::bar  <  int  >  (  0  )  );
+using d3 = decltype(  *(  bar  <  int  >  (  0  )  )  );
+using e3 = decltype(  *(  foo::bar  <  int  >  (  0  )  )  );
+
+using x1 = decltype((0));
+using x2 = decltype(  (  0  )  );


### PR DESCRIPTION
When marking the RHS of a `using` declaration, only set the parent type if the parent type is not already set. This is critical in order to be able to correctly parse more complicated declarations. (In particular, clobbering `CT_TEMPLATE` breaks later detection of template function invocations.)

This fixes #1782.