### PR TITLE
preserve C++11 attribute specifier sequences (take two)

### DIFF
--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1118,7 +1118,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_func_call_user_paren");
       return(cpd.settings[UO_sp_func_call_user_paren].a);
    }
-   if (chunk_is_token(first, CT_ATTRIBUTE))
+   if (chunk_is_token(first, CT_ATTRIBUTE) && chunk_is_paren_open(second))
    {
       log_rule("sp_attribute_paren");
       return(cpd.settings[UO_sp_attribute_paren].a);

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 650 options and minimal documentation.
+There are currently 651 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/tests/config/attribute_specifier_seqs.cfg
+++ b/tests/config/attribute_specifier_seqs.cfg
@@ -1,0 +1,1 @@
+sp_inside_square = add

--- a/tests/config/attribute_specifier_seqs.cfg
+++ b/tests/config/attribute_specifier_seqs.cfg
@@ -1,1 +1,1 @@
-sp_inside_square = add
+# no settings intentionally

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -178,6 +178,8 @@
 30313  sp_brace_brace-r.cfg                 cpp/sp_brace_brace.cpp 
 30314  sp_brace_brace-f.cfg                 cpp/sp_brace_brace.cpp
 
+30400  attribute_specifier_seqs.cfg         cpp/attribute_specifier_seqs.cpp
+
 # function def newlines
 30701  func-def-1.cfg                       cpp/function-def.cpp
 30702  func-def-2.cfg                       cpp/function-def.cpp

--- a/tests/expected/cpp/30400-attribute_specifier_seqs.cpp
+++ b/tests/expected/cpp/30400-attribute_specifier_seqs.cpp
@@ -1,0 +1,75 @@
+void asd(void)
+{
+	a < up_lim() ? do_hi() : do_low;
+	a[ a<b>c ] = d;
+}
+
+[[nodiscard]] inline static CFErrorRef _Nullable CreateErrorIfError(CFStringRef const inDomain, CFIndex const inCode, CFDictionaryRef const inInformation) {
+	[[maybe_unused]] auto const [ iterator, inserted ]{ super_type::insert(ioFileReference) };
+	if (inCode == 0) {
+		return nullptr;
+	}
+	return ::CFErrorCreate(kCFAllocatorDefault, inDomain, inCode, inInformation);
+}
+
+[[gnu::always_inline]] [[gnu::hot]] [[gnu::const]] [[nodiscard]]
+inline int f();
+[[gnu::always_inline, gnu::const, gnu::hot, nodiscard]]
+int f();
+[[using gnu : const, always_inline, hot]] [[nodiscard]]
+int f [[gnu::always_inline]]();
+
+int f(int i) [[expects: i > 0]] [[ensures audit x: x < 1]];
+
+void f() {
+	int i [[cats::meow([[]])]];
+	int x [[unused]] = f();
+}
+
+int f(int i) [[deprecated]] {
+	switch(i) {
+	case 1: [[fallthrough]];
+		[[likely]] case 2: return 1;
+	}
+	return 2;
+}
+
+[[
+unused, deprecated("keeping for reference only")
+]]
+void f()
+{
+}
+
+[[noreturn]] void f() [[deprecated("because")]] {
+	throw "error";
+}
+
+void print2(int * [[carries_dependency]] val)
+{
+	std::cout<<*p<<std::endl;
+}
+
+class X {
+public:
+int v() const {
+	return x;
+}
+int g() [[expects: v() > 0]];
+private:
+int k() [[expects: x > 0]];
+int x;
+};
+
+int g(int* p) [[ensures: p != nullptr]]
+{
+	*p = 42;
+}
+
+bool meow(const int&) {
+	return true;
+}
+void i(int& x) [[ensures: meow(x)]]
+{
+	++x;
+}

--- a/tests/expected/cpp/30400-attribute_specifier_seqs.cpp
+++ b/tests/expected/cpp/30400-attribute_specifier_seqs.cpp
@@ -1,11 +1,11 @@
 void asd(void)
 {
 	a < up_lim() ? do_hi() : do_low;
-	a[ a<b>c ] = d;
+	a[ a<b>c] = d;
 }
 
 [[nodiscard]] inline static CFErrorRef _Nullable CreateErrorIfError(CFStringRef const inDomain, CFIndex const inCode, CFDictionaryRef const inInformation) {
-	[[maybe_unused]] auto const [ iterator, inserted ]{ super_type::insert(ioFileReference) };
+	[[maybe_unused]] auto const [iterator, inserted]{ super_type::insert(ioFileReference) };
 	if (inCode == 0) {
 		return nullptr;
 	}

--- a/tests/expected/oc/50411-attribute_specifier_seqs.mm
+++ b/tests/expected/oc/50411-attribute_specifier_seqs.mm
@@ -1,19 +1,19 @@
-int w1[ 1 ];
+int w1[1];
 int w2 [[maybe_unused]] = 0;
 int w3 [[foo(w1[0])]];                                                                                          // unknown attribute foo
 int w4 [[foo((w1[0]))]];                                                                                        // unknown attribute foo
 int w5 [[foo(w1[0] [[maybe_unused]])]];                                                         // unknown attribute foo
-int w6 [ [ foo(w1[ 0 ] [[maybe_unused]]), [[deprecated]] ] ];                         // expected ] before [[deprecated
-int w7 [ [ w1[ 0 ] ] ] = 0;                                                                                           // expected ] before [ in w1[
-int w8 [[ [[maybe_unused]] ] ];                                                                          // expected ] before [[maybe_unused
+int w6 [[foo(w1[0] [[maybe_unused]]), [[deprecated]]]];                         // expected ] before [[deprecated
+int w7 [[w1[0]]] = 0;                                                                                           // expected ] before [ in w1[
+int w8 [[ [[maybe_unused]] ]];                                                                          // expected ] before [[maybe_unused
 int w9 [ [ foo ] ] = 0;
 
 @implementation Foo
 - (void) message {
-	Foo* foo = [ [ Foo alloc ] init ];
+	Foo* foo = [[Foo alloc] init];
 }
 @end
 
-Foo* foo = [ [ Foo alloc ] init ];
+Foo* foo = [[Foo alloc] init];
 
-[ [ Foo sharedInstance ] broadcast:[ world hello ] ];
+[[Foo sharedInstance] broadcast:[world hello]];

--- a/tests/expected/oc/50411-attribute_specifier_seqs.mm
+++ b/tests/expected/oc/50411-attribute_specifier_seqs.mm
@@ -1,0 +1,19 @@
+int w1[ 1 ];
+int w2 [[maybe_unused]] = 0;
+int w3 [[foo(w1[0])]];                                                                                          // unknown attribute foo
+int w4 [[foo((w1[0]))]];                                                                                        // unknown attribute foo
+int w5 [[foo(w1[0] [[maybe_unused]])]];                                                         // unknown attribute foo
+int w6 [ [ foo(w1[ 0 ] [[maybe_unused]]), [[deprecated]] ] ];                         // expected ] before [[deprecated
+int w7 [ [ w1[ 0 ] ] ] = 0;                                                                                           // expected ] before [ in w1[
+int w8 [[ [[maybe_unused]] ] ];                                                                          // expected ] before [[maybe_unused
+int w9 [ [ foo ] ] = 0;
+
+@implementation Foo
+- (void) message {
+	Foo* foo = [ [ Foo alloc ] init ];
+}
+@end
+
+Foo* foo = [ [ Foo alloc ] init ];
+
+[ [ Foo sharedInstance ] broadcast:[ world hello ] ];

--- a/tests/input/cpp/attribute_specifier_seqs.cpp
+++ b/tests/input/cpp/attribute_specifier_seqs.cpp
@@ -1,0 +1,71 @@
+void asd(void)
+{
+   a < up_lim() ? do_hi() : do_low;
+   a[ a<b>c] = d;
+}
+
+[[nodiscard]] inline static CFErrorRef _Nullable CreateErrorIfError(CFStringRef const inDomain, CFIndex const inCode, CFDictionaryRef const inInformation) {
+[[maybe_unused]] auto const [iterator, inserted]{ super_type::insert(ioFileReference) };
+if (inCode == 0) {
+return nullptr;
+}
+return ::CFErrorCreate(kCFAllocatorDefault, inDomain, inCode, inInformation);
+}
+
+[[gnu::always_inline]] [[gnu::hot]] [[gnu::const]] [[nodiscard]]
+inline int f();
+[[gnu::always_inline, gnu::const, gnu::hot, nodiscard]]
+int f();
+[[using gnu : const, always_inline, hot]] [[nodiscard]]
+int f[[gnu::always_inline]]();
+
+int f(int i) [[expects: i > 0]] [[ensures audit x: x < 1]];
+
+void f() {
+int i [[cats::meow([[]])]];
+int x [[unused]] = f();
+}
+
+int f(int i) [[deprecated]] {
+switch(i) {
+case 1: [[fallthrough]];
+[[likely]] case 2: return 1;
+}
+return 2;
+}
+
+[[
+unused, deprecated("keeping for reference only")
+]]
+void f()
+{
+}
+
+[[noreturn]] void f() [[deprecated("because")]] {
+throw "error";
+}
+
+void print2(int * [[carries_dependency]] val)
+{
+std::cout<<*p<<std::endl;
+}
+
+class X {
+public:
+int v() const { return x; }
+int g() [[expects: v() > 0]];
+private:
+int k() [[expects: x > 0]];
+int x;
+};
+
+int g(int* p) [[ensures: p != nullptr]]
+{
+*p = 42;
+}
+
+bool meow(const int&) { return true; }
+void i(int& x) [[ensures: meow(x)]]
+{
+++x;
+}

--- a/tests/input/oc/attribute_specifier_seqs.mm
+++ b/tests/input/oc/attribute_specifier_seqs.mm
@@ -1,0 +1,19 @@
+int w1[1];
+int w2 [[maybe_unused]] = 0;
+int w3 [[foo(w1[0])]];												// unknown attribute foo
+int w4 [[foo((w1[0]))]];											// unknown attribute foo
+int w5 [[foo(w1[0] [[maybe_unused]])]];								// unknown attribute foo
+int w6 [[foo(w1[0] [[maybe_unused]]), [[deprecated]]]];				// expected ] before [[deprecated
+int w7 [[w1[0]]] = 0;												// expected ] before [ in w1[
+int w8 [[ [[maybe_unused]] ]];										// expected ] before [[maybe_unused
+int w9 [ [ foo ] ] = 0;
+
+@implementation Foo
+- (void) message {
+Foo* foo = [[Foo alloc] init];
+}
+@end
+
+Foo* foo = [[Foo alloc] init];
+
+[[Foo sharedInstance] broadcast:[world hello]];

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -81,6 +81,7 @@
 50400  oc16.cfg                             oc/for.m
 
 50410  oc_cond_colon.cfg                    oc/oc_cond_colon.m              OC+
+50411  attribute_specifier_seqs.cfg         oc/attribute_specifier_seqs.mm  OC+
 
 50500  oc17.cfg                             oc/code_placeholder.m
 


### PR DESCRIPTION
This change tokenizes C++11/14/17/20 attribute specifier sequences thus preserving them when a source file is uncrustified. Attributes are preserved "as is" (no tidying yet). Prior to this change two consecutive left square bracket tokens (`[[`), the contents of the attribute and two consecutive right square bracket tokens (`]]`) were all treated as individual chunks resulting in corrupted source files in some cases when the attribute specifier sequences were altered because the afore mentioned chunks were misinterpreted.

This reworking corrects issues found in Objective-C++ sources where two consecutive left square bracket tokens (`[[`) can occur in messages and should not be interpreted as attribute specifier sequences. The parsing now more closely follows clang's behavior although there is no attempt to recover if the input source is malformed or generate errors as a compiler might. The reworking also loosens the bracket placement requirements to more closely adhere to Clang and GCC behaviors. Sadly, C++ and Objective-C++ more so are notoriously difficult languages to parse without significant lookahead.