### PR TITLE
Set align_var_def_amp_style for uncrustify sources

### DIFF
--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -57,6 +57,7 @@ align_number_right               = true
 align_func_params               = true
 align_var_def_span              = 2
 align_var_def_star_style        = 1
+align_var_def_amp_style         = 1
 align_var_def_colon             = true
 align_var_def_inline            = true
 align_assign_span               = 1

--- a/src/ParseFrame.h
+++ b/src/ParseFrame.h
@@ -61,13 +61,13 @@ public:
 
    bool empty() const;
 
-   paren_stack_entry_t &      at(size_t idx);
+   paren_stack_entry_t       &at(size_t idx);
    const paren_stack_entry_t &at(size_t idx) const;
 
-   paren_stack_entry_t &      prev(size_t idx = 1);
+   paren_stack_entry_t       &prev(size_t idx = 1);
    const paren_stack_entry_t &prev(size_t idx = 1) const;
 
-   paren_stack_entry_t &      top();
+   paren_stack_entry_t       &top();
    const paren_stack_entry_t &top() const;
 
    const paren_stack_entry_t &poped() const;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2426,7 +2426,7 @@ int load_option_file(const char *filename)
 
 const char *get_eol_marker()
 {
-   static char                 eol[3] = { 0x0A, 0x00, 0x00 };
+   static char                eol[3] = { 0x0A, 0x00, 0x00 };
 
    const unc_text::value_type &lines = cpd.newline.get();
 

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -143,8 +143,8 @@ struct tok_ctx
 
 
    const deque<int> &data;
-   tok_info          c; //! current
-   tok_info          s; //! saved
+   tok_info         c; //! current
+   tok_info         s; //! saved
 };
 
 


### PR DESCRIPTION
Add `align_var_def_amp_style=1` to `forUncrustifySources.cfg`, for symmetry with the existing `align_var_def_star_style=1`. Having one without the other leads to strange-looking and inconsistent placement of the `&` type-modifier when compared to placement of the `*` type-modifier.

Closes #1947.