### PR TITLE
better handling for decltype braced-init-list expressions

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1041,6 +1041,17 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       if (chunk_is_paren_open(tmp))
       {
          set_paren_parent(tmp, CT_DECLTYPE);
+
+         // decltype may be followed by a braced-init-list
+         tmp = chunk_get_next_type(tmp, CT_PAREN_CLOSE, tmp->level);
+         if (tmp != nullptr)
+         {
+            tmp = chunk_get_next_ncnl(tmp);
+            if (chunk_is_opening_brace(tmp))
+            {
+               set_paren_parent(tmp, CT_BRACED_INIT_LIST);
+            }
+         }
       }
    }
 

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1040,17 +1040,15 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       tmp = chunk_get_next_ncnl(pc);
       if (chunk_is_paren_open(tmp))
       {
-         set_paren_parent(tmp, CT_DECLTYPE);
-
          // decltype may be followed by a braced-init-list
-         tmp = chunk_get_next_type(tmp, CT_PAREN_CLOSE, tmp->level);
-         if (tmp != nullptr)
+         tmp = set_paren_parent(tmp, CT_DECLTYPE);
+         if (chunk_is_comment(tmp) || chunk_is_newline(tmp))
          {
             tmp = chunk_get_next_ncnl(tmp);
-            if (chunk_is_opening_brace(tmp))
-            {
-               set_paren_parent(tmp, CT_BRACED_INIT_LIST);
-            }
+         }
+         if (chunk_is_opening_brace(tmp))
+         {
+            set_paren_parent(tmp, CT_BRACED_INIT_LIST);
          }
       }
    }

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1042,10 +1042,6 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       {
          // decltype may be followed by a braced-init-list
          tmp = set_paren_parent(tmp, CT_DECLTYPE);
-         if (chunk_is_comment(tmp) || chunk_is_newline(tmp))
-         {
-            tmp = chunk_get_next_ncnl(tmp);
-         }
          if (chunk_is_opening_brace(tmp))
          {
             set_paren_parent(tmp, CT_BRACED_INIT_LIST);

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1231,20 +1231,17 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
       && second->parent_type == CT_BRACED_INIT_LIST)
    {
       auto arg = cpd.settings[UO_sp_type_brace_init_lst].a;
-      if (arg)
+      if (arg || first->parent_type != CT_DECLTYPE)
       {
          // 'int{9}' vs 'int {9}'
          log_rule("sp_type_brace_init_lst");
          return(arg);
       }
       // 'decltype(entity){9}' may be covered by sp_after_decltype
-      if (first->parent_type == CT_DECLTYPE)
+      if (auto arg = cpd.settings[UO_sp_after_decltype].a)
       {
-         if (auto arg = cpd.settings[UO_sp_after_decltype].a)
-         {
-            log_rule("sp_after_decltype");
-            return(arg);
-         }
+         log_rule("sp_after_decltype");
+         return(arg);
       }
       log_rule("sp_type_brace_init_lst");
       return(arg);

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1237,14 +1237,6 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_type_brace_init_lst");
          return(arg);
       }
-      // 'decltype(entity){9}' may be covered by sp_after_decltype
-      if (auto arg = cpd.settings[UO_sp_after_decltype].a)
-      {
-         log_rule("sp_after_decltype");
-         return(arg);
-      }
-      log_rule("sp_type_brace_init_lst");
-      return(arg);
    }
 
    if (chunk_is_token(second, CT_BRACE_CLOSE))

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1228,9 +1228,10 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (  !chunk_is_token(first, CT_BRACE_OPEN)
       && !chunk_is_token(first, CT_FPAREN_OPEN)
       && chunk_is_token(second, CT_BRACE_OPEN)
+      && first->parent_type != CT_DECLTYPE
       && second->parent_type == CT_BRACED_INIT_LIST)
    {
-      // 'int{9}' vs 'int {9}'
+      // 'int{9}' vs 'int {9}' but not 'decltype(var){9}' as it is covered by sp_after_decltype
       log_rule("sp_type_brace_init_lst");
       return(cpd.settings[UO_sp_type_brace_init_lst].a);
    }
@@ -1417,7 +1418,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
       return(cpd.settings[UO_sp_invariant_paren].a);
    }
 
