### PR TITLE
Fix indent_align_paren doc

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -1384,7 +1384,7 @@ indent_preserve_sql;
 extern Option<bool>
 indent_align_assign; // = true
 
-// Whether to align continued statements at the '('. If false or the '(' is not
+// Whether to align continued statements at the '('. If false or the '(' is
 // followed by a newline, the next line indent is one tab.
 extern Option<bool>
 indent_align_paren; // = true

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1122,7 +1122,7 @@ indent_preserve_sql             = false    # true/false
 # Default: true
 indent_align_assign             = true     # true/false
 
-# Whether to align continued statements at the '('. If false or the '(' is not
+# Whether to align continued statements at the '('. If false or the '(' is
 # followed by a newline, the next line indent is one tab.
 #
 # Default: true

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1122,7 +1122,7 @@ indent_preserve_sql             = false    # true/false
 # Default: true
 indent_align_assign             = true     # true/false
 
-# Whether to align continued statements at the '('. If false or the '(' is not
+# Whether to align continued statements at the '('. If false or the '(' is
 # followed by a newline, the next line indent is one tab.
 #
 # Default: true

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1122,7 +1122,7 @@ indent_preserve_sql             = false    # true/false
 # Default: true
 indent_align_assign             = true     # true/false
 
-# Whether to align continued statements at the '('. If false or the '(' is not
+# Whether to align continued statements at the '('. If false or the '(' is
 # followed by a newline, the next line indent is one tab.
 #
 # Default: true

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2587,7 +2587,7 @@ ValueDefault=true
 
 [Indent Align Paren]
 Category=2
-Description="<html>Whether to align continued statements at the '('. If false or the '(' is not<br/>followed by a newline, the next line indent is one tab.<br/><br/>Default: true</html>"
+Description="<html>Whether to align continued statements at the '('. If false or the '(' is<br/>followed by a newline, the next line indent is one tab.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_align_paren=true|indent_align_paren=false


### PR DESCRIPTION
Fix a minor (but important) error in the documentation of `indent_align_paren`, which had a "not" that shouldn't be there.

Based on the documentation for `indent_align_asign` (and also expectation), I think this is correct. However, in testing, the option didn't seem to have any effect?