### PR TITLE
Introduced "Blocks" to fix the bug #1760

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,7 @@ add_executable(uncrustify
   src/align_stack.cpp
   src/args.cpp
   src/backup.cpp
+  src/BlockNumbering.cpp
   src/braces.cpp
   src/brace_cleanup.cpp
   src/ChunkStack.cpp
@@ -226,6 +227,7 @@ add_executable(uncrustify
   src/args.h
   src/backup.h
   src/base_types.h
+  src/BlockNumbering.h
   src/char_table.h
   src/ChunkStack.h
   src/chunk_list.h

--- a/src/BlockNumbering.cpp
+++ b/src/BlockNumbering.cpp
@@ -11,23 +11,23 @@
 #include "log_levels.h"
 #include "logger.h"
 
-static size_t Number = 0;
+static size_t number = 0;
 
 
-size_t GetBlockNumber()
+size_t getBlockNumber()
 {
-   Number++;
-   return(Number);
+   number++;
+   return(number);
 }
 
 
-void NumberTheBlocks()
+void numberTheBlocks()
 {
    LOG_FUNC_ENTRY();
 
    LOG_FMT(LALASS, "%s(%d): Number the blocks.\n", __func__, __LINE__);
 
-   size_t  BlockNumber = GetBlockNumber();
+   size_t  blockNumber = getBlockNumber();
    chunk_t *pc         = chunk_get_head();
    while (pc != nullptr)
    {
@@ -47,10 +47,10 @@ void NumberTheBlocks()
          || chunk_is_token(pc, CT_ANGLE_OPEN))
       {
          // get a new number
-         BlockNumber = GetBlockNumber();
+         blockNumber = getBlockNumber();
       }
 
-      pc->Block_Number = BlockNumber;
+      pc->blockNumber = blockNumber;
 
       if (  chunk_is_token(pc, CT_BRACE_CLOSE)
          || chunk_is_token(pc, CT_FPAREN_CLOSE)
@@ -63,14 +63,14 @@ void NumberTheBlocks()
          // this is the 'old' block number
          if (prev == nullptr)
          {
-            BlockNumber = 0;
+            blockNumber = 0;
          }
          else
          {
-            BlockNumber = prev->Block_Number;
+            blockNumber = prev->blockNumber;
          }
       }
 
       pc = chunk_get_next(pc);
    }
-} // NumberTheBlocks
+} // numberTheBlocks

--- a/src/BlockNumbering.cpp
+++ b/src/BlockNumbering.cpp
@@ -1,0 +1,76 @@
+/**
+ * @file BlockNumbering.cpp
+ *
+ * @author  Guy Maurel
+ *          Juni 2018
+ * @license GPL v2+
+ */
+
+#include "BlockNumbering.h"
+#include "chunk_list.h"
+#include "log_levels.h"
+#include "logger.h"
+
+static size_t Number = 0;
+
+
+size_t GetBlockNumber()
+{
+   Number++;
+   return(Number);
+}
+
+
+void NumberTheBlocks()
+{
+   LOG_FUNC_ENTRY();
+
+   LOG_FMT(LALASS, "%s(%d): Number the blocks.\n", __func__, __LINE__);
+
+   size_t  BlockNumber = GetBlockNumber();
+   chunk_t *pc         = chunk_get_head();
+   while (pc != nullptr)
+   {
+      if (chunk_is_token(pc, CT_NEWLINE))
+      {
+         LOG_FMT(LALASS, "%s(%d): orig_line is %zu, orig_col is %zu, <Newline>\n",
+                 __func__, __LINE__, pc->orig_line, pc->orig_col);
+      }
+      else
+      {
+         LOG_FMT(LALASS, "%s(%d): orig_line is %zu, orig_col is %zu, text() '%s'\n",
+                 __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text());
+      }
+
+      if (  chunk_is_token(pc, CT_BRACE_OPEN)
+         || chunk_is_token(pc, CT_FPAREN_OPEN)
+         || chunk_is_token(pc, CT_ANGLE_OPEN))
+      {
+         // get a new number
+         BlockNumber = GetBlockNumber();
+      }
+
+      pc->Block_Number = BlockNumber;
+
+      if (  chunk_is_token(pc, CT_BRACE_CLOSE)
+         || chunk_is_token(pc, CT_FPAREN_CLOSE)
+         || chunk_is_token(pc, CT_ANGLE_CLOSE))
+      {
+         // look for the opening
+         chunk_t *opening = chunk_get_prev_type(pc, (c_token_t)(pc->type - 1), pc->level);
+         // look for the previous
+         chunk_t *prev = chunk_get_prev(opening);
+         // this is the 'old' block number
+         if (prev == nullptr)
+         {
+            BlockNumber = 0;
+         }
+         else
+         {
+            BlockNumber = prev->Block_Number;
+         }
+      }
+
+      pc = chunk_get_next(pc);
+   }
+} // NumberTheBlocks

--- a/src/BlockNumbering.cpp
+++ b/src/BlockNumbering.cpp
@@ -11,7 +11,7 @@
 #include "log_levels.h"
 #include "logger.h"
 
-static size_t number = 0;
+size_t number = 0;
 
 
 size_t getBlockNumber()
