### PR TITLE
Don't apply nl_func_type_name to ctor prototypes

### DIFF
--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -198,7 +198,7 @@ static chunk_tag_t keywords[] =
    { "error",                           CT_PP_ERROR,         LANG_PAWN | FLAG_PP                                                         }, // PAWN
    { "event",                           CT_TYPE,             LANG_CS                                                                     },
    { "exit",                            CT_FUNCTION,         LANG_PAWN                                                                   }, // PAWN
-   { "explicit",                        CT_TYPE,             LANG_CPP | LANG_CS                                                          },
+   { "explicit",                        CT_QUALIFIER,        LANG_CPP | LANG_CS                                                          },
    { "export",                          CT_EXPORT,           LANG_CPP | LANG_D | LANG_ECMA                                               },
    { "extends",                         CT_QUALIFIER,        LANG_JAVA | LANG_ECMA                                                       },
    { "extern",                          CT_EXTERN,           LANG_C | LANG_CS | LANG_D | LANG_VALA                                       },

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -2388,7 +2388,9 @@ static void newline_func_def_or_call(chunk_t *start)
          const chunk_t *tmp_next = chunk_get_next_ncnl(prev);
          if (tmp_next != nullptr && tmp_next->type != CT_FUNC_CLASS_DEF)
          {
-            iarf_e a = (tmp->parent_type == CT_FUNC_PROTO) ?
+            bool   is_proto = (  tmp->parent_type == CT_FUNC_PROTO
+                              || tmp->parent_type == CT_FUNC_CLASS_PROTO);
+            iarf_e a = (is_proto) ?
                        options::nl_func_proto_type_name() :
                        options::nl_func_type_name();
             if (  (tmp->flags & PCF_IN_CLASS)

--- a/tests/config/nl_func_type_name_mixed.cfg
+++ b/tests/config/nl_func_type_name_mixed.cfg
@@ -1,0 +1,5 @@
+sp_cmt_cpp_start                = add
+nl_func_type_name               = force
+nl_func_proto_type_name         = remove
+align_func_proto_span           = 16
+align_on_operator               = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -272,6 +272,7 @@
 30840  nl_func_type_name_remove.cfg         cpp/nl_func_type_name.cpp
 30841  nl_func_type_name_force.cfg          cpp/nl_func_type_name.cpp
 30842  nl_func_type_name_class.cfg          cpp/nl_func_type_name.cpp
+30843  nl_func_type_name_mixed.cfg          cpp/nl_func_type_name.cpp
 
 30845  ben_026.cfg                          cpp/deref.cpp
 

--- a/tests/expected/cpp/30067-nl_func_type_name.cpp
+++ b/tests/expected/cpp/30067-nl_func_type_name.cpp
@@ -28,6 +28,7 @@ B foo(const B& other)
 class A
 {
 public:
+explicit A(int);
 int aFunct() {
 	return a;
 }

--- a/tests/expected/cpp/30841-nl_func_type_name.cpp
+++ b/tests/expected/cpp/30841-nl_func_type_name.cpp
@@ -33,6 +33,8 @@ foo(const B& other)
 class A
 {
 public:
+explicit
+A(int);
 int
 aFunct() {
 	return a;

--- a/tests/expected/cpp/30842-nl_func_type_name.cpp
+++ b/tests/expected/cpp/30842-nl_func_type_name.cpp
@@ -31,6 +31,7 @@ foo(const B& other)
 class A
 {
 public:
+explicit A(int);
 int aFunct() {
 	return a;
 }

--- a/tests/expected/cpp/30843-nl_func_type_name.cpp
+++ b/tests/expected/cpp/30843-nl_func_type_name.cpp
@@ -12,15 +12,18 @@ public:
 	A&                    operator+(const A& other);
 };
 
-A& A::operator+(const A& other)
+A&
+A::operator+(const A& other)
 {
 }
 
-B operator+(const B& other)
+B
+operator+(const B& other)
 {
 }
 
-B foo(const B& other)
+B
+foo(const B& other)
 {
 }
 
@@ -28,24 +31,28 @@ class A
 {
 public:
 explicit A(int);
-int aFunct() {
+int
+aFunct() {
 	return a;
 }
 int bFunc();
 };
 
 // Another file
-int A::bFunc()
+int
+A::bFunc()
 {
 // some code
 }
 
 template<typename T>
-typename Foo<T>::Type Foo<T>::Func()
+typename Foo<T>::Type
+Foo<T>::Func()
 {
 }
 
-void Foo::bar() {
+void
+Foo::bar() {
 }
 
 namespace foo {
@@ -62,18 +69,21 @@ class Object
 };
 
 template <class T>
-void SampleClassTemplate<T>::connect()
+void
+SampleClassTemplate<T>::connect()
 {
 }
 
 template <>
-inline void bar<MyType>(MyType r)
+inline void
+bar<MyType>(MyType r)
 {
 	foo(r);
 }
 
 template <T>
-inline void baz<>(T r)
+inline void
+baz<>(T r)
 {
 	foo(r);
 }

--- a/tests/input/cpp/nl_func_type_name.cpp
+++ b/tests/input/cpp/nl_func_type_name.cpp
@@ -25,6 +25,7 @@ B foo(const B& other)
 class A
 {
 public:
+explicit A(int);
 int aFunct() { return a; }
 int bFunc();
 };


### PR DESCRIPTION
Fix selection between `nl_func_type_name` and `nl_func_proto_type_name`, which was correctly choosing the latter for regular function prototypes, but incorrectly choosing the former for constructor prototypes. This could lead to incorrectly forcing a newline before `explicit` in certain configurations.