### PR TITLE
The alignment at the sign '=' must be divided in different cases.

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -132,6 +132,8 @@ extern Option<iarf_e>
 sp_cpp_lambda_paren;
 
 // Add or remove space around assignment operator '=' in a prototype.
+//
+// If set to ignore, use sp_assign.
 extern Option<iarf_e>
 sp_assign_default;
 
@@ -2611,6 +2613,12 @@ align_var_def_inline;
 // 0 = Don't align (default).
 extern BoundedOption<unsigned, 0, 5000>
 align_assign_span;
+
+// The span for aligning on '=' in function prototype modifier.
+//
+// 0 = Don't align (default).
+extern BoundedOption<unsigned, 0, 5000>
+align_assign_func_proto;
 
 // The threshold for aligning on '=' in assignments.
 //

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -817,6 +817,23 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       return(options::sp_assign());
    }
 
+   if (chunk_is_token(second, CT_ASSIGN_DEFAULT_ARG))
+   {
+      if (  (options::sp_assign_default() != IARF_IGNORE)
+         && second->parent_type == CT_FUNC_PROTO)
+      {
+         log_rule("sp_assign_default");
+         return(options::sp_assign_default());
+      }
+      if (options::sp_before_assign() != IARF_IGNORE)
+      {
+         log_rule("sp_before_assign");
+         return(options::sp_before_assign());
+      }
+      log_rule("sp_assign");
+      return(options::sp_assign());
+   }
+
    if (chunk_is_token(first, CT_ASSIGN))
    {
       if (first->flags & PCF_IN_ENUM)
@@ -829,6 +846,23 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_enum_assign");
          return(options::sp_enum_assign());
       }
