### PR TITLE
Keep one liner groups

### DIFF
--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -132,6 +132,7 @@ pos_enum_comma                  = trail_force
 nl_max                          = 3
 nl_after_func_proto             = 1
 nl_after_func_proto_group       = 2
+nl_class_leave_one_liner_groups = true
 nl_before_func_body_def         = 3
 nl_after_access_spec            = 1
 nl_comment_func_def             = 1

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -94,6 +94,23 @@ static bool one_liner_nl_ok(chunk_t *pc);
 static void nl_create_one_liner(chunk_t *vbrace_open);
 
 
+/**
+ * Test if a chunk belongs to a one-liner method definition inside a class body
+ */
+static bool is_class_one_liner(chunk_t *pc);
+
+
+/**
+ * Test if a chunk may be combined with a function prototype group.
+ *
+ * If nl_class_leave_one_liner_groups is enabled, a chunk may be combined with
+ * a function prototype group if it is a one-liner inside a class body, and is
+ * a definition of the same sort as surrounding prototypes. This checks against
+ * either the function name, or the function closing brace.
+ */
+bool is_func_proto_group(chunk_t *pc, c_token_t one_liner_type);
+
+
 //! Find the next newline or nl_cont
 static void nl_handle_define(chunk_t *pc);
 
@@ -167,7 +184,7 @@ static void _blank_line_set(chunk_t *pc, const char *text, uncrustify_options uo
  * Doesn't do anything if open brace before it
  * "code\n\ncomment\nif (...)" or "code\ncomment\nif (...)"
  */
-static void newlines_func_pre_blank_lines(chunk_t *start);
+static void newlines_func_pre_blank_lines(chunk_t *start, c_token_t start_type);
 
 
 static chunk_t *get_closing_brace(chunk_t *start);
@@ -920,17 +937,17 @@ static void _blank_line_set(chunk_t *pc, const char *text, uncrustify_options uo
 #define blank_line_set(pc, op)    _blank_line_set(pc, #op, op)
 
 
-static void newlines_func_pre_blank_lines(chunk_t *start)
+static void newlines_func_pre_blank_lines(chunk_t *start, c_token_t start_type)
 {
    LOG_FUNC_ENTRY();
    if (  start == nullptr
-      || (  (  start->type != CT_FUNC_CLASS_DEF
+      || (  (  start_type != CT_FUNC_CLASS_DEF
             || options::nl_before_func_class_def() == 0)
-         && (  start->type != CT_FUNC_CLASS_PROTO
+         && (  start_type != CT_FUNC_CLASS_PROTO
             || options::nl_before_func_class_proto() == 0)
-         && (  start->type != CT_FUNC_DEF
+         && (  start_type != CT_FUNC_DEF
             || options::nl_before_func_body_def() == 0)
-         && (  start->type != CT_FUNC_PROTO
+         && (  start_type != CT_FUNC_PROTO
             || options::nl_before_func_body_proto() == 0)))
    {
       return;
@@ -1017,7 +1034,7 @@ static void newlines_func_pre_blank_lines(chunk_t *start)
    LOG_FMT(LNLFUNCT, "   set blank line(s): for <NL> at O%zu:%zu\n",
            last_nl->orig_line, last_nl->orig_col);
 
-   switch (start->type)
+   switch (start_type)
    {
    case CT_FUNC_CLASS_DEF:
    {
@@ -3658,6 +3675,20 @@ void newline_after_label_colon(void)
 }
 
 
+static bool is_class_one_liner(chunk_t *pc)
+{
+   if (  (  chunk_is_token(pc, CT_FUNC_CLASS_DEF)
+         || chunk_is_token(pc, CT_FUNC_DEF))
+      && (pc->flags & PCF_IN_CLASS))
+   {
+      // Find opening brace
+      pc = chunk_get_next_type(pc, CT_BRACE_OPEN, pc->level);
+      return(pc && (pc->flags & PCF_ONE_LINER));
+   }
+   return(false);
+}
+
+
 void newlines_insert_blank_lines(void)
 {
    LOG_FUNC_ENTRY();
@@ -3701,7 +3732,15 @@ void newlines_insert_blank_lines(void)
               || chunk_is_token(pc, CT_FUNC_CLASS_PROTO)
               || chunk_is_token(pc, CT_FUNC_PROTO))
       {
-         newlines_func_pre_blank_lines(pc);
+         if (  options::nl_class_leave_one_liner_groups()
+            && is_class_one_liner(pc))
+         {
+            newlines_func_pre_blank_lines(pc, CT_FUNC_PROTO);
+         }
+         else
+         {
+            newlines_func_pre_blank_lines(pc, pc->type);
+         }
       }
       else
       {
@@ -4288,6 +4327,27 @@ static void _blank_line_max(chunk_t *pc, const char *text, uncrustify_options uo
 #define blank_line_max(pc, op)    _blank_line_max(pc, # op, op)
 
 
+bool is_func_proto_group(chunk_t *pc, c_token_t one_liner_type)
+{
+   if (  pc && options::nl_class_leave_one_liner_groups()
+      && (pc->type == one_liner_type || pc->parent_type == one_liner_type)
+      && (pc->flags & PCF_IN_CLASS))
+   {
+      if (pc->type == CT_BRACE_CLOSE)
+      {
+         return(pc->flags & PCF_ONE_LINER);
+      }
+      else
+      {
+         // Find opening brace
+         pc = chunk_get_next_type(pc, CT_BRACE_OPEN, pc->level);
+         return(pc && (pc->flags & PCF_ONE_LINER));
+      }
+   }
+   return(false);
+}
+
+
 void do_blank_lines(void)
 {
    LOG_FUNC_ENTRY();
@@ -4466,8 +4526,9 @@ void do_blank_lines(void)
       }
 
       // Add blanks after function prototypes
-      if (  chunk_is_token(prev, CT_SEMICOLON)
-         && prev->parent_type == CT_FUNC_PROTO)
+      if (  (  chunk_is_token(prev, CT_SEMICOLON)
+            && prev->parent_type == CT_FUNC_PROTO)
+         || is_func_proto_group(prev, CT_FUNC_DEF))
       {
          if (options::nl_after_func_proto() > pc->nl_count)
          {
@@ -4476,15 +4537,17 @@ void do_blank_lines(void)
          }
          if (  (options::nl_after_func_proto_group() > pc->nl_count)
             && next != nullptr
-            && next->parent_type != CT_FUNC_PROTO)
+            && next->parent_type != CT_FUNC_PROTO
+            && !is_func_proto_group(next, CT_FUNC_DEF))
          {
             blank_line_set(pc, UO_nl_after_func_proto_group);
          }
       }
 
       // Issue #411: Add blanks after function class prototypes
-      if (  chunk_is_token(prev, CT_SEMICOLON)
-         && prev->parent_type == CT_FUNC_CLASS_PROTO)
+      if (  (  chunk_is_token(prev, CT_SEMICOLON)
+            && prev->parent_type == CT_FUNC_CLASS_PROTO)
+         || is_func_proto_group(prev, CT_FUNC_CLASS_DEF))
       {
          if (options::nl_after_func_class_proto() > pc->nl_count)
          {
@@ -4494,7 +4557,8 @@ void do_blank_lines(void)
          if (  (options::nl_after_func_class_proto_group() > pc->nl_count)
             && next != nullptr
             && next->type != CT_FUNC_CLASS_PROTO
-            && next->parent_type != CT_FUNC_CLASS_PROTO)
+            && next->parent_type != CT_FUNC_CLASS_PROTO
+            && !is_func_proto_group(next, CT_FUNC_CLASS_DEF))
          {
             blank_line_set(pc, UO_nl_after_func_class_proto_group);
          }

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -1382,6 +1382,14 @@ void register_options(void)
                   "The number of newlines after a function class prototype, if followed by another function class prototype.");
    unc_add_option("nl_after_func_class_proto_group", UO_nl_after_func_class_proto_group, AT_UNUM,
                   "The number of newlines after a function class prototype, if not followed by another function class prototype.");
+   unc_add_option("nl_class_leave_one_liner_groups",
+                  UO_nl_class_leave_one_liner_groups, AT_BOOL,
+                  "Whether one-liner method definitions inside a class body "
+                  "should be treated\nas if they were prototypes for the "
+                  "purposes of adding newlines.\n\nRequires "
+                  "nl_class_leave_one_liners=true. Overrides "
+                  "nl_before_func_body_def\nand nl_before_func_class_def for "
+                  "one-liners.");
    unc_add_option("nl_before_func_body_def", UO_nl_before_func_body_def, AT_UNUM,
                   "The number of newlines before a multi-line function def body.");
    unc_add_option("nl_before_func_body_proto", UO_nl_before_func_body_proto, AT_UNUM,

--- a/src/option.h
+++ b/src/option.h
@@ -664,6 +664,7 @@ enum uncrustify_options
                                        // by another function class prototype
    UO_nl_after_func_class_proto_group, // The number of newlines after a function class prototype, if not
                                        // followed by another function class prototype
+   UO_nl_class_leave_one_liner_groups, // treat one-liners as prototypes
    UO_nl_before_func_body_def,         // The number of newlines before a multi-line function def body
    UO_nl_before_func_body_proto,       // The number of newlines before a multi-line function prototype body
    UO_nl_after_func_body,              // The number of newlines after '}' of a multi-line function body

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2871,6 +2871,12 @@ size_t &nl_after_func_class_proto_group()
 }
 
 
+bool &nl_class_leave_one_liner_groups()
+{
+   return(cpd.settings[UO_nl_class_leave_one_liner_groups].b);
+}
+
+
 size_t &nl_before_func_body_def()
 {
    return(cpd.settings[UO_nl_before_func_body_def].u);

--- a/src/options.h
+++ b/src/options.h
@@ -489,6 +489,7 @@ size_t &nl_after_func_proto();
 size_t &nl_after_func_proto_group();
 size_t &nl_after_func_class_proto();
 size_t &nl_after_func_class_proto_group();
+bool &nl_class_leave_one_liner_groups();
 size_t &nl_before_func_body_def();
 size_t &nl_before_func_body_proto();
 size_t &nl_after_func_body();

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 654 options and minimal documentation.
+There are currently 655 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -470,6 +470,7 @@ nl_after_func_proto             = 0
 nl_after_func_proto_group       = 0
 nl_after_func_class_proto       = 0
 nl_after_func_class_proto_group = 0
+nl_class_leave_one_liner_groups = false
 nl_before_func_body_def         = 0
 nl_before_func_body_proto       = 0
 nl_after_func_body              = 0

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1553,6 +1553,13 @@ nl_after_func_class_proto       = 0        # unsigned number
 # The number of newlines after a function class prototype, if not followed by another function class prototype.
 nl_after_func_class_proto_group = 0        # unsigned number
 
+# Whether one-liner method definitions inside a class body should be treated
+# as if they were prototypes for the purposes of adding newlines.
+# 
+# Requires nl_class_leave_one_liners=true. Overrides nl_before_func_body_def
+# and nl_before_func_class_def for one-liners.
+nl_class_leave_one_liner_groups = false    # false/true
+
 # The number of newlines before a multi-line function def body.
 nl_before_func_body_def         = 0        # unsigned number
 

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -470,6 +470,7 @@ nl_after_func_proto             = 0
 nl_after_func_proto_group       = 0
 nl_after_func_class_proto       = 0
 nl_after_func_class_proto_group = 0
+nl_class_leave_one_liner_groups = false
 nl_before_func_body_def         = 0
 nl_before_func_body_proto       = 0
 nl_after_func_body              = 0

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1553,6 +1553,13 @@ nl_after_func_class_proto       = 0        # unsigned number
 # The number of newlines after a function class prototype, if not followed by another function class prototype.
 nl_after_func_class_proto_group = 0        # unsigned number
 
+# Whether one-liner method definitions inside a class body should be treated
+# as if they were prototypes for the purposes of adding newlines.
+# 
+# Requires nl_class_leave_one_liners=true. Overrides nl_before_func_body_def
+# and nl_before_func_class_def for one-liners.
+nl_class_leave_one_liner_groups = false    # false/true
+
 # The number of newlines before a multi-line function def body.
 nl_before_func_body_def         = 0        # unsigned number
 

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1553,6 +1553,13 @@ nl_after_func_class_proto       = 0        # unsigned number
 # The number of newlines after a function class prototype, if not followed by another function class prototype.
 nl_after_func_class_proto_group = 0        # unsigned number
 
+# Whether one-liner method definitions inside a class body should be treated
+# as if they were prototypes for the purposes of adding newlines.
+# 
+# Requires nl_class_leave_one_liners=true. Overrides nl_before_func_body_def
+# and nl_before_func_class_def for one-liners.
+nl_class_leave_one_liner_groups = false    # false/true
+
 # The number of newlines before a multi-line function def body.
 nl_before_func_body_def         = 0        # unsigned number
 

--- a/tests/config/issue_1985.cfg
+++ b/tests/config/issue_1985.cfg
@@ -1,0 +1,6 @@
+nl_class_leave_one_liners       = true
+nl_class_leave_one_liner_groups = true
+nl_after_func_proto_group       = 3
+nl_after_func_class_proto_group = 3
+nl_before_func_body_def         = 3
+eat_blanks_before_close_brace   = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -632,6 +632,7 @@
 34251  bug_1649.cfg                         cpp/bug_1649.cpp
 34252  nl_after_func_proto_group-3.cfg      cpp/issue_2001.cpp
 34253  nl_after_func_proto_group-3.cfg      cpp/friends.cpp
+34254  issue_1985.cfg                       cpp/issue_1985.cpp
 
 34280  UNI-29935.cfg                        cpp/UNI-29935.cpp
 

--- a/tests/expected/cpp/34254-issue_1985.cpp
+++ b/tests/expected/cpp/34254-issue_1985.cpp
@@ -1,0 +1,62 @@
+// Don't break a prototype followed by a one-liner
+class foo1
+{
+foo1();
+foo1(int) {}
+
+
+int bar();
+int bar(int) { return 0; }
+
+
+foo1(long);
+foo1(short) {}
+
+
+int x;
+};
+
+// Don't break a one-liner followed by a prototype
+class foo2
+{
+foo2(int) {}
+foo2();
+
+
+int bar(int) { return 0; }
+int bar();
+
+
+foo2(short) {}
+foo2(long);
+
+
+int x;
+};
+
+// Do break a prototype followed by a multi-line definition
+class foo3
+{
+foo3();
+
+
+foo3(int)
+{
+	x = 0;
+}
+int bar();
+
+
+int bar(int)
+{
+	return 0;
+}
+foo3(long);
+
+
+foo3(short)
+{
+	x = 0;
+}
+int x;
+};

--- a/tests/input/cpp/issue_1985.cpp
+++ b/tests/input/cpp/issue_1985.cpp
@@ -1,0 +1,44 @@
+// Don't break a prototype followed by a one-liner
+class foo1
+{
+foo1();
+foo1(int) {}
+int bar();
+int bar(int) { return 0; }
+foo1(long);
+foo1(short) {}
+int x;
+};
+
+// Don't break a one-liner followed by a prototype
+class foo2
+{
+foo2(int) {}
+foo2();
+int bar(int) { return 0; }
+int bar();
+foo2(short) {}
+foo2(long);
+int x;
+};
+
+// Do break a prototype followed by a multi-line definition
+class foo3
+{
+foo3();
+foo3(int)
+{
+	x = 0;
+}
+int bar();
+int bar(int)
+{
+	return 0;
+}
+foo3(long);
+foo3(short)
+{
+	x = 0;
+}
+int x;
+};


### PR DESCRIPTION
Add new option `nl_leave_class_one_liner_groups` (and enable for uncrustify itself), which allows keeping one-line method definitions within a class body grouped as if they were prototypes. Also, fix a bug grouping ctor/dtor prototypes.

This doesn't affect existing code, although it will impact #1852, and it *would* impact #1986 except for #2005.

Fixes #1985.