### PR TITLE
Add katepart highlighting file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,14 @@ py_gen(option_enum.cpp
   option_enum.cpp.in
 )
 
+py_gen(../etc/uncrustify.xml
+  make_katehl.py
+  ../etc/uncrustify.xml.in
+  options.h
+  option.h
+  token_enum.h
+)
+
 #
 # Uncrustify
 #
@@ -318,6 +326,13 @@ endif()
 # Generate uncrustify.1
 #
 configure_file(man/uncrustify.1.in uncrustify.1 @ONLY)
+
+#
+# Generate uncrustify.xml (katepart highlighting file)
+#
+add_custom_target(katehl
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/etc/uncrustify.xml
+)
 
 #
 # Tests

--- a/etc/uncrustify.xml.in
+++ b/etc/uncrustify.xml.in
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE language SYSTEM "language.dtd">
+<language name="Uncrustify Configuration" section="Configuration" extensions="uncrustify.cfg;uncrustify.conf;.uncrustify.cfg;.uncrustify.conf" mimetype="" version="0.68" kateversion="2.0" author="Matthew Woehlke (mwoehlke.floss@gmail.com)" license="LGPL">
+
+  <highlighting>
+    <list name="options">
+      ##OPTION_KEYWORDS##
+    </list>
+    <list name="values">
+      ##VALUE_KEYWORDS##
+    </list>
+    <list name="tokens">
+      ##TOKEN_TYPE_KEYWORDS##
+    </list>
+    <list name="directives">
+      <item>file_ext</item>
+      <item>include</item>
+      <item>macro-close</item>
+      <item>macro-else</item>
+      <item>macro-open</item>
+      <item>type</item>
+    </list>
+
+    <contexts>
+      <context name="Root" attribute="Normal Text" lineEndContext="#stay">
+        <WordDetect context="SetDirective" attribute="Directive" String="set" />
+        <keyword context="Values" attribute="Directive" String="directives" />
+        <keyword context="Values" attribute="Option" String="options" />
+        <keyword context="Values" attribute="Token" String="tokens" />
+        <DetectChar context="Comment" attribute="Comment" char="#" />
+      </context>
+
+      <context name="Values" attribute="String" lineEndContext="#pop" >
+        <DetectSpaces attribute="Normal Text" />
+        <RegExpr contex="#stay" attribute="Number" String="-?[0-9]+" />
+        <keyword contex="#stay" attribute="Value" String="values" />
+        <DetectChar context="#stay" attribute="Assignment" char="=" />
+        <DetectChar context="StringSQ" attribute="String" char="'" />
+        <DetectChar context="StringDQ" attribute="String" char="&quot;" />
+        <DetectChar context="Comment" attribute="Comment" char="#" />
+      </context>
+
+      <context name="StringSQ" attribute="String" lineEndContext="Error" >
+        <RegExpr context="#stay" attribute="String" String="\\." />
+        <DetectChar context="#pop" attribute="String" char="'" />
+      </context>
+
+      <context name="StringDQ" attribute="String" lineEndContext="Error" >
+        <RegExpr context="#stay" attribute="String" String="\\." />
+        <DetectChar context="#pop" attribute="String" char="&quot;" />
+      </context>
+
+      <context name="SetDirective" attribute="Error" lineEndContext="#pop" >
+        <DetectSpaces attribute="Normal Text" />
+        <keyword context="Values" attribute="Token" String="tokens" />
+      </context>
+
+      <context name="Error" attribute="Error" lineEndContext="#stay" />
+
+      <context name="Comment" attribute="Comment" lineEndContext="#pop">
+        <DetectSpaces />
+        <IncludeRules context="##Alerts" />
+        <DetectIdentifier />
+      </context>
+    </contexts>
+
+    <itemDatas>
+      <itemData name="Normal Text" defStyleNum="dsNormal" />
+      <itemData name="Directive" defStyleNum="dsFunction" />
+      <itemData name="Option" defStyleNum="dsDataType" />
+      <itemData name="Token" defStyleNum="dsChar" />
+      <itemData name="Value" defStyleNum="dsKeyword" />
+      <itemData name="String" defStyleNum="dsString" />
+      <itemData name="Number" defStyleNum="dsDecVal" />
+      <itemData name="Assignment" defStyleNum="dsOthers" />
+      <itemData name="Comment" defStyleNum="dsComment" />
+      <itemData name="Error" defStyleNum="dsError" />
+    </itemDatas>
+  </highlighting>
+
+  <general>
+    <comments>
+      <comment name="singleLine" start="#" />
+    </comments>
+    <keywords casesensitive="0" />
+  </general>
+</language>

