### PR TITLE
Added the align_func_proto_thresh option

### DIFF
--- a/src/align_func_proto.cpp
+++ b/src/align_func_proto.cpp
@@ -18,9 +18,11 @@ void align_func_proto(size_t span)
 {
    LOG_FUNC_ENTRY();
 
+   size_t mythresh = 0;
+   mythresh = options::align_func_proto_thresh();
 
    AlignStack as;
-   as.Start(span, 0);
+   as.Start(span, mythresh);
    as.m_gap        = options::align_func_proto_gap();
    as.m_star_style = static_cast<AlignStack::StarStyle>(options::align_var_def_star_style());
    as.m_amp_style  = static_cast<AlignStack::StarStyle>(options::align_var_def_amp_style());

--- a/src/options.h
+++ b/src/options.h
@@ -2770,6 +2770,12 @@ align_func_proto_span;
 extern BoundedOption<unsigned, 0, 16>
 align_func_proto_gap;
 
+// The threshold for aligning function prototypes.
+//
+// 0 = No limit (default).
+extern BoundedOption<unsigned, 0, 5000>
+align_func_proto_thresh;
+
 // Whether to align function prototypes on the 'operator' keyword instead of
 // what follows.
 extern Option<bool>

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -567,6 +567,7 @@ align_right_cmt_gap             = 0
 align_right_cmt_at_col          = 0
 align_func_proto_span           = 0
 align_func_proto_gap            = 0
+align_func_proto_thresh         = 0
 align_on_operator               = false
 align_mix_var_proto             = false
 align_single_line_func          = false

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -2232,6 +2232,11 @@ align_func_proto_span           = 0        # unsigned number
 # Minimum gap between the return type and the function name.
 align_func_proto_gap            = 0        # unsigned number
 
+# The threshold for aligning function prototypes.
+#
+# 0 = No limit (default).
+align_func_proto_thresh         = 0        # unsigned number
+
 # Whether to align function prototypes on the 'operator' keyword instead of
 # what follows.
 align_on_operator               = false    # true/false

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -567,6 +567,7 @@ align_right_cmt_gap             = 0
 align_right_cmt_at_col          = 0
 align_func_proto_span           = 0
 align_func_proto_gap            = 0
+align_func_proto_thresh         = 0
 align_on_operator               = false
 align_mix_var_proto             = false
 align_single_line_func          = false

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -2232,6 +2232,11 @@ align_func_proto_span           = 0        # unsigned number
 # Minimum gap between the return type and the function name.
 align_func_proto_gap            = 0        # unsigned number
 
+# The threshold for aligning function prototypes.
+#
+# 0 = No limit (default).
+align_func_proto_thresh         = 0        # unsigned number
+
 # Whether to align function prototypes on the 'operator' keyword instead of
 # what follows.
 align_on_operator               = false    # true/false

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -2232,6 +2232,11 @@ align_func_proto_span           = 0        # unsigned number
 # Minimum gap between the return type and the function name.
 align_func_proto_gap            = 0        # unsigned number
 
+# The threshold for aligning function prototypes.
+#
+# 0 = No limit (default).
+align_func_proto_thresh         = 0        # unsigned number
+
 # Whether to align function prototypes on the 'operator' keyword instead of
 # what follows.
 align_on_operator               = false    # true/false

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -5086,6 +5086,16 @@ MinVal=0
 MaxVal=16
 ValueDefault=0
 
+[Align Func Proto Thresh]
+Category=7
+Description="<html>The threshold for aligning function prototypes.<br/><br/>0 = No limit (default).</html>"
+Enabled=false
+EditorType=numeric
+CallName="align_func_proto_thresh="
+MinVal=0
+MaxVal=5000
+ValueDefault=0
+
 [Align On Operator]
 Category=7
 Description="<html>Whether to align function prototypes on the 'operator' keyword instead of<br/>what follows.</html>"

--- a/tests/config/align_func_proto_thresh_1.cfg
+++ b/tests/config/align_func_proto_thresh_1.cfg
@@ -1,0 +1,2 @@
+align_func_proto_span           = 4
+align_func_proto_thresh         = 0

--- a/tests/config/align_func_proto_thresh_2.cfg
+++ b/tests/config/align_func_proto_thresh_2.cfg
@@ -1,0 +1,2 @@
+align_func_proto_span           = 4
+align_func_proto_thresh         = 15

--- a/tests/config/align_func_proto_thresh_3.cfg
+++ b/tests/config/align_func_proto_thresh_3.cfg
@@ -1,0 +1,2 @@
+align_func_proto_span           = 2
+align_func_proto_thresh         = 5

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -697,6 +697,10 @@
 34309 issue_2209.cfg                        cpp/issue_2209-1.cpp
 34310 issue_2209.cfg                        cpp/issue_2209-2.cpp
 
+34315 align_func_proto_thresh_1.cfg        cpp/align_func_proto_thresh.cpp
+34316 align_func_proto_thresh_2.cfg        cpp/align_func_proto_thresh.cpp
+34317 align_func_proto_thresh_3.cfg        cpp/align_func_proto_thresh.cpp
+
 # Adopt some UT tests
 10000  empty.cfg                            cpp/621_this-spacing.cpp
 10001  empty.cfg                            cpp/622_ifdef-indentation.cpp

--- a/tests/expected/cpp/34315-align_func_proto_thresh.cpp
+++ b/tests/expected/cpp/34315-align_func_proto_thresh.cpp
@@ -1,0 +1,17 @@
+class AlignFuncProtoTest {
+public:
+void                                                test1();
+void                                                test2();
+SomeLongType                                        findSomeLongType();
+void*                                               test3();
+void test4(){
+	a=1;
+}
+double                                              test5();
+void                                                test6();
+SomeLongNamespace::OtherLongNamespace::SomeLongType findSomeLongType();
+void                                                test7();
+void                                                test8();
+void                                                test9();
+SomeLongNamespace::SomeLongType long_var;
+}

--- a/tests/expected/cpp/34316-align_func_proto_thresh.cpp
+++ b/tests/expected/cpp/34316-align_func_proto_thresh.cpp
@@ -1,0 +1,17 @@
+class AlignFuncProtoTest {
+public:
+void         test1();
+void         test2();
+SomeLongType findSomeLongType();
+void*        test3();
+void test4(){
+	a=1;
+}
+double       test5();
+void         test6();
+SomeLongNamespace::OtherLongNamespace::SomeLongType findSomeLongType();
+void         test7();
+void         test8();
+void         test9();
+SomeLongNamespace::SomeLongType long_var;
+}

--- a/tests/expected/cpp/34317-align_func_proto_thresh.cpp
+++ b/tests/expected/cpp/34317-align_func_proto_thresh.cpp
@@ -1,0 +1,17 @@
+class AlignFuncProtoTest {
+public:
+void  test1();
+void  test2();
+SomeLongType findSomeLongType();
+void* test3();
+void test4(){
+	a=1;
+}
+double test5();
+void   test6();
+SomeLongNamespace::OtherLongNamespace::SomeLongType findSomeLongType();
+void   test7();
+void   test8();
+void   test9();
+SomeLongNamespace::SomeLongType long_var;
+}

--- a/tests/input/cpp/align_func_proto_thresh.cpp
+++ b/tests/input/cpp/align_func_proto_thresh.cpp
@@ -1,0 +1,15 @@
+class AlignFuncProtoTest {
+  public:
+  void test1();
+  void test2();
+            SomeLongType findSomeLongType();
+  void* test3();
+  void test4(){ a=1;}
+  double test5();
+  void test6();
+            SomeLongNamespace::OtherLongNamespace::SomeLongType findSomeLongType();
+  void test7();
+  void test8();
+  void test9();
+                     SomeLongNamespace::SomeLongType       long_var;
+}


### PR DESCRIPTION
When aligning function prototype that have very long return type
it can result in all prototype function names to be indented very
far. This option limits this.

Ref. #2173