### PR TITLE
fix handling of self calling lambdas

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -5424,6 +5424,7 @@ static void handle_cpp_lambda(chunk_t *sq_o)
    if (  prev == nullptr
       || (  prev->type != CT_ASSIGN
          && prev->type != CT_COMMA
+         && prev->type != CT_PAREN_OPEN   // allow Js like self invoking lambda syntax: ([](){})();
          && prev->type != CT_FPAREN_OPEN
          && prev->type != CT_SQUARE_OPEN
          && prev->type != CT_BRACE_OPEN
@@ -5538,6 +5539,20 @@ static void handle_cpp_lambda(chunk_t *sq_o)
    if (pa_c)
    {
       fix_fcn_def_params(pa_o);
+   }
+
+   //handle self calling lambda paren
+   chunk_t *call_pa_o = chunk_get_next_ncnl(br_c);
+   if (chunk_is_token(call_pa_o, CT_PAREN_OPEN))
+   {
+      chunk_t *call_pa_c = chunk_skip_to_match(call_pa_o);
+      if (call_pa_c != nullptr)
+      {
+         set_chunk_type(call_pa_o, CT_FPAREN_OPEN);
+         set_chunk_parent(call_pa_o, CT_FUNC_CALL);
+         set_chunk_type(call_pa_c, CT_FPAREN_CLOSE);
+         set_chunk_parent(call_pa_c, CT_FUNC_CALL);
+      }
    }
 } // handle_cpp_lambda
 

--- a/tests/config/nl-brAfter-fcallParen.cfg
+++ b/tests/config/nl-brAfter-fcallParen.cfg
@@ -1,0 +1,2 @@
+nl_func_call_paren              = remove
+nl_after_brace_close            = true                                         #

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -573,7 +573,7 @@
 34207  indent_first_for_expr-t.cfg          cpp/for_loop_head.cpp
 
 34208  nl_func_type_name-r.cfg              cpp/conversion_operator.cpp
-
+34209  nl-brAfter-fcallParen.cfg            cpp/lambda_selfcalling.cpp
 
 # TODO: Find relevant test cases for 'override'.
 34210  empty.cfg                            cpp/override_virtual.cpp

--- a/tests/expected/cpp/34209-lambda_selfcalling.cpp
+++ b/tests/expected/cpp/34209-lambda_selfcalling.cpp
@@ -1,0 +1,10 @@
+void f(){
+	int i = 0;
+	const auto j = [](int k){
+			       return k+2;
+		       }       (i);
+
+	const auto l = ([](int k){
+		return k+2;
+	})(i);
+}

--- a/tests/input/cpp/lambda_selfcalling.cpp
+++ b/tests/input/cpp/lambda_selfcalling.cpp
@@ -1,0 +1,12 @@
+void f(){
+	int i = 0;
+	const auto j = [](int k){
+			       return k+2;
+		       }
+	                       (i);
+
+	const auto l = ([](int k){
+		return k+2;
+	})
+	                       (i);
+}


### PR DESCRIPTION
- sets the type of the lambdas call parenthesis to CT_FPAREN

Note the in the tests for the _Js_ styled self calling lambda also removes leading spaces for some reason. I am not certain if it should or should not. I'd sill like to merge this and deal with that problem later (I will open a new issue for that once this is merged). 

~~Also: Why istn't coveralls updating the stats after I force pushed this branch?~~ It actually does edit its comment.