### PR TITLE
Also suppress option_enum.cpp warning on VS

### DIFF
--- a/src/option_enum.cpp.in
+++ b/src/option_enum.cpp.in
@@ -10,7 +10,9 @@
 #include <strings.h>  // strcasecmp()
 #endif
 
-#ifdef __GNUC__
+#if defined(_MSC_VER)
+#pragma warning(disable: 4809)
+#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wswitch-bool"
 #endif
 


### PR DESCRIPTION
Tweak the logic in `option_enum.cpp.in` to suppress warnings about "superfluous" `default` case in `switch` (which aren't, entirely; they could still trip if an invalid value is coerced into an enumeration) to also suppress the warning when using the Visual Studio compiler.

~~Attempts to fix #2068. (Please check CI to verify.)~~
Fixes #2068.