### PR TITLE
Fix string literal output

### DIFF
--- a/tests/expected/cpp/30920-indent-off.cpp
+++ b/tests/expected/cpp/30920-indent-off.cpp
@@ -23,7 +23,7 @@ struct Y
    void operator()(){}
    void func()
    {
-      auto x = "	test\t            ...   ???";
+      auto x = "	test\t 	 	 		...   ???";
    }
 };
 

--- a/tests/expected/cpp/31710-string_replace_tab_chars.cpp
+++ b/tests/expected/cpp/31710-string_replace_tab_chars.cpp
@@ -1,3 +1,3 @@
 void f() {
-	auto x = "	test\t                          ...   ???";
+	auto x = "	test\t 	 	 		...   ???";
 }

--- a/tests/expected/cpp/33006-string_replace_tab_chars.cpp
+++ b/tests/expected/cpp/33006-string_replace_tab_chars.cpp
@@ -1,3 +1,3 @@
 void f() {
-	auto x = "	test\t                          ...   ???";
+	auto x = "	test\t 	 	 		...   ???";
 }


### PR DESCRIPTION
Prevent replacing of tabs in string literals to spaces.
Example:
auto test = " 	  	abcdefg  		 ";