### PR TITLE
Introduce a new option: nl_oc_mdef_brace

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -1885,16 +1885,23 @@ static void newlines_brace_pair(chunk_t *br_open)
       pc = chunk_get_next_ncnl(br_open);
       newline_add_between(br_open, pc);
 
-      val = ((  br_open->parent_type == CT_FUNC_DEF
-             || br_open->parent_type == CT_FUNC_CLASS_DEF
-             || br_open->parent_type == CT_OC_CLASS
-             || br_open->parent_type == CT_OC_MSG_DECL) ?
-             cpd.settings[UO_nl_fdef_brace].a :
-             ((br_open->parent_type == CT_CS_PROPERTY) ?
-              cpd.settings[UO_nl_property_brace].a :
-              ((br_open->parent_type == CT_CPP_LAMBDA) ?
-               cpd.settings[UO_nl_cpp_ldef_brace].a :
-               cpd.settings[UO_nl_fcall_brace].a)));
+      if (br_open->parent_type == CT_OC_MSG_DECL)
+      {
+         // Issue #167
+         val = cpd.settings[UO_nl_oc_mdef_brace].a;
+      }
+      else
+      {
+         val = ((  br_open->parent_type == CT_FUNC_DEF
+                || br_open->parent_type == CT_FUNC_CLASS_DEF
+                || br_open->parent_type == CT_OC_CLASS) ?
+                cpd.settings[UO_nl_fdef_brace].a :
+                ((br_open->parent_type == CT_CS_PROPERTY) ?
+                 cpd.settings[UO_nl_property_brace].a :
+                 ((br_open->parent_type == CT_CPP_LAMBDA) ?
+                  cpd.settings[UO_nl_cpp_ldef_brace].a :
+                  cpd.settings[UO_nl_fcall_brace].a)));
+      }
 
       if (val != AV_IGNORE)
       {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1022,6 +1022,8 @@ void register_options(void)
                   "Don't split one-line while statements - 'while(a) b++;'.");
    unc_add_option("nl_oc_msg_leave_one_liner", UO_nl_oc_msg_leave_one_liner, AT_BOOL,
                   "Don't split one-line OC messages.");
