### PR TITLE
Improve detection of variable declarations

### DIFF
--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -438,6 +438,7 @@ static void write_byte(int ch)
 static void write_utf8(int ch)
 {
    vector<UINT8> vv;
+
    vv.reserve(6);
 
    encode_utf8(ch, vv);

--- a/tests/config/nl_func_var_def_blk-1.cfg
+++ b/tests/config/nl_func_var_def_blk-1.cfg
@@ -1,0 +1,1 @@
+nl_func_var_def_blk             = 1

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -355,6 +355,8 @@
 31633  sp_after_decltype-f.cfg              cpp/sp_after_decltype.cpp
 31634  sp_after_decltype-r.cfg              cpp/sp_after_decltype.cpp
 
+31660  nl_func_var_def_blk-1.cfg            cpp/issue_1919.cpp
+
 31700  toggle_processing_cmt.cfg            cpp/toggle_processing_cmt.cpp
 31701  toggle_processing_cmt2.cfg           cpp/toggle_processing_cmt2.cpp
 

--- a/tests/expected/cpp/30023-templates.cpp
+++ b/tests/expected/cpp/30023-templates.cpp
@@ -27,6 +27,7 @@ void asd(void)
    A<B, C>  bar;
    A<B *>   baz;
    A<B<C> > bay;
+
    if (a < b && b > c)
    {
       a = b < c > 0;
@@ -172,6 +173,7 @@ bool               X = j<3> > 1;
 void foo()
 {
    A<(X > Y)> a;
+
    a = static_cast<List<B> >(ld);
 }
 

--- a/tests/expected/cpp/31660-issue_1919.cpp
+++ b/tests/expected/cpp/31660-issue_1919.cpp
@@ -1,0 +1,15 @@
+void foo()
+{
+	int a;
+	vector<unsigned> b;
+	long c;
+	decltype(a) d;
+}
+
+void bar()
+{
+	int a;
+	std::vector<unsigned> b;
+	long c;
+	decltype(a) d;
+}

--- a/tests/input/cpp/issue_1919.cpp
+++ b/tests/input/cpp/issue_1919.cpp
@@ -1,0 +1,15 @@
+void foo()
+{
+	int a;
+	vector<unsigned> b;
+	long c;
+	decltype(a) d;
+}
+
+void bar()
+{
+	int a;
+	std::vector<unsigned> b;
+	long c;
+	decltype(a) d;
+}


### PR DESCRIPTION
Add a new helper function to detect variable declarations, because the compound expression we had before was not sufficient; it failed to detect declarations if the type was a template or used decltype. Add a test case, and fix genuine bugs in existing test 30023.

Also add some additional logging, and remove unneeded comment (note: the NL value is `option+1` because the option is a *blank lines* option, not a *newlines* option).

This fixes #1919.