### PR TITLE
Remove print_options

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2544,59 +2544,6 @@ int save_option_file(FILE *pfile, bool withDoc)
 }
 
 
-void print_options(FILE *pfile)
-{
-   // TODO refactor to be independent of type positioning
-   const char *names[] =
-   {
-      "{ False, True }",
-      "{ Ignore, Add, Remove, Force }",
-      "Number",
-      "{ Auto, LF, CR, CRLF }",
-      "{ Ignore, Lead, Trail }",
-      "String",
-      "Unsigned Number",
-   };
-
-   fprintf(pfile, "# %s\n", UNCRUSTIFY_VERSION);
-
-   // Print the all out
-   for (auto &jt : group_map)
-   {
-      fprintf(pfile, "#\n# %s\n#\n\n", jt.second.short_desc);
-
-      for (auto option_id : jt.second.options)
-      {
-         const option_map_value *option = get_option_name(option_id);
-         int                    cur     = strlen(option->name);
-         int                    pad     = (cur < MAX_OPTION_NAME_LEN) ? (MAX_OPTION_NAME_LEN - cur) : 1;
-         fprintf(pfile, "%s%*c%s\n",
-                 option->name,
-                 pad, ' ',
-                 names[option->type]);
-
-         const char *text = option->short_desc;
-
-         if (text != nullptr)
-         {
-            fputs("  ", pfile);
-            while (*text != 0)
-            {
-               fputc(*text, pfile);
-               if (*text == '\n')
-               {
-                  fputs("  ", pfile);
-               }
-               text++;
-            }
-         }
-         fputs("\n\n", pfile);
-      }
-   }
-   fprintf(pfile, "%s", DOC_TEXT_END);
-} // print_options
-
-
 void set_option_defaults(void)
 {
    // set all the default values to zero

--- a/src/options.h
+++ b/src/options.h
@@ -1058,8 +1058,6 @@ const group_map_value *get_group_name(size_t ug);
 const option_map_value *get_option_name(uncrustify_options uo);
 
 
-void print_options(FILE *pfile);
-
 /**
  * convert a argument type to a string
  *

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -451,7 +451,8 @@ int main(int argc, char *argv[])
 
    if (arg.Present("--show-config"))
    {
-      print_options(stdout);
+      set_option_defaults();
+      save_option_file(stdout, true);
       return(EXIT_SUCCESS);
    }
 

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 650 options and minimal documentation.
+There are currently 651 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1,2233 +1,2231 @@
 
+
 #
 # General options
 #
 
-newlines                        { Auto, LF, CR, CRLF }
-  The type of line endings. Default=Auto.
+# The type of line endings. Default=Auto.
+newlines                        = auto     # auto/lf/crlf/cr
 
-input_tab_size                  Unsigned Number
-  The original size of tabs in the input. Default=8.
+# The original size of tabs in the input. Default=8.
+input_tab_size                  = 8        # unsigned number
 
-output_tab_size                 Unsigned Number
-  The size of tabs in the output (only used if align_with_tabs=true). Default=8.
+# The size of tabs in the output (only used if align_with_tabs=true). Default=8.
+output_tab_size                 = 8        # unsigned number
 
-string_escape_char              Unsigned Number
-  The ASCII value of the string escape char, usually 92 (\) or 94 (^). (Pawn).
+# The ASCII value of the string escape char, usually 92 (\) or 94 (^). (Pawn).
+string_escape_char              = 92       # unsigned number
 
-string_escape_char2             Unsigned Number
-  Alternate string escape char for Pawn. Only works right before the quote char.
+# Alternate string escape char for Pawn. Only works right before the quote char.
+string_escape_char2             = 0        # unsigned number
 
-string_replace_tab_chars        { False, True }
-  Replace tab characters found in string literals with the escape sequence \t instead.
+# Replace tab characters found in string literals with the escape sequence \t instead.
+string_replace_tab_chars        = false    # false/true
 
-tok_split_gte                   { False, True }
-  Allow interpreting '>=' and '>>=' as part of a template in 'void f(list<list<B>>=val);'.
-  If True, 'assert(x<0 && y>=3)' will be broken. Default=False
-  Improvements to template detection may make this option obsolete.
+# Allow interpreting '>=' and '>>=' as part of a template in 'void f(list<list<B>>=val);'.
+# If True, 'assert(x<0 && y>=3)' will be broken. Default=False
+# Improvements to template detection may make this option obsolete.
+tok_split_gte                   = false    # false/true
 
-disable_processing_cmt          String
-  Override the default ' *INDENT-OFF*' in comments for disabling processing of part of the file.
+# Override the default ' *INDENT-OFF*' in comments for disabling processing of part of the file.
+disable_processing_cmt          = ""         # string
 
-enable_processing_cmt           String
-  Override the default ' *INDENT-ON*' in comments for enabling processing of part of the file.
+# Override the default ' *INDENT-ON*' in comments for enabling processing of part of the file.
+enable_processing_cmt           = ""         # string
 
-enable_digraphs                 { False, True }
-  Enable parsing of digraphs. Default=False.
+# Enable parsing of digraphs. Default=False.
+enable_digraphs                 = false    # false/true
 
-utf8_bom                        { Ignore, Add, Remove, Force }
-  Control what to do with the UTF-8 BOM (recommend 'remove').
+# Control what to do with the UTF-8 BOM (recommend 'remove').
+utf8_bom                        = ignore   # ignore/add/remove/force
 
-utf8_byte                       { False, True }
-  If the file contains bytes with values between 128 and 255, but is not UTF-8, then output as UTF-8.
+# If the file contains bytes with values between 128 and 255, but is not UTF-8, then output as UTF-8.
+utf8_byte                       = false    # false/true
 
-utf8_force                      { False, True }
-  Force the output encoding to UTF-8.
+# Force the output encoding to UTF-8.
+utf8_force                      = false    # false/true
 
 #
 # Spacing options
 #
 
-sp_arith                        { Ignore, Add, Remove, Force }
-  Add or remove space around arithmetic operator '+', '-', '/', '*', etc
-  also '>>>' '<<' '>>' '%' '|'.
+# Add or remove space around arithmetic operator '+', '-', '/', '*', etc
+# also '>>>' '<<' '>>' '%' '|'.
+sp_arith                        = ignore   # ignore/add/remove/force
 
-sp_arith_additive               { Ignore, Add, Remove, Force }
-  Add or remove space around arithmetic operator '+' and '-'. Overrides sp_arith
+# Add or remove space around arithmetic operator '+' and '-'. Overrides sp_arith
+sp_arith_additive               = ignore   # ignore/add/remove/force
 
-sp_assign                       { Ignore, Add, Remove, Force }
-  Add or remove space around assignment operator '=', '+=', etc.
+# Add or remove space around assignment operator '=', '+=', etc.
+sp_assign                       = ignore   # ignore/add/remove/force
 
-sp_cpp_lambda_assign            { Ignore, Add, Remove, Force }
-  Add or remove space around '=' in C++11 lambda capture specifications. Overrides sp_assign.
+# Add or remove space around '=' in C++11 lambda capture specifications. Overrides sp_assign.
+sp_cpp_lambda_assign            = ignore   # ignore/add/remove/force
 
-sp_cpp_lambda_paren             { Ignore, Add, Remove, Force }
-  Add or remove space after the capture specification in C++11 lambda.
+# Add or remove space after the capture specification in C++11 lambda.
+sp_cpp_lambda_paren             = ignore   # ignore/add/remove/force
 
-sp_assign_default               { Ignore, Add, Remove, Force }
-  Add or remove space around assignment operator '=' in a prototype.
+# Add or remove space around assignment operator '=' in a prototype.
+sp_assign_default               = ignore   # ignore/add/remove/force
 
-sp_before_assign                { Ignore, Add, Remove, Force }
-  Add or remove space before assignment operator '=', '+=', etc. Overrides sp_assign.
+# Add or remove space before assignment operator '=', '+=', etc. Overrides sp_assign.
+sp_before_assign                = ignore   # ignore/add/remove/force
 
-sp_after_assign                 { Ignore, Add, Remove, Force }
-  Add or remove space after assignment operator '=', '+=', etc. Overrides sp_assign.
+# Add or remove space after assignment operator '=', '+=', etc. Overrides sp_assign.
+sp_after_assign                 = ignore   # ignore/add/remove/force
 
-sp_enum_paren                   { Ignore, Add, Remove, Force }
-  Add or remove space in 'NS_ENUM ('.
+# Add or remove space in 'NS_ENUM ('.
+sp_enum_paren                   = ignore   # ignore/add/remove/force
 
-sp_enum_assign                  { Ignore, Add, Remove, Force }
-  Add or remove space around assignment '=' in enum.
+# Add or remove space around assignment '=' in enum.
+sp_enum_assign                  = ignore   # ignore/add/remove/force
 
-sp_enum_before_assign           { Ignore, Add, Remove, Force }
-  Add or remove space before assignment '=' in enum. Overrides sp_enum_assign.
+# Add or remove space before assignment '=' in enum. Overrides sp_enum_assign.
+sp_enum_before_assign           = ignore   # ignore/add/remove/force
 
-sp_enum_after_assign            { Ignore, Add, Remove, Force }
-  Add or remove space after assignment '=' in enum. Overrides sp_enum_assign.
+# Add or remove space after assignment '=' in enum. Overrides sp_enum_assign.
+sp_enum_after_assign            = ignore   # ignore/add/remove/force
 
-sp_enum_colon                   { Ignore, Add, Remove, Force }
-  Add or remove space around assignment ':' in enum.
+# Add or remove space around assignment ':' in enum.
+sp_enum_colon                   = ignore   # ignore/add/remove/force
 
-sp_pp_concat                    { Ignore, Add, Remove, Force }
-  Add or remove space around preprocessor '##' concatenation operator. Default=Add.
+# Add or remove space around preprocessor '##' concatenation operator. Default=Add.
+sp_pp_concat                    = add      # ignore/add/remove/force
 
-sp_pp_stringify                 { Ignore, Add, Remove, Force }
-  Add or remove space after preprocessor '#' stringify operator. Also affects the '#@' charizing operator.
+# Add or remove space after preprocessor '#' stringify operator. Also affects the '#@' charizing operator.
+sp_pp_stringify                 = ignore   # ignore/add/remove/force
 
-sp_before_pp_stringify          { Ignore, Add, Remove, Force }
-  Add or remove space before preprocessor '#' stringify operator as in '#define x(y) L#y'.
+# Add or remove space before preprocessor '#' stringify operator as in '#define x(y) L#y'.
+sp_before_pp_stringify          = ignore   # ignore/add/remove/force
 
-sp_bool                         { Ignore, Add, Remove, Force }
-  Add or remove space around boolean operators '&&' and '||'.
+# Add or remove space around boolean operators '&&' and '||'.
+sp_bool                         = ignore   # ignore/add/remove/force
 
-sp_compare                      { Ignore, Add, Remove, Force }
-  Add or remove space around compare operator '<', '>', '==', etc.
+# Add or remove space around compare operator '<', '>', '==', etc.
+sp_compare                      = ignore   # ignore/add/remove/force
 
-sp_inside_paren                 { Ignore, Add, Remove, Force }
-  Add or remove space inside '(' and ')'.
+# Add or remove space inside '(' and ')'.
+sp_inside_paren                 = ignore   # ignore/add/remove/force
 
-sp_paren_paren                  { Ignore, Add, Remove, Force }
-  Add or remove space between nested parens: '((' vs ') )'.
+# Add or remove space between nested parens: '((' vs ') )'.
+sp_paren_paren                  = ignore   # ignore/add/remove/force
 
-sp_cparen_oparen                { Ignore, Add, Remove, Force }
-  Add or remove space between back-to-back parens: ')(' vs ') ('.
+# Add or remove space between back-to-back parens: ')(' vs ') ('.
+sp_cparen_oparen                = ignore   # ignore/add/remove/force
 
-sp_balance_nested_parens        { False, True }
-  Whether to balance spaces inside nested parens.
+# Whether to balance spaces inside nested parens.
+sp_balance_nested_parens        = false    # false/true
 
-sp_paren_brace                  { Ignore, Add, Remove, Force }
-  Add or remove space between ')' and '{'.
+# Add or remove space between ')' and '{'.
+sp_paren_brace                  = ignore   # ignore/add/remove/force
 
-sp_brace_brace                  { Ignore, Add, Remove, Force }
-  Add or remove space between nested braces: '{{' vs '} }'.
+# Add or remove space between nested braces: '{{' vs '} }'.
+sp_brace_brace                  = ignore   # ignore/add/remove/force
 
-sp_before_ptr_star              { Ignore, Add, Remove, Force }
-  Add or remove space before pointer star '*'.
+# Add or remove space before pointer star '*'.
+sp_before_ptr_star              = ignore   # ignore/add/remove/force
 
-sp_before_unnamed_ptr_star      { Ignore, Add, Remove, Force }
-  Add or remove space before pointer star '*' that isn't followed by a variable name
-  If set to 'ignore', sp_before_ptr_star is used instead.
+# Add or remove space before pointer star '*' that isn't followed by a variable name
+# If set to 'ignore', sp_before_ptr_star is used instead.
+sp_before_unnamed_ptr_star      = ignore   # ignore/add/remove/force
 
-sp_between_ptr_star             { Ignore, Add, Remove, Force }
-  Add or remove space between pointer stars '*'.
+# Add or remove space between pointer stars '*'.
+sp_between_ptr_star             = ignore   # ignore/add/remove/force
 
-sp_after_ptr_star               { Ignore, Add, Remove, Force }
-  Add or remove space after pointer star '*', if followed by a word.
+# Add or remove space after pointer star '*', if followed by a word.
+sp_after_ptr_star               = ignore   # ignore/add/remove/force
 
-sp_after_ptr_block_caret        { Ignore, Add, Remove, Force }
-  Add or remove space after pointer caret '^', if followed by a word.
+# Add or remove space after pointer caret '^', if followed by a word.
+sp_after_ptr_block_caret        = ignore   # ignore/add/remove/force
 
-sp_after_ptr_star_qualifier     { Ignore, Add, Remove, Force }
-  Add or remove space after pointer star '*', if followed by a qualifier.
+# Add or remove space after pointer star '*', if followed by a qualifier.
+sp_after_ptr_star_qualifier     = ignore   # ignore/add/remove/force
 
-sp_after_ptr_star_func          { Ignore, Add, Remove, Force }
-  Add or remove space after a pointer star '*', if followed by a func proto/def.
+# Add or remove space after a pointer star '*', if followed by a func proto/def.
+sp_after_ptr_star_func          = ignore   # ignore/add/remove/force
 
-sp_ptr_star_paren               { Ignore, Add, Remove, Force }
-  Add or remove space after a pointer star '*', if followed by an open paren (function types).
+# Add or remove space after a pointer star '*', if followed by an open paren (function types).
+sp_ptr_star_paren               = ignore   # ignore/add/remove/force
 
-sp_before_ptr_star_func         { Ignore, Add, Remove, Force }
-  Add or remove space before a pointer star '*', if followed by a func proto/def.
+# Add or remove space before a pointer star '*', if followed by a func proto/def.
+sp_before_ptr_star_func         = ignore   # ignore/add/remove/force
 
-sp_before_byref                 { Ignore, Add, Remove, Force }
-  Add or remove space before a reference sign '&'.
+# Add or remove space before a reference sign '&'.
+sp_before_byref                 = ignore   # ignore/add/remove/force
 
-sp_before_unnamed_byref         { Ignore, Add, Remove, Force }
-  Add or remove space before a reference sign '&' that isn't followed by a variable name.
-  If set to 'ignore', sp_before_byref is used instead.
+# Add or remove space before a reference sign '&' that isn't followed by a variable name.
+# If set to 'ignore', sp_before_byref is used instead.
+sp_before_unnamed_byref         = ignore   # ignore/add/remove/force
 
-sp_after_byref                  { Ignore, Add, Remove, Force }
-  Add or remove space after reference sign '&', if followed by a word.
+# Add or remove space after reference sign '&', if followed by a word.
+sp_after_byref                  = ignore   # ignore/add/remove/force
 
-sp_after_byref_func             { Ignore, Add, Remove, Force }
-  Add or remove space after a reference sign '&', if followed by a func proto/def.
+# Add or remove space after a reference sign '&', if followed by a func proto/def.
+sp_after_byref_func             = ignore   # ignore/add/remove/force
 
-sp_before_byref_func            { Ignore, Add, Remove, Force }
-  Add or remove space before a reference sign '&', if followed by a func proto/def.
+# Add or remove space before a reference sign '&', if followed by a func proto/def.
+sp_before_byref_func            = ignore   # ignore/add/remove/force
 
-sp_after_type                   { Ignore, Add, Remove, Force }
-  Add or remove space between type and word. Default=Force.
+# Add or remove space between type and word. Default=Force.
+sp_after_type                   = force    # ignore/add/remove/force
 
-sp_after_decltype               { Ignore, Add, Remove, Force }
-  Add or remove space between 'decltype(...)' and word.
+# Add or remove space between 'decltype(...)' and word.
+sp_after_decltype               = ignore   # ignore/add/remove/force
 
-sp_before_template_paren        { Ignore, Add, Remove, Force }
-  Add or remove space before the paren in the D constructs 'template Foo(' and 'class Foo('.
+# Add or remove space before the paren in the D constructs 'template Foo(' and 'class Foo('.
+sp_before_template_paren        = ignore   # ignore/add/remove/force
 
-sp_template_angle               { Ignore, Add, Remove, Force }
-  Add or remove space in 'template <' vs 'template<'.
-  If set to ignore, sp_before_angle is used.
+# Add or remove space in 'template <' vs 'template<'.
+# If set to ignore, sp_before_angle is used.
+sp_template_angle               = ignore   # ignore/add/remove/force
 
-sp_before_angle                 { Ignore, Add, Remove, Force }
-  Add or remove space before '<>'.
+# Add or remove space before '<>'.
+sp_before_angle                 = ignore   # ignore/add/remove/force
 
-sp_inside_angle                 { Ignore, Add, Remove, Force }
-  Add or remove space inside '<' and '>'.
+# Add or remove space inside '<' and '>'.
+sp_inside_angle                 = ignore   # ignore/add/remove/force
 
-sp_angle_colon                  { Ignore, Add, Remove, Force }
-  Add or remove space between '<>' and ':'.
+# Add or remove space between '<>' and ':'.
+sp_angle_colon                  = ignore   # ignore/add/remove/force
 
-sp_after_angle                  { Ignore, Add, Remove, Force }
-  Add or remove space after '<>'.
+# Add or remove space after '<>'.
+sp_after_angle                  = ignore   # ignore/add/remove/force
 
-sp_angle_paren                  { Ignore, Add, Remove, Force }
-  Add or remove space between '<>' and '(' as found in 'new List<byte>(foo);'.
+# Add or remove space between '<>' and '(' as found in 'new List<byte>(foo);'.
+sp_angle_paren                  = ignore   # ignore/add/remove/force
 
-sp_angle_paren_empty            { Ignore, Add, Remove, Force }
-  Add or remove space between '<>' and '()' as found in 'new List<byte>();'.
+# Add or remove space between '<>' and '()' as found in 'new List<byte>();'.
+sp_angle_paren_empty            = ignore   # ignore/add/remove/force
 
-sp_angle_word                   { Ignore, Add, Remove, Force }
-  Add or remove space between '<>' and a word as in 'List<byte> m;' or 'template <typename T> static ...'.
+# Add or remove space between '<>' and a word as in 'List<byte> m;' or 'template <typename T> static ...'.
+sp_angle_word                   = ignore   # ignore/add/remove/force
 
-sp_angle_shift                  { Ignore, Add, Remove, Force }
-  Add or remove space between '>' and '>' in '>>' (template stuff). Default=Add.
+# Add or remove space between '>' and '>' in '>>' (template stuff). Default=Add.
+sp_angle_shift                  = add      # ignore/add/remove/force
 
-sp_permit_cpp11_shift           { False, True }
-  Permit removal of the space between '>>' in 'foo<bar<int> >' (C++11 only). Default=False.
-  sp_angle_shift cannot remove the space without this option.
+# Permit removal of the space between '>>' in 'foo<bar<int> >' (C++11 only). Default=False.
+# sp_angle_shift cannot remove the space without this option.
+sp_permit_cpp11_shift           = false    # false/true
 
-sp_before_sparen                { Ignore, Add, Remove, Force }
-  Add or remove space before '(' of 'if', 'for', 'switch', 'while', etc.
+# Add or remove space before '(' of 'if', 'for', 'switch', 'while', etc.
+sp_before_sparen                = ignore   # ignore/add/remove/force
 
-sp_inside_sparen                { Ignore, Add, Remove, Force }
-  Add or remove space inside if-condition '(' and ')'.
+# Add or remove space inside if-condition '(' and ')'.
+sp_inside_sparen                = ignore   # ignore/add/remove/force
 
-sp_inside_sparen_close          { Ignore, Add, Remove, Force }
-  Add or remove space before if-condition ')'. Overrides sp_inside_sparen.
+# Add or remove space before if-condition ')'. Overrides sp_inside_sparen.
+sp_inside_sparen_close          = ignore   # ignore/add/remove/force
 
-sp_inside_sparen_open           { Ignore, Add, Remove, Force }
-  Add or remove space after if-condition '('. Overrides sp_inside_sparen.
+# Add or remove space after if-condition '('. Overrides sp_inside_sparen.
+sp_inside_sparen_open           = ignore   # ignore/add/remove/force
 
-sp_after_sparen                 { Ignore, Add, Remove, Force }
-  Add or remove space after ')' of 'if', 'for', 'switch', and 'while', etc.
+# Add or remove space after ')' of 'if', 'for', 'switch', and 'while', etc.
+sp_after_sparen                 = ignore   # ignore/add/remove/force
 
-sp_sparen_brace                 { Ignore, Add, Remove, Force }
-  Add or remove space between ')' and '{' of 'if', 'for', 'switch', and 'while', etc.
+# Add or remove space between ')' and '{' of 'if', 'for', 'switch', and 'while', etc.
+sp_sparen_brace                 = ignore   # ignore/add/remove/force
 
-sp_invariant_paren              { Ignore, Add, Remove, Force }
-  Add or remove space between 'invariant' and '(' in the D language.
+# Add or remove space between 'invariant' and '(' in the D language.
+sp_invariant_paren              = ignore   # ignore/add/remove/force
 
-sp_after_invariant_paren        { Ignore, Add, Remove, Force }
-  Add or remove space after the ')' in 'invariant (C) c' in the D language.
+# Add or remove space after the ')' in 'invariant (C) c' in the D language.
+sp_after_invariant_paren        = ignore   # ignore/add/remove/force
 
-sp_special_semi                 { Ignore, Add, Remove, Force }
-  Add or remove space before empty statement ';' on 'if', 'for' and 'while'.
+# Add or remove space before empty statement ';' on 'if', 'for' and 'while'.
+sp_special_semi                 = ignore   # ignore/add/remove/force
 
-sp_before_semi                  { Ignore, Add, Remove, Force }
-  Add or remove space before ';'. Default=Remove.
+# Add or remove space before ';'. Default=Remove.
+sp_before_semi                  = remove   # ignore/add/remove/force
 
-sp_before_semi_for              { Ignore, Add, Remove, Force }
-  Add or remove space before ';' in non-empty 'for' statements.
+# Add or remove space before ';' in non-empty 'for' statements.
+sp_before_semi_for              = ignore   # ignore/add/remove/force
 
-sp_before_semi_for_empty        { Ignore, Add, Remove, Force }
-  Add or remove space before a semicolon of an empty part of a for statement.
+# Add or remove space before a semicolon of an empty part of a for statement.
+sp_before_semi_for_empty        = ignore   # ignore/add/remove/force
 
-sp_after_semi                   { Ignore, Add, Remove, Force }
-  Add or remove space after ';', except when followed by a comment. Default=Add.
+# Add or remove space after ';', except when followed by a comment. Default=Add.
+sp_after_semi                   = add      # ignore/add/remove/force
 
-sp_after_semi_for               { Ignore, Add, Remove, Force }
-  Add or remove space after ';' in non-empty 'for' statements. Default=Force.
+# Add or remove space after ';' in non-empty 'for' statements. Default=Force.
+sp_after_semi_for               = force    # ignore/add/remove/force
 
-sp_after_semi_for_empty         { Ignore, Add, Remove, Force }
-  Add or remove space after the final semicolon of an empty part of a for statement: for ( ; ; <here> ).
+# Add or remove space after the final semicolon of an empty part of a for statement: for ( ; ; <here> ).
+sp_after_semi_for_empty         = ignore   # ignore/add/remove/force
 
-sp_before_square                { Ignore, Add, Remove, Force }
-  Add or remove space before '[' (except '[]').
+# Add or remove space before '[' (except '[]').
+sp_before_square                = ignore   # ignore/add/remove/force
 
-sp_before_squares               { Ignore, Add, Remove, Force }
-  Add or remove space before '[]'.
+# Add or remove space before '[]'.
+sp_before_squares               = ignore   # ignore/add/remove/force
 
-sp_cpp_before_struct_binding    { Ignore, Add, Remove, Force }
-  Add or remove space before structured bindings. Only for C++17.
+# Add or remove space before structured bindings. Only for C++17.
+sp_cpp_before_struct_binding    = ignore   # ignore/add/remove/force
 
-sp_inside_square                { Ignore, Add, Remove, Force }
-  Add or remove space inside a non-empty '[' and ']'.
+# Add or remove space inside a non-empty '[' and ']'.
+sp_inside_square                = ignore   # ignore/add/remove/force
 
-sp_inside_square_oc_array       { Ignore, Add, Remove, Force }
-  Add or remove space inside a non-empty OC boxed array '@[' and ']'.
-  If set to ignore, sp_inside_square is used.
+# Add or remove space inside a non-empty OC boxed array '@[' and ']'.
+# If set to ignore, sp_inside_square is used.
+sp_inside_square_oc_array       = ignore   # ignore/add/remove/force
 
-sp_after_comma                  { Ignore, Add, Remove, Force }
-  Add or remove space after ',', 'a,b' vs 'a, b'.
+# Add or remove space after ',', 'a,b' vs 'a, b'.
+sp_after_comma                  = ignore   # ignore/add/remove/force
 
-sp_before_comma                 { Ignore, Add, Remove, Force }
-  Add or remove space before ','. Default=Remove.
+# Add or remove space before ','. Default=Remove.
+sp_before_comma                 = remove   # ignore/add/remove/force
 
-sp_after_mdatype_commas         { Ignore, Add, Remove, Force }
-  Add or remove space between ',' and ']' in multidimensional array type 'int[,,]'. Only for C#.
+# Add or remove space between ',' and ']' in multidimensional array type 'int[,,]'. Only for C#.
+sp_after_mdatype_commas         = ignore   # ignore/add/remove/force
 
-sp_before_mdatype_commas        { Ignore, Add, Remove, Force }
-  Add or remove space between '[' and ',' in multidimensional array type 'int[,,]'. Only for C#.
+# Add or remove space between '[' and ',' in multidimensional array type 'int[,,]'. Only for C#.
+sp_before_mdatype_commas        = ignore   # ignore/add/remove/force
 
-sp_between_mdatype_commas       { Ignore, Add, Remove, Force }
-  Add or remove space between ',' in multidimensional array type 'int[,,]'. Only for C#.
+# Add or remove space between ',' in multidimensional array type 'int[,,]'. Only for C#.
+sp_between_mdatype_commas       = ignore   # ignore/add/remove/force
 
-sp_paren_comma                  { Ignore, Add, Remove, Force }
-  Add or remove space between an open paren and comma: '(,' vs '( ,'. Default=Force.
+# Add or remove space between an open paren and comma: '(,' vs '( ,'. Default=Force.
+sp_paren_comma                  = force    # ignore/add/remove/force
 
-sp_before_ellipsis              { Ignore, Add, Remove, Force }
-  Add or remove space before the variadic '...' when preceded by a non-punctuator.
+# Add or remove space before the variadic '...' when preceded by a non-punctuator.
+sp_before_ellipsis              = ignore   # ignore/add/remove/force
 
-sp_type_ellipsis                { Ignore, Add, Remove, Force }
-  Add or remove space between a type and '...'.
+# Add or remove space between a type and '...'.
+sp_type_ellipsis                = ignore   # ignore/add/remove/force
 
-sp_paren_ellipsis               { Ignore, Add, Remove, Force }
-  Add or remove space between ')' and '...'.
+# Add or remove space between ')' and '...'.
+sp_paren_ellipsis               = ignore   # ignore/add/remove/force
 
-sp_after_class_colon            { Ignore, Add, Remove, Force }
-  Add or remove space after class ':'.
+# Add or remove space after class ':'.
+sp_after_class_colon            = ignore   # ignore/add/remove/force
 
-sp_before_class_colon           { Ignore, Add, Remove, Force }
-  Add or remove space before class ':'.
+# Add or remove space before class ':'.
+sp_before_class_colon           = ignore   # ignore/add/remove/force
 
-sp_after_constr_colon           { Ignore, Add, Remove, Force }
-  Add or remove space after class constructor ':'.
+# Add or remove space after class constructor ':'.
+sp_after_constr_colon           = ignore   # ignore/add/remove/force
 
-sp_before_constr_colon          { Ignore, Add, Remove, Force }
-  Add or remove space before class constructor ':'.
+# Add or remove space before class constructor ':'.
+sp_before_constr_colon          = ignore   # ignore/add/remove/force
 
-sp_before_case_colon            { Ignore, Add, Remove, Force }
-  Add or remove space before case ':'. Default=Remove.
+# Add or remove space before case ':'. Default=Remove.
+sp_before_case_colon            = remove   # ignore/add/remove/force
 
-sp_after_operator               { Ignore, Add, Remove, Force }
-  Add or remove space between 'operator' and operator sign.
+# Add or remove space between 'operator' and operator sign.
+sp_after_operator               = ignore   # ignore/add/remove/force
 
-sp_after_operator_sym           { Ignore, Add, Remove, Force }
-  Add or remove space between the operator symbol and the open paren, as in 'operator ++('.
+# Add or remove space between the operator symbol and the open paren, as in 'operator ++('.
+sp_after_operator_sym           = ignore   # ignore/add/remove/force
 
-sp_after_operator_sym_empty     { Ignore, Add, Remove, Force }
-  Overrides sp_after_operator_sym when the operator has no arguments, as in 'operator *()'.
+# Overrides sp_after_operator_sym when the operator has no arguments, as in 'operator *()'.
+sp_after_operator_sym_empty     = ignore   # ignore/add/remove/force
 
-sp_after_cast                   { Ignore, Add, Remove, Force }
-  Add or remove space after C/D cast, i.e. 'cast(int)a' vs 'cast(int) a' or '(int)a' vs '(int) a'.
+# Add or remove space after C/D cast, i.e. 'cast(int)a' vs 'cast(int) a' or '(int)a' vs '(int) a'.
+sp_after_cast                   = ignore   # ignore/add/remove/force
 
-sp_inside_paren_cast            { Ignore, Add, Remove, Force }
-  Add or remove spaces inside cast parens.
+# Add or remove spaces inside cast parens.
+sp_inside_paren_cast            = ignore   # ignore/add/remove/force
 
-sp_cpp_cast_paren               { Ignore, Add, Remove, Force }
-  Add or remove space between the type and open paren in a C++ cast, i.e. 'int(exp)' vs 'int (exp)'.
+# Add or remove space between the type and open paren in a C++ cast, i.e. 'int(exp)' vs 'int (exp)'.
+sp_cpp_cast_paren               = ignore   # ignore/add/remove/force
 
-sp_sizeof_paren                 { Ignore, Add, Remove, Force }
-  Add or remove space between 'sizeof' and '('.
+# Add or remove space between 'sizeof' and '('.
+sp_sizeof_paren                 = ignore   # ignore/add/remove/force
 
-sp_sizeof_ellipsis              { Ignore, Add, Remove, Force }
-  Add or remove space between 'sizeof' and '...'.
+# Add or remove space between 'sizeof' and '...'.
+sp_sizeof_ellipsis              = ignore   # ignore/add/remove/force
 
-sp_sizeof_ellipsis_paren        { Ignore, Add, Remove, Force }
-  Add or remove space between 'sizeof...' and '('.
+# Add or remove space between 'sizeof...' and '('.
+sp_sizeof_ellipsis_paren        = ignore   # ignore/add/remove/force
 
-sp_decltype_paren               { Ignore, Add, Remove, Force }
-  Add or remove space between 'decltype' and '('.
+# Add or remove space between 'decltype' and '('.
+sp_decltype_paren               = ignore   # ignore/add/remove/force
 
-sp_after_tag                    { Ignore, Add, Remove, Force }
-  Add or remove space after the tag keyword (Pawn).
+# Add or remove space after the tag keyword (Pawn).
+sp_after_tag                    = ignore   # ignore/add/remove/force
 
-sp_inside_braces_enum           { Ignore, Add, Remove, Force }
-  Add or remove space inside enum '{' and '}'.
+# Add or remove space inside enum '{' and '}'.
+sp_inside_braces_enum           = ignore   # ignore/add/remove/force
 
-sp_inside_braces_struct         { Ignore, Add, Remove, Force }
-  Add or remove space inside struct/union '{' and '}'.
+# Add or remove space inside struct/union '{' and '}'.
+sp_inside_braces_struct         = ignore   # ignore/add/remove/force
 
-sp_inside_braces_oc_dict        { Ignore, Add, Remove, Force }
-  Add or remove space inside OC boxed dictionary @'{' and '}'
+# Add or remove space inside OC boxed dictionary @'{' and '}'
+sp_inside_braces_oc_dict        = ignore   # ignore/add/remove/force
 
-sp_after_type_brace_init_lst_open { Ignore, Add, Remove, Force }
-  Add or remove space after open brace in an unnamed temporary direct-list-initialization.
+# Add or remove space after open brace in an unnamed temporary direct-list-initialization.
+sp_after_type_brace_init_lst_open = ignore   # ignore/add/remove/force
 
-sp_before_type_brace_init_lst_close { Ignore, Add, Remove, Force }
-  Add or remove space before close brace in an unnamed temporary direct-list-initialization.
+# Add or remove space before close brace in an unnamed temporary direct-list-initialization.
+sp_before_type_brace_init_lst_close = ignore   # ignore/add/remove/force
 
-sp_inside_type_brace_init_lst   { Ignore, Add, Remove, Force }
-  Add or remove space inside an unnamed temporary direct-list-initialization.
+# Add or remove space inside an unnamed temporary direct-list-initialization.
+sp_inside_type_brace_init_lst   = ignore   # ignore/add/remove/force
 
-sp_inside_braces                { Ignore, Add, Remove, Force }
-  Add or remove space inside '{' and '}'.
+# Add or remove space inside '{' and '}'.
+sp_inside_braces                = ignore   # ignore/add/remove/force
 
-sp_inside_braces_empty          { Ignore, Add, Remove, Force }
-  Add or remove space inside '{}'.
+# Add or remove space inside '{}'.
+sp_inside_braces_empty          = ignore   # ignore/add/remove/force
 
-sp_type_func                    { Ignore, Add, Remove, Force }
-  Add or remove space between return type and function name
-  A minimum of 1 is forced except for pointer return types.
+# Add or remove space between return type and function name
+# A minimum of 1 is forced except for pointer return types.
+sp_type_func                    = ignore   # ignore/add/remove/force
 
-sp_type_brace_init_lst          { Ignore, Add, Remove, Force }
-  Add or remove space between type and open brace of an unnamed temporary direct-list-initialization.
+# Add or remove space between type and open brace of an unnamed temporary direct-list-initialization.
+sp_type_brace_init_lst          = ignore   # ignore/add/remove/force
 
-sp_func_proto_paren             { Ignore, Add, Remove, Force }
-  Add or remove space between function name and '(' on function declaration.
+# Add or remove space between function name and '(' on function declaration.
+sp_func_proto_paren             = ignore   # ignore/add/remove/force
 
-sp_func_proto_paren_empty       { Ignore, Add, Remove, Force }
-  Add or remove space between function name and '()' on function declaration without parameters.
+# Add or remove space between function name and '()' on function declaration without parameters.
+sp_func_proto_paren_empty       = ignore   # ignore/add/remove/force
 
-sp_func_def_paren               { Ignore, Add, Remove, Force }
-  Add or remove space between function name and '(' on function definition.
+# Add or remove space between function name and '(' on function definition.
+sp_func_def_paren               = ignore   # ignore/add/remove/force
 
-sp_func_def_paren_empty         { Ignore, Add, Remove, Force }
-  Add or remove space between function name and '()' on function definition without parameters.
+# Add or remove space between function name and '()' on function definition without parameters.
+sp_func_def_paren_empty         = ignore   # ignore/add/remove/force
 
-sp_inside_fparens               { Ignore, Add, Remove, Force }
-  Add or remove space inside empty function '()'.
+# Add or remove space inside empty function '()'.
+sp_inside_fparens               = ignore   # ignore/add/remove/force
 
-sp_inside_fparen                { Ignore, Add, Remove, Force }
-  Add or remove space inside function '(' and ')'.
+# Add or remove space inside function '(' and ')'.
+sp_inside_fparen                = ignore   # ignore/add/remove/force
 
-sp_inside_tparen                { Ignore, Add, Remove, Force }
-  Add or remove space inside the first parens in the function type: 'void (*x)(...)'.
+# Add or remove space inside the first parens in the function type: 'void (*x)(...)'.
+sp_inside_tparen                = ignore   # ignore/add/remove/force
 
-sp_after_tparen_close           { Ignore, Add, Remove, Force }
-  Add or remove between the parens in the function type: 'void (*x)(...)'.
+# Add or remove between the parens in the function type: 'void (*x)(...)'.
+sp_after_tparen_close           = ignore   # ignore/add/remove/force
 
-sp_square_fparen                { Ignore, Add, Remove, Force }
-  Add or remove space between ']' and '(' when part of a function call.
+# Add or remove space between ']' and '(' when part of a function call.
+sp_square_fparen                = ignore   # ignore/add/remove/force
 
-sp_fparen_brace                 { Ignore, Add, Remove, Force }
-  Add or remove space between ')' and '{' of function.
+# Add or remove space between ')' and '{' of function.
+sp_fparen_brace                 = ignore   # ignore/add/remove/force
 
-sp_fparen_brace_initializer     { Ignore, Add, Remove, Force }
-  Add or remove space between ')' and '{' of function call in object initialization. Overrides sp_fparen_brace.
+# Add or remove space between ')' and '{' of function call in object initialization. Overrides sp_fparen_brace.
+sp_fparen_brace_initializer     = ignore   # ignore/add/remove/force
 
-sp_fparen_dbrace                { Ignore, Add, Remove, Force }
-  Java: Add or remove space between ')' and '{{' of double brace initializer.
+# Java: Add or remove space between ')' and '{{' of double brace initializer.
+sp_fparen_dbrace                = ignore   # ignore/add/remove/force
 
-sp_func_call_paren              { Ignore, Add, Remove, Force }
-  Add or remove space between function name and '(' on function calls.
+# Add or remove space between function name and '(' on function calls.
+sp_func_call_paren              = ignore   # ignore/add/remove/force
 
-sp_func_call_paren_empty        { Ignore, Add, Remove, Force }
-  Add or remove space between function name and '()' on function calls without parameters.
-  If set to 'ignore' (the default), sp_func_call_paren is used.
+# Add or remove space between function name and '()' on function calls without parameters.
+# If set to 'ignore' (the default), sp_func_call_paren is used.
+sp_func_call_paren_empty        = ignore   # ignore/add/remove/force
 
-sp_func_call_user_paren         { Ignore, Add, Remove, Force }
-  Add or remove space between the user function name and '(' on function calls
-  You need to set a keyword to be a user function, like this: 'set func_call_user _' in the config file.
+# Add or remove space between the user function name and '(' on function calls
+# You need to set a keyword to be a user function, like this: 'set func_call_user _' in the config file.
+sp_func_call_user_paren         = ignore   # ignore/add/remove/force
 
-sp_func_call_user_inside_fparen { Ignore, Add, Remove, Force }
-  Add or remove space inside user function '(' and ')'
-  You need to set a keyword to be a user function, like this: 'set func_call_user _' in the config file.
+# Add or remove space inside user function '(' and ')'
+# You need to set a keyword to be a user function, like this: 'set func_call_user _' in the config file.
+sp_func_call_user_inside_fparen = ignore   # ignore/add/remove/force
 
-sp_func_call_user_paren_paren   { Ignore, Add, Remove, Force }
-  Add or remove space between nested parens with user functions: '((' vs ') )'You need to set a keyword to be a user function, like this: 'set func_call_user _' in the config file.
+# Add or remove space between nested parens with user functions: '((' vs ') )'You need to set a keyword to be a user function, like this: 'set func_call_user _' in the config file.
+sp_func_call_user_paren_paren   = ignore   # ignore/add/remove/force
 
-sp_func_class_paren             { Ignore, Add, Remove, Force }
-  Add or remove space between a constructor/destructor and the open paren.
+# Add or remove space between a constructor/destructor and the open paren.
+sp_func_class_paren             = ignore   # ignore/add/remove/force
 
-sp_func_class_paren_empty       { Ignore, Add, Remove, Force }
-  Add or remove space between a constructor without parameters or destructor and '()'.
+# Add or remove space between a constructor without parameters or destructor and '()'.
+sp_func_class_paren_empty       = ignore   # ignore/add/remove/force
 
-sp_return_paren                 { Ignore, Add, Remove, Force }
-  Add or remove space between 'return' and '('.
+# Add or remove space between 'return' and '('.
+sp_return_paren                 = ignore   # ignore/add/remove/force
 
-sp_attribute_paren              { Ignore, Add, Remove, Force }
-  Add or remove space between '__attribute__' and '('.
+# Add or remove space between '__attribute__' and '('.
+sp_attribute_paren              = ignore   # ignore/add/remove/force
 
-sp_defined_paren                { Ignore, Add, Remove, Force }
-  Add or remove space between 'defined' and '(' in '#if defined (FOO)'.
+# Add or remove space between 'defined' and '(' in '#if defined (FOO)'.
+sp_defined_paren                = ignore   # ignore/add/remove/force
 
-sp_throw_paren                  { Ignore, Add, Remove, Force }
-  Add or remove space between 'throw' and '(' in 'throw (something)'.
+# Add or remove space between 'throw' and '(' in 'throw (something)'.
+sp_throw_paren                  = ignore   # ignore/add/remove/force
 
-sp_after_throw                  { Ignore, Add, Remove, Force }
-  Add or remove space between 'throw' and anything other than '(' as in '@throw [...];'.
+# Add or remove space between 'throw' and anything other than '(' as in '@throw [...];'.
+sp_after_throw                  = ignore   # ignore/add/remove/force
 
-sp_catch_paren                  { Ignore, Add, Remove, Force }
-  Add or remove space between 'catch' and '(' in 'catch (something) { }'
-  If set to ignore, sp_before_sparen is used.
+# Add or remove space between 'catch' and '(' in 'catch (something) { }'
+# If set to ignore, sp_before_sparen is used.
+sp_catch_paren                  = ignore   # ignore/add/remove/force
 
-sp_oc_catch_paren               { Ignore, Add, Remove, Force }
-  Add or remove space between '@catch' and '(' in '@catch (something) { }'
-  If set to ignore, sp_catch_paren is used.
+# Add or remove space between '@catch' and '(' in '@catch (something) { }'
+# If set to ignore, sp_catch_paren is used.
+sp_oc_catch_paren               = ignore   # ignore/add/remove/force
 
-sp_version_paren                { Ignore, Add, Remove, Force }
-  Add or remove space between 'version' and '(' in 'version (something) { }' (D language)
-  If set to ignore, sp_before_sparen is used.
+# Add or remove space between 'version' and '(' in 'version (something) { }' (D language)
+# If set to ignore, sp_before_sparen is used.
+sp_version_paren                = ignore   # ignore/add/remove/force
 
-sp_scope_paren                  { Ignore, Add, Remove, Force }
-  Add or remove space between 'scope' and '(' in 'scope (something) { }' (D language)
-  If set to ignore, sp_before_sparen is used.
+# Add or remove space between 'scope' and '(' in 'scope (something) { }' (D language)
+# If set to ignore, sp_before_sparen is used.
+sp_scope_paren                  = ignore   # ignore/add/remove/force
 
-sp_super_paren                  { Ignore, Add, Remove, Force }
-  Add or remove space between 'super' and '(' in 'super (something)'. Default=Remove.
+# Add or remove space between 'super' and '(' in 'super (something)'. Default=Remove.
+sp_super_paren                  = remove   # ignore/add/remove/force
 
-sp_this_paren                   { Ignore, Add, Remove, Force }
-  Add or remove space between 'this' and '(' in 'this (something)'. Default=Remove.
+# Add or remove space between 'this' and '(' in 'this (something)'. Default=Remove.
+sp_this_paren                   = remove   # ignore/add/remove/force
 
-sp_macro                        { Ignore, Add, Remove, Force }
-  Add or remove space between macro and value.
+# Add or remove space between macro and value.
+sp_macro                        = ignore   # ignore/add/remove/force
 
-sp_macro_func                   { Ignore, Add, Remove, Force }
-  Add or remove space between macro function ')' and value.
+# Add or remove space between macro function ')' and value.
+sp_macro_func                   = ignore   # ignore/add/remove/force
 
-sp_else_brace                   { Ignore, Add, Remove, Force }
-  Add or remove space between 'else' and '{' if on the same line.
+# Add or remove space between 'else' and '{' if on the same line.
+sp_else_brace                   = ignore   # ignore/add/remove/force
 
-sp_brace_else                   { Ignore, Add, Remove, Force }
-  Add or remove space between '}' and 'else' if on the same line.
+# Add or remove space between '}' and 'else' if on the same line.
+sp_brace_else                   = ignore   # ignore/add/remove/force
 
-sp_brace_typedef                { Ignore, Add, Remove, Force }
-  Add or remove space between '}' and the name of a typedef on the same line.
+# Add or remove space between '}' and the name of a typedef on the same line.
+sp_brace_typedef                = ignore   # ignore/add/remove/force
 
-sp_catch_brace                  { Ignore, Add, Remove, Force }
-  Add or remove space before '{' after a catch statement as in 'catch (something) { }' if on the same line.
+# Add or remove space before '{' after a catch statement as in 'catch (something) { }' if on the same line.
+sp_catch_brace                  = ignore   # ignore/add/remove/force
 
-sp_oc_catch_brace               { Ignore, Add, Remove, Force }
-  Add or remove space before '{' after a @catch statement as in '@catch (something) { }' if on the same line.
-  If set to ignore, sp_catch_brace is used.
+# Add or remove space before '{' after a @catch statement as in '@catch (something) { }' if on the same line.
+# If set to ignore, sp_catch_brace is used.
+sp_oc_catch_brace               = ignore   # ignore/add/remove/force
 
-sp_brace_catch                  { Ignore, Add, Remove, Force }
-  Add or remove space between '}' and 'catch' if on the same line.
+# Add or remove space between '}' and 'catch' if on the same line.
+sp_brace_catch                  = ignore   # ignore/add/remove/force
 
-sp_oc_brace_catch               { Ignore, Add, Remove, Force }
-  Add or remove space between '}' and '@catch' if on the same line.
-  If set to ignore, sp_brace_catch is used.
+# Add or remove space between '}' and '@catch' if on the same line.
+# If set to ignore, sp_brace_catch is used.
+sp_oc_brace_catch               = ignore   # ignore/add/remove/force
 
-sp_finally_brace                { Ignore, Add, Remove, Force }
-  Add or remove space between 'finally' and '{' if on the same line.
+# Add or remove space between 'finally' and '{' if on the same line.
+sp_finally_brace                = ignore   # ignore/add/remove/force
 
-sp_brace_finally                { Ignore, Add, Remove, Force }
-  Add or remove space between '}' and 'finally' if on the same line.
+# Add or remove space between '}' and 'finally' if on the same line.
+sp_brace_finally                = ignore   # ignore/add/remove/force
 
-sp_try_brace                    { Ignore, Add, Remove, Force }
-  Add or remove space between 'try' and '{' if on the same line.
+# Add or remove space between 'try' and '{' if on the same line.
+sp_try_brace                    = ignore   # ignore/add/remove/force
 
-sp_getset_brace                 { Ignore, Add, Remove, Force }
-  Add or remove space between get/set and '{' if on the same line.
+# Add or remove space between get/set and '{' if on the same line.
+sp_getset_brace                 = ignore   # ignore/add/remove/force
 
-sp_word_brace                   { Ignore, Add, Remove, Force }
-  Add or remove space between a variable and '{' for C++ uniform initialization. Default=Add.
+# Add or remove space between a variable and '{' for C++ uniform initialization. Default=Add.
+sp_word_brace                   = add      # ignore/add/remove/force
 
-sp_word_brace_ns                { Ignore, Add, Remove, Force }
-  Add or remove space between a variable and '{' for a namespace. Default=Add.
+# Add or remove space between a variable and '{' for a namespace. Default=Add.
+sp_word_brace_ns                = add      # ignore/add/remove/force
 
-sp_before_dc                    { Ignore, Add, Remove, Force }
-  Add or remove space before the '::' operator.
+# Add or remove space before the '::' operator.
+sp_before_dc                    = ignore   # ignore/add/remove/force
 
-sp_after_dc                     { Ignore, Add, Remove, Force }
-  Add or remove space after the '::' operator.
+# Add or remove space after the '::' operator.
+sp_after_dc                     = ignore   # ignore/add/remove/force
 
-sp_d_array_colon                { Ignore, Add, Remove, Force }
-  Add or remove around the D named array initializer ':' operator.
+# Add or remove around the D named array initializer ':' operator.
+sp_d_array_colon                = ignore   # ignore/add/remove/force
 
-sp_not                          { Ignore, Add, Remove, Force }
-  Add or remove space after the '!' (not) operator. Default=Remove.
+# Add or remove space after the '!' (not) operator. Default=Remove.
+sp_not                          = remove   # ignore/add/remove/force
 
-sp_inv                          { Ignore, Add, Remove, Force }
-  Add or remove space after the '~' (invert) operator. Default=Remove.
+# Add or remove space after the '~' (invert) operator. Default=Remove.
+sp_inv                          = remove   # ignore/add/remove/force
 
-sp_addr                         { Ignore, Add, Remove, Force }
-  Add or remove space after the '&' (address-of) operator. Default=Remove
-  This does not affect the spacing after a '&' that is part of a type.
+# Add or remove space after the '&' (address-of) operator. Default=Remove
+# This does not affect the spacing after a '&' that is part of a type.
+sp_addr                         = remove   # ignore/add/remove/force
 
-sp_member                       { Ignore, Add, Remove, Force }
-  Add or remove space around the '.' or '->' operators. Default=Remove.
+# Add or remove space around the '.' or '->' operators. Default=Remove.
+sp_member                       = remove   # ignore/add/remove/force
 
-sp_deref                        { Ignore, Add, Remove, Force }
-  Add or remove space after the '*' (dereference) operator. Default=Remove
-  This does not affect the spacing after a '*' that is part of a type.
+# Add or remove space after the '*' (dereference) operator. Default=Remove
+# This does not affect the spacing after a '*' that is part of a type.
+sp_deref                        = remove   # ignore/add/remove/force
 
-sp_sign                         { Ignore, Add, Remove, Force }
-  Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'. Default=Remove.
+# Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'. Default=Remove.
+sp_sign                         = remove   # ignore/add/remove/force
 
-sp_incdec                       { Ignore, Add, Remove, Force }
-  Add or remove space before or after '++' and '--', as in '(--x)' or 'y++;'. Default=Remove.
+# Add or remove space before or after '++' and '--', as in '(--x)' or 'y++;'. Default=Remove.
+sp_incdec                       = remove   # ignore/add/remove/force
 
-sp_before_nl_cont               { Ignore, Add, Remove, Force }
-  Add or remove space before a backslash-newline at the end of a line. Default=Add.
+# Add or remove space before a backslash-newline at the end of a line. Default=Add.
+sp_before_nl_cont               = add      # ignore/add/remove/force
 
-sp_after_oc_scope               { Ignore, Add, Remove, Force }
-  Add or remove space after the scope '+' or '-', as in '-(void) foo;' or '+(int) bar;'.
+# Add or remove space after the scope '+' or '-', as in '-(void) foo;' or '+(int) bar;'.
+sp_after_oc_scope               = ignore   # ignore/add/remove/force
 
-sp_after_oc_colon               { Ignore, Add, Remove, Force }
-  Add or remove space after the colon in message specs
-  '-(int) f:(int) x;' vs '-(int) f: (int) x;'.
+# Add or remove space after the colon in message specs
+# '-(int) f:(int) x;' vs '-(int) f: (int) x;'.
+sp_after_oc_colon               = ignore   # ignore/add/remove/force
 
-sp_before_oc_colon              { Ignore, Add, Remove, Force }
-  Add or remove space before the colon in message specs
-  '-(int) f: (int) x;' vs '-(int) f : (int) x;'.
+# Add or remove space before the colon in message specs
+# '-(int) f: (int) x;' vs '-(int) f : (int) x;'.
+sp_before_oc_colon              = ignore   # ignore/add/remove/force
 
-sp_after_oc_dict_colon          { Ignore, Add, Remove, Force }
-  Add or remove space after the colon in immutable dictionary expression
-  'NSDictionary *test = @{@"foo" :@"bar"};'.
+# Add or remove space after the colon in immutable dictionary expression
+# 'NSDictionary *test = @{@"foo" :@"bar"};'.
+sp_after_oc_dict_colon          = ignore   # ignore/add/remove/force
 
-sp_before_oc_dict_colon         { Ignore, Add, Remove, Force }
-  Add or remove space before the colon in immutable dictionary expression
-  'NSDictionary *test = @{@"foo" :@"bar"};'.
+# Add or remove space before the colon in immutable dictionary expression
+# 'NSDictionary *test = @{@"foo" :@"bar"};'.
+sp_before_oc_dict_colon         = ignore   # ignore/add/remove/force
 
-sp_after_send_oc_colon          { Ignore, Add, Remove, Force }
-  Add or remove space after the colon in message specs
-  '[object setValue:1];' vs '[object setValue: 1];'.
+# Add or remove space after the colon in message specs
+# '[object setValue:1];' vs '[object setValue: 1];'.
+sp_after_send_oc_colon          = ignore   # ignore/add/remove/force
 
-sp_before_send_oc_colon         { Ignore, Add, Remove, Force }
-  Add or remove space before the colon in message specs
-  '[object setValue:1];' vs '[object setValue :1];'.
+# Add or remove space before the colon in message specs
+# '[object setValue:1];' vs '[object setValue :1];'.
+sp_before_send_oc_colon         = ignore   # ignore/add/remove/force
 
-sp_after_oc_type                { Ignore, Add, Remove, Force }
-  Add or remove space after the (type) in message specs
-  '-(int)f: (int) x;' vs '-(int)f: (int)x;'.
+# Add or remove space after the (type) in message specs
+# '-(int)f: (int) x;' vs '-(int)f: (int)x;'.
+sp_after_oc_type                = ignore   # ignore/add/remove/force
 
-sp_after_oc_return_type         { Ignore, Add, Remove, Force }
-  Add or remove space after the first (type) in message specs
-  '-(int) f:(int)x;' vs '-(int)f:(int)x;'.
+# Add or remove space after the first (type) in message specs
+# '-(int) f:(int)x;' vs '-(int)f:(int)x;'.
+sp_after_oc_return_type         = ignore   # ignore/add/remove/force
 
-sp_after_oc_at_sel              { Ignore, Add, Remove, Force }
-  Add or remove space between '@selector' and '('
-  '@selector(msgName)' vs '@selector (msgName)'
-  Also applies to @protocol() constructs.
+# Add or remove space between '@selector' and '('
+# '@selector(msgName)' vs '@selector (msgName)'
+# Also applies to @protocol() constructs.
+sp_after_oc_at_sel              = ignore   # ignore/add/remove/force
 
-sp_after_oc_at_sel_parens       { Ignore, Add, Remove, Force }
-  Add or remove space between '@selector(x)' and the following word
-  '@selector(foo) a:' vs '@selector(foo)a:'.
+# Add or remove space between '@selector(x)' and the following word
+# '@selector(foo) a:' vs '@selector(foo)a:'.
+sp_after_oc_at_sel_parens       = ignore   # ignore/add/remove/force
 
-sp_inside_oc_at_sel_parens      { Ignore, Add, Remove, Force }
-  Add or remove space inside '@selector' parens
-  '@selector(foo)' vs '@selector( foo )'
-  Also applies to @protocol() constructs.
+# Add or remove space inside '@selector' parens
+# '@selector(foo)' vs '@selector( foo )'
+# Also applies to @protocol() constructs.
+sp_inside_oc_at_sel_parens      = ignore   # ignore/add/remove/force
 
-sp_before_oc_block_caret        { Ignore, Add, Remove, Force }
-  Add or remove space before a block pointer caret
-  '^int (int arg){...}' vs. ' ^int (int arg){...}'.
+# Add or remove space before a block pointer caret
+# '^int (int arg){...}' vs. ' ^int (int arg){...}'.
+sp_before_oc_block_caret        = ignore   # ignore/add/remove/force
 
-sp_after_oc_block_caret         { Ignore, Add, Remove, Force }
-  Add or remove space after a block pointer caret
-  '^int (int arg){...}' vs. '^ int (int arg){...}'.
+# Add or remove space after a block pointer caret
+# '^int (int arg){...}' vs. '^ int (int arg){...}'.
+sp_after_oc_block_caret         = ignore   # ignore/add/remove/force
 
-sp_after_oc_msg_receiver        { Ignore, Add, Remove, Force }
-  Add or remove space between the receiver and selector in a message.
-  '[receiver selector ...]'.
+# Add or remove space between the receiver and selector in a message.
+# '[receiver selector ...]'.
+sp_after_oc_msg_receiver        = ignore   # ignore/add/remove/force
 
-sp_after_oc_property            { Ignore, Add, Remove, Force }
-  Add or remove space after @property.
+# Add or remove space after @property.
+sp_after_oc_property            = ignore   # ignore/add/remove/force
 
-sp_after_oc_synchronized        { Ignore, Add, Remove, Force }
-  Add or remove space between '@synchronized' and the parenthesis
-  '@synchronized(foo)' vs '@synchronized (foo)'.
+# Add or remove space between '@synchronized' and the parenthesis
+# '@synchronized(foo)' vs '@synchronized (foo)'.
+sp_after_oc_synchronized        = ignore   # ignore/add/remove/force
 
-sp_cond_colon                   { Ignore, Add, Remove, Force }
-  Add or remove space around the ':' in 'b ? t : f'.
+# Add or remove space around the ':' in 'b ? t : f'.
+sp_cond_colon                   = ignore   # ignore/add/remove/force
 
-sp_cond_colon_before            { Ignore, Add, Remove, Force }
-  Add or remove space before the ':' in 'b ? t : f'. Overrides sp_cond_colon.
+# Add or remove space before the ':' in 'b ? t : f'. Overrides sp_cond_colon.
+sp_cond_colon_before            = ignore   # ignore/add/remove/force
 
-sp_cond_colon_after             { Ignore, Add, Remove, Force }
-  Add or remove space after the ':' in 'b ? t : f'. Overrides sp_cond_colon.
+# Add or remove space after the ':' in 'b ? t : f'. Overrides sp_cond_colon.
+sp_cond_colon_after             = ignore   # ignore/add/remove/force
 
-sp_cond_question                { Ignore, Add, Remove, Force }
-  Add or remove space around the '?' in 'b ? t : f'.
+# Add or remove space around the '?' in 'b ? t : f'.
+sp_cond_question                = ignore   # ignore/add/remove/force
 
-sp_cond_question_before         { Ignore, Add, Remove, Force }
-  Add or remove space before the '?' in 'b ? t : f'. Overrides sp_cond_question.
+# Add or remove space before the '?' in 'b ? t : f'. Overrides sp_cond_question.
+sp_cond_question_before         = ignore   # ignore/add/remove/force
 
-sp_cond_question_after          { Ignore, Add, Remove, Force }
-  Add or remove space after the '?' in 'b ? t : f'. Overrides sp_cond_question.
+# Add or remove space after the '?' in 'b ? t : f'. Overrides sp_cond_question.
+sp_cond_question_after          = ignore   # ignore/add/remove/force
 
-sp_cond_ternary_short           { Ignore, Add, Remove, Force }
-  In the abbreviated ternary form (a ?: b), add/remove space between ? and :.'. Overrides all other sp_cond_* options.
+# In the abbreviated ternary form (a ?: b), add/remove space between ? and :.'. Overrides all other sp_cond_* options.
+sp_cond_ternary_short           = ignore   # ignore/add/remove/force
 
-sp_case_label                   { Ignore, Add, Remove, Force }
-  Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make sense here.
+# Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make sense here.
+sp_case_label                   = ignore   # ignore/add/remove/force
 
-sp_range                        { Ignore, Add, Remove, Force }
-  Control the space around the D '..' operator.
+# Control the space around the D '..' operator.
+sp_range                        = ignore   # ignore/add/remove/force
 
-sp_after_for_colon              { Ignore, Add, Remove, Force }
-  Control the spacing after ':' in 'for (Type var : expr)'.
+# Control the spacing after ':' in 'for (Type var : expr)'.
+sp_after_for_colon              = ignore   # ignore/add/remove/force
 
-sp_before_for_colon             { Ignore, Add, Remove, Force }
-  Control the spacing before ':' in 'for (Type var : expr)'.
+# Control the spacing before ':' in 'for (Type var : expr)'.
+sp_before_for_colon             = ignore   # ignore/add/remove/force
 
-sp_extern_paren                 { Ignore, Add, Remove, Force }
-  Control the spacing in 'extern (C)' (D).
+# Control the spacing in 'extern (C)' (D).
+sp_extern_paren                 = ignore   # ignore/add/remove/force
 
-sp_cmt_cpp_start                { Ignore, Add, Remove, Force }
-  Control the space after the opening of a C++ comment '// A' vs '//A'.
+# Control the space after the opening of a C++ comment '// A' vs '//A'.
+sp_cmt_cpp_start                = ignore   # ignore/add/remove/force
 
-sp_cmt_cpp_doxygen              { False, True }
-  True: If space is added with sp_cmt_cpp_start, do it after doxygen sequences like '///', '///<', '//!' and '//!<'.
+# True: If space is added with sp_cmt_cpp_start, do it after doxygen sequences like '///', '///<', '//!' and '//!<'.
+sp_cmt_cpp_doxygen              = false    # false/true
 
-sp_cmt_cpp_qttr                 { False, True }
-  True: If space is added with sp_cmt_cpp_start, do it after Qt translator or meta-data comments like '//:', '//=', and '//~'.
+# True: If space is added with sp_cmt_cpp_start, do it after Qt translator or meta-data comments like '//:', '//=', and '//~'.
+sp_cmt_cpp_qttr                 = false    # false/true
 
-sp_endif_cmt                    { Ignore, Add, Remove, Force }
-  Controls the spaces between #else or #endif and a trailing comment.
+# Controls the spaces between #else or #endif and a trailing comment.
+sp_endif_cmt                    = ignore   # ignore/add/remove/force
 
-sp_after_new                    { Ignore, Add, Remove, Force }
-  Controls the spaces after 'new', 'delete' and 'delete[]'.
+# Controls the spaces after 'new', 'delete' and 'delete[]'.
+sp_after_new                    = ignore   # ignore/add/remove/force
 
-sp_between_new_paren            { Ignore, Add, Remove, Force }
-  Controls the spaces between new and '(' in 'new()'.
+# Controls the spaces between new and '(' in 'new()'.
+sp_between_new_paren            = ignore   # ignore/add/remove/force
 
-sp_after_newop_paren            { Ignore, Add, Remove, Force }
-  Controls the spaces between ')' and 'type' in 'new(foo) BAR'.
+# Controls the spaces between ')' and 'type' in 'new(foo) BAR'.
+sp_after_newop_paren            = ignore   # ignore/add/remove/force
 
-sp_inside_newop_paren           { Ignore, Add, Remove, Force }
-  Controls the spaces inside paren of the new operator: 'new(foo) BAR'.
+# Controls the spaces inside paren of the new operator: 'new(foo) BAR'.
+sp_inside_newop_paren           = ignore   # ignore/add/remove/force
 
-sp_inside_newop_paren_open      { Ignore, Add, Remove, Force }
-  Controls the space after open paren of the new operator: 'new(foo) BAR'.
-  Overrides sp_inside_newop_paren.
+# Controls the space after open paren of the new operator: 'new(foo) BAR'.
+# Overrides sp_inside_newop_paren.
+sp_inside_newop_paren_open      = ignore   # ignore/add/remove/force
 
-sp_inside_newop_paren_close     { Ignore, Add, Remove, Force }
-  Controls the space before close paren of the new operator: 'new(foo) BAR'.
-  Overrides sp_inside_newop_paren.
+# Controls the space before close paren of the new operator: 'new(foo) BAR'.
+# Overrides sp_inside_newop_paren.
+sp_inside_newop_paren_close     = ignore   # ignore/add/remove/force
 
-sp_before_tr_emb_cmt            { Ignore, Add, Remove, Force }
-  Controls the spaces before a trailing or embedded comment.
+# Controls the spaces before a trailing or embedded comment.
+sp_before_tr_emb_cmt            = ignore   # ignore/add/remove/force
 
-sp_num_before_tr_emb_cmt        Unsigned Number
-  Number of spaces before a trailing or embedded comment.
+# Number of spaces before a trailing or embedded comment.
+sp_num_before_tr_emb_cmt        = 0        # unsigned number
 
-sp_annotation_paren             { Ignore, Add, Remove, Force }
-  Control space between a Java annotation and the open paren.
+# Control space between a Java annotation and the open paren.
+sp_annotation_paren             = ignore   # ignore/add/remove/force
 
-sp_skip_vbrace_tokens           { False, True }
-  If True, vbrace tokens are dropped to the previous token and skipped.
+# If True, vbrace tokens are dropped to the previous token and skipped.
+sp_skip_vbrace_tokens           = false    # false/true
 
-sp_after_noexcept               { Ignore, Add, Remove, Force }
-  Controls the space after 'noexcept'.
+# Controls the space after 'noexcept'.
+sp_after_noexcept               = ignore   # ignore/add/remove/force
 
-force_tab_after_define          { False, True }
-  If True, a <TAB> is inserted after #define.
+# If True, a <TAB> is inserted after #define.
+force_tab_after_define          = false    # false/true
 
 #
 # Indenting
 #
 
-indent_columns                  Unsigned Number
-  The number of columns to indent per level.
-  Usually 2, 3, 4, or 8. Default=8.
+# The number of columns to indent per level.
+# Usually 2, 3, 4, or 8. Default=8.
+indent_columns                  = 8        # unsigned number
 
-indent_continue                 Number
-  The continuation indent. If non-zero, this overrides the indent of '(' and '=' continuation indents.
-  For FreeBSD, this is set to 4. Negative value is absolute and not increased for each '(' level.
-  negative value are OK.
+# The continuation indent. If non-zero, this overrides the indent of '(' and '=' continuation indents.
+# For FreeBSD, this is set to 4. Negative value is absolute and not increased for each '(' level.
+# negative value are OK.
+indent_continue                 = 0        # number
 
-indent_continue_class_head      Unsigned Number
-  The continuation indent, only for class header line(s).
-  If non-zero, this overrides the indent of 'class' continuation indents.
-  
+# The continuation indent, only for class header line(s).
+# If non-zero, this overrides the indent of 'class' continuation indents.
+indent_continue_class_head      = 0        # unsigned number
 
-indent_single_newlines          { False, True }
-  Indent empty lines - lines which contain only spaces before newline character
+# Indent empty lines - lines which contain only spaces before newline character
+indent_single_newlines          = false    # false/true
 
-indent_param                    Unsigned Number
-  The continuation indent for func_*_param if they are true.
-  If non-zero, this overrides the indent.
+# The continuation indent for func_*_param if they are true.
+# If non-zero, this overrides the indent.
+indent_param                    = 0        # unsigned number
 
-indent_with_tabs                Unsigned Number
-  How to use tabs when indenting code
-  0=spaces only
-  1=indent with tabs to brace level, align with spaces (default)
-  2=indent and align with tabs, using spaces when not on a tabstop
+# How to use tabs when indenting code
+# 0=spaces only
+# 1=indent with tabs to brace level, align with spaces (default)
+# 2=indent and align with tabs, using spaces when not on a tabstop
+indent_with_tabs                = 1        # unsigned number
 
-indent_cmt_with_tabs            { False, True }
-  Comments that are not a brace level are indented with tabs on a tabstop.
-  Requires indent_with_tabs=2. If false, will use spaces.
+# Comments that are not a brace level are indented with tabs on a tabstop.
+# Requires indent_with_tabs=2. If false, will use spaces.
+indent_cmt_with_tabs            = false    # false/true
 
-indent_align_string             { False, True }
-  Whether to indent strings broken by '\' so that they line up.
+# Whether to indent strings broken by '\' so that they line up.
+indent_align_string             = false    # false/true
 
-indent_xml_string               Unsigned Number
-  The number of spaces to indent multi-line XML strings.
-  Requires indent_align_string=True.
+# The number of spaces to indent multi-line XML strings.
+# Requires indent_align_string=True.
+indent_xml_string               = 0        # unsigned number
 
-indent_brace                    Unsigned Number
-  Spaces to indent '{' from level.
+# Spaces to indent '{' from level.
+indent_brace                    = 0        # unsigned number
 
-indent_braces                   { False, True }
-  Whether braces are indented to the body level.
+# Whether braces are indented to the body level.
+indent_braces                   = false    # false/true
 
-indent_braces_no_func           { False, True }
-  Disabled indenting function braces if indent_braces is True.
+# Disabled indenting function braces if indent_braces is True.
+indent_braces_no_func           = false    # false/true
 
-indent_braces_no_class          { False, True }
-  Disabled indenting class braces if indent_braces is True.
+# Disabled indenting class braces if indent_braces is True.
+indent_braces_no_class          = false    # false/true
 
-indent_braces_no_struct         { False, True }
-  Disabled indenting struct braces if indent_braces is True.
+# Disabled indenting struct braces if indent_braces is True.
+indent_braces_no_struct         = false    # false/true
 
-indent_brace_parent             { False, True }
-  Indent based on the size of the brace parent, i.e. 'if' => 3 spaces, 'for' => 4 spaces, etc.
+# Indent based on the size of the brace parent, i.e. 'if' => 3 spaces, 'for' => 4 spaces, etc.
+indent_brace_parent             = false    # false/true
 
-indent_paren_open_brace         { False, True }
-  Indent based on the paren open instead of the brace open in '({\n', default is to indent by brace.
+# Indent based on the paren open instead of the brace open in '({\n', default is to indent by brace.
+indent_paren_open_brace         = false    # false/true
 
-indent_cs_delegate_brace        { False, True }
-  indent a C# delegate by another level, default is to not indent by another level.
+# indent a C# delegate by another level, default is to not indent by another level.
+indent_cs_delegate_brace        = false    # false/true
 
-indent_cs_delegate_body         { False, True }
-  indent a C# delegate(To hanndle delegates with no brace) by another level. default: false
+# indent a C# delegate(To hanndle delegates with no brace) by another level. default: false
+indent_cs_delegate_body         = false    # false/true
 
-indent_namespace                { False, True }
-  Whether the 'namespace' body is indented.
+# Whether the 'namespace' body is indented.
+indent_namespace                = false    # false/true
 
-indent_namespace_single_indent  { False, True }
-  Only indent one namespace and no sub-namespaces.
-  Requires indent_namespace=True.
+# Only indent one namespace and no sub-namespaces.
+# Requires indent_namespace=True.
+indent_namespace_single_indent  = false    # false/true
 
-indent_namespace_level          Unsigned Number
-  The number of spaces to indent a namespace block.
+# The number of spaces to indent a namespace block.
+indent_namespace_level          = 0        # unsigned number
 
-indent_namespace_limit          Unsigned Number
-  If the body of the namespace is longer than this number, it won't be indented.
-  Requires indent_namespace=True. Default=0 (no limit)
+# If the body of the namespace is longer than this number, it won't be indented.
+# Requires indent_namespace=True. Default=0 (no limit)
+indent_namespace_limit          = 0        # unsigned number
 
-indent_extern                   { False, True }
-  Whether the 'extern "C"' body is indented.
+# Whether the 'extern "C"' body is indented.
+indent_extern                   = false    # false/true
 
-indent_class                    { False, True }
-  Whether the 'class' body is indented.
+# Whether the 'class' body is indented.
+indent_class                    = false    # false/true
 
-indent_class_colon              { False, True }
-  Whether to indent the stuff after a leading base class colon.
+# Whether to indent the stuff after a leading base class colon.
+indent_class_colon              = false    # false/true
 
-indent_class_on_colon           { False, True }
-  Indent based on a class colon instead of the stuff after the colon.
-  Requires indent_class_colon=True. Default=False.
+# Indent based on a class colon instead of the stuff after the colon.
+# Requires indent_class_colon=True. Default=False.
+indent_class_on_colon           = false    # false/true
 
-indent_constr_colon             { False, True }
-  Whether to indent the stuff after a leading class initializer colon.
+# Whether to indent the stuff after a leading class initializer colon.
+indent_constr_colon             = false    # false/true
 
-indent_ctor_init_leading        Unsigned Number
-  Virtual indent from the ':' for member initializers. Default=2.
+# Virtual indent from the ':' for member initializers. Default=2.
+indent_ctor_init_leading        = 2        # unsigned number
 
-indent_ctor_init                Number
-  Additional indent for constructor initializer list.
-  Negative values decrease indent down to the first column. Default=0.
+# Additional indent for constructor initializer list.
+# Negative values decrease indent down to the first column. Default=0.
+indent_ctor_init                = 0        # number
 
-indent_else_if                  { False, True }
-  False=treat 'else\nif' as 'else if' for indenting purposes
-  True=indent the 'if' one level.
+# False=treat 'else\nif' as 'else if' for indenting purposes
+# True=indent the 'if' one level.
+indent_else_if                  = false    # false/true
 
-indent_var_def_blk              Number
-  Amount to indent variable declarations after a open brace. neg=relative, pos=absolute.
-  negative value are OK.
+# Amount to indent variable declarations after a open brace. neg=relative, pos=absolute.
+# negative value are OK.
+indent_var_def_blk              = 0        # number
 
-indent_var_def_cont             { False, True }
-  Indent continued variable declarations instead of aligning.
+# Indent continued variable declarations instead of aligning.
+indent_var_def_cont             = false    # false/true
 
-indent_shift                    { False, True }
-  Indent continued shift expressions ('<<' and '>>') instead of aligning.
-  Turn align_left_shift off when enabling this.
+# Indent continued shift expressions ('<<' and '>>') instead of aligning.
+# Turn align_left_shift off when enabling this.
+indent_shift                    = false    # false/true
 
-indent_func_def_force_col1      { False, True }
-  True:  force indentation of function definition to start in column 1
-  False: use the default behavior.
+# True:  force indentation of function definition to start in column 1
+# False: use the default behavior.
+indent_func_def_force_col1      = false    # false/true
 
-indent_func_call_param          { False, True }
-  True:  indent continued function call parameters one indent level
-  False: align parameters under the open paren.
+# True:  indent continued function call parameters one indent level
+# False: align parameters under the open paren.
+indent_func_call_param          = false    # false/true
 
-indent_func_def_param           { False, True }
-  Same as indent_func_call_param, but for function defs.
+# Same as indent_func_call_param, but for function defs.
+indent_func_def_param           = false    # false/true
 
-indent_func_proto_param         { False, True }
-  Same as indent_func_call_param, but for function protos.
+# Same as indent_func_call_param, but for function protos.
+indent_func_proto_param         = false    # false/true
 
-indent_func_class_param         { False, True }
-  Same as indent_func_call_param, but for class declarations.
+# Same as indent_func_call_param, but for class declarations.
+indent_func_class_param         = false    # false/true
 
-indent_func_ctor_var_param      { False, True }
-  Same as indent_func_call_param, but for class variable constructors.
+# Same as indent_func_call_param, but for class variable constructors.
+indent_func_ctor_var_param      = false    # false/true
 
-indent_template_param           { False, True }
-  Same as indent_func_call_param, but for templates.
+# Same as indent_func_call_param, but for templates.
+indent_template_param           = false    # false/true
 
-indent_func_param_double        { False, True }
-  Double the indent for indent_func_xxx_param options.
-  Use both values of the options indent_columns and indent_param.
+# Double the indent for indent_func_xxx_param options.
+# Use both values of the options indent_columns and indent_param.
+indent_func_param_double        = false    # false/true
 
-indent_func_const               Unsigned Number
-  Indentation column for standalone 'const' function decl/proto qualifier.
+# Indentation column for standalone 'const' function decl/proto qualifier.
+indent_func_const               = 0        # unsigned number
 
-indent_func_throw               Unsigned Number
-  Indentation column for standalone 'throw' function decl/proto qualifier.
+# Indentation column for standalone 'throw' function decl/proto qualifier.
+indent_func_throw               = 0        # unsigned number
 
-indent_member                   Unsigned Number
-  The number of spaces to indent a continued '->' or '.'
-  Usually set to 0, 1, or indent_columns.
+# The number of spaces to indent a continued '->' or '.'
+# Usually set to 0, 1, or indent_columns.
+indent_member                   = 0        # unsigned number
 
-indent_member_single            { False, True }
-  setting to true will indent lines broken at '.' or '->' by a single indent
-  UO_indent_member option will not be effective if this is set to true.
+# setting to true will indent lines broken at '.' or '->' by a single indent
+# UO_indent_member option will not be effective if this is set to true.
+indent_member_single            = false    # false/true
 
-indent_sing_line_comments       Unsigned Number
-  Spaces to indent single line ('//') comments on lines before code.
+# Spaces to indent single line ('//') comments on lines before code.
+indent_sing_line_comments       = 0        # unsigned number
 
-indent_relative_single_line_comments { False, True }
-  If set, will indent trailing single line ('//') comments relative
-  to the code instead of trying to keep the same absolute column.
+# If set, will indent trailing single line ('//') comments relative
+# to the code instead of trying to keep the same absolute column.
+indent_relative_single_line_comments = false    # false/true
 
-indent_switch_case              Unsigned Number
-  Spaces to indent 'case' from 'switch'
-  Usually 0 or indent_columns.
+# Spaces to indent 'case' from 'switch'
+# Usually 0 or indent_columns.
+indent_switch_case              = 0        # unsigned number
 
-indent_switch_pp                { False, True }
-  Whether to indent preprocessor statements inside of switch statements.
+# Whether to indent preprocessor statements inside of switch statements.
+indent_switch_pp                = true     # false/true
 
-indent_case_shift               Unsigned Number
-  Spaces to shift the 'case' line, without affecting any other lines
-  Usually 0.
+# Spaces to shift the 'case' line, without affecting any other lines
+# Usually 0.
+indent_case_shift               = 0        # unsigned number
 
-indent_case_brace               Number
-  Spaces to indent '{' from 'case'.
-  By default, the brace will appear under the 'c' in case.
-  Usually set to 0 or indent_columns.
-  negative value are OK.
+# Spaces to indent '{' from 'case'.
+# By default, the brace will appear under the 'c' in case.
+# Usually set to 0 or indent_columns.
+# negative value are OK.
+indent_case_brace               = 0        # number
 
-indent_col1_comment             { False, True }
-  Whether to indent comments found in first column.
+# Whether to indent comments found in first column.
+indent_col1_comment             = false    # false/true
 
-indent_label                    Number
-  How to indent goto labels
-    >0: absolute column where 1 is the leftmost column
-   <=0: subtract from brace indent
-  Default=1
+# How to indent goto labels
+#   >0: absolute column where 1 is the leftmost column
+#  <=0: subtract from brace indent
+# Default=1
+indent_label                    = 1        # number
 
-indent_access_spec              Number
-  Same as indent_label, but for access specifiers that are followed by a colon. Default=1
+# Same as indent_label, but for access specifiers that are followed by a colon. Default=1
+indent_access_spec              = 1        # number
 
-indent_access_spec_body         { False, True }
-  Indent the code after an access specifier by one level.
-  If set, this option forces 'indent_access_spec=0'.
+# Indent the code after an access specifier by one level.
+# If set, this option forces 'indent_access_spec=0'.
+indent_access_spec_body         = false    # false/true
 
-indent_paren_nl                 { False, True }
-  If an open paren is followed by a newline, indent the next line so that it lines up after the open paren (not recommended).
+# If an open paren is followed by a newline, indent the next line so that it lines up after the open paren (not recommended).
+indent_paren_nl                 = false    # false/true
 
-indent_paren_close              Unsigned Number
-  Controls the indent of a close paren after a newline.
-  0: Indent to body level
-  1: Align under the open paren
-  2: Indent to the brace level
+# Controls the indent of a close paren after a newline.
+# 0: Indent to body level
+# 1: Align under the open paren
+# 2: Indent to the brace level
+indent_paren_close              = 0        # unsigned number
 
-indent_paren_after_func_def     { False, True }
-  Controls the indent of the open paren of a function definition, if on it's own line.If True, indents the open paren
+# Controls the indent of the open paren of a function definition, if on it's own line.If True, indents the open paren
+indent_paren_after_func_def     = false    # false/true
 
-indent_paren_after_func_decl    { False, True }
-  Controls the indent of the open paren of a function declaration, if on it's own line.If True, indents the open paren
+# Controls the indent of the open paren of a function declaration, if on it's own line.If True, indents the open paren
+indent_paren_after_func_decl    = false    # false/true
 
-indent_paren_after_func_call    { False, True }
-  Controls the indent of the open paren of a function call, if on it's own line.If True, indents the open paren
+# Controls the indent of the open paren of a function call, if on it's own line.If True, indents the open paren
+indent_paren_after_func_call    = false    # false/true
 
-indent_comma_paren              { False, True }
-  Controls the indent of a comma when inside a paren.If True, aligns under the open paren.
+# Controls the indent of a comma when inside a paren.If True, aligns under the open paren.
+indent_comma_paren              = false    # false/true
 
-indent_bool_paren               { False, True }
-  Controls the indent of a BOOL operator when inside a paren.If True, aligns under the open paren.
+# Controls the indent of a BOOL operator when inside a paren.If True, aligns under the open paren.
+indent_bool_paren               = false    # false/true
 
-indent_semicolon_for_paren      { False, True }
-  Controls the indent of a semicolon when inside a for paren.If True, aligns under the open for paren.
+# Controls the indent of a semicolon when inside a for paren.If True, aligns under the open for paren.
+indent_semicolon_for_paren      = false    # false/true
 
-indent_first_bool_expr          { False, True }
-  If 'indent_bool_paren' is True, controls the indent of the first expression. If True, aligns the first expression to the following ones.
+# If 'indent_bool_paren' is True, controls the indent of the first expression. If True, aligns the first expression to the following ones.
+indent_first_bool_expr          = false    # false/true
 
-indent_first_for_expr           { False, True }
-  If 'indent_semicolon_for_paren' is True, controls the indent of the first expression. If True, aligns the first expression to the following ones.
+# If 'indent_semicolon_for_paren' is True, controls the indent of the first expression. If True, aligns the first expression to the following ones.
+indent_first_for_expr           = false    # false/true
 
-indent_square_nl                { False, True }
-  If an open square is followed by a newline, indent the next line so that it lines up after the open square (not recommended).
+# If an open square is followed by a newline, indent the next line so that it lines up after the open square (not recommended).
+indent_square_nl                = false    # false/true
 
-indent_preserve_sql             { False, True }
-  Don't change the relative indent of ESQL/C 'EXEC SQL' bodies.
+# Don't change the relative indent of ESQL/C 'EXEC SQL' bodies.
+indent_preserve_sql             = false    # false/true
 
-indent_align_assign             { False, True }
-  Align continued statements at the '='. Default=True
-  If False or the '=' is followed by a newline, the next line is indent one tab.
+# Align continued statements at the '='. Default=True
+# If False or the '=' is followed by a newline, the next line is indent one tab.
+indent_align_assign             = true     # false/true
 
-indent_align_paren              { False, True }
-  Align continued statements at the '('. Default=True
-  If FALSE or the '(' is not followed by a newline, the next line indent is one tab.
+# Align continued statements at the '('. Default=True
+# If FALSE or the '(' is not followed by a newline, the next line indent is one tab.
+indent_align_paren              = true     # false/true
 
-indent_oc_block                 { False, True }
-  Indent OC blocks at brace level instead of usual rules.
+# Indent OC blocks at brace level instead of usual rules.
+indent_oc_block                 = false    # false/true
 
-indent_oc_block_msg             Unsigned Number
-  Indent OC blocks in a message relative to the parameter name.
-  0=use indent_oc_block rules, 1+=spaces to indent
+# Indent OC blocks in a message relative to the parameter name.
+# 0=use indent_oc_block rules, 1+=spaces to indent
+indent_oc_block_msg             = 0        # unsigned number
 
-indent_oc_msg_colon             Unsigned Number
-  Minimum indent for subsequent parameters
+# Minimum indent for subsequent parameters
+indent_oc_msg_colon             = 0        # unsigned number
 
-indent_oc_msg_prioritize_first_colon { False, True }
-  If True, prioritize aligning with initial colon (and stripping spaces from lines, if necessary).
-  Default=True.
+# If True, prioritize aligning with initial colon (and stripping spaces from lines, if necessary).
+# Default=True.
+indent_oc_msg_prioritize_first_colon = true     # false/true
 
-indent_oc_block_msg_xcode_style { False, True }
-  If indent_oc_block_msg and this option are on, blocks will be indented the way that Xcode does by default (from keyword if the parameter is on its own line; otherwise, from the previous indentation level).
+# If indent_oc_block_msg and this option are on, blocks will be indented the way that Xcode does by default (from keyword if the parameter is on its own line; otherwise, from the previous indentation level).
+indent_oc_block_msg_xcode_style = false    # false/true
 
-indent_oc_block_msg_from_keyword { False, True }
-  If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg keyword.
+# If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg keyword.
+indent_oc_block_msg_from_keyword = false    # false/true
 
-indent_oc_block_msg_from_colon  { False, True }
-  If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg colon.
+# If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg colon.
+indent_oc_block_msg_from_colon  = false    # false/true
 
-indent_oc_block_msg_from_caret  { False, True }
-  If indent_oc_block_msg and this option are on, blocks will be indented from where the block caret is.
+# If indent_oc_block_msg and this option are on, blocks will be indented from where the block caret is.
+indent_oc_block_msg_from_caret  = false    # false/true
 
-indent_oc_block_msg_from_brace  { False, True }
-  If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is.
+# If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is.
+indent_oc_block_msg_from_brace  = false    # false/true
 
-indent_min_vbrace_open          Unsigned Number
-  When indenting after virtual brace open and newline add further spaces to reach this min. indent.
+# When indenting after virtual brace open and newline add further spaces to reach this min. indent.
+indent_min_vbrace_open          = 0        # unsigned number
 
-indent_vbrace_open_on_tabstop   { False, True }
-  True: When identing after virtual brace open and newline add further spaces after regular indent to reach next tabstop.
+# True: When identing after virtual brace open and newline add further spaces after regular indent to reach next tabstop.
+indent_vbrace_open_on_tabstop   = false    # false/true
 
-indent_token_after_brace        { False, True }
-  If True, a brace followed by another token (not a newline) will indent all contained lines to match the token.Default=True.
+# If True, a brace followed by another token (not a newline) will indent all contained lines to match the token.Default=True.
+indent_token_after_brace        = true     # false/true
 
-indent_cpp_lambda_body          { False, True }
-  If True, cpp lambda body will be indentedDefault=False.
+# If True, cpp lambda body will be indentedDefault=False.
+indent_cpp_lambda_body          = false    # false/true
 
-indent_using_block              { False, True }
-  indent (or not) an using block if no braces are used. Only for C#.Default=True.
+# indent (or not) an using block if no braces are used. Only for C#.Default=True.
+indent_using_block              = true     # false/true
 
-indent_ternary_operator         Unsigned Number
-  indent the continuation of ternary operator.
-  0: (Default) off
-  1: When the `if_false` is a continuation, indent it under `if_false`
-  2: When the `:` is a continuation, indent it under `?`
+# indent the continuation of ternary operator.
+# 0: (Default) off
+# 1: When the `if_false` is a continuation, indent it under `if_false`
+# 2: When the `:` is a continuation, indent it under `?`
+indent_ternary_operator         = 0        # unsigned number
 
-indent_off_after_return_new     { False, True }
-  If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.
+# If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.
+indent_off_after_return_new     = false    # false/true
 
-indent_single_after_return      { False, True }
-  If true, the tokens after return are indented with regular single indentation.By default (false) the indentation is after the return token.
+# If true, the tokens after return are indented with regular single indentation.By default (false) the indentation is after the return token.
+indent_single_after_return      = false    # false/true
 
-indent_ignore_asm_block         { False, True }
-  If true, ignore indent and align for asm blocks as they have their own indentation.
+# If true, ignore indent and align for asm blocks as they have their own indentation.
+indent_ignore_asm_block         = false    # false/true
 
 #
 # Newline adding and removing options
 #
 
-nl_collapse_empty_body          { False, True }
-  Whether to collapse empty blocks between '{' and '}'.
+# Whether to collapse empty blocks between '{' and '}'.
+nl_collapse_empty_body          = false    # false/true
 
-nl_assign_leave_one_liners      { False, True }
-  Don't split one-line braced assignments - 'foo_t f = { 1, 2 };'.
+# Don't split one-line braced assignments - 'foo_t f = { 1, 2 };'.
+nl_assign_leave_one_liners      = false    # false/true
 
-nl_class_leave_one_liners       { False, True }
-  Don't split one-line braced statements inside a class xx { } body.
+# Don't split one-line braced statements inside a class xx { } body.
+nl_class_leave_one_liners       = false    # false/true
 
-nl_enum_leave_one_liners        { False, True }
-  Don't split one-line enums: 'enum foo { BAR = 15 };'
+# Don't split one-line enums: 'enum foo { BAR = 15 };'
+nl_enum_leave_one_liners        = false    # false/true
 
-nl_getset_leave_one_liners      { False, True }
-  Don't split one-line get or set functions.
+# Don't split one-line get or set functions.
+nl_getset_leave_one_liners      = false    # false/true
 
-nl_cs_property_leave_one_liners { False, True }
-  Don't split one-line get or set functions.
+# Don't split one-line get or set functions.
+nl_cs_property_leave_one_liners = false    # false/true
 
-nl_func_leave_one_liners        { False, True }
-  Don't split one-line function definitions - 'int foo() { return 0; }'.
+# Don't split one-line function definitions - 'int foo() { return 0; }'.
+nl_func_leave_one_liners        = false    # false/true
 
-nl_cpp_lambda_leave_one_liners  { False, True }
-  Don't split one-line C++11 lambdas - '[]() { return 0; }'.
+# Don't split one-line C++11 lambdas - '[]() { return 0; }'.
+nl_cpp_lambda_leave_one_liners  = false    # false/true
 
-nl_if_leave_one_liners          { False, True }
-  Don't split one-line if/else statements - 'if(a) b++;'.
+# Don't split one-line if/else statements - 'if(a) b++;'.
+nl_if_leave_one_liners          = false    # false/true
 
-nl_while_leave_one_liners       { False, True }
-  Don't split one-line while statements - 'while(a) b++;'.
+# Don't split one-line while statements - 'while(a) b++;'.
+nl_while_leave_one_liners       = false    # false/true
 
-nl_oc_msg_leave_one_liner       { False, True }
-  Don't split one-line OC messages.
+# Don't split one-line OC messages.
+nl_oc_msg_leave_one_liner       = false    # false/true
 
-nl_oc_mdef_brace                { Ignore, Add, Remove, Force }
-  Add or remove newline between method declaration and '{'.
+# Add or remove newline between method declaration and '{'.
+nl_oc_mdef_brace                = ignore   # ignore/add/remove/force
 
-nl_oc_block_brace               { Ignore, Add, Remove, Force }
-  Add or remove newline between Objective-C block signature and '{'.
+# Add or remove newline between Objective-C block signature and '{'.
+nl_oc_block_brace               = ignore   # ignore/add/remove/force
 
-nl_oc_interface_brace           { Ignore, Add, Remove, Force }
-  Add or remove newline between @interface and '{'.
+# Add or remove newline between @interface and '{'.
+nl_oc_interface_brace           = ignore   # ignore/add/remove/force
 
-nl_oc_implementation_brace      { Ignore, Add, Remove, Force }
-  Add or remove newline between @implementation and '{'.
+# Add or remove newline between @implementation and '{'.
+nl_oc_implementation_brace      = ignore   # ignore/add/remove/force
 
-nl_start_of_file                { Ignore, Add, Remove, Force }
-  Add or remove newlines at the start of the file.
+# Add or remove newlines at the start of the file.
+nl_start_of_file                = ignore   # ignore/add/remove/force
 
-nl_start_of_file_min            Unsigned Number
-  The number of newlines at the start of the file (only used if nl_start_of_file is 'add' or 'force'.
+# The number of newlines at the start of the file (only used if nl_start_of_file is 'add' or 'force'.
+nl_start_of_file_min            = 0        # unsigned number
 
-nl_end_of_file                  { Ignore, Add, Remove, Force }
-  Add or remove newline at the end of the file.
+# Add or remove newline at the end of the file.
+nl_end_of_file                  = ignore   # ignore/add/remove/force
 
-nl_end_of_file_min              Unsigned Number
-  The number of newlines at the end of the file (only used if nl_end_of_file is 'add' or 'force').
+# The number of newlines at the end of the file (only used if nl_end_of_file is 'add' or 'force').
+nl_end_of_file_min              = 0        # unsigned number
 
-nl_assign_brace                 { Ignore, Add, Remove, Force }
-  Add or remove newline between '=' and '{'.
+# Add or remove newline between '=' and '{'.
+nl_assign_brace                 = ignore   # ignore/add/remove/force
 
-nl_assign_square                { Ignore, Add, Remove, Force }
-  Add or remove newline between '=' and '[' (D only).
+# Add or remove newline between '=' and '[' (D only).
+nl_assign_square                = ignore   # ignore/add/remove/force
 
-nl_tsquare_brace                { Ignore, Add, Remove, Force }
-  Add or remove newline between '[]' and '{'.
+# Add or remove newline between '[]' and '{'.
+nl_tsquare_brace                = ignore   # ignore/add/remove/force
 
-nl_after_square_assign          { Ignore, Add, Remove, Force }
-  Add or remove newline after '= [' (D only). Will also affect the newline before the ']'.
+# Add or remove newline after '= [' (D only). Will also affect the newline before the ']'.
+nl_after_square_assign          = ignore   # ignore/add/remove/force
 
-nl_func_var_def_blk             Unsigned Number
-  The number of blank lines after a block of variable definitions at the top of a function body
-  0 = No change (default).
+# The number of blank lines after a block of variable definitions at the top of a function body
+# 0 = No change (default).
+nl_func_var_def_blk             = 0        # unsigned number
 
-nl_typedef_blk_start            Unsigned Number
-  The number of newlines before a block of typedefs
-  0 = No change (default)
-  is overridden by the option 'nl_after_access_spec'.
+# The number of newlines before a block of typedefs
+# 0 = No change (default)
+# is overridden by the option 'nl_after_access_spec'.
+nl_typedef_blk_start            = 0        # unsigned number
 
-nl_typedef_blk_end              Unsigned Number
-  The number of newlines after a block of typedefs
-  0 = No change (default).
+# The number of newlines after a block of typedefs
+# 0 = No change (default).
+nl_typedef_blk_end              = 0        # unsigned number
 
-nl_typedef_blk_in               Unsigned Number
-  The maximum consecutive newlines within a block of typedefs
-  0 = No change (default).
+# The maximum consecutive newlines within a block of typedefs
+# 0 = No change (default).
+nl_typedef_blk_in               = 0        # unsigned number
 
-nl_var_def_blk_start            Unsigned Number
-  The number of newlines before a block of variable definitions not at the top of a function body
-  0 = No change (default)
-  is overridden by the option 'nl_after_access_spec'.
+# The number of newlines before a block of variable definitions not at the top of a function body
+# 0 = No change (default)
+# is overridden by the option 'nl_after_access_spec'.
+nl_var_def_blk_start            = 0        # unsigned number
 
-nl_var_def_blk_end              Unsigned Number
-  The number of newlines after a block of variable definitions not at the top of a function body
-  0 = No change (default).
+# The number of newlines after a block of variable definitions not at the top of a function body
+# 0 = No change (default).
+nl_var_def_blk_end              = 0        # unsigned number
 
-nl_var_def_blk_in               Unsigned Number
-  The maximum consecutive newlines within a block of variable definitions
-  0 = No change (default).
+# The maximum consecutive newlines within a block of variable definitions
+# 0 = No change (default).
+nl_var_def_blk_in               = 0        # unsigned number
 
-nl_fcall_brace                  { Ignore, Add, Remove, Force }
-  Add or remove newline between a function call's ')' and '{', as in:
-  list_for_each(item, &list) { }.
+# Add or remove newline between a function call's ')' and '{', as in:
+# list_for_each(item, &list) { }.
+nl_fcall_brace                  = ignore   # ignore/add/remove/force
 
-nl_enum_brace                   { Ignore, Add, Remove, Force }
-  Add or remove newline between 'enum' and '{'.
+# Add or remove newline between 'enum' and '{'.
+nl_enum_brace                   = ignore   # ignore/add/remove/force
 
-nl_enum_class                   { Ignore, Add, Remove, Force }
-  Add or remove newline between 'enum' and 'class'.
+# Add or remove newline between 'enum' and 'class'.
+nl_enum_class                   = ignore   # ignore/add/remove/force
 
-nl_enum_class_identifier        { Ignore, Add, Remove, Force }
-  Add or remove newline between 'enum class' and the identifier.
+# Add or remove newline between 'enum class' and the identifier.
+nl_enum_class_identifier        = ignore   # ignore/add/remove/force
 
-nl_enum_identifier_colon        { Ignore, Add, Remove, Force }
-  Add or remove newline between 'enum class' type and ':'.
+# Add or remove newline between 'enum class' type and ':'.
+nl_enum_identifier_colon        = ignore   # ignore/add/remove/force
 
-nl_enum_colon_type              { Ignore, Add, Remove, Force }
-  Add or remove newline between 'enum class identifier :' and 'type' and/or 'type'.
+# Add or remove newline between 'enum class identifier :' and 'type' and/or 'type'.
+nl_enum_colon_type              = ignore   # ignore/add/remove/force
 
-nl_struct_brace                 { Ignore, Add, Remove, Force }
-  Add or remove newline between 'struct and '{'.
+# Add or remove newline between 'struct and '{'.
+nl_struct_brace                 = ignore   # ignore/add/remove/force
 
-nl_union_brace                  { Ignore, Add, Remove, Force }
-  Add or remove newline between 'union' and '{'.
+# Add or remove newline between 'union' and '{'.
+nl_union_brace                  = ignore   # ignore/add/remove/force
 
-nl_if_brace                     { Ignore, Add, Remove, Force }
-  Add or remove newline between 'if' and '{'.
+# Add or remove newline between 'if' and '{'.
+nl_if_brace                     = ignore   # ignore/add/remove/force
 
-nl_brace_else                   { Ignore, Add, Remove, Force }
-  Add or remove newline between '}' and 'else'.
+# Add or remove newline between '}' and 'else'.
+nl_brace_else                   = ignore   # ignore/add/remove/force
 
-nl_elseif_brace                 { Ignore, Add, Remove, Force }
-  Add or remove newline between 'else if' and '{'
-  If set to ignore, nl_if_brace is used instead.
+# Add or remove newline between 'else if' and '{'
+# If set to ignore, nl_if_brace is used instead.
+nl_elseif_brace                 = ignore   # ignore/add/remove/force
 
-nl_else_brace                   { Ignore, Add, Remove, Force }
-  Add or remove newline between 'else' and '{'.
+# Add or remove newline between 'else' and '{'.
+nl_else_brace                   = ignore   # ignore/add/remove/force
 
-nl_else_if                      { Ignore, Add, Remove, Force }
-  Add or remove newline between 'else' and 'if'.
+# Add or remove newline between 'else' and 'if'.
+nl_else_if                      = ignore   # ignore/add/remove/force
 
-nl_before_if_closing_paren      { Ignore, Add, Remove, Force }
-  Add or remove newline before 'if'/'else if' closing parenthesis.
+# Add or remove newline before 'if'/'else if' closing parenthesis.
+nl_before_if_closing_paren      = ignore   # ignore/add/remove/force
 
-nl_brace_finally                { Ignore, Add, Remove, Force }
-  Add or remove newline between '}' and 'finally'.
+# Add or remove newline between '}' and 'finally'.
+nl_brace_finally                = ignore   # ignore/add/remove/force
 
-nl_finally_brace                { Ignore, Add, Remove, Force }
-  Add or remove newline between 'finally' and '{'.
+# Add or remove newline between 'finally' and '{'.
+nl_finally_brace                = ignore   # ignore/add/remove/force
 
-nl_try_brace                    { Ignore, Add, Remove, Force }
-  Add or remove newline between 'try' and '{'.
+# Add or remove newline between 'try' and '{'.
+nl_try_brace                    = ignore   # ignore/add/remove/force
 
-nl_getset_brace                 { Ignore, Add, Remove, Force }
-  Add or remove newline between get/set and '{'.
+# Add or remove newline between get/set and '{'.
+nl_getset_brace                 = ignore   # ignore/add/remove/force
 
-nl_for_brace                    { Ignore, Add, Remove, Force }
-  Add or remove newline between 'for' and '{'.
+# Add or remove newline between 'for' and '{'.
+nl_for_brace                    = ignore   # ignore/add/remove/force
 
-nl_catch_brace                  { Ignore, Add, Remove, Force }
-  Add or remove newline before '{' after a catch statement as in 'catch (something) { }'.
+# Add or remove newline before '{' after a catch statement as in 'catch (something) { }'.
+nl_catch_brace                  = ignore   # ignore/add/remove/force
 
-nl_oc_catch_brace               { Ignore, Add, Remove, Force }
-  Add or remove newline before '{' after a @catch statement as in '@catch (something) { }'.
-  If set to ignore, nl_catch_brace is used.
+# Add or remove newline before '{' after a @catch statement as in '@catch (something) { }'.
+# If set to ignore, nl_catch_brace is used.
+nl_oc_catch_brace               = ignore   # ignore/add/remove/force
 
-nl_brace_catch                  { Ignore, Add, Remove, Force }
-  Add or remove newline between '}' and 'catch'.
+# Add or remove newline between '}' and 'catch'.
+nl_brace_catch                  = ignore   # ignore/add/remove/force
 
-nl_oc_brace_catch               { Ignore, Add, Remove, Force }
-  Add or remove newline between '}' and 'catch'.
-  If set to ignore, nl_brace_catch is used.
+# Add or remove newline between '}' and 'catch'.
+# If set to ignore, nl_brace_catch is used.
+nl_oc_brace_catch               = ignore   # ignore/add/remove/force
 
-nl_brace_square                 { Ignore, Add, Remove, Force }
-  Add or remove newline between '}' and ']'.
+# Add or remove newline between '}' and ']'.
+nl_brace_square                 = ignore   # ignore/add/remove/force
 
-nl_brace_fparen                 { Ignore, Add, Remove, Force }
-  Add or remove newline between '}' and ')' in a function invocation.
+# Add or remove newline between '}' and ')' in a function invocation.
+nl_brace_fparen                 = ignore   # ignore/add/remove/force
 
-nl_while_brace                  { Ignore, Add, Remove, Force }
-  Add or remove newline between 'while' and '{'.
+# Add or remove newline between 'while' and '{'.
+nl_while_brace                  = ignore   # ignore/add/remove/force
 
-nl_scope_brace                  { Ignore, Add, Remove, Force }
-  Add or remove newline between 'scope (x)' and '{' (D).
+# Add or remove newline between 'scope (x)' and '{' (D).
+nl_scope_brace                  = ignore   # ignore/add/remove/force
 
-nl_unittest_brace               { Ignore, Add, Remove, Force }
-  Add or remove newline between 'unittest' and '{' (D).
+# Add or remove newline between 'unittest' and '{' (D).
+nl_unittest_brace               = ignore   # ignore/add/remove/force
 
-nl_version_brace                { Ignore, Add, Remove, Force }
-  Add or remove newline between 'version (x)' and '{' (D).
+# Add or remove newline between 'version (x)' and '{' (D).
+nl_version_brace                = ignore   # ignore/add/remove/force
 
-nl_using_brace                  { Ignore, Add, Remove, Force }
-  Add or remove newline between 'using' and '{'.
+# Add or remove newline between 'using' and '{'.
+nl_using_brace                  = ignore   # ignore/add/remove/force
 
-nl_brace_brace                  { Ignore, Add, Remove, Force }
-  Add or remove newline between two open or close braces.
-  Due to general newline/brace handling, REMOVE may not work.
+# Add or remove newline between two open or close braces.
+# Due to general newline/brace handling, REMOVE may not work.
+nl_brace_brace                  = ignore   # ignore/add/remove/force
 
-nl_do_brace                     { Ignore, Add, Remove, Force }
-  Add or remove newline between 'do' and '{'.
+# Add or remove newline between 'do' and '{'.
+nl_do_brace                     = ignore   # ignore/add/remove/force
 
-nl_brace_while                  { Ignore, Add, Remove, Force }
-  Add or remove newline between '}' and 'while' of 'do' statement.
+# Add or remove newline between '}' and 'while' of 'do' statement.
+nl_brace_while                  = ignore   # ignore/add/remove/force
 
-nl_switch_brace                 { Ignore, Add, Remove, Force }
-  Add or remove newline between 'switch' and '{'.
+# Add or remove newline between 'switch' and '{'.
+nl_switch_brace                 = ignore   # ignore/add/remove/force
 
-nl_synchronized_brace           { Ignore, Add, Remove, Force }
-  Add or remove newline between 'synchronized' and '{'.
+# Add or remove newline between 'synchronized' and '{'.
+nl_synchronized_brace           = ignore   # ignore/add/remove/force
 
-nl_multi_line_cond              { False, True }
-  Add a newline between ')' and '{' if the ')' is on a different line than the if/for/etc.
-  Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch and nl_catch_brace.
+# Add a newline between ')' and '{' if the ')' is on a different line than the if/for/etc.
+# Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch and nl_catch_brace.
+nl_multi_line_cond              = false    # false/true
 
-nl_multi_line_define            { False, True }
-  Force a newline in a define after the macro name for multi-line defines.
+# Force a newline in a define after the macro name for multi-line defines.
+nl_multi_line_define            = false    # false/true
 
-nl_before_case                  { False, True }
-  Whether to put a newline before 'case' statement, not after the first 'case'.
+# Whether to put a newline before 'case' statement, not after the first 'case'.
+nl_before_case                  = false    # false/true
 
-nl_before_throw                 { Ignore, Add, Remove, Force }
-  Add or remove newline between ')' and 'throw'.
+# Add or remove newline between ')' and 'throw'.
+nl_before_throw                 = ignore   # ignore/add/remove/force
 
-nl_after_case                   { False, True }
-  Whether to put a newline after 'case' statement.
+# Whether to put a newline after 'case' statement.
+nl_after_case                   = false    # false/true
 
-nl_case_colon_brace             { Ignore, Add, Remove, Force }
-  Add or remove a newline between a case ':' and '{'. Overrides nl_after_case.
+# Add or remove a newline between a case ':' and '{'. Overrides nl_after_case.
+nl_case_colon_brace             = ignore   # ignore/add/remove/force
 
-nl_namespace_brace              { Ignore, Add, Remove, Force }
-  Newline between namespace and {.
+# Newline between namespace and {.
+nl_namespace_brace              = ignore   # ignore/add/remove/force
 
-nl_template_class               { Ignore, Add, Remove, Force }
-  Add or remove newline between 'template<>' and whatever follows.
+# Add or remove newline between 'template<>' and whatever follows.
+nl_template_class               = ignore   # ignore/add/remove/force
 
-nl_class_brace                  { Ignore, Add, Remove, Force }
-  Add or remove newline between 'class' and '{'.
+# Add or remove newline between 'class' and '{'.
+nl_class_brace                  = ignore   # ignore/add/remove/force
 
-nl_class_init_args              { Ignore, Add, Remove, Force }
-  Add or remove newline before/after each ',' in the base class list,
-    (tied to pos_class_comma).
+# Add or remove newline before/after each ',' in the base class list,
+#   (tied to pos_class_comma).
+nl_class_init_args              = ignore   # ignore/add/remove/force
 
-nl_constr_init_args             { Ignore, Add, Remove, Force }
-  Add or remove newline after each ',' in the constructor member initialization.
-  Related to nl_constr_colon, pos_constr_colon and pos_constr_comma.
+# Add or remove newline after each ',' in the constructor member initialization.
+# Related to nl_constr_colon, pos_constr_colon and pos_constr_comma.
+nl_constr_init_args             = ignore   # ignore/add/remove/force
 
-nl_enum_own_lines               { Ignore, Add, Remove, Force }
-  Add or remove newline before first element, after comma, and after last element in enum.
+# Add or remove newline before first element, after comma, and after last element in enum.
+nl_enum_own_lines               = ignore   # ignore/add/remove/force
 
-nl_func_type_name               { Ignore, Add, Remove, Force }
-  Add or remove newline between return type and function name in a function definition.
+# Add or remove newline between return type and function name in a function definition.
+nl_func_type_name               = ignore   # ignore/add/remove/force
 
-nl_func_type_name_class         { Ignore, Add, Remove, Force }
-  Add or remove newline between return type and function name inside a class {}
-  Uses nl_func_type_name or nl_func_proto_type_name if set to ignore.
+# Add or remove newline between return type and function name inside a class {}
+# Uses nl_func_type_name or nl_func_proto_type_name if set to ignore.
+nl_func_type_name_class         = ignore   # ignore/add/remove/force
 
-nl_func_class_scope             { Ignore, Add, Remove, Force }
-  Add or remove newline between class specification and '::' in 'void A::f() { }'
-  Only appears in separate member implementation (does not appear with in-line implmementation).
+# Add or remove newline between class specification and '::' in 'void A::f() { }'
+# Only appears in separate member implementation (does not appear with in-line implmementation).
+nl_func_class_scope             = ignore   # ignore/add/remove/force
 
-nl_func_scope_name              { Ignore, Add, Remove, Force }
-  Add or remove newline between function scope and name
-  Controls the newline after '::' in 'void A::f() { }'.
+# Add or remove newline between function scope and name
+# Controls the newline after '::' in 'void A::f() { }'.
+nl_func_scope_name              = ignore   # ignore/add/remove/force
 
-nl_func_proto_type_name         { Ignore, Add, Remove, Force }
-  Add or remove newline between return type and function name in a prototype.
+# Add or remove newline between return type and function name in a prototype.
+nl_func_proto_type_name         = ignore   # ignore/add/remove/force
 
-nl_func_paren                   { Ignore, Add, Remove, Force }
-  Add or remove newline between a function name and the opening '(' in the declaration.
+# Add or remove newline between a function name and the opening '(' in the declaration.
+nl_func_paren                   = ignore   # ignore/add/remove/force
 
-nl_func_paren_empty             { Ignore, Add, Remove, Force }
-  Overrides nl_func_paren for functions with no parameters.
+# Overrides nl_func_paren for functions with no parameters.
+nl_func_paren_empty             = ignore   # ignore/add/remove/force
 
-nl_func_def_paren               { Ignore, Add, Remove, Force }
-  Add or remove newline between a function name and the opening '(' in the definition.
+# Add or remove newline between a function name and the opening '(' in the definition.
+nl_func_def_paren               = ignore   # ignore/add/remove/force
 
-nl_func_def_paren_empty         { Ignore, Add, Remove, Force }
-  Overrides nl_func_def_paren for functions with no parameters.
+# Overrides nl_func_def_paren for functions with no parameters.
+nl_func_def_paren_empty         = ignore   # ignore/add/remove/force
 
-nl_func_call_paren              { Ignore, Add, Remove, Force }
-  Add or remove newline between a function name and the opening '(' in the call
+# Add or remove newline between a function name and the opening '(' in the call
+nl_func_call_paren              = ignore   # ignore/add/remove/force
 
-nl_func_call_paren_empty        { Ignore, Add, Remove, Force }
-  Overrides nl_func_call_paren for functions with no parameters.
+# Overrides nl_func_call_paren for functions with no parameters.
+nl_func_call_paren_empty        = ignore   # ignore/add/remove/force
 
-nl_func_decl_start              { Ignore, Add, Remove, Force }
-  Add or remove newline after '(' in a function declaration.
+# Add or remove newline after '(' in a function declaration.
+nl_func_decl_start              = ignore   # ignore/add/remove/force
 
-nl_func_def_start               { Ignore, Add, Remove, Force }
-  Add or remove newline after '(' in a function definition.
+# Add or remove newline after '(' in a function definition.
+nl_func_def_start               = ignore   # ignore/add/remove/force
 
-nl_func_decl_start_single       { Ignore, Add, Remove, Force }
-  Overrides nl_func_decl_start when there is only one parameter.
+# Overrides nl_func_decl_start when there is only one parameter.
+nl_func_decl_start_single       = ignore   # ignore/add/remove/force
 
-nl_func_def_start_single        { Ignore, Add, Remove, Force }
-  Overrides nl_func_def_start when there is only one parameter.
+# Overrides nl_func_def_start when there is only one parameter.
+nl_func_def_start_single        = ignore   # ignore/add/remove/force
 
-nl_func_decl_start_multi_line   { False, True }
-  Whether to add newline after '(' in a function declaration if '(' and ')' are in different lines.
+# Whether to add newline after '(' in a function declaration if '(' and ')' are in different lines.
+nl_func_decl_start_multi_line   = false    # false/true
 
-nl_func_def_start_multi_line    { False, True }
-  Whether to add newline after '(' in a function definition if '(' and ')' are in different lines.
+# Whether to add newline after '(' in a function definition if '(' and ')' are in different lines.
+nl_func_def_start_multi_line    = false    # false/true
 
-nl_func_decl_args               { Ignore, Add, Remove, Force }
-  Add or remove newline after each ',' in a function declaration.
+# Add or remove newline after each ',' in a function declaration.
+nl_func_decl_args               = ignore   # ignore/add/remove/force
 
-nl_func_def_args                { Ignore, Add, Remove, Force }
-  Add or remove newline after each ',' in a function definition.
+# Add or remove newline after each ',' in a function definition.
+nl_func_def_args                = ignore   # ignore/add/remove/force
 
-nl_func_decl_args_multi_line    { False, True }
-  Whether to add newline after each ',' in a function declaration if '(' and ')' are in different lines.
+# Whether to add newline after each ',' in a function declaration if '(' and ')' are in different lines.
+nl_func_decl_args_multi_line    = false    # false/true
 
-nl_func_def_args_multi_line     { False, True }
-  Whether to add newline after each ',' in a function definition if '(' and ')' are in different lines.
+# Whether to add newline after each ',' in a function definition if '(' and ')' are in different lines.
+nl_func_def_args_multi_line     = false    # false/true
 
-nl_func_decl_end                { Ignore, Add, Remove, Force }
-  Add or remove newline before the ')' in a function declaration.
+# Add or remove newline before the ')' in a function declaration.
+nl_func_decl_end                = ignore   # ignore/add/remove/force
 
-nl_func_def_end                 { Ignore, Add, Remove, Force }
-  Add or remove newline before the ')' in a function definition.
+# Add or remove newline before the ')' in a function definition.
+nl_func_def_end                 = ignore   # ignore/add/remove/force
 
-nl_func_decl_end_single         { Ignore, Add, Remove, Force }
-  Overrides nl_func_decl_end when there is only one parameter.
+# Overrides nl_func_decl_end when there is only one parameter.
+nl_func_decl_end_single         = ignore   # ignore/add/remove/force
 
-nl_func_def_end_single          { Ignore, Add, Remove, Force }
-  Overrides nl_func_def_end when there is only one parameter.
+# Overrides nl_func_def_end when there is only one parameter.
+nl_func_def_end_single          = ignore   # ignore/add/remove/force
 
-nl_func_decl_end_multi_line     { False, True }
-  Whether to add newline before ')' in a function declaration if '(' and ')' are in different lines.
+# Whether to add newline before ')' in a function declaration if '(' and ')' are in different lines.
+nl_func_decl_end_multi_line     = false    # false/true
 
-nl_func_def_end_multi_line      { False, True }
-  Whether to add newline before ')' in a function definition if '(' and ')' are in different lines.
+# Whether to add newline before ')' in a function definition if '(' and ')' are in different lines.
+nl_func_def_end_multi_line      = false    # false/true
 
-nl_func_decl_empty              { Ignore, Add, Remove, Force }
-  Add or remove newline between '()' in a function declaration.
+# Add or remove newline between '()' in a function declaration.
+nl_func_decl_empty              = ignore   # ignore/add/remove/force
 
-nl_func_def_empty               { Ignore, Add, Remove, Force }
-  Add or remove newline between '()' in a function definition.
+# Add or remove newline between '()' in a function definition.
+nl_func_def_empty               = ignore   # ignore/add/remove/force
 
-nl_func_call_empty              { Ignore, Add, Remove, Force }
-  Add or remove newline between '()' in a function call.
+# Add or remove newline between '()' in a function call.
+nl_func_call_empty              = ignore   # ignore/add/remove/force
 
-nl_func_call_start_multi_line   { False, True }
-  Whether to add newline after '(' in a function call if '(' and ')' are in different lines.
+# Whether to add newline after '(' in a function call if '(' and ')' are in different lines.
+nl_func_call_start_multi_line   = false    # false/true
 
-nl_func_call_args_multi_line    { False, True }
-  Whether to add newline after each ',' in a function call if '(' and ')' are in different lines.
+# Whether to add newline after each ',' in a function call if '(' and ')' are in different lines.
+nl_func_call_args_multi_line    = false    # false/true
 
-nl_func_call_end_multi_line     { False, True }
-  Whether to add newline before ')' in a function call if '(' and ')' are in different lines.
+# Whether to add newline before ')' in a function call if '(' and ')' are in different lines.
+nl_func_call_end_multi_line     = false    # false/true
 
-nl_oc_msg_args                  { False, True }
-  Whether to put each OC message parameter on a separate line
-  See nl_oc_msg_leave_one_liner.
+# Whether to put each OC message parameter on a separate line
+# See nl_oc_msg_leave_one_liner.
+nl_oc_msg_args                  = false    # false/true
 
-nl_fdef_brace                   { Ignore, Add, Remove, Force }
-  Add or remove newline between function signature and '{'.
+# Add or remove newline between function signature and '{'.
+nl_fdef_brace                   = ignore   # ignore/add/remove/force
 
-nl_cpp_ldef_brace               { Ignore, Add, Remove, Force }
-  Add or remove newline between C++11 lambda signature and '{'.
+# Add or remove newline between C++11 lambda signature and '{'.
+nl_cpp_ldef_brace               = ignore   # ignore/add/remove/force
 
-nl_return_expr                  { Ignore, Add, Remove, Force }
-  Add or remove a newline between the return keyword and return expression.
+# Add or remove a newline between the return keyword and return expression.
+nl_return_expr                  = ignore   # ignore/add/remove/force
 
-nl_after_semicolon              { False, True }
-  Whether to put a newline after semicolons, except in 'for' statements.
+# Whether to put a newline after semicolons, except in 'for' statements.
+nl_after_semicolon              = false    # false/true
 
-nl_paren_dbrace_open            { Ignore, Add, Remove, Force }
-  Java: Control the newline between the ')' and '{{' of the double brace initializer.
+# Java: Control the newline between the ')' and '{{' of the double brace initializer.
+nl_paren_dbrace_open            = ignore   # ignore/add/remove/force
 
-nl_type_brace_init_lst          { Ignore, Add, Remove, Force }
-  Whether to put a newline after the type in an unnamed temporary direct-list-initialization.
+# Whether to put a newline after the type in an unnamed temporary direct-list-initialization.
+nl_type_brace_init_lst          = ignore   # ignore/add/remove/force
 
-nl_type_brace_init_lst_open     { Ignore, Add, Remove, Force }
-  Whether to put a newline after open brace in an unnamed temporary direct-list-initialization.
+# Whether to put a newline after open brace in an unnamed temporary direct-list-initialization.
+nl_type_brace_init_lst_open     = ignore   # ignore/add/remove/force
 
-nl_type_brace_init_lst_close    { Ignore, Add, Remove, Force }
-  Whether to put a newline before close brace in an unnamed temporary direct-list-initialization.
+# Whether to put a newline before close brace in an unnamed temporary direct-list-initialization.
+nl_type_brace_init_lst_close    = ignore   # ignore/add/remove/force
 
-nl_after_brace_open             { False, True }
-  Whether to put a newline after brace open.
-  This also adds a newline before the matching brace close.
+# Whether to put a newline after brace open.
+# This also adds a newline before the matching brace close.
+nl_after_brace_open             = false    # false/true
 
-nl_after_brace_open_cmt         { False, True }
-  If nl_after_brace_open and nl_after_brace_open_cmt are True, a newline is
-  placed between the open brace and a trailing single-line comment.
+# If nl_after_brace_open and nl_after_brace_open_cmt are True, a newline is
+# placed between the open brace and a trailing single-line comment.
+nl_after_brace_open_cmt         = false    # false/true
 
-nl_after_vbrace_open            { False, True }
-  Whether to put a newline after a virtual brace open with a non-empty body.
-  These occur in un-braced if/while/do/for statement bodies.
+# Whether to put a newline after a virtual brace open with a non-empty body.
+# These occur in un-braced if/while/do/for statement bodies.
+nl_after_vbrace_open            = false    # false/true
 
-nl_after_vbrace_open_empty      { False, True }
-  Whether to put a newline after a virtual brace open with an empty body.
-  These occur in un-braced if/while/do/for statement bodies.
+# Whether to put a newline after a virtual brace open with an empty body.
+# These occur in un-braced if/while/do/for statement bodies.
+nl_after_vbrace_open_empty      = false    # false/true
 
-nl_after_brace_close            { False, True }
-  Whether to put a newline after a brace close.
-  Does not apply if followed by a necessary ';'.
+# Whether to put a newline after a brace close.
+# Does not apply if followed by a necessary ';'.
+nl_after_brace_close            = false    # false/true
 
-nl_after_vbrace_close           { False, True }
-  Whether to put a newline after a virtual brace close.
-  Would add a newline before return in: 'if (foo) a++; return;'.
+# Whether to put a newline after a virtual brace close.
+# Would add a newline before return in: 'if (foo) a++; return;'.
+nl_after_vbrace_close           = false    # false/true
 
-nl_brace_struct_var             { Ignore, Add, Remove, Force }
-  Control the newline between the close brace and 'b' in: 'struct { int a; } b;'
-  Affects enums, unions and structures. If set to ignore, uses nl_after_brace_close.
+# Control the newline between the close brace and 'b' in: 'struct { int a; } b;'
+# Affects enums, unions and structures. If set to ignore, uses nl_after_brace_close.
+nl_brace_struct_var             = ignore   # ignore/add/remove/force
 
-nl_define_macro                 { False, True }
-  Whether to alter newlines in '#define' macros.
+# Whether to alter newlines in '#define' macros.
+nl_define_macro                 = false    # false/true
 
-nl_squeeze_paren_close          { False, True }
-  Whether to alter newlines between consecutive paren closes, 
-  The number of closing paren in a line will depend on respective open paren lines
+# Whether to alter newlines between consecutive paren closes, 
+# The number of closing paren in a line will depend on respective open paren lines
+nl_squeeze_paren_close          = false    # false/true
 
-nl_squeeze_ifdef                { False, True }
-  Whether to remove blanks after '#ifxx' and '#elxx', or before '#elxx' and '#endif'. Does not affect top-level #ifdefs.
+# Whether to remove blanks after '#ifxx' and '#elxx', or before '#elxx' and '#endif'. Does not affect top-level #ifdefs.
+nl_squeeze_ifdef                = false    # false/true
 
-nl_squeeze_ifdef_top_level      { False, True }
-  Makes the nl_squeeze_ifdef option affect the top-level #ifdefs as well.
+# Makes the nl_squeeze_ifdef option affect the top-level #ifdefs as well.
+nl_squeeze_ifdef_top_level      = false    # false/true
 
-nl_before_if                    { Ignore, Add, Remove, Force }
-  Add or remove blank line before 'if'.
+# Add or remove blank line before 'if'.
+nl_before_if                    = ignore   # ignore/add/remove/force
 
-nl_after_if                     { Ignore, Add, Remove, Force }
-  Add or remove blank line after 'if' statement.
-  Add/Force work only if the next token is not a closing brace.
+# Add or remove blank line after 'if' statement.
+# Add/Force work only if the next token is not a closing brace.
+nl_after_if                     = ignore   # ignore/add/remove/force
 
-nl_before_for                   { Ignore, Add, Remove, Force }
-  Add or remove blank line before 'for'.
+# Add or remove blank line before 'for'.
+nl_before_for                   = ignore   # ignore/add/remove/force
 
-nl_after_for                    { Ignore, Add, Remove, Force }
-  Add or remove blank line after 'for' statement.
+# Add or remove blank line after 'for' statement.
+nl_after_for                    = ignore   # ignore/add/remove/force
 
-nl_before_while                 { Ignore, Add, Remove, Force }
-  Add or remove blank line before 'while'.
+# Add or remove blank line before 'while'.
+nl_before_while                 = ignore   # ignore/add/remove/force
 
-nl_after_while                  { Ignore, Add, Remove, Force }
-  Add or remove blank line after 'while' statement.
+# Add or remove blank line after 'while' statement.
+nl_after_while                  = ignore   # ignore/add/remove/force
 
-nl_before_switch                { Ignore, Add, Remove, Force }
-  Add or remove blank line before 'switch'.
+# Add or remove blank line before 'switch'.
+nl_before_switch                = ignore   # ignore/add/remove/force
 
-nl_after_switch                 { Ignore, Add, Remove, Force }
-  Add or remove blank line after 'switch' statement.
+# Add or remove blank line after 'switch' statement.
+nl_after_switch                 = ignore   # ignore/add/remove/force
 
-nl_before_synchronized          { Ignore, Add, Remove, Force }
-  Add or remove blank line before 'synchronized'.
+# Add or remove blank line before 'synchronized'.
+nl_before_synchronized          = ignore   # ignore/add/remove/force
 
-nl_after_synchronized           { Ignore, Add, Remove, Force }
-  Add or remove blank line after 'synchronized' statement.
+# Add or remove blank line after 'synchronized' statement.
+nl_after_synchronized           = ignore   # ignore/add/remove/force
 
-nl_before_do                    { Ignore, Add, Remove, Force }
-  Add or remove blank line before 'do'.
+# Add or remove blank line before 'do'.
+nl_before_do                    = ignore   # ignore/add/remove/force
 
-nl_after_do                     { Ignore, Add, Remove, Force }
-  Add or remove blank line after 'do/while' statement.
+# Add or remove blank line after 'do/while' statement.
+nl_after_do                     = ignore   # ignore/add/remove/force
 
-nl_ds_struct_enum_cmt           { False, True }
-  Whether to double-space commented-entries in struct/union/enum.
+# Whether to double-space commented-entries in struct/union/enum.
+nl_ds_struct_enum_cmt           = false    # false/true
 
-nl_ds_struct_enum_close_brace   { False, True }
-  force nl before } of a struct/union/enum
-  (lower priority than 'eat_blanks_before_close_brace').
+# force nl before } of a struct/union/enum
+# (lower priority than 'eat_blanks_before_close_brace').
+nl_ds_struct_enum_close_brace   = false    # false/true
 
-nl_before_func_class_def        Unsigned Number
-  Add or remove blank line before 'func_class_def'.
+# Add or remove blank line before 'func_class_def'.
+nl_before_func_class_def        = 0        # unsigned number
 
-nl_before_func_class_proto      Unsigned Number
-  Add or remove blank line before 'func_class_proto'.
+# Add or remove blank line before 'func_class_proto'.
+nl_before_func_class_proto      = 0        # unsigned number
 
-nl_class_colon                  { Ignore, Add, Remove, Force }
-  Add or remove a newline before/after a class colon,
-    (tied to pos_class_colon).
+# Add or remove a newline before/after a class colon,
+#   (tied to pos_class_colon).
+nl_class_colon                  = ignore   # ignore/add/remove/force
 
-nl_constr_colon                 { Ignore, Add, Remove, Force }
-  Add or remove a newline around a class constructor colon.
-  Related to nl_constr_init_args, pos_constr_colon and pos_constr_comma.
+# Add or remove a newline around a class constructor colon.
+# Related to nl_constr_init_args, pos_constr_colon and pos_constr_comma.
+nl_constr_colon                 = ignore   # ignore/add/remove/force
 
-nl_namespace_two_to_one_liner   { False, True }
-  If true turns two liner namespace to one liner,else will make then four liners
+# If true turns two liner namespace to one liner,else will make then four liners
+nl_namespace_two_to_one_liner   = false    # false/true
 
-nl_create_if_one_liner          { False, True }
-  Change simple unbraced if statements into a one-liner
-  'if(b)\n i++;' => 'if(b) i++;'.
+# Change simple unbraced if statements into a one-liner
+# 'if(b)\n i++;' => 'if(b) i++;'.
+nl_create_if_one_liner          = false    # false/true
 
-nl_create_for_one_liner         { False, True }
-  Change simple unbraced for statements into a one-liner
-  'for (i=0;i<5;i++)\n foo(i);' => 'for (i=0;i<5;i++) foo(i);'.
+# Change simple unbraced for statements into a one-liner
+# 'for (i=0;i<5;i++)\n foo(i);' => 'for (i=0;i<5;i++) foo(i);'.
+nl_create_for_one_liner         = false    # false/true
 
-nl_create_while_one_liner       { False, True }
-  Change simple unbraced while statements into a one-liner
-  'while (i<5)\n foo(i++);' => 'while (i<5) foo(i++);'.
+# Change simple unbraced while statements into a one-liner
+# 'while (i<5)\n foo(i++);' => 'while (i<5) foo(i++);'.
+nl_create_while_one_liner       = false    # false/true
 
-nl_create_func_def_one_liner    { False, True }
-  Change simple 4,3,2 liner function def statements into a one-liner
-  
+# Change simple 4,3,2 liner function def statements into a one-liner
+nl_create_func_def_one_liner    = false    # false/true
 
-nl_split_if_one_liner           { False, True }
-   Change a one-liner if statement into simple unbraced if
-  'if(b) i++;' => 'if(b)\n i++;'.
+#  Change a one-liner if statement into simple unbraced if
+# 'if(b) i++;' => 'if(b)\n i++;'.
+nl_split_if_one_liner           = false    # false/true
 
-nl_split_for_one_liner          { False, True }
-  Change a one-liner for statement into simple unbraced for
-  'for (i=0;<5;i++) foo(i);' => 'for (i=0;<5;i++)\n foo(i);'.
+# Change a one-liner for statement into simple unbraced for
+# 'for (i=0;<5;i++) foo(i);' => 'for (i=0;<5;i++)\n foo(i);'.
+nl_split_for_one_liner          = false    # false/true
 
-nl_split_while_one_liner        { False, True }
-  Change a one-liner while statement into simple unbraced while
-  'while (i<5) foo(i++);' => 'while (i<5)\n foo(i++);'.
+# Change a one-liner while statement into simple unbraced while
+# 'while (i<5) foo(i++);' => 'while (i<5)\n foo(i++);'.
+nl_split_while_one_liner        = false    # false/true
 
 #
 # Blank line options
 #
 
-nl_max                          Unsigned Number
-  The maximum consecutive newlines (3 = 2 blank lines).
+# The maximum consecutive newlines (3 = 2 blank lines).
+nl_max                          = 0        # unsigned number
 
-nl_max_blank_in_func            Unsigned Number
-  The maximum consecutive newlines in function.
+# The maximum consecutive newlines in function.
+nl_max_blank_in_func            = 0        # unsigned number
 
-nl_after_func_proto             Unsigned Number
-  The number of newlines after a function prototype, if followed by another function prototype.
+# The number of newlines after a function prototype, if followed by another function prototype.
+nl_after_func_proto             = 0        # unsigned number
 
-nl_after_func_proto_group       Unsigned Number
-  The number of newlines after a function prototype, if not followed by another function prototype.
+# The number of newlines after a function prototype, if not followed by another function prototype.
+nl_after_func_proto_group       = 0        # unsigned number
 
-nl_after_func_class_proto       Unsigned Number
-  The number of newlines after a function class prototype, if followed by another function class prototype.
+# The number of newlines after a function class prototype, if followed by another function class prototype.
+nl_after_func_class_proto       = 0        # unsigned number
 
-nl_after_func_class_proto_group Unsigned Number
-  The number of newlines after a function class prototype, if not followed by another function class prototype.
+# The number of newlines after a function class prototype, if not followed by another function class prototype.
+nl_after_func_class_proto_group = 0        # unsigned number
 
-nl_before_func_body_def         Unsigned Number
-  The number of newlines before a multi-line function def body.
+# The number of newlines before a multi-line function def body.
+nl_before_func_body_def         = 0        # unsigned number
 
-nl_before_func_body_proto       Unsigned Number
-  The number of newlines before a multi-line function prototype body.
+# The number of newlines before a multi-line function prototype body.
+nl_before_func_body_proto       = 0        # unsigned number
 
-nl_after_func_body              Unsigned Number
-  The number of newlines after '}' of a multi-line function body.
+# The number of newlines after '}' of a multi-line function body.
+nl_after_func_body              = 0        # unsigned number
 
-nl_after_func_body_class        Unsigned Number
-  The number of newlines after '}' of a multi-line function body in a class declaration.
+# The number of newlines after '}' of a multi-line function body in a class declaration.
+nl_after_func_body_class        = 0        # unsigned number
 
-nl_after_func_body_one_liner    Unsigned Number
-  The number of newlines after '}' of a single line function body.
+# The number of newlines after '}' of a single line function body.
+nl_after_func_body_one_liner    = 0        # unsigned number
 
-nl_before_block_comment         Unsigned Number
-  The minimum number of newlines before a multi-line comment.
-  Doesn't apply if after a brace open or another multi-line comment.
+# The minimum number of newlines before a multi-line comment.
+# Doesn't apply if after a brace open or another multi-line comment.
+nl_before_block_comment         = 0        # unsigned number
 
-nl_before_c_comment             Unsigned Number
-  The minimum number of newlines before a single-line C comment.
-  Doesn't apply if after a brace open or other single-line C comments.
+# The minimum number of newlines before a single-line C comment.
+# Doesn't apply if after a brace open or other single-line C comments.
+nl_before_c_comment             = 0        # unsigned number
 
-nl_before_cpp_comment           Unsigned Number
-  The minimum number of newlines before a CPP comment.
-  Doesn't apply if after a brace open or other CPP comments.
+# The minimum number of newlines before a CPP comment.
+# Doesn't apply if after a brace open or other CPP comments.
+nl_before_cpp_comment           = 0        # unsigned number
 
-nl_after_multiline_comment      { False, True }
-  Whether to force a newline after a multi-line comment.
+# Whether to force a newline after a multi-line comment.
+nl_after_multiline_comment      = false    # false/true
 
-nl_after_label_colon            { False, True }
-  Whether to force a newline after a label's colon.
+# Whether to force a newline after a label's colon.
+nl_after_label_colon            = false    # false/true
 
-nl_after_struct                 Unsigned Number
-  The number of newlines after '}' or ';' of a struct/enum/union definition.
+# The number of newlines after '}' or ';' of a struct/enum/union definition.
+nl_after_struct                 = 0        # unsigned number
 
-nl_before_class                 Unsigned Number
-  The number of newlines before a class definition.
+# The number of newlines before a class definition.
+nl_before_class                 = 0        # unsigned number
 
-nl_after_class                  Unsigned Number
-  The number of newlines after '}' or ';' of a class definition.
+# The number of newlines after '}' or ';' of a class definition.
+nl_after_class                  = 0        # unsigned number
 
-nl_before_access_spec           Unsigned Number
-  The number of newlines before a 'private:', 'public:', 'protected:', 'signals:', or 'slots:' label.
-  Will not change the newline count if after a brace open.
-  0 = No change.
+# The number of newlines before a 'private:', 'public:', 'protected:', 'signals:', or 'slots:' label.
+# Will not change the newline count if after a brace open.
+# 0 = No change.
+nl_before_access_spec           = 0        # unsigned number
 
-nl_after_access_spec            Unsigned Number
-  The number of newlines after a 'private:', 'public:', 'protected:', 'signals:' or 'slots:' label.
-  0 = No change.
-  Overrides 'nl_typedef_blk_start' and 'nl_var_def_blk_start'.
+# The number of newlines after a 'private:', 'public:', 'protected:', 'signals:' or 'slots:' label.
+# 0 = No change.
+# Overrides 'nl_typedef_blk_start' and 'nl_var_def_blk_start'.
+nl_after_access_spec            = 0        # unsigned number
 
-nl_comment_func_def             Unsigned Number
-  The number of newlines between a function def and the function comment.
-  0 = No change.
+# The number of newlines between a function def and the function comment.
+# 0 = No change.
+nl_comment_func_def             = 0        # unsigned number
 
-nl_after_try_catch_finally      Unsigned Number
-  The number of newlines after a try-catch-finally block that isn't followed by a brace close.
-  0 = No change.
+# The number of newlines after a try-catch-finally block that isn't followed by a brace close.
+# 0 = No change.
+nl_after_try_catch_finally      = 0        # unsigned number
 
-nl_around_cs_property           Unsigned Number
-  The number of newlines before and after a property, indexer or event decl.
-  0 = No change.
+# The number of newlines before and after a property, indexer or event decl.
+# 0 = No change.
+nl_around_cs_property           = 0        # unsigned number
 
-nl_between_get_set              Unsigned Number
-  The number of newlines between the get/set/add/remove handlers in C#.
-  0 = No change.
+# The number of newlines between the get/set/add/remove handlers in C#.
+# 0 = No change.
+nl_between_get_set              = 0        # unsigned number
 
-nl_property_brace               { Ignore, Add, Remove, Force }
-  Add or remove newline between C# property and the '{'.
+# Add or remove newline between C# property and the '{'.
+nl_property_brace               = ignore   # ignore/add/remove/force
 
-eat_blanks_after_open_brace     { False, True }
-  Whether to remove blank lines after '{'.
+# Whether to remove blank lines after '{'.
+eat_blanks_after_open_brace     = false    # false/true
 
-eat_blanks_before_close_brace   { False, True }
-  Whether to remove blank lines before '}'.
+# Whether to remove blank lines before '}'.
+eat_blanks_before_close_brace   = false    # false/true
 
-nl_remove_extra_newlines        Unsigned Number
-  How aggressively to remove extra newlines not in preproc.
-  0: No change
-  1: Remove most newlines not handled by other config
-  2: Remove all newlines and reformat completely by config
+# How aggressively to remove extra newlines not in preproc.
+# 0: No change
+# 1: Remove most newlines not handled by other config
+# 2: Remove all newlines and reformat completely by config
+nl_remove_extra_newlines        = 0        # unsigned number
 
-nl_before_return                { False, True }
-  Whether to put a blank line before 'return' statements, unless after an open brace.
+# Whether to put a blank line before 'return' statements, unless after an open brace.
+nl_before_return                = false    # false/true
 
-nl_after_return                 { False, True }
-  Whether to put a blank line after 'return' statements, unless followed by a close brace.
+# Whether to put a blank line after 'return' statements, unless followed by a close brace.
+nl_after_return                 = false    # false/true
 
-nl_after_annotation             { Ignore, Add, Remove, Force }
-  Whether to put a newline after a Java annotation statement.
-  Only affects annotations that are after a newline.
+# Whether to put a newline after a Java annotation statement.
+# Only affects annotations that are after a newline.
+nl_after_annotation             = ignore   # ignore/add/remove/force
 
-nl_between_annotation           { Ignore, Add, Remove, Force }
-  Controls the newline between two annotations.
+# Controls the newline between two annotations.
+nl_between_annotation           = ignore   # ignore/add/remove/force
 
 #
 # Positioning options
 #
 
-pos_arith                       { Ignore, Lead, Trail }
-  The position of arithmetic operators in wrapped expressions.
+# The position of arithmetic operators in wrapped expressions.
+pos_arith                       = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
-pos_assign                      { Ignore, Lead, Trail }
-  The position of assignment in wrapped expressions.
-  Do not affect '=' followed by '{'.
+# The position of assignment in wrapped expressions.
+# Do not affect '=' followed by '{'.
+pos_assign                      = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
-pos_bool                        { Ignore, Lead, Trail }
-  The position of boolean operators in wrapped expressions.
+# The position of boolean operators in wrapped expressions.
+pos_bool                        = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
-pos_compare                     { Ignore, Lead, Trail }
-  The position of comparison operators in wrapped expressions.
+# The position of comparison operators in wrapped expressions.
+pos_compare                     = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
-pos_conditional                 { Ignore, Lead, Trail }
-  The position of conditional (b ? t : f) operators in wrapped expressions.
+# The position of conditional (b ? t : f) operators in wrapped expressions.
+pos_conditional                 = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
-pos_comma                       { Ignore, Lead, Trail }
-  The position of the comma in wrapped expressions.
+# The position of the comma in wrapped expressions.
+pos_comma                       = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
-pos_enum_comma                  { Ignore, Lead, Trail }
-  The position of the comma in enum entries.
+# The position of the comma in enum entries.
+pos_enum_comma                  = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
-pos_class_comma                 { Ignore, Lead, Trail }
-  The position of the comma in the base class list if there are more than one line,
-    (tied to nl_class_init_args).
+# The position of the comma in the base class list if there are more than one line,
+#   (tied to nl_class_init_args).
+pos_class_comma                 = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
-pos_constr_comma                { Ignore, Lead, Trail }
-  The position of the comma in the constructor initialization list.
-  Related to nl_constr_colon, nl_constr_init_args and pos_constr_colon.
+# The position of the comma in the constructor initialization list.
+# Related to nl_constr_colon, nl_constr_init_args and pos_constr_colon.
+pos_constr_comma                = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
-pos_class_colon                 { Ignore, Lead, Trail }
-  The position of trailing/leading class colon, between class and base class list
-    (tied to nl_class_colon).
+# The position of trailing/leading class colon, between class and base class list
+#   (tied to nl_class_colon).
+pos_class_colon                 = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
-pos_constr_colon                { Ignore, Lead, Trail }
-  The position of colons between constructor and member initialization,
-  (tied to nl_constr_colon).
-  Related to nl_constr_colon, nl_constr_init_args and pos_constr_comma.
+# The position of colons between constructor and member initialization,
+# (tied to nl_constr_colon).
+# Related to nl_constr_colon, nl_constr_init_args and pos_constr_comma.
+pos_constr_colon                = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 #
 # Line Splitting options
 #
 
-code_width                      Unsigned Number
-  Try to limit code width to N number of columns
+# Try to limit code width to N number of columns
+code_width                      = 0        # unsigned number
 
-ls_for_split_full               { False, True }
-  Whether to fully split long 'for' statements at semi-colons.
+# Whether to fully split long 'for' statements at semi-colons.
+ls_for_split_full               = false    # false/true
 
-ls_func_split_full              { False, True }
-  Whether to fully split long function protos/calls at commas.
+# Whether to fully split long function protos/calls at commas.
+ls_func_split_full              = false    # false/true
 
-ls_code_width                   { False, True }
-  Whether to split lines as close to code_width as possible and ignore some groupings.
+# Whether to split lines as close to code_width as possible and ignore some groupings.
+ls_code_width                   = false    # false/true
 
 #
 # Code alignment (not left column spaces/tabs)
 #
 
-align_keep_tabs                 { False, True }
-  Whether to keep non-indenting tabs.
+# Whether to keep non-indenting tabs.
+align_keep_tabs                 = false    # false/true
 
-align_with_tabs                 { False, True }
-  Whether to use tabs for aligning.
+# Whether to use tabs for aligning.
+align_with_tabs                 = false    # false/true
 
-align_on_tabstop                { False, True }
-  Whether to bump out to the next tab when aligning.
+# Whether to bump out to the next tab when aligning.
+align_on_tabstop                = false    # false/true
 
-align_number_right              { False, True }
-  Whether to right-align numbers.
+# Whether to right-align numbers.
+align_number_right              = false    # false/true
 
-align_keep_extra_space          { False, True }
-  Whether to keep whitespace not required for alignment.
+# Whether to keep whitespace not required for alignment.
+align_keep_extra_space          = false    # false/true
 
-align_func_params               { False, True }
-  Align variable definitions in prototypes and functions.
+# Align variable definitions in prototypes and functions.
+align_func_params               = false    # false/true
 
-align_func_params_span          Unsigned Number
-  The span for aligning parameter definitions in function on parameter name (0=don't align).
+# The span for aligning parameter definitions in function on parameter name (0=don't align).
+align_func_params_span          = 0        # unsigned number
 
-align_func_params_thresh        Unsigned Number
-  The threshold for aligning function parameter definitions (0=no limit).
+# The threshold for aligning function parameter definitions (0=no limit).
+align_func_params_thresh        = 0        # unsigned number
 
-align_func_params_gap           Unsigned Number
-  The gap for aligning function parameter definitions.
+# The gap for aligning function parameter definitions.
+align_func_params_gap           = 0        # unsigned number
 
-align_same_func_call_params     { False, True }
-  Align parameters in single-line functions that have the same name.
-  The function names must already be aligned with each other.
+# Align parameters in single-line functions that have the same name.
+# The function names must already be aligned with each other.
+align_same_func_call_params     = false    # false/true
 
-align_var_def_span              Unsigned Number
-  The span for aligning variable definitions (0=don't align)
+# The span for aligning variable definitions (0=don't align)
+align_var_def_span              = 0        # unsigned number
 
-align_var_def_star_style        Unsigned Number
-  How to align the star in variable definitions.
-   0=Part of the type     'void *   foo;'
-   1=Part of the variable 'void     *foo;'
-   2=Dangling             'void    *foo;'
+# How to align the star in variable definitions.
+#  0=Part of the type     'void *   foo;'
+#  1=Part of the variable 'void     *foo;'
+#  2=Dangling             'void    *foo;'
+align_var_def_star_style        = 0        # unsigned number
 
-align_var_def_amp_style         Unsigned Number
-  How to align the '&' in variable definitions.
-   0=Part of the type
-   1=Part of the variable
-   2=Dangling
+# How to align the '&' in variable definitions.
+#  0=Part of the type
+#  1=Part of the variable
+#  2=Dangling
+align_var_def_amp_style         = 0        # unsigned number
 
-align_var_def_thresh            Unsigned Number
-  The threshold for aligning variable definitions (0=no limit)
+# The threshold for aligning variable definitions (0=no limit)
+align_var_def_thresh            = 0        # unsigned number
 
-align_var_def_gap               Unsigned Number
-  The gap for aligning variable definitions.
+# The gap for aligning variable definitions.
+align_var_def_gap               = 0        # unsigned number
 
-align_var_def_colon             { False, True }
-  Whether to align the colon in struct bit fields.
+# Whether to align the colon in struct bit fields.
+align_var_def_colon             = false    # false/true
 
-align_var_def_colon_gap         Unsigned Number
-  align variable defs gap for bit colons.
+# align variable defs gap for bit colons.
+align_var_def_colon_gap         = 0        # unsigned number
 
-align_var_def_attribute         { False, True }
-  Whether to align any attribute after the variable name.
+# Whether to align any attribute after the variable name.
+align_var_def_attribute         = false    # false/true
 
-align_var_def_inline            { False, True }
-  Whether to align inline struct/enum/union variable definitions.
+# Whether to align inline struct/enum/union variable definitions.
+align_var_def_inline            = false    # false/true
 
-align_assign_span               Unsigned Number
-  The span for aligning on '=' in assignments (0=don't align)
+# The span for aligning on '=' in assignments (0=don't align)
+align_assign_span               = 0        # unsigned number
 
-align_assign_thresh             Unsigned Number
-  The threshold for aligning on '=' in assignments (0=no limit)
+# The threshold for aligning on '=' in assignments (0=no limit)
+align_assign_thresh             = 0        # unsigned number
 
-align_assign_decl_func          Unsigned Number
-  Defines how align_assign_span is applied onto function decl. with: virtual ... = 0, = delete, = default.
-  0 - default align_assign_span behavior
-  1 - indent the '=' on their own, with each other
-  2 - don't indent
+# Defines how align_assign_span is applied onto function decl. with: virtual ... = 0, = delete, = default.
+# 0 - default align_assign_span behavior
+# 1 - indent the '=' on their own, with each other
+# 2 - don't indent
+align_assign_decl_func          = 0        # unsigned number
 
-align_enum_equ_span             Unsigned Number
-  The span for aligning on '=' in enums (0=don't align)
+# The span for aligning on '=' in enums (0=don't align)
+align_enum_equ_span             = 0        # unsigned number
 
-align_enum_equ_thresh           Unsigned Number
-  The threshold for aligning on '=' in enums (0=no limit)
+# The threshold for aligning on '=' in enums (0=no limit)
+align_enum_equ_thresh           = 0        # unsigned number
 
-align_var_class_span            Unsigned Number
-  The span for aligning class (0=don't align)
+# The span for aligning class (0=don't align)
+align_var_class_span            = 0        # unsigned number
 
-align_var_class_thresh          Unsigned Number
-  The threshold for aligning class member definitions (0=no limit).
+# The threshold for aligning class member definitions (0=no limit).
+align_var_class_thresh          = 0        # unsigned number
 
-align_var_class_gap             Unsigned Number
-  The gap for aligning class member definitions.
+# The gap for aligning class member definitions.
+align_var_class_gap             = 0        # unsigned number
 
-align_var_struct_span           Unsigned Number
-  The span for aligning struct/union (0=don't align)
+# The span for aligning struct/union (0=don't align)
+align_var_struct_span           = 0        # unsigned number
 
-align_var_struct_thresh         Unsigned Number
-  The threshold for aligning struct/union member definitions (0=no limit)
+# The threshold for aligning struct/union member definitions (0=no limit)
+align_var_struct_thresh         = 0        # unsigned number
 
-align_var_struct_gap            Unsigned Number
-  The gap for aligning struct/union member definitions.
+# The gap for aligning struct/union member definitions.
+align_var_struct_gap            = 0        # unsigned number
 
-align_struct_init_span          Unsigned Number
-  The span for aligning struct initializer values (0=don't align)
+# The span for aligning struct initializer values (0=don't align)
+align_struct_init_span          = 0        # unsigned number
 
-align_typedef_gap               Unsigned Number
-  The minimum space between the type and the synonym of a typedef.
+# The minimum space between the type and the synonym of a typedef.
+align_typedef_gap               = 0        # unsigned number
 
-align_typedef_span              Unsigned Number
-  The span for aligning single-line typedefs (0=don't align).
+# The span for aligning single-line typedefs (0=don't align).
+align_typedef_span              = 0        # unsigned number
 
-align_typedef_func              Unsigned Number
-  How to align typedef'd functions with other typedefs
-  0: Don't mix them at all
-  1: align the open paren with the types
-  2: align the function type name with the other type names
+# How to align typedef'd functions with other typedefs
+# 0: Don't mix them at all
+# 1: align the open paren with the types
+# 2: align the function type name with the other type names
+align_typedef_func              = 0        # unsigned number
 
-align_typedef_star_style        Unsigned Number
-  Controls the positioning of the '*' in typedefs. Just try it.
-  0: Align on typedef type, ignore '*'
-  1: The '*' is part of type name: typedef int  *pint;
-  2: The '*' is part of the type, but dangling: typedef int *pint;
+# Controls the positioning of the '*' in typedefs. Just try it.
+# 0: Align on typedef type, ignore '*'
+# 1: The '*' is part of type name: typedef int  *pint;
+# 2: The '*' is part of the type, but dangling: typedef int *pint;
+align_typedef_star_style        = 0        # unsigned number
 
-align_typedef_amp_style         Unsigned Number
-  Controls the positioning of the '&' in typedefs. Just try it.
-  0: Align on typedef type, ignore '&'
-  1: The '&' is part of type name: typedef int  &pint;
-  2: The '&' is part of the type, but dangling: typedef int &pint;
+# Controls the positioning of the '&' in typedefs. Just try it.
+# 0: Align on typedef type, ignore '&'
+# 1: The '&' is part of type name: typedef int  &pint;
+# 2: The '&' is part of the type, but dangling: typedef int &pint;
+align_typedef_amp_style         = 0        # unsigned number
 
-align_right_cmt_span            Unsigned Number
-  The span for aligning comments that end lines (0=don't align)
+# The span for aligning comments that end lines (0=don't align)
+align_right_cmt_span            = 0        # unsigned number
 
-align_right_cmt_mix             { False, True }
-  If aligning comments, mix with comments after '}' and #endif with less than 3 spaces before the comment.
+# If aligning comments, mix with comments after '}' and #endif with less than 3 spaces before the comment.
+align_right_cmt_mix             = false    # false/true
 
-align_right_cmt_same_level      { False, True }
-  Whether to only align trailing comments that are at the same brace level.
+# Whether to only align trailing comments that are at the same brace level.
+align_right_cmt_same_level      = false    # false/true
 
-align_right_cmt_gap             Unsigned Number
-  If a trailing comment is more than this number of columns away from the text it follows,
-  it will qualify for being aligned. This has to be > 0 to do anything.
+# If a trailing comment is more than this number of columns away from the text it follows,
+# it will qualify for being aligned. This has to be > 0 to do anything.
+align_right_cmt_gap             = 0        # unsigned number
 
-align_right_cmt_at_col          Unsigned Number
-  Align trailing comment at or beyond column N; 'pulls in' comments as a bonus side effect (0=ignore)
+# Align trailing comment at or beyond column N; 'pulls in' comments as a bonus side effect (0=ignore)
+align_right_cmt_at_col          = 0        # unsigned number
 
-align_func_proto_span           Unsigned Number
-  The span for aligning function prototypes (0=don't align).
+# The span for aligning function prototypes (0=don't align).
+align_func_proto_span           = 0        # unsigned number
 
-align_func_proto_gap            Unsigned Number
-  Minimum gap between the return type and the function name.
+# Minimum gap between the return type and the function name.
+align_func_proto_gap            = 0        # unsigned number
 
-align_on_operator               { False, True }
-  Align function protos on the 'operator' keyword instead of what follows.
+# Align function protos on the 'operator' keyword instead of what follows.
+align_on_operator               = false    # false/true
 
-align_mix_var_proto             { False, True }
-  Whether to mix aligning prototype and variable declarations.
-  If True, align_var_def_XXX options are used instead of align_func_proto_XXX options.
+# Whether to mix aligning prototype and variable declarations.
+# If True, align_var_def_XXX options are used instead of align_func_proto_XXX options.
+align_mix_var_proto             = false    # false/true
 
-align_single_line_func          { False, True }
-  Align single-line functions with function prototypes, uses align_func_proto_span.
+# Align single-line functions with function prototypes, uses align_func_proto_span.
+align_single_line_func          = false    # false/true
 
-align_single_line_brace         { False, True }
-  Aligning the open brace of single-line functions.
-  Requires align_single_line_func=True, uses align_func_proto_span.
+# Aligning the open brace of single-line functions.
+# Requires align_single_line_func=True, uses align_func_proto_span.
+align_single_line_brace         = false    # false/true
 
-align_single_line_brace_gap     Unsigned Number
-  Gap for align_single_line_brace.
+# Gap for align_single_line_brace.
+align_single_line_brace_gap     = 0        # unsigned number
 
-align_oc_msg_spec_span          Unsigned Number
-  The span for aligning ObjC msg spec (0=don't align)
+# The span for aligning ObjC msg spec (0=don't align)
+align_oc_msg_spec_span          = 0        # unsigned number
 
-align_nl_cont                   { False, True }
-  Whether to align macros wrapped with a backslash and a newline.
-  This will not work right if the macro contains a multi-line comment.
+# Whether to align macros wrapped with a backslash and a newline.
+# This will not work right if the macro contains a multi-line comment.
+align_nl_cont                   = false    # false/true
 
-align_pp_define_together        { False, True }
-  # Align macro functions and variables together.
+# # Align macro functions and variables together.
+align_pp_define_together        = false    # false/true
 
-align_pp_define_gap             Unsigned Number
-  The minimum space between label and value of a preprocessor define.
+# The minimum space between label and value of a preprocessor define.
+align_pp_define_gap             = 0        # unsigned number
 
-align_pp_define_span            Unsigned Number
-  The span for aligning on '#define' bodies (0=don't align, other=number of lines including comments between blocks)
+# The span for aligning on '#define' bodies (0=don't align, other=number of lines including comments between blocks)
+align_pp_define_span            = 0        # unsigned number
 
-align_left_shift                { False, True }
-  Align lines that start with '<<' with previous '<<'. Default=True.
+# Align lines that start with '<<' with previous '<<'. Default=True.
+align_left_shift                = true     # false/true
 
-align_asm_colon                 { False, True }
-  Align text after asm volatile () colons.
+# Align text after asm volatile () colons.
+align_asm_colon                 = false    # false/true
 
-align_oc_msg_colon_span         Unsigned Number
-  Span for aligning parameters in an Obj-C message call on the ':' (0=don't align)
+# Span for aligning parameters in an Obj-C message call on the ':' (0=don't align)
+align_oc_msg_colon_span         = 0        # unsigned number
 
-align_oc_msg_colon_first        { False, True }
-  If True, always align with the first parameter, even if it is too short.
+# If True, always align with the first parameter, even if it is too short.
+align_oc_msg_colon_first        = false    # false/true
 
-align_oc_decl_colon             { False, True }
-  Aligning parameters in an Obj-C '+' or '-' declaration on the ':'.
+# Aligning parameters in an Obj-C '+' or '-' declaration on the ':'.
+align_oc_decl_colon             = false    # false/true
 
 #
 # Comment modifications
 #
 
-cmt_width                       Unsigned Number
-  Try to wrap comments at cmt_width columns
+# Try to wrap comments at cmt_width columns
+cmt_width                       = 0        # unsigned number
 
-cmt_reflow_mode                 Unsigned Number
-  Set the comment reflow mode (Default=0)
-  0: no reflowing (apart from the line wrapping due to cmt_width)
-  1: no touching at all
-  2: full reflow
+# Set the comment reflow mode (Default=0)
+# 0: no reflowing (apart from the line wrapping due to cmt_width)
+# 1: no touching at all
+# 2: full reflow
+cmt_reflow_mode                 = 0        # unsigned number
 
-cmt_convert_tab_to_spaces       { False, True }
-  Whether to convert all tabs to spaces in comments. Default is to leave tabs inside comments alone, unless used for indenting.
+# Whether to convert all tabs to spaces in comments. Default is to leave tabs inside comments alone, unless used for indenting.
+cmt_convert_tab_to_spaces       = false    # false/true
 
-cmt_indent_multi                { False, True }
-  If False, disable all multi-line comment changes, including cmt_width. keyword substitution and leading chars.
-  Default=True.
+# If False, disable all multi-line comment changes, including cmt_width. keyword substitution and leading chars.
+# Default=True.
+cmt_indent_multi                = true     # false/true
 
-cmt_c_group                     { False, True }
-  Whether to group c-comments that look like they are in a block.
+# Whether to group c-comments that look like they are in a block.
+cmt_c_group                     = false    # false/true
 
-cmt_c_nl_start                  { False, True }
-  Whether to put an empty '/*' on the first line of the combined c-comment.
+# Whether to put an empty '/*' on the first line of the combined c-comment.
+cmt_c_nl_start                  = false    # false/true
 
-cmt_c_nl_end                    { False, True }
-  Whether to put a newline before the closing '*/' of the combined c-comment.
+# Whether to put a newline before the closing '*/' of the combined c-comment.
+cmt_c_nl_end                    = false    # false/true
 
-cmt_cpp_group                   { False, True }
-  Whether to group cpp-comments that look like they are in a block.
+# Whether to group cpp-comments that look like they are in a block.
+cmt_cpp_group                   = false    # false/true
 
-cmt_cpp_nl_start                { False, True }
-  Whether to put an empty '/*' on the first line of the combined cpp-comment.
+# Whether to put an empty '/*' on the first line of the combined cpp-comment.
+cmt_cpp_nl_start                = false    # false/true
 
-cmt_cpp_nl_end                  { False, True }
-  Whether to put a newline before the closing '*/' of the combined cpp-comment.
+# Whether to put a newline before the closing '*/' of the combined cpp-comment.
+cmt_cpp_nl_end                  = false    # false/true
 
-cmt_cpp_to_c                    { False, True }
-  Whether to change cpp-comments into c-comments.
+# Whether to change cpp-comments into c-comments.
+cmt_cpp_to_c                    = false    # false/true
 
-cmt_star_cont                   { False, True }
-  Whether to put a star on subsequent comment lines.
+# Whether to put a star on subsequent comment lines.
+cmt_star_cont                   = false    # false/true
 
-cmt_sp_before_star_cont         Unsigned Number
-  The number of spaces to insert at the start of subsequent comment lines.
+# The number of spaces to insert at the start of subsequent comment lines.
+cmt_sp_before_star_cont         = 0        # unsigned number
 
-cmt_sp_after_star_cont          Number
-  The number of spaces to insert after the star on subsequent comment lines.
+# The number of spaces to insert after the star on subsequent comment lines.
+cmt_sp_after_star_cont          = 0        # number
 
-cmt_multi_check_last            { False, True }
-  For multi-line comments with a '*' lead, remove leading spaces if the first and last lines of
-  the comment are the same length. Default=True.
+# For multi-line comments with a '*' lead, remove leading spaces if the first and last lines of
+# the comment are the same length. Default=True.
+cmt_multi_check_last            = true     # false/true
 
-cmt_multi_first_len_minimum     Unsigned Number
-  For multi-line comments with a '*' lead, remove leading spaces if the first and last lines of
-  the comment are the same length AND if the length is bigger as the first_len minimum. Default=4
+# For multi-line comments with a '*' lead, remove leading spaces if the first and last lines of
+# the comment are the same length AND if the length is bigger as the first_len minimum. Default=4
+cmt_multi_first_len_minimum     = 4        # unsigned number
 
-cmt_insert_file_header          String
-  The filename that contains text to insert at the head of a file if the file doesn't start with a C/C++ comment.
-  Will substitute $(filename) with the current file's name.
+# The filename that contains text to insert at the head of a file if the file doesn't start with a C/C++ comment.
+# Will substitute $(filename) with the current file's name.
+cmt_insert_file_header          = ""         # string
 
-cmt_insert_file_footer          String
-  The filename that contains text to insert at the end of a file if the file doesn't end with a C/C++ comment.
-  Will substitute $(filename) with the current file's name.
+# The filename that contains text to insert at the end of a file if the file doesn't end with a C/C++ comment.
+# Will substitute $(filename) with the current file's name.
+cmt_insert_file_footer          = ""         # string
 
-cmt_insert_func_header          String
-  The filename that contains text to insert before a function implementation if the function isn't preceded with a C/C++ comment.
-  Will substitute $(function) with the function name and $(javaparam) with the javadoc @param and @return stuff.
-  Will also substitute $(fclass) with the class name: void CFoo::Bar() { ... }.
+# The filename that contains text to insert before a function implementation if the function isn't preceded with a C/C++ comment.
+# Will substitute $(function) with the function name and $(javaparam) with the javadoc @param and @return stuff.
+# Will also substitute $(fclass) with the class name: void CFoo::Bar() { ... }.
+cmt_insert_func_header          = ""         # string
 
-cmt_insert_class_header         String
-  The filename that contains text to insert before a class if the class isn't preceded with a C/C++ comment.
-  Will substitute $(class) with the class name.
+# The filename that contains text to insert before a class if the class isn't preceded with a C/C++ comment.
+# Will substitute $(class) with the class name.
+cmt_insert_class_header         = ""         # string
 
-cmt_insert_oc_msg_header        String
-  The filename that contains text to insert before a Obj-C message specification if the method isn't preceded with a C/C++ comment.
-  Will substitute $(message) with the function name and $(javaparam) with the javadoc @param and @return stuff.
+# The filename that contains text to insert before a Obj-C message specification if the method isn't preceded with a C/C++ comment.
+# Will substitute $(message) with the function name and $(javaparam) with the javadoc @param and @return stuff.
+cmt_insert_oc_msg_header        = ""         # string
 
-cmt_insert_before_preproc       { False, True }
-  If a preprocessor is encountered when stepping backwards from a function name, then
-  this option decides whether the comment should be inserted.
-  Affects cmt_insert_oc_msg_header, cmt_insert_func_header and cmt_insert_class_header.
+# If a preprocessor is encountered when stepping backwards from a function name, then
+# this option decides whether the comment should be inserted.
+# Affects cmt_insert_oc_msg_header, cmt_insert_func_header and cmt_insert_class_header.
+cmt_insert_before_preproc       = false    # false/true
 
-cmt_insert_before_inlines       { False, True }
-  If a function is declared inline to a class definition, then
-  this option decides whether the comment should be inserted.
-  Affects cmt_insert_func_header.
+# If a function is declared inline to a class definition, then
+# this option decides whether the comment should be inserted.
+# Affects cmt_insert_func_header.
+cmt_insert_before_inlines       = true     # false/true
 
-cmt_insert_before_ctor_dtor     { False, True }
-  If the function is a constructor/destructor, then
-  this option decides whether the comment should be inserted.
-  Affects cmt_insert_func_header.
+# If the function is a constructor/destructor, then
+# this option decides whether the comment should be inserted.
+# Affects cmt_insert_func_header.
+cmt_insert_before_ctor_dtor     = false    # false/true
 
 #
 # Code modifying options (non-whitespace)
 #
 
-mod_full_brace_do               { Ignore, Add, Remove, Force }
-  Add or remove braces on single-line 'do' statement.
+# Add or remove braces on single-line 'do' statement.
+mod_full_brace_do               = ignore   # ignore/add/remove/force
 
-mod_full_brace_for              { Ignore, Add, Remove, Force }
-  Add or remove braces on single-line 'for' statement.
+# Add or remove braces on single-line 'for' statement.
+mod_full_brace_for              = ignore   # ignore/add/remove/force
 
-mod_full_brace_function         { Ignore, Add, Remove, Force }
-  Add or remove braces on single-line function definitions. (Pawn).
+# Add or remove braces on single-line function definitions. (Pawn).
+mod_full_brace_function         = ignore   # ignore/add/remove/force
 
-mod_full_brace_if               { Ignore, Add, Remove, Force }
-  Add or remove braces on single-line 'if' statement. Will not remove the braces if they contain an 'else'.
+# Add or remove braces on single-line 'if' statement. Will not remove the braces if they contain an 'else'.
+mod_full_brace_if               = ignore   # ignore/add/remove/force
 
-mod_full_brace_if_chain         { False, True }
-  Make all if/elseif/else statements in a chain be braced or not. Overrides mod_full_brace_if.
-  If any must be braced, they are all braced.  If all can be unbraced, then the braces are removed.
+# Make all if/elseif/else statements in a chain be braced or not. Overrides mod_full_brace_if.
+# If any must be braced, they are all braced.  If all can be unbraced, then the braces are removed.
+mod_full_brace_if_chain         = false    # false/true
 
-mod_full_brace_if_chain_only    { False, True }
-  Make all if/elseif/else statements with at least one 'else' or 'else if' fully braced.
-  If mod_full_brace_if_chain is used together with this option, all if-else chains will get braces,
-  and simple 'if' statements will lose them (if possible).
+# Make all if/elseif/else statements with at least one 'else' or 'else if' fully braced.
+# If mod_full_brace_if_chain is used together with this option, all if-else chains will get braces,
+# and simple 'if' statements will lose them (if possible).
+mod_full_brace_if_chain_only    = false    # false/true
 
-mod_full_brace_nl               Unsigned Number
-  Don't remove braces around statements that span N newlines
+# Don't remove braces around statements that span N newlines
+mod_full_brace_nl               = 0        # unsigned number
 
-mod_full_brace_nl_block_rem_mlcond { False, True }
-  Blocks removal of braces if the parenthesis of if/for/while/.. span multiple lines.
+# Blocks removal of braces if the parenthesis of if/for/while/.. span multiple lines.
+mod_full_brace_nl_block_rem_mlcond = false    # false/true
 
-mod_full_brace_while            { Ignore, Add, Remove, Force }
-  Add or remove braces on single-line 'while' statement.
+# Add or remove braces on single-line 'while' statement.
+mod_full_brace_while            = ignore   # ignore/add/remove/force
 
-mod_full_brace_using            { Ignore, Add, Remove, Force }
-  Add or remove braces on single-line 'using ()' statement.
+# Add or remove braces on single-line 'using ()' statement.
+mod_full_brace_using            = ignore   # ignore/add/remove/force
 
-mod_paren_on_return             { Ignore, Add, Remove, Force }
-  Add or remove unnecessary paren on 'return' statement.
+# Add or remove unnecessary paren on 'return' statement.
+mod_paren_on_return             = ignore   # ignore/add/remove/force
 
-mod_pawn_semicolon              { False, True }
-  Whether to change optional semicolons to real semicolons.
+# Whether to change optional semicolons to real semicolons.
+mod_pawn_semicolon              = false    # false/true
 
-mod_full_paren_if_bool          { False, True }
-  Add parens on 'while' and 'if' statement around bools.
+# Add parens on 'while' and 'if' statement around bools.
+mod_full_paren_if_bool          = false    # false/true
 
-mod_remove_extra_semicolon      { False, True }
-  Whether to remove superfluous semicolons.
+# Whether to remove superfluous semicolons.
+mod_remove_extra_semicolon      = false    # false/true
 
-mod_add_long_function_closebrace_comment Unsigned Number
-  If a function body exceeds the specified number of newlines and doesn't have a comment after
-  the close brace, a comment will be added.
+# If a function body exceeds the specified number of newlines and doesn't have a comment after
+# the close brace, a comment will be added.
+mod_add_long_function_closebrace_comment = 0        # unsigned number
 
-mod_add_long_namespace_closebrace_comment Unsigned Number
-  If a namespace body exceeds the specified number of newlines and doesn't have a comment after
-  the close brace, a comment will be added.
+# If a namespace body exceeds the specified number of newlines and doesn't have a comment after
+# the close brace, a comment will be added.
+mod_add_long_namespace_closebrace_comment = 0        # unsigned number
 
-mod_add_long_class_closebrace_comment Unsigned Number
-  If a class body exceeds the specified number of newlines and doesn't have a comment after
-  the close brace, a comment will be added.
+# If a class body exceeds the specified number of newlines and doesn't have a comment after
+# the close brace, a comment will be added.
+mod_add_long_class_closebrace_comment = 0        # unsigned number
 
-mod_add_long_switch_closebrace_comment Unsigned Number
-  If a switch body exceeds the specified number of newlines and doesn't have a comment after
-  the close brace, a comment will be added.
+# If a switch body exceeds the specified number of newlines and doesn't have a comment after
+# the close brace, a comment will be added.
+mod_add_long_switch_closebrace_comment = 0        # unsigned number
 
-mod_add_long_ifdef_endif_comment Unsigned Number
-  If an #ifdef body exceeds the specified number of newlines and doesn't have a comment after
-  the #endif, a comment will be added.
+# If an #ifdef body exceeds the specified number of newlines and doesn't have a comment after
+# the #endif, a comment will be added.
+mod_add_long_ifdef_endif_comment = 0        # unsigned number
 
-mod_add_long_ifdef_else_comment Unsigned Number
-  If an #ifdef or #else body exceeds the specified number of newlines and doesn't have a comment after
-  the #else, a comment will be added.
+# If an #ifdef or #else body exceeds the specified number of newlines and doesn't have a comment after
+# the #else, a comment will be added.
+mod_add_long_ifdef_else_comment = 0        # unsigned number
 
-mod_sort_import                 { False, True }
-  If True, will sort consecutive single-line 'import' statements [Java, D].
+# If True, will sort consecutive single-line 'import' statements [Java, D].
+mod_sort_import                 = false    # false/true
 
-mod_sort_using                  { False, True }
-  If True, will sort consecutive single-line 'using' statements [C#].
+# If True, will sort consecutive single-line 'using' statements [C#].
+mod_sort_using                  = false    # false/true
 
-mod_sort_include                { False, True }
-  If True, will sort consecutive single-line '#include' statements [C/C++] and '#import' statements [Obj-C]
-  This is generally a bad idea, as it may break your code.
+# If True, will sort consecutive single-line '#include' statements [C/C++] and '#import' statements [Obj-C]
+# This is generally a bad idea, as it may break your code.
+mod_sort_include                = false    # false/true
 
-mod_move_case_break             { False, True }
-  If True, it will move a 'break' that appears after a fully braced 'case' before the close brace.
+# If True, it will move a 'break' that appears after a fully braced 'case' before the close brace.
+mod_move_case_break             = false    # false/true
 
-mod_case_brace                  { Ignore, Add, Remove, Force }
-  Will add or remove the braces around a fully braced case statement.
-  Will only remove the braces if there are no variable declarations in the block.
+# Will add or remove the braces around a fully braced case statement.
+# Will only remove the braces if there are no variable declarations in the block.
+mod_case_brace                  = ignore   # ignore/add/remove/force
 
-mod_remove_empty_return         { False, True }
-  If True, it will remove a void 'return;' that appears as the last statement in a function.
+# If True, it will remove a void 'return;' that appears as the last statement in a function.
+mod_remove_empty_return         = false    # false/true
 
-mod_sort_oc_properties          { False, True }
-  If True, it will organize the properties (Obj-C).
+# If True, it will organize the properties (Obj-C).
+mod_sort_oc_properties          = false    # false/true
 
-mod_sort_oc_property_class_weight Number
-  Determines weight of class property modifier (Obj-C).
+# Determines weight of class property modifier (Obj-C).
+mod_sort_oc_property_class_weight = 0        # number
 
-mod_sort_oc_property_thread_safe_weight Number
-  Determines weight of atomic, nonatomic (Obj-C).
+# Determines weight of atomic, nonatomic (Obj-C).
+mod_sort_oc_property_thread_safe_weight = 0        # number
 
-mod_sort_oc_property_readwrite_weight Number
-  Determines weight of readwrite (Obj-C).
+# Determines weight of readwrite (Obj-C).
+mod_sort_oc_property_readwrite_weight = 0        # number
 
-mod_sort_oc_property_reference_weight Number
-  Determines weight of reference type (retain, copy, assign, weak, strong) (Obj-C).
+# Determines weight of reference type (retain, copy, assign, weak, strong) (Obj-C).
+mod_sort_oc_property_reference_weight = 0        # number
 
-mod_sort_oc_property_getter_weight Number
-  Determines weight of getter type (getter=) (Obj-C).
+# Determines weight of getter type (getter=) (Obj-C).
+mod_sort_oc_property_getter_weight = 0        # number
 
-mod_sort_oc_property_setter_weight Number
-  Determines weight of setter type (setter=) (Obj-C).
+# Determines weight of setter type (setter=) (Obj-C).
+mod_sort_oc_property_setter_weight = 0        # number
 
-mod_sort_oc_property_nullability_weight Number
-  Determines weight of nullability type (nullable, nonnull, null_unspecified, null_resettable) (Obj-C).
+# Determines weight of nullability type (nullable, nonnull, null_unspecified, null_resettable) (Obj-C).
+mod_sort_oc_property_nullability_weight = 0        # number
 
-mod_enum_last_comma             { Ignore, Add, Remove, Force }
-  add or remove the comma between the last token and the closing brace.
+# add or remove the comma between the last token and the closing brace.
+mod_enum_last_comma             = ignore   # ignore/add/remove/force
 
 #
 # Preprocessor options
 #
 
-pp_indent                       { Ignore, Add, Remove, Force }
-  Control indent of preprocessors inside #if blocks at brace level 0 (file-level).
+# Control indent of preprocessors inside #if blocks at brace level 0 (file-level).
+pp_indent                       = ignore   # ignore/add/remove/force
 
-pp_indent_at_level              { False, True }
-  Whether to indent #if/#else/#endif at the brace level (True) or from column 1 (False).
+# Whether to indent #if/#else/#endif at the brace level (True) or from column 1 (False).
+pp_indent_at_level              = false    # false/true
 
-pp_indent_count                 Unsigned Number
-  Specifies the number of columns to indent preprocessors per level at brace level 0 (file-level).
-  If pp_indent_at_level=False, specifies the number of columns to indent preprocessors per level at brace level > 0 (function-level).
-  Default=1.
+# Specifies the number of columns to indent preprocessors per level at brace level 0 (file-level).
+# If pp_indent_at_level=False, specifies the number of columns to indent preprocessors per level at brace level > 0 (function-level).
+# Default=1.
+pp_indent_count                 = 1        # unsigned number
 
-pp_space                        { Ignore, Add, Remove, Force }
-  Add or remove space after # based on pp_level of #if blocks.
+# Add or remove space after # based on pp_level of #if blocks.
+pp_space                        = ignore   # ignore/add/remove/force
 
-pp_space_count                  Unsigned Number
-  Sets the number of spaces added with pp_space.
+# Sets the number of spaces added with pp_space.
+pp_space_count                  = 0        # unsigned number
 
-pp_indent_region                Number
-  The indent for #region and #endregion in C# and '#pragma region' in C/C++.
-  negative value are OK.
+# The indent for #region and #endregion in C# and '#pragma region' in C/C++.
+# negative value are OK.
+pp_indent_region                = 0        # number
 
-pp_region_indent_code           { False, True }
-  Whether to indent the code between #region and #endregion.
+# Whether to indent the code between #region and #endregion.
+pp_region_indent_code           = false    # false/true
 
-pp_indent_if                    Number
-  If pp_indent_at_level=True, sets the indent for #if, #else and #endif when not at file-level.
-  0:  indent preprocessors using output_tab_size.
-  >0: column at which all preprocessors will be indented.
-  negative value are OK.
+# If pp_indent_at_level=True, sets the indent for #if, #else and #endif when not at file-level.
+# 0:  indent preprocessors using output_tab_size.
+# >0: column at which all preprocessors will be indented.
+# negative value are OK.
+pp_indent_if                    = 0        # number
 
-pp_if_indent_code               { False, True }
-  Control whether to indent the code between #if, #else and #endif.
+# Control whether to indent the code between #if, #else and #endif.
+pp_if_indent_code               = false    # false/true
 
-pp_define_at_level              { False, True }
-  Whether to indent '#define' at the brace level (True) or from column 1 (false).
+# Whether to indent '#define' at the brace level (True) or from column 1 (false).
+pp_define_at_level              = false    # false/true
 
-pp_ignore_define_body           { False, True }
-  Whether to ignore the '#define' body while formatting.
+# Whether to ignore the '#define' body while formatting.
+pp_ignore_define_body           = false    # false/true
 
-pp_indent_case                  { False, True }
-  Whether to indent case statements between #if, #else, and #endif.
-  Only applies to the indent of the preprocesser that the case statements directly inside of.
+# Whether to indent case statements between #if, #else, and #endif.
+# Only applies to the indent of the preprocesser that the case statements directly inside of.
+pp_indent_case                  = true     # false/true
 
-pp_indent_func_def              { False, True }
-  Whether to indent whole function definitions between #if, #else, and #endif.
-  Only applies to the indent of the preprocesser that the function definition is directly inside of.
+# Whether to indent whole function definitions between #if, #else, and #endif.
+# Only applies to the indent of the preprocesser that the function definition is directly inside of.
+pp_indent_func_def              = true     # false/true
 
-pp_indent_extern                { False, True }
-  Whether to indent extern C blocks between #if, #else, and #endif.
-  Only applies to the indent of the preprocesser that the extern block is directly inside of.
+# Whether to indent extern C blocks between #if, #else, and #endif.
+# Only applies to the indent of the preprocesser that the extern block is directly inside of.
+pp_indent_extern                = true     # false/true
 
-pp_indent_brace                 { False, True }
-  Whether to indent braces directly inside #if, #else, and #endif.
-  Only applies to the indent of the preprocesser that the braces are directly inside of.
+# Whether to indent braces directly inside #if, #else, and #endif.
+# Only applies to the indent of the preprocesser that the braces are directly inside of.
+pp_indent_brace                 = true     # false/true
 
 #
 # Sort includes options
 #
 
-include_category_0              String
-  The regex for include category with priority 0.
+# The regex for include category with priority 0.
+include_category_0              = ""         # string
 
-include_category_1              String
-  The regex for include category with priority 1.
+# The regex for include category with priority 1.
+include_category_1              = ""         # string
 
-include_category_2              String
-  The regex for include category with priority 2.
+# The regex for include category with priority 2.
+include_category_2              = ""         # string
 
 #
 # Use or Do not Use options
 #
 
-use_indent_func_call_param      { False, True }
-  True:  indent_func_call_param will be used (default)
-  False: indent_func_call_param will NOT be used.
+# True:  indent_func_call_param will be used (default)
+# False: indent_func_call_param will NOT be used.
+use_indent_func_call_param      = true     # false/true
 
-use_indent_continue_only_once   { False, True }
-  The value of the indentation for a continuation line is calculate differently if the statement is:
-    a declaration: your case with QString fileName ...
-    an assignment: your case with pSettings = new QSettings( ...
-  At the second case the indentation value might be used twice:
-    at the assignment
-    at the function call (if present)
-  To prevent the double use of the indentation value, use this option with the value 'True'.
-  True:  indent_continue will be used only once
-  False: indent_continue will be used every time (default).
+# The value of the indentation for a continuation line is calculate differently if the statement is:
+#   a declaration: your case with QString fileName ...
+#   an assignment: your case with pSettings = new QSettings( ...
+# At the second case the indentation value might be used twice:
+#   at the assignment
+#   at the function call (if present)
+# To prevent the double use of the indentation value, use this option with the value 'True'.
+# True:  indent_continue will be used only once
+# False: indent_continue will be used every time (default).
+use_indent_continue_only_once   = false    # false/true
 
-indent_cpp_lambda_only_once     { False, True }
-  the value might be used twice:
-    at the assignment
-    at the opening brace
-  To prevent the double use of the indentation value, use this option with the value 'True'.
-  True:  indentation will be used only once
-  False: indentation will be used every time (default).
+# the value might be used twice:
+#   at the assignment
+#   at the opening brace
+# To prevent the double use of the indentation value, use this option with the value 'True'.
+# True:  indentation will be used only once
+# False: indentation will be used every time (default).
+indent_cpp_lambda_only_once     = false    # false/true
 
-use_options_overriding_for_qt_macros { False, True }
-  SIGNAL/SLOT Qt macros have special formatting options. See options_for_QT.cpp for details.
-  Default=True.
+# SIGNAL/SLOT Qt macros have special formatting options. See options_for_QT.cpp for details.
+# Default=True.
+use_options_overriding_for_qt_macros = true     # false/true
 
 #
 # Warn levels - 1: error, 2: warning (default), 3: note
 #
 
-warn_level_tabs_found_in_verbatim_string_literals Unsigned Number
-  Warning is given if doing tab-to-\t replacement and we have found one in a C# verbatim string literal.
-
+# Warning is given if doing tab-to-\t replacement and we have found one in a C# verbatim string literal.
+warn_level_tabs_found_in_verbatim_string_literals = 2        # unsigned number
 
 # Meaning of the settings:
 #   Ignore - do not do any changes
@@ -2280,4 +2278,6 @@ warn_level_tabs_found_in_verbatim_string_literals Unsigned Number
 #       `macro-open  BEGIN_MESSAGE_MAP`
 #       `macro-close END_MESSAGE_MAP`
 #
+#
+# option(s) with 'not default' value: 0
 #


### PR DESCRIPTION
Since #1865 didn't get the feedback I was hoping, let's try a more... direct approach.

This removes `print_options`. The command line option `--show-config` is retained, but effectively becomes a synonym for `--update-config-with-doc`.

This is useful both in eliminating a code path of unclear utility (less maintenance; yay!), and in that `uncrustify --show-config > mine.cfg` becomes a quick (and perhaps slightly more obvious) way to generate a new, clean configuration file.

(And not needing to preserve two different ways to output the set of possible option values will make me very happy w.r.t. #1852 :smile:.)

Since @mihaipopescu mentioned "we're using that to generate our own base config" (but didn't get back to me when I requested clarification), I guess this should probably get at least his approval.

Closes #1865.