### PR TITLE
Fix newlines before multi-line prototype

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -949,6 +949,7 @@ static void newlines_func_pre_blank_lines(chunk_t *start)
    chunk_t *last_nl      = nullptr;
    chunk_t *last_comment = nullptr;
    bool    do_it         = false;
+   size_t  first_line    = start->orig_line;
    for (pc = chunk_get_prev(start); pc != nullptr; pc = chunk_get_prev(pc))
    {
       LOG_FMT(LNLFUNCT, "   O%zu:%zu %s '%s'\n", pc->orig_line, pc->orig_col,
@@ -964,8 +965,8 @@ static void newlines_func_pre_blank_lines(chunk_t *start)
       if (chunk_is_comment(pc))
       {
          LOG_FMT(LNLFUNCT, "   <chunk_is_comment> found at line=%zu column=%zu\n", pc->orig_line, pc->orig_col);
-         if (  (  pc->orig_line < start->orig_line
-               && ((start->orig_line - pc->orig_line
+         if (  (  pc->orig_line < first_line
+               && ((first_line - pc->orig_line
                     - (chunk_is_token(pc, CT_COMMENT_MULTI) ? pc->nl_count : 0))) < 2)
             || (  last_comment != nullptr
                && chunk_is_token(pc, CT_COMMENT_CPP) // combine only cpp comments
@@ -989,12 +990,14 @@ static void newlines_func_pre_blank_lines(chunk_t *start)
          || chunk_is_token(pc, CT_TYPE)
          || chunk_is_token(pc, CT_TYPE))
       {
+         first_line = pc->orig_line;
          continue;
       }
       // skip template stuff to add newlines before it
       if (chunk_is_token(pc, CT_ANGLE_CLOSE) && pc->parent_type == CT_TEMPLATE)
       {
-         pc = chunk_get_prev_type(pc, CT_TEMPLATE, -1);
+         pc         = chunk_get_prev_type(pc, CT_TEMPLATE, -1);
+         first_line = pc->orig_line;
          continue;
       }
 

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -984,6 +984,7 @@ static void newlines_func_pre_blank_lines(chunk_t *start)
 
       if (  chunk_is_token(pc, CT_DESTRUCTOR)
          || chunk_is_token(pc, CT_TYPE)
+         || chunk_is_token(pc, CT_TEMPLATE)
          || chunk_is_token(pc, CT_QUALIFIER)
          || chunk_is_token(pc, CT_PTR_TYPE)
          || chunk_is_token(pc, CT_DC_MEMBER)
@@ -996,8 +997,11 @@ static void newlines_func_pre_blank_lines(chunk_t *start)
       // skip template stuff to add newlines before it
       if (chunk_is_token(pc, CT_ANGLE_CLOSE) && pc->parent_type == CT_TEMPLATE)
       {
-         pc         = chunk_get_prev_type(pc, CT_TEMPLATE, -1);
-         first_line = pc->orig_line;
+         pc = chunk_skip_to_match_rev(pc);
+         if (pc)
+         {
+            first_line = pc->orig_line;
+         }
          continue;
       }
 

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <deque>
 
+
 /**
  * Advances to the next tab stop.
  * Column 1 is the left-most column.

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -534,6 +534,7 @@
 34113! nl_before_func_body_def-1.cfg        cpp/bug_902.cpp
 34114  nl_before_func_body_def-2.cfg        cpp/bug_902.cpp
 34115  nl_before_func_body_def-2.cfg        cpp/nl_before_func_body_def.cpp
+34116  nl_before_func_body_def-2.cfg        cpp/issue_2000.cpp
 
 34120  align_assign_span-1.cfg              cpp/bug_i_999.cpp
 34121  bug_1717.cfg                         cpp/bug_1717.cpp

--- a/tests/expected/cpp/34116-issue_2000.cpp
+++ b/tests/expected/cpp/34116-issue_2000.cpp
@@ -1,5 +1,11 @@
 int bar;
 
+// blank line should be inserted before this comment
+vector<int> foo()
+{
+	return {};
+}
+
 // blank line should be inserted before this comment, not after
 template<>
 volatile

--- a/tests/expected/cpp/34116-issue_2000.cpp
+++ b/tests/expected/cpp/34116-issue_2000.cpp
@@ -1,0 +1,10 @@
+int bar;
+
+// blank line should be inserted before this comment, not after
+template<>
+volatile
+int x::
+foo()
+{
+	return 0;
+}

--- a/tests/input/cpp/issue_2000.cpp
+++ b/tests/input/cpp/issue_2000.cpp
@@ -1,4 +1,9 @@
 int bar;
+// blank line should be inserted before this comment
+vector<int> foo()
+{
+	return {};
+}
 // blank line should be inserted before this comment, not after
 template<>
 volatile

--- a/tests/input/cpp/issue_2000.cpp
+++ b/tests/input/cpp/issue_2000.cpp
@@ -1,0 +1,9 @@
+int bar;
+// blank line should be inserted before this comment, not after
+template<>
+volatile
+int x::
+foo()
+{
+	return 0;
+}


### PR DESCRIPTION
Tweak `newlines_func_pre_blank_lines` to consider the delta from the first line of the function prototype, rather than the line on which the function name appears, when considering preceding comments. This fixes incorrect insertion of newlines (e.g. after the comment, rather than before) when the function prototype spans multiple lines.

Fixes #2000.