### PR TITLE
Improve option description consistency

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -1324,7 +1324,7 @@ indent_paren_nl;
 
 // How to indent a close parenthesis after a newline.
 //
-// 0: Indent to body level
+// 0: Indent to body level (default)
 // 1: Align under the open parenthesis
 // 2: Indent to the brace level
 extern BoundedOption<unsigned, 0, 2>
@@ -1589,26 +1589,26 @@ nl_after_square_assign;
 // The number of blank lines after a block of variable definitions at the top
 // of a function body.
 //
-// 0 = No change (default)
+// 0 = No change (default).
 extern BoundedOption<unsigned, 0, 16>
 nl_func_var_def_blk;
 
 // The number of newlines before a block of typedefs. If nl_after_access_spec
 // is non-zero, that option takes precedence.
 //
-// 0 = No change (default)
+// 0 = No change (default).
 extern BoundedOption<unsigned, 0, 16>
 nl_typedef_blk_start;
 
 // The number of newlines after a block of typedefs.
 //
-// 0 = No change (default)
+// 0 = No change (default).
 extern BoundedOption<unsigned, 0, 16>
 nl_typedef_blk_end;
 
 // The maximum number of consecutive newlines within a block of typedefs.
 //
-// 0 = No change (default)
+// 0 = No change (default).
 extern BoundedOption<unsigned, 0, 16>
 nl_typedef_blk_in;
 
@@ -1616,21 +1616,21 @@ nl_typedef_blk_in;
 // of a function body. If nl_after_access_spec is non-zero, that option takes
 // precedence.
 //
-// 0 = No change (default)
+// 0 = No change (default).
 extern BoundedOption<unsigned, 0, 16>
 nl_var_def_blk_start;
 
 // The number of newlines after a block of variable definitions not at the top
 // of a function body.
 //
-// 0 = No change (default)
+// 0 = No change (default).
 extern BoundedOption<unsigned, 0, 16>
 nl_var_def_blk_end;
 
 // The maximum number of consecutive newlines within a block of variable
 // definitions.
 //
-// 0 = No change (default)
+// 0 = No change (default).
 extern BoundedOption<unsigned, 0, 16>
 nl_var_def_blk_in;
 
@@ -2307,7 +2307,7 @@ nl_after_class;
 // the Qt-specific 'signals:' and 'slots:'. Will not change the newline count
 // if after a brace open.
 //
-// 0 = No change.
+// 0 = No change (default).
 extern BoundedOption<unsigned, 0, 16>
 nl_before_access_spec;
 
@@ -2315,7 +2315,7 @@ nl_before_access_spec;
 // the Qt-specific 'signals:' and 'slots:'. Will not change the newline count
 // if after a brace open.
 //
-// 0 = No change.
+// 0 = No change (default).
 //
 // Overrides nl_typedef_blk_start and nl_var_def_blk_start.
 extern BoundedOption<unsigned, 0, 16>
@@ -2324,27 +2324,27 @@ nl_after_access_spec;
 // The number of newlines between a function definition and the function
 // comment, as in '// comment\n <here> void foo() {...}'.
 //
-// 0 = No change.
+// 0 = No change (default).
 extern BoundedOption<unsigned, 0, 16>
 nl_comment_func_def;
 
 // The number of newlines after a try-catch-finally block that isn't followed
 // by a brace close.
 //
-// 0 = No change.
+// 0 = No change (default).
 extern BoundedOption<unsigned, 0, 16>
 nl_after_try_catch_finally;
 
 // (C#) The number of newlines before and after a property, indexer or event
 // declaration.
 //
-// 0 = No change.
+// 0 = No change (default).
 extern BoundedOption<unsigned, 0, 16>
 nl_around_cs_property;
 
 // (C#) The number of newlines between the get/set/add/remove handlers.
 //
-// 0 = No change.
+// 0 = No change (default).
 extern BoundedOption<unsigned, 0, 16>
 nl_between_get_set;
 
@@ -2372,7 +2372,7 @@ eat_blanks_before_close_brace;
 
 // How aggressively to remove extra newlines not in preprocessor.
 //
-// 0: No change
+// 0: No change (default)
 // 1: Remove most newlines not handled by other config
 // 2: Remove all newlines and reformat completely by config
 extern BoundedOption<unsigned, 0, 2>
@@ -2505,7 +2505,7 @@ align_func_params;
 
 // The span for aligning parameter definitions in function on parameter name.
 //
-// 0 = Don't align (default)
+// 0 = Don't align (default).
 extern BoundedOption<unsigned, 0, 16>
 align_func_params_span;
 
@@ -2526,13 +2526,13 @@ align_same_func_call_params;
 
 // The span for aligning variable definitions.
 //
-// 0 = Don't align (default)
+// 0 = Don't align (default).
 extern BoundedOption<unsigned, 0, 5000>
 align_var_def_span;
 
 // How to align the '*' in variable definitions.
 //
-// 0: Part of the type     'void *   foo;'
+// 0: Part of the type     'void *   foo;' (default)
 // 1: Part of the variable 'void     *foo;'
 // 2: Dangling             'void    *foo;'
 extern BoundedOption<unsigned, 0, 2>
