### PR TITLE
Fix declaration of chunk_ppa_search

### DIFF
--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -95,7 +95,7 @@ static chunk_t *chunk_search(chunk_t *cur, const check_t check_fct, const scope_
  * @retval chunk_t  pointer to the found chunk or pointer to the chunk at the
  *                  end of the preprocessor directive
  */
-static chunk_t *chunk_ppa_search(chunk_t *cur, const check_t check_fct, const scope_e scope = scope_e::ALL, const direction_e dir = direction_e::FORWARD, const bool cond = true);
+static chunk_t *chunk_ppa_search(chunk_t *cur, const check_t check_fct, const bool cond = true);
 
 
 static void chunk_log(chunk_t *pc, const char *text);


### PR DESCRIPTION
At some point while adding `chunk_ppa_search` (in da35dada2dc0), the forward declaration got out of sync with the actual function, resulting in an 'unused function' warning regarding the declaration. Fix the declaration to match the actual definition.

Fixes #2009.