### PR TITLE
Introduce nl_inside_namespace

### DIFF
--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -133,6 +133,7 @@ nl_after_func_proto_group       = 2
 nl_before_func_body_def         = 3
 nl_after_access_spec            = 1
 nl_comment_func_def             = 1
+nl_inside_namespace             = 2
 eat_blanks_after_open_brace     = true
 eat_blanks_before_close_brace   = true
 nl_after_return                 = true

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -1430,6 +1430,13 @@ void register_options(void)
                   "0 = No change.");
    unc_add_option("nl_property_brace", UO_nl_property_brace, AT_IARF,
                   "Add or remove newline between C# property and the '{'.");
+   unc_add_option("nl_inside_namespace", UO_nl_inside_namespace, AT_UNUM,
+                  "The number of newlines after '{' of a namespace. This also "
+                  "adds newlines\nbefore the matching '}'.\n\n"
+                  "0 = Apply eat_blanks_after_open_brace or "
+                  "eat_blanks_before_close_brace if\n    applicable, otherwise "
+                  "no change.\n\nOverrides eat_blanks_after_open_brace "
+                  "and eat_blanks_before_close_brace.");
    unc_add_option("eat_blanks_after_open_brace", UO_eat_blanks_after_open_brace, AT_BOOL,
                   "Whether to remove blank lines after '{'.");
    unc_add_option("eat_blanks_before_close_brace", UO_eat_blanks_before_close_brace, AT_BOOL,

--- a/src/option.h
+++ b/src/option.h
@@ -698,6 +698,7 @@ enum uncrustify_options
    UO_nl_between_get_set,              // The number of newlines between the get/set/add/remove handlers in C#
                                        // (0 = No change)
    UO_nl_property_brace,               // Add or remove newline between C# property and the '{'
+   UO_nl_inside_namespace,             // blank lines inside namespace braces
    UO_eat_blanks_after_open_brace,     // remove blank lines after {
    UO_eat_blanks_before_close_brace,   // remove blank lines before }
    UO_nl_remove_extra_newlines,        // How aggressively to remove extra newlines not in preproc

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -33,8 +33,10 @@
 
 namespace uncrustify
 {
+
 namespace options
 {
+
 lineends_e &newlines()
 {
    return(cpd.settings[UO_newlines].le);
@@ -3997,5 +3999,7 @@ size_t &warn_level_tabs_found_in_verbatim_string_literals()
 {
    return(cpd.settings[UO_warn_level_tabs_found_in_verbatim_string_literals].u);
 }
+
 } // namespace option
+
 } // namespace uncrustify

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2989,6 +2989,12 @@ iarf_e &nl_property_brace()
 }
 
 
+size_t &nl_inside_namespace()
+{
+   return(cpd.settings[UO_nl_inside_namespace].u);
+}
+
+
 bool &eat_blanks_after_open_brace()
 {
    return(cpd.settings[UO_eat_blanks_after_open_brace].b);

--- a/src/options.h
+++ b/src/options.h
@@ -507,6 +507,7 @@ size_t &nl_after_try_catch_finally();
 size_t &nl_around_cs_property();
 size_t &nl_between_get_set();
 iarf_e &nl_property_brace();
+size_t &nl_inside_namespace();
 bool &eat_blanks_after_open_brace();
 bool &eat_blanks_before_close_brace();
 size_t &nl_remove_extra_newlines();

--- a/src/options.h
+++ b/src/options.h
@@ -14,8 +14,10 @@
 
 namespace uncrustify
 {
+
 namespace options
 {
+
 lineends_e &newlines();
 size_t &input_tab_size();
 size_t &output_tab_size();
@@ -670,7 +672,9 @@ bool &use_indent_continue_only_once();
 bool &indent_cpp_lambda_only_once();
 bool &use_options_overriding_for_qt_macros();
 size_t &warn_level_tabs_found_in_verbatim_string_literals();
+
 } // namespace options
+
 } // namespace uncrustify
 
 #endif /* OPTIONS_H_INCLUDED */

--- a/src/options_for_QT.cpp
+++ b/src/options_for_QT.cpp
@@ -20,6 +20,7 @@ bool   restoreValues        = false;
 
 namespace
 {
+
 //-----------------------------------------------------------------------------
 class temporary_iarf_option
 {
@@ -81,6 +82,7 @@ temporary_iarf_option for_qt_options[] = {
 // connect( a, SIGNAL(b(c< d >)), this, SLOT(e(f< g >)) );
    { &options::sp_inside_angle            },
 };
+
 } // anonymous namespace
 
 

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 653 options and minimal documentation.
+There are currently 654 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -490,6 +490,7 @@ nl_after_try_catch_finally      = 0
 nl_around_cs_property           = 0
 nl_between_get_set              = 0
 nl_property_brace               = ignore
+nl_inside_namespace             = 0
 eat_blanks_after_open_brace     = false
 eat_blanks_before_close_brace   = false
 nl_remove_extra_newlines        = 0

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1624,6 +1624,15 @@ nl_between_get_set              = 0        # unsigned number
 # Add or remove newline between C# property and the '{'.
 nl_property_brace               = ignore   # ignore/add/remove/force
 
+# The number of newlines after '{' of a namespace. This also adds newlines
+# before the matching '}'.
+# 
+# 0 = Apply eat_blanks_after_open_brace or eat_blanks_before_close_brace if
+#     applicable, otherwise no change.
+# 
+# Overrides eat_blanks_after_open_brace and eat_blanks_before_close_brace.
+nl_inside_namespace             = 0        # unsigned number
+
 # Whether to remove blank lines after '{'.
 eat_blanks_after_open_brace     = false    # false/true
 

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -490,6 +490,7 @@ nl_after_try_catch_finally      = 0
 nl_around_cs_property           = 0
 nl_between_get_set              = 0
 nl_property_brace               = ignore
+nl_inside_namespace             = 0
 eat_blanks_after_open_brace     = false
 eat_blanks_before_close_brace   = false
 nl_remove_extra_newlines        = 0

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1624,6 +1624,15 @@ nl_between_get_set              = 0        # unsigned number
 # Add or remove newline between C# property and the '{'.
 nl_property_brace               = ignore   # ignore/add/remove/force
 
+# The number of newlines after '{' of a namespace. This also adds newlines
+# before the matching '}'.
+# 
+# 0 = Apply eat_blanks_after_open_brace or eat_blanks_before_close_brace if
+#     applicable, otherwise no change.
+# 
+# Overrides eat_blanks_after_open_brace and eat_blanks_before_close_brace.
+nl_inside_namespace             = 0        # unsigned number
+
 # Whether to remove blank lines after '{'.
 eat_blanks_after_open_brace     = false    # false/true
 

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1624,6 +1624,15 @@ nl_between_get_set              = 0        # unsigned number
 # Add or remove newline between C# property and the '{'.
 nl_property_brace               = ignore   # ignore/add/remove/force
 
+# The number of newlines after '{' of a namespace. This also adds newlines
+# before the matching '}'.
+# 
+# 0 = Apply eat_blanks_after_open_brace or eat_blanks_before_close_brace if
+#     applicable, otherwise no change.
+# 
+# Overrides eat_blanks_after_open_brace and eat_blanks_before_close_brace.
+nl_inside_namespace             = 0        # unsigned number
+
 # Whether to remove blank lines after '{'.
 eat_blanks_after_open_brace     = false    # false/true
 

--- a/tests/config/nl_inside_namespace_1.cfg
+++ b/tests/config/nl_inside_namespace_1.cfg
@@ -1,0 +1,1 @@
+nl_inside_namespace             = 2

--- a/tests/config/nl_inside_namespace_2.cfg
+++ b/tests/config/nl_inside_namespace_2.cfg
@@ -1,0 +1,3 @@
+nl_inside_namespace             = 2
+eat_blanks_after_open_brace     = true
+eat_blanks_before_close_brace   = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -65,6 +65,9 @@
 30055  nl_after_func_body.cfg               cpp/nl_func.cpp
 30056  nl_after_func_body-2.cfg             cpp/nl_func.cpp
 
+30057  nl_inside_namespace_1.cfg            cpp/nl_inside_namespace.cpp
+30058  nl_inside_namespace_2.cfg            cpp/nl_inside_namespace.cpp
+
 # Class colon positioning
 30061  class-colon-pos-eol.cfg              cpp/class-init.cpp
 30062  class-colon-pos-sol.cfg              cpp/class-init.cpp

--- a/tests/expected/cpp/30057-nl_inside_namespace.cpp
+++ b/tests/expected/cpp/30057-nl_inside_namespace.cpp
@@ -1,0 +1,29 @@
+namespace cats
+{ // rule
+
+int count;
+void meow();
+
+}
+
+namespace dogs { // drool
+
+int count;
+void bark();
+
+}
+
+namespace pigs {
+
+int count;
+void oink();
+
+}
+
+namespace owls
+{
+
+int count;
+void hoot();
+
+}

--- a/tests/expected/cpp/30058-nl_inside_namespace.cpp
+++ b/tests/expected/cpp/30058-nl_inside_namespace.cpp
@@ -1,0 +1,29 @@
+namespace cats
+{ // rule
+
+int count;
+void meow();
+
+}
+
+namespace dogs { // drool
+
+int count;
+void bark();
+
+}
+
+namespace pigs {
+
+int count;
+void oink();
+
+}
+
+namespace owls
+{
+
+int count;
+void hoot();
+
+}

--- a/tests/input/cpp/nl_inside_namespace.cpp
+++ b/tests/input/cpp/nl_inside_namespace.cpp
@@ -1,0 +1,37 @@
+namespace cats
+{ // rule
+
+
+int count;
+void meow();
+
+
+}
+
+namespace dogs { // drool
+
+
+int count;
+void bark();
+
+
+}
+
+namespace pigs {
+
+
+int count;
+void oink();
+
+
+}
+
+namespace owls
+{
+
+
+int count;
+void hoot();
+
+
+}


### PR DESCRIPTION
Add new option `nl_inside_namespace`:

    The number of newlines after '{' of a namespace. This also adds newlines
    before the matching '}'.

    0 = Apply eat_blanks_after_open_brace or eat_blanks_before_close_brace if
        applicable, otherwise no change.

    Overrides eat_blanks_after_open_brace and eat_blanks_before_close_brace.

...and apply it to uncrustify itself.

I'm going to claim that this fixes #1784. While it doesn't, strictly speaking, implement the feature as described in the original request, it *does* solve the cases I actually care about... and #1784 is my issue, so I can close it if I want to :stuck_out_tongue_winking_eye:.