### PR TITLE
add spacial align-assign-span treatment for: virtual .. = 0, = delete, = default

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -807,12 +807,16 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
       {
          equ_count++;
 
-         if (  !(pc->flags & PCF_IN_FCN_DEF)
+         if (  cpd.settings[UO_align_assign_decl_func].u != 0
+            && !(pc->flags & PCF_IN_FCN_DEF)
             && (  pc->parent_type == CT_QUALIFIER         // '= 0;' of a virtual function
                || pc->parent_type == CT_FUNC_CLASS_PROTO  // '= delete|default; of a xtor
                || pc->parent_type == CT_FUNC_PROTO))      // '= delete|default; of other special functions
          {
-            fcnEnd_as.Add(pc);
+            if (cpd.settings[UO_align_assign_decl_func].u != 2)
+            {
+               fcnEnd_as.Add(pc);
+            }
          }
          else if (var_def_cnt != 0)
          {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1533,6 +1533,11 @@ void register_options(void)
                   "The span for aligning on '=' in assignments (0=don't align)", "", 0, 5000);
    unc_add_option("align_assign_thresh", UO_align_assign_thresh, AT_UNUM,
                   "The threshold for aligning on '=' in assignments (0=no limit)", "", 0, 5000);
+   unc_add_option("align_assign_decl_func", UO_align_assign_decl_func, AT_UNUM,
+                  "Defines how align_assign_span is applied onto function decl. with: virtual ... = 0, = delete, = default.\n"
+                  "0 - default align_assign_span behavior\n"
+                  "1 - indent the '=' on their own, with each other\n"
+                  "2 - don't indent", "", 0, 2);
    unc_add_option("align_enum_equ_span", UO_align_enum_equ_span, AT_UNUM,
                   "The span for aligning on '=' in enums (0=don't align)", "", 0, 5000);
    unc_add_option("align_enum_equ_thresh", UO_align_enum_equ_thresh, AT_UNUM,

--- a/src/options.h
+++ b/src/options.h
@@ -761,6 +761,7 @@ enum uncrustify_options
    UO_align_var_def_inline,        // also align inline struct/enum/union var defs
    UO_align_assign_span,           // align on '='. 0=don't align
    UO_align_assign_thresh,         // threshold for aligning on '='. 0=no limit
+   UO_align_assign_decl_func,      // how to handle assign in special function decls (ro5 & pure virtual)
    UO_align_enum_equ_span,         // align the '=' in enums
    UO_align_enum_equ_thresh,       // threshold for aligning on '=' in enums. 0=no limit
    UO_align_var_class_span,        // span for class (0=don't align)

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 649 options and minimal documentation.
+There are currently 650 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -530,6 +530,7 @@ align_var_def_attribute         = false
 align_var_def_inline            = false
 align_assign_span               = 0
 align_assign_thresh             = 0
+align_assign_decl_func          = 0
 align_enum_equ_span             = 0
 align_enum_equ_thresh           = 0
 align_var_class_span            = 0

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1773,6 +1773,12 @@ align_assign_span               = 0        # unsigned number
 # The threshold for aligning on '=' in assignments (0=no limit)
 align_assign_thresh             = 0        # unsigned number
 
+# Defines how align_assign_span is applied onto function decl. with: virtual ... = 0, = delete, = default.
+# 0 - default align_assign_span behavior
+# 1 - indent the '=' on their own, with each other
+# 2 - don't indent
+align_assign_decl_func          = 0        # unsigned number
+
 # The span for aligning on '=' in enums (0=don't align)
 align_enum_equ_span             = 0        # unsigned number
 

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -530,6 +530,7 @@ align_var_def_attribute         = false
 align_var_def_inline            = false
 align_assign_span               = 0
 align_assign_thresh             = 0
+align_assign_decl_func          = 0
 align_enum_equ_span             = 0
 align_enum_equ_thresh           = 0
 align_var_class_span            = 0

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1773,6 +1773,12 @@ align_assign_span               = 0        # unsigned number
 # The threshold for aligning on '=' in assignments (0=no limit)
 align_assign_thresh             = 0        # unsigned number
 
+# Defines how align_assign_span is applied onto function decl. with: virtual ... = 0, = delete, = default.
+# 0 - default align_assign_span behavior
+# 1 - indent the '=' on their own, with each other
+# 2 - don't indent
+align_assign_decl_func          = 0        # unsigned number
+
 # The span for aligning on '=' in enums (0=don't align)
 align_enum_equ_span             = 0        # unsigned number
 

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1774,6 +1774,12 @@ align_assign_span               Unsigned Number
 align_assign_thresh             Unsigned Number
   The threshold for aligning on '=' in assignments (0=no limit)
 
+align_assign_decl_func          Unsigned Number
+  Defines how align_assign_span is applied onto function decl. with: virtual ... = 0, = delete, = default.
+  0 - default align_assign_span behavior
+  1 - indent the '=' on their own, with each other
+  2 - don't indent
+
 align_enum_equ_span             Unsigned Number
   The span for aligning on '=' in enums (0=don't align)
 

--- a/tests/config/align_assign_decl_func-0.cfg
+++ b/tests/config/align_assign_decl_func-0.cfg
@@ -1,0 +1,2 @@
+align_assign_span               = 3
+align_assign_decl_func          = 0                                            #

--- a/tests/config/align_assign_decl_func-1.cfg
+++ b/tests/config/align_assign_decl_func-1.cfg
@@ -1,1 +1,2 @@
 align_assign_span               = 3
+align_assign_decl_func          = 1

--- a/tests/config/align_assign_decl_func-2.cfg
+++ b/tests/config/align_assign_decl_func-2.cfg
@@ -1,0 +1,2 @@
+align_assign_span               = 3
+align_assign_decl_func          = 2

--- a/tests/config/align_assign_span-3.cfg
+++ b/tests/config/align_assign_span-3.cfg
@@ -1,0 +1,1 @@
+align_assign_span               = 3

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -611,7 +611,9 @@
 34295  sp_after_type_brace_init_lst_open-r.cfg  cpp/brace_brace_init_lst.cpp
 
 34296  i1768.cfg                            cpp/i1768.cpp
-34297  align_assign_span-3.cfg              cpp/align-assign-mixed.cpp
+34297  align_assign_decl_func-0.cfg         cpp/align-assign-mixed.cpp
+34298  align_assign_decl_func-1.cfg         cpp/align-assign-mixed.cpp
+34299  align_assign_decl_func-2.cfg         cpp/align-assign-mixed.cpp
 
 # __asm__
 34300  bug_1236.cfg                         cpp/bug_1236.cpp

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -611,6 +611,7 @@
 34295  sp_after_type_brace_init_lst_open-r.cfg  cpp/brace_brace_init_lst.cpp
 
 34296  i1768.cfg                            cpp/i1768.cpp
+34297  align_assign_span-3.cfg              cpp/align-assign-mixed.cpp
 
 # __asm__
 34300  bug_1236.cfg                         cpp/bug_1236.cpp

--- a/tests/expected/cpp/34297-align-assign-mixed.cpp
+++ b/tests/expected/cpp/34297-align-assign-mixed.cpp
@@ -1,0 +1,11 @@
+class X16
+{
+X16()                        = delete;
+public:
+void z(int x   = 0);
+virtual void f(int x, int y) = 0;
+int hhi = 9;
+void g(int x   = 0);
+int i   = 9;
+void x(int ggs = 0);
+};

--- a/tests/expected/cpp/34298-align-assign-mixed.cpp
+++ b/tests/expected/cpp/34298-align-assign-mixed.cpp
@@ -2,10 +2,10 @@ class X16
 {
 X16()                        = delete;
 public:
-void z(int x                 = 0);
+void z(int x   = 0);
 virtual void f(int x, int y) = 0;
 int hhi = 9;
-void g(int x                 = 0);
+void g(int x   = 0);
 int i   = 9;
-void x(int ggs               = 0);
+void x(int ggs = 0);
 };

--- a/tests/expected/cpp/34299-align-assign-mixed.cpp
+++ b/tests/expected/cpp/34299-align-assign-mixed.cpp
@@ -2,10 +2,10 @@ class X16
 {
 X16() = delete;
 public:
-void z(int x = 0);
+void z(int x   = 0);
 virtual void f(int x, int y) = 0;
 int hhi = 9;
-void g(int x = 0);
-int i = 9;
+void g(int x   = 0);
+int i   = 9;
 void x(int ggs = 0);
 };

--- a/tests/input/cpp/align-assign-mixed.cpp
+++ b/tests/input/cpp/align-assign-mixed.cpp
@@ -1,0 +1,11 @@
+class X16
+{
+X16() = delete;
+public:
+void z(int x = 0);
+virtual void f(int x, int y) = 0;
+int hhi = 9;
+void g(int x = 0);
+int i = 9;
+void x(int ggs = 0);
+};


### PR DESCRIPTION
in order to prevent following alignments:
```cpp
    virtual void f(int x, int y) = 0;
    void g(int x                 = 0);
```

- adds a new align stack for the above mentioned cases to treat them on their own
- sets parent type of the special assigns in order to differentiate them from other assigns, this is used for the new align stack

-------

Adds new option to control what should happen for those special cases - defaults to the current behaviour

-------

ref: #1760 
superseeds: #1841

-------

Btw. what happened with the coveralls comment? I never saw it appear in here.