### PR TITLE
WIP: Extra zealous mod_remove_extra_semicolon

### DIFF
--- a/tests/c-sharp.test
+++ b/tests/c-sharp.test
@@ -133,3 +133,4 @@
 60040  UNI-30498_2.cfg                      cs/UNI-30498_2.cs
 60041  squeeze-paren-close-Option.cfg       cs/squeeze-paren-close-Option.cs
 60044  UNI-37241.cfg                        cs/UNI-37241.cs
+60045  UNI-58354.cfg                        cs/UNI-58354.cs

--- a/tests/config/UNI-58354.cfg
+++ b/tests/config/UNI-58354.cfg
@@ -1,0 +1,6 @@
+indent_with_tabs=0
+indent_columns=4
+indent_class=true
+nl_class_leave_one_liners=true
+
+mod_remove_extra_semicolon=true

--- a/tests/expected/cs/60045-UNI-58354.cs
+++ b/tests/expected/cs/60045-UNI-58354.cs
@@ -1,0 +1,4 @@
+public static class Extensions
+{
+    public static FluentXboxOneSdk VS2017(this FluentPlatform<XboxOnePlatform> _) => new FluentXboxOneSdk {MsvcVersion = new Version(15, 0)};
+}

--- a/tests/input/cs/UNI-58354.cs
+++ b/tests/input/cs/UNI-58354.cs
@@ -1,0 +1,4 @@
+public static class Extensions
+{
+    public static FluentXboxOneSdk VS2017(this FluentPlatform<XboxOnePlatform> _) => new FluentXboxOneSdk {MsvcVersion = new Version(15, 0)};
+}


### PR DESCRIPTION
This is a PR for proving that `mod_remove_extra_semicolon` can remove "good" semicolons and by doing so it breaks code compilation.