+   unc_add_option("nl_oc_mdef_brace", UO_nl_oc_mdef_brace, AT_IARF,
+                  "Add or remove newline between method declaration and '{'.");
    unc_add_option("nl_oc_block_brace", UO_nl_oc_block_brace, AT_IARF,
                   "Add or remove newline between Objective-C block signature and '{'.");
    unc_add_option("nl_oc_interface_brace", UO_nl_oc_interface_brace, AT_IARF,

--- a/src/options.h
+++ b/src/options.h
@@ -471,6 +471,7 @@ enum uncrustify_options
    UO_nl_if_leave_one_liners,          //
    UO_nl_while_leave_one_liners,       //
    UO_nl_oc_msg_leave_one_liner,       // Don't split one-line OC messages
+   UO_nl_oc_mdef_brace,                // Add or remove newline between method declaration and '{'
    UO_nl_oc_block_brace,               // Add or remove newline between Objective-C block signature and '{'
    UO_nl_oc_interface_brace,           // Add or remove newline between @interface and '{'
    UO_nl_oc_implementation_brace,      // Add or remove newline between @implementation and '{'

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 644 options and minimal documentation.
+There are currently 645 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -314,6 +314,7 @@ nl_cpp_lambda_leave_one_liners  = false
 nl_if_leave_one_liners          = false
 nl_while_leave_one_liners       = false
 nl_oc_msg_leave_one_liner       = false
+nl_oc_mdef_brace                = ignore
 nl_oc_block_brace               = ignore
 nl_oc_interface_brace           = ignore
 nl_oc_implementation_brace      = ignore

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1042,6 +1042,9 @@ nl_while_leave_one_liners       = false    # false/true
 # Don't split one-line OC messages.
 nl_oc_msg_leave_one_liner       = false    # false/true
 
+# Add or remove newline between method declaration and '{'.
+nl_oc_mdef_brace                = ignore   # ignore/add/remove/force
+
 # Add or remove newline between Objective-C block signature and '{'.
 nl_oc_block_brace               = ignore   # ignore/add/remove/force
 

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -314,6 +314,7 @@ nl_cpp_lambda_leave_one_liners  = false
 nl_if_leave_one_liners          = false
 nl_while_leave_one_liners       = false
 nl_oc_msg_leave_one_liner       = false
+nl_oc_mdef_brace                = ignore
 nl_oc_block_brace               = ignore
 nl_oc_interface_brace           = ignore
 nl_oc_implementation_brace      = ignore

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1042,6 +1042,9 @@ nl_while_leave_one_liners       = false    # false/true
 # Don't split one-line OC messages.
 nl_oc_msg_leave_one_liner       = false    # false/true
 
+# Add or remove newline between method declaration and '{'.
+nl_oc_mdef_brace                = ignore   # ignore/add/remove/force
+
 # Add or remove newline between Objective-C block signature and '{'.
 nl_oc_block_brace               = ignore   # ignore/add/remove/force
 

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1042,6 +1042,9 @@ nl_while_leave_one_liners       { False, True }
 nl_oc_msg_leave_one_liner       { False, True }
   Don't split one-line OC messages.
 
+nl_oc_mdef_brace                { Ignore, Add, Remove, Force }
+  Add or remove newline between method declaration and '{'.
+
 nl_oc_block_brace               { Ignore, Add, Remove, Force }
   Add or remove newline between Objective-C block signature and '{'.
 

--- a/tests/config/aet-sp_after_oc_msg_receiver.cfg
+++ b/tests/config/aet-sp_after_oc_msg_receiver.cfg
@@ -1,3 +1,3 @@
 include "aet.cfg"
 
-sp_after_oc_msg_receiver=remove
+sp_after_oc_msg_receiver = remove

--- a/tests/config/aet.cfg
+++ b/tests/config/aet.cfg
@@ -500,3 +500,6 @@ pp_region_indent_code                                = false
 pp_indent_if                                         = 0
 pp_if_indent_code                                    = false
 pp_define_at_level                                   = false
+
+# Add or remove newline between method declaration and '{'
+nl_oc_mdef_brace                                     = remove

--- a/tests/config/blocks.cfg
+++ b/tests/config/blocks.cfg
@@ -23,3 +23,6 @@ nl_after_brace_open             = true
 mod_full_brace_for              = add
 mod_full_brace_if               = add
 mod_full_brace_while            = add
+
+# Add or remove newline between method declaration and '{'
+nl_oc_mdef_brace                = force

--- a/tests/config/bug_167.cfg
+++ b/tests/config/bug_167.cfg
@@ -1,0 +1,5 @@
+# Add or remove newline between function signature and '{'
+nl_fdef_brace                            = force   # ignore/add/remove/force
+
+# Add or remove newline between method declaration and '{'
+nl_oc_mdef_brace                         = remove   # ignore/add/remove/force

--- a/tests/config/nl_brace_square.cfg
+++ b/tests/config/nl_brace_square.cfg
@@ -20,3 +20,6 @@ nl_after_brace_open             = true
 mod_full_brace_for              = add
 mod_full_brace_if               = add
 mod_full_brace_while            = add
+
+# Add or remove newline between method declaration and '{'
+nl_oc_mdef_brace                = force

--- a/tests/config/oc10.cfg
+++ b/tests/config/oc10.cfg
@@ -7,3 +7,6 @@ sp_after_oc_scope               = remove
 sp_after_oc_msg_receiver        = force
 indent_columns                  = 3
 nl_fdef_brace                   = add
+
+# Add or remove newline between method declaration and '{'
+nl_oc_mdef_brace                = force

--- a/tests/config/oc13.cfg
+++ b/tests/config/oc13.cfg
@@ -7,3 +7,6 @@ nl_after_brace_open             = true
 align_var_def_span              = 2
 align_var_def_star_style        = 1
 align_assign_span               = 1
+
+# Add or remove newline between method declaration and '{'
+nl_oc_mdef_brace                = force

--- a/tests/config/oc19.cfg
+++ b/tests/config/oc19.cfg
@@ -5,3 +5,6 @@ nl_end_of_file_min              = 1
 nl_switch_brace                 = add
 nl_fdef_brace                   = add
 eat_blanks_after_open_brace     = true
+
+# Add or remove newline between method declaration and '{'
+nl_oc_mdef_brace                = force

--- a/tests/config/oc2.cfg
+++ b/tests/config/oc2.cfg
@@ -1,3 +1,6 @@
 sp_inside_fparen                = remove
 indent_columns                  = 3
 nl_fdef_brace                   = add
+
+# Add or remove newline between method declaration and '{'
+nl_oc_mdef_brace                = force

--- a/tests/config/sp_after_oc_block_caret_add.cfg
+++ b/tests/config/sp_after_oc_block_caret_add.cfg
@@ -23,3 +23,6 @@ nl_after_brace_open             = true
 mod_full_brace_for              = add
 mod_full_brace_if               = add
 mod_full_brace_while            = add
+
+# Add or remove newline between method declaration and '{'
+nl_oc_mdef_brace                = force

--- a/tests/config/sp_after_oc_block_caret_force.cfg
+++ b/tests/config/sp_after_oc_block_caret_force.cfg
@@ -23,3 +23,6 @@ nl_after_brace_open             = true
 mod_full_brace_for              = add
 mod_full_brace_if               = add
 mod_full_brace_while            = add
+
+# Add or remove newline between method declaration and '{'
+nl_oc_mdef_brace                = force

--- a/tests/config/sp_after_oc_return_type_add.cfg
+++ b/tests/config/sp_after_oc_return_type_add.cfg
@@ -4,3 +4,6 @@ sp_after_oc_return_type         = add
 indent_columns                  = 4
 nl_fdef_brace                   = force
 align_oc_msg_spec_span          = 2
+
+# Add or remove newline between method declaration and '{'
+nl_oc_mdef_brace                = force

--- a/tests/config/sp_after_oc_return_type_force.cfg
+++ b/tests/config/sp_after_oc_return_type_force.cfg
@@ -4,3 +4,6 @@ sp_after_oc_return_type         = force
 indent_columns                  = 4
 nl_fdef_brace                   = force
 align_oc_msg_spec_span          = 2
+
+# Add or remove newline between method declaration and '{'
+nl_oc_mdef_brace                = force

--- a/tests/config/sp_after_oc_return_type_remove.cfg
+++ b/tests/config/sp_after_oc_return_type_remove.cfg
@@ -4,3 +4,6 @@ sp_after_oc_return_type         = remove
 indent_columns                  = 4
 nl_fdef_brace                   = force
 align_oc_msg_spec_span          = 2
+
+# Add or remove newline between method declaration and '{'
+nl_oc_mdef_brace                = force

--- a/tests/config/sp_before_oc_block_caret_force.cfg
+++ b/tests/config/sp_before_oc_block_caret_force.cfg
@@ -22,3 +22,6 @@ nl_after_brace_open             = true
 mod_full_brace_for              = add
 mod_full_brace_if               = add
 mod_full_brace_while            = add
+
+# Add or remove newline between method declaration and '{'
+nl_oc_mdef_brace                = force

--- a/tests/config/sp_before_oc_block_caret_remove.cfg
+++ b/tests/config/sp_before_oc_block_caret_remove.cfg
@@ -24,3 +24,6 @@ nl_after_brace_open             = true
 mod_full_brace_for              = add
 mod_full_brace_if               = add
 mod_full_brace_while            = add
+
+# Add or remove newline between method declaration and '{'
+nl_oc_mdef_brace                = force

--- a/tests/expected/oc/50061-bug_167.m
+++ b/tests/expected/oc/50061-bug_167.m
@@ -1,0 +1,7 @@
+- (void)dealloc {
+	[self closeFile];
+
+	[self setData:nil];
+
+	[super dealloc];
+}

--- a/tests/input/oc/bug_167.m
+++ b/tests/input/oc/bug_167.m
@@ -1,0 +1,7 @@
+- (void)dealloc {
+    [self closeFile];
+
+    [self setData:nil];
+
+    [super dealloc];
+}

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -37,6 +37,7 @@
 50050  objc_complex_method.cfg              oc/real_world_file.m
 
 50060  align_oc_msg_colon_span-1.cfg        oc/oc-split.m
+50061  bug_167.cfg                          oc/bug_167.m
 
 50070  blocks.cfg                           oc/blocks.m
 50071  sp_before_oc_block_caret_force.cfg   oc/blocks.m


### PR DESCRIPTION
Ref. #167 
Add or remove newline between method declaration and '{'

Some configuration files must be updated to use the option.