### PR TITLE
Label a variable which is define with decltype

### DIFF
--- a/src/align_var_def_brace.cpp
+++ b/src/align_var_def_brace.cpp
@@ -126,7 +126,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
             || (  chunk_is_token(pc, CT_FUNC_DEF)
                && options::align_single_line_func()))
          {
-            LOG_FMT(LAVDB, "%s(%d): add=[%s], orig_line is %zu, orig_col is %zu, level is %zu\n",
+            LOG_FMT(LAVDB, "%s(%d): add = '%s', orig_line is %zu, orig_col is %zu, level is %zu\n",
                     __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col, pc->level);
 
             chunk_t *toadd;

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1008,6 +1008,13 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
                chunk_flags_clr(tmp, PCF_EXPR_START | PCF_STMT_START);
             }
          }
+         else
+         {
+            if (chunk_is_token(tmp, CT_WORD))
+            {
+               chunk_flags_set(tmp, PCF_VAR_1ST_DEF);
+            }
+         }
       }
    }
 

--- a/tests/config/Issue_1923.cfg
+++ b/tests/config/Issue_1923.cfg
@@ -1,0 +1,3 @@
+indent_align_assign = true
+align_assign_span   = 5
+align_var_def_span  = 5

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -405,6 +405,7 @@
 31633  sp_after_decltype-f.cfg              cpp/sp_after_decltype.cpp
 31634  sp_after_decltype-r.cfg              cpp/sp_after_decltype.cpp
 31635  empty.cfg                            cpp/sp_decltype.cpp
+31636  Issue_1923.cfg                       cpp/Issue_1923.cpp
 
 31660  nl_func_var_def_blk-1.cfg            cpp/issue_1919.cpp
 

--- a/tests/expected/cpp/31636-Issue_1923.cpp
+++ b/tests/expected/cpp/31636-Issue_1923.cpp
@@ -1,0 +1,5 @@
+int          x1      = 0;
+foobar       long_x2 = 0;
+foo<int>     x3      = 0;
+int          x4[]    = {1, 2, 3};
+decltype(x1) x5      = 0;

--- a/tests/input/cpp/Issue_1923.cpp
+++ b/tests/input/cpp/Issue_1923.cpp
@@ -1,0 +1,5 @@
+int x1 = 0;
+foobar long_x2 = 0;
+foo<int> x3 = 0;
+int x4[] = {1, 2, 3};
+decltype(x1) x5 = 0;


### PR DESCRIPTION
The statement decltype define a variable, which must be labeled.
Ref. #1923