### PR TITLE
Unify the style of static inline functions

### DIFF
--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -23,8 +23,7 @@
  * @param tabsize The tabsize
  * @return the next tabstop column
  */
-static inline
-size_t calc_next_tab_column(size_t col, size_t tabsize)
+static inline size_t calc_next_tab_column(size_t col, size_t tabsize)
 {
    if (col == 0)
    {
@@ -49,8 +48,7 @@ size_t calc_next_tab_column(size_t col, size_t tabsize)
  * @param col  The current column
  * @return the next tabstop column
  */
-static inline
-size_t next_tab_column(size_t col)
+static inline size_t next_tab_column(size_t col)
 {
    return(calc_next_tab_column(col, uncrustify::options::output_tab_size()));
 }
@@ -62,8 +60,7 @@ size_t next_tab_column(size_t col)
  * @param col  The current column
  * @return the next tabstop column
  */
-static inline
-size_t align_tab_column(size_t col)
+static inline size_t align_tab_column(size_t col)
 {
    //if (col <= 0)
    if (col == 0)


### PR DESCRIPTION
The most of them have not a new line after "inline".
3 of them at prototypes.h are different.
Unify the style.