@@ -43,6 +43,7 @@ void numberTheBlocks()
       }
 
       if (  chunk_is_token(pc, CT_BRACE_OPEN)
+         || chunk_is_token(pc, CT_VBRACE_OPEN)
          || chunk_is_token(pc, CT_FPAREN_OPEN)
          || chunk_is_token(pc, CT_ANGLE_OPEN))
       {
@@ -53,6 +54,7 @@ void numberTheBlocks()
       pc->blockNumber = blockNumber;
 
       if (  chunk_is_token(pc, CT_BRACE_CLOSE)
+         || chunk_is_token(pc, CT_VBRACE_CLOSE)
          || chunk_is_token(pc, CT_FPAREN_CLOSE)
          || chunk_is_token(pc, CT_ANGLE_CLOSE))
       {

--- a/src/BlockNumbering.h
+++ b/src/BlockNumbering.h
@@ -1,0 +1,33 @@
+/**
+ * @file BlockNumbering.h
+ *
+ * @author  Guy Maurel
+ *          Juni 2018
+ * @license GPL v2+
+ */
+
+#ifndef BLOCKNUMBERING_H_INCLUDED
+#define BLOCKNUMBERING_H_INCLUDED
+
+/*
+ * To align (or not align) the assign character it is important to know if:
+ *    1. the level of the chunk is the same
+ *    2. the block number of the statements are the same.
+ *
+ * A new block is opened if the type of the chunk is:
+ *    CT_BRACE_OPEN
+ *    CT_FPAREN_OPEN
+ *    CT_ANGLE_OPEN
+ *
+ * With this we get:
+ *    virtual void f(int x, int y) = 133;
+ *    void g(int x = 144);
+ *
+ * and not (Issue #1760)
+ *    virtual void f(int x, int y) = 133;
+ *    void g(int x                 = 144);
+ */
+
+void NumberTheBlocks();
+
+#endif /* BLOCKNUMBERING_H_INCLUDED */

--- a/src/BlockNumbering.h
+++ b/src/BlockNumbering.h
@@ -17,6 +17,7 @@
  * Introducing block numbering as:
  * A new block is opened if the type of the chunk is:
  *    CT_BRACE_OPEN
+ *    CT_VBRACE_OPEN
  *    CT_FPAREN_OPEN
  *    CT_ANGLE_OPEN
  *

--- a/src/BlockNumbering.h
+++ b/src/BlockNumbering.h
@@ -11,9 +11,10 @@
 
 /*
  * To align (or not align) the assign character it is important to know if:
- *    1. the level of the chunk is the same
- *    2. the block number of the statements are the same.
+ *    1. the levels of the chunks are the same
+ *    2. the block numbers of the statements are the same.
  *
+ * Introducing block numbering as:
  * A new block is opened if the type of the chunk is:
  *    CT_BRACE_OPEN
  *    CT_FPAREN_OPEN
@@ -28,6 +29,6 @@
  *    void g(int x                 = 144);
  */
 
-void NumberTheBlocks();
+void numberTheBlocks();
 
 #endif /* BLOCKNUMBERING_H_INCLUDED */

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -705,8 +705,8 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
    chunk_t *pc = first;
    while (pc != nullptr)
    {
-      LOG_FMT(LALASS, "%s(%d): orig_line is %zu, pc->Block_Number is %zu, check pc->text() '%s', type is %s\n",
-              __func__, __LINE__, pc->orig_line, pc->Block_Number, pc->text(), get_token_name(pc->type));
+      LOG_FMT(LALASS, "%s(%d): orig_line is %zu, pc->blockNumber is %zu, check pc->text() '%s', type is %s\n",
+              __func__, __LINE__, pc->orig_line, pc->blockNumber, pc->text(), get_token_name(pc->type));
       // Don't check inside PAREN or SQUARE groups
       if (  chunk_is_token(pc, CT_SPAREN_OPEN)
             // || chunk_is_token(pc, CT_FPAREN_OPEN)  // Issue #1340
@@ -820,11 +820,11 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
             {
                // compare the block number
                chunk_t *t2 = as.m_aligned.Top()->m_pc;
-               LOG_FMT(LAS, "AlignStack::%s(%d): pc->Block_Number is %zu\n",
-                       __func__, __LINE__, pc->Block_Number);
-               LOG_FMT(LAS, "AlignStack::%s(%d): t2->Block_Number is %zu\n",
-                       __func__, __LINE__, t2->Block_Number);
-               if (pc->Block_Number != t2->Block_Number)
+               LOG_FMT(LAS, "AlignStack::%s(%d): pc->blockbNumber is %zu\n",
+                       __func__, __LINE__, pc->blockNumber);
+               LOG_FMT(LAS, "AlignStack::%s(%d): t2->blockNumber is %zu\n",
+                       __func__, __LINE__, t2->blockNumber);
+               if (pc->blockNumber != t2->blockNumber)
                {
                   do_it = false;
                }

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -705,13 +705,13 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
    chunk_t *pc = first;
    while (pc != nullptr)
    {
-      LOG_FMT(LALASS, "%s(%d): orig_line is %zu, check pc->text() '%s'\n",
-              __func__, __LINE__, pc->orig_line, pc->text());
+      LOG_FMT(LALASS, "%s(%d): orig_line is %zu, pc->Block_Number is %zu, check pc->text() '%s', type is %s\n",
+              __func__, __LINE__, pc->orig_line, pc->Block_Number, pc->text(), get_token_name(pc->type));
       // Don't check inside PAREN or SQUARE groups
       if (  chunk_is_token(pc, CT_SPAREN_OPEN)
-            // || chunk_is_token(pc, CT_FPAREN_OPEN) Issue #1340
-         || chunk_is_token(pc, CT_SQUARE_OPEN)
-         || chunk_is_token(pc, CT_PAREN_OPEN))
+            // || chunk_is_token(pc, CT_FPAREN_OPEN)  // Issue #1340
+            // || chunk_is_token(pc, CT_PAREN_OPEN)   // Issue #1760
+         || chunk_is_token(pc, CT_SQUARE_OPEN))
       {
          LOG_FMT(LALASS, "%s(%d): Don't check inside PAREN or SQUARE groups, type is %s\n",
                  __func__, __LINE__, get_token_name(pc->type));
@@ -726,7 +726,11 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
       }
 
       // Recurse if a brace set is found
-      if (chunk_is_token(pc, CT_BRACE_OPEN) || chunk_is_token(pc, CT_VBRACE_OPEN))
+      // This a new block
+      // Issue #1760
+      if (  chunk_is_token(pc, CT_BRACE_OPEN)
+         || chunk_is_token(pc, CT_PAREN_OPEN)
+         || chunk_is_token(pc, CT_VBRACE_OPEN))
       {
          size_t myspan;
          size_t mythresh;
@@ -744,6 +748,7 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
             mythresh = cpd.settings[UO_align_assign_thresh].u;
          }
 
+         LOG_FMT(LALASS, "%s(%d): Recurse if a brace set is found\n", __func__, __LINE__);
          pc = align_assign(chunk_get_next_ncnl(pc), myspan, mythresh, &sub_nl_count);
          if (sub_nl_count > 0)
          {
@@ -758,7 +763,11 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
       }
 
       // Done with this brace set?
-      if (chunk_is_token(pc, CT_BRACE_CLOSE) || chunk_is_token(pc, CT_VBRACE_CLOSE))
+      // The new block is closed
+      // Issue #1760
+      if (  chunk_is_token(pc, CT_BRACE_CLOSE)
+         || chunk_is_token(pc, CT_PAREN_CLOSE)
+         || chunk_is_token(pc, CT_VBRACE_CLOSE))
       {
          pc = chunk_get_next(pc);
          break;
@@ -798,14 +807,33 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
                  __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text());
          LOG_FMT(LALASS, "%s(%d): var_def_cnt is %zu\n",
                  __func__, __LINE__, var_def_cnt);
-         equ_count++;
          if (var_def_cnt != 0)
          {
             vdas.Add(pc);
+            equ_count++;
          }
          else
          {
-            as.Add(pc);
+            // Issue #1760
+            bool do_it = true;
+            if (!as.m_aligned.Empty())
+            {
+               // compare the block number
+               chunk_t *t2 = as.m_aligned.Top()->m_pc;
+               LOG_FMT(LAS, "AlignStack::%s(%d): pc->Block_Number is %zu\n",
+                       __func__, __LINE__, pc->Block_Number);
+               LOG_FMT(LAS, "AlignStack::%s(%d): t2->Block_Number is %zu\n",
+                       __func__, __LINE__, t2->Block_Number);
+               if (pc->Block_Number != t2->Block_Number)
+               {
+                  do_it = false;
+               }
+            }
+            if (do_it)
+            {
+               equ_count++;
+               as.Add(pc);
+            }
          }
       }
 

--- a/src/align_stack.cpp
+++ b/src/align_stack.cpp
@@ -64,6 +64,9 @@ void AlignStack::ReAddSkipped()
 void AlignStack::Add(chunk_t *start, size_t seqnum)
 {
    LOG_FUNC_ENTRY();
+   LOG_FMT(LAS, "AlignStack::%s(%d): m_aligned.Len() is %zu\n",
+           __func__, __LINE__, m_aligned.Len());
+
    // Assign a seqnum if needed
    if (seqnum == 0)
    {
@@ -204,7 +207,8 @@ void AlignStack::Add(chunk_t *start, size_t seqnum)
                     __func__, __LINE__, next->column, tmp_col);
             if (next->column != tmp_col)
             {
-               LOG_FMT(LAS, "AlignStack::%s(%d): Call align_to_column\n", __func__, __LINE__);
+               LOG_FMT(LAS, "AlignStack::%s(%d): Call align_to_column %zu\n",
+                       __func__, __LINE__, tmp_col);
                align_to_column(next, tmp_col);
             }
          }
@@ -286,9 +290,12 @@ void AlignStack::Add(chunk_t *start, size_t seqnum)
       }
       else
       {
-         LOG_FMT(LAS, "AlignStack::Add-aligned [%zu/%zu/%zu]: line %zu, col %zu : col %zu <= %zu - min_col %zu\n",
-                 seqnum, m_nl_seqnum, m_seqnum,
-                 ali->orig_line, ali->column, endcol, m_max_col, m_min_col);
+         LOG_FMT(LAS, "AlignStack::%s(%d): Add-aligned: seqnum is %zu, m_nl_seqnum is %zu, m_seqnum is %zu\n",
+                 __func__, __LINE__, seqnum, m_nl_seqnum, m_seqnum);
+         LOG_FMT(LAS, "AlignStack::%s(%d):    ali->orig_line is %zu, ali->column is %zu, max_col old is %zu, new is %zu, m_min_col is %zu\n",
+                 __func__, __LINE__, ali->orig_line, ali->column, endcol, m_max_col, m_min_col);
+         LOG_FMT(LAS, "AlignStack::%s(%d): m_aligned.Len() is %zu\n",
+                 __func__, __LINE__, m_aligned.Len());
       }
    }
    else
@@ -325,7 +332,8 @@ void AlignStack::NewLines(size_t cnt)
 
 void AlignStack::Flush()
 {
-   LOG_FMT(LAS, "AlignStack::%s(%d): m_aligned.Len() is %zu\n", __func__, __LINE__, m_aligned.Len());
+   LOG_FMT(LAS, "AlignStack::%s(%d): m_aligned.Len() is %zu\n",
+           __func__, __LINE__, m_aligned.Len());
    LOG_FMT(LAS, "   (min is %zu, max is %zu)\n", m_min_col, m_max_col);
 
    if (m_aligned.Len() == 1)

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -512,7 +512,7 @@ static_inline chunk_t *chunk_skip_to_match_rev(chunk_t *cur, scope_e scope = sco
 
 
 //! skip to the final word/type in a :: chain
-chunk_t *chunk_skip_dc_member(chunk_t *start, scope_e scope     = scope_e::ALL);
+chunk_t *chunk_skip_dc_member(chunk_t *start, scope_e scope = scope_e::ALL);
 chunk_t *chunk_skip_dc_member_rev(chunk_t *start, scope_e scope = scope_e::ALL);
 
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -424,17 +424,17 @@ void output_parsed(FILE *pfile)
    // output.cpp, line 427: fprintf(pfile, "# Line              Tag                Parent...
    // and              431: ... make_message("%s# %3zu>%19.19s[%19.19s] ...
    // here                                              xx xx   xx xx
-   fprintf(pfile, "# Line                Tag              Parent          Columns Br/Lvl/pp     Flag   Nl  Text");
+   fprintf(pfile, "# Line                Tag              Parent          Columns Br/Lvl/pp     Flag   Nl  Block-N Text");
    for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next(pc))
    {
       char *outputMessage;
-      outputMessage = make_message("%s# %3zu>%19.19s[%19.19s][%3zu/%3zu/%3zu/%3d][%zu/%zu/%zu][%10" PRIx64 "][%zu-%d]",
+      outputMessage = make_message("%s# %3zu>%19.19s[%19.19s][%3zu/%3zu/%3zu/%3d][%zu/%zu/%zu][%10" PRIx64 "][%zu-%d]%8zu",
                                    eol_marker,
                                    pc->orig_line, get_token_name(pc->type),
                                    get_token_name(pc->parent_type),
                                    pc->column, pc->orig_col, pc->orig_col_end, pc->orig_prev_sp,
                                    pc->brace_level, pc->level, pc->pp_level,
-                                   pc->flags, pc->nl_count, pc->after_tab);
+                                   pc->flags, pc->nl_count, pc->after_tab, pc->Block_Number);
       fprintf(pfile, "%s", outputMessage);
       free(outputMessage);
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -424,7 +424,7 @@ void output_parsed(FILE *pfile)
    // output.cpp, line 427: fprintf(pfile, "# Line              Tag                Parent...
    // and              431: ... make_message("%s# %3zu>%19.19s[%19.19s] ...
    // here                                              xx xx   xx xx
-   fprintf(pfile, "# Line                Tag              Parent          Columns Br/Lvl/pp     Flag   Nl  blockNu Text");
+   fprintf(pfile, "# Line                Tag              Parent          Columns Br/Lvl/Pp     Flag   Nl    Block Text");
    for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next(pc))
    {
       char *outputMessage;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -424,7 +424,7 @@ void output_parsed(FILE *pfile)
    // output.cpp, line 427: fprintf(pfile, "# Line              Tag                Parent...
    // and              431: ... make_message("%s# %3zu>%19.19s[%19.19s] ...
    // here                                              xx xx   xx xx
-   fprintf(pfile, "# Line                Tag              Parent          Columns Br/Lvl/pp     Flag   Nl  Block-N Text");
+   fprintf(pfile, "# Line                Tag              Parent          Columns Br/Lvl/pp     Flag   Nl  blockNu Text");
    for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next(pc))
    {
       char *outputMessage;
@@ -434,7 +434,7 @@ void output_parsed(FILE *pfile)
                                    get_token_name(pc->parent_type),
                                    pc->column, pc->orig_col, pc->orig_col_end, pc->orig_prev_sp,
                                    pc->brace_level, pc->level, pc->pp_level,
-                                   pc->flags, pc->nl_count, pc->after_tab, pc->Block_Number);
+                                   pc->flags, pc->nl_count, pc->after_tab, pc->blockNumber);
       fprintf(pfile, "%s", outputMessage);
       free(outputMessage);
 

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1892,7 +1892,7 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
       }
 
       // number the blocks
-      NumberTheBlocks();
+      numberTheBlocks();
 
       // Add parens
       do_parens();

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -15,6 +15,7 @@
 #include "chunk_list.h"
 #include "align.h"
 #include "args.h"
+#include "BlockNumbering.h"
 #include "brace_cleanup.h"
 #include "braces.h"
 #include "backup.h"
@@ -1889,6 +1890,9 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
       {
          remove_extra_returns();
       }
+
+      // number the blocks
+      NumberTheBlocks();
 
       // Add parens
       do_parens();

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -250,7 +250,7 @@ struct chunk_t
       brace_level   = 0;
       pp_level      = 0;
       after_tab     = false;
-      Block_Number  = 0;
+      blockNumber   = 0;
       str.clear();
    }
 