@@ -2540,7 +2540,7 @@ align_var_def_star_style;
 
 // How to align the '&' in variable definitions.
 //
-// 0: Part of the type     'long &   foo;'
+// 0: Part of the type     'long &   foo;' (default)
 // 1: Part of the variable 'long     &foo;'
 // 2: Dangling             'long    &foo;'
 extern BoundedOption<unsigned, 0, 2>
@@ -2587,7 +2587,7 @@ align_assign_thresh;
 // How to apply align_assign_span to function declaration "assignments", i.e.
 // 'virtual void foo() = 0' or '~foo() = {default|delete}'.
 //
-// 0: Align with other assignments
+// 0: Align with other assignments (default)
 // 1: Align with each other, ignoring regular assignments
 // 2: Don't align
 extern BoundedOption<unsigned, 0, 2>
@@ -2655,7 +2655,7 @@ align_typedef_span;
 
 // How to align typedef'd functions with other typedefs.
 //
-// 0: Don't mix them at all
+// 0: Don't mix them at all (default)
 // 1: Align the open parenthesis with the types
 // 2: Align the function type name with the other type names
 extern BoundedOption<unsigned, 0, 2>
@@ -2663,7 +2663,7 @@ align_typedef_func;
 
 // How to align the '*' in typedefs.
 //
-// 0: Align on typedef type, ignore '*'
+// 0: Align on typedef type, ignore '*' (default)
 // 1: The '*' is part of type name: 'typedef int  *pint;'
 // 2: The '*' is part of the type, but dangling: 'typedef int *pint;'
 extern BoundedOption<unsigned, 0, 2>
@@ -2671,7 +2671,7 @@ align_typedef_star_style;
 
 // How to align the '&' in typedefs.
 //
-// 0: Align on typedef type, ignore '&'
+// 0: Align on typedef type, ignore '&' (default)
 // 1: The '&' is part of type name: 'typedef int  &pint;'
 // 2: The '&' is part of the type, but dangling: 'typedef int &pint;'
 extern BoundedOption<unsigned, 0, 2>
@@ -2802,7 +2802,7 @@ cmt_width;
 
 // How to reflow comments.
 //
-// 0: No reflowing (apart from the line wrapping due to cmt_width)
+// 0: No reflowing (apart from the line wrapping due to cmt_width) (default)
 // 1: No touching at all
 // 2: Full reflow
 extern BoundedOption<unsigned, 0, 2>

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1072,7 +1072,7 @@ indent_paren_nl                 = false    # true/false
 
 # How to indent a close parenthesis after a newline.
 #
-# 0: Indent to body level
+# 0: Indent to body level (default)
 # 1: Align under the open parenthesis
 # 2: Indent to the brace level
 indent_paren_close              = 0        # unsigned number
@@ -1291,42 +1291,42 @@ nl_after_square_assign          = ignore   # ignore/add/remove/force
 # The number of blank lines after a block of variable definitions at the top
 # of a function body.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_func_var_def_blk             = 0        # unsigned number
 
 # The number of newlines before a block of typedefs. If nl_after_access_spec
 # is non-zero, that option takes precedence.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_typedef_blk_start            = 0        # unsigned number
 
 # The number of newlines after a block of typedefs.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_typedef_blk_end              = 0        # unsigned number
 
 # The maximum number of consecutive newlines within a block of typedefs.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_typedef_blk_in               = 0        # unsigned number
 
 # The number of newlines before a block of variable definitions not at the top
 # of a function body. If nl_after_access_spec is non-zero, that option takes
 # precedence.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_var_def_blk_start            = 0        # unsigned number
 
 # The number of newlines after a block of variable definitions not at the top
 # of a function body.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_var_def_blk_end              = 0        # unsigned number
 
 # The maximum number of consecutive newlines within a block of variable
 # definitions.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_var_def_blk_in               = 0        # unsigned number
 
 # Add or remove newline between a function call's ')' and '{', as in
@@ -1855,14 +1855,14 @@ nl_after_class                  = 0        # unsigned number
 # the Qt-specific 'signals:' and 'slots:'. Will not change the newline count
 # if after a brace open.
 #
-# 0 = No change.
+# 0 = No change (default).
 nl_before_access_spec           = 0        # unsigned number
 
 # The number of newlines after an access specifier label. This also includes
 # the Qt-specific 'signals:' and 'slots:'. Will not change the newline count
 # if after a brace open.
 #
-# 0 = No change.
+# 0 = No change (default).
 #
 # Overrides nl_typedef_blk_start and nl_var_def_blk_start.
 nl_after_access_spec            = 0        # unsigned number
@@ -1870,24 +1870,24 @@ nl_after_access_spec            = 0        # unsigned number
 # The number of newlines between a function definition and the function
 # comment, as in '// comment\n <here> void foo() {...}'.
 #
-# 0 = No change.
+# 0 = No change (default).
 nl_comment_func_def             = 0        # unsigned number
 
 # The number of newlines after a try-catch-finally block that isn't followed
 # by a brace close.
 #
