### PR TITLE
Don't match braces of namespace alias

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3739,13 +3739,29 @@ void newlines_cleanup_braces(bool first)
       else if (  chunk_is_token(pc, CT_NAMESPACE)
               && pc->parent_type != CT_USING)
       {
-         // Issue #1235
-         // Issue #2186
-         chunk_t *braceOpen = chunk_get_next_type(pc, CT_BRACE_OPEN, pc->level);
-         LOG_FMT(LNEWLINE, "%s(%d): braceOpen->orig_line is %zu, orig_col is %zu, text() is '%s'\n",
-                 __func__, __LINE__, braceOpen->orig_line, braceOpen->orig_col, braceOpen->text());
-         log_pcf_flags(LNEWLINE, braceOpen->flags);
-         newlines_namespace(pc);
+         // Issue #2387
+         next = chunk_get_next_ncnl(pc);
+         if (next != nullptr)
+         {
+            next = chunk_get_next_ncnl(next);
+            if (!chunk_is_token(next, CT_ASSIGN))
+            {
+               // Issue #1235
+               // Issue #2186
+               chunk_t *braceOpen = chunk_get_next_type(pc, CT_BRACE_OPEN, pc->level);
+               if (!braceOpen)
+               {
+                  // fatal error
+                  LOG_FMT(LERR, "%s(%d): Missing BRACE_OPEN after namespace\n   orig_line is %zu, orig_col is %zu\n",
+                          __func__, __LINE__, pc->orig_line, pc->orig_col);
+                  exit(EXIT_FAILURE);
+               }
+               LOG_FMT(LNEWLINE, "%s(%d): braceOpen->orig_line is %zu, orig_col is %zu, text() is '%s'\n",
+                       __func__, __LINE__, braceOpen->orig_line, braceOpen->orig_col, braceOpen->text());
+               log_pcf_flags(LNEWLINE, braceOpen->flags);
+               newlines_namespace(pc);
+            }
+         }
       }
       else if (chunk_is_token(pc, CT_SQUARE_OPEN))
       {

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -316,6 +316,7 @@
 30916  empty.cfg                            cpp/Issue_1737.cpp
 30917  Issue_2345.cfg                       cpp/Issue_2345-3.cpp
 30918  Issue_2345.cfg                       cpp/Issue_2345-4.cpp
+30919  empty.cfg                            cpp/Issue_2387.cpp
 
 30920  ben_027.cfg                          cpp/indent-off.cpp
 30921  ben_028.cfg                          cpp/variadic-template.h

--- a/tests/expected/cpp/30919-Issue_2387.cpp
+++ b/tests/expected/cpp/30919-Issue_2387.cpp
@@ -1,0 +1,14 @@
+namespace bar
+{
+void none();
+};
+
+void foo()
+{
+	namespace // does not
+	x         // start a
+	        = // namespace
+	          bar;
+
+	x::none();
+}

--- a/tests/input/cpp/Issue_2387.cpp
+++ b/tests/input/cpp/Issue_2387.cpp
@@ -1,0 +1,14 @@
+namespace bar
+{
+void none();
+};
+
+void foo()
+{
+	namespace // does not
+	x         // start a
+	=         // namespace
+	bar;
+
+	x::none();
+}


### PR DESCRIPTION
Tweak the code that tries to match namespace braces to recognize and ignore namespace aliases, which don't have associated braces. Also, check if a brace was found before trying to dereference the matching token.

This fixes a crash if there is no brace anywhere in the input after a namespace or namespace alias. The latter is perfectly valid code, and while the former is malformed, it is better to complain than to crash.

Fixes #2387.