### PR TITLE
Two fixes for braced initializer lists

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1045,7 +1045,11 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
          tmp = set_paren_parent(tmp, CT_DECLTYPE);
          if (chunk_is_opening_brace(tmp))
          {
-            set_paren_parent(tmp, CT_BRACED_INIT_LIST);
+            tmp = set_paren_parent(tmp, CT_BRACED_INIT_LIST);
+            if (tmp)
+            {
+               chunk_flags_clr(tmp, PCF_EXPR_START | PCF_STMT_START);
+            }
          }
       }
    }
@@ -1504,6 +1508,12 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
             {
                set_chunk_parent(brace_open, CT_BRACED_INIT_LIST);
                set_chunk_parent(brace_close, CT_BRACED_INIT_LIST);
+
+               tmp = chunk_get_next_ncnl(brace_close);
+               if (tmp)
+               {
+                  chunk_flags_clr(tmp, PCF_EXPR_START | PCF_STMT_START);
+               }
 
                // TODO: Change pc->type CT_WORD -> CT_TYPE
                // for the case CT_ASSIGN (and others).

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3220,6 +3220,7 @@ void newlines_cleanup_braces(bool first)
             }
          }
          else if (  pc->parent_type != CT_OC_AT
+                 && pc->parent_type != CT_BRACED_INIT_LIST
                  && (  options::nl_after_brace_close()
                     || pc->parent_type == CT_FUNC_CLASS_DEF
                     || pc->parent_type == CT_FUNC_DEF

--- a/tests/config/issue_1997.cfg
+++ b/tests/config/issue_1997.cfg
@@ -1,0 +1,3 @@
+sp_arith                        = force
+nl_after_brace_open             = true
+nl_after_brace_close            = true

--- a/tests/config/issue_1997.cfg
+++ b/tests/config/issue_1997.cfg
@@ -1,3 +1,4 @@
 sp_arith                        = force
+sp_after_decltype               = remove
 nl_after_brace_open             = true
 nl_after_brace_close            = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -185,6 +185,7 @@
 30312  sp_inside_type_brace_init_lst-f.cfg  cpp/return_init_list.cpp
 30313  sp_brace_brace-r.cfg                 cpp/sp_brace_brace.cpp
 30314  sp_brace_brace-f.cfg                 cpp/sp_brace_brace.cpp
+30315  issue_1997.cfg                       cpp/return_braced_init.cpp
 
 30320  sp_return_paren-r.cfg                cpp/returns.cpp
 30321  sp_return_paren-f.cfg                cpp/returns.cpp

--- a/tests/expected/cpp/30315-return_braced_init.cpp
+++ b/tests/expected/cpp/30315-return_braced_init.cpp
@@ -1,5 +1,18 @@
-int foo()
+int foo1()
 {
 	// should not have newline before '.'
 	return std::pair<int, int>{1, 2}.first;
+}
+
+int foo2()
+{
+	// should be ARITH, not ADDR
+	return int{3} & 2;
+}
+
+int foo3()
+{
+	// should be ARITH, not ADDR
+	constexpr static int x = 3;
+	return decltype(x){x} & 2;
 }

--- a/tests/expected/cpp/30315-return_braced_init.cpp
+++ b/tests/expected/cpp/30315-return_braced_init.cpp
@@ -1,0 +1,5 @@
+int foo()
+{
+	// should not have newline before '.'
+	return std::pair<int, int>{1, 2}.first;
+}

--- a/tests/input/cpp/return_braced_init.cpp
+++ b/tests/input/cpp/return_braced_init.cpp
@@ -1,5 +1,18 @@
-int foo()
+int foo1()
 {
 	// should not have newline before '.'
 	return std::pair<int, int>{1, 2}.first;
+}
+
+int foo2()
+{
+	// should be ARITH, not ADDR
+	return int{3} & 2;
+}
+
+int foo3()
+{
+	// should be ARITH, not ADDR
+	constexpr static int x = 3;
+	return decltype(x){x} & 2;
 }

--- a/tests/input/cpp/return_braced_init.cpp
+++ b/tests/input/cpp/return_braced_init.cpp
@@ -1,0 +1,5 @@
+int foo()
+{
+	// should not have newline before '.'
+	return std::pair<int, int>{1, 2}.first;
+}


### PR DESCRIPTION
Suppress `nl_after_brace_close` for the close brace of a braced initializer list. Clear `PCF_STMT_START` and `PCF_EXPR_START` from the token following the close brace of a braced initializer list, as these flags are not correct in that context.

Fixes #1997.