### PR TITLE
Normalize debug output in test_cli_options.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -143,8 +143,6 @@ script:
   - if [ "x${BUILD_TYPE}" == "xcoverage" ]; then make coverage; fi
   # test if all the sources are conform to the forUncrustifySources.cfg config file
   - if [ "x${BUILD_TYPE}" == "xrelease" ]; then cd ../ && ./scripts/Run_uncrustify_for_sources.sh; cd -; fi
-  # test if uncrustify runs for (some) command line options
-  - if [ "x${BUILD_TYPE}" == "xrelease" ]; then cd ../tests/cli && ./test_cli_options.py; cd -; fi
 
   # DO NOT REMOVE (debugging purposes)
   #- /home/travis/build/uncrustify/uncrustify/build/uncrustify -l cs -c /home/travis/build/uncrustify/uncrustify/tests/config/U10-Cpp.cfg -f /home/travis/build/uncrustify/uncrustify/tests/input/cs/newlines.mm -L A

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,39 +50,23 @@ else()
   endforeach()
 endif()
 
-if (CMAKE_CONFIGURATION_TYPES)
-  # Not really, but just to make the following if() true
-  set(_build_type release)
-  set(_configs CONFIGURATIONS Release RelWithDebInfo MinSizeRel)
-else()
-  string(TOLOWER "${CMAKE_BUILD_TYPE}" _build_type)
-  set(_configs)
-endif()
+add_test(
+  NAME cli_options
+  COMMAND ${PYTHON_EXECUTABLE}
+    test_cli_options.py
+    --build ${uncrustify_BINARY_DIR}
+    --diff
+  ${_configs}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cli
+)
 
-# Only enable test_cli_options stuff if building a release configuration,
-# or using a multi-configuration generator (note: in the latter case, these
-# will fail if a release configuration has not been built)
-if (_build_type MATCHES "release|relwithdebinfo|minsizerel")
-  add_test(
-    NAME cli_options
-    COMMAND ${PYTHON_EXECUTABLE}
-      test_cli_options.py
-      --build ${uncrustify_BINARY_DIR}
-      --cache ${CMAKE_BINARY_DIR}/CMakeCache.txt
-      --diff
-    ${_configs}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cli
-  )
-
-  add_custom_target(update-cli-options
-    COMMAND ${PYTHON_EXECUTABLE}
-      test_cli_options.py
-      --build ${uncrustify_BINARY_DIR}
-      --cache ${CMAKE_BINARY_DIR}/CMakeCache.txt
-      --apply
-    DEPENDS uncrustify
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cli
-  )
-endif()
+add_custom_target(update-cli-options
+  COMMAND ${PYTHON_EXECUTABLE}
+    test_cli_options.py
+    --build ${uncrustify_BINARY_DIR}
+    --apply
+  DEPENDS uncrustify
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cli
+)
 
 add_test(NAME sanity COMMAND uncrustify --help)

--- a/tests/cli/output/25.txt
+++ b/tests/cli/output/25.txt
@@ -1,9 +1,9 @@
 Newline loop start: 
-newline_add_between(): ';'[SEMICOLON] line : and '}' line : : [CallStack:-DEBUG NOT SET-]
-newline_add_between(): '{'[BRACE_OPEN] line : and '}' line : : [CallStack:-DEBUG NOT SET-]
-newline_add_between(): '{'[BRACE_OPEN] line : and '}' line : : [CallStack:-DEBUG NOT SET-]
-newline_add_between(): '{'[BRACE_OPEN] line : and '}' line : : [CallStack:-DEBUG NOT SET-]
-newline_add_between(): '{'[BRACE_OPEN] line : and '}' line : : [CallStack:-DEBUG NOT SET-]
+newline_add_between(): ';'[SEMICOLON] line : and '}' line : : [CallStack]
+newline_add_between(): '{'[BRACE_OPEN] line : and '}' line : : [CallStack]
+newline_add_between(): '{'[BRACE_OPEN] line : and '}' line : : [CallStack]
+newline_add_between(): '{'[BRACE_OPEN] line : and '}' line : : [CallStack]
+newline_add_between(): '{'[BRACE_OPEN] line : and '}' line : : [CallStack]
 newlines_insert_blank_lines(): orig_line is , orig_col is , text() 'struct', type is STRUCT
 newlines_insert_blank_lines(): ignore it
 newlines_insert_blank_lines(): orig_line is , orig_col is , text() 'TelegramIndex', type is TYPE

