### PR TITLE
Add --unbuffered option for stdout/stderr

### DIFF
--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -273,6 +273,7 @@ void usage(const char *argv0)
            " --frag       : Code fragment, assume the first line is indented correctly.\n"
            " --assume FN  : Uses the filename FN for automatic language detection if reading\n"
            "                from stdin unless -l is specified.\n"
+           " --unbuffered : Set stdout/stderr output to be unbuffered.\n"
            "\n"
            "Config/Help Options:\n"
            " -h -? --help --usage     : Print this message and exit.\n"
@@ -473,6 +474,13 @@ int main(int argc, char *argv[])
    {
       logmask_from_string("", mask);
       log_set_mask(mask);
+   }
+
+   // Unbuffered output option
+   if (arg.Present("--unbuffered"))
+   {
+      setvbuf(stdout, NULL, _IONBF, 0);
+      setvbuf(stderr, NULL, _IONBF, 0);
    }
 
    const char *p_arg;

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -37,6 +37,7 @@ Basic Options:
  --frag       : Code fragment, assume the first line is indented correctly.
  --assume FN  : Uses the filename FN for automatic language detection if reading
                 from stdin unless -l is specified.
+ --unbuffered : Set stdout/stderr output to be unbuffered.
 
 Config/Help Options:
  -h -? --help --usage     : Print this message and exit.


### PR DESCRIPTION
This solves the mixed output that you get when you redirect Uncrustify
output (stdout and stderr) to the same file.

Issue: #2043 