### PR TITLE
Don't mark extern prototype as CT_FUNC_CTOR_VAR

### DIFF
--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -628,6 +628,7 @@
 
 34250  empty.cfg                            cpp/bug_1607.cpp
 34251  bug_1649.cfg                         cpp/bug_1649.cpp
+34252  nl_after_func_proto_group-3.cfg      cpp/issue_2001.cpp
 
 34280  UNI-29935.cfg                        cpp/UNI-29935.cpp
 

--- a/tests/expected/cpp/34252-issue_2001.cpp
+++ b/tests/expected/cpp/34252-issue_2001.cpp
@@ -1,0 +1,2 @@
+extern int foo();
+extern int foo(size_t);

--- a/tests/input/cpp/issue_2001.cpp
+++ b/tests/input/cpp/issue_2001.cpp
@@ -1,0 +1,2 @@
+extern int foo();
+extern int foo(size_t);


### PR DESCRIPTION
Determining if certain C++ expressions are function prototypes or variable initializations is, as our comment notes, hard, and since we aren't a C++ compiler able to tell if an identifier might be a type name (for non-built-in types), we sometimes get it wrong. However, a statement that starts with `extern` *can't* be an initializer, so add a check for this.

Fixes #2001.