### PR TITLE
Change mark_class_ctor to Skip Attributes Specifiers

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -5195,6 +5195,9 @@ static void mark_class_ctor(chunk_t *start)
    LOG_FUNC_ENTRY();
 
    chunk_t *pclass = chunk_get_next_ncnl(start, scope_e::PREPROC);
+
+   pclass = skip_attribute_next(pclass);
+
    if (chunk_is_token(pclass, CT_DECLSPEC))  // Issue 1289
    {
       pclass = chunk_get_next_ncnl(pclass);

--- a/tests/config/bug_2285.cfg
+++ b/tests/config/bug_2285.cfg
@@ -1,0 +1,7 @@
+indent_with_tabs                = 0
+indent_columns                  = 4
+indent_continue                 = 4
+nl_constr_colon                 = force
+nl_constr_init_args             = force
+pos_constr_colon                = trail_force
+pos_constr_comma                = trail_force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -704,6 +704,7 @@
 34318 align_assign_func_proto_1.cfg        cpp/align_assign_func_proto.cpp
 34319 align_func_proto_thresh_4.cfg        cpp/align_func_proto_thresh2.cpp
 34320 align_func_proto_thresh_5.cfg        cpp/align_func_proto_thresh2.cpp
+34321 bug_2285.cfg                         cpp/bug_2285.cpp
 
 # Adopt some UT tests
 10000  empty.cfg                            cpp/621_this-spacing.cpp

--- a/tests/expected/cpp/34321-bug_2285.cpp
+++ b/tests/expected/cpp/34321-bug_2285.cpp
@@ -1,0 +1,13 @@
+class __attribute__ ((visibility ("default"))) Test
+{
+public:
+Test() :
+    member1(),
+    member2()
+{
+}
+
+private:
+int member1;
+int member2;
+};

--- a/tests/input/cpp/bug_2285.cpp
+++ b/tests/input/cpp/bug_2285.cpp
@@ -1,0 +1,11 @@
+class __attribute__ ((visibility ("default"))) Test
+{
+public:
+Test() : member1(), member2()
+{
+}
+
+private:
+int member1;
+int member2;
+};


### PR DESCRIPTION
This is the fix to the issue described in #2285. It looks like this was previously fixed for `__declspec` specifiers, but `__attribute__` specifiers still cause `mark_class_ctor` to return prematurely.