### PR TITLE
Fix some issues with one-off extern

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -1678,6 +1678,12 @@ static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
          }
 
          prev = chunk_get_prev_ncnl(pc);
+         if (  chunk_is_token(prev, CT_STRING)
+            && prev->parent_type == CT_EXTERN
+            && chunk_is_token(prev->prev, CT_EXTERN))
+         {
+            prev = chunk_get_prev_ncnl(prev->prev);
+         }
          if (chunk_is_token(pc, CT_TYPEDEF))
          {
             // set newlines before typedef block

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -1003,8 +1003,8 @@ static void newlines_func_pre_blank_lines(chunk_t *start, c_token_t start_type)
          || chunk_is_token(pc, CT_QUALIFIER)
          || chunk_is_token(pc, CT_PTR_TYPE)
          || chunk_is_token(pc, CT_DC_MEMBER)
-         || chunk_is_token(pc, CT_TYPE)
-         || chunk_is_token(pc, CT_TYPE))
+         || chunk_is_token(pc, CT_EXTERN)
+         || (chunk_is_token(pc, CT_STRING) && pc->parent_type == CT_EXTERN))
       {
          first_line = pc->orig_line;
          continue;

--- a/tests/config/extern_func.cfg
+++ b/tests/config/extern_func.cfg
@@ -1,0 +1,1 @@
+nl_before_func_body_def         = 2

--- a/tests/config/extern_func.cfg
+++ b/tests/config/extern_func.cfg
@@ -1,1 +1,2 @@
 nl_before_func_body_def         = 2
+nl_var_def_blk_start            = 2

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -540,6 +540,7 @@
 34114  nl_before_func_body_def-2.cfg        cpp/bug_902.cpp
 34115  nl_before_func_body_def-2.cfg        cpp/nl_before_func_body_def.cpp
 34116  nl_before_func_body_def-2.cfg        cpp/issue_2000.cpp
+34117  extern_func.cfg                      cpp/extern_func.cpp
 
 34120  align_assign_span-1.cfg              cpp/bug_i_999.cpp
 34121  bug_1717.cfg                         cpp/bug_1717.cpp

--- a/tests/expected/cpp/34117-extern_func.cpp
+++ b/tests/expected/cpp/34117-extern_func.cpp
@@ -1,0 +1,8 @@
+void foo();
+
+// hello
+extern "C"
+BAR_EXPORT
+void bar()
+{
+}

--- a/tests/input/cpp/extern_func.cpp
+++ b/tests/input/cpp/extern_func.cpp
@@ -1,0 +1,7 @@
+void foo();
+// hello
+extern "C"
+BAR_EXPORT
+void bar()
+{
+}


### PR DESCRIPTION
Fix `is_var_def` and `newlines_func_pre_blank_lines` being confused by a one-off `extern` and not considering it as part of a function prototype or variable declaration, as it should be.

For example, in the following code:
```
void foo();
extern "C"
void bar() {}
```

...affected options (in particular, `nl_before_func_body_def` and `newline_def_blk`) would, without these fixes, try to insert blank lines between the `extern "C"` and `void bar`, when correctly they should be inserting blank lines *before* the `extern "C"`.