### PR TITLE
Add some comments

### DIFF
--- a/src/args.cpp
+++ b/src/args.cpp
@@ -63,6 +63,8 @@ const char *Args::Params(const char *token, size_t &index)
 {
    if (token == nullptr)
    {
+      // coveralls will complain
+      // can only occur with a call such as: arg.Param(nullptr)
       return(nullptr);
    }
 


### PR DESCRIPTION
Ref. https://coveralls.io/builds/17772219/source?filename=src/args.cpp#L66
Coveralls will never trace. But complain.