-# 0 = No change.
+# 0 = No change (default).
 nl_after_try_catch_finally      = 0        # unsigned number
 
 # (C#) The number of newlines before and after a property, indexer or event
 # declaration.
 #
-# 0 = No change.
+# 0 = No change (default).
 nl_around_cs_property           = 0        # unsigned number
 
 # (C#) The number of newlines between the get/set/add/remove handlers.
 #
-# 0 = No change.
+# 0 = No change (default).
 nl_between_get_set              = 0        # unsigned number
 
 # (C#) Add or remove newline between property and the '{'.
@@ -1910,7 +1910,7 @@ eat_blanks_before_close_brace   = false    # true/false
 
 # How aggressively to remove extra newlines not in preprocessor.
 #
-# 0: No change
+# 0: No change (default)
 # 1: Remove most newlines not handled by other config
 # 2: Remove all newlines and reformat completely by config
 nl_remove_extra_newlines        = 0        # unsigned number
@@ -2014,7 +2014,7 @@ align_func_params               = false    # true/false
 
 # The span for aligning parameter definitions in function on parameter name.
 #
-# 0 = Don't align (default)
+# 0 = Don't align (default).
 align_func_params_span          = 0        # unsigned number
 
 # The threshold for aligning function parameter definitions.
@@ -2031,19 +2031,19 @@ align_same_func_call_params     = false    # true/false
 
 # The span for aligning variable definitions.
 #
-# 0 = Don't align (default)
+# 0 = Don't align (default).
 align_var_def_span              = 0        # unsigned number
 
 # How to align the '*' in variable definitions.
 #
-# 0: Part of the type     'void *   foo;'
+# 0: Part of the type     'void *   foo;' (default)
 # 1: Part of the variable 'void     *foo;'
 # 2: Dangling             'void    *foo;'
 align_var_def_star_style        = 0        # unsigned number
 
 # How to align the '&' in variable definitions.
 #
-# 0: Part of the type     'long &   foo;'
+# 0: Part of the type     'long &   foo;' (default)
 # 1: Part of the variable 'long     &foo;'
 # 2: Dangling             'long    &foo;'
 align_var_def_amp_style         = 0        # unsigned number
@@ -2081,7 +2081,7 @@ align_assign_thresh             = 0        # unsigned number
 # How to apply align_assign_span to function declaration "assignments", i.e.
 # 'virtual void foo() = 0' or '~foo() = {default|delete}'.
 #
-# 0: Align with other assignments
+# 0: Align with other assignments (default)
 # 1: Align with each other, ignoring regular assignments
 # 2: Don't align
 align_assign_decl_func          = 0        # unsigned number
@@ -2137,21 +2137,21 @@ align_typedef_span              = 0        # unsigned number
 
 # How to align typedef'd functions with other typedefs.
 #
-# 0: Don't mix them at all
+# 0: Don't mix them at all (default)
 # 1: Align the open parenthesis with the types
 # 2: Align the function type name with the other type names
 align_typedef_func              = 0        # unsigned number
 
 # How to align the '*' in typedefs.
 #
-# 0: Align on typedef type, ignore '*'
+# 0: Align on typedef type, ignore '*' (default)
 # 1: The '*' is part of type name: 'typedef int  *pint;'
 # 2: The '*' is part of the type, but dangling: 'typedef int *pint;'
 align_typedef_star_style        = 0        # unsigned number
 
 # How to align the '&' in typedefs.
 #
-# 0: Align on typedef type, ignore '&'
+# 0: Align on typedef type, ignore '&' (default)
 # 1: The '&' is part of type name: 'typedef int  &pint;'
 # 2: The '&' is part of the type, but dangling: 'typedef int &pint;'
 align_typedef_amp_style         = 0        # unsigned number
@@ -2259,7 +2259,7 @@ cmt_width                       = 0        # unsigned number
 
 # How to reflow comments.
 #
-# 0: No reflowing (apart from the line wrapping due to cmt_width)
+# 0: No reflowing (apart from the line wrapping due to cmt_width) (default)
 # 1: No touching at all
 # 2: Full reflow
 cmt_reflow_mode                 = 0        # unsigned number

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1072,7 +1072,7 @@ indent_paren_nl                 = false    # true/false
 
 # How to indent a close parenthesis after a newline.
 #
-# 0: Indent to body level
+# 0: Indent to body level (default)
 # 1: Align under the open parenthesis
 # 2: Indent to the brace level
 indent_paren_close              = 0        # unsigned number