+      if (  (options::sp_assign_default() != IARF_IGNORE)
+         && first->parent_type == CT_FUNC_PROTO)
+      {
+         log_rule("sp_assign_default");
+         return(options::sp_assign_default());
+      }
+      if (options::sp_after_assign() != IARF_IGNORE)
+      {
+         log_rule("sp_after_assign");
+         return(options::sp_after_assign());
+      }
+      log_rule("sp_assign");
+      return(options::sp_assign());
+   }
+
+   if (chunk_is_token(first, CT_ASSIGN_DEFAULT_ARG))
+   {
       if (  (options::sp_assign_default() != IARF_IGNORE)
          && first->parent_type == CT_FUNC_PROTO)
       {

--- a/src/token_enum.h
+++ b/src/token_enum.h
@@ -85,6 +85,14 @@ enum c_token_t
    CT_ASSIGN,              // =, +=, /=, etc
    CT_ASSIGN_NL,           // Assign followed by a newline - fake item for indenting
    CT_SASSIGN,             // 'and_eq'
+
+   CT_ASSIGN_DEFAULT_ARG,  // Default argument such as
+                           // Foo( int Foo = 5 );
+   CT_ASSIGN_FUNC_PROTO,   // function prototype modifier such as
+                           // void* operator new(std::size_t) = delete;
+                           // Foo( const Foo & ) = default;
+                           // Foo( const Foo & ) = 0;
+
    CT_COMPARE,             // ==, !=, <=, >=
    CT_SCOMPARE,            // compare op that is a string 'is', 'neq'
    CT_BOOL,                // || or &&
@@ -154,6 +162,8 @@ enum c_token_t
    CT_NEW,              // may turn into CT_PBRACED if followed by a '('
    CT_OPERATOR,
    CT_OPERATOR_VAL,
+   CT_ASSIGN_OPERATOR,  // the value after 'operator' such as:
+                        // Foo &operator= ( const Foo & );
    CT_ACCESS,
    CT_ACCESS_COLON,
    CT_THROW,

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 662 options and minimal documentation.
+There are currently x options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -541,6 +541,7 @@ align_var_def_colon_gap         = 0
 align_var_def_attribute         = false
 align_var_def_inline            = false
 align_assign_span               = 0
+align_assign_func_proto         = 0
 align_assign_thresh             = 0
 align_assign_decl_func          = 0
 align_enum_equ_span             = 0

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -86,6 +86,8 @@ sp_cpp_lambda_assign            = ignore   # ignore/add/remove/force
 sp_cpp_lambda_paren             = ignore   # ignore/add/remove/force
 
 # Add or remove space around assignment operator '=' in a prototype.
+#
+# If set to ignore, use sp_assign.
 sp_assign_default               = ignore   # ignore/add/remove/force
 
 # Add or remove space before assignment operator '=', '+=', etc.
@@ -2099,6 +2101,11 @@ align_var_def_inline            = false    # true/false
 #
 # 0 = Don't align (default).
 align_assign_span               = 0        # unsigned number
+
+# The span for aligning on '=' in function prototype modifier.
+#
+# 0 = Don't align (default).
+align_assign_func_proto         = 0        # unsigned number
 
 # The threshold for aligning on '=' in assignments.
 #

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -541,6 +541,7 @@ align_var_def_colon_gap         = 0
 align_var_def_attribute         = false
 align_var_def_inline            = false
 align_assign_span               = 0
+align_assign_func_proto         = 0
 align_assign_thresh             = 0
 align_assign_decl_func          = 0
 align_enum_equ_span             = 0

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -86,6 +86,8 @@ sp_cpp_lambda_assign            = ignore   # ignore/add/remove/force
 sp_cpp_lambda_paren             = ignore   # ignore/add/remove/force
 
 # Add or remove space around assignment operator '=' in a prototype.
+#
+# If set to ignore, use sp_assign.
 sp_assign_default               = ignore   # ignore/add/remove/force
 
 # Add or remove space before assignment operator '=', '+=', etc.
@@ -2099,6 +2101,11 @@ align_var_def_inline            = false    # true/false
 #
 # 0 = Don't align (default).
 align_assign_span               = 0        # unsigned number
+
+# The span for aligning on '=' in function prototype modifier.
+#
+# 0 = Don't align (default).
+align_assign_func_proto         = 0        # unsigned number
 
 # The threshold for aligning on '=' in assignments.
 #

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -86,6 +86,8 @@ sp_cpp_lambda_assign            = ignore   # ignore/add/remove/force
 sp_cpp_lambda_paren             = ignore   # ignore/add/remove/force
 
 # Add or remove space around assignment operator '=' in a prototype.
+#
+# If set to ignore, use sp_assign.
 sp_assign_default               = ignore   # ignore/add/remove/force
 
 # Add or remove space before assignment operator '=', '+=', etc.
@@ -2099,6 +2101,11 @@ align_var_def_inline            = false    # true/false
 #
 # 0 = Don't align (default).
 align_assign_span               = 0        # unsigned number
+
+# The span for aligning on '=' in function prototype modifier.
+#
+# 0 = Don't align (default).
+align_assign_func_proto         = 0        # unsigned number
 
 # The threshold for aligning on '=' in assignments.
 #

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -178,7 +178,7 @@ ValueDefault=ignore
 
 [Sp Assign Default]
 Category=1
-Description="<html>Add or remove space around assignment operator '=' in a prototype.</html>"
+Description="<html>Add or remove space around assignment operator '=' in a prototype.<br/><br/>If set to ignore, use sp_assign.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_assign_default=ignore|sp_assign_default=add|sp_assign_default=remove|sp_assign_default=force
@@ -4829,6 +4829,16 @@ Description="<html>The span for aligning on '=' in assignments.<br/><br/>0 = Don
 Enabled=false
 EditorType=numeric
 CallName="align_assign_span="
+MinVal=0
+MaxVal=5000
+ValueDefault=0
+
+[Align Assign Func Proto]
+Category=7
+Description="<html>The span for aligning on '=' in function prototype modifier.<br/><br/>0 = Don't align (default).</html>"
+Enabled=false
+EditorType=numeric
+CallName="align_assign_func_proto="
 MinVal=0
 MaxVal=5000
 ValueDefault=0

--- a/tests/cli/test_cli_options.py
+++ b/tests/cli/test_cli_options.py
@@ -513,7 +513,8 @@ def main(args):
             out_result_path=s_path_join(sc_dir, 'results/help.txt'),
             out_result_manip=[
                 string_replace(' --mtime      : Preserve mtime on replaced files.\n', ''),
-                string_replace('.exe', '')
+                string_replace('.exe', ''),
+                reg_replace(r'currently \d+ options', 'currently x options')
             ]):
         return_flag = False
 

--- a/tests/config/DefaultAndDelete-0.cfg
+++ b/tests/config/DefaultAndDelete-0.cfg
@@ -1,0 +1,6 @@
+indent_columns         = 3
+indent_with_tabs       = 0
+#
+align_assign_decl_func = 0
+#
+align_assign_span      = 6

--- a/tests/config/DefaultAndDelete-1.cfg
+++ b/tests/config/DefaultAndDelete-1.cfg
@@ -1,0 +1,6 @@
+indent_columns         = 3
+indent_with_tabs       = 0
+#
+align_assign_decl_func = 1
+#
+align_assign_span      = 6

--- a/tests/config/DefaultAndDelete-2.cfg
+++ b/tests/config/DefaultAndDelete-2.cfg
@@ -1,0 +1,6 @@
+indent_columns         = 3
+indent_with_tabs       = 0
+#
+align_assign_decl_func = 2
+#
+align_assign_span      = 6

--- a/tests/config/Issue_2170.cfg
+++ b/tests/config/Issue_2170.cfg
@@ -1,2 +1,2 @@
-align_assign_span      = 3
+align_assign_span      = 1
 align_assign_decl_func = 1

--- a/tests/config/align_assign_decl_func-0.cfg
+++ b/tests/config/align_assign_decl_func-0.cfg
@@ -1,2 +1,2 @@
-align_assign_span               = 3
-align_assign_decl_func          = 0                                            #
+align_assign_span      = 3
+align_assign_decl_func = 0

--- a/tests/config/align_assign_decl_func-2.cfg
+++ b/tests/config/align_assign_decl_func-2.cfg
@@ -1,2 +1,2 @@
-align_assign_span               = 3
-align_assign_decl_func          = 2
+align_assign_span      = 3
+align_assign_decl_func = 2

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -220,6 +220,11 @@
 30741  al.cfg                               cpp/al.cpp
 30742  indent_columns-2.cfg                 cpp/delete.cpp
 
+30745  Issue_2170.cfg                       cpp/Issue_2170.cpp
+30746  DefaultAndDelete-0.cfg               cpp/DefaultAndDelete.cpp
+30747  DefaultAndDelete-1.cfg               cpp/DefaultAndDelete.cpp
+30748  DefaultAndDelete-2.cfg               cpp/DefaultAndDelete.cpp
+
 # TODO: Reduce the number of options, leave only those that affect lambda.
 # TODO: Add tests for nested lambdas.
 

--- a/tests/expected/cpp/30744-Issue_2170.cpp
+++ b/tests/expected/cpp/30744-Issue_2170.cpp
@@ -1,0 +1,8 @@
+class Foo
+{
+public:
+Foo( int bar = 1 );
+Foo( const Foo & )             = delete;
+Foo &operator= ( const Foo & ) = delete;
+~Foo();
+};

--- a/tests/expected/cpp/30745-Issue_2170.cpp
+++ b/tests/expected/cpp/30745-Issue_2170.cpp
@@ -1,0 +1,8 @@
+class Foo
+{
+public:
+Foo( int bar = 1 );
+Foo( const Foo & )             = delete;
+Foo &operator= ( const Foo & ) = delete;
+~Foo();
+};

--- a/tests/expected/cpp/30746-DefaultAndDelete.cpp
+++ b/tests/expected/cpp/30746-DefaultAndDelete.cpp
@@ -1,0 +1,12 @@
+class Foo
+{
+public:
+Foo( int bar)                  = 0;
+Foo( int bar                   = 777 );
+Foo( const Foo & )             = delete;
+Foo( int boo )                 = default;
+Foo( unsigned int )            = default;
+Foo( unsigned int boo          =999 );
+Foo &operator= ( const Foo & ) = delete;
+~Foo();
+};

--- a/tests/expected/cpp/30747-DefaultAndDelete.cpp
+++ b/tests/expected/cpp/30747-DefaultAndDelete.cpp
@@ -1,0 +1,12 @@
+class Foo
+{
+public:
+Foo( int bar)                  = 0;
+Foo( int bar         = 777 );
+Foo( const Foo & )             = delete;
+Foo( int boo )                 = default;
+Foo( unsigned int )            = default;
+Foo( unsigned int boo=999 );
+Foo &operator= ( const Foo & ) = delete;
+~Foo();
+};

--- a/tests/expected/cpp/30748-DefaultAndDelete.cpp
+++ b/tests/expected/cpp/30748-DefaultAndDelete.cpp
@@ -1,0 +1,12 @@
+class Foo
+{
+public:
+Foo( int bar) = 0;
+Foo( int bar = 777 );
+Foo( const Foo & ) = delete;
+Foo( int boo ) = default;
+Foo( unsigned int ) = default;
+Foo( unsigned int boo=999 );
+Foo &operator= ( const Foo & ) = delete;
+~Foo();
+};

--- a/tests/expected/cpp/34297-align-assign-mixed.cpp
+++ b/tests/expected/cpp/34297-align-assign-mixed.cpp
@@ -2,10 +2,10 @@ class X16
 {
 X16()                        = delete;
 public:
-void z(int x                 = 0);
+void z(int x   = 0);
 virtual void f(int x, int y) = 0;
 int hhi = 9;
-void g(int x                 = 0);
+void g(int x   = 0);
 int i   = 9;
-void x(int ggs               = 0);
+void x(int ggs = 0);
 };

--- a/tests/expected/cpp/34298-align-assign-mixed.cpp
+++ b/tests/expected/cpp/34298-align-assign-mixed.cpp
@@ -6,6 +6,6 @@ void z(int x   = 0);
 virtual void f(int x, int y) = 0;
 int hhi = 9;
 void g(int x   = 0);
-int i   = 9;
+int i = 9;
 void x(int ggs = 0);
 };

