### PR TITLE
comma is inserted after preproc directive

### DIFF
--- a/src/enum_cleanup.cpp
+++ b/src/enum_cleanup.cpp
@@ -32,7 +32,7 @@ void enum_cleanup(void)
       {
          LOG_FMT(LTOK, "%s(%d): orig_line is %zu, type is %s\n",
                  __func__, __LINE__, pc->orig_line, get_token_name(pc->type));
-         chunk_t *prev = chunk_get_prev_ncnl(pc);
+         chunk_t *prev = chunk_get_prev_ncnlnp(pc);
          // test of (prev == nullptr) is not necessary
          if (chunk_is_token(prev, CT_COMMA))
          {

--- a/tests/c.test
+++ b/tests/c.test
@@ -376,6 +376,7 @@
 09614  empty.cfg                            c/string_prefixes.c
 09615  i1564.cfg                            c/i1564.c
 
+09616  enum_comma_ifdef.cfg                 c/enum_comma_ifdef.c
 
 10005  empty.cfg                            c/i1270.c
 

--- a/tests/config/enum_comma_ifdef.cfg
+++ b/tests/config/enum_comma_ifdef.cfg
@@ -1,0 +1,2 @@
+mod_enum_last_comma = force
+

--- a/tests/expected/c/09616-enum_comma_ifdef.c
+++ b/tests/expected/c/09616-enum_comma_ifdef.c
@@ -1,0 +1,7 @@
+enum A {
+	a,
+	b,
+#ifdef __clang__
+	c,
+#endif
+};

--- a/tests/input/c/enum_comma_ifdef.c
+++ b/tests/input/c/enum_comma_ifdef.c
@@ -1,0 +1,7 @@
+enum A {
+  a,
+  b,
+#ifdef __clang__
+  c
+#endif
+};


### PR DESCRIPTION
if `mod_enum_last_comma = force` and last statement of enum is
preprocessor directive, comma is inserted after it