--- a/tests/cli/output/31.txt
+++ b/tests/cli/output/31.txt
@@ -27,7 +27,7 @@ indent_text(): orig_line is , orig_col is , column is , for 'TelegramIndex'
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 reindent_line(): orig_line is , orig_col is , on 'TelegramIndex' [FUNC_CLASS_DEF/NONE] => 
- [CallStack:-DEBUG NOT SET-]
+ [CallStack]
 indent_text(): orig_line is , orig_col is , column is , for '('
    [x:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text(): frm.pse_tos is , ...indent_tmp is 
@@ -87,7 +87,7 @@ indent_text(): orig_line is , orig_col is , column is , for 'pTelName'
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 reindent_line(): orig_line is , orig_col is , on 'pTelName' [FUNC_CTOR_VAR/NONE] => 
- [CallStack:-DEBUG NOT SET-]
+ [CallStack]
 indent_text(): orig_line is , orig_col is , column is , for '('
    [x:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text(): frm.pse_tos is , ...indent_tmp is 
@@ -117,7 +117,7 @@ indent_text(): orig_line is , orig_col is , column is , for 'nTelIndex'
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 reindent_line(): orig_line is , orig_col is , on 'nTelIndex' [FUNC_CTOR_VAR/NONE] => 
- [CallStack:-DEBUG NOT SET-]
+ [CallStack]
 indent_text(): orig_line is , orig_col is , column is , for '('
    [x:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text(): frm.pse_tos is , ...indent_tmp is 
@@ -145,7 +145,7 @@ indent_text(): frm.pse_tos is , ...indent_tmp is
 indent_text(): frm.pse_tos is , ... indent is 
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 reindent_line(): orig_line is , orig_col is , on '{' [BRACE_OPEN/FUNC_CLASS_DEF] => 
- [CallStack:-DEBUG NOT SET-]
+ [CallStack]
 indent_text(): orig_line is , <Newline>
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 indent_text(): frm.pse_tos is , ...indent_tmp is 
@@ -156,7 +156,7 @@ indent_text(): orig_line is , orig_col is , column is , for '}'
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 reindent_line(): orig_line is , orig_col is , on '}' [BRACE_CLOSE/FUNC_CLASS_DEF] => 
- [CallStack:-DEBUG NOT SET-]
+ [CallStack]
 indent_text(): orig_line is , <Newline>
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 indent_text(): frm.pse_tos is , ...indent_tmp is 
@@ -167,7 +167,7 @@ indent_text(): orig_line is , orig_col is , column is , for '~'
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 reindent_line(): orig_line is , orig_col is , on '~' [DESTRUCTOR/NONE] => 
- [CallStack:-DEBUG NOT SET-]
+ [CallStack]
 indent_text(): orig_line is , orig_col is , column is , for 'TelegramIndex'
    [x:IN_STRUCT,IN_CLASS,EXPR_START]
 indent_text(): frm.pse_tos is , ...indent_tmp is 
@@ -195,7 +195,7 @@ indent_text(): frm.pse_tos is , ...indent_tmp is
 indent_text(): frm.pse_tos is , ... indent is 
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 reindent_line(): orig_line is , orig_col is , on '{' [BRACE_OPEN/FUNC_CLASS_DEF] => 
- [CallStack:-DEBUG NOT SET-]
+ [CallStack]
 indent_text(): orig_line is , <Newline>
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 indent_text(): frm.pse_tos is , ...indent_tmp is 
@@ -206,7 +206,7 @@ indent_text(): orig_line is , orig_col is , column is , for '}'
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 reindent_line(): orig_line is , orig_col is , on '}' [BRACE_CLOSE/FUNC_CLASS_DEF] => 
- [CallStack:-DEBUG NOT SET-]
+ [CallStack]
 indent_text(): orig_line is , <Newline>
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 indent_text(): frm.pse_tos is , ...indent_tmp is 
@@ -217,7 +217,7 @@ indent_text(): orig_line is , orig_col is , column is , for 'const'
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 reindent_line(): orig_line is , orig_col is , on 'const' [QUALIFIER/NONE] => 
- [CallStack:-DEBUG NOT SET-]
+ [CallStack]
 indent_text(): orig_line is , orig_col is , column is , for 'char'
    [x:IN_STRUCT,IN_CLASS,VAR_TYPE]
 indent_text(): frm.pse_tos is , ...indent_tmp is 
@@ -248,7 +248,7 @@ indent_text(): orig_line is , orig_col is , column is , for 'unsigned'
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 indent_text(): frm.pse_tos is , ...indent_tmp is 
 reindent_line(): orig_line is , orig_col is , on 'unsigned' [TYPE/NONE] => 
- [CallStack:-DEBUG NOT SET-]
+ [CallStack]
 indent_text(): orig_line is , orig_col is , column is , for 'long'
    [x:IN_STRUCT,IN_CLASS,FORCE_SPACE,VAR_TYPE]
 indent_text(): frm.pse_tos is , ...indent_tmp is 

--- a/tests/cli/output/66.txt
+++ b/tests/cli/output/66.txt
@@ -257,255 +257,255 @@ space_text(): orig_line is , orig_col is , pc-text() ';', type is SEMICOLON
 do_space(): orig_line is , orig_col is , first->text() ';', type is SEMICOLON
 space_text(): rule = REMOVE @  => 
 space_text(): orig_line is , orig_col is , <Newline>, nl is 
-space_col_align(): orig_line is , orig_col is , [FUNC_CLASS_DEF/NONE] 'TelegramIndex' <==> orig_line is , orig_col is  [FPAREN_OPEN/FUNC_CLASS_DEF] '(' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [FUNC_CLASS_DEF/NONE] 'TelegramIndex' <==> orig_line is , orig_col is  [FPAREN_OPEN/FUNC_CLASS_DEF] '(' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'TelegramIndex', type is FUNC_CLASS_DEF
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'TelegramIndex', [FUNC_CLASS_DEF/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() '(', [FPAREN_OPEN/FUNC_CLASS_DEF] : rule sp_func_class_paren[line ]
 space_col_align(): av is ignore
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [FPAREN_OPEN/FUNC_CLASS_DEF] '(' <==> orig_line is , orig_col is  [QUALIFIER/NONE] 'const' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [FPAREN_OPEN/FUNC_CLASS_DEF] '(' <==> orig_line is , orig_col is  [QUALIFIER/NONE] 'const' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() '(', type is FPAREN_OPEN
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is '(', [FPAREN_OPEN/FUNC_CLASS_DEF] <===>
    second->orig_line is , second->orig_col is , second->text() 'const', [QUALIFIER/NONE] : rule sp_inside_fparen[line ]
 space_col_align(): av is ignore
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [QUALIFIER/NONE] 'const' <==> orig_line is , orig_col is  [TYPE/NONE] 'char' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [QUALIFIER/NONE] 'const' <==> orig_line is , orig_col is  [TYPE/NONE] 'char' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'const', type is QUALIFIER
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'const', [QUALIFIER/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() 'char', [TYPE/NONE] : rule sp_after_type[line ]
  <force between 'const' and 'char'>space_col_align(): av is force
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [TYPE/NONE] 'char' <==> orig_line is , orig_col is  [PTR_TYPE/NONE] '*' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [TYPE/NONE] 'char' <==> orig_line is , orig_col is  [PTR_TYPE/NONE] '*' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'char', type is TYPE
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'char', [TYPE/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() '*', [PTR_TYPE/NONE] : rule IGNORE[line ]
 space_col_align(): av is ignore
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [PTR_TYPE/NONE] '*' <==> orig_line is , orig_col is  [WORD/NONE] 'pN' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [PTR_TYPE/NONE] '*' <==> orig_line is , orig_col is  [WORD/NONE] 'pN' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() '*', type is PTR_TYPE
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is '*', [PTR_TYPE/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() 'pN', [WORD/NONE] : rule IGNORE[line ]
 space_col_align(): av is ignore
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [WORD/NONE] 'pN' <==> orig_line is , orig_col is  [COMMA/NONE] ',' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [WORD/NONE] 'pN' <==> orig_line is , orig_col is  [COMMA/NONE] ',' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'pN', type is WORD
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'pN', [WORD/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() ',', [COMMA/NONE] : rule sp_before_comma[line ]
 space_col_align(): av is remove
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [COMMA/NONE] ',' <==> orig_line is , orig_col is  [TYPE/NONE] 'unsigned' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [COMMA/NONE] ',' <==> orig_line is , orig_col is  [TYPE/NONE] 'unsigned' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() ',', type is COMMA
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is ',', [COMMA/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() 'unsigned', [TYPE/NONE] : rule sp_after_comma[line ]
 space_col_align(): av is ignore
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [TYPE/NONE] 'unsigned' <==> orig_line is , orig_col is  [TYPE/NONE] 'long' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [TYPE/NONE] 'unsigned' <==> orig_line is , orig_col is  [TYPE/NONE] 'long' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'unsigned', type is TYPE
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'unsigned', [TYPE/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() 'long', [TYPE/NONE] : rule sp_after_type[line ]
  <force between 'unsigned' and 'long'>space_col_align(): av is force
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [TYPE/NONE] 'long' <==> orig_line is , orig_col is  [WORD/NONE] 'nI' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [TYPE/NONE] 'long' <==> orig_line is , orig_col is  [WORD/NONE] 'nI' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'long', type is TYPE
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'long', [TYPE/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() 'nI', [WORD/NONE] : rule sp_after_type[line ]
  <force between 'long' and 'nI'>space_col_align(): av is force
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [WORD/NONE] 'nI' <==> orig_line is , orig_col is  [FPAREN_CLOSE/FUNC_CLASS_DEF] ')' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [WORD/NONE] 'nI' <==> orig_line is , orig_col is  [FPAREN_CLOSE/FUNC_CLASS_DEF] ')' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'nI', type is WORD
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'nI', [WORD/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() ')', [FPAREN_CLOSE/FUNC_CLASS_DEF] : rule sp_inside_fparen[line ]
 space_col_align(): av is ignore
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [FPAREN_CLOSE/FUNC_CLASS_DEF] ')' <==> orig_line is , orig_col is  [CONSTR_COLON/NONE] ':' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [FPAREN_CLOSE/FUNC_CLASS_DEF] ')' <==> orig_line is , orig_col is  [CONSTR_COLON/NONE] ':' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() ')', type is FPAREN_CLOSE
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is ')', [FPAREN_CLOSE/FUNC_CLASS_DEF] <===>
    second->orig_line is , second->orig_col is , second->text() ':', [CONSTR_COLON/NONE] : rule ADD as default value[line ]
 space_col_align(): av is add
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [CONSTR_COLON/NONE] ':' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [CONSTR_COLON/NONE] ':' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() ':', type is CONSTR_COLON
 space_col_align(): av is remove
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [FUNC_CTOR_VAR/NONE] 'pTelName' <==> orig_line is , orig_col is  [FPAREN_OPEN/FUNC_CTOR_VAR] '(' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [FUNC_CTOR_VAR/NONE] 'pTelName' <==> orig_line is , orig_col is  [FPAREN_OPEN/FUNC_CTOR_VAR] '(' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'pTelName', type is FUNC_CTOR_VAR
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'pTelName', [FUNC_CTOR_VAR/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() '(', [FPAREN_OPEN/FUNC_CTOR_VAR] : rule sp_func_call_paren[line ]
 space_col_align(): av is ignore
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [FPAREN_OPEN/FUNC_CTOR_VAR] '(' <==> orig_line is , orig_col is  [WORD/NONE] 'pN' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [FPAREN_OPEN/FUNC_CTOR_VAR] '(' <==> orig_line is , orig_col is  [WORD/NONE] 'pN' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() '(', type is FPAREN_OPEN
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is '(', [FPAREN_OPEN/FUNC_CTOR_VAR] <===>
    second->orig_line is , second->orig_col is , second->text() 'pN', [WORD/NONE] : rule sp_inside_fparen[line ]
 space_col_align(): av is ignore
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [WORD/NONE] 'pN' <==> orig_line is , orig_col is  [FPAREN_CLOSE/FUNC_CTOR_VAR] ')' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [WORD/NONE] 'pN' <==> orig_line is , orig_col is  [FPAREN_CLOSE/FUNC_CTOR_VAR] ')' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'pN', type is WORD
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'pN', [WORD/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() ')', [FPAREN_CLOSE/FUNC_CTOR_VAR] : rule sp_inside_fparen[line ]
 space_col_align(): av is ignore
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [FPAREN_CLOSE/FUNC_CTOR_VAR] ')' <==> orig_line is , orig_col is  [COMMA/NONE] ',' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [FPAREN_CLOSE/FUNC_CTOR_VAR] ')' <==> orig_line is , orig_col is  [COMMA/NONE] ',' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() ')', type is FPAREN_CLOSE
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is ')', [FPAREN_CLOSE/FUNC_CTOR_VAR] <===>
    second->orig_line is , second->orig_col is , second->text() ',', [COMMA/NONE] : rule sp_before_comma[line ]
 space_col_align(): av is remove
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [COMMA/NONE] ',' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [COMMA/NONE] ',' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() ',', type is COMMA
 space_col_align(): av is remove
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [FUNC_CTOR_VAR/NONE] 'nTelIndex' <==> orig_line is , orig_col is  [FPAREN_OPEN/FUNC_CTOR_VAR] '(' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [FUNC_CTOR_VAR/NONE] 'nTelIndex' <==> orig_line is , orig_col is  [FPAREN_OPEN/FUNC_CTOR_VAR] '(' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'nTelIndex', type is FUNC_CTOR_VAR
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'nTelIndex', [FUNC_CTOR_VAR/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() '(', [FPAREN_OPEN/FUNC_CTOR_VAR] : rule sp_func_call_paren[line ]
 space_col_align(): av is ignore
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [FPAREN_OPEN/FUNC_CTOR_VAR] '(' <==> orig_line is , orig_col is  [WORD/NONE] 'n' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [FPAREN_OPEN/FUNC_CTOR_VAR] '(' <==> orig_line is , orig_col is  [WORD/NONE] 'n' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() '(', type is FPAREN_OPEN
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is '(', [FPAREN_OPEN/FUNC_CTOR_VAR] <===>
    second->orig_line is , second->orig_col is , second->text() 'n', [WORD/NONE] : rule sp_inside_fparen[line ]
 space_col_align(): av is ignore
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [WORD/NONE] 'n' <==> orig_line is , orig_col is  [FPAREN_CLOSE/FUNC_CTOR_VAR] ')' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [WORD/NONE] 'n' <==> orig_line is , orig_col is  [FPAREN_CLOSE/FUNC_CTOR_VAR] ')' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'n', type is WORD
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'n', [WORD/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() ')', [FPAREN_CLOSE/FUNC_CTOR_VAR] : rule sp_inside_fparen[line ]
 space_col_align(): av is ignore
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [FPAREN_CLOSE/FUNC_CTOR_VAR] ')' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [FPAREN_CLOSE/FUNC_CTOR_VAR] ')' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() ')', type is FPAREN_CLOSE
 space_col_align(): av is remove
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [BRACE_OPEN/FUNC_CLASS_DEF] '{' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [BRACE_OPEN/FUNC_CLASS_DEF] '{' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() '{', type is BRACE_OPEN
 space_col_align(): av is remove
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [BRACE_CLOSE/FUNC_CLASS_DEF] '}' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [BRACE_CLOSE/FUNC_CLASS_DEF] '}' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() '}', type is BRACE_CLOSE
 space_col_align(): av is remove
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [DESTRUCTOR/NONE] '~' <==> orig_line is , orig_col is  [FUNC_CLASS_DEF/DESTRUCTOR] 'TelegramIndex' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [DESTRUCTOR/NONE] '~' <==> orig_line is , orig_col is  [FUNC_CLASS_DEF/DESTRUCTOR] 'TelegramIndex' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() '~', type is DESTRUCTOR
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is '~', [DESTRUCTOR/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() 'TelegramIndex', [FUNC_CLASS_DEF/DESTRUCTOR] : rule REMOVE[line ]
 space_col_align(): av is remove
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [FUNC_CLASS_DEF/DESTRUCTOR] 'TelegramIndex' <==> orig_line is , orig_col is  [FPAREN_OPEN/FUNC_CLASS_DEF] '(' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [FUNC_CLASS_DEF/DESTRUCTOR] 'TelegramIndex' <==> orig_line is , orig_col is  [FPAREN_OPEN/FUNC_CLASS_DEF] '(' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'TelegramIndex', type is FUNC_CLASS_DEF
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'TelegramIndex', [FUNC_CLASS_DEF/DESTRUCTOR] <===>
    second->orig_line is , second->orig_col is , second->text() '(', [FPAREN_OPEN/FUNC_CLASS_DEF] : rule sp_func_class_paren[line ]
 space_col_align(): av is ignore
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [FPAREN_OPEN/FUNC_CLASS_DEF] '(' <==> orig_line is , orig_col is  [FPAREN_CLOSE/FUNC_CLASS_DEF] ')' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [FPAREN_OPEN/FUNC_CLASS_DEF] '(' <==> orig_line is , orig_col is  [FPAREN_CLOSE/FUNC_CLASS_DEF] ')' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() '(', type is FPAREN_OPEN
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is '(', [FPAREN_OPEN/FUNC_CLASS_DEF] <===>
    second->orig_line is , second->orig_col is , second->text() ')', [FPAREN_CLOSE/FUNC_CLASS_DEF] : rule sp_inside_fparens[line ]
 space_col_align(): av is ignore
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [FPAREN_CLOSE/FUNC_CLASS_DEF] ')' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [FPAREN_CLOSE/FUNC_CLASS_DEF] ')' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() ')', type is FPAREN_CLOSE
 space_col_align(): av is remove
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [BRACE_OPEN/FUNC_CLASS_DEF] '{' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [BRACE_OPEN/FUNC_CLASS_DEF] '{' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() '{', type is BRACE_OPEN
 space_col_align(): av is remove
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [BRACE_CLOSE/FUNC_CLASS_DEF] '}' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [BRACE_CLOSE/FUNC_CLASS_DEF] '}' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() '}', type is BRACE_CLOSE
 space_col_align(): av is remove
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [QUALIFIER/NONE] 'const' <==> orig_line is , orig_col is  [TYPE/NONE] 'char' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [QUALIFIER/NONE] 'const' <==> orig_line is , orig_col is  [TYPE/NONE] 'char' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'const', type is QUALIFIER
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'const', [QUALIFIER/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() 'char', [TYPE/NONE] : rule sp_after_type[line ]
  <force between 'const' and 'char'>space_col_align(): av is force
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [TYPE/NONE] 'char' <==> orig_line is , orig_col is  [PTR_TYPE/NONE] '*' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [TYPE/NONE] 'char' <==> orig_line is , orig_col is  [PTR_TYPE/NONE] '*' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'char', type is TYPE
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'char', [TYPE/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() '*', [PTR_TYPE/NONE] : rule IGNORE[line ]
 space_col_align(): av is ignore
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [PTR_TYPE/NONE] '*' <==> orig_line is , orig_col is  [QUALIFIER/NONE] 'const' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [PTR_TYPE/NONE] '*' <==> orig_line is , orig_col is  [QUALIFIER/NONE] 'const' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() '*', type is PTR_TYPE
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is '*', [PTR_TYPE/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() 'const', [QUALIFIER/NONE] : rule IGNORE[line ]
 space_col_align(): av is ignore
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [QUALIFIER/NONE] 'const' <==> orig_line is , orig_col is  [WORD/NONE] 'pTelName' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [QUALIFIER/NONE] 'const' <==> orig_line is , orig_col is  [WORD/NONE] 'pTelName' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'const', type is QUALIFIER
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'const', [QUALIFIER/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() 'pTelName', [WORD/NONE] : rule sp_after_type[line ]
  <force between 'const' and 'pTelName'>space_col_align(): av is force
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [WORD/NONE] 'pTelName' <==> orig_line is , orig_col is  [SEMICOLON/NONE] ';' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [WORD/NONE] 'pTelName' <==> orig_line is , orig_col is  [SEMICOLON/NONE] ';' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'pTelName', type is WORD
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'pTelName', [WORD/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() ';', [SEMICOLON/NONE] : rule sp_before_semi[line ]
 space_col_align(): av is remove
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [SEMICOLON/NONE] ';' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [SEMICOLON/NONE] ';' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() ';', type is SEMICOLON
 space_col_align(): av is remove
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [TYPE/NONE] 'unsigned' <==> orig_line is , orig_col is  [TYPE/NONE] 'long' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [TYPE/NONE] 'unsigned' <==> orig_line is , orig_col is  [TYPE/NONE] 'long' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'unsigned', type is TYPE
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'unsigned', [TYPE/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() 'long', [TYPE/NONE] : rule sp_after_type[line ]
  <force between 'unsigned' and 'long'>space_col_align(): av is force
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [TYPE/NONE] 'long' <==> orig_line is , orig_col is  [WORD/NONE] 'nTelIndex' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [TYPE/NONE] 'long' <==> orig_line is , orig_col is  [WORD/NONE] 'nTelIndex' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'long', type is TYPE
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'long', [TYPE/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() 'nTelIndex', [WORD/NONE] : rule sp_after_type[line ]
  <force between 'long' and 'nTelIndex'>space_col_align(): av is force
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [WORD/NONE] 'nTelIndex' <==> orig_line is , orig_col is  [SEMICOLON/NONE] ';' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [WORD/NONE] 'nTelIndex' <==> orig_line is , orig_col is  [SEMICOLON/NONE] ';' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() 'nTelIndex', type is WORD
 log_rule(): Spacing: first->orig_line is , first->orig_col is , first->text() is 'nTelIndex', [WORD/NONE] <===>
    second->orig_line is , second->orig_col is , second->text() ';', [SEMICOLON/NONE] : rule sp_before_semi[line ]
 space_col_align(): av is remove
    len is 
    => coldiff is 
-space_col_align(): orig_line is , orig_col is , [SEMICOLON/NONE] ';' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack:-DEBUG NOT SET-]
+space_col_align(): orig_line is , orig_col is , [SEMICOLON/NONE] ';' <==> orig_line is , orig_col is  [NEWLINE/NONE] '' [CallStack]
 do_space(): orig_line is , orig_col is , first->text() ';', type is SEMICOLON
 space_col_align(): av is remove
    len is 

--- a/tests/cli/output/92.txt
+++ b/tests/cli/output/92.txt
@@ -1,34 +1,34 @@
 set_chunk_real(): orig_line is , orig_col is , pc->text() 'TelegramIndex'
-   pc->type is WORD, pc->parent_type is NONE => *type is TYPE, *parent_type is NONE [CallStack:-DEBUG NOT SET-]
+   pc->type is WORD, pc->parent_type is NONE => *type is TYPE, *parent_type is NONE [CallStack]
 set_chunk_real(): orig_line is , orig_col is , pc->text() '*'
-   pc->type is STAR, pc->parent_type is NONE => *type is PTR_TYPE, *parent_type is NONE [CallStack:-DEBUG NOT SET-]
+   pc->type is STAR, pc->parent_type is NONE => *type is PTR_TYPE, *parent_type is NONE [CallStack]
 set_chunk_real(): orig_line is , orig_col is , pc->text() '*'
-   pc->type is STAR, pc->parent_type is NONE => *type is PTR_TYPE, *parent_type is NONE [CallStack:-DEBUG NOT SET-]
+   pc->type is STAR, pc->parent_type is NONE => *type is PTR_TYPE, *parent_type is NONE [CallStack]
 set_chunk_real(): orig_line is , orig_col is , pc->text() 'TelegramIndex'
-   pc->type is WORD, pc->parent_type is NONE => *type is FUNC_CLASS_DEF, *parent_type is NONE [CallStack:-DEBUG NOT SET-]
+   pc->type is WORD, pc->parent_type is NONE => *type is FUNC_CLASS_DEF, *parent_type is NONE [CallStack]
 set_chunk_real(): orig_line is , orig_col is , pc->text() '('
-   pc->type is PAREN_OPEN, pc->parent_type is NONE => *type is FPAREN_OPEN, *parent_type is NONE [CallStack:-DEBUG NOT SET-]
+   pc->type is PAREN_OPEN, pc->parent_type is NONE => *type is FPAREN_OPEN, *parent_type is NONE [CallStack]
 set_chunk_real(): orig_line is , orig_col is , pc->text() ')'
-   pc->type is PAREN_CLOSE, pc->parent_type is NONE => *type is FPAREN_CLOSE, *parent_type is NONE [CallStack:-DEBUG NOT SET-]
+   pc->type is PAREN_CLOSE, pc->parent_type is NONE => *type is FPAREN_CLOSE, *parent_type is NONE [CallStack]
 set_chunk_real(): orig_line is , orig_col is , pc->text() ':'
-   pc->type is COLON, pc->parent_type is NONE => *type is CONSTR_COLON, *parent_type is NONE [CallStack:-DEBUG NOT SET-]
+   pc->type is COLON, pc->parent_type is NONE => *type is CONSTR_COLON, *parent_type is NONE [CallStack]
 set_chunk_real(): orig_line is , orig_col is , pc->text() 'pTelName'
-   pc->type is WORD, pc->parent_type is NONE => *type is FUNC_CTOR_VAR, *parent_type is NONE [CallStack:-DEBUG NOT SET-]
+   pc->type is WORD, pc->parent_type is NONE => *type is FUNC_CTOR_VAR, *parent_type is NONE [CallStack]
 set_chunk_real(): orig_line is , orig_col is , pc->text() '('
-   pc->type is PAREN_OPEN, pc->parent_type is NONE => *type is FPAREN_OPEN, *parent_type is NONE [CallStack:-DEBUG NOT SET-]
+   pc->type is PAREN_OPEN, pc->parent_type is NONE => *type is FPAREN_OPEN, *parent_type is NONE [CallStack]
 set_chunk_real(): orig_line is , orig_col is , pc->text() ')'
-   pc->type is PAREN_CLOSE, pc->parent_type is NONE => *type is FPAREN_CLOSE, *parent_type is NONE [CallStack:-DEBUG NOT SET-]
+   pc->type is PAREN_CLOSE, pc->parent_type is NONE => *type is FPAREN_CLOSE, *parent_type is NONE [CallStack]
 set_chunk_real(): orig_line is , orig_col is , pc->text() 'nTelIndex'
-   pc->type is WORD, pc->parent_type is NONE => *type is FUNC_CTOR_VAR, *parent_type is NONE [CallStack:-DEBUG NOT SET-]
+   pc->type is WORD, pc->parent_type is NONE => *type is FUNC_CTOR_VAR, *parent_type is NONE [CallStack]
 set_chunk_real(): orig_line is , orig_col is , pc->text() '('
-   pc->type is PAREN_OPEN, pc->parent_type is NONE => *type is FPAREN_OPEN, *parent_type is NONE [CallStack:-DEBUG NOT SET-]
+   pc->type is PAREN_OPEN, pc->parent_type is NONE => *type is FPAREN_OPEN, *parent_type is NONE [CallStack]
 set_chunk_real(): orig_line is , orig_col is , pc->text() ')'
-   pc->type is PAREN_CLOSE, pc->parent_type is NONE => *type is FPAREN_CLOSE, *parent_type is NONE [CallStack:-DEBUG NOT SET-]
+   pc->type is PAREN_CLOSE, pc->parent_type is NONE => *type is FPAREN_CLOSE, *parent_type is NONE [CallStack]
 set_chunk_real(): orig_line is , orig_col is , pc->text() 'TelegramIndex'
-   pc->type is WORD, pc->parent_type is NONE => *type is FUNC_CLASS_DEF, *parent_type is NONE [CallStack:-DEBUG NOT SET-]
+   pc->type is WORD, pc->parent_type is NONE => *type is FUNC_CLASS_DEF, *parent_type is NONE [CallStack]
 set_chunk_real(): orig_line is , orig_col is , pc->text() '~'
-   pc->type is INV, pc->parent_type is NONE => *type is DESTRUCTOR, *parent_type is NONE [CallStack:-DEBUG NOT SET-]
+   pc->type is INV, pc->parent_type is NONE => *type is DESTRUCTOR, *parent_type is NONE [CallStack]
 set_chunk_real(): orig_line is , orig_col is , pc->text() '('
-   pc->type is PAREN_OPEN, pc->parent_type is NONE => *type is FPAREN_OPEN, *parent_type is NONE [CallStack:-DEBUG NOT SET-]
+   pc->type is PAREN_OPEN, pc->parent_type is NONE => *type is FPAREN_OPEN, *parent_type is NONE [CallStack]
 set_chunk_real(): orig_line is , orig_col is , pc->text() ')'
-   pc->type is PAREN_CLOSE, pc->parent_type is NONE => *type is FPAREN_CLOSE, *parent_type is NONE [CallStack:-DEBUG NOT SET-]
+   pc->type is PAREN_CLOSE, pc->parent_type is NONE => *type is FPAREN_CLOSE, *parent_type is NONE [CallStack]

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 652 options and minimal documentation.
+There are currently 653 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 


### PR DESCRIPTION
Modify `test_cli_options.py` to tweak uncrustify's output in order to normalize some differences between debug and release builds. This allows the script to be used with debug builds, and allows us to get rid of all the logic to only run it against release builds.

Besides simplifying things, which is always good, this will allow the script to be run on coverage builds, which will help with coverage.