### PR TITLE
Rename argval_t → iarf_e

### DIFF
--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -170,7 +170,7 @@ void do_braces(void)
         cpd.settings[UO_mod_full_brace_do].a |
         cpd.settings[UO_mod_full_brace_for].a |
         cpd.settings[UO_mod_full_brace_using].a |
-        cpd.settings[UO_mod_full_brace_while].a) & AV_REMOVE)
+        cpd.settings[UO_mod_full_brace_while].a) & IARF_REMOVE)
    {
       examine_braces();
    }
@@ -181,7 +181,7 @@ void do_braces(void)
         cpd.settings[UO_mod_full_brace_for].a |
         cpd.settings[UO_mod_full_brace_function].a |
         cpd.settings[UO_mod_full_brace_using].a |
-        cpd.settings[UO_mod_full_brace_while].a) & AV_ADD)
+        cpd.settings[UO_mod_full_brace_while].a) & IARF_ADD)
    {
       convert_vbrace_to_brace();
    }
@@ -220,7 +220,7 @@ void do_braces(void)
       }
    }
 
-   if (cpd.settings[UO_mod_case_brace].a != AV_IGNORE)
+   if (cpd.settings[UO_mod_case_brace].a != IARF_IGNORE)
    {
       mod_case_brace();
    }
@@ -246,15 +246,15 @@ static void examine_braces(void)
          && (  (  (  pc->parent_type == CT_IF
                   || pc->parent_type == CT_ELSE
                   || pc->parent_type == CT_ELSEIF)
-               && cpd.settings[UO_mod_full_brace_if].a == AV_REMOVE)
+               && cpd.settings[UO_mod_full_brace_if].a == IARF_REMOVE)
             || (  pc->parent_type == CT_DO
-               && cpd.settings[UO_mod_full_brace_do].a == AV_REMOVE)
+               && cpd.settings[UO_mod_full_brace_do].a == IARF_REMOVE)
             || (  pc->parent_type == CT_FOR
-               && cpd.settings[UO_mod_full_brace_for].a == AV_REMOVE)
+               && cpd.settings[UO_mod_full_brace_for].a == IARF_REMOVE)
             || (  pc->parent_type == CT_USING_STMT
-               && cpd.settings[UO_mod_full_brace_using].a == AV_REMOVE)
+               && cpd.settings[UO_mod_full_brace_using].a == IARF_REMOVE)
             || (  pc->parent_type == CT_WHILE
-               && cpd.settings[UO_mod_full_brace_while].a == AV_REMOVE)))
+               && cpd.settings[UO_mod_full_brace_while].a == IARF_REMOVE)))
       {
          if (multiline_block && paren_multiline_before_brace(pc))
          {
@@ -641,7 +641,7 @@ static void examine_brace(chunk_t *bopen)
                chunk_del(bopen);
                chunk_del(pc);
                newline_del_between(tmp_prev, tmp_next);
-               if (cpd.settings[UO_nl_else_if].a & AV_ADD)
+               if (cpd.settings[UO_nl_else_if].a & IARF_ADD)
                {
                   newline_add_between(tmp_prev, tmp_next);
                }
@@ -775,18 +775,18 @@ static void convert_vbrace_to_brace(void)
       if (  (  (  pc->parent_type == CT_IF
                || pc->parent_type == CT_ELSE
                || pc->parent_type == CT_ELSEIF)
-            && (cpd.settings[UO_mod_full_brace_if].a & AV_ADD)
+            && (cpd.settings[UO_mod_full_brace_if].a & IARF_ADD)
             && !cpd.settings[UO_mod_full_brace_if_chain].b)
          || (  pc->parent_type == CT_FOR
-            && (cpd.settings[UO_mod_full_brace_for].a & AV_ADD))
+            && (cpd.settings[UO_mod_full_brace_for].a & IARF_ADD))
          || (  pc->parent_type == CT_DO
-            && (cpd.settings[UO_mod_full_brace_do].a & AV_ADD))
+            && (cpd.settings[UO_mod_full_brace_do].a & IARF_ADD))
          || (  pc->parent_type == CT_WHILE
-            && (cpd.settings[UO_mod_full_brace_while].a & AV_ADD))
+            && (cpd.settings[UO_mod_full_brace_while].a & IARF_ADD))
          || (  pc->parent_type == CT_USING_STMT
-            && (cpd.settings[UO_mod_full_brace_using].a & AV_ADD))
+            && (cpd.settings[UO_mod_full_brace_using].a & IARF_ADD))
          || (  pc->parent_type == CT_FUNC_DEF
-            && (cpd.settings[UO_mod_full_brace_function].a & AV_ADD)))
+            && (cpd.settings[UO_mod_full_brace_function].a & IARF_ADD)))
       {
          // Find the matching vbrace close
          chunk_t *vbc = nullptr;
@@ -1195,13 +1195,13 @@ static void mod_case_brace(void)
          return;
       }
 
