### PR TITLE
Coveralls space768

### DIFF
--- a/tests/config/indent_with_tabs-0.cfg
+++ b/tests/config/indent_with_tabs-0.cfg
@@ -1,1 +1,2 @@
-indent_with_tabs                = 0
+indent_with_tabs      = 0
+sp_enum_before_assign = remove

--- a/tests/expected/cpp/30302-bug_1315.cpp
+++ b/tests/expected/cpp/30302-bug_1315.cpp
@@ -4,14 +4,14 @@ dookie::wookie << "asd"
 
 typedef enum
 {
-        A = 0,
-        B = 1 << 0,
-        C = 1 << 1
+        A= 0,
+        B= 1 << 0,
+        C= 1 << 1
 };
 
 enum
 {
-        A = 0,
-        B = 1 << 0,
-        C = 1 << 1
+        A= 0,
+        B= 1 << 0,
+        C= 1 << 1
 };


### PR DESCRIPTION
Change the value of the option sp_enum_before_assign
This test was missed bei https://coveralls.io/builds/17772219/source?filename=src/space.cpp#L768