### PR TITLE
coveralls informs us about a missing test.

### DIFF
--- a/tests/config/sp_after_constr_colon.cfg
+++ b/tests/config/sp_after_constr_colon.cfg
@@ -1,18 +1,9 @@
-# (244)Virtual indent from the ':' for member initializers. Default=2.
-#indent_ctor_init_leading        = 
-# (93)Add or remove space after class constructor ':'
 sp_after_constr_colon           = remove
-
 indent_columns                  = 2
 indent_class_colon              = true
 indent_constr_colon             = true
 indent_ctor_init                = 2
-indent_func_class_param         = true
-indent_func_param_double        = true
-indent_access_spec              = 2
 nl_collapse_empty_body          = true
-nl_constr_init_args             = add
-nl_func_def_start               = add
-nl_func_def_args                = add
-nl_before_access_spec           = 2
+nl_constr_init_args             = remove
+nl_func_def_args                = force
 pos_constr_comma                = trail_force

--- a/tests/config/sp_after_constr_colon.cfg
+++ b/tests/config/sp_after_constr_colon.cfg
@@ -1,0 +1,18 @@
+# (244)Virtual indent from the ':' for member initializers. Default=2.
+#indent_ctor_init_leading        = 
+# (93)Add or remove space after class constructor ':'
+sp_after_constr_colon           = remove
+
+indent_columns                  = 2
+indent_class_colon              = true
+indent_constr_colon             = true
+indent_ctor_init                = 2
+indent_func_class_param         = true
+indent_func_param_double        = true
+indent_access_spec              = 2
+nl_collapse_empty_body          = true
+nl_constr_init_args             = add
+nl_func_def_start               = add
+nl_func_def_args                = add
+nl_before_access_spec           = 2
+pos_constr_comma                = trail_force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -144,7 +144,7 @@
 30256  empty.cfg                            cpp/func_call.cpp
 30257  indent_columns-4.cfg                 cpp/func_call_chain.cpp
 30258  indent_columns-3.cfg                 cpp/casts.cpp
-
+30259  sp_after_constr_colon.cfg            cpp/sp_after_constr_colon.cpp
 30260  var_def_gap.cfg                      cpp/var_def_gap.cpp
 30261  align_var_def_thresh_1.cfg           cpp/align_var_def_thresh.cpp
 30262  align_var_def_thresh_2.cfg           cpp/align_var_def_thresh.cpp

--- a/tests/expected/cpp/30259-sp_after_constr_colon.cpp
+++ b/tests/expected/cpp/30259-sp_after_constr_colon.cpp
@@ -1,0 +1,17 @@
+struct MyClass : public Foo,
+                 private Bar {
+  MyClass(
+      int a,
+      int b,
+      int c)
+      :m_a(a),
+        m_b(b),
+        m_c(c) {}
+
+ private:
+  int m_a, m_b, m_c;
+};
+
+struct TheirClass
+  : public Foo,
+    private Bar {};

--- a/tests/expected/cpp/30259-sp_after_constr_colon.cpp
+++ b/tests/expected/cpp/30259-sp_after_constr_colon.cpp
@@ -1,17 +1,6 @@
-struct MyClass : public Foo,
-                 private Bar {
-  MyClass(
-      int a,
-      int b,
-      int c)
-      :m_a(a),
-        m_b(b),
-        m_c(c) {}
-
- private:
-  int m_a, m_b, m_c;
+struct MyClass : public Foo {
+  MyClass(int a,
+          int b,
+          int c)
+      :m_a(a), m_b(b), m_c(c) {}
 };
-
-struct TheirClass
-  : public Foo,
-    private Bar {};

--- a/tests/input/cpp/sp_after_constr_colon.cpp
+++ b/tests/input/cpp/sp_after_constr_colon.cpp
@@ -1,0 +1,12 @@
+struct MyClass : public Foo,
+                 private Bar {
+  MyClass(int a, int b, int c)
+	 : m_a(a), m_b(b),
+   m_c(c) {}
+private :
+  int m_a, m_b, m_c;
+};
+
+struct TheirClass
+: public Foo,
+private Bar {};

--- a/tests/input/cpp/sp_after_constr_colon.cpp
+++ b/tests/input/cpp/sp_after_constr_colon.cpp
@@ -1,12 +1,6 @@
-struct MyClass : public Foo,
-                 private Bar {
-  MyClass(int a, int b, int c)
-	 : m_a(a), m_b(b),
-   m_c(c) {}
-private :
-  int m_a, m_b, m_c;
+struct MyClass : public Foo {
+  MyClass(int a,
+          int b,
+          int c)
+      : m_a(a), m_b(b), m_c(c) {}
 };
-
-struct TheirClass
-: public Foo,
-private Bar {};


### PR DESCRIPTION
For the option sp_after_constr_colon
This trace was missed at https://coveralls.io/builds/17772219/source?filename=src/space.cpp#L1685
Add a new test for it.