-   if (chunk_is_token(first, CT_PAREN_CLOSE))
+   if (chunk_is_token(first, CT_PAREN_CLOSE) && first->parent_type != CT_DECLTYPE)
    {
       if (first->parent_type == CT_D_TEMPLATE)
       {
@@ -1986,6 +1987,11 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
       {
          log_rule("sp_after_decltype");
          return(arg);
+      }
+      if (cpd.settings[UO_sp_type_brace_init_lst].a && second->parent_type == CT_BRACED_INIT_LIST)
+      {
+         log_rule("sp_type_brace_init_lst");
+         return(cpd.settings[UO_sp_type_brace_init_lst].a);
       }
       log_rule("sp_after_type");
       return(cpd.settings[UO_sp_after_type].a);

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1228,12 +1228,26 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (  !chunk_is_token(first, CT_BRACE_OPEN)
       && !chunk_is_token(first, CT_FPAREN_OPEN)
       && chunk_is_token(second, CT_BRACE_OPEN)
-      && first->parent_type != CT_DECLTYPE
       && second->parent_type == CT_BRACED_INIT_LIST)
    {
-      // 'int{9}' vs 'int {9}' but not 'decltype(var){9}' as it is covered by sp_after_decltype
+      auto arg = cpd.settings[UO_sp_type_brace_init_lst].a;
+      if (arg)
+      {
+         // 'int{9}' vs 'int {9}'
+         log_rule("sp_type_brace_init_lst");
+         return(arg);
+      }
+      // 'decltype(entity){9}' may be covered by sp_after_decltype
+      if (first->parent_type == CT_DECLTYPE)
+      {
+         if (auto arg = cpd.settings[UO_sp_after_decltype].a)
+         {
+            log_rule("sp_after_decltype");
+            return(arg);
+         }
+      }
       log_rule("sp_type_brace_init_lst");
-      return(cpd.settings[UO_sp_type_brace_init_lst].a);
+      return(arg);
    }
 
    if (chunk_is_token(second, CT_BRACE_CLOSE))
@@ -1987,11 +2001,6 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
       {
          log_rule("sp_after_decltype");
          return(arg);
-      }
-      if (cpd.settings[UO_sp_type_brace_init_lst].a && second->parent_type == CT_BRACED_INIT_LIST)
-      {
-         log_rule("sp_type_brace_init_lst");
-         return(cpd.settings[UO_sp_type_brace_init_lst].a);
       }
       log_rule("sp_after_type");
       return(cpd.settings[UO_sp_after_type].a);

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -349,6 +349,8 @@
 31630  sp_after_type-f.cfg                  cpp/issue_1916.cpp
 31631  sp_after_type-r.cfg                  cpp/issue_1916.cpp
 31632  issue_1916.cfg                       cpp/issue_1916.cpp
+31633  sp_after_decltype-f.cfg              cpp/sp_after_decltype.cpp
+31634  sp_after_decltype-r.cfg              cpp/sp_after_decltype.cpp
 
 31700  toggle_processing_cmt.cfg            cpp/toggle_processing_cmt.cpp
 31701  toggle_processing_cmt2.cfg           cpp/toggle_processing_cmt2.cpp

--- a/tests/expected/cpp/31633-sp_after_decltype.cpp
+++ b/tests/expected/cpp/31633-sp_after_decltype.cpp
@@ -1,0 +1,8 @@
+int x;
+char y;
+auto x1 = decltype(x) {0};
+auto y1 = decltype(y) {'a'};
+
+unsigned rows;
+for (auto row = decltype(rows) {0}; row < rows; ++row) {
+}

--- a/tests/expected/cpp/31634-sp_after_decltype.cpp
+++ b/tests/expected/cpp/31634-sp_after_decltype.cpp
@@ -1,0 +1,8 @@
+int x;
+char y;
+auto x1 = decltype(x){0};
+auto y1 = decltype(y){'a'};
+
+unsigned rows;
+for (auto row = decltype(rows){0}; row < rows; ++row) {
+}

--- a/tests/input/cpp/sp_after_decltype.cpp
+++ b/tests/input/cpp/sp_after_decltype.cpp
@@ -1,0 +1,8 @@
+int x;
+char y;
+auto x1 = decltype(x)  {0};
+auto y1 = decltype(y)  {'a'};
+
+unsigned rows;
+for (auto row = decltype(rows){0}; row < rows; ++row) {
+}


### PR DESCRIPTION
A C++ decltype specifier may also be followed by a braced-init-list. Mark the brace-init-list as such and format `decltype(<name|expression>){<value>}` using the `sp_after_decltype` setting unless it is `ignore` in which case fall back to the setting for `sp_type_brace_init_lst`. If both are `ignore` the code falls back to the setting for `sp_after_type`.
