### PR TITLE
Fix nl_after_struct option

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -4576,7 +4576,7 @@ void do_blank_lines(void)
                {
                   LOG_FMT(LBLANK, "%s(%d): %zu:%zu token is '%s'\n",
                           __func__, __LINE__, tmp->orig_line, tmp->orig_col, tmp->text());
-                  if (tmp->flags & PCF_VAR_DEF)
+                  if ((tmp->flags & PCF_VAR_DEF) && !(tmp->flags & PCF_IN_STRUCT))
                   {
                      is_var_def = true;
                   }


### PR DESCRIPTION
In latest code, the nl_after_struct was broken due to a fix to avoid newlines for forward declarations for struct type variables(Issue #1702 as mentioned in the comment). 
The fix is to check both PCF_IN_STRUCT and PCF_VAR_DEF to determine it is a variable or not. 