### PR TITLE
Fix returns in macros

### DIFF
--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -198,7 +198,7 @@ chunk_t *chunk_get_next_nnl(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
- * Gets the next non-NEWLINE and non-comment chunk, non-preprocessor chunk
+ * Gets the next non-NEWLINE and non-comment chunk
  *
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
@@ -213,6 +213,18 @@ chunk_t *chunk_get_next_ncnl(chunk_t *cur, scope_e scope = scope_e::ALL);
  * @param scope  code region to search in
  */
 chunk_t *chunk_get_next_ncnlnp(chunk_t *cur, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Gets the next non-NEWLINE and non-comment chunk (preprocessor aware).
+ * Unlike chunk_get_next_ncnl, this will also ignore a line continuation if
+ * the starting chunk is in a preprocessor directive, and may return a newline
+ * if the search reaches the end of a preprocessor directive.
+ *
+ * @param cur    chunk to use as start point
+ * @param scope  code region to search in
+ */
+chunk_t *chunk_ppa_get_next_ncnl(chunk_t *cur);
 
 
 /**

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2624,6 +2624,12 @@ static chunk_t *process_return(chunk_t *pc)
       }
    }
 
+   // We don't have a fully paren'd return. Should we add some?
+   if ((options::mod_paren_on_return() & IARF_ADD) == 0)
+   {
+      return(next);
+   }
+
    // Issue #1917
    // Never add parens to a braced init list; that breaks the code
    //   return {args...};    // C++11 type elision; okay
@@ -2634,12 +2640,6 @@ static chunk_t *process_return(chunk_t *pc)
       LOG_FMT(LRETURN, "%s(%d): not adding parens around braced initializer"
               " on orig_line %zd\n",
               __func__, __LINE__, pc->orig_line);
-      return(next);
-   }
-
-   // We don't have a fully paren'd return. Should we add some?
-   if ((options::mod_paren_on_return() & IARF_ADD) == 0)
-   {
       return(next);
    }
 

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2687,6 +2687,7 @@ static chunk_t *process_return(chunk_t *pc)
       chunk.level       = pc->level;
       chunk.brace_level = pc->brace_level;
       chunk.orig_line   = pc->orig_line;
+      chunk.orig_col    = next->orig_col - 1;
       chunk.parent_type = CT_RETURN;
       chunk.flags       = pc->flags & PCF_COPY_FLAGS;
       chunk_add_before(&chunk, next);
@@ -2694,6 +2695,7 @@ static chunk_t *process_return(chunk_t *pc)
       chunk.type      = CT_PAREN_CLOSE;
       chunk.str       = ")";
       chunk.orig_line = semi->orig_line;
+      chunk.orig_col  = semi->orig_col - 1;
       cpar            = chunk_add_before(&chunk, semi);
 
       LOG_FMT(LRETURN, "%s(%d): added parens on orig_line %zu\n",

--- a/tests/c.test
+++ b/tests/c.test
@@ -328,6 +328,9 @@
 02453  return-3.cfg                         c/nl_return_expr.c
 02454  return-4.cfg                         c/nl_return_expr.c
 
+02455  mod_paren_on_return-a.cfg            c/macro-returns.c
+02456  mod_paren_on_return-r.cfg            c/macro-returns.c
+
 02460  freebsd.cfg                          c/freebsd.c
 
 02486  doxy-comment-no.cfg                  c/doxy-comment.c

--- a/tests/expected/c/00070-return-multi.c
+++ b/tests/expected/c/00070-return-multi.c
@@ -20,7 +20,7 @@ dcrp_license_feature(int32_t idx)
 {
 #define FEATURESTR(f)      \
 case DCRMIB_LICENSE_ ## f: \
-   return DCRP_LICENSE_FEATURE_ ## f ## _STR
+   return(DCRP_LICENSE_FEATURE_ ## f ## _STR)
 
    switch (idx)
    {
@@ -36,7 +36,7 @@ isValidLicenseType(int32_t idx)
 {
 #define CHECKFEATURE(f)    \
 case DCRMIB_LICENSE_ ## f: \
-   return 1
+   return(1)
 
    switch (idx)
    {

--- a/tests/expected/c/02455-macro-returns.c
+++ b/tests/expected/c/02455-macro-returns.c
@@ -1,0 +1,15 @@
+#define foo1 return(x + \
+	            y)
+
+#define foo2 return (x + \
+	             y)
+
+#define foo3 return \
+	        (0)
+
+#define foo4 return \
+	        (0)
+
+#define foo5 return /* empty */
+
+#define foo6 return \

--- a/tests/expected/c/02456-macro-returns.c
+++ b/tests/expected/c/02456-macro-returns.c
@@ -1,0 +1,15 @@
+#define foo1 return x + \
+	       y
+
+#define foo2 return x + \
+	       y
+
+#define foo3 return \
+	        0
+
+#define foo4 return \
+	        0
+
+#define foo5 return /* empty */
+
+#define foo6 return \

--- a/tests/expected/cpp/30320-returns.cpp
+++ b/tests/expected/cpp/30320-returns.cpp
@@ -1,8 +1,14 @@
-#define case1(x)    { return  x; }
-#define case2(x)    { return(x); }
-#define case3(x)    { return(x); }
-#define case4(x)    { return{x}; }
-#define case5(x)    { return  {x}; }
+#define foo1(x) { return x; }
+#define foo2(x) { return(x); }
+#define foo3(x) { return(x); }
+#define foo4(x) { return{x}; }
+#define foo5(x) { return  {x}; }
+
+#define case1(x) return x
+#define case2(x) return(x)
+#define case3(x) return(x)
+#define case4(x) return{x}
+#define case5(x) return  {x}
 
 void foo(int x)
 {

--- a/tests/expected/cpp/30320-returns.cpp
+++ b/tests/expected/cpp/30320-returns.cpp
@@ -1,3 +1,9 @@
+#define case1(x)    { return  x; }
+#define case2(x)    { return(x); }
+#define case3(x)    { return(x); }
+#define case4(x)    { return{x}; }
+#define case5(x)    { return  {x}; }
+
 void foo(int x)
 {
 	switch (x)
@@ -9,7 +15,7 @@ void foo(int x)
 	case 3:
 		return(3);
 	case 4:
-		return  {4};
+		return{4};
 	case 5:
 		return  {5};
 	default:

--- a/tests/expected/cpp/30321-returns.cpp
+++ b/tests/expected/cpp/30321-returns.cpp
@@ -1,8 +1,14 @@
-#define case1(x)    { return x; }
-#define case2(x)    { return (x); }
-#define case3(x)    { return (x); }
-#define case4(x)    { return{x}; }
-#define case5(x)    { return  {x}; }
+#define foo1(x) { return x; }
+#define foo2(x) { return (x); }
+#define foo3(x) { return (x); }
+#define foo4(x) { return{x}; }
+#define foo5(x) { return  {x}; }
+
+#define case1(x) return x
+#define case2(x) return (x)
+#define case3(x) return (x)
+#define case4(x) return{x}
+#define case5(x) return  {x}
 
 void foo(int x)
 {

--- a/tests/expected/cpp/30321-returns.cpp
+++ b/tests/expected/cpp/30321-returns.cpp
@@ -1,3 +1,9 @@
+#define case1(x)    { return x; }
+#define case2(x)    { return (x); }
+#define case3(x)    { return (x); }
+#define case4(x)    { return{x}; }
+#define case5(x)    { return  {x}; }
+
 void foo(int x)
 {
 	switch (x)
@@ -9,7 +15,7 @@ void foo(int x)
 	case 3:
 		return (3);
 	case 4:
-		return  {4};
+		return{4};
 	case 5:
 		return  {5};
 	default:

--- a/tests/expected/cpp/30322-returns.cpp
+++ b/tests/expected/cpp/30322-returns.cpp
@@ -1,8 +1,14 @@
-#define case1(x)    { return x; }
-#define case2(x)    { return(x); }
-#define case3(x)    { return  (x); }
-#define case4(x)    { return{x}; }
-#define case5(x)    { return{x}; }
+#define foo1(x) { return x; }
+#define foo2(x) { return(x); }
+#define foo3(x) { return  (x); }
+#define foo4(x) { return{x}; }
+#define foo5(x) { return{x}; }
+
+#define case1(x) return x
+#define case2(x) return(x)
+#define case3(x) return  (x)
+#define case4(x) return{x}
+#define case5(x) return{x}
 
 void foo(int x)
 {

--- a/tests/expected/cpp/30322-returns.cpp
+++ b/tests/expected/cpp/30322-returns.cpp
@@ -1,3 +1,9 @@
+#define case1(x)    { return x; }
+#define case2(x)    { return(x); }
+#define case3(x)    { return  (x); }
+#define case4(x)    { return{x}; }
+#define case5(x)    { return{x}; }
+
 void foo(int x)
 {
 	switch (x)

--- a/tests/expected/cpp/30323-returns.cpp
+++ b/tests/expected/cpp/30323-returns.cpp
@@ -1,8 +1,14 @@
-#define case1(x)    { return x; }
-#define case2(x)    { return(x); }
-#define case3(x)    { return  (x); }
-#define case4(x)    { return {x}; }
-#define case5(x)    { return {x}; }
+#define foo1(x) { return x; }
+#define foo2(x) { return(x); }
+#define foo3(x) { return  (x); }
+#define foo4(x) { return {x}; }
+#define foo5(x) { return {x}; }
+
+#define case1(x) return x
+#define case2(x) return(x)
+#define case3(x) return  (x)
+#define case4(x) return {x}
+#define case5(x) return {x}
 
 void foo(int x)
 {

--- a/tests/expected/cpp/30323-returns.cpp
+++ b/tests/expected/cpp/30323-returns.cpp
@@ -1,3 +1,9 @@
+#define case1(x)    { return x; }
+#define case2(x)    { return(x); }
+#define case3(x)    { return  (x); }
+#define case4(x)    { return {x}; }
+#define case5(x)    { return {x}; }
+
 void foo(int x)
 {
 	switch (x)

--- a/tests/expected/cpp/30324-returns.cpp
+++ b/tests/expected/cpp/30324-returns.cpp
@@ -1,10 +1,10 @@
-#define foo1(x) { return(x); }
+#define foo1(x) { return (x); }
 #define foo2(x) { return(x); }
 #define foo3(x) { return  (x); }
 #define foo4(x) { return{x}; }
 #define foo5(x) { return  {x}; }
 
-#define case1(x) return(x)
+#define case1(x) return (x)
 #define case2(x) return(x)
 #define case3(x) return  (x)
 #define case4(x) return{x}
@@ -15,7 +15,7 @@ void foo(int x)
 	switch (x)
 	{
 	case 1:
-		return(1);
+		return (1);
 	case 2:
 		return(2);
 	case 3:

--- a/tests/expected/cpp/30324-returns.cpp
+++ b/tests/expected/cpp/30324-returns.cpp
@@ -1,8 +1,14 @@
-#define case1(x)    { return(x); }
-#define case2(x)    { return(x); }
-#define case3(x)    { return  (x); }
-#define case4(x)    { return{x}; }
-#define case5(x)    { return  {x}; }
+#define foo1(x) { return(x); }
+#define foo2(x) { return(x); }
+#define foo3(x) { return  (x); }
+#define foo4(x) { return{x}; }
+#define foo5(x) { return  {x}; }
+
+#define case1(x) return(x)
+#define case2(x) return(x)
+#define case3(x) return  (x)
+#define case4(x) return{x}
+#define case5(x) return  {x}
 
 void foo(int x)
 {

--- a/tests/expected/cpp/30324-returns.cpp
+++ b/tests/expected/cpp/30324-returns.cpp
@@ -1,3 +1,9 @@
+#define case1(x)    { return(x); }
+#define case2(x)    { return(x); }
+#define case3(x)    { return  (x); }
+#define case4(x)    { return{x}; }
+#define case5(x)    { return  {x}; }
+
 void foo(int x)
 {
 	switch (x)
@@ -9,7 +15,7 @@ void foo(int x)
 	case 3:
 		return  (3);
 	case 4:
-		return  {4};
+		return{4};
 	case 5:
 		return  {5};
 	default:

--- a/tests/expected/cpp/30325-returns.cpp
+++ b/tests/expected/cpp/30325-returns.cpp
@@ -1,8 +1,14 @@
-#define case1(x)    { return x; }
-#define case2(x)    { return x; }
-#define case3(x)    { return x; }
-#define case4(x)    { return{x}; }
-#define case5(x)    { return  {x}; }
+#define foo1(x) { return x; }
+#define foo2(x) { return x; }
+#define foo3(x) { return x; }
+#define foo4(x) { return{x}; }
+#define foo5(x) { return  {x}; }
+
+#define case1(x) return x
+#define case2(x) return x
+#define case3(x) return x
+#define case4(x) return{x}
+#define case5(x) return  {x}
 
 void foo(int x)
 {

--- a/tests/expected/cpp/30325-returns.cpp
+++ b/tests/expected/cpp/30325-returns.cpp
@@ -1,3 +1,9 @@
+#define case1(x)    { return x; }
+#define case2(x)    { return x; }
+#define case3(x)    { return x; }
+#define case4(x)    { return{x}; }
+#define case5(x)    { return  {x}; }
+
 void foo(int x)
 {
 	switch (x)
@@ -9,7 +15,7 @@ void foo(int x)
 	case 3:
 		return 3;
 	case 4:
-		return  {4};
+		return{4};
 	case 5:
 		return  {5};
 	default:

--- a/tests/expected/cpp/30810-ptr-star.cpp
+++ b/tests/expected/cpp/30810-ptr-star.cpp
@@ -40,11 +40,11 @@ struct X
 
    int f()
    {
-      return(*b); // 7:8
+      return (*b); // 7:8
    }
    int g()
    {
-      return(*c); // 11:8
+      return (*c); // 11:8
    }
 };
 

--- a/tests/input/c/macro-returns.c
+++ b/tests/input/c/macro-returns.c
@@ -1,0 +1,15 @@
+#define foo1 return x + \
+  y
+
+#define foo2 return (x + \
+  y)
+
+#define foo3 return \
+  0
+
+#define foo4 return \
+  (0)
+
+#define foo5 return /* empty */
+
+#define foo6 return \

--- a/tests/input/cpp/returns.cpp
+++ b/tests/input/cpp/returns.cpp
@@ -1,8 +1,14 @@
-#define case1(x)    { return  x; }
-#define case2(x)    { return(x); }
-#define case3(x)    { return  (x); }
-#define case4(x)    { return{x}; }
-#define case5(x)    { return  {x}; }
+#define foo1(x) { return  x; }
+#define foo2(x) { return(x); }
+#define foo3(x) { return  (x); }
+#define foo4(x) { return{x}; }
+#define foo5(x) { return  {x}; }
+
+#define case1(x) return  x
+#define case2(x) return(x)
+#define case3(x) return  (x)
+#define case4(x) return{x}
+#define case5(x) return  {x}
 
 void foo(int x)
 {

--- a/tests/input/cpp/returns.cpp
+++ b/tests/input/cpp/returns.cpp
@@ -1,3 +1,9 @@
+#define case1(x)    { return  x; }
+#define case2(x)    { return(x); }
+#define case3(x)    { return  (x); }
+#define case4(x)    { return{x}; }
+#define case5(x)    { return  {x}; }
+
 void foo(int x)
 {
 	switch (x)
@@ -9,7 +15,7 @@ void foo(int x)
 	case 3:
 		return  (3);
 	case 4:
-		return  {4};
+		return{4};
 	case 5:
 		return  {5};
 	default:


### PR DESCRIPTION
Implement parsing return statements inside of preprocessor directives. This fixes both `mod_paren_on_return` and (because the parentheses are now marked properly) `sp_return_paren` for return statements in macro definitions.

Fixes #1982.