### PR TITLE
Add sp_inside_angle_empty

### DIFF
--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -22,6 +22,7 @@ sp_before_byref                 = force
 sp_after_byref                  = remove
 sp_before_angle                 = remove
 sp_inside_angle                 = remove
+sp_inside_angle_empty           = remove
 sp_after_angle                  = force
 sp_angle_paren                  = remove
 sp_angle_paren_empty            = remove

--- a/src/options.h
+++ b/src/options.h
@@ -306,6 +306,10 @@ sp_before_angle;
 extern Option<iarf_e>
 sp_inside_angle;
 
+// Add or remove space inside '<>'.
+extern Option<iarf_e>
+sp_inside_angle_empty;
+
 // Add or remove space between '>' and ':'.
 extern Option<iarf_e>
 sp_angle_colon;

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -933,8 +933,17 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    }
 
    // spacing around template < > stuff
-   if (chunk_is_token(first, CT_ANGLE_OPEN) || chunk_is_token(second, CT_ANGLE_CLOSE))
+   if (  chunk_is_token(first, CT_ANGLE_OPEN)
+      || chunk_is_token(second, CT_ANGLE_CLOSE))
    {
+      if (  chunk_is_token(first, CT_ANGLE_OPEN)
+         && chunk_is_token(second, CT_ANGLE_CLOSE))
+      {
+         log_rule("sp_inside_angle_empty");
+
+         return(options::sp_inside_angle_empty());
+      }
+
       log_rule("sp_inside_angle");
 
       iarf_e op = options::sp_inside_angle();

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 657 options and minimal documentation.
+There are currently 658 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -56,6 +56,7 @@ sp_before_template_paren        = ignore
 sp_template_angle               = ignore
 sp_before_angle                 = ignore
 sp_inside_angle                 = ignore
+sp_inside_angle_empty           = ignore
 sp_angle_colon                  = ignore
 sp_after_angle                  = ignore
 sp_angle_paren                  = ignore

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -225,6 +225,9 @@ sp_before_angle                 = ignore   # ignore/add/remove/force
 # Add or remove space inside '<' and '>'.
 sp_inside_angle                 = ignore   # ignore/add/remove/force
 
+# Add or remove space inside '<>'.
+sp_inside_angle_empty           = ignore   # ignore/add/remove/force
+
 # Add or remove space between '>' and ':'.
 sp_angle_colon                  = ignore   # ignore/add/remove/force
 

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -56,6 +56,7 @@ sp_before_template_paren        = ignore
 sp_template_angle               = ignore
 sp_before_angle                 = ignore
 sp_inside_angle                 = ignore
+sp_inside_angle_empty           = ignore
 sp_angle_colon                  = ignore
 sp_after_angle                  = ignore
 sp_angle_paren                  = ignore

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -225,6 +225,9 @@ sp_before_angle                 = ignore   # ignore/add/remove/force
 # Add or remove space inside '<' and '>'.
 sp_inside_angle                 = ignore   # ignore/add/remove/force
 
+# Add or remove space inside '<>'.
+sp_inside_angle_empty           = ignore   # ignore/add/remove/force
+
 # Add or remove space between '>' and ':'.
 sp_angle_colon                  = ignore   # ignore/add/remove/force
 

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -225,6 +225,9 @@ sp_before_angle                 = ignore   # ignore/add/remove/force
 # Add or remove space inside '<' and '>'.
 sp_inside_angle                 = ignore   # ignore/add/remove/force
 
+# Add or remove space inside '<>'.
+sp_inside_angle_empty           = ignore   # ignore/add/remove/force
+
 # Add or remove space between '>' and ':'.
 sp_angle_colon                  = ignore   # ignore/add/remove/force
 

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -526,6 +526,15 @@ Choices=sp_inside_angle=ignore|sp_inside_angle=add|sp_inside_angle=remove|sp_ins
 ChoicesReadable="Ignore Sp Inside Angle|Add Sp Inside Angle|Remove Sp Inside Angle|Force Sp Inside Angle"
 ValueDefault=ignore
 
+[Sp Inside Angle Empty]
+Category=1
+Description="<html>Add or remove space inside '&lt;&gt;'.</html>"
+Enabled=false
+EditorType=multiple
+Choices=sp_inside_angle_empty=ignore|sp_inside_angle_empty=add|sp_inside_angle_empty=remove|sp_inside_angle_empty=force
+ChoicesReadable="Ignore Sp Inside Angle Empty|Add Sp Inside Angle Empty|Remove Sp Inside Angle Empty|Force Sp Inside Angle Empty"
+ValueDefault=ignore
+
 [Sp Angle Colon]
 Category=1
 Description="<html>Add or remove space between '&gt;' and ':'.</html>"

--- a/tests/config/ben_014.cfg
+++ b/tests/config/ben_014.cfg
@@ -10,6 +10,7 @@ sp_after_ptr_star               = remove
 sp_before_byref                 = remove
 sp_before_angle                 = remove
 sp_inside_angle                 = remove
+sp_inside_angle_empty           = remove
 sp_angle_paren_empty            = remove
 sp_angle_word                   = force
 sp_inside_square                = remove

--- a/tests/config/template_sp-force.cfg
+++ b/tests/config/template_sp-force.cfg
@@ -7,6 +7,7 @@ sp_after_byref                  = force
 sp_template_angle               = remove
 sp_before_angle                 = force
 sp_inside_angle                 = force
+sp_inside_angle_empty           = force
 sp_after_angle                  = force
 sp_angle_paren                  = force
 sp_angle_paren_empty            = force

--- a/tests/config/template_sp-remove.cfg
+++ b/tests/config/template_sp-remove.cfg
@@ -6,6 +6,7 @@ sp_before_byref                 = remove
 sp_after_byref                  = force
 sp_before_angle                 = remove
 sp_inside_angle                 = remove
+sp_inside_angle_empty           = remove
 sp_after_angle                  = remove
 sp_angle_paren_empty            = remove
 sp_inside_braces_struct         = force


### PR DESCRIPTION
Add new option to control space inside empty `<>`, to allow omitting space here while space would otherwise be added. This mirrors many similar options, e.g. `sp_inside_braces` and `sp_inside_braces_empty`.