### PR TITLE
Respect --no-backup

### DIFF
--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -249,8 +249,8 @@ void usage(const char *argv0)
            "\n"
            "Errors are always dumped to stderr\n"
            "\n"
-           "The '-f' and '-o' options may not be used with '-F', '--replace' or '--no-backup'.\n"
-           "The '--prefix' and '--suffix' options may not be used with '--replace' or '--no-backup'.\n"
+           "The '-f' and '-o' options may not be used with '-F' or '--replace'.\n"
+           "The '--prefix' and '--suffix' options may not be used with '--replace'.\n"
            "\n"
            "Basic Options:\n"
            " -c CFG       : Use the config file CFG.\n"
@@ -265,7 +265,7 @@ void usage(const char *argv0)
            " --suffix SFX : Append SFX to the output filename. The default is '.uncrustify'\n"
            " --prefix PFX : Prepend PFX to the output filename path.\n"
            " --replace    : Replace source files (creates a backup).\n"
-           " --no-backup  : Replace files, no backup. Useful if files are under source control.\n"
+           " --no-backup  : Do not create backup and md5 files. Useful if files are under source control.\n"
            " --if-changed : Write to stdout (or create output FILE) only if a change was detected.\n"
 #ifdef HAVE_UTIME_H
            " --mtime      : Preserve mtime on replaced files.\n"
@@ -637,7 +637,7 @@ int main(int argc, char *argv[])
 
    if (!cpd.do_check)
    {
-      if (replace || no_backup)
+      if (replace)
       {
          if (prefix != nullptr || suffix != nullptr)
          {
@@ -646,7 +646,7 @@ int main(int argc, char *argv[])
          }
          if (source_file != nullptr || output_file != nullptr)
          {
-            usage_error("Cannot use --replace or --no-backup with -f or -o");
+            usage_error("Cannot use --replace with -f or -o");
             return(EX_NOINPUT);
          }
       }

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -13,8 +13,8 @@ the output is dumped to stdout, unless redirected with -o FILE.
 
 Errors are always dumped to stderr
 
-The '-f' and '-o' options may not be used with '-F', '--replace' or '--no-backup'.
-The '--prefix' and '--suffix' options may not be used with '--replace' or '--no-backup'.
+The '-f' and '-o' options may not be used with '-F' or '--replace'.
+The '--prefix' and '--suffix' options may not be used with '--replace'.
 
 Basic Options:
  -c CFG       : Use the config file CFG.
@@ -29,7 +29,7 @@ Basic Options:
  --suffix SFX : Append SFX to the output filename. The default is '.uncrustify'
  --prefix PFX : Prepend PFX to the output filename path.
  --replace    : Replace source files (creates a backup).
- --no-backup  : Replace files, no backup. Useful if files are under source control.
+ --no-backup  : Do not create backup and md5 files. Useful if files are under source control.
  --if-changed : Write to stdout (or create output FILE) only if a change was detected.
  -l           : Language override: C, CPP, D, CS, JAVA, PAWN, OC, OC+, VALA.
  -t           : Load a file with types (usually not needed).


### PR DESCRIPTION
Trust the user when it asks for no backup files,
especially when it also configures input and output files,
even if that would mean that it will replace the input file
without having a backup file.  The `--no-backup` option is
recommended to be used under VCS but in any case, the user
should know what he is doing.  Addresses issue #2174.