### PR TITLE
Fix configure with CMake < 3.x

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,10 +20,11 @@ if (NOT ENABLE_CODECOVERAGE)
   list(APPEND test_suites staging.test)
 endif()
 
-option("UNCRUSTIFY_SEPARATE_TESTS"
-  "Create a separate CTest test for each test case;\
-\ this is slower, especially with Python 3" OFF
+set(stdoc
+  "Create a separate CTest test for each test case"
+  " this is slower, especially with Python 3"
 )
+option("UNCRUSTIFY_SEPARATE_TESTS" "${stdoc}" OFF)
 if (UNCRUSTIFY_SEPARATE_TESTS)
   set(tests_ctest_file "${CMAKE_CURRENT_BINARY_DIR}/tests.cmake")
   set_property(DIRECTORY PROPERTY TEST_INCLUDE_FILE ${tests_ctest_file})


### PR DESCRIPTION
Fiddle with how we specify an option's documentation to pacify older versions of CMake. (Apparently, CMake ≥ 3.x supports a greater range of escape sequences than CMake < 3.x; 2.8.12 didn't like the clever way I was specifying a documentation string that needed to span multiple lines while trying to keep the indentation less ugly. Fortunately, the string naturally breaks at a `;`, which allows a reasonably nice way to build the documentation string in a separate `set()` to be passed to `option()`. While I have not attempted to determine the exact CMake version cutoff, I suspect it is 3.0 due to introduction of raw string literals as of that version.)

Fixes #2082.