### PR TITLE
Don't suppress unknown warning for clang

### DIFF
--- a/src/enum_flags.h
+++ b/src/enum_flags.h
@@ -9,9 +9,9 @@
 #ifndef ENUM_FLAGS_H_INCLUDED
 #define ENUM_FLAGS_H_INCLUDED
 
-#if __GNUC__ == 4
+#if __GNUC__ == 4 && !defined (__clang__)
 #pragma GCC diagnostic push
-#if __GNUC_MAJOR__ < 9 || __GNUC_PATCHLEVEL__ < 2
+#if __GNUC_MINOR__ < 9 || __GNUC_PATCHLEVEL__ < 2
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59624
 #pragma GCC diagnostic ignored "-Wunused-but-set-parameter"
 #endif
@@ -89,7 +89,7 @@ protected:
 
 } // namespace uncrustify
 
-#if __GNUC__ == 4
+#if __GNUC__ == 4 && !defined (__clang__)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
Tweak the change from 07542680196e to not do anything when building with clang, which doesn't have the troublesome warning. For some unknown reason, clang defines `__GNUC_PATCHLEVEL__` but *not* `__GNUC_MAJOR__`, which makes it awkward to try to write the GCC version check to work in the face of clang, so instead just check for clang directly.

See also https://github.com/uncrustify/uncrustify/pull/2017#issuecomment-419041603. Fixes #2024.

@nivekkagicom, please let me know if you know any platform where this is not sufficient.