### PR TITLE
Fix cast-align warnings in md5.cpp on armhf 

### DIFF
--- a/src/md5.h
+++ b/src/md5.h
@@ -65,7 +65,9 @@ public:
 private:
    UINT32 m_buf[4];
    UINT32 m_bits[2];
-   UINT8  m_in[64];
+   UINT32 m_in32[16];
+   // Alternate view of m_in32
+   UINT8  *m_in8;
    bool   m_need_byteswap;
    bool   m_big_endian;
 


### PR DESCRIPTION
When building this package using GCC for `armhf` platform, the `-Wcast-align` warning is raised on the `(UINT32 *)` casts from `UINT8 *`, because the compiler can't guarantee the access is word-aligned. 

By having the default view of this `m_in` variable be a `UINT32`, and casting the other way to `UINT8` where needed, we get some assurance that `UINT32` accesses are aligned.