### PR TITLE
Newline before comment block is now correct

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -4721,8 +4721,11 @@ void do_blank_lines(void)
          && chunk_is_token(next, CT_COMMENT_MULTI))
       {
          // Don't add blanks after a open brace
-         if (  prev == nullptr
-            || (prev->type != CT_BRACE_OPEN && prev->type != CT_VBRACE_OPEN))
+         if (  (  prev == nullptr
+               || (  prev->type != CT_BRACE_OPEN
+                  && prev->type != CT_VBRACE_OPEN))
+            && pcmt != nullptr                          // Issue #2383
+            && pcmt->type != CT_COMMENT_MULTI)
          {
             blank_line_set(pc, options::nl_before_block_comment);
          }
@@ -4733,11 +4736,11 @@ void do_blank_lines(void)
          && chunk_is_token(next, CT_COMMENT))
       {
          // Don't add blanks after a open brace or a comment
-         if (  prev == nullptr
-            || (  prev->type != CT_BRACE_OPEN
-               && prev->type != CT_VBRACE_OPEN
-               && pcmt != nullptr
-               && pcmt->type != CT_COMMENT))
+         if (  (  prev == nullptr
+               || (  prev->type != CT_BRACE_OPEN
+                  && prev->type != CT_VBRACE_OPEN))
+            && pcmt != nullptr                          // Issue #2383
+            && pcmt->type != CT_COMMENT)
          {
             blank_line_set(pc, options::nl_before_c_comment);
          }
@@ -4748,11 +4751,11 @@ void do_blank_lines(void)
          && chunk_is_token(next, CT_COMMENT_CPP))
       {
          // Don't add blanks after a open brace
-         if (  prev == nullptr
-            || (  prev->type != CT_BRACE_OPEN
-               && prev->type != CT_VBRACE_OPEN
-               && pcmt != nullptr
-               && pcmt->type != CT_COMMENT_CPP))
+         if (  (  prev == nullptr
+               || (  prev->type != CT_BRACE_OPEN
+                  && prev->type != CT_VBRACE_OPEN))
+            && pcmt != nullptr                          // Issue #2383
+            && pcmt->type != CT_COMMENT_CPP)
          {
             blank_line_set(pc, options::nl_before_cpp_comment);
          }

--- a/tests/config/Issue_2383.cfg
+++ b/tests/config/Issue_2383.cfg
@@ -1,0 +1,3 @@
+nl_before_block_comment         = 2
+nl_before_c_comment             = 2
+nl_before_cpp_comment           = 2

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -88,6 +88,7 @@
 30075  empty.cfg                            cpp/goto.cpp
 
 30080  nl_brace_brace-a.cfg                 cpp/nl_brace_brace.cpp
+30081  Issue_2383.cfg                       cpp/Issue_2383.cpp
 
 30085  nSolve.cfg                           cpp/align_class.cpp
 30086  align_class-constr.cfg               cpp/align_class-constr.cpp

--- a/tests/expected/cpp/30081-Issue_2383.cpp
+++ b/tests/expected/cpp/30081-Issue_2383.cpp
@@ -1,0 +1,7 @@
+// Smooth
+// Copyright (C) 2017 Per
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.

--- a/tests/input/cpp/Issue_2383.cpp
+++ b/tests/input/cpp/Issue_2383.cpp
@@ -1,0 +1,7 @@
+// Smooth
+// Copyright (C) 2017 Per
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.


### PR DESCRIPTION
Correct the parentheses.
Ref. #2383