### PR TITLE
Don't align_assign_decl_func in our own sources

### DIFF
--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -61,6 +61,7 @@ align_var_def_amp_style         = 1
 align_var_def_colon             = true
 align_var_def_inline            = true
 align_assign_span               = 1
+align_assign_decl_func          = 2
 align_enum_equ_span             = 4
 align_var_class_span            = 2
 align_var_struct_span           = 3


### PR DESCRIPTION
Set `align_assign_decl_func` to "don't align" in `forUncrustifySources.cfg`. See also #1925. This will affect #1852, but it does not affect any current code.

This can be considered an RFC; I worded the commit as "we don't want this" so that it is merge-ready, but please feel free to object to this PR :slightly_smiling_face:.