### PR TITLE
Correct indentation for multi namespace.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,7 @@ set(uncrustify_sources
   src/compat_win32.cpp
   src/detect.cpp
   src/enum_cleanup.cpp
+  src/flag_parens.cpp
   src/indent.cpp
   src/keywords.cpp
   src/lang_pawn.cpp
@@ -323,6 +324,7 @@ set(uncrustify_headers
   src/chunk_list.h
   src/enum_cleanup.h
   src/enum_flags.h
+  src/flag_parens.h
   src/language_tools.h
   src/ListManager.h
   src/logger.h

--- a/src/flag_parens.cpp
+++ b/src/flag_parens.cpp
@@ -1,0 +1,67 @@
+/**
+ * @file flag_parens.cpp
+ *
+ * @author  Guy Maurel
+ * @license GPL v2+
+ */
+
+#include "flag_parens.h"
+#include "uncrustify.h"
+
+
+chunk_t *flag_parens(chunk_t *po, UINT64 flags, c_token_t opentype, c_token_t parenttype, bool parent_all)
+{
+   LOG_FUNC_ENTRY();
+   chunk_t *paren_close;
+
+   paren_close = chunk_skip_to_match(po, scope_e::PREPROC);
+   if (paren_close == nullptr)
+   {
+      LOG_FMT(LERR, "%s(%d): no match for '%s' at [%zu:%zu]",
+              __func__, __LINE__, po->text(), po->orig_line, po->orig_col);
+      log_func_stack_inline(LERR);
+      cpd.error_count++;
+      return(nullptr);
+   }
+
+   LOG_FMT(LFLPAREN, "%s(%d): between  po is '%s', orig_line is %zu, orig_col is %zu, and\n",
+           __func__, __LINE__, po->text(), po->orig_line, po->orig_col);
+   LOG_FMT(LFLPAREN, "%s(%d): paren_close is '%s', orig_line is %zu, orig_col is %zu, type is %s, parent_type is %s\n",
+           __func__, __LINE__, paren_close->text(), paren_close->orig_line, paren_close->orig_col,
+           get_token_name(opentype), get_token_name(parenttype));
+   log_func_stack_inline(LFLPAREN);
+
+   // the last chunk must be also modified. Issue #2149
+   chunk_t *after_paren_close = chunk_get_next(paren_close);
+   if (po != paren_close)
+   {
+      if (  flags != 0
+         || (parent_all && parenttype != CT_NONE))
+      {
+         chunk_t *pc;
+         for (pc = chunk_get_next(po, scope_e::PREPROC);
+              pc != nullptr && pc != after_paren_close;
+              pc = chunk_get_next(pc, scope_e::PREPROC))
+         {
+            chunk_flags_set(pc, flags);
+            if (parent_all)
+            {
+               set_chunk_parent(pc, parenttype);
+            }
+         }
+      }
+
+      if (opentype != CT_NONE)
+      {
+         set_chunk_type(po, opentype);
+         set_chunk_type(paren_close, (c_token_t)(opentype + 1));
+      }
+
+      if (parenttype != CT_NONE)
+      {
+         set_chunk_parent(po, parenttype);
+         set_chunk_parent(paren_close, parenttype);
+      }
+   }
+   return(chunk_get_next_ncnl(paren_close, scope_e::PREPROC));
+} // flag_parens

--- a/src/flag_parens.h
+++ b/src/flag_parens.h
@@ -1,0 +1,28 @@
+/**
+ * @file flag_parens.h
+ *
+ * @author  Guy Maurel
+ * @license GPL v2+
+ */
+
+#ifndef FLAG_PARENS_H_INCLUDED
+#define FLAG_PARENS_H_INCLUDED
+
+#include "chunk_list.h"
+
+
+/**
+ * Flags everything from the open paren to the close paren.
+ *
+ * @param po          Pointer to the open parenthesis
+ * @param flags       flags to add
+ * @param opentype
+ * @param parenttype
+ * @param parent_all
+ *
+ * @return The token after the close paren
+ */
+chunk_t *flag_parens(chunk_t *po, UINT64 flags, c_token_t opentype, c_token_t parenttype, bool parent_all);
+
+
+#endif /* FLAG_PARENS_H_INCLUDED */

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1185,8 +1185,9 @@ void indent_text(void)
          && !chunk_is_comment(pc)
          && log_sev_on(LINDPC))
       {
-         LOG_FMT(LINDPC, " -=[ %zu:%zu %s ]=-\n",
-                 pc->orig_line, pc->orig_col, pc->text());
+         LOG_FMT(LINDPC, "%s(%d):\n", __func__, __LINE__);
+         LOG_FMT(LINDPC, " -=[ pc->orig_line is %zu, orig_col is %zu %s ]=-, frm.size() is %zu\n",
+                 pc->orig_line, pc->orig_col, pc->text(), frm.size());
          for (size_t ttidx = frm.size() - 1; ttidx > 0; ttidx--)
          {
             LOG_FMT(LINDPC, "     [%zu %zu:%zu %s %s/%s tmp=%zu ind=%zu bri=%zu tab=%zu cont=%d lvl=%zu blvl=%zu]\n",

--- a/src/options.h
+++ b/src/options.h
@@ -1174,6 +1174,7 @@ extern Option<bool>
 indent_namespace_single_indent;
 
 // The number of spaces to indent a namespace block.
+// If set to zero, use the value indent_columns
 extern BoundedOption<unsigned, 0, 16>
 indent_namespace_level;
 

--- a/src/unc_tools.h
+++ b/src/unc_tools.h
@@ -1,8 +1,8 @@
 /**
  * @file unc_tools.h
  *
- * @author  Guy Maurel since version 0.62 for uncrustify4Qt
- *          October 2015, 2016
+ * @author  Guy Maurel
+ *          October 2015, 2016, 2017, 2018, 2019
  * @license GPL v2+
  */
 

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -946,6 +946,7 @@ indent_namespace                = false    # true/false
 indent_namespace_single_indent  = false    # true/false
 
 # The number of spaces to indent a namespace block.
+# If set to zero, use the value indent_columns
 indent_namespace_level          = 0        # unsigned number
 
 # If the body of the namespace is longer than this number, it won't be

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -946,6 +946,7 @@ indent_namespace                = false    # true/false
 indent_namespace_single_indent  = false    # true/false
 
 # The number of spaces to indent a namespace block.
+# If set to zero, use the value indent_columns
 indent_namespace_level          = 0        # unsigned number
 
 # If the body of the namespace is longer than this number, it won't be

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -946,6 +946,7 @@ indent_namespace                = false    # true/false
 indent_namespace_single_indent  = false    # true/false
 
 # The number of spaces to indent a namespace block.
+# If set to zero, use the value indent_columns
 indent_namespace_level          = 0        # unsigned number
 
 # If the body of the namespace is longer than this number, it won't be

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2209,7 +2209,7 @@ ValueDefault=false
 
 [Indent Namespace Level]
 Category=2
-Description="<html>The number of spaces to indent a namespace block.</html>"
+Description="<html>The number of spaces to indent a namespace block.<br/>If set to zero, use the value indent_columns</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_namespace_level="

--- a/tests/config/Issue_1813.cfg
+++ b/tests/config/Issue_1813.cfg
@@ -1,0 +1,11 @@
+indent_columns                  = 2
+indent_with_tabs                = 0
+indent_namespace                = true
+indent_namespace_single_indent  = true
+
+#The number of spaces to indent a namespace block.
+#indent_namespace_level         =
+
+#Whether to indent only the first namespace, and not any nested namespaces.
+#Requires indent_namespace=true.
+indent_namespace_single_indent  = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -301,6 +301,8 @@
 30902  region-2.cfg                         cpp/region.cpp
 30903  region-3.cfg                         cpp/region.cpp
 
+30908  Issue_1813.cfg                       cpp/Issue_1813-2.cpp
+30909  Issue_1813.cfg                       cpp/Issue_1813-3.cpp
 30910  indent_namespace-t.cfg               cpp/indent_namespace.h
 30911  indent_class-t.cfg                   cpp/indent_namespace.h
 30912  long_namespace.cfg                   cpp/long_namespace.cpp

--- a/tests/expected/cpp/30908-Issue_1813-2.cpp
+++ b/tests/expected/cpp/30908-Issue_1813-2.cpp
@@ -1,0 +1,11 @@
+namespace n1 {
+namespace n2 {
+
+  void func() {
+    another_func([]() {
+      return 42;
+    });
+  }
+
+}
+}

--- a/tests/expected/cpp/30909-Issue_1813-3.cpp
+++ b/tests/expected/cpp/30909-Issue_1813-3.cpp
@@ -1,0 +1,13 @@
+namespace n1 {
+namespace n2 {
+namespace n3 {
+
+  void func() {
+    another_func([]() {
+      return 42;
+    });
+  }
+
+}
+}
+}

--- a/tests/expected/cpp/30912-long_namespace.cpp
+++ b/tests/expected/cpp/30912-long_namespace.cpp
@@ -6,10 +6,10 @@ namespace boo3 {
 }
 
 namespace boo4 {
-int Fun2()
-{
-	int a = 7;
-	int b = 8;
-	return a+b;
-}
+	int Fun2()
+	{
+		int a = 7;
+		int b = 8;
+		return a+b;
+	}
 }

--- a/tests/input/cpp/Issue_1813-2.cpp
+++ b/tests/input/cpp/Issue_1813-2.cpp
@@ -1,0 +1,11 @@
+namespace n1 {
+   namespace n2 {
+
+ void func() {
+           another_func([]() {
+         return 42;
+                     });
+       }
+
+           }
+   }

--- a/tests/input/cpp/Issue_1813-3.cpp
+++ b/tests/input/cpp/Issue_1813-3.cpp
@@ -1,0 +1,13 @@
+namespace n1 {
+                 namespace n2 {
+      namespace n3 {
+
+        void func() {
+      another_func([]() {
+                                     return 42;
+          });
+    }
+
+    }
+    }
+    }


### PR DESCRIPTION
Ref. #1813 
Test of the option indent_namespace_single_indent must be earlier.