@@ -1291,42 +1291,42 @@ nl_after_square_assign          = ignore   # ignore/add/remove/force
 # The number of blank lines after a block of variable definitions at the top
 # of a function body.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_func_var_def_blk             = 0        # unsigned number
 
 # The number of newlines before a block of typedefs. If nl_after_access_spec
 # is non-zero, that option takes precedence.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_typedef_blk_start            = 0        # unsigned number
 
 # The number of newlines after a block of typedefs.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_typedef_blk_end              = 0        # unsigned number
 
 # The maximum number of consecutive newlines within a block of typedefs.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_typedef_blk_in               = 0        # unsigned number
 
 # The number of newlines before a block of variable definitions not at the top
 # of a function body. If nl_after_access_spec is non-zero, that option takes
 # precedence.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_var_def_blk_start            = 0        # unsigned number
 
 # The number of newlines after a block of variable definitions not at the top
 # of a function body.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_var_def_blk_end              = 0        # unsigned number
 
 # The maximum number of consecutive newlines within a block of variable
 # definitions.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_var_def_blk_in               = 0        # unsigned number
 
 # Add or remove newline between a function call's ')' and '{', as in
@@ -1855,14 +1855,14 @@ nl_after_class                  = 0        # unsigned number
 # the Qt-specific 'signals:' and 'slots:'. Will not change the newline count
 # if after a brace open.
 #
-# 0 = No change.
+# 0 = No change (default).
 nl_before_access_spec           = 0        # unsigned number
 
 # The number of newlines after an access specifier label. This also includes
 # the Qt-specific 'signals:' and 'slots:'. Will not change the newline count
 # if after a brace open.
 #
-# 0 = No change.
+# 0 = No change (default).
 #
 # Overrides nl_typedef_blk_start and nl_var_def_blk_start.
 nl_after_access_spec            = 0        # unsigned number
@@ -1870,24 +1870,24 @@ nl_after_access_spec            = 0        # unsigned number
 # The number of newlines between a function definition and the function
 # comment, as in '// comment\n <here> void foo() {...}'.
 #
-# 0 = No change.
+# 0 = No change (default).
 nl_comment_func_def             = 0        # unsigned number
 
 # The number of newlines after a try-catch-finally block that isn't followed
 # by a brace close.
 #
-# 0 = No change.
+# 0 = No change (default).
 nl_after_try_catch_finally      = 0        # unsigned number
 
 # (C#) The number of newlines before and after a property, indexer or event
 # declaration.
 #
-# 0 = No change.
+# 0 = No change (default).
 nl_around_cs_property           = 0        # unsigned number
 
 # (C#) The number of newlines between the get/set/add/remove handlers.
 #
-# 0 = No change.
+# 0 = No change (default).
 nl_between_get_set              = 0        # unsigned number
 
 # (C#) Add or remove newline between property and the '{'.
@@ -1910,7 +1910,7 @@ eat_blanks_before_close_brace   = false    # true/false
 
 # How aggressively to remove extra newlines not in preprocessor.
 #
-# 0: No change
+# 0: No change (default)
 # 1: Remove most newlines not handled by other config
 # 2: Remove all newlines and reformat completely by config
 nl_remove_extra_newlines        = 0        # unsigned number
@@ -2014,7 +2014,7 @@ align_func_params               = false    # true/false
 
 # The span for aligning parameter definitions in function on parameter name.
 #
-# 0 = Don't align (default)
+# 0 = Don't align (default).
 align_func_params_span          = 0        # unsigned number
 
 # The threshold for aligning function parameter definitions.
@@ -2031,19 +2031,19 @@ align_same_func_call_params     = false    # true/false
 
 # The span for aligning variable definitions.
 #
-# 0 = Don't align (default)
+# 0 = Don't align (default).
 align_var_def_span              = 0        # unsigned number
 
 # How to align the '*' in variable definitions.
 #
-# 0: Part of the type     'void *   foo;'
+# 0: Part of the type     'void *   foo;' (default)
 # 1: Part of the variable 'void     *foo;'
 # 2: Dangling             'void    *foo;'
 align_var_def_star_style        = 0        # unsigned number
 
 # How to align the '&' in variable definitions.
 #
-# 0: Part of the type     'long &   foo;'
+# 0: Part of the type     'long &   foo;' (default)
 # 1: Part of the variable 'long     &foo;'
 # 2: Dangling             'long    &foo;'
 align_var_def_amp_style         = 0        # unsigned number
@@ -2081,7 +2081,7 @@ align_assign_thresh             = 0        # unsigned number
 # How to apply align_assign_span to function declaration "assignments", i.e.
 # 'virtual void foo() = 0' or '~foo() = {default|delete}'.
 #
-# 0: Align with other assignments
+# 0: Align with other assignments (default)
 # 1: Align with each other, ignoring regular assignments
 # 2: Don't align
 align_assign_decl_func          = 0        # unsigned number
@@ -2137,21 +2137,21 @@ align_typedef_span              = 0        # unsigned number
 
 # How to align typedef'd functions with other typedefs.
 #
-# 0: Don't mix them at all
+# 0: Don't mix them at all (default)
 # 1: Align the open parenthesis with the types
 # 2: Align the function type name with the other type names
 align_typedef_func              = 0        # unsigned number
 
 # How to align the '*' in typedefs.
 #
-# 0: Align on typedef type, ignore '*'
+# 0: Align on typedef type, ignore '*' (default)
 # 1: The '*' is part of type name: 'typedef int  *pint;'
 # 2: The '*' is part of the type, but dangling: 'typedef int *pint;'
 align_typedef_star_style        = 0        # unsigned number
 
 # How to align the '&' in typedefs.
 #
