### PR TITLE
Fix identification of array reference parameters

### DIFF
--- a/src/space.cpp
+++ b/src/space.cpp
@@ -992,7 +992,8 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
       return(cpd.settings[UO_sp_after_byref].a);
    }
 
-   if (chunk_is_token(second, CT_BYREF))
+   if (  chunk_is_token(second, CT_BYREF)
+      && !chunk_is_token(first, CT_PAREN_OPEN))
    {
       if (cpd.settings[UO_sp_before_byref_func].a != AV_IGNORE)
       {

--- a/tests/config/issue_1804.cfg
+++ b/tests/config/issue_1804.cfg
@@ -1,0 +1,10 @@
+sp_after_type                   = force
+sp_after_cast                   = remove
+sp_inside_paren_cast            = remove
+sp_cpp_cast_paren               = remove
+sp_addr                         = remove
+sp_after_byref                  = force
+sp_inside_paren                 = force
+sp_inside_fparen                = force
+sp_inside_square                = force
+sp_before_square                = force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -314,6 +314,7 @@
 31594  issue_672.cfg                        cpp/issue_672.cpp
 31595  issue_1778.cfg                       cpp/issue_1778.cpp
 31596  issue_1782.cfg                       cpp/issue_1782.cpp
+31597  issue_1804.cfg                       cpp/issue_1804.cpp
 
 31600  sp_paren_ellipsis-f.cfg              cpp/parameter-packs.cpp
 31601  sp_paren_ellipsis-r.cfg              cpp/parameter-packs.cpp

--- a/tests/expected/cpp/31597-issue_1804.cpp
+++ b/tests/expected/cpp/31597-issue_1804.cpp
@@ -1,0 +1,2 @@
+void foo1( int ( & x ) [ 2 ] );
+void foo2( int ( & x ) [ 2 ] );

--- a/tests/input/cpp/issue_1804.cpp
+++ b/tests/input/cpp/issue_1804.cpp
@@ -1,0 +1,2 @@
+void foo1(int(&x)[2]);
+void foo2(  int  (  &  x  )  [  2  ]  );


### PR DESCRIPTION
Tweak code that detects C++ casts to also detect and correctly mark array reference parameters (rather than incorrectly marking them as C++ casts). Tweak application of `sp_before_byref` to prevent applying it between an open parenthesis and an ampersand, which causes `sp_inside_paren` to be applied instead (see commit message and tests for rationale).

This fixes #1804.