### PR TITLE
The wrong value is used

### DIFF
--- a/src/option.h
+++ b/src/option.h
@@ -220,7 +220,7 @@ protected:
          OptionWarning w{ this };
          w("requested value %ld for option %s "
            "is greater than the maximum value %ld",
-           val, this->name(), static_cast<long>(min));
+           val, this->name(), static_cast<long>(max));
          return(false);
       }
       return(true);


### PR DESCRIPTION
The max value must be used