@@ -289,7 +289,7 @@ struct chunk_t
    size_t       brace_level;      //! nest level in braces only
    size_t       pp_level;         //! nest level in preprocessor
    bool         after_tab;        //! whether this token was after a tab
-   size_t       Block_Number;     //! The block number
+   size_t       blockNumber;      //! The block number
    unc_text     str;              //! the token text
 };
 

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -250,6 +250,7 @@ struct chunk_t
       brace_level   = 0;
       pp_level      = 0;
       after_tab     = false;
+      Block_Number  = 0;
       str.clear();
    }
 
@@ -288,6 +289,7 @@ struct chunk_t
    size_t       brace_level;      //! nest level in braces only
    size_t       pp_level;         //! nest level in preprocessor
    bool         after_tab;        //! whether this token was after a tab
+   size_t       Block_Number;     //! The block number
    unc_text     str;              //! the token text
 };
 

--- a/tests/cli/output/p.txt
+++ b/tests/cli/output/p.txt
@@ -3,62 +3,62 @@ newlines                        = crlf
 # option(s) with 'not default' value: 1
 #
 # -=====-
-# Line                Tag              Parent          Columns Br/Lvl/pp     Flag   Nl  Text
-#   1>             STRUCT[               NONE][  1/  1/  7/  0][0/0/0][     70002][0-0] struct
-#   1>               TYPE[             STRUCT][  8/  8/ 21/  1][0/0/0][         2][0-0]        TelegramIndex
-#   1>            NEWLINE[               NONE][ 21/ 21/  1/  0][0/0/0][         2][1-0]
-#   2>         BRACE_OPEN[             STRUCT][  1/  1/  2/  0][0/0/0][ 100000402][0-0] {
-#   2>            NEWLINE[               NONE][  2/  2/  1/  0][1/1/0][         2][1-0]
-#   3>     FUNC_CLASS_DEF[               NONE][  9/  1/ 14/  0][1/1/0][     60402][0-0]         TelegramIndex
-#   3>        FPAREN_OPEN[     FUNC_CLASS_DEF][ 22/ 14/ 15/  0][1/1/0][ 100000502][0-0]                      (
-#   3>          QUALIFIER[               NONE][ 23/ 15/ 20/  0][1/2/0][     50512][0-0]                       const
-#   3>               TYPE[               NONE][ 29/ 21/ 25/  1][1/2/0][    400512][0-0]                             char
-#   3>           PTR_TYPE[               NONE][ 33/ 25/ 26/  0][1/2/0][ 100000512][0-0]                                 *
-#   3>               WORD[               NONE][ 35/ 27/ 29/  1][1/2/0][    800512][0-0]                                   pN
-#   3>              COMMA[               NONE][ 37/ 29/ 30/  0][1/2/0][ 100000512][0-0]                                     ,
-#   3>               TYPE[               NONE][ 39/ 31/ 39/  1][1/2/0][    450512][0-0]                                       unsigned
-#   3>               TYPE[               NONE][ 48/ 40/ 44/  1][1/2/0][    410512][0-0]                                                long
-#   3>               WORD[               NONE][ 53/ 45/ 47/  1][1/2/0][    800512][0-0]                                                     nI
-#   3>       FPAREN_CLOSE[     FUNC_CLASS_DEF][ 55/ 47/ 48/  0][1/1/0][ 100000502][0-0]                                                       )
-#   3>       CONSTR_COLON[               NONE][ 57/ 49/ 50/  1][1/1/0][ 100000502][0-0]                                                         :
-#   3>            NEWLINE[               NONE][ 58/ 50/  1/  0][1/1/0][         2][1-0]
-#   4>      FUNC_CTOR_VAR[               NONE][ 17/  1/  9/  0][1/1/0][     60502][0-0]                 pTelName
-#   4>        FPAREN_OPEN[      FUNC_CTOR_VAR][ 25/  9/ 10/  0][1/1/0][ 100000502][0-0]                         (
-#   4>               WORD[               NONE][ 26/ 10/ 12/  0][1/2/0][     40512][0-0]                          pN
-#   4>       FPAREN_CLOSE[      FUNC_CTOR_VAR][ 28/ 12/ 13/  0][1/1/0][ 100000502][0-0]                            )
-#   4>              COMMA[               NONE][ 29/ 13/ 14/  0][1/1/0][ 100000502][0-0]                             ,
-#   4>            NEWLINE[               NONE][ 30/ 14/  1/  0][1/1/0][         2][1-0]
-#   5>      FUNC_CTOR_VAR[               NONE][ 17/  1/ 10/  0][1/1/0][     40502][0-0]                 nTelIndex
-#   5>        FPAREN_OPEN[      FUNC_CTOR_VAR][ 26/ 10/ 11/  0][1/1/0][ 100000502][0-0]                          (
-#   5>               WORD[               NONE][ 27/ 11/ 12/  0][1/2/0][     40512][0-0]                           n
-#   5>       FPAREN_CLOSE[      FUNC_CTOR_VAR][ 28/ 12/ 13/  0][1/1/0][ 100000502][0-0]                            )
-#   5>            NEWLINE[               NONE][ 29/ 13/  1/  0][1/1/0][         2][1-0]
-#   6>         BRACE_OPEN[     FUNC_CLASS_DEF][  9/  1/  2/  0][1/1/0][ 140000402][0-0]         {
-#   6>            NEWLINE[               NONE][ 10/  2/  1/  0][2/2/0][         2][1-0]
-#   7>        BRACE_CLOSE[     FUNC_CLASS_DEF][  9/  1/  2/  0][1/1/0][ 140000402][0-0]         }
-#   7>            NEWLINE[               NONE][ 10/  2/  1/  0][1/1/0][         2][2-0]
-#   9>         DESTRUCTOR[               NONE][  9/  1/  2/  0][1/1/0][ 100060402][0-0]         ~
-#   9>     FUNC_CLASS_DEF[         DESTRUCTOR][ 10/  2/ 15/  0][1/1/0][     40402][0-0]          TelegramIndex
-#   9>        FPAREN_OPEN[     FUNC_CLASS_DEF][ 23/ 15/ 16/  0][1/1/0][ 100000502][0-0]                       (
-#   9>       FPAREN_CLOSE[     FUNC_CLASS_DEF][ 24/ 16/ 17/  0][1/1/0][ 100000502][0-0]                        )
-#   9>            NEWLINE[               NONE][ 25/ 17/  1/  0][1/1/0][         2][1-0]
-#  10>         BRACE_OPEN[     FUNC_CLASS_DEF][  9/  1/  2/  0][1/1/0][ 140000402][0-0]         {
-#  10>            NEWLINE[               NONE][ 10/  2/  1/  0][2/2/0][         2][1-0]
-#  11>        BRACE_CLOSE[     FUNC_CLASS_DEF][  9/  1/  2/  0][1/1/0][ 140000402][0-0]         }
-#  11>            NEWLINE[               NONE][ 10/  2/  1/  0][1/1/0][         2][2-0]
-#  13>          QUALIFIER[               NONE][  9/  1/  6/  0][1/1/0][    470402][0-0]         const
-#  13>               TYPE[               NONE][ 15/  7/ 11/  1][1/1/0][    400402][0-0]               char
-#  13>           PTR_TYPE[               NONE][ 19/ 11/ 12/  0][1/1/0][ 100400402][0-0]                   *
-#  13>          QUALIFIER[               NONE][ 21/ 13/ 18/  1][1/1/0][    410402][0-0]                     const
-#  13>               WORD[               NONE][ 27/ 19/ 27/  1][1/1/0][   1800402][0-0]                           pTelName
-#  13>          SEMICOLON[               NONE][ 35/ 27/ 28/  0][1/1/0][ 100000402][0-0]                                   ;
-#  13>            NEWLINE[               NONE][ 36/ 28/  1/  0][1/1/0][         2][1-0]
-#  14>               TYPE[               NONE][  9/  1/  9/  0][1/1/0][    470402][0-0]         unsigned
-#  14>               TYPE[               NONE][ 18/ 10/ 14/  1][1/1/0][    410402][0-0]                  long
-#  14>               WORD[               NONE][ 23/ 15/ 24/  1][1/1/0][   1800402][0-0]                       nTelIndex
-#  14>          SEMICOLON[               NONE][ 32/ 24/ 25/  0][1/1/0][ 100000402][0-0]                                ;
-#  14>            NEWLINE[               NONE][ 33/ 25/  1/  0][1/1/0][         2][1-0]
-#  15>        BRACE_CLOSE[             STRUCT][  1/  1/  2/  0][0/0/0][ 100000400][0-0] }
-#  15>          SEMICOLON[             STRUCT][  2/  2/  3/  0][0/0/0][ 100000000][0-0]  ;
-#  15>            NEWLINE[               NONE][  3/  3/  1/  0][0/0/0][         0][2-0]
+# Line                Tag              Parent          Columns Br/Lvl/pp     Flag   Nl  Block-N Text
+#   1>             STRUCT[               NONE][  1/  1/  7/  0][0/0/0][     70002][0-0]       1 struct
+#   1>               TYPE[             STRUCT][  8/  8/ 21/  1][0/0/0][         2][0-0]       1        TelegramIndex
+#   1>            NEWLINE[               NONE][ 21/ 21/  1/  0][0/0/0][         2][1-0]       1
+#   2>         BRACE_OPEN[             STRUCT][  1/  1/  2/  0][0/0/0][ 100000402][0-0]       2 {
+#   2>            NEWLINE[               NONE][  2/  2/  1/  0][1/1/0][         2][1-0]       2
+#   3>     FUNC_CLASS_DEF[               NONE][  9/  1/ 14/  0][1/1/0][     60402][0-0]       2         TelegramIndex
+#   3>        FPAREN_OPEN[     FUNC_CLASS_DEF][ 22/ 14/ 15/  0][1/1/0][ 100000502][0-0]       3                      (
+#   3>          QUALIFIER[               NONE][ 23/ 15/ 20/  0][1/2/0][     50512][0-0]       3                       const
+#   3>               TYPE[               NONE][ 29/ 21/ 25/  1][1/2/0][    400512][0-0]       3                             char
+#   3>           PTR_TYPE[               NONE][ 33/ 25/ 26/  0][1/2/0][ 100000512][0-0]       3                                 *
+#   3>               WORD[               NONE][ 35/ 27/ 29/  1][1/2/0][    800512][0-0]       3                                   pN
+#   3>              COMMA[               NONE][ 37/ 29/ 30/  0][1/2/0][ 100000512][0-0]       3                                     ,
+#   3>               TYPE[               NONE][ 39/ 31/ 39/  1][1/2/0][    450512][0-0]       3                                       unsigned
+#   3>               TYPE[               NONE][ 48/ 40/ 44/  1][1/2/0][    410512][0-0]       3                                                long
+#   3>               WORD[               NONE][ 53/ 45/ 47/  1][1/2/0][    800512][0-0]       3                                                     nI
+#   3>       FPAREN_CLOSE[     FUNC_CLASS_DEF][ 55/ 47/ 48/  0][1/1/0][ 100000502][0-0]       3                                                       )
+#   3>       CONSTR_COLON[               NONE][ 57/ 49/ 50/  1][1/1/0][ 100000502][0-0]       2                                                         :
+#   3>            NEWLINE[               NONE][ 58/ 50/  1/  0][1/1/0][         2][1-0]       2
+#   4>      FUNC_CTOR_VAR[               NONE][ 17/  1/  9/  0][1/1/0][     60502][0-0]       2                 pTelName
+#   4>        FPAREN_OPEN[      FUNC_CTOR_VAR][ 25/  9/ 10/  0][1/1/0][ 100000502][0-0]       4                         (
+#   4>               WORD[               NONE][ 26/ 10/ 12/  0][1/2/0][     40512][0-0]       4                          pN
+#   4>       FPAREN_CLOSE[      FUNC_CTOR_VAR][ 28/ 12/ 13/  0][1/1/0][ 100000502][0-0]       4                            )
+#   4>              COMMA[               NONE][ 29/ 13/ 14/  0][1/1/0][ 100000502][0-0]       2                             ,
+#   4>            NEWLINE[               NONE][ 30/ 14/  1/  0][1/1/0][         2][1-0]       2
+#   5>      FUNC_CTOR_VAR[               NONE][ 17/  1/ 10/  0][1/1/0][     40502][0-0]       2                 nTelIndex
+#   5>        FPAREN_OPEN[      FUNC_CTOR_VAR][ 26/ 10/ 11/  0][1/1/0][ 100000502][0-0]       5                          (
+#   5>               WORD[               NONE][ 27/ 11/ 12/  0][1/2/0][     40512][0-0]       5                           n
+#   5>       FPAREN_CLOSE[      FUNC_CTOR_VAR][ 28/ 12/ 13/  0][1/1/0][ 100000502][0-0]       5                            )
+#   5>            NEWLINE[               NONE][ 29/ 13/  1/  0][1/1/0][         2][1-0]       2
+#   6>         BRACE_OPEN[     FUNC_CLASS_DEF][  9/  1/  2/  0][1/1/0][ 140000402][0-0]       6         {
+#   6>            NEWLINE[               NONE][ 10/  2/  1/  0][2/2/0][         2][1-0]       6
+#   7>        BRACE_CLOSE[     FUNC_CLASS_DEF][  9/  1/  2/  0][1/1/0][ 140000402][0-0]       6         }
+#   7>            NEWLINE[               NONE][ 10/  2/  1/  0][1/1/0][         2][2-0]       2
+#   9>         DESTRUCTOR[               NONE][  9/  1/  2/  0][1/1/0][ 100060402][0-0]       2         ~
+#   9>     FUNC_CLASS_DEF[         DESTRUCTOR][ 10/  2/ 15/  0][1/1/0][     40402][0-0]       2          TelegramIndex
+#   9>        FPAREN_OPEN[     FUNC_CLASS_DEF][ 23/ 15/ 16/  0][1/1/0][ 100000502][0-0]       7                       (
+#   9>       FPAREN_CLOSE[     FUNC_CLASS_DEF][ 24/ 16/ 17/  0][1/1/0][ 100000502][0-0]       7                        )
+#   9>            NEWLINE[               NONE][ 25/ 17/  1/  0][1/1/0][         2][1-0]       2
+#  10>         BRACE_OPEN[     FUNC_CLASS_DEF][  9/  1/  2/  0][1/1/0][ 140000402][0-0]       8         {
+#  10>            NEWLINE[               NONE][ 10/  2/  1/  0][2/2/0][         2][1-0]       8
+#  11>        BRACE_CLOSE[     FUNC_CLASS_DEF][  9/  1/  2/  0][1/1/0][ 140000402][0-0]       8         }
+#  11>            NEWLINE[               NONE][ 10/  2/  1/  0][1/1/0][         2][2-0]       2
+#  13>          QUALIFIER[               NONE][  9/  1/  6/  0][1/1/0][    470402][0-0]       2         const
+#  13>               TYPE[               NONE][ 15/  7/ 11/  1][1/1/0][    400402][0-0]       2               char
+#  13>           PTR_TYPE[               NONE][ 19/ 11/ 12/  0][1/1/0][ 100400402][0-0]       2                   *
+#  13>          QUALIFIER[               NONE][ 21/ 13/ 18/  1][1/1/0][    410402][0-0]       2                     const
+#  13>               WORD[               NONE][ 27/ 19/ 27/  1][1/1/0][   1800402][0-0]       2                           pTelName
+#  13>          SEMICOLON[               NONE][ 35/ 27/ 28/  0][1/1/0][ 100000402][0-0]       2                                   ;
+#  13>            NEWLINE[               NONE][ 36/ 28/  1/  0][1/1/0][         2][1-0]       2
+#  14>               TYPE[               NONE][  9/  1/  9/  0][1/1/0][    470402][0-0]       2         unsigned
+#  14>               TYPE[               NONE][ 18/ 10/ 14/  1][1/1/0][    410402][0-0]       2                  long
+#  14>               WORD[               NONE][ 23/ 15/ 24/  1][1/1/0][   1800402][0-0]       2                       nTelIndex
+#  14>          SEMICOLON[               NONE][ 32/ 24/ 25/  0][1/1/0][ 100000402][0-0]       2                                ;
+#  14>            NEWLINE[               NONE][ 33/ 25/  1/  0][1/1/0][         2][1-0]       2
+#  15>        BRACE_CLOSE[             STRUCT][  1/  1/  2/  0][0/0/0][ 100000400][0-0]       2 }
+#  15>          SEMICOLON[             STRUCT][  2/  2/  3/  0][0/0/0][ 100000000][0-0]       1  ;
+#  15>            NEWLINE[               NONE][  3/  3/  1/  0][0/0/0][         0][2-0]       1
 # -=====-

