### PR TITLE
Introduce a new option: nl_func_call_start

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3547,6 +3547,12 @@ void newlines_cleanup_braces(bool first)
          {
             newline_func_def_or_call(pc);
          }
+         else if (  (  pc->parent_type == CT_FUNC_CALL                // Issue #2020
+                    || pc->parent_type == CT_FUNC_CALL_USER)
+                 && options::nl_func_call_start() != IARF_IGNORE)
+         {
+            newline_iarf(pc, options::nl_func_call_start());
+         }
          else if (  (  pc->parent_type == CT_FUNC_CALL
                     || pc->parent_type == CT_FUNC_CALL_USER)
                  && (  (options::nl_func_call_start_multi_line())

--- a/src/options.h
+++ b/src/options.h
@@ -1954,6 +1954,11 @@ nl_func_def_empty;
 extern Option<iarf_e>
 nl_func_call_empty;
 
+// Whether to add a newline after '(' in a function call,
+// has preference over nl_func_call_start_multi_line.
+extern Option<iarf_e>
+nl_func_call_start;
+
 // Whether to add a newline after '(' in a function call if '(' and ')' are in
 // different lines.
 extern Option<bool>

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -414,6 +414,7 @@ nl_func_def_end_multi_line      = false
 nl_func_decl_empty              = ignore
 nl_func_def_empty               = ignore
 nl_func_call_empty              = ignore
+nl_func_call_start              = ignore
 nl_func_call_start_multi_line   = false
 nl_func_call_args_multi_line    = false
 nl_func_call_end_multi_line     = false

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1573,6 +1573,10 @@ nl_func_def_empty               = ignore   # ignore/add/remove/force
 # Add or remove newline between '()' in a function call.
 nl_func_call_empty              = ignore   # ignore/add/remove/force
 
+# Whether to add a newline after '(' in a function call,
+# has preference over nl_func_call_start_multi_line.
+nl_func_call_start              = ignore   # ignore/add/remove/force
+
 # Whether to add a newline after '(' in a function call if '(' and ')' are in
 # different lines.
 nl_func_call_start_multi_line   = false    # true/false

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -414,6 +414,7 @@ nl_func_def_end_multi_line      = false
 nl_func_decl_empty              = ignore
 nl_func_def_empty               = ignore
 nl_func_call_empty              = ignore
+nl_func_call_start              = ignore
 nl_func_call_start_multi_line   = false
 nl_func_call_args_multi_line    = false
 nl_func_call_end_multi_line     = false

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1573,6 +1573,10 @@ nl_func_def_empty               = ignore   # ignore/add/remove/force
 # Add or remove newline between '()' in a function call.
 nl_func_call_empty              = ignore   # ignore/add/remove/force
 
+# Whether to add a newline after '(' in a function call,
+# has preference over nl_func_call_start_multi_line.
+nl_func_call_start              = ignore   # ignore/add/remove/force
+
 # Whether to add a newline after '(' in a function call if '(' and ')' are in
 # different lines.
 nl_func_call_start_multi_line   = false    # true/false

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1573,6 +1573,10 @@ nl_func_def_empty               = ignore   # ignore/add/remove/force
 # Add or remove newline between '()' in a function call.
 nl_func_call_empty              = ignore   # ignore/add/remove/force
 
+# Whether to add a newline after '(' in a function call,
+# has preference over nl_func_call_start_multi_line.
+nl_func_call_start              = ignore   # ignore/add/remove/force
+
 # Whether to add a newline after '(' in a function call if '(' and ')' are in
 # different lines.
 nl_func_call_start_multi_line   = false    # true/false

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -3687,6 +3687,15 @@ Choices=nl_func_call_empty=ignore|nl_func_call_empty=add|nl_func_call_empty=remo
 ChoicesReadable="Ignore Nl Func Call Empty|Add Nl Func Call Empty|Remove Nl Func Call Empty|Force Nl Func Call Empty"
 ValueDefault=ignore
 
+[Nl Func Call Start]
+Category=3
+Description="<html>Whether to add a newline after '(' in a function call,<br/>has preference over nl_func_call_start_multi_line.</html>"
+Enabled=false
+EditorType=multiple
+Choices=nl_func_call_start=ignore|nl_func_call_start=add|nl_func_call_start=remove|nl_func_call_start=force
+ChoicesReadable="Ignore Nl Func Call Start|Add Nl Func Call Start|Remove Nl Func Call Start|Force Nl Func Call Start"
+ValueDefault=ignore
+
 [Nl Func Call Start Multi Line]
 Category=3
 Description="<html>Whether to add a newline after '(' in a function call if '(' and ')' are in<br/>different lines.</html>"

--- a/tests/config/Issue_2020.cfg
+++ b/tests/config/Issue_2020.cfg
@@ -1,0 +1,4 @@
+nl_func_decl_start = remove
+nl_func_def_start  = remove
+nl_func_call_empty = remove
+nl_func_call_start = remove

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -47,7 +47,7 @@
 
 30040  nl_class-r.cfg                       cpp/nl-class.h
 30041  nl_class-a.cfg                       cpp/nl-class.h
-
+30042  Issue_2020.cfg                       cpp/Issue_2020.cpp
 30043  nl_func_call_empty-r.cfg             cpp/nl_func_call_empty.cpp
 30044  nl_func_call_paren_empty-r.cfg       cpp/nl_func_call_paren_empty.cpp
 30045  nl_func_decl_1.cfg                   cpp/nl_func_decl.cpp

--- a/tests/expected/cpp/30042-Issue_2020.cpp
+++ b/tests/expected/cpp/30042-Issue_2020.cpp
@@ -1,0 +1,17 @@
+class X21
+{
+public:
+void f(int p1, int p2);
+};
+
+void
+X21::f(int p1, int p2)
+{
+}
+
+void
+n1()
+{
+	X21 x21;
+	x21.f(111, 122);
+}

--- a/tests/input/cpp/Issue_2020.cpp
+++ b/tests/input/cpp/Issue_2020.cpp
@@ -1,0 +1,20 @@
+class X21
+{
+public:
+void f(
+int p1, int p2);
+};
+
+void
+X21::f(
+int p1, int p2)
+{
+}
+
+void
+n1()
+{
+	X21 x21;
+	x21.f(
+111, 122);
+}


### PR DESCRIPTION
to remove or force a newline within a function call.
Ref. #2020