### PR TITLE
Fix alignment of assignment of virtual cons function proto types

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -700,7 +700,9 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       log_pcf_flags(LSYS, pc->flags);
       set_chunk_type(pc, CT_ASSIGN_DEFAULT_ARG);
    }
-   if (  chunk_is_token(prev, CT_FPAREN_CLOSE)
+   if (  (  chunk_is_token(prev, CT_FPAREN_CLOSE)
+         || (  chunk_is_str(prev, "const", 5)
+            && chunk_is_token(prev->prev, CT_FPAREN_CLOSE)))
       && chunk_is_token(pc, CT_ASSIGN)
       && (  chunk_is_token(next, CT_DEFAULT)
          || chunk_is_token(next, CT_DELETE)

--- a/tests/config/align_assign_func_proto_1.cfg
+++ b/tests/config/align_assign_func_proto_1.cfg
@@ -1,0 +1,2 @@
+align_assign_span               = 1
+

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -700,7 +700,8 @@
 34315 align_func_proto_thresh_1.cfg        cpp/align_func_proto_thresh.cpp
 34316 align_func_proto_thresh_2.cfg        cpp/align_func_proto_thresh.cpp
 34317 align_func_proto_thresh_3.cfg        cpp/align_func_proto_thresh.cpp
-
+34318 align_assign_func_proto_1.cfg        cpp/align_assign_func_proto.cpp
+      
 # Adopt some UT tests
 10000  empty.cfg                            cpp/621_this-spacing.cpp
 10001  empty.cfg                            cpp/622_ifdef-indentation.cpp

--- a/tests/expected/cpp/34318-align_assign_func_proto.cpp
+++ b/tests/expected/cpp/34318-align_assign_func_proto.cpp
@@ -1,0 +1,7 @@
+const int *ptr const = 0;
+virtual void f1()       = 0;
+virtual void f2()       = 0;
+virtual void f3() const = 0;
+virtual void f4() const = 0;
+virtual void f5()       = 0;
+virtual void f6()       = 0;

--- a/tests/input/cpp/align_assign_func_proto.cpp
+++ b/tests/input/cpp/align_assign_func_proto.cpp
@@ -1,0 +1,7 @@
+const int *ptr const = 0;
+    virtual void f1()= 0;
+    virtual void f2()= 0;
+    virtual void f3() const = 0;
+    virtual void f4() const = 0;
+      virtual void f5() = 0;
+       virtual void f6()= 0;


### PR DESCRIPTION
Added an additional check for a const preceded by a CT_FPAREN_CLOSE
for alignment of the = 0; for the pure virtual function in cpp.

refs. #2251