### PR TITLE
Clean up ".rerun" test stuff

### DIFF
--- a/tests/c-sharp.test
+++ b/tests/c-sharp.test
@@ -83,7 +83,7 @@
 10027  U01-Cs.cfg                           cs/oneline_property.cs
 10028  U02-Cs.cfg                           cs/ifcolalign.cs
 10029  U03-Cs.cfg                           cs/when.cs
-10033! U11-Cpp.cfg                          cs/objc.mm
+10033  U11-Cpp.cfg                          cs/objc.mm
 10034  U12-Cpp.cfg                          cs/asm.h.mm
 10035  U13-Cpp.cfg                          cs/definesalign.h.mm
 10036  U14-Cpp.cfg                          cs/inttypes.h.mm
@@ -115,7 +115,7 @@
 60005  UNI-2685.cfg                         cs/UNI-2685.cs
 60007  UNI-3083.cfg                         cs/UNI-3083.cs
 60008  U-J.cfg                              cs/UNI-17253.cs
-60009! UNI-9917.cfg                         cs/UNI-9917.cs
+60009  UNI-9917.cfg                         cs/UNI-9917.cs
 60011  UNI-11095.cfg                        cs/UNI-11095.mm
 60012  U13-Cs.cfg                           cs/UNI-12303.cs
 60013  UNI-13955.cfg                        cs/UNI-13955.cs

--- a/tests/config/U10-Cpp.rerun.cfg
+++ b/tests/config/U10-Cpp.rerun.cfg
@@ -1,1 +1,0 @@
-include "U10-Cpp.cfg"

--- a/tests/config/U11-Cpp.rerun.cfg
+++ b/tests/config/U11-Cpp.rerun.cfg
@@ -1,1 +1,0 @@
-include "U11-Cpp.cfg"

--- a/tests/config/UNI-9917.rerun.cfg
+++ b/tests/config/UNI-9917.rerun.cfg
@@ -1,9 +1,0 @@
-sp_inside_braces_empty          = remove
-indent_columns                  = 4
-indent_with_tabs                = 0
-indent_namespace                = true
-indent_class                    = true
-nl_class_leave_one_liners       = true
-nl_end_of_file                  = force
-nl_end_of_file_min              = 1
-nl_class_brace                  = force

--- a/tests/config/long_br_cmt.rerun.cfg
+++ b/tests/config/long_br_cmt.rerun.cfg
@@ -1,1 +1,0 @@
-include "long_br_cmt.cfg"

--- a/tests/config/verbatim_strings.rerun.cfg
+++ b/tests/config/verbatim_strings.rerun.cfg
@@ -1,2 +1,0 @@
-include                           "verbatim_strings.cfg"
-warn_level_tabs_found_in_verbatim_string_literals = 1

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -148,7 +148,7 @@
 30262  align_var_def_thresh_2.cfg           cpp/align_var_def_thresh.cpp
 30263  align_var_def_thresh_3.cfg           cpp/align_var_def_thresh.cpp
 
-30265! long_br_cmt.cfg                      cpp/long_br_cmt.cpp
+30265  long_br_cmt.cfg                      cpp/long_br_cmt.cpp
 
 30270  const_throw.cfg                      cpp/const_throw.cpp
 30271  sp_throw_paren-r.cfg                 cpp/sp_throw_paren.cpp


### PR DESCRIPTION
Remove special ".rerun" handling from some tests that don't need it, and for which the "alternate" files did not anyway have different content. Also remove some orphaned ".rerun" files.

With this, only five tests have special handling; one of which appears to be using it correctly, one of which is unfortunate but difficult to argue that uncrustify is doing anything wrong, and three of which look suspiciously like real bugs. (See https://github.com/uncrustify/uncrustify/pull/1821#issuecomment-403633879 for a detailed analysis.)