### PR TITLE
D language has the same syntax

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -580,8 +580,7 @@ void align_struct_initializers(void)
    {
       chunk_t *prev = chunk_get_prev_ncnl(pc);
       if (  chunk_is_token(prev, CT_ASSIGN)
-         && (  chunk_is_token(pc, CT_BRACE_OPEN)
-            || (language_is_set(LANG_D) && chunk_is_token(pc, CT_SQUARE_OPEN))))
+         && chunk_is_token(pc, CT_BRACE_OPEN))
       {
          align_init_brace(pc);
       }


### PR DESCRIPTION
A extra condition for D is not necessary.
Ref. https://dlang.org/spec/struct.html
Static Initialization of Structs
```.d
struct S { int a, b, c, d = 7; }
S s = { a:1, b:2 };           // s.a = 1, s.b = 2, s.c = 0, s.d = 7
```