--- a/tests/cli/output/p.txt
+++ b/tests/cli/output/p.txt
@@ -3,7 +3,7 @@ newlines                        = crlf
 # option(s) with 'not default' value: 1
 #
 # -=====-
-# Line                Tag              Parent          Columns Br/Lvl/pp     Flag   Nl  blockNu Text
+# Line                Tag              Parent          Columns Br/Lvl/Pp     Flag   Nl    Block Text
 #   1>             STRUCT[               NONE][  1/  1/  7/  0][0/0/0][     70002][0-0]       1 struct
 #   1>               TYPE[             STRUCT][  8/  8/ 21/  1][0/0/0][         2][0-0]       1        TelegramIndex
 #   1>            NEWLINE[               NONE][ 21/ 21/  1/  0][0/0/0][         2][1-0]       1

--- a/tests/cli/output/p.txt
+++ b/tests/cli/output/p.txt
@@ -3,7 +3,7 @@ newlines                        = crlf
 # option(s) with 'not default' value: 1
 #
 # -=====-
-# Line                Tag              Parent          Columns Br/Lvl/pp     Flag   Nl  Block-N Text
+# Line                Tag              Parent          Columns Br/Lvl/pp     Flag   Nl  blockNu Text
 #   1>             STRUCT[               NONE][  1/  1/  7/  0][0/0/0][     70002][0-0]       1 struct
 #   1>               TYPE[             STRUCT][  8/  8/ 21/  1][0/0/0][         2][0-0]       1        TelegramIndex
 #   1>            NEWLINE[               NONE][ 21/ 21/  1/  0][0/0/0][         2][1-0]       1

