### PR TITLE
Fix return brace

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2624,6 +2624,19 @@ static chunk_t *process_return(chunk_t *pc)
       }
    }
 
+   // Issue #1917
+   // Never add parens to a braced init list; that breaks the code
+   //   return {args...};    // C++11 type elision; okay
+   //   return ({args...});  // ill-formed
+   if (  language_is_set(LANG_CPP) && chunk_is_token(next, CT_BRACE_OPEN)
+      && next->parent_type == CT_BRACED_INIT_LIST)
+   {
+      LOG_FMT(LRETURN, "%s(%d): not adding parens around braced initializer"
+              " on orig_line %zd\n",
+              __func__, __LINE__, pc->orig_line);
+      return(next);
+   }
+
    // We don't have a fully paren'd return. Should we add some?
    if ((options::mod_paren_on_return() & IARF_ADD) == 0)
    {

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -582,6 +582,8 @@ void register_options(void)
                   "Add or remove space between a constructor without parameters or destructor and '()'.");
    unc_add_option("sp_return_paren", UO_sp_return_paren, AT_IARF,
                   "Add or remove space between 'return' and '('.");
+   unc_add_option("sp_return_brace", UO_sp_return_brace, AT_IARF,
+                  "Add or remove space between 'return' and '{'.");
    unc_add_option("sp_attribute_paren", UO_sp_attribute_paren, AT_IARF,
                   "Add or remove space between '__attribute__' and '('.");
    unc_add_option("sp_defined_paren", UO_sp_defined_paren, AT_IARF,

--- a/src/option.h
+++ b/src/option.h
@@ -278,6 +278,7 @@ enum uncrustify_options
    UO_sp_func_class_paren,         // space between ctor/dtor and '('
    UO_sp_func_class_paren_empty,   // space between ctor/dtor and '()'
    UO_sp_return_paren,             // space between 'return' and '('
+   UO_sp_return_brace,             // space between 'return' and '{'
    UO_sp_attribute_paren,          // space between '__attribute__' and '('
    UO_sp_defined_paren,            //
    UO_sp_throw_paren,              //

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -869,6 +869,12 @@ iarf_e &sp_return_paren()
 }
 
 
