### PR TITLE
Expected to fail support for tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 find_package(Git QUIET)
 
+# sorted by lexicographic order
 set(test_suites
     c-sharp.test
     c.test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,16 +3,16 @@ cmake_minimum_required(VERSION 2.8)
 find_package(Git QUIET)
 
 set(test_suites
-    c-sharp.test
     c.test
+    c-sharp.test
     cpp.test
     d.test
-    ecma.test
-    imported.test
-    java.test
     objective-c.test
     pawn.test
     vala.test
+    java.test
+    ecma.test
+    imported.test
 )
 
 option("UNCRUSTIFY_SEPARATE_TESTS"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,10 @@ set(test_suites
     imported.test
 )
 
+if (NOT ENABLE_CODECOVERAGE)
+  list(APPEND test_suites staging.test)
+endif()
+
 option("UNCRUSTIFY_SEPARATE_TESTS"
   "Create a separate CTest test for each test case;\
 \ this is slower, especially with Python 3" OFF
@@ -50,24 +54,26 @@ else()
   endforeach()
 endif()
 
-add_test(
-  NAME sources_format
-  COMMAND ${PYTHON_EXECUTABLE} run_sources_tests.py
-    --executable $<TARGET_FILE:uncrustify>
-    -d --git ${GIT_EXECUTABLE}
-    --result-dir ${CMAKE_CURRENT_BINARY_DIR}
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
+if (NOT ENABLE_CODECOVERAGE)
+  add_test(
+    NAME sources_format
+    COMMAND ${PYTHON_EXECUTABLE} run_sources_tests.py
+      --executable $<TARGET_FILE:uncrustify>
+      -d --git ${GIT_EXECUTABLE}
+      --result-dir ${CMAKE_CURRENT_BINARY_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
 
-add_test(
-  NAME cli_options
-  COMMAND ${PYTHON_EXECUTABLE}
-    test_cli_options.py
-    --build ${uncrustify_BINARY_DIR}
-    --diff
-  ${_configs}
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cli
-)
+  add_test(
+    NAME cli_options
+    COMMAND ${PYTHON_EXECUTABLE}
+      test_cli_options.py
+      --build ${uncrustify_BINARY_DIR}
+      --diff
+    ${_configs}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cli
+  )
+endif()
 
 add_custom_target(update-cli-options
   COMMAND ${PYTHON_EXECUTABLE}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,17 +63,17 @@ if (NOT ENABLE_CODECOVERAGE)
       --result-dir ${CMAKE_CURRENT_BINARY_DIR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
-
-  add_test(
-    NAME cli_options
-    COMMAND ${PYTHON_EXECUTABLE}
-      test_cli_options.py
-      --build ${uncrustify_BINARY_DIR}
-      --diff
-    ${_configs}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cli
-  )
 endif()
+
+add_test(
+  NAME cli_options
+  COMMAND ${PYTHON_EXECUTABLE}
+    test_cli_options.py
+    --build ${uncrustify_BINARY_DIR}
+    --diff
+  ${_configs}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cli
+)
 
 add_custom_target(update-cli-options
   COMMAND ${PYTHON_EXECUTABLE}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,16 +3,16 @@ cmake_minimum_required(VERSION 2.8)
 find_package(Git QUIET)
 
 set(test_suites
-    c.test
     c-sharp.test
+    c.test
     cpp.test
     d.test
+    ecma.test
+    imported.test
+    java.test
     objective-c.test
     pawn.test
     vala.test
-    java.test
-    ecma.test
-    imported.test
 )
 
 if (NOT ENABLE_CODECOVERAGE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,16 +55,14 @@ else()
   endforeach()
 endif()
 
-if (NOT ENABLE_CODECOVERAGE)
-  add_test(
-    NAME sources_format
-    COMMAND ${PYTHON_EXECUTABLE} run_sources_tests.py
-      --executable $<TARGET_FILE:uncrustify>
-      -d --git ${GIT_EXECUTABLE}
-      --result-dir ${CMAKE_CURRENT_BINARY_DIR}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  )
-endif()
+add_test(
+  NAME sources_format
+  COMMAND ${PYTHON_EXECUTABLE} run_sources_tests.py
+    --executable $<TARGET_FILE:uncrustify>
+    -d --git ${GIT_EXECUTABLE}
+    --result-dir ${CMAKE_CURRENT_BINARY_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
 
 add_test(
   NAME cli_options

--- a/tests/run_sources_tests.py
+++ b/tests/run_sources_tests.py
@@ -29,8 +29,7 @@ def main(argv):
         if os.path.splitext(s)[1] in ('.cpp', '.h'):
             t = tu.SourceTest()
             filepath = os.path.join(src_dir, s)
-            t.build(test_input=filepath,
-                    test_lang='CPP', test_config=config,
+            t.build(test_input=filepath, test_lang='CPP', test_config=config,
                     test_expected=filepath)
             tests.append(t)
 

--- a/tests/run_sources_tests.py
+++ b/tests/run_sources_tests.py
@@ -28,8 +28,10 @@ def main(argv):
     for s in os.listdir(src_dir):
         if os.path.splitext(s)[1] in ('.cpp', '.h'):
             t = tu.SourceTest()
-            t.build(test_input=os.path.join(src_dir, s),
-                    test_lang='CPP', test_config=config)
+            filepath = os.path.join(src_dir, s)
+            t.build(test_input=filepath,
+                    test_lang='CPP', test_config=config,
+                    test_expected=filepath)
             tests.append(t)
 
     counts = tu.run_tests(tests, args)

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -4,4 +4,4 @@
 # Range: reserve ID from dedicated language range
 # test.name  config.file  input.file  lang
 
-19000  UNI-58354.cfg                        cs/UNI-58354.cs     CS
+19000~ UNI-58354.cfg                        cs/UNI-58354.cs     CS

--- a/tests/test_uncrustify/config.py
+++ b/tests/test_uncrustify/config.py
@@ -9,18 +9,19 @@ import os
 
 test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
+# sorted by lexicographic order
 all_tests = [
     'c-sharp',
     'c',
     'cpp',
     'd',
-    'java',
-    'pawn',
-    'objective-c',
-    'vala',
     'ecma',
     'imported',
-    'staging'
+    'java',
+    'objective-c',
+    'pawn',
+    'staging',
+    'vala',
 ]
 
 FAIL_ATTRS     = {'bold': True}

--- a/tests/test_uncrustify/config.py
+++ b/tests/test_uncrustify/config.py
@@ -10,14 +10,14 @@ import os
 test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
 all_tests = [
-    'c-sharp',
     'c',
+    'c-sharp',
     'cpp',
     'd',
-    'java',
-    'pawn',
     'objective-c',
+    'pawn',
     'vala',
+    'java',
     'ecma',
     'imported'
 ]

--- a/tests/test_uncrustify/config.py
+++ b/tests/test_uncrustify/config.py
@@ -19,7 +19,8 @@ all_tests = [
     'vala',
     'java',
     'ecma',
-    'imported'
+    'imported',
+    'staging'
 ]
 
 FAIL_ATTRS     = {'bold': True}

--- a/tests/test_uncrustify/config.py
+++ b/tests/test_uncrustify/config.py
@@ -10,14 +10,14 @@ import os
 test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
 all_tests = [
-    'c',
     'c-sharp',
+    'c',
     'cpp',
     'd',
-    'objective-c',
-    'pawn',
-    'vala',
     'java',
+    'pawn',
+    'objective-c',
+    'vala',
     'ecma',
     'imported',
     'staging'

--- a/tests/test_uncrustify/failure.py
+++ b/tests/test_uncrustify/failure.py
@@ -58,7 +58,7 @@ class UnstableFailure(Failure):
             self.actual_path, self.expected_path)
 
 # =============================================================================
-class UnexpectedlyPassing(Failure):
+class UnexpectedlyPassingFailure(Failure):
     # -------------------------------------------------------------------------
     def __init__(self, expected, actual):
         self.expected_path = expected

--- a/tests/test_uncrustify/failure.py
+++ b/tests/test_uncrustify/failure.py
@@ -8,6 +8,18 @@
 class Failure(Exception):
     pass
 
+# =============================================================================
+class TestDeclarationParseError(Failure):
+    # -------------------------------------------------------------------------
+    def __init__(self, test_suite, line_number):
+        self.test_suite = test_suite
+        self.line_number = line_number
+
+    # -------------------------------------------------------------------------
+    def __str__(self):
+        return 'Error parsing line {!r} from the {!r} test suite'.format(
+            self.line_number, self.test_suite)
+
 
 # =============================================================================
 class ExecutionFailure(Failure):

--- a/tests/test_uncrustify/failure.py
+++ b/tests/test_uncrustify/failure.py
@@ -66,7 +66,7 @@ class UnstableFailure(Failure):
 
     # -------------------------------------------------------------------------
     def __str__(self):
-        return 'Output {!r} does not match expected output {!r}'.format(
+        return 'Output {!r} unexpectedly matches expected output {!r}'.format(
             self.actual_path, self.expected_path)
 
 # =============================================================================

--- a/tests/test_uncrustify/failure.py
+++ b/tests/test_uncrustify/failure.py
@@ -66,7 +66,7 @@ class UnstableFailure(Failure):
 
     # -------------------------------------------------------------------------
     def __str__(self):
-        return 'Output {!r} unexpectedly matches expected output {!r}'.format(
+        return 'Output {!r} does not match expected output {!r}'.format(
             self.actual_path, self.expected_path)
 
 # =============================================================================
@@ -78,5 +78,5 @@ class UnexpectedlyPassingFailure(Failure):
 
     # -------------------------------------------------------------------------
     def __str__(self):
-        return 'Output {!r} was not expected to match output {!r}'.format(
+        return 'Output {!r} unexpectedly matches expected output {!r}'.format(
             self.actual_path, self.expected_path)

--- a/tests/test_uncrustify/failure.py
+++ b/tests/test_uncrustify/failure.py
@@ -66,5 +66,5 @@ class UnexpectedlyPassingFailure(Failure):
 
     # -------------------------------------------------------------------------
     def __str__(self):
-        return 'Output {!r} was not expected to match expected output {!r}'.format(
+        return 'Output {!r} was not expected to match output {!r}'.format(
             self.actual_path, self.expected_path)

--- a/tests/test_uncrustify/failure.py
+++ b/tests/test_uncrustify/failure.py
@@ -56,3 +56,15 @@ class UnstableFailure(Failure):
     def __str__(self):
         return 'Output {!r} does not match expected output {!r}'.format(
             self.actual_path, self.expected_path)
+
+# =============================================================================
+class UnexpectedlyPassing(Failure):
+    # -------------------------------------------------------------------------
+    def __init__(self, expected, actual):
+        self.expected_path = expected
+        self.actual_path = actual
+
+    # -------------------------------------------------------------------------
+    def __str__(self):
+        return 'Output {!r} was not expected to match expected output {!r}'.format(
+            self.actual_path, self.expected_path)

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -151,6 +151,10 @@ class FormatTest(SourceTest):
     pass_input = ['test_input', 'test_expected']
     pass_expected = ['test_expected', 'test_rerun_expected']
 
+    re_test_declaration = re.compile(r'^(?P<num>\d+)(?P<mark>[~!])?\s+'
+                          r'(?P<config>\S+)\s+(?P<input>\S+)'
+                          r'(?:\s+(?P<lang>\S+))?$')
+
     # -------------------------------------------------------------------------
     def _build_pass(self, i):
         p = SourceTest()
@@ -190,11 +194,7 @@ class FormatTest(SourceTest):
 
     # -------------------------------------------------------------------------
     def build_from_declaration(self, decl, group, line_number):
-        prog = re.compile(r'^(?P<num>\d+)(?P<mark>[~!])?\s+'
-                          r'(?P<config>\S+)\s+(?P<input>\S+)'
-                          r'(?:\s+(?P<lang>\S+))?$')
-
-        match = prog.match(decl)
+        match = self.re_test_declaration.match(decl)
         if not match:
             raise TestDeclarationParseError(group, line_number)
 

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -119,6 +119,7 @@ class SourceTest(object):
             else:
                 if args.xdiff:
                     print(output)
+                if not args.show_all:
                     printc('XFAILED: ', msg, **PASS_ATTRS)
                 return
         finally:

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -126,19 +126,18 @@ class SourceTest(object):
         try:
             has_diff = not filecmp.cmp(_expected, _result)
             if has_diff and not self.test_xfail:
-                printc('{}: '.format(self.diff_text),
-                       self.test_name, **self.diff_attrs)
                 if args.diff:
                     self._diff(_expected, _result)
+                printc('{}: '.format(self.diff_text),
+                       self.test_name, **self.diff_attrs)
                 raise self.diff_exception(_expected, _result)
             if not has_diff and self.test_xfail:
                 raise UnexpectedlyPassingFailure(_expected, _result)
             if has_diff and self.test_xfail:
                 if args.xdiff:
-                    msg = '{}: Difference on expected failure'
-                    msg = msg.format(self.test_name)
-                    printc('XFAILED: ', msg, **PASS_ATTRS)
                     self._diff(_expected, _result)
+                    if not args.show_all:
+                        printc('XFAILED: ', self.test_name, **PASS_ATTRS)
         except OSError as exc:
             printc('MISSING: ', self.test_name, **self.diff_attrs)
             raise MissingFailure(exc, _expected)

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -119,8 +119,8 @@ class SourceTest(object):
             else:
                 if args.xdiff:
                     print(output)
-                if not args.show_all:
-                    printc('XFAILED: ', msg, **PASS_ATTRS)
+                    if not args.show_all:
+                        printc('XFAILED: ', msg, **PASS_ATTRS)
                 return
         finally:
             if args.debug:
@@ -140,6 +140,8 @@ class SourceTest(object):
             if has_diff and self.test_xfail:
                 if args.xdiff:
                     self._diff(_expected, _result)
+                    if not args.show_all:
+                        printc('XFAILED: ', msg, **PASS_ATTRS)
                 return
         except OSError as exc:
             printc('MISSING: ', self.test_name, **self.diff_attrs)

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -113,12 +113,12 @@ class SourceTest(object):
             msg = '{}: Uncrustify error code {}'
             msg = msg.format(self.test_name, exc.returncode)
             if not self.test_xfail:
-                printc(output)
+                print(output)
                 printc('FAILED: ', msg, **FAIL_ATTRS)
                 raise ExecutionFailure(exc)
             else:
                 if args.xdiff:
-                    printc(output)
+                    print(output)
                     printc('XFAILED: ', msg, **FAIL_ATTRS)
                 return
         finally:

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -149,7 +149,7 @@ class FormatTest(SourceTest):
     pass_input = ['test_input', 'test_expected']
     pass_expected = ['test_expected', 'test_rerun_expected']
 
-    re_test_declaration = re.compile(r'^(?P<num>\d+)(?P<mark>[~!])?\s+'
+    re_test_declaration = re.compile(r'^(?P<num>\d+)(?P<mark>[~!]*)\s+'
                           r'(?P<config>\S+)\s+(?P<input>\S+)'
                           r'(?:\s+(?P<lang>\S+))?$')
 
@@ -197,8 +197,8 @@ class FormatTest(SourceTest):
             raise TestDeclarationParseError(group, line_number)
 
         num = match.group('num')
-        is_rerun = match.group('mark') == '!'
-        is_xfail = match.group('mark') == '~'
+        is_rerun = ('!' in match.group('mark'))
+        is_xfail = ('~' in match.group('mark'))
 
         self.test_xfail = is_xfail
 

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -111,10 +111,13 @@ class SourceTest(object):
         except subprocess.CalledProcessError as exc:
             output = exc.output
             if not self.test_xfail:
-                msg = '{}: Uncrustify error code {}'
+                print(output.rstrip())
+                msg = '{} (Uncrustify error code {})'
                 msg = msg.format(self.test_name, exc.returncode)
                 printc('FAILED: ', msg, **FAIL_ATTRS)
                 raise ExecutionFailure(exc)
+            elif args.xdiff:
+                print(output.rstrip())
         finally:
             if args.debug:
                 with open(_result + '.log', 'wt') as f:

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -176,7 +176,9 @@ class FormatTest(SourceTest):
         else:
             self.test_lang = test_dir
 
-        if parts[0].endswith('!'):
+        is_rerun = parts[0].endswith('!')
+
+        if is_rerun:
             num = parts[0][:-1]
         else:
             num = parts[0]
@@ -190,7 +192,7 @@ class FormatTest(SourceTest):
             parts = name.split('.')
             return '.'.join(parts[:-1] + ['rerun'] + parts[-1:])
 
-        if parts[0].endswith('!'):
+        if is_rerun:
             self.test_rerun_config = rerun_file(self.test_config)
             self.test_rerun_expected = rerun_file(self.test_expected)
         else:

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -132,10 +132,10 @@ class SourceTest(object):
                 raise UnexpectedlyPassingFailure(_expected, _result)
             if has_diff and self.test_xfail:
                 if args.xdiff:
+                    msg = '{}: Difference on expected failure'
+                    msg = msg.format(self.test_name)
+                    printc('XFAILED: ', msg, **PASS_ATTRS)
                     self._diff(_expected, _result)
-                    if not args.show_all:
-                        printc('XFAILED: ', msg, **PASS_ATTRS)
-                return
         except OSError as exc:
             printc('MISSING: ', self.test_name, **self.diff_attrs)
             raise MissingFailure(exc, _expected)

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -46,12 +46,12 @@ class SourceTest(object):
         subprocess.call(cmd)
 
     # -------------------------------------------------------------------------
-    def build(self, test_input, test_lang, test_config):
+    def build(self, test_input, test_lang, test_config, test_expected):
         self.test_name = os.path.basename(test_input)
         self.test_lang = test_lang
         self.test_input = test_input
         self.test_config = test_config
-        self.test_expected = test_input
+        self.test_expected = test_expected
 
     # -------------------------------------------------------------------------
     def _check(self):

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -110,18 +110,11 @@ class SourceTest(object):
             output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as exc:
             output = exc.output
-            msg = '{}: Uncrustify error code {}'
-            msg = msg.format(self.test_name, exc.returncode)
             if not self.test_xfail:
-                print(output)
+                msg = '{}: Uncrustify error code {}'
+                msg = msg.format(self.test_name, exc.returncode)
                 printc('FAILED: ', msg, **FAIL_ATTRS)
                 raise ExecutionFailure(exc)
-            else:
-                if args.xdiff:
-                    print(output)
-                    if not args.show_all:
-                        printc('XFAILED: ', msg, **PASS_ATTRS)
-                return
         finally:
             if args.debug:
                 with open(_result + '.log', 'wt') as f:

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -68,11 +68,6 @@ class SourceTest(object):
 
     # -------------------------------------------------------------------------
     def run(self, args):
-        """Runs a test.
-        On failure, it throws a specific exception except if it's a known
-        failure when it just returns 1.
-        Otherwise it returns 0.
-        """
         self._check()
 
         _expected = self.test_expected
@@ -127,7 +122,7 @@ class SourceTest(object):
                 if args.xdiff:
                     printc(exc.output)
                     printc('XFAILED: ', msg, **FAIL_ATTRS)
-                return 1
+                return
         finally:
             del stderr
 
@@ -144,12 +139,11 @@ class SourceTest(object):
             if has_diff and self.test_xfail:
                 if args.xdiff:
                     self._diff(_expected, _result)
-                return 1
+                return
         except OSError as exc:
             printc('MISSING: ', self.test_name, **self.diff_attrs)
             raise MissingFailure(exc, _expected)
-        
-        return 0
+
 
 # =============================================================================
 class FormatTest(SourceTest):
@@ -289,6 +283,4 @@ class FormatTest(SourceTest):
     # -------------------------------------------------------------------------
     def run(self, args):
         for p in self.test_passes:
-            if not p.run(args):
-                return 1
-        return 0
+            p.run(args)

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -253,7 +253,9 @@ class FormatTest(SourceTest):
         def to_cmake_path(path):
             if type(path) is dict:
                 return {k: to_cmake_path(v) for k, v in path.items()}
-            return path.replace(os.sep, '/')
+            if type(path) is str:
+                return path.replace(os.sep, '/')
+            return path
 
         runner = os.path.join(test_dir, 'run_test.py')
 
@@ -267,13 +269,14 @@ class FormatTest(SourceTest):
              '    --expected       "{test_expected}"\n' +
              '    --rerun-config   "{test_rerun_config}"\n' +
              '    --rerun-expected "{test_rerun_expected}"\n' +
-             '    --xfail          "{test_xfail}"\n' +
              '    -d --git         "{git_exe}"\n' +
+             '{xfail}' +
              ')\n').format(
                  test_runner=to_cmake_path(runner),
                  python_exe=to_cmake_path(config.python_exe),
                  uncrustify_exe=to_cmake_path(config.uncrustify_exe),
                  git_exe=to_cmake_path(config.git_exe),
+                 xfail=('    --xfail\n' if self.test_xfail else ''),
                  **to_cmake_path(self.__dict__)))
         out_file.write(
             ('set_tests_properties({}\n' +

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -15,7 +15,7 @@ from .config import (config, test_dir, FAIL_ATTRS,
                      MISMATCH_ATTRS, UNSTABLE_ATTRS)
 from .failure import (ExecutionFailure, MissingFailure,
                       MismatchFailure, UnstableFailure,
-                      UnexpectedlyPassing)
+                      UnexpectedlyPassingFailure)
 
 
 # =============================================================================
@@ -130,7 +130,7 @@ class SourceTest(object):
                     self._diff(_expected, _result)
                 raise self.diff_exception(_expected, _result)
             if not has_diff and self.test_xfail:
-                raise UnexpectedlyPassing(_expected, _result)
+                raise UnexpectedlyPassingFailure(_expected, _result)
             if has_diff and self.test_xfail:
                 msg = '{}: Difference'
                 msg = msg.format(self.test_name)

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -231,7 +231,7 @@ class FormatTest(SourceTest):
         self.test_expected = args.expected
         self.test_rerun_config = args.rerun_config or args.config
         self.test_rerun_expected = args.rerun_expected or args.expected
-        self.test_xfail = False
+        self.test_xfail = args.xfail
 
         self._build_passes()
 
@@ -256,6 +256,7 @@ class FormatTest(SourceTest):
              '    --expected       "{test_expected}"\n' +
              '    --rerun-config   "{test_rerun_config}"\n' +
              '    --rerun-expected "{test_rerun_expected}"\n' +
+             '    --xfail          "{test_xfail}"\n' +
              '    -d --git         "{git_exe}"\n' +
              ')\n').format(
                  test_runner=to_cmake_path(runner),

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -12,7 +12,7 @@ import subprocess
 import sys
 
 from .ansicolor import printc
-from .config import (config, test_dir, FAIL_ATTRS,
+from .config import (config, test_dir, FAIL_ATTRS, PASS_ATTRS,
                      MISMATCH_ATTRS, UNSTABLE_ATTRS)
 from .failure import (ExecutionFailure, MismatchFailure, MissingFailure,
                       TestDeclarationParseError, UnexpectedlyPassingFailure,
@@ -119,7 +119,7 @@ class SourceTest(object):
             else:
                 if args.xdiff:
                     print(output)
-                    printc('XFAILED: ', msg, **FAIL_ATTRS)
+                    printc('XFAILED: ', msg, **PASS_ATTRS)
                 return
         finally:
             if args.debug:

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -81,7 +81,7 @@ class SourceTest(object):
             print('    Config : {}'.format(self.test_config))
             print('  Expected : {}'.format(_expected))
             print('    Result : {}'.format(_result))
-            print('ExpectFail : {}'.format(self.test_xfail))
+            print('     XFail : {}'.format(self.test_xfail))
 
         if not os.path.exists(os.path.dirname(_result)):
             os.makedirs(os.path.dirname(_result))

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -14,10 +14,9 @@ import sys
 from .ansicolor import printc
 from .config import (config, test_dir, FAIL_ATTRS,
                      MISMATCH_ATTRS, UNSTABLE_ATTRS)
-from .failure import (ExecutionFailure, MissingFailure,
-                      MismatchFailure, UnstableFailure,
-                      UnexpectedlyPassingFailure,
-                      TestDeclarationParseError)
+from .failure import (ExecutionFailure, MismatchFailure, MissingFailure,
+                      TestDeclarationParseError, UnexpectedlyPassingFailure,
+                      UnstableFailure)
 
 
 # =============================================================================

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -253,12 +253,12 @@ class FormatTest(SourceTest):
     def print_as_ctest(self, out_file=sys.stdout):
         self._check()
 
-        def to_cmake_path(path):
-            if type(path) is dict:
-                return {k: to_cmake_path(v) for k, v in path.items()}
-            if type(path) is str:
-                return path.replace(os.sep, '/')
-            return path
+        def to_cmake_path(obj):
+            if type(obj) is dict:
+                return {k: to_cmake_path(v) for k, v in obj.items()}
+            if type(obj) is str:
+                return obj.replace(os.sep, '/')
+            return obj
 
         runner = os.path.join(test_dir, 'run_test.py')
 

--- a/tests/test_uncrustify/utilities.py
+++ b/tests/test_uncrustify/utilities.py
@@ -12,7 +12,8 @@ import sys
 
 from .ansicolor import printc
 from .config import config, all_tests, FAIL_ATTRS, PASS_ATTRS, SKIP_ATTRS
-from .failure import Failure, MismatchFailure, UnstableFailure
+from .failure import (Failure, MismatchFailure, UnexpectedlyPassingFailure,
+                      UnstableFailure)
 from .test import FormatTest
 
 

--- a/tests/test_uncrustify/utilities.py
+++ b/tests/test_uncrustify/utilities.py
@@ -54,6 +54,7 @@ def add_test_arguments(parser):
     parser.add_argument("--expected",           type=str, required=True)
     parser.add_argument("--rerun-config",       type=str, metavar='INPUT')
     parser.add_argument("--rerun-expected",     type=str, metavar='CONFIG')
+    parser.add_argument("--xfail",              action='store_true')
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_uncrustify/utilities.py
+++ b/tests/test_uncrustify/utilities.py
@@ -136,8 +136,7 @@ def run_tests(tests, args, selector=None):
             test.run(args)
             if args.show_all:
                 outcome = 'XFAILED' if test.test_xfail else 'PASSED'
-                if not test.test_xfail or not args.xdiff:
-                    printc('{}: '.format(outcome), test.test_name, **PASS_ATTRS)
+                printc('{}: '.format(outcome), test.test_name, **PASS_ATTRS)
             pass_count += 1
         except UnstableFailure:
             unstable_count += 1

--- a/tests/test_uncrustify/utilities.py
+++ b/tests/test_uncrustify/utilities.py
@@ -136,7 +136,7 @@ def run_tests(tests, args, selector=None):
             test.run(args)
             if args.show_all:
                 outcome = 'XFAILED' if test.test_xfail else 'PASSED'
-                printc('%s: '.format(outcome), test.test_name, **PASS_ATTRS)
+                printc('{}: '.format(outcome), test.test_name, **PASS_ATTRS)
             pass_count += 1
         except UnstableFailure:
             unstable_count += 1

--- a/tests/test_uncrustify/utilities.py
+++ b/tests/test_uncrustify/utilities.py
@@ -136,7 +136,8 @@ def run_tests(tests, args, selector=None):
             test.run(args)
             if args.show_all:
                 outcome = 'XFAILED' if test.test_xfail else 'PASSED'
-                printc('{}: '.format(outcome), test.test_name, **PASS_ATTRS)
+                if not test.test_xfail or not args.xdiff:
+                    printc('{}: '.format(outcome), test.test_name, **PASS_ATTRS)
             pass_count += 1
         except UnstableFailure:
             unstable_count += 1

--- a/tests/test_uncrustify/utilities.py
+++ b/tests/test_uncrustify/utilities.py
@@ -120,6 +120,7 @@ def run_tests(tests, args, selector=None):
     fail_count = 0
     mismatch_count = 0
     unstable_count = 0
+    unexpectedly_passing_count = 0
 
     for test in tests:
         if selector is not None and not selector.test(test.test_name):
@@ -136,6 +137,8 @@ def run_tests(tests, args, selector=None):
             unstable_count += 1
         except MismatchFailure:
             mismatch_count += 1
+        except UnexpectedlyPassingFailure:
+            unexpectedly_passing_count += 1
         except Failure:
             fail_count += 1
 
@@ -143,7 +146,8 @@ def run_tests(tests, args, selector=None):
         'passing': pass_count,
         'failing': fail_count,
         'mismatch': mismatch_count,
-        'unstable': unstable_count
+        'unstable': unstable_count,
+        'xpass': unexpectedly_passing_count
     }
 
 
@@ -162,6 +166,9 @@ def report(counts):
     if counts['unstable'] > 0:
         printc('{unstable} tests were unstable'.format(**counts),
                **FAIL_ATTRS)
+    if counts['xpass'] > 0:
+        printc('{xpass} tests passed but were expected to fail'
+            .format(**counts), **FAIL_ATTRS)
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_uncrustify/utilities.py
+++ b/tests/test_uncrustify/utilities.py
@@ -27,6 +27,9 @@ def _add_common_arguments(parser):
     parser.add_argument('-d', '--diff', action='store_true',
                         help='show diff on failure')
 
+    parser.add_argument('-x', '--xdiff', action='store_true',
+                        help='show diff on expected failure')
+
     parser.add_argument('-g', '--debug', action='store_true',
                         help='generate debug files (.log, .unc)')
 
@@ -130,9 +133,12 @@ def run_tests(tests, args, selector=None):
             continue
 
         try:
-            test.run(args)
+            result = test.run(args)
             if args.show_all:
-                printc('PASSED: ', test.test_name, **PASS_ATTRS)
+                if result == 0:
+                    printc('PASSED: ', test.test_name, **PASS_ATTRS)
+                else:
+                    printc('XFAILED: ', test.test_name, **PASS_ATTRS)
             pass_count += 1
         except UnstableFailure:
             unstable_count += 1

--- a/tests/test_uncrustify/utilities.py
+++ b/tests/test_uncrustify/utilities.py
@@ -183,8 +183,11 @@ def read_format_tests(filename, group):
     tests = []
 
     print("Processing " + filename)
+    line_number = 0
     with open(filename, 'rt') as f:
         for line in f:
+            line_number += 1
+
             line = line.strip()
             if not len(line):
                 continue
@@ -192,7 +195,7 @@ def read_format_tests(filename, group):
                 continue
 
             test = FormatTest()
-            test.build_from_declaration(line, group)
+            test.build_from_declaration(line, group, line_number)
             tests.append(test)
 
     return tests

--- a/tests/test_uncrustify/utilities.py
+++ b/tests/test_uncrustify/utilities.py
@@ -133,10 +133,10 @@ def run_tests(tests, args, selector=None):
             continue
 
         try:
-            result = test.run(args)
+            test.run(args)
             if args.show_all:
                 outcome = 'XFAILED' if test.test_xfail else 'PASSED'
-                printc('%s: ' % outcome, test.test_name, **PASS_ATTRS)
+                printc('%s: '.format(outcome), test.test_name, **PASS_ATTRS)
             pass_count += 1
         except UnstableFailure:
             unstable_count += 1
@@ -181,11 +181,8 @@ def read_format_tests(filename, group):
     tests = []
 
     print("Processing " + filename)
-    line_number = 0
     with open(filename, 'rt') as f:
-        for line in f:
-            line_number += 1
-
+        for line_number, line in enumerate(f, 1):
             line = line.strip()
             if not len(line):
                 continue

--- a/tests/test_uncrustify/utilities.py
+++ b/tests/test_uncrustify/utilities.py
@@ -135,10 +135,8 @@ def run_tests(tests, args, selector=None):
         try:
             result = test.run(args)
             if args.show_all:
-                if result == 0:
-                    printc('PASSED: ', test.test_name, **PASS_ATTRS)
-                else:
-                    printc('XFAILED: ', test.test_name, **PASS_ATTRS)
+                outcome = 'XFAILED' if test.test_xfail else 'PASSED'
+                printc('%s: ' % outcome, test.test_name, **PASS_ATTRS)
             pass_count += 1
         except UnstableFailure:
             unstable_count += 1


### PR DESCRIPTION
As previously proposed, this adds support for staging tests that are expected to fail. This allows reporters and maintainers quickly add bugs as to this suite to be able to separate between reporting and fixing process. This is better for keeping track of known issues as well.

They should not contribute to the coverage but should fail when the test passes. When that happens, the bug should be moved to its dedicated language suite and the related bug closed.

This PR also moves the test added by #2008 to be checked by Uncrustify as expected failure.

This is also a preliminary step for #1810.