### PR TITLE
Enforce sp_return_brace on ourselves

### DIFF
--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -46,6 +46,7 @@ sp_inside_fparen                = remove
 sp_after_tparen_close           = remove
 sp_func_call_paren              = remove
 sp_return_paren                 = remove
+sp_return_brace                 = remove
 sp_attribute_paren              = remove
 sp_defined_paren                = force
 sp_brace_typedef                = force


### PR DESCRIPTION
Let's agree on how we want `return`s of initializer lists to be formatted:
```c++
// Option 1
return(0);
return{0};

// Option 2
return(0);
return{ 0 };

// Option 3
return(0);
return { 0 };

// Option 4
return 0;
return { 0 };
```

There are quite a few others, but I think the above are the only practical ones. This PR will implement something.

- Option 1
  - **Pros:** Consistent. I suspect we'd prefer this.
  - **Cons:** Either we omit spaces in initializer lists *only* in a `return` (which is inconsistent and would require a new option), or we omit them in *all* initializer lists (which I'm *far* from convinced is desirable in general, and would affect a lot of extant code).
- Option 2
  - **Pros:** Easy to implement.
  - **Cons:** Inconsistent whitespace.
- Option 3
  - **Pros:** Compromise between (2) and (4). Whitespace inconsistency is less jarring.
  - **Cons:** Compromise between (2) and (4).
- Option 4
  - **Pros:** Widely prevalent in other code bases. Whitespace feels consistent.
  - **Cons:** Does not appear to be favored by other devs. Would change a *ton* of extant code.

There are many other options, but I think the above are the most practical/likely. However, I'm happy to entertain other suggestions.

This PR currently implements (2), although (3) might be better? (I, personally, prefer (4), but I'm pretty sure I've lost that fight :slightly_smiling_face:...)

(Keep in mind that we might start seeing `return{}`/`return {}` also.)

This resolves #1917.