--- a/scripts/make_katehl.py
+++ b/scripts/make_katehl.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+
+import argparse
+import io
+import os
+import re
+
+re_token = re.compile(r'^CT_(\w+),')
+re_option = re.compile(r'extern (Bounded)?Option<[^>]+>')
+re_enum_decl = re.compile(r'enum class (\w+)( *// *<(\w+)>)?')
+re_enum_value = re.compile(r'(\w+)(?= *([,=]|//|$))')
+re_aliases = re.compile(r'UNC_OPTVAL_ALIAS\(([^)]+)\)')
+
+options = set()
+values = set()
+tokens = set()
+
+root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+script = os.path.relpath(__file__, root)
+
+
+# -----------------------------------------------------------------------------
+def read_enum(f):
+    global values
+
+    for line in iter(f.readline, ''):
+        line = line.strip()
+
+        if line.startswith('{'):
+            for line in iter(f.readline, ''):
+                line = line.strip()
+
+                if line.startswith('};'):
+                    return
+
+                if 'UNC_INTERNAL' in line:
+                    return
+
+                if 'UNC_CONVERT_INTERNAL' in line:
+                    return
+
+                mv = re_enum_value.match(line)
+                if mv is not None:
+                    values.add(mv.group(1).lower())
+
+
+# -----------------------------------------------------------------------------
+def write_items(out, items):
+    for i in sorted(items):
+        out.write(u'      <item>{}</item>\n'.format(i))
+
+
+# -----------------------------------------------------------------------------
+def write_options(out, args):
+    write_items(out, options)
+
+
+# -----------------------------------------------------------------------------
+def write_values(out, args):
+    write_items(out, values)
+
+
+# -----------------------------------------------------------------------------
+def write_tokens(out, args):
+    write_items(out, tokens)
+
+
+# -----------------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser(description='Generate uncrustify.xml')
+    parser.add_argument('output', type=str,
+                        help='location of uncrustify.xml to write')
+    parser.add_argument('template', type=str,
+                        help='location of uncrustify.xml.in ' +
+                             'to use as template')
+    parser.add_argument('options', type=str,
+                        help='location of options.h to read')
+    parser.add_argument('optvals', type=str,
+                        help='location of option.h to read')
+    parser.add_argument('tokens', type=str,
+                        help='location of token_enum.h to read')
+    args = parser.parse_args()
+
+    # Read options
+    with io.open(args.options, 'rt', encoding='utf-8') as f:
+        global options
+        for line in iter(f.readline, ''):
+            line = line.strip()
+
+            if re_option.match(line):
+                n, d = f.readline().split(';')
+                options.add(n)
+
+    # Read option values
+    with io.open(args.optvals, 'rt', encoding='utf-8') as f:
+        global values
+        for line in iter(f.readline, ''):
+            line = line.strip()
+
+            if re_enum_decl.match(line):
+                read_enum(f)
+                continue
+
+            ma = re_aliases.match(line)
+            if ma:
+                for v in ma.group(1).split(',')[2:]:
+                    v = v.strip()[1:-1]
+                    values.add(v)
+
+    # Read tokens
+    with io.open(args.tokens, 'rt', encoding='utf-8') as f:
+        global tokens
+        for line in iter(f.readline, ''):
+            line = line.strip()
+
+            m = re_token.match(line)
+            if m and not m.group(1).endswith(u'_'):
+                tokens.add(m.group(1).lower())
+
+    # Declare replacements
+    replacements = {
+        u'##OPTION_KEYWORDS##': write_options,
+        u'##VALUE_KEYWORDS##': write_values,
+        u'##TOKEN_TYPE_KEYWORDS##': write_tokens,
+    }
+
+    # Write output file
+    with io.open(args.output, 'wt', encoding='utf-8') as out:
+        with io.open(args.template, 'rt', encoding='utf-8') as t:
+            for line in t:
+                directive = line.strip()
+                if directive in replacements:
+                    replacements[directive](out, args)
+                else:
+                    out.write(line)
+
+# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add a skeleton XML for katepart highlighting. Add a script to generate a "complete" XML given the template. (The script generates several keyword lists from our sources, so that the XML does not need to be updated by hand.) Add a target (not in ALL) to generate the "complete" XML.

I tried to replicate how uncrustify itself parses the config, although it won't flag missing arguments. (I also don't plan to implement compatibility if/when #1815 happens, i.e. renamed options will show up "funny".) Tested locally and seems to work... I won't swear it is 100% bug-free :slightly_smiling_face:, but it should be okay for most users and provide a better experience over INI or whatever silly default HL katepart is choosing these days. (Unfortunately, it doesn't seem to want to use this by default, but that can be worked around by adding a modeline to your config.)

No attempt is made to install the resulting file; it needs to be copied by hand to either the user's local syntax cache, or to the katepart repo. (The expectation is that someone will generate this and copy it into katepart's repository for distribution, not that we will try to distribute it ourselves.)