### PR TITLE
Remove broken conversion in test_cli_options.py

### DIFF
--- a/tests/cli/test_cli_options.py
+++ b/tests/cli/test_cli_options.py
@@ -183,7 +183,7 @@ def check_generated_output(gen_expected_path, gen_result_path,
 
     if gen_res_txt != gen_exp_txt:
         with open(gen_result_path, 'w', encoding="utf-8", newline="") as f:
-                f.write(unicode(gen_res_txt, 'utf-8'))
+            f.write(gen_res_txt)
 
         if program_args.apply and program_args.auto_output_path:
                 write_to_output_path(program_args.auto_output_path, gen_res_txt)


### PR DESCRIPTION
Remove spurious conversion to `unicode` from `test_cli_options.py`. Because we are using `io.open` and not built-in `open` to read files, with an encoding specified, the read file content is already `unicode`. Thus, the requested conversion to `unicode` is superfluous. However, 05278c0e3c2c changed this to explicitly request conversion from UTF-8 (since otherwise a conversion from `str` would try to convert ASCII and potentially fail), which changed the conversion from superfluous to broken.