-# 0: Align on typedef type, ignore '&'
+# 0: Align on typedef type, ignore '&' (default)
 # 1: The '&' is part of type name: 'typedef int  &pint;'
 # 2: The '&' is part of the type, but dangling: 'typedef int &pint;'
 align_typedef_amp_style         = 0        # unsigned number
@@ -2259,7 +2259,7 @@ cmt_width                       = 0        # unsigned number
 
 # How to reflow comments.
 #
-# 0: No reflowing (apart from the line wrapping due to cmt_width)
+# 0: No reflowing (apart from the line wrapping due to cmt_width) (default)
 # 1: No touching at all
 # 2: Full reflow
 cmt_reflow_mode                 = 0        # unsigned number

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1072,7 +1072,7 @@ indent_paren_nl                 = false    # true/false
 
 # How to indent a close parenthesis after a newline.
 #
-# 0: Indent to body level
+# 0: Indent to body level (default)
 # 1: Align under the open parenthesis
 # 2: Indent to the brace level
 indent_paren_close              = 0        # unsigned number
@@ -1291,42 +1291,42 @@ nl_after_square_assign          = ignore   # ignore/add/remove/force
 # The number of blank lines after a block of variable definitions at the top
 # of a function body.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_func_var_def_blk             = 0        # unsigned number
 
 # The number of newlines before a block of typedefs. If nl_after_access_spec
 # is non-zero, that option takes precedence.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_typedef_blk_start            = 0        # unsigned number
 
 # The number of newlines after a block of typedefs.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_typedef_blk_end              = 0        # unsigned number
 
 # The maximum number of consecutive newlines within a block of typedefs.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_typedef_blk_in               = 0        # unsigned number
 
 # The number of newlines before a block of variable definitions not at the top
 # of a function body. If nl_after_access_spec is non-zero, that option takes
 # precedence.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_var_def_blk_start            = 0        # unsigned number
 
 # The number of newlines after a block of variable definitions not at the top
 # of a function body.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_var_def_blk_end              = 0        # unsigned number
 
 # The maximum number of consecutive newlines within a block of variable
 # definitions.
 #
-# 0 = No change (default)
+# 0 = No change (default).
 nl_var_def_blk_in               = 0        # unsigned number
 
 # Add or remove newline between a function call's ')' and '{', as in
@@ -1855,14 +1855,14 @@ nl_after_class                  = 0        # unsigned number
 # the Qt-specific 'signals:' and 'slots:'. Will not change the newline count
 # if after a brace open.
 #
-# 0 = No change.
+# 0 = No change (default).
 nl_before_access_spec           = 0        # unsigned number
 
 # The number of newlines after an access specifier label. This also includes
 # the Qt-specific 'signals:' and 'slots:'. Will not change the newline count
 # if after a brace open.
 #
-# 0 = No change.
+# 0 = No change (default).
 #
 # Overrides nl_typedef_blk_start and nl_var_def_blk_start.
 nl_after_access_spec            = 0        # unsigned number
@@ -1870,24 +1870,24 @@ nl_after_access_spec            = 0        # unsigned number
 # The number of newlines between a function definition and the function
 # comment, as in '// comment\n <here> void foo() {...}'.
 #
-# 0 = No change.
+# 0 = No change (default).
 nl_comment_func_def             = 0        # unsigned number
 
 # The number of newlines after a try-catch-finally block that isn't followed
 # by a brace close.
 #
-# 0 = No change.
+# 0 = No change (default).
 nl_after_try_catch_finally      = 0        # unsigned number
 
 # (C#) The number of newlines before and after a property, indexer or event
 # declaration.
 #
-# 0 = No change.
+# 0 = No change (default).
 nl_around_cs_property           = 0        # unsigned number
 
 # (C#) The number of newlines between the get/set/add/remove handlers.
 #
-# 0 = No change.
+# 0 = No change (default).
 nl_between_get_set              = 0        # unsigned number
 
 # (C#) Add or remove newline between property and the '{'.
@@ -1910,7 +1910,7 @@ eat_blanks_before_close_brace   = false    # true/false
 
 # How aggressively to remove extra newlines not in preprocessor.
 #
-# 0: No change
+# 0: No change (default)
 # 1: Remove most newlines not handled by other config
 # 2: Remove all newlines and reformat completely by config
 nl_remove_extra_newlines        = 0        # unsigned number
@@ -2014,7 +2014,7 @@ align_func_params               = false    # true/false
 
 # The span for aligning parameter definitions in function on parameter name.
 #
-# 0 = Don't align (default)
+# 0 = Don't align (default).
 align_func_params_span          = 0        # unsigned number
 
 # The threshold for aligning function parameter definitions.
@@ -2031,19 +2031,19 @@ align_same_func_call_params     = false    # true/false
 
 # The span for aligning variable definitions.
 #
-# 0 = Don't align (default)
+# 0 = Don't align (default).
 align_var_def_span              = 0        # unsigned number
 
 # How to align the '*' in variable definitions.
 #
