### PR TITLE
Add nl_before_class newline before comments

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -4471,6 +4471,11 @@ void do_blank_lines(void)
       {
          chunk_t *tmp = chunk_get_prev_type(prev, CT_CLASS, prev->level);
          tmp = chunk_get_prev_nc(tmp);
+         while (  chunk_is_token(tmp, CT_NEWLINE)
+               && chunk_is_comment(tmp->prev))
+         {
+            tmp = chunk_get_prev_nc(tmp->prev);
+         }
          if (options::nl_before_class() > pc->nl_count)
          {
             blank_line_set(tmp, options::nl_before_class);

--- a/tests/expected/cpp/34001-nl_before_after.h
+++ b/tests/expected/cpp/34001-nl_before_after.h
@@ -15,3 +15,21 @@ public:
 
 } // namespace S
 } // namespace A
+
+namespace B {
+
+// This is a comment!
+class D
+{
+public:
+    D();
+};
+
+} // namespace B
+
+// This is also a comment!
+class E
+{
+public:
+    E();
+};

--- a/tests/input/cpp/nl_before_after.h
+++ b/tests/input/cpp/nl_before_after.h
@@ -13,3 +13,19 @@ public:
 };
 } // namespace S
 } // namespace A
+
+namespace B {
+// This is a comment!
+class D
+{
+public:
+    D();
+};
+} // namespace B
+
+// This is also a comment!
+class E
+{
+public:
+    E();
+};


### PR DESCRIPTION
Fix a bug in `nl_before_class` where it would add the newline in between the class and a preceding comment, iff the class (and comment) are in a namespace. This is almost certainly not the "correct" behavior, especially as it differs from the behavior for classes in the global namespace.

Without this change, the updated unit test produces:
```c++
namespace B {
// This is a comment!

class D
{
public:
    D();
};

} // namespace B
```