### PR TITLE
proper handling of an C++11 initialization list in a return statement

### DIFF
--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -552,6 +552,10 @@ static void parse_cleanup(ParseFrame &frm, chunk_t *pc)
             {
                parent = CT_ASSIGN;
             }
+            else if (chunk_is_token(prev, CT_RETURN) && language_is_set(LANG_CPP))
+            {
+               parent = CT_RETURN;
+            }
             // Carry through CT_ENUM parent in NS_ENUM (type, name) {
             else if (  chunk_is_token(prev, CT_FPAREN_CLOSE)
                     && language_is_set(LANG_OC)

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1420,6 +1420,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       if (  chunk_is_token(pc, CT_WORD)
          || chunk_is_token(pc, CT_TYPE)
          || chunk_is_token(pc, CT_ASSIGN)
+         || chunk_is_token(pc, CT_RETURN)
          || chunk_is_token(pc, CT_COMMA)
          || chunk_is_token(pc, CT_ANGLE_CLOSE)
          || chunk_is_token(pc, CT_SQUARE_CLOSE)
@@ -1433,6 +1434,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
          if (  chunk_is_token(brace_open, CT_BRACE_OPEN)
             && (  brace_open->parent_type == CT_NONE
                || brace_open->parent_type == CT_ASSIGN
+               || brace_open->parent_type == CT_RETURN
                || brace_open->parent_type == CT_BRACED_INIT_LIST))
          {
             auto brace_close = chunk_skip_to_match(next);

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1538,6 +1538,19 @@ void indent_text(void)
             }
             log_indent();
          }
+         else if (  pc->parent_type == CT_BRACED_INIT_LIST
+                 && frm.prev().type == CT_RETURN)
+         {
+            if (frm.prev().indent_cont)
+            {
+               frm.top().indent = frm.prev().indent_tmp;
+            }
+            else
+            {
+               frm.top().indent = frm.prev().indent_tmp + indent_size;
+            }
+            log_indent();
+         }
          else
          {
             // Use the prev indent level + indent_size.

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -173,6 +173,7 @@
 30310  empty.cfg                            cpp/braced_init_list.cpp
 #30310  sp_word_brace_force.cfg              cpp/uniform_initialization.cpp
 #30311  sp_word_brace_remove.cfg             cpp/uniform_initialization.cpp
+30312  sp_inside_type_brace_init_lst-f.cfg   cpp/return_init_list.cpp
 
 # function def newlines
 30701  func-def-1.cfg                       cpp/function-def.cpp

--- a/tests/expected/cpp/30312-return_init_list.cpp
+++ b/tests/expected/cpp/30312-return_init_list.cpp
@@ -1,0 +1,30 @@
+inline static std::tuple<bool, std::string> foo(void) {
+// should remain a one liner
+	return { true, ""s };
+}
+inline static std::tuple<bool, std::string, std::string> foo(void) {
+	if (condition) {
+// should remain a one liner
+		return { true, ""s, ""s };
+	}
+// should remain a one liner
+	return { false, ""s, ""s };
+}
+inline static std::tuple<bool, std::string> foo(void) {
+// should indent one level
+	return {
+	        true, ""s
+	};
+}
+inline static std::tuple<bool, std::string> foo(void) {
+// should indent one level on new line
+	return
+	        { true, ""s };
+}
+inline static std::tuple<bool, std::string> foo(void) {
+// should indent one level for braces and another level for values
+	return
+	        {
+	                true, ""s
+		};
+}

--- a/tests/input/cpp/return_init_list.cpp
+++ b/tests/input/cpp/return_init_list.cpp
@@ -1,0 +1,30 @@
+inline static std::tuple<bool, std::string> foo(void) {
+// should remain a one liner
+return{true, ""s};
+}
+inline static std::tuple<bool, std::string, std::string> foo(void) {
+if (condition) {
+// should remain a one liner
+return{true, ""s, ""s};
+}
+// should remain a one liner
+return{false, ""s, ""s};
+}
+inline static std::tuple<bool, std::string> foo(void) {
+// should indent one level
+return{
+true, ""s
+};
+}
+inline static std::tuple<bool, std::string> foo(void) {
+// should indent one level on new line
+return
+{ true, ""s };
+}
+inline static std::tuple<bool, std::string> foo(void) {
+// should indent one level for braces and another level for values
+return
+{
+true, ""s
+};
+}


### PR DESCRIPTION
For some reason C++11 initialization lists in a `return` statement were not included in the change to "Add CT_BRACED_INIT_LIST for C++ 'braced-init-list'" (81ce3ff). This change adds support for initialization lists in a `return` statement.

A test is also provided to check that uncrustify handles formatting these as C++11 initialization lists rather than as scope blocks.