### PR TITLE
Fix dereference operator spacing in C++ macros

### DIFF
--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -546,7 +546,18 @@ static void parse_cleanup(ParseFrame &frm, chunk_t *pc)
             || chunk_is_token(pc, CT_SPAREN_OPEN))
          {
             // Set the parent for parenthesis and change parenthesis type
-            if (frm.top().stage != brace_stage_e::NONE)
+            if (  chunk_is_token(prev, CT_IF)
+               || chunk_is_token(prev, CT_ELSEIF)
+               || chunk_is_token(prev, CT_WHILE)
+               || chunk_is_token(prev, CT_DO)
+               || chunk_is_token(prev, CT_FOR)
+               || chunk_is_token(prev, CT_SWITCH)
+               || chunk_is_token(prev, CT_CATCH)
+               || chunk_is_token(prev, CT_SYNCHRONIZED)
+               || chunk_is_token(prev, CT_D_VERSION)
+               || chunk_is_token(prev, CT_D_VERSION_IF)
+               || chunk_is_token(prev, CT_D_SCOPE)
+               || chunk_is_token(prev, CT_D_SCOPE_IF))
             {
                set_chunk_type(pc, CT_SPAREN_OPEN);
                parent = frm.top().type;

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1734,6 +1734,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
             set_chunk_type(pc,
                            (  (prev->flags & PCF_PUNCTUATOR)
                            && (  !chunk_is_paren_close(prev)
+                              || chunk_is_token(prev, CT_SPAREN_CLOSE)
                               || prev->parent_type == CT_MACRO_FUNC)
                            && prev->type != CT_SQUARE_CLOSE
                            && prev->type != CT_DC_MEMBER) ? CT_DEREF : CT_ARITH);

--- a/tests/config/align_asterisk_after_type_cast.cfg
+++ b/tests/config/align_asterisk_after_type_cast.cfg
@@ -1,0 +1,9 @@
+indent_columns = 4
+output_tab_size = 4
+indent_with_tabs = 0
+
+sp_before_ptr_star = force
+sp_between_ptr_star = remove
+sp_after_ptr_star = remove
+
+sp_after_sparen = force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -781,3 +781,4 @@
 60042  UNI-18777.cfg                        cpp/UNI-18777.cpp
 60043  nl_remove_extra_newlines-1.cfg       cpp/i2033.cpp
 60044  nl_fdef_brace-r__nl_collapse_empty_body-t.cfg  cpp/i2116.cpp
+60045  align_asterisk_after_type_cast.cfg   cpp/align_asterisk_after_type_cast.cpp

--- a/tests/expected/cpp/60045-align_asterisk_after_type_cast.cpp
+++ b/tests/expected/cpp/60045-align_asterisk_after_type_cast.cpp
@@ -1,0 +1,30 @@
+#define MEM_ASSERT1(x) if (!(x)) *(volatile int *)0 = 1
+#define MEM_ASSERT2(x) if (!(x)) *(volatile int *)0 = 1
+#define MEM_ASSERT3(x) if (!(x)) *(volatile int *)0 = 1;
+#define MEM_ASSERT4(x) if (!(x)) *(volatile int *)0 = 1;
+#define MEM_ASSERT5(x) if (!(x)) { *(volatile int *)0 = 1; }
+#define MEM_ASSERT6(x) if (!(x)) { *(volatile int *)0 = 1; }
+
+#define FOO1(x) while (!(x)) { *(volatile int *)0 = 1; }
+#define FOO2(x) while (!(x)) *(volatile int *)0 = 1;
+#define FOO3(x) { *(volatile int *)0 = 1; }
+#define FOO4(x) *(volatile int *)0 = 1;
+#define FOO5(x) for(;;) (!(x)) { *(volatile int *)0 = 1; }
+#define FOO6(x) for(;;) (!(x)) *(volatile int *)0 = 1;
+#define FOO7(x) do { *(volatile int *)0 = 1; } while (false);
+
+void foo1(int x) {
+    if (!(x)) *(volatile int *)0 = 1;
+}
+
+void foo2(int x) {
+    if (!(x)) *(volatile int *)0 = 1;
+}
+
+void foo3(int x) {
+    if (!(x)) { *(volatile int *)0 = 1; }
+}
+
+void foo4(int x) {
+    if (!(x)) { *(volatile int *)0 = 1; }
+}

--- a/tests/input/cpp/align_asterisk_after_type_cast.cpp
+++ b/tests/input/cpp/align_asterisk_after_type_cast.cpp
@@ -1,0 +1,30 @@
+#define MEM_ASSERT1(x) if (!(x)) *  (volatile int *)0 = 1
+#define MEM_ASSERT2(x) if (!(x))*(volatile int*)0 = 1
+#define MEM_ASSERT3(x) if (!(x)) *  (volatile int *)0 = 1;
+#define MEM_ASSERT4(x) if (!(x))*(volatile int*)0 = 1;
+#define MEM_ASSERT5(x) if (!(x)) { *  (volatile int *)0 = 1; }
+#define MEM_ASSERT6(x) if (!(x)) { *(volatile int*)0 = 1; }
+
+#define FOO1(x) while (!(x)) { *  (volatile int*)0 = 1; }
+#define FOO2(x) while (!(x)) *  (volatile int*)0 = 1;
+#define FOO3(x) { *  (volatile int*)0 = 1; }
+#define FOO4(x) *  (volatile int*)0 = 1;
+#define FOO5(x) for(;;) (!(x)) { *  (volatile int*)0 = 1; }
+#define FOO6(x) for(;;) (!(x)) *  (volatile int*)0 = 1;
+#define FOO7(x) do { *  (volatile int*)0 = 1; } while (false);
+
+void foo1(int x) {
+    if (!(x)) *  (volatile int *)0 = 1;
+}
+
+void foo2(int x) {
+    if (!(x))*(volatile int*)0 = 1;
+}
+
+void foo3(int x) {
+    if (!(x)) { *  (volatile int *)0 = 1; }
+}
+
+void foo4(int x) {
+    if (!(x)) { *(volatile int*)0 = 1; }
+}


### PR DESCRIPTION
```c++
#define MEM_ASSERT1(x) if (!(x)) *(volatile int *)0 = 1
```

```
# Uncrustify_d-0.69.0-116-1bc0703-dirty
output_tab_size                 = 4
sp_before_ptr_star              = force
sp_between_ptr_star             = remove
sp_after_ptr_star               = remove
indent_columns                  = 4
indent_with_tabs                = 0
# option(s) with 'not default' value: 6
#
# -=====-
# Line                Tag              Parent          Columns Br/Lvl/pp     Flag   Nl  Text
#   1>            PREPROC[          PP_DEFINE][  1/  1/  2/  0][1/1/0][ 1000e0001][0-0] #
#   1>          PP_DEFINE[               NONE][  2/  2/  8/  0][1/1/0][     10001][0-0]  define
#   1>         MACRO_FUNC[               NONE][  9/  9/ 20/  1][1/1/0][     40001][0-0]         MEM_ASSERT1
#   1>        FPAREN_OPEN[         MACRO_FUNC][ 20/ 20/ 21/  0][1/1/0][ 100000001][0-0]                    (
#   1>               WORD[               NONE][ 21/ 21/ 22/  0][1/2/0][     40011][0-0]                     x
#   1>       FPAREN_CLOSE[         MACRO_FUNC][ 22/ 22/ 23/  0][1/1/0][ 100000011][0-0]                      )
#   1>                 IF[               NONE][ 24/ 24/ 26/  1][1/1/0][         1][0-0]                        if
#   1>        SPAREN_OPEN[                 IF][ 27/ 27/ 28/  1][1/1/0][ 100000001][0-0]                           (
#   1>                NOT[               NONE][ 28/ 28/ 29/  0][1/2/0][ 100040021][0-0]                            !
#   1>         PAREN_OPEN[               NONE][ 29/ 29/ 30/  0][1/2/0][ 100040021][0-0]                             (
#   1>               WORD[               NONE][ 30/ 30/ 31/  0][1/3/0][     40021][0-0]                              x
#   1>        PAREN_CLOSE[               NONE][ 31/ 31/ 32/  0][1/2/0][ 100000021][0-0]                               )
#   1>       SPAREN_CLOSE[                 IF][ 32/ 32/ 33/  0][1/1/0][ 100000001][0-0]                                )
#   1>              ARITH[               NONE][ 34/ 34/ 35/  1][1/1/0][ 100000001][0-0]                                  *
#   1>        SPAREN_OPEN[                 IF][ 37/ 37/ 38/  2][1/1/0][ 100040001][0-0]                                     (
#   1>          QUALIFIER[               NONE][ 38/ 38/ 46/  0][1/2/0][     50021][0-0]                                      volatile
#   1>               TYPE[               NONE][ 47/ 47/ 50/  1][1/2/0][        21][0-0]                                               int
#   1>           PTR_TYPE[               NONE][ 51/ 51/ 52/  1][1/2/0][ 100000021][0-0]                                                   *
#   1>       SPAREN_CLOSE[                 IF][ 52/ 52/ 53/  0][1/1/0][ 100000001][0-0]                                                    )
#   1>             NUMBER[               NONE][ 54/ 53/ 54/  0][1/1/0][     60001][0-0]                                                      0
#   1>             ASSIGN[               NONE][ 56/ 55/ 56/  1][1/1/0][ 100000001][0-0]                                                        =
#   1>             NUMBER[               NONE][ 58/ 57/ 58/  1][1/1/0][     40001][0-0]                                                          1
#   1>            NEWLINE[               NONE][ 59/ 58/  1/  0][0/0/0][         0][1-0]
# -=====-
```

Dereference operator was spaced incorrectly due to following:
1. '*' was treated as CT_ARITH instead of CT_DEREF.
2. '(' for type cast inside 'if' body without braces was treated as
CT_SPAREN_OPEN.