### PR TITLE
Remove Uncrustify's own source code from counting to test coverage

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,14 +50,16 @@ else()
   endforeach()
 endif()
 
-add_test(
-  NAME sources_format
-  COMMAND ${PYTHON_EXECUTABLE} run_sources_tests.py
-    --executable $<TARGET_FILE:uncrustify>
-    -d --git ${GIT_EXECUTABLE}
-    --result-dir ${CMAKE_CURRENT_BINARY_DIR}
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
+if (NOT ENABLE_CODECOVERAGE)
+  add_test(
+    NAME sources_format
+    COMMAND ${PYTHON_EXECUTABLE} run_sources_tests.py
+      --executable $<TARGET_FILE:uncrustify>
+      -d --git ${GIT_EXECUTABLE}
+      --result-dir ${CMAKE_CURRENT_BINARY_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+endif()
 
 add_test(
   NAME cli_options


### PR DESCRIPTION
While formatting its own source code can be regarded as a test in itself
it is not correct from the coverage point of view.

Imagine you're doing some refactoring and removing some code. That piece
of code was triggering some other part from uncrustify and that was the
only thing that was covering. Suddenly you're getting an unexpected drop
in coverage and forced to add some coverage to a totally unrelated piece
of uncrustify's code base.

With normal tests is different. There is a clear input/expected output
and nothing should be changing underneath your feet while you are
changing the code. The input/expected remain static in this process.