### PR TITLE
correct the type of token by a catch... when statement

### DIFF
--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1157,7 +1157,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       return(options::sp_cpp_cast_paren());
    }
 
-   if (chunk_is_token(first, CT_PAREN_CLOSE) && chunk_is_token(second, CT_WHEN))
+   if (chunk_is_token(first, CT_SPAREN_CLOSE) && chunk_is_token(second, CT_WHEN))
    {
       log_rule("FORCE");
       return(IARF_FORCE); // TODO: make this configurable?

--- a/tests/input/cs/exception-filters.cs
+++ b/tests/input/cs/exception-filters.cs
@@ -24,7 +24,7 @@ try {
 }
 try {
   int a = (int)when.foo();
-} catch (Exception e) when (DateTime.Now.DayOfWeek == DayOfWeek.Saturday)
+} catch (Exception e)when (DateTime.Now.DayOfWeek == DayOfWeek.Saturday)
 {
   string b = ((int)when.prop).ToString();
 }}}


### PR DESCRIPTION
} catch (Exception e) when (DateTime.Now.DayOfWeek == DayOfWeek.Saturday)
The type must be CT_SPAREN_CLOSE