### PR TITLE
Missing test for sp_before_constr_colon

### DIFF
--- a/tests/config/sp_before_constr_colon.cfg
+++ b/tests/config/sp_before_constr_colon.cfg
@@ -1,0 +1,10 @@
+sp_before_constr_colon          = remove
+indent_columns                  = 2
+indent_class_colon              = true
+indent_constr_colon             = true
+indent_ctor_init                = 2
+nl_collapse_empty_body          = true
+nl_constr_init_args             = remove
+nl_func_def_args                = remove
+pos_constr_comma                = trail_force
+pos_constr_colon                = trail_force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -305,6 +305,7 @@
 
 30950  sp_before_tr_emb_cmt-f.cfg           cpp/sp_before_tr_emb_cmt_input.cpp
 30951  sp_before_tr_emb_cmt-a.cfg           cpp/sp_before_tr_emb_cmt_input.cpp
+30952  sp_before_constr_colon.cfg           cpp/sp_before_constr_colon.cpp
 30955  indent_ctor_init.cfg                 cpp/indent_ctor_init.cpp
 30956  indent_ctor_init_leading.cfg         cpp/indent_ctor_init.cpp
 30957  negative_indent.cfg                  cpp/class-init.cpp

--- a/tests/expected/cpp/30952-sp_before_constr_colon.cpp
+++ b/tests/expected/cpp/30952-sp_before_constr_colon.cpp
@@ -1,0 +1,4 @@
+struct MyClass : public Foo {
+  MyClass(int a, int b, int c):
+      m_a(a), m_b(b), m_c(c) {}
+};

--- a/tests/input/cpp/sp_before_constr_colon.cpp
+++ b/tests/input/cpp/sp_before_constr_colon.cpp
@@ -1,0 +1,4 @@
+struct MyClass : public Foo {
+  MyClass(int a, int b, int c) :
+      m_a(a), m_b(b), m_c(c) {}
+};


### PR DESCRIPTION
For the option sp_before_constr_colon

This trace was missed at https://coveralls.io/builds/17772219/source?filename=src/space.cpp#L1693
Add a new test for it.