### PR TITLE
Make sp_endif_cmt works also with cpp comment.

### DIFF
--- a/src/space.cpp
+++ b/src/space.cpp
@@ -374,8 +374,10 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
       return(arg);
    }
 
-   if (  chunk_is_token(second, CT_COMMENT)
-      && (chunk_is_token(first, CT_PP_ELSE) || chunk_is_token(first, CT_PP_ENDIF)))
+   if (  (  chunk_is_token(second, CT_COMMENT)
+         || chunk_is_token(second, CT_COMMENT_CPP))
+      && (  chunk_is_token(first, CT_PP_ELSE)
+         || chunk_is_token(first, CT_PP_ENDIF)))
    {
       if (cpd.settings[UO_sp_endif_cmt].a != AV_IGNORE)
       {

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 645 options and minimal documentation.
+There are currently 646 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/tests/config/bug_1862.cfg
+++ b/tests/config/bug_1862.cfg
@@ -1,0 +1,3 @@
+# Controls the spaces between #else or #endif and a trailing comment.
+sp_endif_cmt=remove
+#sp_endif_cmt=force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -110,6 +110,7 @@
 30113  bug_1452.cfg                         cpp/bug_1452.cpp
 30114  empty.cfg                            cpp/bug_1462.cpp
 
+30200  bug_1862.cfg                         cpp/bug_1862.cpp
 30201  cmt_indent-1.cfg                     cpp/cmt_indent.cpp
 30202  cmt_indent-2.cfg                     cpp/cmt_indent.cpp
 30203  cmt_indent-3.cfg                     cpp/cmt_indent.cpp

--- a/tests/expected/cpp/30200-bug_1862.cpp
+++ b/tests/expected/cpp/30200-bug_1862.cpp
@@ -1,0 +1,11 @@
+#if _MSC_VER < 1300
+#define __func__    "???"
+#else/* comment 1 */
+#define __func__    __FUNCTION__
+#endif/* comment 2 */
+
+#if _MSC_VER < 1300
+#define __func__    "???"
+#else// comment 1
+#define __func__    __FUNCTION__
+#endif// comment 2

--- a/tests/input/cpp/bug_1862.cpp
+++ b/tests/input/cpp/bug_1862.cpp
@@ -1,0 +1,11 @@
+#if _MSC_VER < 1300
+#define __func__    "???"
+#else  /* comment 1 */
+#define __func__    __FUNCTION__
+#endif  /* comment 2 */
+
+#if _MSC_VER < 1300
+#define __func__    "???"
+#else  // comment 1
+#define __func__    __FUNCTION__
+#endif  // comment 2


### PR DESCRIPTION
ref. #1862 
The warning from coveralls for the line 382 is also fixed.