### PR TITLE
Fix suppression of -Wswitch-bool

### DIFF
--- a/src/option_enum.cpp.in
+++ b/src/option_enum.cpp.in
@@ -12,7 +12,7 @@
 
 #if defined(_MSC_VER)
 #pragma warning(disable: 4809)
-#elif defined(__GNUC__)
+#elif __GNUC__ > 4 || __clang_major__ > 3 || __clang_minor__ > 4
 #pragma GCC diagnostic ignored "-Wswitch-bool"
 #endif
 


### PR DESCRIPTION
Tweak the preprocessor conditional around the pragma to suppress `-Wswitch-bool` to check for a sufficiently new compiler. This should avoid an unknown pragma warning when building with very old GCC (4.x) or clang (3.4.x or earlier).

Fixes #2190.