### PR TITLE
Fix sp_after_type evaluation

### DIFF
--- a/src/space.cpp
+++ b/src/space.cpp
@@ -2077,7 +2077,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    {
       iarf_e arg = options::sp_after_type();
       log_rule("sp_after_type");
-      return((arg != IARF_REMOVE) ? arg : IARF_FORCE);
+      return(arg);
    }
 
    if (  chunk_is_token(first, CT_MACRO_OPEN)

--- a/tests/config/2203.cfg
+++ b/tests/config/2203.cfg
@@ -1,0 +1,1 @@
+sp_after_type = Remove

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -680,6 +680,8 @@
 34303  nl_fdef_brace_cond-fr.cfg            cpp/nl_fdef_brace_cond-fr.cpp
 34304  nl_fdef_brace_cond-rf.cfg            cpp/nl_fdef_brace_cond-rf.cpp
 
+34307 2203.cfg                              cpp/2203.cpp
+
 # Adopt some UT tests
 10000  empty.cfg                            cpp/621_this-spacing.cpp
 10001  empty.cfg                            cpp/622_ifdef-indentation.cpp

--- a/tests/expected/cpp/34307-2203.cpp
+++ b/tests/expected/cpp/34307-2203.cpp
@@ -1,0 +1,1 @@
+using Foo = std::function<void(const bool)>;

--- a/tests/input/cpp/2203.cpp
+++ b/tests/input/cpp/2203.cpp
@@ -1,0 +1,1 @@
+using Foo = std::function<void (const bool)>;


### PR DESCRIPTION
When was the sp_after_type set to remove, it was always silently reset to force.