### PR TITLE
Don't remove the space(s)

### DIFF
--- a/src/detect.cpp
+++ b/src/detect.cpp
@@ -312,15 +312,23 @@ static void detect_space_options(void)
             if (chunk_is_token(prev, CT_SPAREN_OPEN))
             {
                // empty, ie for (;;)
+               //               ^ is prev
+               //                ^ is pc
                vote_sp_before_semi_for_empty.vote(prev, pc);
             }
             else if (chunk_is_token(next, CT_SPAREN_CLOSE))
             {
                // empty, ie for (;;)
+               //                 ^ is pc
+               //                  ^ is next
                vote_sp_after_semi_for_empty.vote(pc, next);
             }
             else if (prev->type != CT_SEMICOLON)
             {
+               // empty, ie for (; i < 8;)
+               //                       ^ is pc
+               // or
+               //                      ^ is prev
                vote_sp_before_semi_for.vote(prev, pc);
             }
          }

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -350,10 +350,15 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    {
       if (second->parent_type == CT_FOR)
       {
-         if (  (options::sp_before_semi_for_empty() != IARF_IGNORE)
-            && (  chunk_is_token(first, CT_SPAREN_OPEN)
-               || chunk_is_token(first, CT_SEMICOLON)))
+         if (  chunk_is_token(first, CT_SPAREN_OPEN) // a
+            || chunk_is_token(first, CT_SEMICOLON))  // b
          {
+            // empty, ie for (;;)
+            //               ^ is first    // a
+            //                ^ is second  // a
+            // or
+            //                ^ is first   // b
+            //                 ^ is second // b
             log_rule("sp_before_semi_for_empty");
             return(options::sp_before_semi_for_empty());
          }

--- a/tests/expected/cpp/30713-fix_for_relational_operators.cpp
+++ b/tests/expected/cpp/30713-fix_for_relational_operators.cpp
@@ -3,6 +3,6 @@ void foo()
 	while (a < b && c > d)
 		i++;
 
-	for  (; a < b && c > d; )
+	for  (  ; a < b && c > d; )
 		i++;
 }


### PR DESCRIPTION
if sp_before_semi_for_empty is set to ignore.
The expected data for test 30713 must be corrected.
The two spaces before the first semi (at the for statement) must stay.