-# 0: Part of the type     'void *   foo;'
+# 0: Part of the type     'void *   foo;' (default)
 # 1: Part of the variable 'void     *foo;'
 # 2: Dangling             'void    *foo;'
 align_var_def_star_style        = 0        # unsigned number
 
 # How to align the '&' in variable definitions.
 #
-# 0: Part of the type     'long &   foo;'
+# 0: Part of the type     'long &   foo;' (default)
 # 1: Part of the variable 'long     &foo;'
 # 2: Dangling             'long    &foo;'
 align_var_def_amp_style         = 0        # unsigned number
@@ -2081,7 +2081,7 @@ align_assign_thresh             = 0        # unsigned number
 # How to apply align_assign_span to function declaration "assignments", i.e.
 # 'virtual void foo() = 0' or '~foo() = {default|delete}'.
 #
-# 0: Align with other assignments
+# 0: Align with other assignments (default)
 # 1: Align with each other, ignoring regular assignments
 # 2: Don't align
 align_assign_decl_func          = 0        # unsigned number
@@ -2137,21 +2137,21 @@ align_typedef_span              = 0        # unsigned number
 
 # How to align typedef'd functions with other typedefs.
 #
-# 0: Don't mix them at all
+# 0: Don't mix them at all (default)
 # 1: Align the open parenthesis with the types
 # 2: Align the function type name with the other type names
 align_typedef_func              = 0        # unsigned number
 
 # How to align the '*' in typedefs.
 #
-# 0: Align on typedef type, ignore '*'
+# 0: Align on typedef type, ignore '*' (default)
 # 1: The '*' is part of type name: 'typedef int  *pint;'
 # 2: The '*' is part of the type, but dangling: 'typedef int *pint;'
 align_typedef_star_style        = 0        # unsigned number
 
 # How to align the '&' in typedefs.
 #
-# 0: Align on typedef type, ignore '&'
+# 0: Align on typedef type, ignore '&' (default)
 # 1: The '&' is part of type name: 'typedef int  &pint;'
 # 2: The '&' is part of the type, but dangling: 'typedef int &pint;'
 align_typedef_amp_style         = 0        # unsigned number
@@ -2259,7 +2259,7 @@ cmt_width                       = 0        # unsigned number
 
 # How to reflow comments.
 #
-# 0: No reflowing (apart from the line wrapping due to cmt_width)
+# 0: No reflowing (apart from the line wrapping due to cmt_width) (default)
 # 1: No touching at all
 # 2: Full reflow
 cmt_reflow_mode                 = 0        # unsigned number

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2489,7 +2489,7 @@ ValueDefault=false
 
 [Indent Paren Close]
 Category=2
-Description="<html>How to indent a close parenthesis after a newline.<br/><br/>0: Indent to body level<br/>1: Align under the open parenthesis<br/>2: Indent to the brace level</html>"
+Description="<html>How to indent a close parenthesis after a newline.<br/><br/>0: Indent to body level (default)<br/>1: Align under the open parenthesis<br/>2: Indent to the brace level</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_paren_close="
@@ -2953,7 +2953,7 @@ ValueDefault=ignore
 
 [Nl Func Var Def Blk]
 Category=3
-Description="<html>The number of blank lines after a block of variable definitions at the top<br/>of a function body.<br/><br/>0 = No change (default)</html>"
+Description="<html>The number of blank lines after a block of variable definitions at the top<br/>of a function body.<br/><br/>0 = No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_func_var_def_blk="
@@ -2963,7 +2963,7 @@ ValueDefault=0
 
 [Nl Typedef Blk Start]
 Category=3
-Description="<html>The number of newlines before a block of typedefs. If nl_after_access_spec<br/>is non-zero, that option takes precedence.<br/><br/>0 = No change (default)</html>"
+Description="<html>The number of newlines before a block of typedefs. If nl_after_access_spec<br/>is non-zero, that option takes precedence.<br/><br/>0 = No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_typedef_blk_start="
@@ -2973,7 +2973,7 @@ ValueDefault=0
 
 [Nl Typedef Blk End]
 Category=3
-Description="<html>The number of newlines after a block of typedefs.<br/><br/>0 = No change (default)</html>"
+Description="<html>The number of newlines after a block of typedefs.<br/><br/>0 = No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_typedef_blk_end="
@@ -2983,7 +2983,7 @@ ValueDefault=0
 
 [Nl Typedef Blk In]
 Category=3
-Description="<html>The maximum number of consecutive newlines within a block of typedefs.<br/><br/>0 = No change (default)</html>"
+Description="<html>The maximum number of consecutive newlines within a block of typedefs.<br/><br/>0 = No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_typedef_blk_in="
@@ -2993,7 +2993,7 @@ ValueDefault=0
 
 [Nl Var Def Blk Start]
 Category=3
