### PR TITLE
Fix warning of comparing signed and unsigned it

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -2741,7 +2741,7 @@ align_typedef_amp_style;
 // The span for aligning comments that end lines.
 //
 // 0 = Don't align (default).
-extern BoundedOption<signed, -1000, 5000>
+extern BoundedOption<unsigned, 0, 5000>
 align_right_cmt_span;
 
 // If aligning comments, whether to mix with comments after '}' and #endif with

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -2210,7 +2210,7 @@ align_typedef_amp_style         = 0        # unsigned number
 # The span for aligning comments that end lines.
 #
 # 0 = Don't align (default).
-align_right_cmt_span            = 0        # number
+align_right_cmt_span            = 0        # unsigned number
 
 # If aligning comments, whether to mix with comments after '}' and #endif with
 # less than three spaces before the comment.

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -2210,7 +2210,7 @@ align_typedef_amp_style         = 0        # unsigned number
 # The span for aligning comments that end lines.
 #
 # 0 = Don't align (default).
-align_right_cmt_span            = 0        # number
+align_right_cmt_span            = 0        # unsigned number
 
 # If aligning comments, whether to mix with comments after '}' and #endif with
 # less than three spaces before the comment.

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -2210,7 +2210,7 @@ align_typedef_amp_style         = 0        # unsigned number
 # The span for aligning comments that end lines.
 #
 # 0 = Don't align (default).
-align_right_cmt_span            = 0        # number
+align_right_cmt_span            = 0        # unsigned number
 
 # If aligning comments, whether to mix with comments after '}' and #endif with
 # less than three spaces before the comment.

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -5026,7 +5026,7 @@ Description="<html>The span for aligning comments that end lines.<br/><br/>0 = D
 Enabled=false
 EditorType=numeric
 CallName="align_right_cmt_span="
-MinVal=-1000
+MinVal=0
 MaxVal=5000
 ValueDefault=0
 


### PR DESCRIPTION
This option should not have been changed to unisgned int as
only the thresholds are supporting negative values because of
the aboslute threshold. Reverting the change to
options::align_right_cmt_span

refs. #2257