### PR TITLE
Add OT_BOOL → OT_IARF "upgrade" path

### DIFF
--- a/src/option.h
+++ b/src/option.h
@@ -251,9 +251,9 @@ UNC_IMPLEMENT_OPTION(std::string);
 UNC_OPTVAL_ALIAS(bool, false, "0", "f", "n", "no");
 UNC_OPTVAL_ALIAS(bool, true, "1", "t", "y", "yes");
 UNC_OPTVAL_ALIAS(iarf_e, IGNORE, "i");
-UNC_OPTVAL_ALIAS(iarf_e, ADD, "a");
-UNC_OPTVAL_ALIAS(iarf_e, REMOVE, "r");
-UNC_OPTVAL_ALIAS(iarf_e, FORCE, "f");
+UNC_OPTVAL_ALIAS(iarf_e, ADD, "a", "2", "t", "true", "y", "yes");
+UNC_OPTVAL_ALIAS(iarf_e, REMOVE, "r", "0", "f", "false", "n", "no");
+UNC_OPTVAL_ALIAS(iarf_e, FORCE, "f", "1");
 
 // Possible values for options, by type
 #define UNC_OPTVALS(e)    extern const char *const e ## _values[]


### PR DESCRIPTION
(As promised...)

Add additional aliases for `IARF` options in order to support a transition path for converting `OT_BOOL` options to `OT_IARF` in a way that should minimize breakage of existing user configuration files.

This replaces the `TFI` option type that was recently removed, which existed for much the same purpose.

Please look carefully at the aliases (one major reason I wanted this as a separate PR), as there is a small potential "gotcha": `true` maps to `ADD`, but `1` maps to `force`. From a general standpoint, I think this makes sense (and for options that would have been `TFI`, which under this model may not distinguish between `ADD` and `FORCE` as synonyms, it potentially won't matter), but it's debatable, and I am happy to entertain debating.

Other options:

1. Don't map numbers at all.
2. Map `1` to `ADD` instead.
3. Change our minds and re-add `TFI` after all.
4. Something else?

Obviously I am on record as not favoring (3) :slightly_smiling_face:. Besides this giving us a way to not add a new option type, it's not *entirely* implausible for `ADD` and `FORCE` to differ for some options that are currently `OT_BOOL`, e.g. if other options don't say otherwise, allow multiple `\n` between tokens.