### PR TITLE
Improve option documentation consistency

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -239,7 +239,7 @@ extern Option<iarf_e>
 sp_before_ptr_star;
 
 // Add or remove space before pointer star '*' that isn't followed by a
-// variable name. If set to 'ignore', sp_before_ptr_star is used instead.
+// variable name. If set to ignore, sp_before_ptr_star is used instead.
 extern Option<iarf_e>
 sp_before_unnamed_ptr_star;
 
@@ -279,7 +279,7 @@ extern Option<iarf_e>
 sp_before_byref;
 
 // Add or remove space before a reference sign '&' that isn't followed by a
-// variable name. If set to 'ignore', sp_before_byref is used instead.
+// variable name. If set to ignore, sp_before_byref is used instead.
 extern Option<iarf_e>
 sp_before_unnamed_byref;
 
@@ -669,7 +669,7 @@ extern Option<iarf_e>
 sp_func_call_paren;
 
 // Add or remove space between function name and '()' on function calls without
-// parameters. If set to 'ignore' (the default), sp_func_call_paren is used.
+// parameters. If set to ignore (the default), sp_func_call_paren is used.
 extern Option<iarf_e>
 sp_func_call_paren_empty;
 

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -172,7 +172,7 @@ sp_brace_brace                  = ignore   # ignore/add/remove/force
 sp_before_ptr_star              = ignore   # ignore/add/remove/force
 
 # Add or remove space before pointer star '*' that isn't followed by a
-# variable name. If set to 'ignore', sp_before_ptr_star is used instead.
+# variable name. If set to ignore, sp_before_ptr_star is used instead.
 sp_before_unnamed_ptr_star      = ignore   # ignore/add/remove/force
 
 # Add or remove space between pointer stars '*'.
@@ -203,7 +203,7 @@ sp_before_ptr_star_func         = ignore   # ignore/add/remove/force
 sp_before_byref                 = ignore   # ignore/add/remove/force
 
 # Add or remove space before a reference sign '&' that isn't followed by a
-# variable name. If set to 'ignore', sp_before_byref is used instead.
+# variable name. If set to ignore, sp_before_byref is used instead.
 sp_before_unnamed_byref         = ignore   # ignore/add/remove/force
 
 # Add or remove space after reference sign '&', if followed by a word.
@@ -520,7 +520,7 @@ sp_fparen_dbrace                = ignore   # ignore/add/remove/force
 sp_func_call_paren              = ignore   # ignore/add/remove/force
 
 # Add or remove space between function name and '()' on function calls without
-# parameters. If set to 'ignore' (the default), sp_func_call_paren is used.
+# parameters. If set to ignore (the default), sp_func_call_paren is used.
 sp_func_call_paren_empty        = ignore   # ignore/add/remove/force
 
 # Add or remove space between the user function name and '(' on function

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -172,7 +172,7 @@ sp_brace_brace                  = ignore   # ignore/add/remove/force
 sp_before_ptr_star              = ignore   # ignore/add/remove/force
 
 # Add or remove space before pointer star '*' that isn't followed by a
-# variable name. If set to 'ignore', sp_before_ptr_star is used instead.
+# variable name. If set to ignore, sp_before_ptr_star is used instead.
 sp_before_unnamed_ptr_star      = ignore   # ignore/add/remove/force
 
 # Add or remove space between pointer stars '*'.
@@ -203,7 +203,7 @@ sp_before_ptr_star_func         = ignore   # ignore/add/remove/force
 sp_before_byref                 = ignore   # ignore/add/remove/force
 
 # Add or remove space before a reference sign '&' that isn't followed by a
-# variable name. If set to 'ignore', sp_before_byref is used instead.
+# variable name. If set to ignore, sp_before_byref is used instead.
 sp_before_unnamed_byref         = ignore   # ignore/add/remove/force
 
 # Add or remove space after reference sign '&', if followed by a word.
