### PR TITLE
Don't include end "quote" when sorting includes

### DIFF
--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -108,6 +108,16 @@ static int get_chunk_priority(chunk_t *pc)
 }
 
 
+static unc_text chunk_sort_str(chunk_t *pc)
+{
+   if (pc->parent_type == CT_PP_INCLUDE)
+   {
+      return(unc_text{ pc->str, 0, pc->len() - 1 });
+   }
+   return(pc->str);
+}
+
+
 //! Compare two chunks
 static int compare_chunks(chunk_t *pc1, chunk_t *pc2, bool tcare)
 {
@@ -130,8 +140,9 @@ static int compare_chunks(chunk_t *pc1, chunk_t *pc2, bool tcare)
 
       LOG_FMT(LSORT, "text=%s, pc1->len=%zu, line=%zu, column=%zu\n", pc1->text(), pc1->len(), pc1->orig_line, pc1->orig_col);
       LOG_FMT(LSORT, "text=%s, pc2->len=%zu, line=%zu, column=%zu\n", pc2->text(), pc2->len(), pc2->orig_line, pc2->orig_col);
-      size_t min_len = (pc1->len() < pc2->len()) ? pc1->len() : pc2->len();
-      int    ret_val = unc_text::compare(pc1->str, pc2->str, min_len, tcare);
+      auto const &s1     = chunk_sort_str(pc1);
+      auto const &s2     = chunk_sort_str(pc2);
+      int        ret_val = unc_text::compare(s1, s2, std::min(s1.size(), s2.size()), tcare);
       LOG_FMT(LSORT, "ret_val=%d\n", ret_val);
 
       if (ret_val != 0)

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -2034,6 +2034,7 @@ static bool parse_next(tok_ctx &ctx, chunk_t &pc)
          || ((ch == '<') && cpd.in_preproc == CT_PP_INCLUDE))
       {
          parse_string(ctx, pc, unc_isalpha(ch) ? 1 : 0, true);
+         set_chunk_parent(&pc, CT_PP_INCLUDE);
          return(true);
       }
 

--- a/tests/expected/c/02325-sort_include.c
+++ b/tests/expected/c/02325-sort_include.c
@@ -9,3 +9,14 @@
 // should be just bbb
 #include "bbb"
 
+// should be a, aa
+#include "a"
+#include "aa"
+
+// should be a, aa
+#include <a>
+#include <aa>
+
+// should be b, a
+#include "b"
+#include <a>

--- a/tests/input/c/sort_include.c
+++ b/tests/input/c/sort_include.c
@@ -9,3 +9,14 @@
 // should be just bbb
 #include "bbb"
 
+// should be a, aa
+#include "aa"
+#include "a"
+
+// should be a, aa
+#include <aa>
+#include <a>
+
+// should be b, a
+#include <a>
+#include "b"


### PR DESCRIPTION
Tweak sorting behavior so that, when sorting includes, the closing "quote" (double-quote or right-angle-bracket) is not considered. This fixes a bug where shorter strings would be sorted after longer strings, which is contrary to the order one usually expects.

Fixes #2384.