-      if (  cpd.settings[UO_mod_case_brace].a == AV_REMOVE
+      if (  cpd.settings[UO_mod_case_brace].a == IARF_REMOVE
          && chunk_is_token(pc, CT_BRACE_OPEN)
          && pc->parent_type == CT_CASE)
       {
          pc = mod_case_brace_remove(pc);
       }
-      else if (  (cpd.settings[UO_mod_case_brace].a & AV_ADD)
+      else if (  (cpd.settings[UO_mod_case_brace].a & IARF_ADD)
               && chunk_is_token(pc, CT_CASE_COLON)
               && next->type != CT_BRACE_OPEN
               && next->type != CT_BRACE_CLOSE

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2560,7 +2560,7 @@ static chunk_t *process_return(chunk_t *pc)
       return(next);
    }
 
-   if (cpd.settings[UO_nl_return_expr].a != AV_IGNORE)
+   if (cpd.settings[UO_nl_return_expr].a != IARF_IGNORE)
    {
       newline_iarf(pc, cpd.settings[UO_nl_return_expr].a);
    }
@@ -2580,7 +2580,7 @@ static chunk_t *process_return(chunk_t *pc)
       }
       if (chunk_is_semicolon(semi))
       {
-         if (cpd.settings[UO_mod_paren_on_return].a == AV_REMOVE)
+         if (cpd.settings[UO_mod_paren_on_return].a == IARF_REMOVE)
          {
             LOG_FMT(LRETURN, "%s(%d): removing parens on orig_line %zu\n",
                     __func__, __LINE__, pc->orig_line);
@@ -2619,7 +2619,7 @@ static chunk_t *process_return(chunk_t *pc)
    }
 
    // We don't have a fully paren'd return. Should we add some?
-   if ((cpd.settings[UO_mod_paren_on_return].a & AV_ADD) == 0)
+   if ((cpd.settings[UO_mod_paren_on_return].a & IARF_ADD) == 0)
    {
       return(next);
    }
@@ -6892,8 +6892,8 @@ static void handle_wrap(chunk_t *pc)
       && chunk_is_token(opp, CT_PAREN_OPEN)
       && (chunk_is_token(name, CT_WORD) || chunk_is_token(name, CT_TYPE)))
    {
-      const char *psp = (pav & AV_ADD) ? " " : "";
-      const char *fsp = (av & AV_ADD) ? " " : "";
+      const char *psp = (pav & IARF_ADD) ? " " : "";
+      const char *fsp = (av & IARF_ADD) ? " " : "";
 
       pc->str.append(psp);
       pc->str.append("(");

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -6876,17 +6876,17 @@ void remove_extra_returns(void)
 static void handle_wrap(chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
-   chunk_t  *opp  = chunk_get_next(pc);
-   chunk_t  *name = chunk_get_next(opp);
-   chunk_t  *clp  = chunk_get_next(name);
+   chunk_t *opp  = chunk_get_next(pc);
+   chunk_t *name = chunk_get_next(opp);
+   chunk_t *clp  = chunk_get_next(name);
 
-   argval_t pav = (pc->type == CT_FUNC_WRAP) ?
-                  cpd.settings[UO_sp_func_call_paren].a :
-                  cpd.settings[UO_sp_cpp_cast_paren].a;
+   iarf_e  pav = (pc->type == CT_FUNC_WRAP) ?
+                 cpd.settings[UO_sp_func_call_paren].a :
+                 cpd.settings[UO_sp_cpp_cast_paren].a;
 
-   argval_t av = (pc->type == CT_FUNC_WRAP) ?
-                 cpd.settings[UO_sp_inside_fparen].a :
-                 cpd.settings[UO_sp_inside_paren_cast].a;
+   iarf_e av = (pc->type == CT_FUNC_WRAP) ?
+               cpd.settings[UO_sp_inside_fparen].a :
+               cpd.settings[UO_sp_inside_paren_cast].a;
 
    if (  chunk_is_token(clp, CT_PAREN_CLOSE)
       && chunk_is_token(opp, CT_PAREN_OPEN)

--- a/src/detect.cpp
+++ b/src/detect.cpp
@@ -23,13 +23,13 @@ static void detect_space_options(void);
 class sp_votes
 {
 protected:
-   size_t   m_add;
-   size_t   m_remove;
-   size_t   m_force;
-   argval_t *m_av;
+   size_t m_add;
+   size_t m_remove;
+   size_t m_force;
+   iarf_e *m_av;
 
 public:
-   sp_votes(argval_t &av)
+   sp_votes(iarf_e &av)
    {
       m_add    = 0;
       m_remove = 0;

--- a/src/detect.cpp
+++ b/src/detect.cpp
@@ -85,11 +85,11 @@ sp_votes::~sp_votes()
 
    if (m_remove == 0)
    {
-      *m_av = (m_force > m_add) ? AV_FORCE : AV_ADD;
+      *m_av = (m_force > m_add) ? IARF_FORCE : IARF_ADD;
    }
    else if (m_force == 0 && m_add == 0)
    {
-      *m_av = AV_REMOVE;
+      *m_av = IARF_REMOVE;
    }
    else
    {

--- a/src/enum_cleanup.cpp
+++ b/src/enum_cleanup.cpp
@@ -16,7 +16,7 @@ void enum_cleanup(void)
 {
    LOG_FUNC_ENTRY();
 
-   if (cpd.settings[UO_mod_enum_last_comma].a == AV_IGNORE)
+   if (cpd.settings[UO_mod_enum_last_comma].a == IARF_IGNORE)
    {
       // nothing to do
       return;
@@ -34,15 +34,15 @@ void enum_cleanup(void)
          // test of (prev == nullptr) is not necessary
          if (chunk_is_token(prev, CT_COMMA))
          {
-            if (cpd.settings[UO_mod_enum_last_comma].a == AV_REMOVE)
+            if (cpd.settings[UO_mod_enum_last_comma].a == IARF_REMOVE)
             {
                chunk_del(prev);
             }
          }
          else
          {
-            if (  cpd.settings[UO_mod_enum_last_comma].a == AV_ADD
-               || cpd.settings[UO_mod_enum_last_comma].a == AV_FORCE)
+            if (  cpd.settings[UO_mod_enum_last_comma].a == IARF_ADD
+               || cpd.settings[UO_mod_enum_last_comma].a == IARF_FORCE)
             {
                // create a comma
                chunk_t comma;

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -3318,24 +3318,24 @@ void indent_preproc(void)
                               ? pc->pp_level - pp_level_sub : 0;
 
       // Adjust the indent of the '#'
-      if (cpd.settings[UO_pp_indent].a & AV_ADD)
+      if (cpd.settings[UO_pp_indent].a & IARF_ADD)
       {
          reindent_line(pc, 1 + pp_level * cpd.settings[UO_pp_indent_count].u);
       }
-      else if (cpd.settings[UO_pp_indent].a & AV_REMOVE)
+      else if (cpd.settings[UO_pp_indent].a & IARF_REMOVE)
       {
          reindent_line(pc, 1);
       }
 
       // Add spacing by adjusting the length
-      if ((cpd.settings[UO_pp_space].a != AV_IGNORE) && next != nullptr)
+      if ((cpd.settings[UO_pp_space].a != IARF_IGNORE) && next != nullptr)
       {
-         if (cpd.settings[UO_pp_space].a & AV_ADD)
+         if (cpd.settings[UO_pp_space].a & IARF_ADD)
          {
             const auto mult = max<size_t>(cpd.settings[UO_pp_space_count].u, 1);
             reindent_line(next, pc->column + pc->len() + (pp_level * mult));
          }
-         else if (cpd.settings[UO_pp_space].a & AV_REMOVE)
+         else if (cpd.settings[UO_pp_space].a & IARF_REMOVE)
          {
             reindent_line(next, pc->column + pc->len());
          }

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -332,13 +332,13 @@ static bool can_increase_nl(chunk_t *nl)
       return(false);
    }
 
-   if (!pcmt && (cpd.settings[UO_nl_start_of_file].a != AV_IGNORE))
+   if (!pcmt && (cpd.settings[UO_nl_start_of_file].a != IARF_IGNORE))
    {
       LOG_FMT(LBLANKD, "%s(%d): SOF no prev %zu\n", __func__, __LINE__, nl->orig_line);
       return(false);
    }
 
-   if (!next && (cpd.settings[UO_nl_end_of_file].a != AV_IGNORE))
+   if (!next && (cpd.settings[UO_nl_end_of_file].a != IARF_IGNORE))
    {
       LOG_FMT(LBLANKD, "%s(%d): EOF no next %zu\n", __func__, __LINE__, nl->orig_line);
       return(false);
@@ -706,7 +706,7 @@ static bool newlines_if_for_while_switch(chunk_t *start, iarf_e nl_opt)
 {
    LOG_FUNC_ENTRY();
 
-   if (  nl_opt == AV_IGNORE
+   if (  nl_opt == IARF_IGNORE
       || (  (start->flags & PCF_IN_PREPROC)
          && !cpd.settings[UO_nl_define_macro].b))
    {
@@ -730,7 +730,7 @@ static bool newlines_if_for_while_switch(chunk_t *start, iarf_e nl_opt)
             {
                if (chunk_is_newline(pc))
                {
-                  nl_opt = AV_ADD;
+                  nl_opt = IARF_ADD;
                   break;
                }
             }
@@ -739,7 +739,7 @@ static bool newlines_if_for_while_switch(chunk_t *start, iarf_e nl_opt)
          if (chunk_is_token(brace_open, CT_VBRACE_OPEN))
          {
             // Can only add - we don't want to create a one-line here
-            if (nl_opt & AV_ADD)
+            if (nl_opt & IARF_ADD)
             {
                newline_iarf_pair(close_paren, chunk_get_next_ncnl(brace_open), nl_opt);
                pc = chunk_get_next_type(brace_open, CT_VBRACE_CLOSE, brace_open->level);
@@ -772,7 +772,7 @@ static void newlines_if_for_while_switch_pre_blank_lines(chunk_t *start, iarf_e 
 {
    LOG_FUNC_ENTRY();
 
-   if (  nl_opt == AV_IGNORE
+   if (  nl_opt == IARF_IGNORE
       || (  (start->flags & PCF_IN_PREPROC)
          && !cpd.settings[UO_nl_define_macro].b))
    {
@@ -783,7 +783,7 @@ static void newlines_if_for_while_switch_pre_blank_lines(chunk_t *start, iarf_e 
    chunk_t *next;
    chunk_t *last_nl = nullptr;
    size_t  level    = start->level;
-   bool    do_add   = nl_opt & AV_ADD;
+   bool    do_add   = nl_opt & IARF_ADD;
 
    /*
     * look backwards until we find
@@ -800,7 +800,7 @@ static void newlines_if_for_while_switch_pre_blank_lines(chunk_t *start, iarf_e 
          if (pc->nl_count > 1 || chunk_is_newline(chunk_get_prev_nvb(pc)))
          {
             // need to remove
-            if ((nl_opt & AV_REMOVE) && ((pc->flags & PCF_VAR_DEF) == 0))
+            if ((nl_opt & IARF_REMOVE) && ((pc->flags & PCF_VAR_DEF) == 0))
             {
                // if we're also adding, take care of that here
                size_t nl_count = do_add ? 2 : 1;
@@ -1100,7 +1100,7 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, iarf_e
 
    LOG_FMT(LNEWLINE, "%s:\n   (%d):start->..., type %s, line %zu, column %zu,\n",
            __func__, __LINE__, get_token_name(start->type), start->orig_line, start->orig_col);
-   if (  nl_opt == AV_IGNORE
+   if (  nl_opt == IARF_IGNORE
       || (  (start->flags & PCF_IN_PREPROC)
          && !cpd.settings[UO_nl_define_macro].b))
    {
@@ -1181,7 +1181,7 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, iarf_e
    {
       LOG_FMT(LNEWLINE, "   (%d): have_pre_vbrace_nl is FALSE\n", __LINE__);
    }
-   if (nl_opt & AV_REMOVE)
+   if (nl_opt & IARF_REMOVE)
    {
       // if chunk before is a vbrace, remove any newlines after it
       if (have_pre_vbrace_nl)
@@ -1208,7 +1208,7 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, iarf_e
 
    // may have a newline before and after vbrace
    // don't do anything with it if the next non newline chunk is a closing brace
-   if (nl_opt & AV_ADD)
+   if (nl_opt & IARF_ADD)
    {
       chunk_t *nextNNL = chunk_get_next_nnl(pc);
       do
@@ -1319,7 +1319,7 @@ static void newlines_struct_union(chunk_t *start, iarf_e nl_opt, bool leave_trai
    LOG_FUNC_ENTRY();
    chunk_t *pc;
 
-   if (  nl_opt == AV_IGNORE
+   if (  nl_opt == IARF_IGNORE
       || (  (start->flags & PCF_IN_PREPROC)
          && !cpd.settings[UO_nl_define_macro].b))
    {
@@ -1357,7 +1357,7 @@ static void newlines_struct_union(chunk_t *start, iarf_e nl_opt, bool leave_trai
          && !chunk_is_comment(next)
          && !chunk_is_newline(next))
       {
-         nl_opt = AV_IGNORE;
+         nl_opt = IARF_IGNORE;
       }
 
       newline_iarf_pair(start, pc, nl_opt);
@@ -1449,7 +1449,7 @@ static void newlines_enum(chunk_t *start)
       }
       if (!chunk_is_comment(next) && !chunk_is_newline(next))
       {
-         nl_opt = AV_IGNORE;
+         nl_opt = IARF_IGNORE;
       }
       else
       {
@@ -1484,7 +1484,7 @@ static void newlines_do_else(chunk_t *start, iarf_e nl_opt)
    LOG_FUNC_ENTRY();
    chunk_t *next;
 
-   if (  nl_opt == AV_IGNORE
+   if (  nl_opt == IARF_IGNORE
       || (  (start->flags & PCF_IN_PREPROC)
          && !cpd.settings[UO_nl_define_macro].b))
    {
@@ -1506,7 +1506,7 @@ static void newlines_do_else(chunk_t *start, iarf_e nl_opt)
       if (chunk_is_token(next, CT_VBRACE_OPEN))
       {
          // Can only add - we don't want to create a one-line here
-         if (nl_opt & AV_ADD)
+         if (nl_opt & IARF_ADD)
          {
             newline_iarf_pair(start, chunk_get_next_ncnl(next), nl_opt);
             chunk_t *tmp = chunk_get_next_type(next, CT_VBRACE_CLOSE, next->level);
@@ -1794,7 +1794,7 @@ static void newlines_brace_pair(chunk_t *br_open)
             if (chunk_is_newline(tmp))
             {
                tmp = chunk_get_prev(tmp);
-               newline_iarf_pair(tmp, chunk_get_next_ncnl(tmp), AV_REMOVE);
+               newline_iarf_pair(tmp, chunk_get_next_ncnl(tmp), IARF_REMOVE);
             }
 
             chunk_flags_set(br_open, PCF_ONE_LINER);         // set the one liner flag if needed
@@ -1863,7 +1863,7 @@ static void newlines_brace_pair(chunk_t *br_open)
       }
    }
 
-   iarf_e val            = AV_IGNORE;
+   iarf_e val            = IARF_IGNORE;
    bool   nl_close_brace = false;
    // Handle the cases where the brace is part of a function call or definition
    if (  br_open->parent_type == CT_FUNC_DEF
@@ -1903,7 +1903,7 @@ static void newlines_brace_pair(chunk_t *br_open)
                   cpd.settings[UO_nl_fcall_brace].a)));
       }
 
-      if (val != AV_IGNORE)
+      if (val != IARF_IGNORE)
       {
          // Grab the chunk before the open brace
          prev = chunk_get_prev_ncnl(br_open);
@@ -2103,17 +2103,17 @@ static void newline_iarf_pair(chunk_t *before, chunk_t *after, iarf_e av)
 
    if (before != nullptr && after != nullptr)
    {
-      if ((av & AV_ADD) != 0)
+      if ((av & IARF_ADD) != 0)
       {
          chunk_t *nl = newline_add_between(before, after);
          if (  nl
-            && av == AV_FORCE
+            && av == IARF_FORCE
             && nl->nl_count > 1)
          {
             nl->nl_count = 1;
          }
       }
-      else if ((av & AV_REMOVE) != 0)
+      else if ((av & IARF_REMOVE) != 0)
       {
          newline_del_between(before, after);
       }
@@ -2181,12 +2181,12 @@ static void newline_func_multi_line(chunk_t *start)
    {
       if (add_start && !chunk_is_newline(chunk_get_next(start)))
       {
-         newline_iarf(start, AV_ADD);
+         newline_iarf(start, IARF_ADD);
       }
 
       if (add_end && !chunk_is_newline(chunk_get_prev(pc)))
       {
-         newline_iarf(chunk_get_prev(pc), AV_ADD);
+         newline_iarf(chunk_get_prev(pc), IARF_ADD);
       }
 
       if (add_args)
@@ -2205,7 +2205,7 @@ static void newline_func_multi_line(chunk_t *start)
 
                if (!chunk_is_newline(chunk_get_next(pc)))
                {
-                  newline_iarf(pc, AV_ADD);
+                  newline_iarf(pc, IARF_ADD);
                }
             }
          }
@@ -2231,7 +2231,7 @@ static void newline_func_def_or_call(chunk_t *start)
    if (is_call)
    {
       iarf_e atmp = cpd.settings[UO_nl_func_call_paren].a;
-      if (atmp != AV_IGNORE)
+      if (atmp != IARF_IGNORE)
       {
          prev = chunk_get_prev_ncnl(start);
          if (prev != nullptr)
@@ -2244,7 +2244,7 @@ static void newline_func_def_or_call(chunk_t *start)
       if (chunk_is_str(pc, ")", 1))
       {
          atmp = cpd.settings[UO_nl_func_call_paren_empty].a;
-         if (atmp != AV_IGNORE)
+         if (atmp != IARF_IGNORE)
          {
             prev = chunk_get_prev_ncnl(start);
             if (prev != nullptr)
@@ -2254,7 +2254,7 @@ static void newline_func_def_or_call(chunk_t *start)
          }
 
          atmp = cpd.settings[UO_nl_func_call_empty].a;
-         if (atmp != AV_IGNORE)
+         if (atmp != IARF_IGNORE)
          {
             newline_iarf(start, atmp);
          }
@@ -2264,7 +2264,7 @@ static void newline_func_def_or_call(chunk_t *start)
    else
    {
       iarf_e atmp = cpd.settings[is_def ? UO_nl_func_def_paren : UO_nl_func_paren].a;
-      if (atmp != AV_IGNORE)
+      if (atmp != IARF_IGNORE)
       {
          prev = chunk_get_prev_ncnl(start);
          if (prev != nullptr)
@@ -2280,7 +2280,7 @@ static void newline_func_def_or_call(chunk_t *start)
       prev = chunk_is_paren_close(prev) ? nullptr : chunk_get_prev_ncnl(prev);
 
       if (  chunk_is_token(prev, CT_DC_MEMBER)
-         && (cpd.settings[UO_nl_func_class_scope].a != AV_IGNORE))
+         && (cpd.settings[UO_nl_func_class_scope].a != IARF_IGNORE))
       {
          newline_iarf(chunk_get_prev_ncnl(prev), cpd.settings[UO_nl_func_class_scope].a);
       }
@@ -2300,7 +2300,7 @@ static void newline_func_def_or_call(chunk_t *start)
 
          if (chunk_is_token(prev, CT_DC_MEMBER))
          {
-            if (cpd.settings[UO_nl_func_scope_name].a != AV_IGNORE)
+            if (cpd.settings[UO_nl_func_scope_name].a != IARF_IGNORE)
             {
                newline_iarf(prev, cpd.settings[UO_nl_func_scope_name].a);
             }
@@ -2313,12 +2313,12 @@ static void newline_func_def_or_call(chunk_t *start)
                        cpd.settings[UO_nl_func_proto_type_name].a :
                        cpd.settings[UO_nl_func_type_name].a;
             if (  (tmp->flags & PCF_IN_CLASS)
-               && (cpd.settings[UO_nl_func_type_name_class].a != AV_IGNORE))
+               && (cpd.settings[UO_nl_func_type_name_class].a != IARF_IGNORE))
             {
                a = cpd.settings[UO_nl_func_type_name_class].a;
             }
 
-            if (a != AV_IGNORE && prev != nullptr)
+            if (a != IARF_IGNORE && prev != nullptr)
             {
                LOG_FMT(LNFD, "%s(%d): prev %zu:%zu '%s' [%s/%s]\n",
                        __func__, __LINE__, prev->orig_line, prev->orig_col,
@@ -2363,13 +2363,13 @@ static void newline_func_def_or_call(chunk_t *start)
       if (chunk_is_str(pc, ")", 1))
       {
          atmp = cpd.settings[is_def ? UO_nl_func_def_empty : UO_nl_func_decl_empty].a;
-         if (atmp != AV_IGNORE)
+         if (atmp != IARF_IGNORE)
          {
             newline_iarf(start, atmp);
          }
 
          atmp = cpd.settings[is_def ? UO_nl_func_def_paren_empty : UO_nl_func_paren_empty].a;
-         if (atmp != AV_IGNORE)
+         if (atmp != IARF_IGNORE)
          {
             prev = chunk_get_prev_ncnl(start);
             if (prev != nullptr)
@@ -2416,13 +2416,13 @@ static void newline_func_def_or_call(chunk_t *start)
       iarf_e atmp;
       atmp = cpd.settings[is_def ? UO_nl_func_def_start_single :
                           UO_nl_func_decl_start_single].a;
-      if (atmp != AV_IGNORE)
+      if (atmp != IARF_IGNORE)
       {
          as = atmp;
       }
       atmp = cpd.settings[is_def ? UO_nl_func_def_end_single :
                           UO_nl_func_decl_end_single].a;
-      if (atmp != AV_IGNORE)
+      if (atmp != IARF_IGNORE)
       {
          ae = atmp;
       }
@@ -2721,7 +2721,7 @@ void newlines_remove_newlines(void)
       {
          next = pc->next;
          prev = pc->prev;
-         newline_iarf(pc, AV_REMOVE);
+         newline_iarf(pc, IARF_REMOVE);
          if (next == chunk_get_head())
          {
             pc = next;
@@ -2771,7 +2771,7 @@ void newlines_cleanup_braces(bool first)
       {
          iarf_e arg = cpd.settings[UO_nl_elseif_brace].a;
          newlines_if_for_while_switch(
-            pc, (arg != AV_IGNORE) ? arg : cpd.settings[UO_nl_if_brace].a);
+            pc, (arg != IARF_IGNORE) ? arg : cpd.settings[UO_nl_if_brace].a);
          tmp = chunk_get_next_type(pc, CT_SPAREN_CLOSE, pc->level);
          if (tmp != nullptr)
          {
@@ -2791,7 +2791,7 @@ void newlines_cleanup_braces(bool first)
       {
          if (  language_is_set(LANG_OC)
             && (pc->str[0] == '@')
-            && (cpd.settings[UO_nl_oc_brace_catch].a != AV_IGNORE))
+            && (cpd.settings[UO_nl_oc_brace_catch].a != IARF_IGNORE))
          {
             newlines_cuddle_uncuddle(pc, cpd.settings[UO_nl_oc_brace_catch].a);
          }
@@ -2803,7 +2803,7 @@ void newlines_cleanup_braces(bool first)
          if (chunk_is_token(next, CT_BRACE_OPEN))
          {
             if (  language_is_set(LANG_OC)
-               && (cpd.settings[UO_nl_oc_catch_brace].a != AV_IGNORE))
+               && (cpd.settings[UO_nl_oc_catch_brace].a != IARF_IGNORE))
             {
                newlines_do_else(pc, cpd.settings[UO_nl_oc_catch_brace].a);
             }
@@ -2815,7 +2815,7 @@ void newlines_cleanup_braces(bool first)
          else
          {
             if (  language_is_set(LANG_OC)
-               && (cpd.settings[UO_nl_oc_catch_brace].a != AV_IGNORE))
+               && (cpd.settings[UO_nl_oc_catch_brace].a != IARF_IGNORE))
             {
                newlines_if_for_while_switch(pc, cpd.settings[UO_nl_oc_catch_brace].a);
             }
@@ -2891,7 +2891,7 @@ void newlines_cleanup_braces(bool first)
          {
          case CT_DOUBLE_BRACE:
          {
-            if (cpd.settings[UO_nl_paren_dbrace_open].a != AV_IGNORE)
+            if (cpd.settings[UO_nl_paren_dbrace_open].a != IARF_IGNORE)
             {
                prev = chunk_get_prev_ncnl(pc, scope_e::PREPROC);
                if (chunk_is_paren_close(prev))
@@ -2904,7 +2904,7 @@ void newlines_cleanup_braces(bool first)
 
          case CT_ENUM:
          {
-            if (cpd.settings[UO_nl_enum_own_lines].a != AV_IGNORE)
+            if (cpd.settings[UO_nl_enum_own_lines].a != IARF_IGNORE)
             {
                newlines_enum_entries(pc, cpd.settings[UO_nl_enum_own_lines].a);
             }
@@ -2984,7 +2984,7 @@ void newlines_cleanup_braces(bool first)
          }
          } // switch
 
-         if (cpd.settings[UO_nl_brace_brace].a != AV_IGNORE)
+         if (cpd.settings[UO_nl_brace_brace].a != IARF_IGNORE)
          {
             next = chunk_get_next_nc(pc, scope_e::PREPROC);
             if (chunk_is_token(next, CT_BRACE_OPEN))
@@ -3047,7 +3047,7 @@ void newlines_cleanup_braces(bool first)
                      tmp = chunk_get_prev(tmp);
                   }
                   // Add the newline
-                  newline_iarf(tmp, AV_ADD);
+                  newline_iarf(tmp, IARF_ADD);
                }
             }
          }
@@ -3056,8 +3056,8 @@ void newlines_cleanup_braces(bool first)
          // than curly braces that determine a structure of a source code,
          // so, don't add a newline before a closing brace. Issue #1405.
          if (!(  pc->parent_type == CT_BRACED_INIT_LIST
-              && cpd.settings[UO_nl_type_brace_init_lst_open].a == AV_IGNORE
-              && cpd.settings[UO_nl_type_brace_init_lst_close].a == AV_IGNORE))
+              && cpd.settings[UO_nl_type_brace_init_lst_open].a == IARF_IGNORE
+              && cpd.settings[UO_nl_type_brace_init_lst_close].a == IARF_IGNORE))
          {
             newlines_brace_pair(pc);
          }
@@ -3065,7 +3065,7 @@ void newlines_cleanup_braces(bool first)
       else if (chunk_is_token(pc, CT_BRACE_CLOSE))
       {
          // newline between a close brace and x
-         if (cpd.settings[UO_nl_brace_brace].a != AV_IGNORE)
+         if (cpd.settings[UO_nl_brace_brace].a != IARF_IGNORE)
          {
             next = chunk_get_next_nc(pc, scope_e::PREPROC);
             if (chunk_is_token(next, CT_BRACE_CLOSE))
@@ -3074,7 +3074,7 @@ void newlines_cleanup_braces(bool first)
             }
          }
 
-         if (cpd.settings[UO_nl_brace_square].a != AV_IGNORE)
+         if (cpd.settings[UO_nl_brace_square].a != IARF_IGNORE)
          {
             next = chunk_get_next_nc(pc, scope_e::PREPROC);
             if (chunk_is_token(next, CT_SQUARE_CLOSE))
@@ -3083,11 +3083,11 @@ void newlines_cleanup_braces(bool first)
             }
          }
 
-         if (cpd.settings[UO_nl_brace_fparen].a != AV_IGNORE)
+         if (cpd.settings[UO_nl_brace_fparen].a != IARF_IGNORE)
          {
             next = chunk_get_next_nc(pc, scope_e::PREPROC);
             if (  chunk_is_token(next, CT_NEWLINE)
-               && (cpd.settings[UO_nl_brace_fparen].a == AV_REMOVE))
+               && (cpd.settings[UO_nl_brace_fparen].a == IARF_REMOVE))
             {
                next = chunk_get_next_nc(next, scope_e::PREPROC);  // Issue #1000
             }
@@ -3099,7 +3099,7 @@ void newlines_cleanup_braces(bool first)
 
          // newline before a close brace
          if (  pc->parent_type == CT_BRACED_INIT_LIST
-            && cpd.settings[UO_nl_type_brace_init_lst_close].a != AV_IGNORE)
+            && cpd.settings[UO_nl_type_brace_init_lst_close].a != IARF_IGNORE)
          {
             // Handle unnamed temporary direct-list-initialization
             newline_iarf_pair(chunk_get_prev_nnl(pc), pc,
@@ -3143,7 +3143,7 @@ void newlines_cleanup_braces(bool first)
          }
 
          // Force a newline after a close brace
-         if (  (cpd.settings[UO_nl_brace_struct_var].a != AV_IGNORE)
+         if (  (cpd.settings[UO_nl_brace_struct_var].a != IARF_IGNORE)
             && (  pc->parent_type == CT_STRUCT
                || pc->parent_type == CT_ENUM
                || pc->parent_type == CT_UNION))
@@ -3203,7 +3203,7 @@ void newlines_cleanup_braces(bool first)
             }
             if (add_it)
             {
-               newline_iarf(pc, AV_ADD);
+               newline_iarf(pc, IARF_ADD);
             }
          }
 
@@ -3251,7 +3251,7 @@ void newlines_cleanup_braces(bool first)
          {
             if (!chunk_is_newline(chunk_get_next_nc(pc)))
             {
-               newline_iarf(pc, AV_ADD);
+               newline_iarf(pc, IARF_ADD);
             }
          }
       }
@@ -3294,7 +3294,7 @@ void newlines_cleanup_braces(bool first)
       {
          next = chunk_get_next_nnl(pc);
          if (  chunk_is_token(next, CT_BRACE_OPEN)
-            && cpd.settings[UO_nl_case_colon_brace].a != AV_IGNORE)
+            && cpd.settings[UO_nl_case_colon_brace].a != IARF_IGNORE)
          {
             newline_iarf(pc, cpd.settings[UO_nl_case_colon_brace].a);
          }
@@ -3343,7 +3343,7 @@ void newlines_cleanup_braces(bool first)
                if (one_liner_nl_ok(next))
                {
                   LOG_FMT(LNL1LINE, "%s(%d): a new line may be added\n", __func__, __LINE__);
-                  newline_iarf(pc, AV_ADD);
+                  newline_iarf(pc, IARF_ADD);
                }
                else
                {
@@ -3355,7 +3355,7 @@ void newlines_cleanup_braces(bool first)
          {
             if (cpd.settings[UO_nl_after_class].u > 0)
             {
-               newline_iarf(pc, AV_ADD);
+               newline_iarf(pc, IARF_ADD);
             }
          }
       }
@@ -3366,33 +3366,33 @@ void newlines_cleanup_braces(bool first)
                || pc->parent_type == CT_FUNC_CLASS_DEF
                || pc->parent_type == CT_FUNC_CLASS_PROTO
                || pc->parent_type == CT_OPERATOR)
-            && (  cpd.settings[UO_nl_func_decl_start].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_def_start].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_decl_start_single].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_def_start_single].a != AV_IGNORE
+            && (  cpd.settings[UO_nl_func_decl_start].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_def_start].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_decl_start_single].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_def_start_single].a != IARF_IGNORE
                || cpd.settings[UO_nl_func_decl_start_multi_line].b
                || cpd.settings[UO_nl_func_def_start_multi_line].b
-               || cpd.settings[UO_nl_func_decl_args].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_def_args].a != AV_IGNORE
+               || cpd.settings[UO_nl_func_decl_args].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_def_args].a != IARF_IGNORE
                || cpd.settings[UO_nl_func_decl_args_multi_line].b
                || cpd.settings[UO_nl_func_def_args_multi_line].b
-               || cpd.settings[UO_nl_func_decl_end].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_def_end].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_decl_end_single].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_def_end_single].a != AV_IGNORE
+               || cpd.settings[UO_nl_func_decl_end].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_def_end].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_decl_end_single].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_def_end_single].a != IARF_IGNORE
                || cpd.settings[UO_nl_func_decl_end_multi_line].b
                || cpd.settings[UO_nl_func_def_end_multi_line].b
-               || cpd.settings[UO_nl_func_decl_empty].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_def_empty].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_type_name].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_type_name_class].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_class_scope].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_scope_name].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_proto_type_name].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_paren].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_def_paren].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_def_paren_empty].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_paren_empty].a != AV_IGNORE))
+               || cpd.settings[UO_nl_func_decl_empty].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_def_empty].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_type_name].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_type_name_class].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_class_scope].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_scope_name].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_proto_type_name].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_paren].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_def_paren].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_def_paren_empty].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_paren_empty].a != IARF_IGNORE))
          {
             newline_func_def_or_call(pc);
          }
@@ -3401,13 +3401,13 @@ void newlines_cleanup_braces(bool first)
                  && (  (cpd.settings[UO_nl_func_call_start_multi_line].b)
                     || (cpd.settings[UO_nl_func_call_args_multi_line].b)
                     || (cpd.settings[UO_nl_func_call_end_multi_line].b)
-                    || (cpd.settings[UO_nl_func_call_paren].a != AV_IGNORE)
-                    || (cpd.settings[UO_nl_func_call_paren_empty].a != AV_IGNORE)
-                    || (cpd.settings[UO_nl_func_call_empty].a != AV_IGNORE)))
+                    || (cpd.settings[UO_nl_func_call_paren].a != IARF_IGNORE)
+                    || (cpd.settings[UO_nl_func_call_paren_empty].a != IARF_IGNORE)
+                    || (cpd.settings[UO_nl_func_call_empty].a != IARF_IGNORE)))
          {
-            if (  cpd.settings[UO_nl_func_call_paren].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_call_paren_empty].a != AV_IGNORE
-               || cpd.settings[UO_nl_func_call_empty].a != AV_IGNORE)
+            if (  cpd.settings[UO_nl_func_call_paren].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_call_paren_empty].a != IARF_IGNORE
+               || cpd.settings[UO_nl_func_call_empty].a != IARF_IGNORE)
             {
                newline_func_def_or_call(pc);
             }
@@ -3415,7 +3415,7 @@ void newlines_cleanup_braces(bool first)
          }
          else if (first && (cpd.settings[UO_nl_remove_extra_newlines].u == 1))
          {
-            newline_iarf(pc, AV_REMOVE);
+            newline_iarf(pc, IARF_REMOVE);
          }
       }
       else if (chunk_is_token(pc, CT_ANGLE_CLOSE))
@@ -3451,9 +3451,9 @@ void newlines_cleanup_braces(bool first)
 
             iarf_e arg = cpd.settings[UO_nl_after_square_assign].a;
 
-            if (cpd.settings[UO_nl_assign_square].a & AV_ADD)
+            if (cpd.settings[UO_nl_assign_square].a & IARF_ADD)
             {
-               arg = AV_ADD;
+               arg = IARF_ADD;
             }
             newline_iarf(pc, arg);
 
@@ -3507,7 +3507,7 @@ void newlines_cleanup_braces(bool first)
               && (cpd.settings[UO_nl_remove_extra_newlines].u == 1)
               && !(pc->flags & PCF_IN_PREPROC))
       {
-         newline_iarf(pc, AV_REMOVE);
+         newline_iarf(pc, IARF_REMOVE);
       }
       else
       {
@@ -3807,8 +3807,8 @@ void newlines_eat_start_end(void)
 
    // Process newlines at the start of the file
    if (  cpd.frag_cols == 0
-      && (  (cpd.settings[UO_nl_start_of_file].a & AV_REMOVE)
-         || (  (cpd.settings[UO_nl_start_of_file].a & AV_ADD)
+      && (  (cpd.settings[UO_nl_start_of_file].a & IARF_REMOVE)
+         || (  (cpd.settings[UO_nl_start_of_file].a & IARF_ADD)
             && (cpd.settings[UO_nl_start_of_file_min].u > 0))))
    {
       pc = chunk_get_head();
@@ -3816,14 +3816,14 @@ void newlines_eat_start_end(void)
       {
          if (chunk_is_token(pc, CT_NEWLINE))
          {
-            if (cpd.settings[UO_nl_start_of_file].a == AV_REMOVE)
+            if (cpd.settings[UO_nl_start_of_file].a == IARF_REMOVE)
             {
                LOG_FMT(LBLANKD, "%s(%d): eat_blanks_start_of_file %zu\n",
                        __func__, __LINE__, pc->orig_line);
                chunk_del(pc);
                MARK_CHANGE();
             }
-            else if (  cpd.settings[UO_nl_start_of_file].a == AV_FORCE
+            else if (  cpd.settings[UO_nl_start_of_file].a == IARF_FORCE
                     || (pc->nl_count < cpd.settings[UO_nl_start_of_file_min].u))
             {
                LOG_FMT(LBLANKD, "%s(%d): set_blanks_start_of_file %zu\n",
@@ -3832,7 +3832,7 @@ void newlines_eat_start_end(void)
                MARK_CHANGE();
             }
          }
-         else if (  (cpd.settings[UO_nl_start_of_file].a & AV_ADD)
+         else if (  (cpd.settings[UO_nl_start_of_file].a & IARF_ADD)
                  && (cpd.settings[UO_nl_start_of_file_min].u > 0))
          {
             chunk_t chunk;
@@ -3849,8 +3849,8 @@ void newlines_eat_start_end(void)
 
    // Process newlines at the end of the file
    if (  cpd.frag_cols == 0
-      && (  (cpd.settings[UO_nl_end_of_file].a & AV_REMOVE)
-         || (  (cpd.settings[UO_nl_end_of_file].a & AV_ADD)
+      && (  (cpd.settings[UO_nl_end_of_file].a & IARF_REMOVE)
+         || (  (cpd.settings[UO_nl_end_of_file].a & IARF_ADD)
             && (cpd.settings[UO_nl_end_of_file_min].u > 0))))
    {
       pc = chunk_get_tail();
@@ -3858,14 +3858,14 @@ void newlines_eat_start_end(void)
       {
          if (chunk_is_token(pc, CT_NEWLINE))
          {
-            if (cpd.settings[UO_nl_end_of_file].a == AV_REMOVE)
+            if (cpd.settings[UO_nl_end_of_file].a == IARF_REMOVE)
             {
                LOG_FMT(LBLANKD, "%s(%d): eat_blanks_end_of_file %zu\n",
                        __func__, __LINE__, pc->orig_line);
                chunk_del(pc);
                MARK_CHANGE();
             }
-            else if (  cpd.settings[UO_nl_end_of_file].a == AV_FORCE
+            else if (  cpd.settings[UO_nl_end_of_file].a == IARF_FORCE
                     || (pc->nl_count < cpd.settings[UO_nl_end_of_file_min].u))
             {
                if (pc->nl_count != cpd.settings[UO_nl_end_of_file_min].u)
@@ -3877,7 +3877,7 @@ void newlines_eat_start_end(void)
                }
             }
          }
-         else if (  (cpd.settings[UO_nl_end_of_file].a & AV_ADD)
+         else if (  (cpd.settings[UO_nl_end_of_file].a & IARF_ADD)
                  && (cpd.settings[UO_nl_end_of_file_min].u > 0))
          {
             chunk_t chunk;
@@ -4085,14 +4085,14 @@ void newlines_class_colon_pos(c_token_t tok)
 
          if (  !chunk_is_newline(prev)
             && !chunk_is_newline(next)
-            && ((anc & AV_ADD) != 0))
+            && ((anc & IARF_ADD) != 0))
          {
             newline_add_after(pc);
             prev = chunk_get_prev_nc(pc);
             next = chunk_get_next_nc(pc);
          }
 
-         if (anc == AV_REMOVE)
+         if (anc == IARF_REMOVE)
          {
             if (chunk_is_newline(prev) && chunk_safe_to_del_nl(prev))
             {
@@ -4137,11 +4137,11 @@ void newlines_class_colon_pos(c_token_t tok)
 
          if (chunk_is_token(pc, CT_COMMA) && pc->level == ccolon->level)
          {
-            if ((ncia & AV_ADD) != 0)
+            if ((ncia & IARF_ADD) != 0)
             {
                if (pcc & TP_TRAIL)
                {
-                  if (ncia == AV_FORCE)
+                  if (ncia == IARF_FORCE)
                   {
                      newline_force_after(pc);
                   }
@@ -4158,7 +4158,7 @@ void newlines_class_colon_pos(c_token_t tok)
                }
                else if (pcc & TP_LEAD)
                {
-                  if (ncia == AV_FORCE)
+                  if (ncia == IARF_FORCE)
                   {
                      newline_force_before(pc);
                   }
@@ -4174,7 +4174,7 @@ void newlines_class_colon_pos(c_token_t tok)
                   }
                }
             }
-            else if (ncia == AV_REMOVE)
+            else if (ncia == IARF_REMOVE)
             {
                next = chunk_get_next(pc);
                if (chunk_is_newline(next) && chunk_safe_to_del_nl(next))

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -75,7 +75,7 @@ static void newlines_double_space_struct_enum_union(chunk_t *open_brace);
 
 
 //! If requested, make sure each entry in an enum is on its own line
-static void newlines_enum_entries(chunk_t *open_brace, argval_t av);
+static void newlines_enum_entries(chunk_t *open_brace, iarf_e av);
 
 
 /**
@@ -102,7 +102,7 @@ static void nl_handle_define(chunk_t *pc);
  * @param after   The second chunk
  * @param av      The IARF value
  */
-static void newline_iarf_pair(chunk_t *before, chunk_t *after, argval_t av);
+static void newline_iarf_pair(chunk_t *before, chunk_t *after, iarf_e av);
 
 
 /**
@@ -142,7 +142,7 @@ static void newline_end_newline(chunk_t *br_close);
  * For virtual braces, we can only add a newline after the vbrace open.
  * If we do so, also add a newline after the vbrace close.
  */
-static bool newlines_if_for_while_switch(chunk_t *start, argval_t nl_opt);
+static bool newlines_if_for_while_switch(chunk_t *start, iarf_e nl_opt);
 
 
 /**
@@ -151,7 +151,7 @@ static bool newlines_if_for_while_switch(chunk_t *start, argval_t nl_opt);
  * Doesn't do anything if open brace before it
  * "code\n\ncomment\nif (...)" or "code\ncomment\nif (...)"
  */
-static void newlines_if_for_while_switch_pre_blank_lines(chunk_t *start, argval_t nl_opt);
+static void newlines_if_for_while_switch_pre_blank_lines(chunk_t *start, iarf_e nl_opt);
 
 
 static void _blank_line_set(chunk_t *pc, const char *text, uncrustify_options uo);
@@ -184,7 +184,7 @@ static void remove_next_newlines(chunk_t *start);
  * VBraces will stay VBraces, conversion to real ones should have already happened
  * "if (...)\ncode\ncode" or "if (...)\ncode\n\ncode"
  */
-static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, argval_t nl_opt);
+static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, iarf_e nl_opt);
 
 
 /**
@@ -195,7 +195,7 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, argval
  *
  * "struct [name] {" or "struct [name] \n {"
  */
-static void newlines_struct_union(chunk_t *start, argval_t nl_opt, bool leave_trailing);
+static void newlines_struct_union(chunk_t *start, iarf_e nl_opt, bool leave_trailing);
 static void newlines_enum(chunk_t *start);
 
 
@@ -207,14 +207,14 @@ static void newlines_enum(chunk_t *start);
  *
  * @param start  The chunk - should be CT_ELSE or CT_WHILE_OF_DO
  */
-static void newlines_cuddle_uncuddle(chunk_t *start, argval_t nl_opt);
+static void newlines_cuddle_uncuddle(chunk_t *start, iarf_e nl_opt);
 
 
 /**
  * Adds/removes a newline between else and '{'.
  * "else {" or "else \n {"
  */
-static void newlines_do_else(chunk_t *start, argval_t nl_opt);
+static void newlines_do_else(chunk_t *start, iarf_e nl_opt);
 
 
 //! Put a newline before and after a block of variable definitions
@@ -702,7 +702,7 @@ void newline_del_between(chunk_t *start, chunk_t *end)
 } // newline_del_between
 
 
-static bool newlines_if_for_while_switch(chunk_t *start, argval_t nl_opt)
+static bool newlines_if_for_while_switch(chunk_t *start, iarf_e nl_opt)
 {
    LOG_FUNC_ENTRY();
 
@@ -768,7 +768,7 @@ static bool newlines_if_for_while_switch(chunk_t *start, argval_t nl_opt)
 } // newlines_if_for_while_switch
 
 
-static void newlines_if_for_while_switch_pre_blank_lines(chunk_t *start, argval_t nl_opt)
+static void newlines_if_for_while_switch_pre_blank_lines(chunk_t *start, iarf_e nl_opt)
 {
    LOG_FUNC_ENTRY();
 
@@ -1091,7 +1091,7 @@ static void remove_next_newlines(chunk_t *start)
 }
 
 
-static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, argval_t nl_opt)
+static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, iarf_e nl_opt)
 {
    LOG_FUNC_ENTRY();
    chunk_t *pc;
@@ -1314,7 +1314,7 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, argval
 } // newlines_if_for_while_switch_post_blank_lines
 
 
-static void newlines_struct_union(chunk_t *start, argval_t nl_opt, bool leave_trailing)
+static void newlines_struct_union(chunk_t *start, iarf_e nl_opt, bool leave_trailing)
 {
    LOG_FUNC_ENTRY();
    chunk_t *pc;
@@ -1376,13 +1376,13 @@ static void newlines_struct_union(chunk_t *start, argval_t nl_opt, bool leave_tr
 static void newlines_enum(chunk_t *start)
 {
    LOG_FUNC_ENTRY();
-   chunk_t  *pc;
-   chunk_t  *pcClass;
-   chunk_t  *pcType;
-   chunk_t  *pcColon;
-   chunk_t  *pcType1;
-   chunk_t  *pcType2;
-   argval_t nl_opt;
+   chunk_t *pc;
+   chunk_t *pcClass;
+   chunk_t *pcType;
+   chunk_t *pcColon;
+   chunk_t *pcType1;
+   chunk_t *pcType2;
+   iarf_e  nl_opt;
 
    if ((start->flags & PCF_IN_PREPROC) && !cpd.settings[UO_nl_define_macro].b)
    {
@@ -1461,7 +1461,7 @@ static void newlines_enum(chunk_t *start)
 } // newlines_enum
 
 
-static void newlines_cuddle_uncuddle(chunk_t *start, argval_t nl_opt)
+static void newlines_cuddle_uncuddle(chunk_t *start, iarf_e nl_opt)
 {
    LOG_FUNC_ENTRY();
    chunk_t *br_close;
@@ -1479,7 +1479,7 @@ static void newlines_cuddle_uncuddle(chunk_t *start, argval_t nl_opt)
 }
 
 
-static void newlines_do_else(chunk_t *start, argval_t nl_opt)
+static void newlines_do_else(chunk_t *start, iarf_e nl_opt)
 {
    LOG_FUNC_ENTRY();
    chunk_t *next;
@@ -1863,8 +1863,8 @@ static void newlines_brace_pair(chunk_t *br_open)
       }
    }
 
-   argval_t val            = AV_IGNORE;
-   bool     nl_close_brace = false;
+   iarf_e val            = AV_IGNORE;
+   bool   nl_close_brace = false;
    // Handle the cases where the brace is part of a function call or definition
    if (  br_open->parent_type == CT_FUNC_DEF
       || br_open->parent_type == CT_FUNC_CALL
@@ -2096,7 +2096,7 @@ static void newline_after_return(chunk_t *start)
 }
 
 
-static void newline_iarf_pair(chunk_t *before, chunk_t *after, argval_t av)
+static void newline_iarf_pair(chunk_t *before, chunk_t *after, iarf_e av)
 {
    LOG_FUNC_ENTRY();
    log_func_stack(LNEWLINE, "Call Stack:");
@@ -2121,7 +2121,7 @@ static void newline_iarf_pair(chunk_t *before, chunk_t *after, argval_t av)
 }
 
 
-void newline_iarf(chunk_t *pc, argval_t av)
+void newline_iarf(chunk_t *pc, iarf_e av)
 {
    LOG_FUNC_ENTRY();
    log_func_stack(LNEWLINE, "CallStack:");
@@ -2230,7 +2230,7 @@ static void newline_func_def_or_call(chunk_t *start)
 
    if (is_call)
    {
-      argval_t atmp = cpd.settings[UO_nl_func_call_paren].a;
+      iarf_e atmp = cpd.settings[UO_nl_func_call_paren].a;
       if (atmp != AV_IGNORE)
       {
          prev = chunk_get_prev_ncnl(start);
@@ -2263,7 +2263,7 @@ static void newline_func_def_or_call(chunk_t *start)
    }
    else
    {
-      argval_t atmp = cpd.settings[is_def ? UO_nl_func_def_paren : UO_nl_func_paren].a;
+      iarf_e atmp = cpd.settings[is_def ? UO_nl_func_def_paren : UO_nl_func_paren].a;
       if (atmp != AV_IGNORE)
       {
          prev = chunk_get_prev_ncnl(start);
@@ -2309,9 +2309,9 @@ static void newline_func_def_or_call(chunk_t *start)
          const chunk_t *tmp_next = chunk_get_next_ncnl(prev);
          if (tmp_next != nullptr && tmp_next->type != CT_FUNC_CLASS_DEF)
          {
-            argval_t a = (tmp->parent_type == CT_FUNC_PROTO) ?
-                         cpd.settings[UO_nl_func_proto_type_name].a :
-                         cpd.settings[UO_nl_func_type_name].a;
+            iarf_e a = (tmp->parent_type == CT_FUNC_PROTO) ?
+                       cpd.settings[UO_nl_func_proto_type_name].a :
+                       cpd.settings[UO_nl_func_type_name].a;
             if (  (tmp->flags & PCF_IN_CLASS)
                && (cpd.settings[UO_nl_func_type_name_class].a != AV_IGNORE))
             {
@@ -2409,11 +2409,11 @@ static void newline_func_def_or_call(chunk_t *start)
       }
    }
 
-   argval_t as = cpd.settings[is_def ? UO_nl_func_def_start : UO_nl_func_decl_start].a;
-   argval_t ae = cpd.settings[is_def ? UO_nl_func_def_end : UO_nl_func_decl_end].a;
+   iarf_e as = cpd.settings[is_def ? UO_nl_func_def_start : UO_nl_func_decl_start].a;
+   iarf_e ae = cpd.settings[is_def ? UO_nl_func_def_end : UO_nl_func_decl_end].a;
    if (comma_count == 0)
    {
-      argval_t atmp;
+      iarf_e atmp;
       atmp = cpd.settings[is_def ? UO_nl_func_def_start_single :
                           UO_nl_func_decl_start_single].a;
       if (atmp != AV_IGNORE)
@@ -2769,7 +2769,7 @@ void newlines_cleanup_braces(bool first)
       }
       else if (chunk_is_token(pc, CT_ELSEIF))
       {
-         argval_t arg = cpd.settings[UO_nl_elseif_brace].a;
+         iarf_e arg = cpd.settings[UO_nl_elseif_brace].a;
          newlines_if_for_while_switch(
             pc, (arg != AV_IGNORE) ? arg : cpd.settings[UO_nl_if_brace].a);
          tmp = chunk_get_next_type(pc, CT_SPAREN_CLOSE, pc->level);
@@ -3449,7 +3449,7 @@ void newlines_cleanup_braces(bool first)
             tmp = chunk_get_prev_ncnl(pc);
             newline_iarf(tmp, cpd.settings[UO_nl_assign_square].a);
 
-            argval_t arg = cpd.settings[UO_nl_after_square_assign].a;
+            iarf_e arg = cpd.settings[UO_nl_after_square_assign].a;
 
             if (cpd.settings[UO_nl_assign_square].a & AV_ADD)
             {
@@ -4049,8 +4049,8 @@ void newlines_class_colon_pos(c_token_t tok)
 
    tokenpos_e tpc;
    tokenpos_e pcc;
-   argval_t   anc;
-   argval_t   ncia;
+   iarf_e     anc;
+   iarf_e     ncia;
 
    if (tok == CT_CLASS_COLON)
    {
@@ -4570,7 +4570,7 @@ void newlines_cleanup_dup(void)
 }
 
 
-static void newlines_enum_entries(chunk_t *open_brace, argval_t av)
+static void newlines_enum_entries(chunk_t *open_brace, iarf_e av)
 {
    LOG_FUNC_ENTRY();
    chunk_t *pc = open_brace;

--- a/src/newlines.h
+++ b/src/newlines.h
@@ -115,7 +115,7 @@ void undo_one_liner(chunk_t *pc);
  * @param pc  The chunk
  * @param av  The IARF value
  */
-void newline_iarf(chunk_t *pc, argval_t av);
+void newline_iarf(chunk_t *pc, iarf_e av);
 
 
 /**

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2160,22 +2160,22 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
    // Must be AT_IARF
    if ((strcasecmp(val, "add") == 0) || (strcasecmp(val, "a") == 0))
    {
-      dest->a = AV_ADD;
+      dest->a = IARF_ADD;
       return;
    }
    if ((strcasecmp(val, "remove") == 0) || (strcasecmp(val, "r") == 0))
    {
-      dest->a = AV_REMOVE;
+      dest->a = IARF_REMOVE;
       return;
    }
    if ((strcasecmp(val, "force") == 0) || (strcasecmp(val, "f") == 0))
    {
-      dest->a = AV_FORCE;
+      dest->a = IARF_FORCE;
       return;
    }
    if ((strcasecmp(val, "ignore") == 0) || (strcasecmp(val, "i") == 0))
    {
-      dest->a = AV_IGNORE;
+      dest->a = IARF_IGNORE;
       return;
    }
    if (  ((tmp = unc_find_option(val)) != nullptr)
@@ -2188,7 +2188,7 @@ static void convert_value(const option_map_value *entry, const char *val, op_val
            cpd.filename.c_str(), cpd.line_number, entry->name, val);
    log_flush(true);
    cpd.error_count++;
-   dest->a = AV_IGNORE;
+   dest->a = IARF_IGNORE;
 } // convert_value
 
 
@@ -2627,27 +2627,27 @@ void set_option_defaults(void)
    cpd.defaults[UO_newlines].le                                         = LE_AUTO;
    cpd.defaults[UO_output_tab_size].u                                   = 8;
    cpd.defaults[UO_pp_indent_count].u                                   = 1;
-   cpd.defaults[UO_sp_addr].a                                           = AV_REMOVE;
-   cpd.defaults[UO_sp_after_semi].a                                     = AV_ADD;
-   cpd.defaults[UO_sp_after_semi_for].a                                 = AV_FORCE;
-   cpd.defaults[UO_sp_after_type].a                                     = AV_FORCE;
-   cpd.defaults[UO_sp_angle_shift].a                                    = AV_ADD;
-   cpd.defaults[UO_sp_before_case_colon].a                              = AV_REMOVE;
-   cpd.defaults[UO_sp_before_comma].a                                   = AV_REMOVE;
-   cpd.defaults[UO_sp_before_nl_cont].a                                 = AV_ADD;
-   cpd.defaults[UO_sp_before_semi].a                                    = AV_REMOVE;
-   cpd.defaults[UO_sp_deref].a                                          = AV_REMOVE;
-   cpd.defaults[UO_sp_incdec].a                                         = AV_REMOVE;
-   cpd.defaults[UO_sp_inv].a                                            = AV_REMOVE;
-   cpd.defaults[UO_sp_member].a                                         = AV_REMOVE;
-   cpd.defaults[UO_sp_not].a                                            = AV_REMOVE;
-   cpd.defaults[UO_sp_paren_comma].a                                    = AV_FORCE;
-   cpd.defaults[UO_sp_pp_concat].a                                      = AV_ADD;
-   cpd.defaults[UO_sp_sign].a                                           = AV_REMOVE;
-   cpd.defaults[UO_sp_super_paren].a                                    = AV_REMOVE;
-   cpd.defaults[UO_sp_this_paren].a                                     = AV_REMOVE;
-   cpd.defaults[UO_sp_word_brace].a                                     = AV_ADD;
-   cpd.defaults[UO_sp_word_brace_ns].a                                  = AV_ADD;
+   cpd.defaults[UO_sp_addr].a                                           = IARF_REMOVE;
+   cpd.defaults[UO_sp_after_semi].a                                     = IARF_ADD;
+   cpd.defaults[UO_sp_after_semi_for].a                                 = IARF_FORCE;
+   cpd.defaults[UO_sp_after_type].a                                     = IARF_FORCE;
+   cpd.defaults[UO_sp_angle_shift].a                                    = IARF_ADD;
+   cpd.defaults[UO_sp_before_case_colon].a                              = IARF_REMOVE;
+   cpd.defaults[UO_sp_before_comma].a                                   = IARF_REMOVE;
+   cpd.defaults[UO_sp_before_nl_cont].a                                 = IARF_ADD;
+   cpd.defaults[UO_sp_before_semi].a                                    = IARF_REMOVE;
+   cpd.defaults[UO_sp_deref].a                                          = IARF_REMOVE;
+   cpd.defaults[UO_sp_incdec].a                                         = IARF_REMOVE;
+   cpd.defaults[UO_sp_inv].a                                            = IARF_REMOVE;
+   cpd.defaults[UO_sp_member].a                                         = IARF_REMOVE;
+   cpd.defaults[UO_sp_not].a                                            = IARF_REMOVE;
+   cpd.defaults[UO_sp_paren_comma].a                                    = IARF_FORCE;
+   cpd.defaults[UO_sp_pp_concat].a                                      = IARF_ADD;
+   cpd.defaults[UO_sp_sign].a                                           = IARF_REMOVE;
+   cpd.defaults[UO_sp_super_paren].a                                    = IARF_REMOVE;
+   cpd.defaults[UO_sp_this_paren].a                                     = IARF_REMOVE;
+   cpd.defaults[UO_sp_word_brace].a                                     = IARF_ADD;
+   cpd.defaults[UO_sp_word_brace_ns].a                                  = IARF_ADD;
    cpd.defaults[UO_string_escape_char].u                                = '\\';
    cpd.defaults[UO_use_indent_func_call_param].b                        = true;
    cpd.defaults[UO_use_options_overriding_for_qt_macros].b              = true;
@@ -2826,16 +2826,16 @@ string argval_to_string(iarf_e argval)
 {
    switch (argval)
    {
-   case AV_IGNORE:
+   case IARF_IGNORE:
       return("ignore");
 
-   case AV_ADD:
+   case IARF_ADD:
       return("add");
 
-   case AV_REMOVE:
+   case IARF_REMOVE:
       return("remove");
 
-   case AV_FORCE:
+   case IARF_FORCE:
       return("force");
 
    default:

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2822,7 +2822,7 @@ string tfi_to_string(TrueFalseIgnore_e val)
 }
 
 
-string argval_to_string(argval_t argval)
+string argval_to_string(iarf_e argval)
 {
    switch (argval)
    {

--- a/src/options.h
+++ b/src/options.h
@@ -42,11 +42,11 @@ enum argtype_e
 //! Arg values - these are bit fields
 enum iarf_e
 {
-   AV_IGNORE      = 0,                    //! option ignores a given feature
-   AV_ADD         = (1u << 0),            //! option adds a given feature
-   AV_REMOVE      = (1u << 1),            //! option removes a given feature
-   AV_FORCE       = (AV_ADD | AV_REMOVE), //! option forces the usage of a given feature
-   AV_NOT_DEFINED = (1u << 2)             //! to be used with QT, SIGNAL SLOT macros
+   IARF_IGNORE      = 0,                        //! option ignores a given feature
+   IARF_ADD         = (1u << 0),                //! option adds a given feature
+   IARF_REMOVE      = (1u << 1),                //! option removes a given feature
+   IARF_FORCE       = (IARF_ADD | IARF_REMOVE), //! option forces the usage of a given feature
+   IARF_NOT_DEFINED = (1u << 2)                 //! for debugging
 };
 
 //! Line endings

--- a/src/options.h
+++ b/src/options.h
@@ -40,7 +40,7 @@ enum argtype_e
 };
 
 //! Arg values - these are bit fields
-enum argval_t
+enum iarf_e
 {
    AV_IGNORE      = 0,                    //! option ignores a given feature
    AV_ADD         = (1u << 0),            //! option adds a given feature
@@ -89,7 +89,7 @@ enum TrueFalseIgnore_e
  */
 union op_val_t
 {
-   argval_t          a;    //! ignore / add / remove / force
+   iarf_e            a;    //! ignore / add / remove / force
    int               n;    //! a signed number
    bool              b;    //! a bool flag
    lineends_e        le;   //! line ending type
@@ -1079,7 +1079,7 @@ std::string bool_to_string(bool val);
  *
  * @param val  argument value to convert
  */
-std::string argval_to_string(argval_t argval);
+std::string argval_to_string(iarf_e argval);
 
 /**
  * convert a line ending type to a string

--- a/src/options_for_QT.cpp
+++ b/src/options_for_QT.cpp
@@ -15,18 +15,18 @@
 bool   QT_SIGNAL_SLOT_found      = false;
 size_t QT_SIGNAL_SLOT_level      = 0;
 bool   restoreValues             = false;
-iarf_e SaveUO_sp_inside_fparen_A = AV_NOT_DEFINED;
+iarf_e SaveUO_sp_inside_fparen_A = IARF_NOT_DEFINED;
 // Issue #481
 // connect( timer,SIGNAL( timeout() ),this,SLOT( timeoutImage() ) );
-iarf_e SaveUO_sp_inside_fparens_A = AV_NOT_DEFINED;
-iarf_e SaveUO_sp_paren_paren_A    = AV_NOT_DEFINED;
-iarf_e SaveUO_sp_before_comma_A   = AV_NOT_DEFINED;
-iarf_e SaveUO_sp_after_comma_A    = AV_NOT_DEFINED;
+iarf_e SaveUO_sp_inside_fparens_A = IARF_NOT_DEFINED;
+iarf_e SaveUO_sp_paren_paren_A    = IARF_NOT_DEFINED;
+iarf_e SaveUO_sp_before_comma_A   = IARF_NOT_DEFINED;
+iarf_e SaveUO_sp_after_comma_A    = IARF_NOT_DEFINED;
 // Bug #654
 // connect(&mapper, SIGNAL(mapped(QString &)), this, SLOT(onSomeEvent(QString &)));
-iarf_e SaveUO_sp_before_byref_A         = AV_NOT_DEFINED;
-iarf_e SaveUO_sp_before_unnamed_byref_A = AV_NOT_DEFINED;
-iarf_e SaveUO_sp_after_type_A           = AV_NOT_DEFINED;
+iarf_e SaveUO_sp_before_byref_A         = IARF_NOT_DEFINED;
+iarf_e SaveUO_sp_before_unnamed_byref_A = IARF_NOT_DEFINED;
+iarf_e SaveUO_sp_after_type_A           = IARF_NOT_DEFINED;
 
 
 void save_set_options_for_QT(size_t level)
@@ -45,14 +45,14 @@ void save_set_options_for_QT(size_t level)
    SaveUO_sp_before_unnamed_byref_A = cpd.settings[UO_sp_before_unnamed_byref].a;
    SaveUO_sp_after_type_A           = cpd.settings[UO_sp_after_type].a;
    // set values for SIGNAL/SLOT
-   cpd.settings[UO_sp_inside_fparen].a        = AV_REMOVE;
-   cpd.settings[UO_sp_inside_fparens].a       = AV_REMOVE;
-   cpd.settings[UO_sp_paren_paren].a          = AV_REMOVE;
-   cpd.settings[UO_sp_before_comma].a         = AV_REMOVE;
-   cpd.settings[UO_sp_after_comma].a          = AV_REMOVE;
-   cpd.settings[UO_sp_before_byref].a         = AV_REMOVE;
-   cpd.settings[UO_sp_before_unnamed_byref].a = AV_REMOVE;
-   cpd.settings[UO_sp_after_type].a           = AV_REMOVE;
+   cpd.settings[UO_sp_inside_fparen].a        = IARF_REMOVE;
+   cpd.settings[UO_sp_inside_fparens].a       = IARF_REMOVE;
+   cpd.settings[UO_sp_paren_paren].a          = IARF_REMOVE;
+   cpd.settings[UO_sp_before_comma].a         = IARF_REMOVE;
+   cpd.settings[UO_sp_after_comma].a          = IARF_REMOVE;
+   cpd.settings[UO_sp_before_byref].a         = IARF_REMOVE;
+   cpd.settings[UO_sp_before_unnamed_byref].a = IARF_REMOVE;
+   cpd.settings[UO_sp_after_type].a           = IARF_REMOVE;
    QT_SIGNAL_SLOT_found                       = true;
 }
 
@@ -72,14 +72,14 @@ void restore_options_for_QT(void)
    cpd.settings[UO_sp_before_byref].a         = SaveUO_sp_before_byref_A;
    cpd.settings[UO_sp_before_unnamed_byref].a = SaveUO_sp_before_unnamed_byref_A;
    cpd.settings[UO_sp_after_type].a           = SaveUO_sp_after_type_A;
-   SaveUO_sp_inside_fparen_A                  = AV_NOT_DEFINED;
-   SaveUO_sp_inside_fparens_A                 = AV_NOT_DEFINED;
-   SaveUO_sp_paren_paren_A                    = AV_NOT_DEFINED;
-   SaveUO_sp_before_comma_A                   = AV_NOT_DEFINED;
-   SaveUO_sp_after_comma_A                    = AV_NOT_DEFINED;
-   SaveUO_sp_before_byref_A                   = AV_NOT_DEFINED;
-   SaveUO_sp_before_unnamed_byref_A           = AV_NOT_DEFINED;
-   SaveUO_sp_after_type_A                     = AV_NOT_DEFINED;
+   SaveUO_sp_inside_fparen_A                  = IARF_NOT_DEFINED;
+   SaveUO_sp_inside_fparens_A                 = IARF_NOT_DEFINED;
+   SaveUO_sp_paren_paren_A                    = IARF_NOT_DEFINED;
+   SaveUO_sp_before_comma_A                   = IARF_NOT_DEFINED;
+   SaveUO_sp_after_comma_A                    = IARF_NOT_DEFINED;
+   SaveUO_sp_before_byref_A                   = IARF_NOT_DEFINED;
+   SaveUO_sp_before_unnamed_byref_A           = IARF_NOT_DEFINED;
+   SaveUO_sp_after_type_A                     = IARF_NOT_DEFINED;
    QT_SIGNAL_SLOT_found                       = false;
    restoreValues                              = false;
 }

--- a/src/options_for_QT.cpp
+++ b/src/options_for_QT.cpp
@@ -12,21 +12,21 @@
 #include "options_for_QT.h"
 
 // for the modification of options within the SIGNAL/SLOT call.
-bool     QT_SIGNAL_SLOT_found      = false;
-size_t   QT_SIGNAL_SLOT_level      = 0;
-bool     restoreValues             = false;
-argval_t SaveUO_sp_inside_fparen_A = AV_NOT_DEFINED;
+bool   QT_SIGNAL_SLOT_found      = false;
+size_t QT_SIGNAL_SLOT_level      = 0;
+bool   restoreValues             = false;
+iarf_e SaveUO_sp_inside_fparen_A = AV_NOT_DEFINED;
 // Issue #481
 // connect( timer,SIGNAL( timeout() ),this,SLOT( timeoutImage() ) );
-argval_t SaveUO_sp_inside_fparens_A = AV_NOT_DEFINED;
-argval_t SaveUO_sp_paren_paren_A    = AV_NOT_DEFINED;
-argval_t SaveUO_sp_before_comma_A   = AV_NOT_DEFINED;
-argval_t SaveUO_sp_after_comma_A    = AV_NOT_DEFINED;
+iarf_e SaveUO_sp_inside_fparens_A = AV_NOT_DEFINED;
+iarf_e SaveUO_sp_paren_paren_A    = AV_NOT_DEFINED;
+iarf_e SaveUO_sp_before_comma_A   = AV_NOT_DEFINED;
+iarf_e SaveUO_sp_after_comma_A    = AV_NOT_DEFINED;
 // Bug #654
 // connect(&mapper, SIGNAL(mapped(QString &)), this, SLOT(onSomeEvent(QString &)));
-argval_t SaveUO_sp_before_byref_A         = AV_NOT_DEFINED;
-argval_t SaveUO_sp_before_unnamed_byref_A = AV_NOT_DEFINED;
-argval_t SaveUO_sp_after_type_A           = AV_NOT_DEFINED;
+iarf_e SaveUO_sp_before_byref_A         = AV_NOT_DEFINED;
+iarf_e SaveUO_sp_before_unnamed_byref_A = AV_NOT_DEFINED;
+iarf_e SaveUO_sp_after_type_A           = AV_NOT_DEFINED;
 
 
 void save_set_options_for_QT(size_t level)

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -506,9 +506,9 @@ void output_text(FILE *pfile)
          // FIXME: this really shouldn't be done here!
          if ((pc->flags & PCF_WAS_ALIGNED) == 0)
          {
-            if (cpd.settings[UO_sp_before_nl_cont].a & AV_REMOVE)
+            if (cpd.settings[UO_sp_before_nl_cont].a & IARF_REMOVE)
             {
-               pc->column = cpd.column + (cpd.settings[UO_sp_before_nl_cont].a == AV_FORCE);
+               pc->column = cpd.column + (cpd.settings[UO_sp_before_nl_cont].a == IARF_FORCE);
             }
             else
             {
@@ -545,7 +545,7 @@ void output_text(FILE *pfile)
                         exit(EX_SOFTWARE);
                      }
                      pc->column = cpd.column + orig_sp;
-                     if (  (cpd.settings[UO_sp_before_nl_cont].a != AV_IGNORE)
+                     if (  (cpd.settings[UO_sp_before_nl_cont].a != IARF_IGNORE)
                         && (pc->column < (cpd.column + 1)))
                      {
                         pc->column = cpd.column + 1;
@@ -1190,13 +1190,13 @@ static chunk_t *output_comment_cpp(chunk_t *first)
    if (!cpd.settings[UO_cmt_cpp_to_c].b)
    {
       cmt.cont_text = leadin;
-      if (cpd.settings[UO_sp_cmt_cpp_start].a != AV_REMOVE)
+      if (cpd.settings[UO_sp_cmt_cpp_start].a != IARF_REMOVE)
       {
          cmt.cont_text += ' ';
       }
       LOG_CONTTEXT();
 
-      if (cpd.settings[UO_sp_cmt_cpp_start].a == AV_IGNORE)
+      if (cpd.settings[UO_sp_cmt_cpp_start].a == IARF_IGNORE)
       {
          add_comment_text(first->str, cmt, false);
       }
@@ -1208,7 +1208,7 @@ static chunk_t *output_comment_cpp(chunk_t *first)
 
          tmp.set(first->str, iLISz, first->len() - iLISz);
 
-         if (cpd.settings[UO_sp_cmt_cpp_start].a & AV_REMOVE)
+         if (cpd.settings[UO_sp_cmt_cpp_start].a & IARF_REMOVE)
          {
             while ((tmp.size() > 0) && unc_isspace(tmp[0]))
             {
@@ -1217,7 +1217,7 @@ static chunk_t *output_comment_cpp(chunk_t *first)
          }
          if (tmp.size() > 0)
          {
-            if (cpd.settings[UO_sp_cmt_cpp_start].a & AV_ADD)
+            if (cpd.settings[UO_sp_cmt_cpp_start].a & IARF_ADD)
             {
                if (!unc_isspace(tmp[0]) && (tmp[0] != '/'))
                {
@@ -1243,7 +1243,7 @@ static chunk_t *output_comment_cpp(chunk_t *first)
       add_text("/*");
       // patch # 32, 2012-03-23
       if (  !unc_isspace(first->str[2])
-         && (cpd.settings[UO_sp_cmt_cpp_start].a & AV_ADD))
+         && (cpd.settings[UO_sp_cmt_cpp_start].a & IARF_ADD))
       {
          add_char(' ');
       }

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -47,7 +47,7 @@ static void log_rule2(size_t line, const char *rule, chunk_t *first, chunk_t *se
  * @param first   The first chunk
  * @param second  The second chunk
  *
- * @return AV_IGNORE, AV_ADD, AV_REMOVE or AV_FORCE
+ * @return IARF_IGNORE, IARF_ADD, IARF_REMOVE or IARF_FORCE
  */
 static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp);
 
@@ -59,7 +59,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp);
  * @param second  The second chunk
  * @param av      Av from the do_space()
  *
- * @return AV_IGNORE, AV_ADD, AV_REMOVE or AV_FORCE
+ * @return IARF_IGNORE, IARF_ADD, IARF_REMOVE or IARF_FORCE
  */
 static iarf_e ensure_force_space(chunk_t *first, chunk_t *second, iarf_e av);
 
@@ -153,13 +153,13 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(first, CT_IGNORED) || chunk_is_token(second, CT_IGNORED))
    {
       log_rule("IGNORED");
-      return(AV_REMOVE);
+      return(IARF_REMOVE);
    }
    if (chunk_is_token(first, CT_PP_IGNORE) && chunk_is_token(second, CT_PP_IGNORE))
    {
       // Leave spacing alone between PP_IGNORE tokens as we don't want the default behavior (which is ADD).
       log_rule("PP_IGNORE");
-      return(AV_IGNORE);
+      return(IARF_IGNORE);
    }
    if (chunk_is_token(first, CT_PP) || chunk_is_token(second, CT_PP))
    {
@@ -182,46 +182,46 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(first, CT_SPACE) || chunk_is_token(second, CT_SPACE))
    {
       log_rule("REMOVE");
-      return(AV_REMOVE);
+      return(IARF_REMOVE);
    }
 
    if (chunk_is_token(first, CT_DECLSPEC))  // Issue 1289
    {
       log_rule("Remove");
-      return(AV_REMOVE);
+      return(IARF_REMOVE);
    }
    // there are not any data for this case, this block will never been reached
    //if (chunk_is_token(first, CT_PAREN_CLOSE) && first->parent_type == CT_DECLSPEC)
    //{
    //   log_rule("Ignore");
-   //   return(AV_IGNORE);
+   //   return(IARF_IGNORE);
    //}
    if (chunk_is_token(second, CT_NEWLINE) || chunk_is_token(second, CT_VBRACE_OPEN))
    {
       log_rule("REMOVE");
-      return(AV_REMOVE);
+      return(IARF_REMOVE);
    }
    if (  chunk_is_token(first, CT_VBRACE_OPEN)
       && second->type != CT_NL_CONT
       && second->type != CT_SEMICOLON) // # Issue 1158
    {
       log_rule("FORCE");
-      return(AV_FORCE);
+      return(IARF_FORCE);
    }
    if (chunk_is_token(first, CT_VBRACE_CLOSE) && second->type != CT_NL_CONT)
    {
       log_rule("REMOVE");
-      return(AV_REMOVE);
+      return(IARF_REMOVE);
    }
    if (chunk_is_token(second, CT_VSEMICOLON))
    {
       log_rule("REMOVE");
-      return(AV_REMOVE);
+      return(IARF_REMOVE);
    }
    if (chunk_is_token(first, CT_MACRO_FUNC))
    {
       log_rule("REMOVE");
-      return(AV_REMOVE);
+      return(IARF_REMOVE);
    }
    if (chunk_is_token(second, CT_NL_CONT))
    {
@@ -239,7 +239,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       && ((CharTable::IsKw1(second->str[0]) || chunk_is_token(second, CT_NUMBER))))
    {
       log_rule("sp_case_label");
-      return(iarf_e(cpd.settings[UO_sp_case_label].a | AV_ADD));
+      return(iarf_e(cpd.settings[UO_sp_case_label].a | IARF_ADD));
    }
 
    if (chunk_is_token(first, CT_FOR_COLON))
@@ -257,7 +257,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    if (chunk_is_token(first, CT_QUESTION) && chunk_is_token(second, CT_COND_COLON))
    {
-      if (cpd.settings[UO_sp_cond_ternary_short].a != AV_IGNORE)
+      if (cpd.settings[UO_sp_cond_ternary_short].a != IARF_IGNORE)
       {
          log_rule("sp_cond_ternary_short");
          return(cpd.settings[UO_sp_cond_ternary_short].a);
@@ -267,18 +267,18 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(first, CT_QUESTION) || chunk_is_token(second, CT_QUESTION))
    {
       if (  chunk_is_token(second, CT_QUESTION)
-         && (cpd.settings[UO_sp_cond_question_before].a != AV_IGNORE))
+         && (cpd.settings[UO_sp_cond_question_before].a != IARF_IGNORE))
       {
          log_rule("sp_cond_question_before");
          return(cpd.settings[UO_sp_cond_question_before].a);
       }
       if (  chunk_is_token(first, CT_QUESTION)
-         && (cpd.settings[UO_sp_cond_question_after].a != AV_IGNORE))
+         && (cpd.settings[UO_sp_cond_question_after].a != IARF_IGNORE))
       {
          log_rule("sp_cond_question_after");
          return(cpd.settings[UO_sp_cond_question_after].a);
       }
-      if (cpd.settings[UO_sp_cond_question].a != AV_IGNORE)
+      if (cpd.settings[UO_sp_cond_question].a != IARF_IGNORE)
       {
          log_rule("sp_cond_question");
          return(cpd.settings[UO_sp_cond_question].a);
@@ -288,18 +288,18 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(first, CT_COND_COLON) || chunk_is_token(second, CT_COND_COLON))
    {
       if (  chunk_is_token(second, CT_COND_COLON)
-         && (cpd.settings[UO_sp_cond_colon_before].a != AV_IGNORE))
+         && (cpd.settings[UO_sp_cond_colon_before].a != IARF_IGNORE))
       {
          log_rule("sp_cond_colon_before");
          return(cpd.settings[UO_sp_cond_colon_before].a);
       }
       if (  chunk_is_token(first, CT_COND_COLON)
-         && (cpd.settings[UO_sp_cond_colon_after].a != AV_IGNORE))
+         && (cpd.settings[UO_sp_cond_colon_after].a != IARF_IGNORE))
       {
          log_rule("sp_cond_colon_after");
          return(cpd.settings[UO_sp_cond_colon_after].a);
       }
-      if (cpd.settings[UO_sp_cond_colon].a != AV_IGNORE)
+      if (cpd.settings[UO_sp_cond_colon].a != IARF_IGNORE)
       {
          log_rule("sp_cond_colon");
          return(cpd.settings[UO_sp_cond_colon].a);
@@ -315,7 +315,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(first, CT_COLON) && first->parent_type == CT_SQL_EXEC)
    {
       log_rule("REMOVE");
-      return(AV_REMOVE);
+      return(IARF_REMOVE);
    }
 
    // Macro stuff can only return IGNORE, ADD, or FORCE
@@ -323,40 +323,40 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    {
       log_rule("sp_macro");
       iarf_e arg = cpd.settings[UO_sp_macro].a;
-      return(static_cast<iarf_e>(arg | ((arg != AV_IGNORE) ? AV_ADD : AV_IGNORE)));
+      return(static_cast<iarf_e>(arg | ((arg != IARF_IGNORE) ? IARF_ADD : IARF_IGNORE)));
    }
 
    if (chunk_is_token(first, CT_FPAREN_CLOSE) && first->parent_type == CT_MACRO_FUNC)
    {
       log_rule("sp_macro_func");
       iarf_e arg = cpd.settings[UO_sp_macro_func].a;
-      return(static_cast<iarf_e>(arg | ((arg != AV_IGNORE) ? AV_ADD : AV_IGNORE)));
+      return(static_cast<iarf_e>(arg | ((arg != IARF_IGNORE) ? IARF_ADD : IARF_IGNORE)));
    }
 
    if (chunk_is_token(first, CT_PREPROC))
    {
       // Remove spaces, unless we are ignoring. See indent_preproc()
-      if (cpd.settings[UO_pp_space].a == AV_IGNORE)
+      if (cpd.settings[UO_pp_space].a == IARF_IGNORE)
       {
          log_rule("IGNORE");
-         return(AV_IGNORE);
+         return(IARF_IGNORE);
       }
       log_rule("REMOVE");
-      return(AV_REMOVE);
+      return(IARF_REMOVE);
    }
 
    if (chunk_is_token(second, CT_SEMICOLON))
    {
       if (second->parent_type == CT_FOR)
       {
-         if (  (cpd.settings[UO_sp_before_semi_for_empty].a != AV_IGNORE)
+         if (  (cpd.settings[UO_sp_before_semi_for_empty].a != IARF_IGNORE)
             && (  chunk_is_token(first, CT_SPAREN_OPEN)
                || chunk_is_token(first, CT_SEMICOLON)))
          {
             log_rule("sp_before_semi_for_empty");
             return(cpd.settings[UO_sp_before_semi_for_empty].a);
          }
-         if (cpd.settings[UO_sp_before_semi_for].a != AV_IGNORE)
+         if (cpd.settings[UO_sp_before_semi_for].a != IARF_IGNORE)
          {
             log_rule("sp_before_semi_for");
             return(cpd.settings[UO_sp_before_semi_for].a);
@@ -382,7 +382,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       && (  chunk_is_token(first, CT_PP_ELSE)
          || chunk_is_token(first, CT_PP_ENDIF)))
    {
-      if (cpd.settings[UO_sp_endif_cmt].a != AV_IGNORE)
+      if (cpd.settings[UO_sp_endif_cmt].a != IARF_IGNORE)
       {
          set_chunk_type(second, CT_COMMENT_ENDIF);
          log_rule("sp_endif_cmt");
@@ -390,7 +390,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       }
    }
 
-   if (  (cpd.settings[UO_sp_before_tr_emb_cmt].a != AV_IGNORE)
+   if (  (cpd.settings[UO_sp_before_tr_emb_cmt].a != IARF_IGNORE)
       && (  second->parent_type == CT_COMMENT_END
          || second->parent_type == CT_COMMENT_EMBED))
    {
@@ -405,15 +405,15 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       {
       case 0:
          log_rule("orig_prev_sp-REMOVE");
-         return(AV_REMOVE);
+         return(IARF_REMOVE);
 
       case 1:
          log_rule("orig_prev_sp-FORCE");
-         return(AV_FORCE);
+         return(IARF_FORCE);
 
       default:
          log_rule("orig_prev_sp-ADD");
-         return(AV_ADD);
+         return(IARF_ADD);
       }
    }
 
@@ -422,13 +422,13 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    {
       if (first->parent_type == CT_FOR)
       {
-         if (  (cpd.settings[UO_sp_after_semi_for_empty].a != AV_IGNORE)
+         if (  (cpd.settings[UO_sp_after_semi_for_empty].a != IARF_IGNORE)
             && chunk_is_token(second, CT_SPAREN_CLOSE))
          {
             log_rule("sp_after_semi_for_empty");
             return(cpd.settings[UO_sp_after_semi_for_empty].a);
          }
-         if (  (cpd.settings[UO_sp_after_semi_for].a != AV_IGNORE)
+         if (  (cpd.settings[UO_sp_after_semi_for].a != IARF_IGNORE)
             && second->type != CT_SPAREN_CLOSE)  // Issue 1324
          {
             log_rule("sp_after_semi_for");
@@ -452,7 +452,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          || chunk_is_token(second, CT_ARITH)))
    {
       log_rule("ADD");
-      return(AV_ADD);
+      return(IARF_ADD);
    }
 
    // "return(a);" vs "return (foo_t)a + 3;" vs "return a;" vs "return;"
@@ -465,7 +465,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       }
       // everything else requires a space
       log_rule("FORCE");
-      return(AV_FORCE);
+      return(IARF_FORCE);
    }
 
    // "sizeof(foo_t)" vs "sizeof (foo_t)"
@@ -482,7 +482,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          return(cpd.settings[UO_sp_sizeof_ellipsis].a);
       }
       log_rule("FORCE");
-      return(AV_FORCE);
+      return(IARF_FORCE);
    }
 
    // "decltype(foo_t)" vs "decltype (foo_t)"
@@ -494,7 +494,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          return(cpd.settings[UO_sp_decltype_paren].a);
       }
       log_rule("FORCE");
-      return(AV_FORCE);
+      return(IARF_FORCE);
    }
 
    // handle '::'
@@ -544,7 +544,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       case CT_UNION:
       case CT_USING:
          log_rule("FORCE");
-         return(AV_FORCE);
+         return(IARF_FORCE);
 
       default:
          break;
@@ -559,7 +559,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          && (first->prev->type == CT_FRIEND && first->next->type != CT_DC_MEMBER))
       {
          log_rule("FORCE");
-         return(AV_FORCE);
+         return(IARF_FORCE);
       }
 
       if (  (  chunk_is_token(first, CT_WORD)
@@ -592,7 +592,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       // Don't add extra space after comma immediately followed by Angle close
       if (chunk_is_token(second, CT_ANGLE_CLOSE))
       {
-         return(AV_IGNORE);
+         return(IARF_IGNORE);
       }
 
       log_rule("sp_after_comma");
@@ -619,7 +619,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          return(cpd.settings[UO_sp_before_mdatype_commas].a);
       }
       if (  chunk_is_token(first, CT_PAREN_OPEN)
-         && (cpd.settings[UO_sp_paren_comma].a != AV_IGNORE))
+         && (cpd.settings[UO_sp_paren_comma].a != IARF_IGNORE))
       {
          log_rule("sp_paren_comma");
          return(cpd.settings[UO_sp_paren_comma].a);
@@ -639,7 +639,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       }
 
       if (  ((first->flags & PCF_PUNCTUATOR) == 0)
-         && (cpd.settings[UO_sp_before_ellipsis].a != AV_IGNORE))
+         && (cpd.settings[UO_sp_before_ellipsis].a != IARF_IGNORE))
       {
          log_rule("sp_before_ellipsis");
          return(cpd.settings[UO_sp_before_ellipsis].a);
@@ -655,7 +655,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (chunk_is_token(first, CT_TAG_COLON))
       {
          log_rule("FORCE");
-         return(AV_FORCE);
+         return(IARF_FORCE);
       }
    }
    if (chunk_is_token(first, CT_ELLIPSIS))
@@ -663,7 +663,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (CharTable::IsKw1(second->str[0]))
       {
          log_rule("FORCE");
-         return(AV_FORCE);
+         return(IARF_FORCE);
       }
       if (  chunk_is_token(second, CT_PAREN_OPEN)
          && first->prev && chunk_is_token(first->prev, CT_SIZEOF))
@@ -680,20 +680,20 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(second, CT_TAG_COLON))
    {
       log_rule("REMOVE");
-      return(AV_REMOVE);
+      return(IARF_REMOVE);
    }
 
    // handle '~'
    if (chunk_is_token(first, CT_DESTRUCTOR))
    {
       log_rule("REMOVE");
-      return(AV_REMOVE);
+      return(IARF_REMOVE);
    }
 
    if (  language_is_set(LANG_OC)
       && chunk_is_token(first, CT_CATCH)
       && chunk_is_token(second, CT_SPAREN_OPEN)
-      && (cpd.settings[UO_sp_oc_catch_paren].a != AV_IGNORE))
+      && (cpd.settings[UO_sp_oc_catch_paren].a != IARF_IGNORE))
    {
       log_rule("sp_oc_catch_paren");
       return(cpd.settings[UO_sp_oc_catch_paren].a);
@@ -701,7 +701,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    if (  chunk_is_token(first, CT_CATCH)
       && chunk_is_token(second, CT_SPAREN_OPEN)
-      && (cpd.settings[UO_sp_catch_paren].a != AV_IGNORE))
+      && (cpd.settings[UO_sp_catch_paren].a != IARF_IGNORE))
    {
       log_rule("sp_catch_paren");
       return(cpd.settings[UO_sp_catch_paren].a);
@@ -709,7 +709,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    if (  chunk_is_token(first, CT_D_VERSION_IF)
       && chunk_is_token(second, CT_SPAREN_OPEN)
-      && (cpd.settings[UO_sp_version_paren].a != AV_IGNORE))
+      && (cpd.settings[UO_sp_version_paren].a != IARF_IGNORE))
    {
       log_rule("sp_version_paren");
       return(cpd.settings[UO_sp_version_paren].a);
@@ -717,7 +717,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    if (  chunk_is_token(first, CT_D_SCOPE_IF)
       && chunk_is_token(second, CT_SPAREN_OPEN)
-      && (cpd.settings[UO_sp_scope_paren].a != AV_IGNORE))
+      && (cpd.settings[UO_sp_scope_paren].a != IARF_IGNORE))
    {
       log_rule("sp_scope_paren");
       return(cpd.settings[UO_sp_scope_paren].a);
@@ -745,7 +745,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    // Handle the special lambda case for C++11:
    //    [=](Something arg){.....}
-   if (  (cpd.settings[UO_sp_cpp_lambda_assign].a != AV_IGNORE)
+   if (  (cpd.settings[UO_sp_cpp_lambda_assign].a != IARF_IGNORE)
       && (  (  chunk_is_token(first, CT_SQUARE_OPEN)
             && first->parent_type == CT_CPP_LAMBDA
             && chunk_is_token(second, CT_ASSIGN))
@@ -759,7 +759,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    // Handle the special lambda case for C++11:
    //    [](Something arg){.....}
-   if (  (cpd.settings[UO_sp_cpp_lambda_paren].a != AV_IGNORE)
+   if (  (cpd.settings[UO_sp_cpp_lambda_paren].a != IARF_IGNORE)
       && chunk_is_token(first, CT_SQUARE_CLOSE)
       && first->parent_type == CT_CPP_LAMBDA
       && chunk_is_token(second, CT_FPAREN_OPEN))
@@ -770,7 +770,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    if (chunk_is_token(first, CT_ENUM) && chunk_is_token(second, CT_FPAREN_OPEN))
    {
-      if (cpd.settings[UO_sp_enum_paren].a != AV_IGNORE)
+      if (cpd.settings[UO_sp_enum_paren].a != IARF_IGNORE)
       {
          log_rule("sp_enum_paren");
          return(cpd.settings[UO_sp_enum_paren].a);
@@ -781,7 +781,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    {
       if (second->flags & PCF_IN_ENUM)
       {
-         if (cpd.settings[UO_sp_enum_before_assign].a != AV_IGNORE)
+         if (cpd.settings[UO_sp_enum_before_assign].a != IARF_IGNORE)
          {
             log_rule("sp_enum_before_assign");
             return(cpd.settings[UO_sp_enum_before_assign].a);
@@ -789,13 +789,13 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_enum_assign");
          return(cpd.settings[UO_sp_enum_assign].a);
       }
-      if (  (cpd.settings[UO_sp_assign_default].a != AV_IGNORE)
+      if (  (cpd.settings[UO_sp_assign_default].a != IARF_IGNORE)
          && second->parent_type == CT_FUNC_PROTO)
       {
          log_rule("sp_assign_default");
          return(cpd.settings[UO_sp_assign_default].a);
       }
-      if (cpd.settings[UO_sp_before_assign].a != AV_IGNORE)
+      if (cpd.settings[UO_sp_before_assign].a != IARF_IGNORE)
       {
          log_rule("sp_before_assign");
          return(cpd.settings[UO_sp_before_assign].a);
@@ -808,7 +808,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    {
       if (first->flags & PCF_IN_ENUM)
       {
-         if (cpd.settings[UO_sp_enum_after_assign].a != AV_IGNORE)
+         if (cpd.settings[UO_sp_enum_after_assign].a != IARF_IGNORE)
          {
             log_rule("sp_enum_after_assign");
             return(cpd.settings[UO_sp_enum_after_assign].a);
@@ -816,13 +816,13 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_enum_assign");
          return(cpd.settings[UO_sp_enum_assign].a);
       }
-      if (  (cpd.settings[UO_sp_assign_default].a != AV_IGNORE)
+      if (  (cpd.settings[UO_sp_assign_default].a != IARF_IGNORE)
          && first->parent_type == CT_FUNC_PROTO)
       {
          log_rule("sp_assign_default");
          return(cpd.settings[UO_sp_assign_default].a);
       }
-      if (cpd.settings[UO_sp_after_assign].a != AV_IGNORE)
+      if (cpd.settings[UO_sp_after_assign].a != IARF_IGNORE)
       {
          log_rule("sp_after_assign");
          return(cpd.settings[UO_sp_after_assign].a);
@@ -852,7 +852,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(first, CT_OC_AVAILABLE_VALUE) || chunk_is_token(second, CT_OC_AVAILABLE_VALUE))
    {
       log_rule("IGNORE");
-      return(AV_IGNORE);
+      return(IARF_IGNORE);
    }
    if (chunk_is_token(second, CT_OC_BLOCK_CARET))
    {
@@ -866,12 +866,12 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    }
    if (chunk_is_token(second, CT_OC_MSG_FUNC))
    {
-      if (  (cpd.settings[UO_sp_after_oc_msg_receiver].a == AV_REMOVE)
+      if (  (cpd.settings[UO_sp_after_oc_msg_receiver].a == IARF_REMOVE)
          && (  (first->type != CT_SQUARE_CLOSE)
             && (first->type != CT_FPAREN_CLOSE)
             && (first->type != CT_PAREN_CLOSE)))
       {
-         return(AV_FORCE);
+         return(IARF_FORCE);
       }
 
       log_rule("sp_after_oc_msg_receiver");
@@ -897,7 +897,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    {
       if (((second->flags & PCF_IN_SPAREN) != 0) && (chunk_is_token(first, CT_IN)))
       {
-         return(AV_FORCE);
+         return(IARF_FORCE);
       }
 
       log_rule("sp_before_square");
@@ -911,7 +911,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       return(cpd.settings[UO_sp_before_squares].a);
    }
 
-   if (  (cpd.settings[UO_sp_angle_shift].a != AV_IGNORE)
+   if (  (cpd.settings[UO_sp_angle_shift].a != IARF_IGNORE)
       && chunk_is_token(first, CT_ANGLE_CLOSE)
       && chunk_is_token(second, CT_ANGLE_CLOSE))
    {
@@ -927,12 +927,12 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       iarf_e op = cpd.settings[UO_sp_inside_angle].a;
 
       // special: if we're not supporting digraphs, then we shouldn't create them!
-      if (  (op == AV_REMOVE)
+      if (  (op == IARF_REMOVE)
          && !cpd.settings[UO_enable_digraphs].b
          && chunk_is_token(first, CT_ANGLE_OPEN)
          && chunk_is_token(second, CT_DC_MEMBER))
       {
-         op = AV_IGNORE;
+         op = IARF_IGNORE;
       }
 
       return(op);
@@ -940,7 +940,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(second, CT_ANGLE_OPEN))
    {
       if (  chunk_is_token(first, CT_TEMPLATE)
-         && (cpd.settings[UO_sp_template_angle].a != AV_IGNORE))
+         && (cpd.settings[UO_sp_template_angle].a != IARF_IGNORE))
       {
          log_rule("sp_template_angle");
          return(cpd.settings[UO_sp_template_angle].a);
@@ -955,7 +955,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    {
       if (chunk_is_token(second, CT_WORD) || CharTable::IsKw1(second->str[0]))
       {
-         if (cpd.settings[UO_sp_angle_word].a != AV_IGNORE)
+         if (cpd.settings[UO_sp_angle_word].a != IARF_IGNORE)
          {
             log_rule("sp_angle_word");
             return(cpd.settings[UO_sp_angle_word].a);
@@ -984,7 +984,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          && second->type != CT_PAREN_CLOSE)
       {
          if (  chunk_is_token(second, CT_CLASS_COLON)
-            && cpd.settings[UO_sp_angle_colon].a != AV_IGNORE)
+            && cpd.settings[UO_sp_angle_colon].a != IARF_IGNORE)
          {
             log_rule("sp_angle_colon");
             return(cpd.settings[UO_sp_angle_colon].a);
@@ -995,7 +995,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    }
 
    if (  chunk_is_token(first, CT_BYREF)
-      && (cpd.settings[UO_sp_after_byref_func].a != AV_IGNORE)
+      && (cpd.settings[UO_sp_after_byref_func].a != IARF_IGNORE)
       && (  first->parent_type == CT_FUNC_DEF
          || first->parent_type == CT_FUNC_PROTO))
    {
@@ -1013,7 +1013,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (  chunk_is_token(second, CT_BYREF)
       && !chunk_is_token(first, CT_PAREN_OPEN))
    {
-      if (cpd.settings[UO_sp_before_byref_func].a != AV_IGNORE)
+      if (cpd.settings[UO_sp_before_byref_func].a != IARF_IGNORE)
       {
          chunk_t *next = chunk_get_next(second);
          if (  next != nullptr
@@ -1025,7 +1025,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          }
       }
 
-      if (cpd.settings[UO_sp_before_unnamed_byref].a != AV_IGNORE)
+      if (cpd.settings[UO_sp_before_unnamed_byref].a != IARF_IGNORE)
       {
          chunk_t *next = chunk_get_next_nc(second);
          if (next != nullptr && next->type != CT_WORD)
@@ -1044,25 +1044,25 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       {
          if (second->parent_type == CT_CATCH)
          {
-            if (language_is_set(LANG_OC) && (cpd.settings[UO_sp_oc_catch_brace].a != AV_IGNORE))
+            if (language_is_set(LANG_OC) && (cpd.settings[UO_sp_oc_catch_brace].a != IARF_IGNORE))
             {
                log_rule("sp_oc_catch_brace");
                return(cpd.settings[UO_sp_oc_catch_brace].a);
             }
-            if (cpd.settings[UO_sp_catch_brace].a != AV_IGNORE)
+            if (cpd.settings[UO_sp_catch_brace].a != IARF_IGNORE)
             {
                log_rule("sp_catch_brace");
                return(cpd.settings[UO_sp_catch_brace].a);
             }
          }
-         if (cpd.settings[UO_sp_sparen_brace].a != AV_IGNORE)
+         if (cpd.settings[UO_sp_sparen_brace].a != IARF_IGNORE)
          {
             log_rule("sp_sparen_brace");
             return(cpd.settings[UO_sp_sparen_brace].a);
          }
       }
       if (  !chunk_is_comment(second)
-         && (cpd.settings[UO_sp_after_sparen].a != AV_IGNORE))
+         && (cpd.settings[UO_sp_after_sparen].a != IARF_IGNORE))
       {
          log_rule("sp_after_sparen");
          return(cpd.settings[UO_sp_after_sparen].a);
@@ -1077,9 +1077,9 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    if (  chunk_is_token(second, CT_FPAREN_OPEN)
       && first->parent_type == CT_OPERATOR
-      && (cpd.settings[UO_sp_after_operator_sym].a != AV_IGNORE))
+      && (cpd.settings[UO_sp_after_operator_sym].a != IARF_IGNORE))
    {
-      if (  (cpd.settings[UO_sp_after_operator_sym_empty].a != AV_IGNORE)
+      if (  (cpd.settings[UO_sp_after_operator_sym_empty].a != IARF_IGNORE)
          && chunk_is_token(second, CT_FPAREN_OPEN))
       {
          chunk_t *next = chunk_get_next_ncnl(second);
@@ -1100,7 +1100,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       || chunk_is_token(first, CT_CNG_HASINC)
       || chunk_is_token(first, CT_CNG_HASINCN))
    {
-      if (  (cpd.settings[UO_sp_func_call_paren_empty].a != AV_IGNORE)
+      if (  (cpd.settings[UO_sp_func_call_paren_empty].a != IARF_IGNORE)
          && chunk_is_token(second, CT_FPAREN_OPEN))
       {
          chunk_t *next = chunk_get_next_ncnl(second);
@@ -1125,7 +1125,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    }
    if (chunk_is_token(first, CT_FUNC_DEF))
    {
-      if (  (cpd.settings[UO_sp_func_def_paren_empty].a != AV_IGNORE)
+      if (  (cpd.settings[UO_sp_func_def_paren_empty].a != IARF_IGNORE)
          && chunk_is_token(second, CT_FPAREN_OPEN))
       {
          chunk_t *next = chunk_get_next_ncnl(second);
@@ -1147,7 +1147,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(first, CT_PAREN_CLOSE) && chunk_is_token(second, CT_WHEN))
    {
       log_rule("FORCE");
-      return(AV_FORCE); // TODO: make this configurable?
+      return(IARF_FORCE); // TODO: make this configurable?
    }
 
    if (  chunk_is_token(first, CT_PAREN_CLOSE)
@@ -1162,7 +1162,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
       // Must be an indirect/chained function call?
       log_rule("REMOVE");
-      return(AV_REMOVE);  // TODO: make this configurable?
+      return(IARF_REMOVE);  // TODO: make this configurable?
    }
 
    // handle the space between parens in fcn type 'void (*f)(void)'
@@ -1185,7 +1185,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       || (  chunk_is_token(second, CT_FPAREN_OPEN)
          && second->parent_type == CT_FUNC_PROTO))
    {
-      if (  (cpd.settings[UO_sp_func_proto_paren_empty].a != AV_IGNORE)
+      if (  (cpd.settings[UO_sp_func_proto_paren_empty].a != IARF_IGNORE)
          && chunk_is_token(second, CT_FPAREN_OPEN))
       {
          chunk_t *next = chunk_get_next_ncnl(second);
@@ -1200,7 +1200,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    }
    if (chunk_is_token(first, CT_FUNC_CLASS_DEF) || chunk_is_token(first, CT_FUNC_CLASS_PROTO))
    {
-      if (  (cpd.settings[UO_sp_func_class_paren_empty].a != AV_IGNORE)
+      if (  (cpd.settings[UO_sp_func_class_paren_empty].a != IARF_IGNORE)
          && chunk_is_token(second, CT_FPAREN_OPEN))
       {
          chunk_t *next = chunk_get_next_ncnl(second);
@@ -1216,7 +1216,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(first, CT_CLASS) && !(first->flags & PCF_IN_OC_MSG))
    {
       log_rule("FORCE");
-      return(AV_FORCE);
+      return(IARF_FORCE);
    }
 
    if (chunk_is_token(first, CT_BRACE_OPEN) && chunk_is_token(second, CT_BRACE_CLOSE))
@@ -1248,13 +1248,13 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          chunk_t *tmp = chunk_get_prev_ncnl(chunk_skip_to_match_rev(second));
          if (chunk_is_token(tmp, CT_ASSIGN))
          {
-            return(AV_IGNORE);
+            return(IARF_IGNORE);
          }
          log_rule("sp_inside_braces_struct");
          return(cpd.settings[UO_sp_inside_braces_struct].a);
       }
       else if (  second->parent_type == CT_OC_AT
-              && cpd.settings[UO_sp_inside_braces_oc_dict].a != AV_IGNORE)
+              && cpd.settings[UO_sp_inside_braces_oc_dict].a != IARF_IGNORE)
       {
          log_rule("sp_inside_braces_oc_dict");
          return(cpd.settings[UO_sp_inside_braces_oc_dict].a);
@@ -1262,19 +1262,19 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
       if (second->parent_type == CT_BRACED_INIT_LIST)
       {
-         if (  cpd.settings[UO_sp_brace_brace].a != AV_IGNORE
+         if (  cpd.settings[UO_sp_brace_brace].a != IARF_IGNORE
             && chunk_is_token(first, CT_BRACE_CLOSE)
             && first->parent_type == CT_BRACED_INIT_LIST)
          {
             log_rule("sp_brace_brace");
             return(cpd.settings[UO_sp_brace_brace].a);
          }
-         if (cpd.settings[UO_sp_before_type_brace_init_lst_close].a != AV_IGNORE)
+         if (cpd.settings[UO_sp_before_type_brace_init_lst_close].a != IARF_IGNORE)
          {
             log_rule("sp_before_type_brace_init_lst_close");
             return(cpd.settings[UO_sp_before_type_brace_init_lst_close].a);
          }
-         if (cpd.settings[UO_sp_inside_type_brace_init_lst].a != AV_IGNORE)
+         if (cpd.settings[UO_sp_inside_type_brace_init_lst].a != IARF_IGNORE)
          {
             log_rule("sp_inside_type_brace_init_lst");
             return(cpd.settings[UO_sp_inside_type_brace_init_lst].a);
@@ -1288,7 +1288,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(first, CT_D_CAST))
    {
       log_rule("REMOVE");
-      return(AV_REMOVE);
+      return(IARF_REMOVE);
    }
 
    if (chunk_is_token(first, CT_PP_DEFINED) && chunk_is_token(second, CT_PAREN_OPEN))
@@ -1317,13 +1317,13 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(first, CT_STATE) && chunk_is_token(second, CT_PAREN_OPEN))
    {
       log_rule("ADD");
-      return(AV_ADD);
+      return(IARF_ADD);
    }
 
    if (chunk_is_token(first, CT_DELEGATE) && chunk_is_token(second, CT_PAREN_OPEN))
    {
       log_rule("REMOVE");
-      return(AV_REMOVE);
+      return(IARF_REMOVE);
    }
 
    if (chunk_is_token(first, CT_MEMBER) || chunk_is_token(second, CT_MEMBER))
@@ -1336,7 +1336,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    {
       // always remove space(s) after then '.' of a C99-member
       log_rule("REMOVE");
-      return(AV_REMOVE);
+      return(IARF_REMOVE);
    }
 
    if (chunk_is_token(first, CT_SUPER) && chunk_is_token(second, CT_PAREN_OPEN))
@@ -1371,7 +1371,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(first, CT_D_TEMPLATE) || chunk_is_token(second, CT_D_TEMPLATE))
    {
       log_rule("REMOVE");
-      return(AV_REMOVE);
+      return(IARF_REMOVE);
    }
 
    if (chunk_is_token(first, CT_ELSE) && chunk_is_token(second, CT_BRACE_OPEN))
@@ -1383,7 +1383,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(first, CT_ELSE) && chunk_is_token(second, CT_ELSEIF))
    {
       log_rule("FORCE");
-      return(AV_FORCE);
+      return(IARF_FORCE);
    }
 
    if (chunk_is_token(first, CT_FINALLY) && chunk_is_token(second, CT_BRACE_OPEN))
@@ -1429,7 +1429,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (first->parent_type == CT_D_TEMPLATE)
       {
          log_rule("FORCE");
-         return(AV_FORCE);
+         return(IARF_FORCE);
       }
 
       if (first->parent_type == CT_INVARIANT)
@@ -1449,14 +1449,14 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (first->parent_type == CT_DELEGATE)
       {
          log_rule("ADD");
-         return(AV_ADD);
+         return(IARF_ADD);
       }
 
       // PAWN-specific: "state (condition) next"
       if (first->parent_type == CT_STATE)
       {
          log_rule("ADD");
-         return(AV_ADD);
+         return(IARF_ADD);
       }
 
       /* C++ new operator: new(bar) Foo */
@@ -1530,7 +1530,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       }
    }
 
-   if (cpd.settings[UO_sp_inside_oc_at_sel_parens].a != AV_IGNORE)
+   if (cpd.settings[UO_sp_inside_oc_at_sel_parens].a != IARF_IGNORE)
    {
       if (  (  chunk_is_token(first, CT_PAREN_OPEN)
             && (  first->parent_type == CT_OC_SEL
@@ -1567,12 +1567,12 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       }
       if (first->parent_type == CT_NEW)
       {
-         if (cpd.settings[UO_sp_inside_newop_paren_open].a != AV_IGNORE)
+         if (cpd.settings[UO_sp_inside_newop_paren_open].a != IARF_IGNORE)
          {
             log_rule("sp_inside_newop_paren_open");
             return(cpd.settings[UO_sp_inside_newop_paren_open].a);
          }
-         if (cpd.settings[UO_sp_inside_newop_paren].a != AV_IGNORE)
+         if (cpd.settings[UO_sp_inside_newop_paren].a != IARF_IGNORE)
          {
             log_rule("sp_inside_newop_paren");
             return(cpd.settings[UO_sp_inside_newop_paren].a);
@@ -1593,12 +1593,12 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       }
       if (second->parent_type == CT_NEW)
       {
-         if (cpd.settings[UO_sp_inside_newop_paren_close].a != AV_IGNORE)
+         if (cpd.settings[UO_sp_inside_newop_paren_close].a != IARF_IGNORE)
          {
             log_rule("sp_inside_newop_paren_close");
             return(cpd.settings[UO_sp_inside_newop_paren_close].a);
          }
-         if (cpd.settings[UO_sp_inside_newop_paren].a != AV_IGNORE)
+         if (cpd.settings[UO_sp_inside_newop_paren].a != IARF_IGNORE)
          {
             log_rule("sp_inside_newop_paren");
             return(cpd.settings[UO_sp_inside_newop_paren].a);
@@ -1614,7 +1614,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (  language_is_set(LANG_OC)
          && (  (first->parent_type == CT_OC_AT && chunk_is_token(first, CT_SQUARE_OPEN))
             || (second->parent_type == CT_OC_AT && chunk_is_token(second, CT_SQUARE_CLOSE)))
-         && (cpd.settings[UO_sp_inside_square_oc_array].a != AV_IGNORE))
+         && (cpd.settings[UO_sp_inside_square_oc_array].a != IARF_IGNORE))
       {
          log_rule("sp_inside_square_oc_array");
          return(cpd.settings[UO_sp_inside_square_oc_array].a);
@@ -1630,13 +1630,13 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    // "if(...)" vs "if( ... )"
    if (  chunk_is_token(second, CT_SPAREN_CLOSE)
-      && (cpd.settings[UO_sp_inside_sparen_close].a != AV_IGNORE))
+      && (cpd.settings[UO_sp_inside_sparen_close].a != IARF_IGNORE))
    {
       log_rule("sp_inside_sparen_close");
       return(cpd.settings[UO_sp_inside_sparen_close].a);
    }
    if (  chunk_is_token(first, CT_SPAREN_OPEN)
-      && (cpd.settings[UO_sp_inside_sparen_open].a != AV_IGNORE))
+      && (cpd.settings[UO_sp_inside_sparen_open].a != IARF_IGNORE))
    {
       log_rule("sp_inside_sparen_open");
       return(cpd.settings[UO_sp_inside_sparen_open].a);
@@ -1653,14 +1653,14 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          && (  !chunk_get_prev_type(first, CT_OC_INTF, first->level, scope_e::ALL)
             && !chunk_get_prev_type(first, CT_OC_IMPL, first->level, scope_e::ALL)))
       {
-         if (cpd.settings[UO_sp_after_oc_colon].a != AV_IGNORE)
+         if (cpd.settings[UO_sp_after_oc_colon].a != IARF_IGNORE)
          {
             log_rule("sp_after_oc_colon");
             return(cpd.settings[UO_sp_after_oc_colon].a);
          }
       }
 
-      if (cpd.settings[UO_sp_after_class_colon].a != AV_IGNORE)
+      if (cpd.settings[UO_sp_after_class_colon].a != IARF_IGNORE)
       {
          log_rule("sp_after_class_colon");
          return(cpd.settings[UO_sp_after_class_colon].a);
@@ -1674,7 +1674,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       {
          if (second->parent_type == CT_OC_CLASS && !chunk_get_prev_type(second, CT_OC_INTF, second->level, scope_e::ALL))
          {
-            if (cpd.settings[UO_sp_before_oc_colon].a != AV_IGNORE)
+            if (cpd.settings[UO_sp_before_oc_colon].a != IARF_IGNORE)
             {
                log_rule("sp_before_oc_colon");
                return(cpd.settings[UO_sp_before_oc_colon].a);
@@ -1682,14 +1682,14 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          }
       }
 
-      if (cpd.settings[UO_sp_before_class_colon].a != AV_IGNORE)
+      if (cpd.settings[UO_sp_before_class_colon].a != IARF_IGNORE)
       {
          log_rule("sp_before_class_colon");
          return(cpd.settings[UO_sp_before_class_colon].a);
       }
    }
 
-   if (  (cpd.settings[UO_sp_after_constr_colon].a != AV_IGNORE)
+   if (  (cpd.settings[UO_sp_after_constr_colon].a != IARF_IGNORE)
       && chunk_is_token(first, CT_CONSTR_COLON))
    {
       min_sp = cpd.settings[UO_indent_ctor_init_leading].u - 1; // default indent is 1 space
@@ -1697,14 +1697,14 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_after_constr_colon");
       return(cpd.settings[UO_sp_after_constr_colon].a);
    }
-   if (  (cpd.settings[UO_sp_before_constr_colon].a != AV_IGNORE)
+   if (  (cpd.settings[UO_sp_before_constr_colon].a != IARF_IGNORE)
       && chunk_is_token(second, CT_CONSTR_COLON))
    {
       log_rule("sp_before_constr_colon");
       return(cpd.settings[UO_sp_before_constr_colon].a);
    }
 
-   if (  (cpd.settings[UO_sp_before_case_colon].a != AV_IGNORE)
+   if (  (cpd.settings[UO_sp_before_case_colon].a != IARF_IGNORE)
       && chunk_is_token(second, CT_CASE_COLON))
    {
       log_rule("sp_before_case_colon");
@@ -1714,12 +1714,12 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(first, CT_DOT))
    {
       log_rule("REMOVE");
-      return(AV_REMOVE);
+      return(IARF_REMOVE);
    }
    if (chunk_is_token(second, CT_DOT))
    {
       log_rule("ADD");
-      return(AV_ADD);
+      return(IARF_ADD);
    }
 
    if (chunk_is_token(first, CT_NULLCOND) || chunk_is_token(second, CT_NULLCOND))
@@ -1733,7 +1733,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       || chunk_is_token(second, CT_ARITH)
       || chunk_is_token(second, CT_CARET))
    {
-      if (cpd.settings[UO_sp_arith_additive].a != AV_IGNORE)
+      if (cpd.settings[UO_sp_arith_additive].a != IARF_IGNORE)
       {
          auto arith_char = (chunk_is_token(first, CT_ARITH) || chunk_is_token(first, CT_CARET))
                            ? first->str[0] : second->str[0];
@@ -1752,9 +1752,9 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       iarf_e arg = cpd.settings[UO_sp_bool].a;
       if (  (cpd.settings[UO_pos_bool].tp != TP_IGNORE)
          && first->orig_line != second->orig_line
-         && arg != AV_REMOVE)
+         && arg != IARF_REMOVE)
       {
-         arg = static_cast<iarf_e>(arg | AV_ADD);
+         arg = static_cast<iarf_e>(arg | IARF_ADD);
       }
       log_rule("sp_bool");
       return(arg);
@@ -1768,11 +1768,11 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(first, CT_PAREN_OPEN) && chunk_is_token(second, CT_PTR_TYPE))
    {
       log_rule("REMOVE");
-      return(AV_REMOVE);
+      return(IARF_REMOVE);
    }
 
    if (  chunk_is_token(first, CT_PTR_TYPE)
-      && (cpd.settings[UO_sp_ptr_star_paren].a != AV_IGNORE)
+      && (cpd.settings[UO_sp_ptr_star_paren].a != IARF_IGNORE)
       && (chunk_is_token(second, CT_FPAREN_OPEN) || chunk_is_token(second, CT_TPAREN_OPEN)))
    {
       log_rule("sp_ptr_star_paren");
@@ -1781,14 +1781,14 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    if (  chunk_is_token(first, CT_PTR_TYPE)
       && chunk_is_token(second, CT_PTR_TYPE)
-      && (cpd.settings[UO_sp_between_ptr_star].a != AV_IGNORE))
+      && (cpd.settings[UO_sp_between_ptr_star].a != IARF_IGNORE))
    {
       log_rule("sp_between_ptr_star");
       return(cpd.settings[UO_sp_between_ptr_star].a);
    }
 
    if (  chunk_is_token(first, CT_PTR_TYPE)
-      && (cpd.settings[UO_sp_after_ptr_star_func].a != AV_IGNORE)
+      && (cpd.settings[UO_sp_after_ptr_star_func].a != IARF_IGNORE)
       && (  first->parent_type == CT_FUNC_DEF
          || first->parent_type == CT_FUNC_PROTO
          || first->parent_type == CT_FUNC_VAR))
@@ -1807,20 +1807,20 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       }
 
       if (  (first->parent_type == CT_FUNC_VAR || first->parent_type == CT_FUNC_TYPE)
-         && cpd.settings[UO_sp_after_ptr_block_caret].a != AV_IGNORE)
+         && cpd.settings[UO_sp_after_ptr_block_caret].a != IARF_IGNORE)
       {
          log_rule("sp_after_ptr_block_caret");
          return(cpd.settings[UO_sp_after_ptr_block_caret].a);
       }
 
       if (  chunk_is_token(second, CT_QUALIFIER)
-         && (cpd.settings[UO_sp_after_ptr_star_qualifier].a != AV_IGNORE))
+         && (cpd.settings[UO_sp_after_ptr_star_qualifier].a != IARF_IGNORE))
       {
          log_rule("sp_after_ptr_star_qualifier");
          return(cpd.settings[UO_sp_after_ptr_star_qualifier].a);
       }
 
-      if (cpd.settings[UO_sp_after_ptr_star].a != AV_IGNORE)
+      if (cpd.settings[UO_sp_after_ptr_star].a != IARF_IGNORE)
       {
          log_rule("sp_after_ptr_star");
          return(cpd.settings[UO_sp_after_ptr_star].a);
@@ -1832,9 +1832,9 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (language_is_set(LANG_CS) && chunk_is_nullable(second))
       {
          min_sp = 0;
-         return(AV_REMOVE);
+         return(IARF_REMOVE);
       }
-      if (cpd.settings[UO_sp_before_ptr_star_func].a != AV_IGNORE)
+      if (cpd.settings[UO_sp_before_ptr_star_func].a != IARF_IGNORE)
       {
          // Find the next non-'*' chunk
          chunk_t *next = second;
@@ -1850,7 +1850,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          }
       }
 
-      if (cpd.settings[UO_sp_before_unnamed_ptr_star].a != AV_IGNORE)
+      if (cpd.settings[UO_sp_before_unnamed_ptr_star].a != IARF_IGNORE)
       {
          chunk_t *next = chunk_get_next_nc(second);
          while (chunk_is_token(next, CT_PTR_TYPE))
@@ -1863,7 +1863,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             return(cpd.settings[UO_sp_before_unnamed_ptr_star].a);
          }
       }
-      if (cpd.settings[UO_sp_before_ptr_star].a != AV_IGNORE)
+      if (cpd.settings[UO_sp_before_ptr_star].a != IARF_IGNORE)
       {
          log_rule("sp_before_ptr_star");
          return(cpd.settings[UO_sp_before_ptr_star].a);
@@ -1881,7 +1881,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (first->type != CT_PTR_TYPE)
       {
          log_rule("sp_type_func|ADD");
-         return(static_cast<iarf_e>(cpd.settings[UO_sp_type_func].a | AV_ADD));
+         return(static_cast<iarf_e>(cpd.settings[UO_sp_type_func].a | IARF_ADD));
       }
       log_rule("sp_type_func");
       return(cpd.settings[UO_sp_type_func].a);
@@ -1905,7 +1905,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
       if (  language_is_set(LANG_OC)
          && chunk_is_token(second, CT_CATCH)
-         && (cpd.settings[UO_sp_oc_brace_catch].a != AV_IGNORE))
+         && (cpd.settings[UO_sp_oc_brace_catch].a != IARF_IGNORE))
       {
          log_rule("sp_oc_brace_catch");
          return(cpd.settings[UO_sp_oc_brace_catch].a);
@@ -1937,32 +1937,32 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          chunk_t *tmp = chunk_get_prev_ncnl(first);
          if (chunk_is_token(tmp, CT_ASSIGN))
          {
-            return(AV_IGNORE);
+            return(IARF_IGNORE);
          }
          log_rule("sp_inside_braces_struct");
          return(cpd.settings[UO_sp_inside_braces_struct].a);
       }
       else if (  first->parent_type == CT_OC_AT
-              && cpd.settings[UO_sp_inside_braces_oc_dict].a != AV_IGNORE)
+              && cpd.settings[UO_sp_inside_braces_oc_dict].a != IARF_IGNORE)
       {
          log_rule("sp_inside_braces_oc_dict");
          return(cpd.settings[UO_sp_inside_braces_oc_dict].a);
       }
       if (first->parent_type == CT_BRACED_INIT_LIST)
       {
-         if (  cpd.settings[UO_sp_brace_brace].a != AV_IGNORE
+         if (  cpd.settings[UO_sp_brace_brace].a != IARF_IGNORE
             && chunk_is_token(second, CT_BRACE_OPEN)
             && second->parent_type == CT_BRACED_INIT_LIST)
          {
             log_rule("sp_brace_brace");
             return(cpd.settings[UO_sp_brace_brace].a);
          }
-         if (cpd.settings[UO_sp_after_type_brace_init_lst_open].a != AV_IGNORE)
+         if (cpd.settings[UO_sp_after_type_brace_init_lst_open].a != IARF_IGNORE)
          {
             log_rule("sp_after_type_brace_init_lst_open");
             return(cpd.settings[UO_sp_after_type_brace_init_lst_open].a);
          }
-         if (cpd.settings[UO_sp_inside_type_brace_init_lst].a != AV_IGNORE)
+         if (cpd.settings[UO_sp_inside_type_brace_init_lst].a != IARF_IGNORE)
          {
             log_rule("sp_inside_type_brace_init_lst");
             return(cpd.settings[UO_sp_inside_type_brace_init_lst].a);
@@ -2010,7 +2010,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    {
       iarf_e arg = cpd.settings[UO_sp_after_type].a;
       log_rule("sp_after_type");
-      return((arg != AV_REMOVE) ? arg : AV_FORCE);
+      return((arg != IARF_REMOVE) ? arg : IARF_FORCE);
    }
 
    if (  chunk_is_token(first, CT_MACRO_OPEN)
@@ -2023,14 +2023,14 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          return(cpd.settings[UO_sp_func_call_paren].a);
       }
       log_rule("IGNORE");
-      return(AV_IGNORE);
+      return(IARF_IGNORE);
    }
 
    // If nothing claimed the PTR_TYPE, then return ignore
    if (chunk_is_token(first, CT_PTR_TYPE) || chunk_is_token(second, CT_PTR_TYPE))
    {
       log_rule("IGNORE");
-      return(AV_IGNORE);
+      return(IARF_IGNORE);
    }
 
    if (chunk_is_token(first, CT_NOT))
@@ -2066,12 +2066,12 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(second, CT_CS_SQ_COLON))
    {
       log_rule("REMOVE");
-      return(AV_REMOVE);
+      return(IARF_REMOVE);
    }
    if (chunk_is_token(first, CT_CS_SQ_COLON))
    {
       log_rule("FORCE");
-      return(AV_FORCE);
+      return(IARF_FORCE);
    }
    if (chunk_is_token(first, CT_OC_SCOPE))
    {
@@ -2115,19 +2115,19 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(second, CT_COMMENT) && second->parent_type == CT_COMMENT_EMBED)
    {
       log_rule("FORCE");
-      return(AV_FORCE);
+      return(IARF_FORCE);
    }
 
    if (chunk_is_comment(second))
    {
       log_rule("IGNORE");
-      return(AV_IGNORE);
+      return(IARF_IGNORE);
    }
 
    if (chunk_is_token(first, CT_COMMENT))
    {
       log_rule("FORCE");
-      return(AV_FORCE);
+      return(IARF_FORCE);
    }
 
    if (chunk_is_token(first, CT_NEW) && chunk_is_token(second, CT_PAREN_OPEN))
@@ -2167,7 +2167,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          || (chunk_is_token(first, CT_FPAREN_CLOSE) && first->parent_type == CT_ATTRIBUTE)))
    {
       log_rule("FORCE");
-      return(AV_FORCE);  /* TODO: make this configurable? */
+      return(IARF_FORCE);  /* TODO: make this configurable? */
    }
 
    // this table lists out all combos where a space should NOT be present
@@ -2178,7 +2178,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          && (it.second == CT_UNKNOWN || it.second == second->type))
       {
          log_rule("REMOVE from no_space_table");
-         return(AV_REMOVE);
+         return(IARF_REMOVE);
       }
    }
 
@@ -2197,7 +2197,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
              second->orig_line, second->orig_col, second->text(), get_token_name(second->type));
 
    log_rule("ADD as default value");
-   return(AV_ADD);
+   return(IARF_ADD);
 } // do_space
 
 
@@ -2208,7 +2208,7 @@ static iarf_e ensure_force_space(chunk_t *first, chunk_t *second, iarf_e av)
       int av_int = av;
       LOG_FMT(LSPACE, " <force between '%s' and '%s'>",
               first->text(), second->text());
-      av_int |= AV_ADD;
+      av_int |= IARF_ADD;
       return(static_cast<iarf_e>(av_int));
    }
 
@@ -2400,11 +2400,11 @@ void space_text(void)
          min_sp = max(1, min_sp);
          switch (av)
          {
-         case AV_FORCE:
+         case IARF_FORCE:
             column += min_sp;  // add exactly the specified number of spaces
             break;
 
-         case AV_ADD:
+         case IARF_ADD:
          {
             int delta = min_sp;
             if (next->orig_col >= pc->orig_col_end && pc->orig_col_end != 0)
@@ -2420,12 +2420,11 @@ void space_text(void)
             break;
          }
 
-         case AV_REMOVE:
-         // the symbols will be back-to-back "a+3"
-         case AV_NOT_DEFINED:
+         case IARF_REMOVE:
+            // the symbols will be back-to-back "a+3"
             break;
 
-         case AV_IGNORE:
+         case IARF_IGNORE:
             // Keep the same relative spacing, if possible
             if (next->orig_col >= pc->orig_col_end && pc->orig_col_end != 0)
             {
@@ -2441,6 +2440,10 @@ void space_text(void)
                }
             }
             break;
+
+         default:
+            // If we got here, something is wrong...
+            break;
          } // switch
 
          if (  chunk_is_comment(next)
@@ -2451,10 +2454,10 @@ void space_text(void)
              * do some comment adjustments if sp_before_tr_emb_cmt and
              * sp_endif_cmt did not apply.
              */
-            if (  (  cpd.settings[UO_sp_before_tr_emb_cmt].a == AV_IGNORE
+            if (  (  cpd.settings[UO_sp_before_tr_emb_cmt].a == IARF_IGNORE
                   || (  next->parent_type != CT_COMMENT_END
                      && next->parent_type != CT_COMMENT_EMBED))
-               && (  cpd.settings[UO_sp_endif_cmt].a == AV_IGNORE
+               && (  cpd.settings[UO_sp_endif_cmt].a == IARF_IGNORE
                   || (  pc->type != CT_PP_ELSE
                      && pc->type != CT_PP_ENDIF)))
             {
@@ -2483,9 +2486,9 @@ void space_text(void)
          next->column = column;
 
          LOG_FMT(LSPACE, "%s(%d): rule = %s @ %zu => %zu\n", __func__, __LINE__,
-                 (av == AV_IGNORE) ? "IGNORE" :
-                 (av == AV_ADD) ? "ADD" :
-                 (av == AV_REMOVE) ? "REMOVE" : "FORCE",
+                 (av == IARF_IGNORE) ? "IGNORE" :
+                 (av == IARF_ADD) ? "ADD" :
+                 (av == IARF_REMOVE) ? "REMOVE" : "FORCE",
                  column - prev_column, next->column);
          if (restoreValues)    // guy 2015-09-22
          {
@@ -2572,14 +2575,14 @@ size_t space_needed(chunk_t *first, chunk_t *second)
    int min_sp;
    switch (do_space_ensured(first, second, min_sp))
    {
-   case AV_ADD:
-   case AV_FORCE:
+   case IARF_ADD:
+   case IARF_FORCE:
       return(max(1, min_sp));
 
-   case AV_REMOVE:
+   case IARF_REMOVE:
       return(0);
 
-   case AV_IGNORE:
+   case IARF_IGNORE:
    default:
       return(second->orig_col > (first->orig_col + first->len()));
    }
@@ -2617,22 +2620,23 @@ size_t space_col_align(chunk_t *first, chunk_t *second)
 
    switch (av)
    {
-   case AV_ADD:
-   case AV_FORCE:
+   case IARF_ADD:
+   case IARF_FORCE:
       coldiff++;
       break;
 
-   case AV_REMOVE:
+   case IARF_REMOVE:
       break;
 
-   case AV_IGNORE:
+   case IARF_IGNORE:
       if (second->orig_col > (first->orig_col + first->len()))
       {
          coldiff++;
       }
       break;
 
-   case AV_NOT_DEFINED:
+   default:
+      // If we got here, something is wrong...
       break;
    }
    LOG_FMT(LSPACE, "   => coldiff is %zu\n", coldiff);

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -49,7 +49,7 @@ static void log_rule2(size_t line, const char *rule, chunk_t *first, chunk_t *se
  *
  * @return AV_IGNORE, AV_ADD, AV_REMOVE or AV_FORCE
  */
-static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp);
+static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp);
 
 /**
  * Ensure to force the space between the \a first and the \a second chunks
@@ -61,7 +61,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp);
  *
  * @return AV_IGNORE, AV_ADD, AV_REMOVE or AV_FORCE
  */
-static argval_t ensure_force_space(chunk_t *first, chunk_t *second, argval_t av);
+static iarf_e ensure_force_space(chunk_t *first, chunk_t *second, iarf_e av);
 
 //! type that stores two chunks between those no space shall occur
 struct no_space_table_t
@@ -142,7 +142,7 @@ static void log_rule2(size_t line, const char *rule, chunk_t *first, chunk_t *se
  * this function is called for every chunk in the input file.
  * Thus it is important to keep this function efficient
  */
-static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
+static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 {
    LOG_FUNC_ENTRY();
 
@@ -239,7 +239,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
       && ((CharTable::IsKw1(second->str[0]) || chunk_is_token(second, CT_NUMBER))))
    {
       log_rule("sp_case_label");
-      return(argval_t(cpd.settings[UO_sp_case_label].a | AV_ADD));
+      return(iarf_e(cpd.settings[UO_sp_case_label].a | AV_ADD));
    }
 
    if (chunk_is_token(first, CT_FOR_COLON))
@@ -322,15 +322,15 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(first, CT_MACRO))
    {
       log_rule("sp_macro");
-      argval_t arg = cpd.settings[UO_sp_macro].a;
-      return(static_cast<argval_t>(arg | ((arg != AV_IGNORE) ? AV_ADD : AV_IGNORE)));
+      iarf_e arg = cpd.settings[UO_sp_macro].a;
+      return(static_cast<iarf_e>(arg | ((arg != AV_IGNORE) ? AV_ADD : AV_IGNORE)));
    }
 
    if (chunk_is_token(first, CT_FPAREN_CLOSE) && first->parent_type == CT_MACRO_FUNC)
    {
       log_rule("sp_macro_func");
-      argval_t arg = cpd.settings[UO_sp_macro_func].a;
-      return(static_cast<argval_t>(arg | ((arg != AV_IGNORE) ? AV_ADD : AV_IGNORE)));
+      iarf_e arg = cpd.settings[UO_sp_macro_func].a;
+      return(static_cast<iarf_e>(arg | ((arg != AV_IGNORE) ? AV_ADD : AV_IGNORE)));
    }
 
    if (chunk_is_token(first, CT_PREPROC))
@@ -363,12 +363,12 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
          }
       }
 
-      argval_t arg = cpd.settings[UO_sp_before_semi].a;
+      iarf_e arg = cpd.settings[UO_sp_before_semi].a;
       if (  chunk_is_token(first, CT_SPAREN_CLOSE)
          && first->parent_type != CT_WHILE_OF_DO)
       {
          log_rule("sp_special_semi");
-         arg = static_cast<argval_t>(arg | cpd.settings[UO_sp_special_semi].a);
+         arg = static_cast<iarf_e>(arg | cpd.settings[UO_sp_special_semi].a);
       }
       else
       {
@@ -924,7 +924,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
    {
       log_rule("sp_inside_angle");
 
-      argval_t op = cpd.settings[UO_sp_inside_angle].a;
+      iarf_e op = cpd.settings[UO_sp_inside_angle].a;
 
       // special: if we're not supporting digraphs, then we shouldn't create them!
       if (  (op == AV_REMOVE)
@@ -1749,12 +1749,12 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
    }
    if (chunk_is_token(first, CT_BOOL) || chunk_is_token(second, CT_BOOL))
    {
-      argval_t arg = cpd.settings[UO_sp_bool].a;
+      iarf_e arg = cpd.settings[UO_sp_bool].a;
       if (  (cpd.settings[UO_pos_bool].tp != TP_IGNORE)
          && first->orig_line != second->orig_line
          && arg != AV_REMOVE)
       {
-         arg = static_cast<argval_t>(arg | AV_ADD);
+         arg = static_cast<iarf_e>(arg | AV_ADD);
       }
       log_rule("sp_bool");
       return(arg);
@@ -1881,7 +1881,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (first->type != CT_PTR_TYPE)
       {
          log_rule("sp_type_func|ADD");
-         return(static_cast<argval_t>(cpd.settings[UO_sp_type_func].a | AV_ADD));
+         return(static_cast<iarf_e>(cpd.settings[UO_sp_type_func].a | AV_ADD));
       }
       log_rule("sp_type_func");
       return(cpd.settings[UO_sp_type_func].a);
@@ -2008,7 +2008,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (  !chunk_is_token(second, CT_PTR_TYPE)
       && (chunk_is_token(first, CT_QUALIFIER) || chunk_is_token(first, CT_TYPE)))
    {
-      argval_t arg = cpd.settings[UO_sp_after_type].a;
+      iarf_e arg = cpd.settings[UO_sp_after_type].a;
       log_rule("sp_after_type");
       return((arg != AV_REMOVE) ? arg : AV_FORCE);
    }
@@ -2201,7 +2201,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
 } // do_space
 
 
-static argval_t ensure_force_space(chunk_t *first, chunk_t *second, argval_t av)
+static iarf_e ensure_force_space(chunk_t *first, chunk_t *second, iarf_e av)
 {
    if (first->flags & PCF_FORCE_SPACE)
    {
@@ -2209,14 +2209,14 @@ static argval_t ensure_force_space(chunk_t *first, chunk_t *second, argval_t av)
       LOG_FMT(LSPACE, " <force between '%s' and '%s'>",
               first->text(), second->text());
       av_int |= AV_ADD;
-      return(static_cast<argval_t>(av_int));
+      return(static_cast<iarf_e>(av_int));
    }
 
    return(av);
 }
 
 
-static argval_t do_space_ensured(chunk_t *first, chunk_t *second, int &min_sp)
+static iarf_e do_space_ensured(chunk_t *first, chunk_t *second, int &min_sp)
 {
    return(ensure_force_space(first, second, do_space(first, second, min_sp)));
 }
@@ -2396,7 +2396,7 @@ void space_text(void)
          int min_sp;
          LOG_FMT(LSPACE, "%s(%d): orig_line is %zu, orig_col is %zu, pc-text() '%s', type is %s\n",
                  __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(), get_token_name(pc->type));
-         argval_t av = do_space_ensured(pc, next, min_sp);
+         iarf_e av = do_space_ensured(pc, next, min_sp);
          min_sp = max(1, min_sp);
          switch (av)
          {
@@ -2599,8 +2599,8 @@ size_t space_col_align(chunk_t *first, chunk_t *second)
            second->text());
    log_func_stack_inline(LSPACE);
 
-   int      min_sp;
-   argval_t av = do_space_ensured(first, second, min_sp);
+   int    min_sp;
+   iarf_e av = do_space_ensured(first, second, min_sp);
 
    LOG_FMT(LSPACE, "%s(%d): av is %s\n", __func__, __LINE__, argval_to_string(av).c_str());
    size_t coldiff;

--- a/src/space.h
+++ b/src/space.h
@@ -28,7 +28,7 @@ size_t space_needed(chunk_t *first, chunk_t *second);
 
 /**
  * Calculates the column difference between two chunks.
- * The rules are bent a bit here, as AV_IGNORE and AV_ADD become AV_FORCE.
+ * The rules are bent a bit here, as IARF_IGNORE and IARF_ADD become IARF_FORCE.
  * So the column difference is either first->len or first->len + 1.
  *
  * @param first   The first chunk

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1820,18 +1820,18 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
 
    case char_encoding_e::e_UTF16_LE:
    case char_encoding_e::e_UTF16_BE:
-      av = AV_FORCE;
+      av = IARF_FORCE;
       break;
 
    default:
-      av = AV_IGNORE;
+      av = IARF_IGNORE;
       break;
    }
-   if (av == AV_REMOVE)
+   if (av == IARF_REMOVE)
    {
       cpd.bom = false;
    }
-   else if (av != AV_IGNORE)
+   else if (av != IARF_IGNORE)
    {
       cpd.bom = true;
    }

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1811,7 +1811,7 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
    {
       cpd.enc = char_encoding_e::e_UTF8;
    }
-   argval_t av;
+   iarf_e av;
    switch (cpd.enc)
    {
    case char_encoding_e::e_UTF8:

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 650 options and minimal documentation.
+There are currently 651 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 


### PR DESCRIPTION
Rename `argval_t` to `iarf_e`. This is more consistent with the names of our other enumerations, and "argval" is a bit potentially misleading since it is not the only possible type of an "arg" (i.e. an option). Rename its values from `AV_*` to `IARF_*` for consistency with the new name. Remove `AV_NOT_DEFINED` which is not really needed and unnecessarily complicates things.

This is the first of what I expect will be at least two, if not several PRs that attempts to break down #1852 into smaller chunks. (I am especially trying to separate out stuff like this that has minimal semantic impact but lots of code churn.)