@@ -520,7 +520,7 @@ sp_fparen_dbrace                = ignore   # ignore/add/remove/force
 sp_func_call_paren              = ignore   # ignore/add/remove/force
 
 # Add or remove space between function name and '()' on function calls without
-# parameters. If set to 'ignore' (the default), sp_func_call_paren is used.
+# parameters. If set to ignore (the default), sp_func_call_paren is used.
 sp_func_call_paren_empty        = ignore   # ignore/add/remove/force
 
 # Add or remove space between the user function name and '(' on function

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -172,7 +172,7 @@ sp_brace_brace                  = ignore   # ignore/add/remove/force
 sp_before_ptr_star              = ignore   # ignore/add/remove/force
 
 # Add or remove space before pointer star '*' that isn't followed by a
-# variable name. If set to 'ignore', sp_before_ptr_star is used instead.
+# variable name. If set to ignore, sp_before_ptr_star is used instead.
 sp_before_unnamed_ptr_star      = ignore   # ignore/add/remove/force
 
 # Add or remove space between pointer stars '*'.
@@ -203,7 +203,7 @@ sp_before_ptr_star_func         = ignore   # ignore/add/remove/force
 sp_before_byref                 = ignore   # ignore/add/remove/force
 
 # Add or remove space before a reference sign '&' that isn't followed by a
-# variable name. If set to 'ignore', sp_before_byref is used instead.
+# variable name. If set to ignore, sp_before_byref is used instead.
 sp_before_unnamed_byref         = ignore   # ignore/add/remove/force
 
 # Add or remove space after reference sign '&', if followed by a word.
@@ -520,7 +520,7 @@ sp_fparen_dbrace                = ignore   # ignore/add/remove/force
 sp_func_call_paren              = ignore   # ignore/add/remove/force
 
 # Add or remove space between function name and '()' on function calls without
-# parameters. If set to 'ignore' (the default), sp_func_call_paren is used.
+# parameters. If set to ignore (the default), sp_func_call_paren is used.
 sp_func_call_paren_empty        = ignore   # ignore/add/remove/force
 
 # Add or remove space between the user function name and '(' on function

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -384,7 +384,7 @@ ValueDefault=ignore
 
 [Sp Before Unnamed Ptr Star]
 Category=1
-Description="<html>Add or remove space before pointer star '*' that isn't followed by a<br/>variable name. If set to 'ignore', sp_before_ptr_star is used instead.</html>"
+Description="<html>Add or remove space before pointer star '*' that isn't followed by a<br/>variable name. If set to ignore, sp_before_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_unnamed_ptr_star=ignore|sp_before_unnamed_ptr_star=add|sp_before_unnamed_ptr_star=remove|sp_before_unnamed_ptr_star=force
@@ -465,7 +465,7 @@ ValueDefault=ignore
 
 [Sp Before Unnamed Byref]
 Category=1
-Description="<html>Add or remove space before a reference sign '&amp;' that isn't followed by a<br/>variable name. If set to 'ignore', sp_before_byref is used instead.</html>"
+Description="<html>Add or remove space before a reference sign '&amp;' that isn't followed by a<br/>variable name. If set to ignore, sp_before_byref is used instead.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_unnamed_byref=ignore|sp_before_unnamed_byref=add|sp_before_unnamed_byref=remove|sp_before_unnamed_byref=force
@@ -1265,7 +1265,7 @@ ValueDefault=ignore
 
 [Sp Func Call Paren Empty]
 Category=1
-Description="<html>Add or remove space between function name and '()' on function calls without<br/>parameters. If set to 'ignore' (the default), sp_func_call_paren is used.</html>"
+Description="<html>Add or remove space between function name and '()' on function calls without<br/>parameters. If set to ignore (the default), sp_func_call_paren is used.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_func_call_paren_empty=ignore|sp_func_call_paren_empty=add|sp_func_call_paren_empty=remove|sp_func_call_paren_empty=force


### PR DESCRIPTION
Tweak option documentation to more consistently omit quotes around option values.