-Description="<html>The number of newlines before a block of variable definitions not at the top<br/>of a function body. If nl_after_access_spec is non-zero, that option takes<br/>precedence.<br/><br/>0 = No change (default)</html>"
+Description="<html>The number of newlines before a block of variable definitions not at the top<br/>of a function body. If nl_after_access_spec is non-zero, that option takes<br/>precedence.<br/><br/>0 = No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_var_def_blk_start="
@@ -3003,7 +3003,7 @@ ValueDefault=0
 
 [Nl Var Def Blk End]
 Category=3
-Description="<html>The number of newlines after a block of variable definitions not at the top<br/>of a function body.<br/><br/>0 = No change (default)</html>"
+Description="<html>The number of newlines after a block of variable definitions not at the top<br/>of a function body.<br/><br/>0 = No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_var_def_blk_end="
@@ -3013,7 +3013,7 @@ ValueDefault=0
 
 [Nl Var Def Blk In]
 Category=3
-Description="<html>The maximum number of consecutive newlines within a block of variable<br/>definitions.<br/><br/>0 = No change (default)</html>"
+Description="<html>The maximum number of consecutive newlines within a block of variable<br/>definitions.<br/><br/>0 = No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_var_def_blk_in="
@@ -4318,7 +4318,7 @@ ValueDefault=0
 
 [Nl Before Access Spec]
 Category=4
-Description="<html>The number of newlines before an access specifier label. This also includes<br/>the Qt-specific 'signals:' and 'slots:'. Will not change the newline count<br/>if after a brace open.<br/><br/>0 = No change.</html>"
+Description="<html>The number of newlines before an access specifier label. This also includes<br/>the Qt-specific 'signals:' and 'slots:'. Will not change the newline count<br/>if after a brace open.<br/><br/>0 = No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_before_access_spec="
@@ -4328,7 +4328,7 @@ ValueDefault=0
 
 [Nl After Access Spec]
 Category=4
-Description="<html>The number of newlines after an access specifier label. This also includes<br/>the Qt-specific 'signals:' and 'slots:'. Will not change the newline count<br/>if after a brace open.<br/><br/>0 = No change.<br/><br/>Overrides nl_typedef_blk_start and nl_var_def_blk_start.</html>"
+Description="<html>The number of newlines after an access specifier label. This also includes<br/>the Qt-specific 'signals:' and 'slots:'. Will not change the newline count<br/>if after a brace open.<br/><br/>0 = No change (default).<br/><br/>Overrides nl_typedef_blk_start and nl_var_def_blk_start.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_after_access_spec="
@@ -4338,7 +4338,7 @@ ValueDefault=0
 
 [Nl Comment Func Def]
 Category=4
-Description="<html>The number of newlines between a function definition and the function<br/>comment, as in '// comment\n &lt;here&gt; void foo() {...}'.<br/><br/>0 = No change.</html>"
+Description="<html>The number of newlines between a function definition and the function<br/>comment, as in '// comment\n &lt;here&gt; void foo() {...}'.<br/><br/>0 = No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_comment_func_def="
@@ -4348,7 +4348,7 @@ ValueDefault=0
 
 [Nl After Try Catch Finally]
 Category=4
-Description="<html>The number of newlines after a try-catch-finally block that isn't followed<br/>by a brace close.<br/><br/>0 = No change.</html>"
+Description="<html>The number of newlines after a try-catch-finally block that isn't followed<br/>by a brace close.<br/><br/>0 = No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_after_try_catch_finally="
@@ -4358,7 +4358,7 @@ ValueDefault=0
 
 [Nl Around Cs Property]
 Category=4
-Description="<html>(C#) The number of newlines before and after a property, indexer or event<br/>declaration.<br/><br/>0 = No change.</html>"
+Description="<html>(C#) The number of newlines before and after a property, indexer or event<br/>declaration.<br/><br/>0 = No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_around_cs_property="
@@ -4368,7 +4368,7 @@ ValueDefault=0
 
 [Nl Between Get Set]
 Category=4
-Description="<html>(C#) The number of newlines between the get/set/add/remove handlers.<br/><br/>0 = No change.</html>"
+Description="<html>(C#) The number of newlines between the get/set/add/remove handlers.<br/><br/>0 = No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_between_get_set="
@@ -4413,7 +4413,7 @@ ValueDefault=false
 
 [Nl Remove Extra Newlines]
 Category=4
-Description="<html>How aggressively to remove extra newlines not in preprocessor.<br/><br/>0: No change<br/>1: Remove most newlines not handled by other config<br/>2: Remove all newlines and reformat completely by config</html>"
+Description="<html>How aggressively to remove extra newlines not in preprocessor.<br/><br/>0: No change (default)<br/>1: Remove most newlines not handled by other config<br/>2: Remove all newlines and reformat completely by config</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_remove_extra_newlines="
@@ -4638,7 +4638,7 @@ ValueDefault=false
 
 [Align Func Params Span]
 Category=7
-Description="<html>The span for aligning parameter definitions in function on parameter name.<br/><br/>0 = Don't align (default)</html>"
+Description="<html>The span for aligning parameter definitions in function on parameter name.<br/><br/>0 = Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_func_params_span="
@@ -4676,7 +4676,7 @@ ValueDefault=false
 
 [Align Var Def Span]
 Category=7
