### PR TITLE
Add a test for those lines.

### DIFF
--- a/src/space.cpp
+++ b/src/space.cpp
@@ -501,8 +501,6 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_decltype_paren");
          return(options::sp_decltype_paren());
       }
-      log_rule("FORCE");
-      return(IARF_FORCE);
    }
 
    // handle '::'

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -501,6 +501,8 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_decltype_paren");
          return(options::sp_decltype_paren());
       }
+      log_rule("FORCE");
+      return(IARF_FORCE);
    }
 
    // handle '::'

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -376,6 +376,7 @@
 31632  issue_1916.cfg                       cpp/issue_1916.cpp
 31633  sp_after_decltype-f.cfg              cpp/sp_after_decltype.cpp
 31634  sp_after_decltype-r.cfg              cpp/sp_after_decltype.cpp
+31635  empty.cfg                            cpp/sp_decltype.cpp
 
 31660  nl_func_var_def_blk-1.cfg            cpp/issue_1919.cpp
 

--- a/tests/expected/cpp/31635-sp_decltype.cpp
+++ b/tests/expected/cpp/31635-sp_decltype.cpp
@@ -1,0 +1,2 @@
+#define foo(expr) (expr)
+using x = decltype foo(int);

--- a/tests/input/cpp/sp_decltype.cpp
+++ b/tests/input/cpp/sp_decltype.cpp
@@ -1,0 +1,2 @@
+#define foo(expr) (expr)
+using x = decltype          foo(int);


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/language/decltype says:
Syntax:
decltype ( entity )
decltype ( expression )

nothing else is possible.