### PR TITLE
Update our internal config with new lambda options

### DIFF
--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -1,5 +1,6 @@
 # The uncrustify sources are uncrustified with this config file.
-#
+using 0.70
+
 # General options
 output_tab_size                           = 3
 tok_split_gte                             = true
@@ -180,7 +181,9 @@ sp_cond_question_after                    = force
 sp_cond_question_before                   = force
 sp_cpp_before_struct_binding              = remove
 sp_cpp_cast_paren                         = remove
-sp_cpp_lambda_paren                       = remove
+sp_cpp_lambda_square_paren                = remove
+sp_cpp_lambda_square_brace                = force
+sp_cpp_lambda_paren_brace                 = force
 sp_decltype_paren                         = remove
 sp_defined_paren                          = force
 sp_deref                                  = remove


### PR DESCRIPTION
Update the config used to format our own sources to specify that we don't need compatibility with pre-0.70 versions, and to enforce recently added options for styling of C++11 lambdas.

For now, this doesn't affect anything (we have very few lambdas, and it seems they all follow the new rules already), but this will help keep things consistent going forward.