### PR TITLE
Don't align comments at different brace levels

### DIFF
--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -68,6 +68,7 @@ align_typedef_gap               = 3
 align_typedef_span              = 5
 align_typedef_star_style        = 1
 align_right_cmt_span            = 3
+align_right_cmt_same_level      = true
 align_nl_cont                   = true
 align_pp_define_gap             = 4
 align_pp_define_span            = 3

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -1531,10 +1531,12 @@ chunk_t *align_trailing_comments(chunk_t *start)
    size_t          min_col  = 0;
    size_t          min_orig = 0;
    chunk_t         *pc      = start;
+   const size_t    lvl      = start->brace_level;
    size_t          nl_count = 0;
    ChunkStack      cs;
    size_t          col;
    size_t          intended_col = cpd.settings[UO_align_right_cmt_at_col].u;
+   const bool      same_level   = cpd.settings[UO_align_right_cmt_same_level].b;
    comment_align_e cmt_type_cur;
    comment_align_e cmt_type_start = get_comment_align_type(pc);
 
@@ -1547,6 +1549,12 @@ chunk_t *align_trailing_comments(chunk_t *start)
    {
       if ((pc->flags & PCF_RIGHT_COMMENT) && pc->column > 1)
       {
+         if (same_level && pc->brace_level != lvl)
+         {
+            pc = chunk_get_prev(pc);
+            break;
+         }
+
          cmt_type_cur = get_comment_align_type(pc);
 
          if (cmt_type_cur == cmt_type_start)

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1570,6 +1570,8 @@ void register_options(void)
                   "The span for aligning comments that end lines (0=don't align)", "", 0, 5000);
    unc_add_option("align_right_cmt_mix", UO_align_right_cmt_mix, AT_BOOL,
                   "If aligning comments, mix with comments after '}' and #endif with less than 3 spaces before the comment.");
+   unc_add_option("align_right_cmt_same_level", UO_align_right_cmt_same_level, AT_BOOL,
+                  "Whether to only align trailing comments that are at the same brace level.");
    unc_add_option("align_right_cmt_gap", UO_align_right_cmt_gap, AT_UNUM,
                   "If a trailing comment is more than this number of columns away from the text it follows,\n"
                   "it will qualify for being aligned. This has to be > 0 to do anything.");

--- a/src/options.h
+++ b/src/options.h
@@ -778,6 +778,7 @@ enum uncrustify_options
    UO_align_typedef_amp_style,     // align_typedef_star_style for ref '&' stuff
    UO_align_right_cmt_span,        // align comment that end lines. 0=don't align
    UO_align_right_cmt_mix,         // mix comments after '}' and preproc with others
+   UO_align_right_cmt_same_level,  // only align comments at same brace level
    UO_align_right_cmt_gap,         //
    UO_align_right_cmt_at_col,      // align comment that end lines at or beyond column N;
                                    // 'pulls in' comments as a bonus side effect

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 646 options and minimal documentation.
+There are currently 647 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -544,6 +544,7 @@ align_typedef_star_style        = 0
 align_typedef_amp_style         = 0
 align_right_cmt_span            = 0
 align_right_cmt_mix             = false
+align_right_cmt_same_level      = false
 align_right_cmt_gap             = 0
 align_right_cmt_at_col          = 0
 align_func_proto_span           = 0

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1824,6 +1824,9 @@ align_right_cmt_span            = 0        # unsigned number
 # If aligning comments, mix with comments after '}' and #endif with less than 3 spaces before the comment.
 align_right_cmt_mix             = false    # false/true
 
+# Whether to only align trailing comments that are at the same brace level.
+align_right_cmt_same_level      = false    # false/true
+
 # If a trailing comment is more than this number of columns away from the text it follows,
 # it will qualify for being aligned. This has to be > 0 to do anything.
 align_right_cmt_gap             = 0        # unsigned number

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -544,6 +544,7 @@ align_typedef_star_style        = 0
 align_typedef_amp_style         = 0
 align_right_cmt_span            = 0
 align_right_cmt_mix             = false
+align_right_cmt_same_level      = false
 align_right_cmt_gap             = 0
 align_right_cmt_at_col          = 0
 align_func_proto_span           = 0

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1824,6 +1824,9 @@ align_right_cmt_span            = 0        # unsigned number
 # If aligning comments, mix with comments after '}' and #endif with less than 3 spaces before the comment.
 align_right_cmt_mix             = false    # false/true
 
+# Whether to only align trailing comments that are at the same brace level.
+align_right_cmt_same_level      = false    # false/true
+
 # If a trailing comment is more than this number of columns away from the text it follows,
 # it will qualify for being aligned. This has to be > 0 to do anything.
 align_right_cmt_gap             = 0        # unsigned number

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1825,6 +1825,9 @@ align_right_cmt_span            Unsigned Number
 align_right_cmt_mix             { False, True }
   If aligning comments, mix with comments after '}' and #endif with less than 3 spaces before the comment.
 
+align_right_cmt_same_level      { False, True }
+  Whether to only align trailing comments that are at the same brace level.
+
 align_right_cmt_gap             Unsigned Number
   If a trailing comment is more than this number of columns away from the text it follows,
   it will qualify for being aligned. This has to be > 0 to do anything.

--- a/tests/config/issue_1887.cfg
+++ b/tests/config/issue_1887.cfg
@@ -1,0 +1,3 @@
+indent_with_tabs                = 0
+align_right_cmt_span            = 3
+align_right_cmt_same_level      = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -124,6 +124,7 @@
 30211  space_indent_class-t_columns-4.cfg   cpp/indent_comment_align_thresh.cpp
 30212  indent_comment_align_thresh_2.cfg    cpp/indent_comment_align_thresh.cpp
 30213  align_right_comment.cfg              cpp/align_right_comment.cpp
+30214  issue_1887.cfg                       cpp/align_across_braces.cpp
 
 30220  bug_1340.cfg                         cpp/bug_1340.cpp
 

--- a/tests/expected/cpp/30214-align_across_braces.cpp
+++ b/tests/expected/cpp/30214-align_across_braces.cpp
@@ -1,0 +1,7 @@
+enum foo // comment
+{
+        long_enum_value, // these comments should be aligned
+        another_value,   // with each other, but not
+        shorter,         // with the first line
+};          // this comment should start a new group
+void bar(); // this one should align with the previous line

--- a/tests/input/cpp/align_across_braces.cpp
+++ b/tests/input/cpp/align_across_braces.cpp
@@ -1,0 +1,7 @@
+enum foo // comment
+{
+  long_enum_value, // these comments should be aligned
+  another_value, // with each other, but not
+  shorter, // with the first line
+}; // this comment should start a new group
+void bar(); // this one should align with the previous line


### PR DESCRIPTION
Add new option `align_right_cmt_same_level` to prevent aligning trailing comments at different brace levels. Apply this to uncrustify's own sources. (Currently, uncrustify does not have any comments that are affected by this.)

Fixes #1887.