### PR TITLE
A proposal to introduce an option mod_enum_last_comma.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ add_executable(uncrustify
   src/compat_win32.cpp
   src/defines.cpp
   src/detect.cpp
+  src/enum_cleanup.cpp
   src/helper_for_print.cpp
   src/indent.cpp
   src/keywords.cpp
@@ -229,6 +230,7 @@ add_executable(uncrustify
   src/char_table.h
   src/ChunkStack.h
   src/chunk_list.h
+  src/enum_cleanup.h
   src/helper_for_print.h
   src/language_tools.h
   src/ListManager.h

--- a/src/enum_cleanup.cpp
+++ b/src/enum_cleanup.cpp
@@ -25,16 +25,13 @@ void enum_cleanup(void)
    chunk_t *pc = chunk_get_head();  // Issue #858
    while (pc != nullptr)
    {
-      if (  chunk_is_token(pc, CT_BRACE_CLOSE)
-         && pc->parent_type == CT_ENUM)
+      if (  pc->parent_type == CT_ENUM
+         && chunk_is_token(pc, CT_BRACE_CLOSE))
       {
          LOG_FMT(LTOK, "%s(%d): orig_line is %zu, type is %s\n",
                  __func__, __LINE__, pc->orig_line, get_token_name(pc->type));
          chunk_t *prev = chunk_get_prev_ncnl(pc);
-         if (prev == nullptr)
-         {
-            return;
-         }
+         // test of (prev == nullptr) is not necessary
          if (chunk_is_token(prev, CT_COMMA))
          {
             if (cpd.settings[UO_mod_enum_last_comma].a == AV_REMOVE)

--- a/src/enum_cleanup.cpp
+++ b/src/enum_cleanup.cpp
@@ -1,0 +1,64 @@
+/**
+ * @file enum_cleanup.cpp
+ * works on the last comma withing enum
+ *
+ * @author  Guy Maurel Juli 2018
+ * @license GPL v2+
+ */
+#include "enum_cleanup.h"
+#include "uncrustify_types.h"
+#include "uncrustify.h"
+#include "chunk_list.h"
+#include "logger.h"
+
+
+void enum_cleanup(void)
+{
+   LOG_FUNC_ENTRY();
+
+   if (cpd.settings[UO_mod_enum_last_comma].a == AV_IGNORE)
+   {
+      // nothing to do
+      return;
+   }
+
+   chunk_t *pc = chunk_get_head();  // Issue #858
+   while (pc != nullptr)
+   {
+      if (  chunk_is_token(pc, CT_BRACE_CLOSE)
+         && pc->parent_type == CT_ENUM)
+      {
+         LOG_FMT(LTOK, "%s(%d): orig_line is %zu, type is %s\n",
+                 __func__, __LINE__, pc->orig_line, get_token_name(pc->type));
+         chunk_t *prev = chunk_get_prev_ncnl(pc);
+         if (prev == nullptr)
+         {
+            return;
+         }
+         if (chunk_is_token(prev, CT_COMMA))
+         {
+            if (cpd.settings[UO_mod_enum_last_comma].a == AV_REMOVE)
+            {
+               chunk_del(prev);
+            }
+         }
+         else
+         {
+            if (  cpd.settings[UO_mod_enum_last_comma].a == AV_ADD
+               || cpd.settings[UO_mod_enum_last_comma].a == AV_FORCE)
+            {
+               // create a comma
+               chunk_t comma;
+               comma.orig_line = prev->orig_line;
+               comma.orig_col  = prev->orig_col + 1;
+               comma.nl_count  = 0;
+               comma.flags     = 0;
+               comma.type      = CT_COMMA;
+               comma.str       = ",";
+               chunk_add_after(&comma, prev);
+            }
+         }
+      }
+      pc = chunk_get_next(pc);
+   }
+} // enum_cleanup

--- a/src/enum_cleanup.h
+++ b/src/enum_cleanup.h
@@ -1,0 +1,16 @@
+/**
+ * @file enum_cleanup.h
+ *
+ * @author  Guy Maurel Juli 2018
+ * @license GPL v2+
+ */
+#ifndef ENUM_CLEANUP_H_INCLUDED
+#define ENUM_CLEANUP_H_INCLUDED
+
+/**
+ * Scans through the whole list and does stuff.
+ * works on the last comma withing enum
+ */
+void enum_cleanup(void);
+
+#endif /* ENUM_CLEANUP_H_INCLUDED */

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1764,6 +1764,8 @@ void register_options(void)
                   "Determines weight of setter type (setter=) (Obj-C).");
    unc_add_option("mod_sort_oc_property_nullability_weight", UO_mod_sort_oc_property_nullability_weight, AT_NUM,
                   "Determines weight of nullability type (nullable, nonnull, null_unspecified, null_resettable) (Obj-C).");
+   unc_add_option("mod_enum_last_comma", UO_mod_enum_last_comma, AT_IARF,
+                  "add or remove the comma between the last token and the closing brace.");
 
    unc_begin_group(UG_preprocessor, "Preprocessor options");
    unc_add_option("pp_indent", UO_pp_indent, AT_IARF,

--- a/src/options.h
+++ b/src/options.h
@@ -872,6 +872,7 @@ enum uncrustify_options
    UO_mod_sort_oc_property_getter_weight,        // Determines weight of getter type (getter=)
    UO_mod_sort_oc_property_setter_weight,        // Determines weight of setter type (setter=)
    UO_mod_sort_oc_property_nullability_weight,   // Determines weight of nullability type (nullable/nonnull)
+   UO_mod_enum_last_comma,                       // add or remove the comma between the last token and the closing brace
 
 
    // group: UG_preprocessor, "Preprocessor options"                                                10

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -22,6 +22,7 @@
 #include "compat.h"
 #include "detect.h"
 #include "defines.h"
+#include "enum_cleanup.h"
 #include "indent.h"
 #include "keywords.h"
 #include "logger.h"
@@ -1792,6 +1793,8 @@ static void uncrustify_start(const deque<int> &data)
 
    // Look at all colons ':' and mark labels, :? sequences, etc.
    combine_labels();
+
+   enum_cleanup();
 } // uncrustify_start
 
 

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 644 options and minimal documentation.
+There are currently 645 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -620,6 +620,7 @@ mod_sort_oc_property_reference_weight = 0
 mod_sort_oc_property_getter_weight = 0
 mod_sort_oc_property_setter_weight = 0
 mod_sort_oc_property_nullability_weight = 0
+mod_enum_last_comma             = ignore
 pp_indent                       = ignore
 pp_indent_at_level              = false
 pp_indent_count                 = 1

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -2093,6 +2093,9 @@ mod_sort_oc_property_setter_weight = 0        # number
 # Determines weight of nullability type (nullable, nonnull, null_unspecified, null_resettable) (Obj-C).
 mod_sort_oc_property_nullability_weight = 0        # number
 
+# add or remove the comma between the last token and the closing brace.
+mod_enum_last_comma             = ignore   # ignore/add/remove/force
+
 #
 # Preprocessor options
 #

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -620,6 +620,7 @@ mod_sort_oc_property_reference_weight = 0
 mod_sort_oc_property_getter_weight = 0
 mod_sort_oc_property_setter_weight = 0
 mod_sort_oc_property_nullability_weight = 0
+mod_enum_last_comma             = ignore
 pp_indent                       = ignore
 pp_indent_at_level              = false
 pp_indent_count                 = 1

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -2093,6 +2093,9 @@ mod_sort_oc_property_setter_weight = 0        # number
 # Determines weight of nullability type (nullable, nonnull, null_unspecified, null_resettable) (Obj-C).
 mod_sort_oc_property_nullability_weight = 0        # number
 
+# add or remove the comma between the last token and the closing brace.
+mod_enum_last_comma             = ignore   # ignore/add/remove/force
+
 #
 # Preprocessor options
 #

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -2094,6 +2094,9 @@ mod_sort_oc_property_setter_weight Number
 mod_sort_oc_property_nullability_weight Number
   Determines weight of nullability type (nullable, nonnull, null_unspecified, null_resettable) (Obj-C).
 
+mod_enum_last_comma             { Ignore, Add, Remove, Force }
+  add or remove the comma between the last token and the closing brace.
+
 #
 # Preprocessor options
 #

--- a/tests/config/bug_858-f.cfg
+++ b/tests/config/bug_858-f.cfg
@@ -1,0 +1,5 @@
+indent_columns   = 3
+indent_with_tabs = 0
+nl_enum_brace    = force
+sp_enum_assign   = force
+mod_enum_last_comma = force

--- a/tests/config/bug_858-r.cfg
+++ b/tests/config/bug_858-r.cfg
@@ -1,0 +1,5 @@
+indent_columns   = 3
+indent_with_tabs = 0
+nl_enum_brace    = force
+sp_enum_assign   = force
+mod_enum_last_comma = remove

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -452,6 +452,8 @@
 33100  enum_comma-4.cfg                     cpp/enum_comma.h
 33101  pos_comma-tb.cfg                     cpp/enum_comma.h
 33102  enum_comma-6.cfg                     cpp/enum_comma.h
+33103  bug_858-f.cfg                        cpp/bug_858.cpp
+33104  bug_858-r.cfg                        cpp/bug_858.cpp
 
 33105  empty.cfg                            cpp/bug_1001.cpp
 

--- a/tests/expected/cpp/33103-bug_858.cpp
+++ b/tests/expected/cpp/33103-bug_858.cpp
@@ -9,3 +9,9 @@ enum
    item3,
    item4,  // comment 4
 }
+enum { x, y,};
+enum { x, y = 0,};
+enum { x, y = 0,/*comment*/ };
+enum { x, y,};
+enum { x, y = 0,};
+enum { x, y = 0,/*comment*/ };

--- a/tests/expected/cpp/33103-bug_858.cpp
+++ b/tests/expected/cpp/33103-bug_858.cpp
@@ -1,0 +1,11 @@
+enum
+{
+   item1 = 123,
+   item2, // comment 2
+}
+
+enum
+{
+   item3,
+   item4,  // comment 4
+}

--- a/tests/expected/cpp/33104-bug_858.cpp
+++ b/tests/expected/cpp/33104-bug_858.cpp
@@ -1,0 +1,11 @@
+enum
+{
+   item1 = 123,
+   item2  // comment 2
+}
+
+enum
+{
+   item3,
+   item4   // comment 4
+}

--- a/tests/expected/cpp/33104-bug_858.cpp
+++ b/tests/expected/cpp/33104-bug_858.cpp
@@ -9,3 +9,9 @@ enum
    item3,
    item4   // comment 4
 }
+enum { x, y };
+enum { x, y = 0 };
+enum { x, y = 0 /*comment*/ };
+enum { x, y };
+enum { x, y = 0 };
+enum { x, y = 0 /*comment*/ };

--- a/tests/input/cpp/bug_858.cpp
+++ b/tests/input/cpp/bug_858.cpp
@@ -8,3 +8,9 @@ enum
     item3,
     item4, // comment 4
 }
+enum { x, y };
+enum { x, y=0 };
+enum { x, y=0 /*comment*/ };
+enum { x, y,};
+enum { x, y=0,};
+enum { x, y=0,/*comment*/ };

--- a/tests/input/cpp/bug_858.cpp
+++ b/tests/input/cpp/bug_858.cpp
@@ -1,0 +1,10 @@
+enum {
+    item1=123,
+    item2 // comment 2
+}
+
+enum
+{
+    item3,
+    item4, // comment 4
+}


### PR DESCRIPTION
To: add or remove the comma between the last token and the closing brace.

Ref.  #858