+iarf_e &sp_return_brace()
+{
+   return(cpd.settings[UO_sp_return_brace].a);
+}
+
+
 iarf_e &sp_attribute_paren()
 {
    return(cpd.settings[UO_sp_attribute_paren].a);

--- a/src/options.h
+++ b/src/options.h
@@ -155,6 +155,7 @@ iarf_e &sp_func_call_user_paren_paren();
 iarf_e &sp_func_class_paren();
 iarf_e &sp_func_class_paren_empty();
 iarf_e &sp_return_paren();
+iarf_e &sp_return_brace();
 iarf_e &sp_attribute_paren();
 iarf_e &sp_defined_paren();
 iarf_e &sp_throw_paren();

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -459,10 +459,17 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    // "return(a);" vs "return (foo_t)a + 3;" vs "return a;" vs "return;"
    if (chunk_is_token(first, CT_RETURN))
    {
-      if (chunk_is_token(second, CT_PAREN_OPEN) && second->parent_type == CT_RETURN)
+      if (  chunk_is_token(second, CT_PAREN_OPEN)
+         && second->parent_type == CT_RETURN)
       {
          log_rule("sp_return_paren");
          return(options::sp_return_paren());
+      }
+      else if (  chunk_is_token(second, CT_BRACE_OPEN)
+              && second->parent_type == CT_BRACED_INIT_LIST)
+      {
+         log_rule("sp_return_brace");
+         return(options::sp_return_brace());
       }
       // everything else requires a space
       log_rule("FORCE");

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 651 options and minimal documentation.
+There are currently 652 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -138,6 +138,7 @@ sp_func_call_user_paren_paren   = ignore
 sp_func_class_paren             = ignore
 sp_func_class_paren_empty       = ignore
 sp_return_paren                 = ignore
+sp_return_brace                 = ignore
 sp_attribute_paren              = ignore
 sp_defined_paren                = ignore
 sp_throw_paren                  = ignore

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -437,6 +437,9 @@ sp_func_class_paren_empty       = ignore   # ignore/add/remove/force
 # Add or remove space between 'return' and '('.
 sp_return_paren                 = ignore   # ignore/add/remove/force
 
+# Add or remove space between 'return' and '{'.
+sp_return_brace                 = ignore   # ignore/add/remove/force
+
 # Add or remove space between '__attribute__' and '('.
 sp_attribute_paren              = ignore   # ignore/add/remove/force
 

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -138,6 +138,7 @@ sp_func_call_user_paren_paren   = ignore
 sp_func_class_paren             = ignore
 sp_func_class_paren_empty       = ignore
 sp_return_paren                 = ignore
+sp_return_brace                 = ignore
 sp_attribute_paren              = ignore
 sp_defined_paren                = ignore
 sp_throw_paren                  = ignore

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -437,6 +437,9 @@ sp_func_class_paren_empty       = ignore   # ignore/add/remove/force
 # Add or remove space between 'return' and '('.
 sp_return_paren                 = ignore   # ignore/add/remove/force
 
+# Add or remove space between 'return' and '{'.
+sp_return_brace                 = ignore   # ignore/add/remove/force
+
 # Add or remove space between '__attribute__' and '('.
 sp_attribute_paren              = ignore   # ignore/add/remove/force
 

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -437,6 +437,9 @@ sp_func_class_paren_empty       = ignore   # ignore/add/remove/force
 # Add or remove space between 'return' and '('.
 sp_return_paren                 = ignore   # ignore/add/remove/force
 
+# Add or remove space between 'return' and '{'.
+sp_return_brace                 = ignore   # ignore/add/remove/force
+
 # Add or remove space between '__attribute__' and '('.
 sp_attribute_paren              = ignore   # ignore/add/remove/force
 

--- a/tests/config/mod_paren_on_return-a.cfg
+++ b/tests/config/mod_paren_on_return-a.cfg
@@ -1,0 +1,1 @@
+mod_paren_on_return             = add

--- a/tests/config/mod_paren_on_return-r.cfg
+++ b/tests/config/mod_paren_on_return-r.cfg
@@ -1,0 +1,1 @@
+mod_paren_on_return             = remove

--- a/tests/config/sp_return_brace-f.cfg
+++ b/tests/config/sp_return_brace-f.cfg
@@ -1,0 +1,1 @@
+sp_return_brace                 = force

--- a/tests/config/sp_return_brace-r.cfg
+++ b/tests/config/sp_return_brace-r.cfg
@@ -1,0 +1,1 @@
+sp_return_brace                 = remove

--- a/tests/config/sp_return_paren-f.cfg
+++ b/tests/config/sp_return_paren-f.cfg
@@ -1,0 +1,1 @@
+sp_return_paren                 = force

--- a/tests/config/sp_return_paren-r.cfg
+++ b/tests/config/sp_return_paren-r.cfg
@@ -1,0 +1,1 @@
+sp_return_paren                 = remove

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -180,8 +180,13 @@
 #30310  sp_word_brace_force.cfg              cpp/uniform_initialization.cpp
 #30311  sp_word_brace_remove.cfg             cpp/uniform_initialization.cpp
 30312  sp_inside_type_brace_init_lst-f.cfg  cpp/return_init_list.cpp
-30313  sp_brace_brace-r.cfg                 cpp/sp_brace_brace.cpp 
+30313  sp_brace_brace-r.cfg                 cpp/sp_brace_brace.cpp
 30314  sp_brace_brace-f.cfg                 cpp/sp_brace_brace.cpp
+
+30320  sp_return_paren-r.cfg                cpp/returns.cpp
+30321  sp_return_paren-f.cfg                cpp/returns.cpp
+30322  sp_return_brace-r.cfg                cpp/returns.cpp
+30323  sp_return_brace-f.cfg                cpp/returns.cpp
 
 30400  attribute_specifier_seqs.cfg         cpp/attribute_specifier_seqs.cpp
 

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -187,6 +187,8 @@
 30321  sp_return_paren-f.cfg                cpp/returns.cpp
 30322  sp_return_brace-r.cfg                cpp/returns.cpp
 30323  sp_return_brace-f.cfg                cpp/returns.cpp
+30324  mod_paren_on_return-a.cfg            cpp/returns.cpp
+30325  mod_paren_on_return-r.cfg            cpp/returns.cpp
 
 30400  attribute_specifier_seqs.cfg         cpp/attribute_specifier_seqs.cpp
 

--- a/tests/expected/cpp/30312-return_init_list.cpp
+++ b/tests/expected/cpp/30312-return_init_list.cpp
@@ -1,18 +1,18 @@
 inline static std::tuple<bool, std::string> foo(void) {
 // should remain a one liner
-	return { true, ""s };
+	return{ true, ""s };
 }
 inline static std::tuple<bool, std::string, std::string> foo(void) {
 	if (condition) {
 // should remain a one liner
-		return { true, ""s, ""s };
+		return{ true, ""s, ""s };
 	}
 // should remain a one liner
-	return { false, ""s, ""s };
+	return{ false, ""s, ""s };
 }
 inline static std::tuple<bool, std::string> foo(void) {
 // should indent one level
-	return {
+	return{
 	        true, ""s
 	};
 }

--- a/tests/expected/cpp/30320-returns.cpp
+++ b/tests/expected/cpp/30320-returns.cpp
@@ -1,0 +1,18 @@
+void foo(int x)
+{
+	switch (x)
+	{
+	case 1:
+		return 1;
+	case 2:
+		return(2);
+	case 3:
+		return(3);
+	case 4:
+		return  {4};
+	case 5:
+		return  {5};
+	default:
+		return;
+	}
+}

--- a/tests/expected/cpp/30321-returns.cpp
+++ b/tests/expected/cpp/30321-returns.cpp
@@ -1,0 +1,18 @@
+void foo(int x)
+{
+	switch (x)
+	{
+	case 1:
+		return 1;
+	case 2:
+		return (2);
+	case 3:
+		return (3);
+	case 4:
+		return  {4};
+	case 5:
+		return  {5};
+	default:
+		return;
+	}
+}

--- a/tests/expected/cpp/30322-returns.cpp
+++ b/tests/expected/cpp/30322-returns.cpp
@@ -1,0 +1,18 @@
+void foo(int x)
+{
+	switch (x)
+	{
+	case 1:
+		return 1;
+	case 2:
+		return(2);
+	case 3:
+		return  (3);
+	case 4:
+		return{4};
+	case 5:
+		return{5};
+	default:
+		return;
+	}
+}

--- a/tests/expected/cpp/30323-returns.cpp
+++ b/tests/expected/cpp/30323-returns.cpp
@@ -1,0 +1,18 @@
+void foo(int x)
+{
+	switch (x)
+	{
+	case 1:
+		return 1;
+	case 2:
+		return(2);
+	case 3:
+		return  (3);
+	case 4:
+		return {4};
+	case 5:
+		return {5};
+	default:
+		return;
+	}
+}

--- a/tests/expected/cpp/30324-returns.cpp
+++ b/tests/expected/cpp/30324-returns.cpp
@@ -1,0 +1,18 @@
+void foo(int x)
+{
+	switch (x)
+	{
+	case 1:
+		return(1);
+	case 2:
+		return(2);
+	case 3:
+		return  (3);
+	case 4:
+		return  {4};
+	case 5:
+		return  {5};
+	default:
+		return;
+	}
+}

--- a/tests/expected/cpp/30325-returns.cpp
+++ b/tests/expected/cpp/30325-returns.cpp
@@ -1,0 +1,18 @@
+void foo(int x)
+{
+	switch (x)
+	{
+	case 1:
+		return 1;
+	case 2:
+		return 2;
+	case 3:
+		return 3;
+	case 4:
+		return  {4};
+	case 5:
+		return  {5};
+	default:
+		return;
+	}
+}

--- a/tests/input/cpp/returns.cpp
+++ b/tests/input/cpp/returns.cpp
@@ -1,0 +1,18 @@
+void foo(int x)
+{
+	switch (x)
+	{
+	case 1:
+		return  1;
+	case 2:
+		return(2);
+	case 3:
+		return  (3);
+	case 4:
+		return  {4};
+	case 5:
+		return  {5};
+	default:
+		return;
+	}
+}


### PR DESCRIPTION
Add `sp_return_brace`  to control space between return and brace, mirroring `sp_return_paren`. Prevent `mod_paren_on_return` from being applied around braced initializers, as it breaks the code.

See also #1917. (I'm not going to claim this as "fixing" that, since the issue partly deals with how we format uncrustify's own sources, which remains an open question. In particular, even with this, I anticipate needing a change to `forUncrustifySources.cfg` — even if it's just be adding `sp_return_brace=??` — before I would consider #1917 "closed".)