-Description="<html>The span for aligning variable definitions.<br/><br/>0 = Don't align (default)</html>"
+Description="<html>The span for aligning variable definitions.<br/><br/>0 = Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_var_def_span="
@@ -4686,7 +4686,7 @@ ValueDefault=0
 
 [Align Var Def Star Style]
 Category=7
-Description="<html>How to align the '*' in variable definitions.<br/><br/>0: Part of the type     'void *   foo;'<br/>1: Part of the variable 'void     *foo;'<br/>2: Dangling             'void    *foo;'</html>"
+Description="<html>How to align the '*' in variable definitions.<br/><br/>0: Part of the type     'void *   foo;' (default)<br/>1: Part of the variable 'void     *foo;'<br/>2: Dangling             'void    *foo;'</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_var_def_star_style="
@@ -4696,7 +4696,7 @@ ValueDefault=0
 
 [Align Var Def Amp Style]
 Category=7
-Description="<html>How to align the '&amp;' in variable definitions.<br/><br/>0: Part of the type     'long &amp;   foo;'<br/>1: Part of the variable 'long     &amp;foo;'<br/>2: Dangling             'long    &amp;foo;'</html>"
+Description="<html>How to align the '&amp;' in variable definitions.<br/><br/>0: Part of the type     'long &amp;   foo;' (default)<br/>1: Part of the variable 'long     &amp;foo;'<br/>2: Dangling             'long    &amp;foo;'</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_var_def_amp_style="
@@ -4780,7 +4780,7 @@ ValueDefault=0
 
 [Align Assign Decl Func]
 Category=7
-Description="<html>How to apply align_assign_span to function declaration "assignments", i.e.<br/>'virtual void foo() = 0' or '~foo() = {default|delete}'.<br/><br/>0: Align with other assignments<br/>1: Align with each other, ignoring regular assignments<br/>2: Don't align</html>"
+Description="<html>How to apply align_assign_span to function declaration "assignments", i.e.<br/>'virtual void foo() = 0' or '~foo() = {default|delete}'.<br/><br/>0: Align with other assignments (default)<br/>1: Align with each other, ignoring regular assignments<br/>2: Don't align</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_assign_decl_func="
@@ -4900,7 +4900,7 @@ ValueDefault=0
 
 [Align Typedef Func]
 Category=7
-Description="<html>How to align typedef'd functions with other typedefs.<br/><br/>0: Don't mix them at all<br/>1: Align the open parenthesis with the types<br/>2: Align the function type name with the other type names</html>"
+Description="<html>How to align typedef'd functions with other typedefs.<br/><br/>0: Don't mix them at all (default)<br/>1: Align the open parenthesis with the types<br/>2: Align the function type name with the other type names</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_typedef_func="
@@ -4910,7 +4910,7 @@ ValueDefault=0
 
 [Align Typedef Star Style]
 Category=7
-Description="<html>How to align the '*' in typedefs.<br/><br/>0: Align on typedef type, ignore '*'<br/>1: The '*' is part of type name: 'typedef int  *pint;'<br/>2: The '*' is part of the type, but dangling: 'typedef int *pint;'</html>"
+Description="<html>How to align the '*' in typedefs.<br/><br/>0: Align on typedef type, ignore '*' (default)<br/>1: The '*' is part of type name: 'typedef int  *pint;'<br/>2: The '*' is part of the type, but dangling: 'typedef int *pint;'</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_typedef_star_style="
@@ -4920,7 +4920,7 @@ ValueDefault=0
 
 [Align Typedef Amp Style]
 Category=7
-Description="<html>How to align the '&amp;' in typedefs.<br/><br/>0: Align on typedef type, ignore '&amp;'<br/>1: The '&amp;' is part of type name: 'typedef int  &amp;pint;'<br/>2: The '&amp;' is part of the type, but dangling: 'typedef int &amp;pint;'</html>"
+Description="<html>How to align the '&amp;' in typedefs.<br/><br/>0: Align on typedef type, ignore '&amp;' (default)<br/>1: The '&amp;' is part of type name: 'typedef int  &amp;pint;'<br/>2: The '&amp;' is part of the type, but dangling: 'typedef int &amp;pint;'</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_typedef_amp_style="
@@ -5136,7 +5136,7 @@ ValueDefault=0
 
 [Cmt Reflow Mode]
 Category=8
-Description="<html>How to reflow comments.<br/><br/>0: No reflowing (apart from the line wrapping due to cmt_width)<br/>1: No touching at all<br/>2: Full reflow</html>"
+Description="<html>How to reflow comments.<br/><br/>0: No reflowing (apart from the line wrapping due to cmt_width) (default)<br/>1: No touching at all<br/>2: Full reflow</html>"
 Enabled=false
 EditorType=numeric
 CallName="cmt_reflow_mode="


### PR DESCRIPTION
Make some minor changes to option documentation to further improve consistency. In particular, when we enumerate possible option values, always mark the default, and always end the stand-alone `0 = ...` with a period.