### PR TITLE
Change the test source to get a trace for the option sp_before_semi

### DIFF
--- a/tests/input/cpp/bug_1158.cpp
+++ b/tests/input/cpp/bug_1158.cpp
@@ -1,4 +1,4 @@
 void Class1::Func(void)
 {
-        while (Next());
+        while (Next()) ;
 }


### PR DESCRIPTION
Change the value of option sp_before_semi

To get a better trace of coveralls

This trace was missed at https://coveralls.io/builds/17772219/source?filename=src/space.cpp#L1038