### PR TITLE
Fix indentation of statement which goes after '<<'

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2070,7 +2070,8 @@ void indent_text(void)
           */
          frm.push(*pc);
          if (  chunk_is_newline(chunk_get_prev(pc))
-            && pc->column != indent_column)
+            && pc->column != indent_column
+            && !(pc->flags & PCF_DONT_INDENT))
          {
             LOG_FMT(LINDENT, "%s[line %d]: %zu] indent => %zu [%s]\n",
                     __func__, __LINE__, pc->orig_line, indent_column, pc->text());

--- a/tests/config/align_continuation_left_shift.cfg
+++ b/tests/config/align_continuation_left_shift.cfg
@@ -1,0 +1,3 @@
+indent_columns = 4
+output_tab_size = 4
+indent_with_tabs = 0

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -783,3 +783,4 @@
 60043  nl_remove_extra_newlines-1.cfg       cpp/i2033.cpp
 60044  nl_fdef_brace-r__nl_collapse_empty_body-t.cfg  cpp/i2116.cpp
 60045  align_asterisk_after_type_cast.cfg   cpp/align_asterisk_after_type_cast.cpp
+60046  align_continuation_left_shift.cfg    cpp/align_continuation_left_shift.cpp

--- a/tests/expected/cpp/60046-align_continuation_left_shift.cpp
+++ b/tests/expected/cpp/60046-align_continuation_left_shift.cpp
@@ -1,0 +1,25 @@
+std::string foo(struct tm* local) {
+    std::stringstream timestamp;
+    timestamp <<
+        (local->tm_year + 1900) << "." <<
+        (local->tm_mon + 1) << "." <<
+        local->tm_mday << "-" <<
+        local->tm_hour << "." <<
+        local->tm_min << "." <<
+        local->tm_sec;
+    return timestamp.str();
+}
+
+std::string foo2(struct tm* local) {
+    std::stringstream timestamp;
+    int year = local->tm_year + 1900;
+    int mon = local->tm_mon + 1;
+    timestamp <<
+        year << "." <<
+        mon << "." <<
+        local->tm_mday << "-" <<
+        local->tm_hour << "." <<
+        local->tm_min << "." <<
+        local->tm_sec;
+    return timestamp.str();
+}

--- a/tests/input/cpp/align_continuation_left_shift.cpp
+++ b/tests/input/cpp/align_continuation_left_shift.cpp
@@ -1,0 +1,25 @@
+std::string foo(struct tm* local) {
+    std::stringstream timestamp;
+    timestamp <<
+        (local->tm_year + 1900) << "." <<
+        (local->tm_mon + 1) << "." <<
+        local->tm_mday << "-" <<
+        local->tm_hour << "." <<
+        local->tm_min << "." <<
+        local->tm_sec;
+    return timestamp.str();
+}
+
+std::string foo2(struct tm* local) {
+    std::stringstream timestamp;
+    int year = local->tm_year + 1900;
+    int mon = local->tm_mon + 1;
+    timestamp <<
+        year << "." <<
+        mon << "." <<
+        local->tm_mday << "-" <<
+        local->tm_hour << "." <<
+        local->tm_min << "." <<
+        local->tm_sec;
+    return timestamp.str();
+}


### PR DESCRIPTION
If statement continues on the next line after `<<` and starts with `(`, it's indented incorrectly, i.e.

```c++
void foo() {
    cout <<
        (a + 1);
}
```

turns into

```c++
void foo() {
    cout <<
    (a + 1);
}
```