### PR TITLE
Clear PCF_VAR_1ST_DEF from function prototypes

### DIFF
--- a/src/ParseFrame.h
+++ b/src/ParseFrame.h
@@ -61,13 +61,13 @@ public:
 
    bool empty() const;
 
-   paren_stack_entry_t       &at(size_t idx);
+   paren_stack_entry_t &at(size_t idx);
    const paren_stack_entry_t &at(size_t idx) const;
 
-   paren_stack_entry_t       &prev(size_t idx = 1);
+   paren_stack_entry_t &prev(size_t idx       = 1);
    const paren_stack_entry_t &prev(size_t idx = 1) const;
 
-   paren_stack_entry_t       &top();
+   paren_stack_entry_t &top();
    const paren_stack_entry_t &top() const;
 
    const paren_stack_entry_t &poped() const;

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -4792,6 +4792,7 @@ static void mark_function(chunk_t *pc)
       if (tmp->level < pc->level)
       {
          // No semicolon - guess that it is a prototype
+         chunk_flags_clr(pc, PCF_VAR_1ST_DEF);
          set_chunk_type(pc, CT_FUNC_PROTO);
          break;
       }
@@ -4806,6 +4807,7 @@ static void mark_function(chunk_t *pc)
          {
             // Set the parent for the semicolon for later
             semi = tmp;
+            chunk_flags_clr(pc, PCF_VAR_1ST_DEF);
             set_chunk_type(pc, CT_FUNC_PROTO);
             D_LOG_FMT(LFCN, "%s(%d): ", __func__, __LINE__);
             LOG_FMT(LFCN, "  2) Marked [%s] as FUNC_PROTO on line %zu col %zu\n",

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -92,6 +92,7 @@
 30094  align-1.cfg                          cpp/bug_495.cpp
 30095  ben_017.cfg                          cpp/bug_485.cpp
 30096  bug_1854.cfg                         cpp/bug_1854.cpp
+30097  align-1.cfg                          cpp/issue_1946.cpp
 
 30099  sp_arith-f.cfg                       cpp/bug_1127.cpp
 30100  nl_template_class-force.cfg          cpp/templates.cpp

--- a/tests/expected/cpp/30097-issue_1946.cpp
+++ b/tests/expected/cpp/30097-issue_1946.cpp
@@ -1,0 +1,5 @@
+namespace foo
+{
+long_type_name_t &foo1();
+foo_t &foo2();
+}

--- a/tests/input/cpp/issue_1946.cpp
+++ b/tests/input/cpp/issue_1946.cpp
@@ -1,0 +1,5 @@
+namespace foo
+{
+long_type_name_t &foo1();
+foo_t &foo2();
+}


### PR DESCRIPTION
When `mark_function` marks a `CT_FUNC_PROTO`, also clear `PCF_VAR_1ST_DEF` from the marked prototype name. This prevents function prototypes from being aligned as if they were variable declarations or definitions, which can happen when a `WORD`, `AMP`, `WORD` sequence transforms the first `WORD` into a `TYPE`:
https://github.com/uncrustify/uncrustify/blob/0fea36c35f644467086a9e55c0de9aeab274f9c8/src/combine.cpp#L1813

Fixes #1946.