--- a/tests/config/bug_1760.cfg
+++ b/tests/config/bug_1760.cfg
@@ -1,0 +1,1 @@
+align_assign_span = 1

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -544,6 +544,7 @@
 34174  arith-vs-ptr.cfg                     cpp/i1466.cpp
 34175  align_assign_span-1.cfg              cpp/i1509.cpp
 34176  align_assign_span-1.cfg              cpp/i1509_bug_1112_correction.cpp
+34177  bug_1760.cfg                         cpp/bug_1760.cpp
 
 34180  bug_1402.cfg                         cpp/bug_1402.cpp
 

--- a/tests/expected/cpp/30023-templates.cpp
+++ b/tests/expected/cpp/30023-templates.cpp
@@ -163,7 +163,7 @@ void g(X<>& x);
 typedef std::vector<std::vector<int> >    Table; // OK
 typedef std::vector<std::vector<bool> >   Flags; // Error
 
-void func(List<B>        =default_val1);
+void func(List<B> =default_val1);
 void func(List<List<B> > =default_val2);
 
 BLAH<(3.14 >= 42)> blah;

--- a/tests/expected/cpp/34177-bug_1760.cpp
+++ b/tests/expected/cpp/34177-bug_1760.cpp
@@ -1,0 +1,6 @@
+class X16
+{
+public:
+virtual void f(int x, int y) = 133;
+void g(int x = 144);
+};

--- a/tests/input/cpp/bug_1760.cpp
+++ b/tests/input/cpp/bug_1760.cpp
@@ -1,0 +1,6 @@
+class X16
+{
+public:
+virtual void f(int x, int y) = 133;
+void g(int x = 144);
+};


### PR DESCRIPTION
 To align (or not align) the assign character it is important to know if:
    1. the levels of the assign chunks are the same
    2. the block numbers of the statements are the same.
 
Introducing block numbering as:
 A new block is opened if the type of the chunk is:
```.txt
    CT_BRACE_OPEN
    CT_FPAREN_OPEN
    CT_ANGLE_OPEN
```

 With this we get:
```.cpp
    virtual void f(int x, int y) = 133;
    void g(int x = 144);
```

 and not (Issue #1760)
```.cpp
    virtual void f(int x, int y) = 133;
    void g(int x                 = 144);

```
Add some more LOG_FMT statements.
Update the result of test cpp/30023