--- a/tests/input/cpp/DefaultAndDelete.cpp
+++ b/tests/input/cpp/DefaultAndDelete.cpp
@@ -1,0 +1,12 @@
+class Foo
+{ 
+  public:
+    Foo( int bar)=0;
+    Foo( int bar = 777 );
+    Foo( const Foo & ) = delete;
+    Foo( int boo ) =default;
+    Foo( unsigned int ) =default;
+    Foo( unsigned int boo=999 );
+    Foo &operator= ( const Foo & ) = delete;
+    ~Foo();
+};

--- a/tests/input/cpp/Issue_2170.cpp
+++ b/tests/input/cpp/Issue_2170.cpp
@@ -1,0 +1,8 @@
+class Foo
+{
+  public:
+    Foo( int bar = 1 );
+    Foo( const Foo & ) = delete;
+    Foo &operator= ( const Foo & ) = delete;
+    ~Foo();
+};


### PR DESCRIPTION
Case  **CT_ASSIGN**
        The most common case such as:
```.cpp
        a = 1;
        bbb = 13;
```

Case  **CT_ASSIGN_DEFAULT_ARG**
        The default value for an argument such as:
```.cpp
        Foo( int Foo = 5 );
```

Case  **CT_ASSIGN_FUNC_PROTO**
        The function prototype modifier such as:
```.cpp
        void* operator new(std::size_t) = delete;
        Foo( const Foo & ) = default;
        Foo( const Foo & ) = 0;
```

Introduce the new option align_assign_func_proto

Ref. #1340, #2170