### PR TITLE
Mark friends as CT_FUNC_PROTO

### DIFF
--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -631,6 +631,7 @@
 34250  empty.cfg                            cpp/bug_1607.cpp
 34251  bug_1649.cfg                         cpp/bug_1649.cpp
 34252  nl_after_func_proto_group-3.cfg      cpp/issue_2001.cpp
+34253  nl_after_func_proto_group-3.cfg      cpp/friends.cpp
 
 34280  UNI-29935.cfg                        cpp/UNI-29935.cpp
 

--- a/tests/expected/cpp/34253-friends.cpp
+++ b/tests/expected/cpp/34253-friends.cpp
@@ -1,0 +1,8 @@
+class foo
+{
+friend void bar();
+friend void none();
+template <typename T> friend vector<T> vec();
+
+
+};

--- a/tests/input/cpp/friends.cpp
+++ b/tests/input/cpp/friends.cpp
@@ -1,0 +1,6 @@
+class foo
+{
+friend void bar();
+friend void none();
+template <typename T> friend vector<T> vec();
+};


### PR DESCRIPTION
Tweak mark_function_return_type to also back up and mark the `friend` of a friend declaration with the parent type (which should always be `CT_FUNC_PROTO`), as well as the template specification if any. This prevents every friend declaration from being seen as its own group, which caused `nl_after_func_proto_group` to add newlines after *every* friend declaration, rather than just after groups thereof.