### PR TITLE
Fix coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,8 @@ before_install:
     if [ "x${BUILD_TYPE}" == "xcoverage" ]; then
       sudo apt-get update
       sudo apt-get install -qy python3-pip lcov
+      pip3 install --user --upgrade setuptools
+      pip3 install --user --upgrade pip
       pip3 install --user PyYAML
       pip3 install --user --upgrade cpp-coveralls
     fi


### PR DESCRIPTION
~~There [appears](https://github.com/uncrustify/uncrustify/pull/1852#issuecomment-430341152) to be a problem with coverage. This PR is to trigger a build to test if it is working... if it is broken as I suspect, this PR will later become a PR to fix it.~~

Tweak the CI script to upgrade setuptools and pip. One of coveralls dependencies ([note](https://github.com/uncrustify/uncrustify/pull/1852#issuecomment-430341152)) needs a newer version of setuptools than is available on the CI VM, which in turn has problems with the old version of pip if that is not upgraded also.

This should get coveralls working again.