### PR TITLE
Improve parallelism of CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,28 @@ matrix:
     - os: linux
       dist: trusty
       env: BADGE=linux BUILD_TYPE=debug
+      addons:
+        apt:
+          update: true
+          packages:
+            - ninja-build
+
     - os: linux
       dist: trusty
       env: BADGE=linux BUILD_TYPE=release
+      addons:
+        apt:
+          update: true
+          packages:
+            - ninja-build
+
     - os: linux
       dist: trusty
       env: BADGE=linux BUILD_TYPE=release NO_MACRO_VARARG=1
 
     # GCC 6
     - os: linux
-      dist: trusty 
+      dist: trusty
       env: BADGE=linux C_COMPILER=gcc-6 CXX_COMPILER=g++-6
       addons:
         apt:
@@ -25,6 +37,7 @@ matrix:
           packages:
             - gcc-6
             - g++-6
+            - ninja-build
 
     # Clang 3.8 address sanitizer
     - os: linux
@@ -85,6 +98,7 @@ before_install:
   - cmake --version
   - mkdir build
   - cd build
+  - type -p ninja && export GENERATOR=-GNinja || true
 
 before_script:
   # to stop the script after an error/warning
@@ -100,29 +114,29 @@ before_script:
   - |-
     case "${BUILD_TYPE}" in
       "coverage")
-        cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_CODECOVERAGE=ON ..
+        cmake ${GENERATOR} -DCMAKE_BUILD_TYPE=Debug -DENABLE_CODECOVERAGE=ON ..
         ;;
       "asan")
-        cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_SANITIZER=address ..
+        cmake ${GENERATOR} -DCMAKE_BUILD_TYPE=Debug -DENABLE_SANITIZER=address ..
         ;;
       "ubsan")
-        cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_SANITIZER=undefined ..
+        cmake ${GENERATOR} -DCMAKE_BUILD_TYPE=Debug -DENABLE_SANITIZER=undefined ..
         ;;
       "cross")
-        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-mingw64.cmake -DCMAKE_EXE_LINKER_FLAGS="-static -s" ..
+        cmake ${GENERATOR} -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-mingw64.cmake -DCMAKE_EXE_LINKER_FLAGS="-static -s" ..
         ;;
       "release")
-        cmake -DCMAKE_BUILD_TYPE=Release ..
+        cmake ${GENERATOR} -DCMAKE_BUILD_TYPE=Release ..
         ;;
       *)
-        cmake ..
+        cmake ${GENERATOR} ..
         ;;
     esac
 
 
 script:
   # build
-  - make VERBOSE=1
+  - if [ -f build.ninja ]; then ninja -v; else make VERBOSE=1; fi
   # run all tests
   - if [ "x${BUILD_TYPE}" != "xcross" ]; then ctest --output-on-failure -j 4; fi
   # collect coverage (needs to be after running tests)

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,7 +138,7 @@ script:
   # build
   - if [ -f build.ninja ]; then ninja -v; else make VERBOSE=1; fi
   # run all tests
-  - if [ "x${BUILD_TYPE}" != "xcross" ]; then ctest --output-on-failure -j 4; fi
+  - if [ "x${BUILD_TYPE}" != "xcross" ]; then ../scripts/run_ctest.py; fi
   # collect coverage (needs to be after running tests)
   - if [ "x${BUILD_TYPE}" == "xcoverage" ]; then make coverage; fi
   # test if all the sources are conform to the forUncrustifySources.cfg config file

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,5 +31,5 @@ build_script:
 test_script:
 #  - echo This is for test only
 #  - C:/projects/uncrustify/build/Debug/uncrustify.exe -c C:/projects/uncrustify/tests/config/mono.cfg -f C:/projects/uncrustify/tests/input/cs/simple.cs -L 66
-  - ctest -C %CONFIGURATION% --output-on-failure
+  - python ../scripts/run_ctest.py -- -C %CONFIGURATION%
 deploy: off

--- a/scripts/run_ctest.py
+++ b/scripts/run_ctest.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+import argparse
+import math
+import os
+import subprocess
+import sys
+
+from multiprocessing import cpu_count
+
+default_jobs = min(cpu_count() + 2, cpu_count() * 2)
+
+# -----------------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser(description='Run CTest')
+    parser.add_argument('-q', '--quiet', action='store_true',
+                        help='suppress output of failing tests')
+    parser.add_argument('-j', '--parallel', type=int, default=default_jobs,
+                        help='number of jobs to use for parallel execution')
+    parser.add_argument('args', metavar='ARGS', nargs='*', default=[],
+                        help='additional arguments to pass to CTest')
+    args = parser.parse_args()
+
+    if not os.path.exists('CTestTestfile.cmake'):
+        print('No test configuration file found!')
+        print('(Note: This script must be run from your build directory.)')
+        sys.exit(-1)
+
+    cmd = ['ctest', '-j{}'.format(args.parallel)]
+    if not args.quiet:
+        cmd.append('--output-on-failure')
+    cmd += args.args
+
+    try:
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as exc:
+        sys.exit(exc.returncode)
+
+
+# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This changes some (but not all) of the CI builds to use [ninja](https://ninja-build.org/) instead of make to build. Besides improving build system coverage, ninja is usually faster, particularly since it defaults to parallel builds. This also introduces a small(ish) script to wrap invoking CTest that will automatically make a guess at an appropriate level of parallelism, and changes *all* the CI builds (appveyor, particularly) to use it.

While I'm certainly not accusing @mihaipopescu (#1814) of picking `-j4` out of a hat, this approach will always come up with a "good" answer even if the CI hardware changes or is different for different builds. (The main reason for the script, however, is to DTRT on Windows, where — unlike with a proper shell — it's much more awkward to just grab the number of CPU's and use that to form a command line... and since we need it there, we might as well use it everywhere for consistency's sake.)