### PR TITLE
Don't enfore nl_before_func_class_def on ourselves

### DIFF
--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -122,7 +122,6 @@ nl_after_brace_open             = true
 nl_after_vbrace_open            = true
 nl_after_brace_close            = true
 nl_squeeze_ifdef                = true
-nl_before_func_class_def        = 3
 nl_constr_colon                 = force
 pos_constr_comma                = lead_force
 pos_constr_colon                = lead_break


### PR DESCRIPTION
Remove `nl_before_func_class_def` from `forUncrustifySources.cfg`. This is fine for large, inline constructors (which possibly ought to not be inline, anyway), but somewhat ugly for one-liners.

(Removing it entirely, rather than setting it to e.g. `1`, allows existing code to remain unchanged.)

This is somewhat of an RFC... for #1852, I have some code like:
```c++
   inline flags() : m_i{0} {}
   inline flags(Enum flag) : m_i{static_cast<int>(flag)} {}
   inline flags(const flags &other) : m_i{other.m_i} {}

   inline flags &operator=(const flags &other)
   { m_i = other.i; return(*this); }

   inline flags &operator&=(int mask)
   { m_i &= mask; return(*this); }
   inline flags &operator&=(unsigned int mask)
   { m_i &= mask; return(*this); }
```

...that I think should be left as-is rather than having bunches of empty lines inserted around the ctors.

(The code shown above actually will probably come in an earlier PR — it is part of #1852 now, but I am planning on spinning that part out in my ongoing effort to minimize the changes that will actually be in the final #1852 — but there is similar stuff in #1852's `option.h` that is part of "#1852 proper".)

This is an "easy" solution, but I'd also be amenable to adding an option to disable `nl_before_func_class_def` for one-liners...