### PR TITLE
Improve sp_type_ellipsis

### DIFF
--- a/src/space.cpp
+++ b/src/space.cpp
@@ -700,15 +700,22 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    if (chunk_is_token(second, CT_ELLIPSIS))
    {
-      // non-punc followed by a ellipsis
-      if (  chunk_is_token(first, CT_TYPE)
-         || chunk_is_token(first, CT_QUALIFIER))
+      // type followed by a ellipsis
+      chunk_t *tmp = first;
+      if (  chunk_is_token(tmp, CT_PTR_TYPE)
+         || chunk_is_token(tmp, CT_BYREF))
+      {
+         tmp = chunk_get_prev_ncnl(tmp);
+      }
+      if (  chunk_is_token(tmp, CT_TYPE)
+         || chunk_is_token(tmp, CT_QUALIFIER))
       {
          // Add or remove space between a type and '...'.
          log_rule("sp_type_ellipsis");
          return(options::sp_type_ellipsis());
       }
 
+      // non-punc followed by a ellipsis
       if (  ((first->flags & PCF_PUNCTUATOR) == 0)
          && (options::sp_before_ellipsis() != IARF_IGNORE))
       {

--- a/tests/expected/cpp/31600-parameter-packs.cpp
+++ b/tests/expected/cpp/31600-parameter-packs.cpp
@@ -4,7 +4,7 @@ struct foo1 : foo1<A..., (sizeof...(A)+B) ...>
 	foo1() {
 		int x = sizeof...(A);
 	}
-}
+};
 
 template<int... X> int bar1()
 {
@@ -14,17 +14,36 @@ template<int... X> int bar1()
 }
 
 template<class R, typename ... Args>
-struct invoke1<R(fp*)(FArgs...)>
+void call1v(R (*fp)(Args...));
+
+template<class R, typename ... Args>
+void call1p(R (*fp)(Args*...));
+
+template<class R, typename ... Args>
+void call1r(R (*fp)(Args&&...));
+
+template<class R, typename ... Args>
+struct invoke1v : invoke<R (*)(Args...)>
+{
+};
+
+template<class R, typename ... Args>
+struct invoke1p : invoke<R (*)(Args*...)>
+{
+};
+
+template<class R, typename ... Args>
+struct invoke1r : invoke<R (*)(Args&&...)>
 {
 };
 
 template  <  typename  ... A, int  ... B  >
-struct foo2 :  foo2<  A  ..., (  sizeof  ...  (  A  )  +  B  ) ...  >
+struct foo2 :  foo2  <  A  ..., (  sizeof  ...  (  A  )  +  B  ) ...  >
 {
 	foo2() {
 		int x = sizeof  ...  (  A  );
 	}
-}
+};
 
 template  <  int  ... X  > int bar2()
 {
@@ -34,6 +53,25 @@ template  <  int  ... X  > int bar2()
 }
 
 template  <  class R, typename  ... Args  >
-struct invoke2  <  R  (  fp*  )  (  FArgs  ...  )  >
+void call2v(  R (  *fp  )(  Args  ...  )  );
+
+template  <  class R, typename  ... Args  >
+void call2p(  R (  *fp  )(  Args  *  ...  )  );
+
+template  <  class R, typename  ... Args  >
+void call2r(  R (  *fp  )(  Args  &&  ...  )  );
+
+template  <  class R, typename  ... Args  >
+struct invoke2v :  invoke  <  R (  *  )(  Args  ...  )  >
+{
+};
+
+template  <  class R, typename  ... Args  >
+struct invoke2p :  invoke  <  R (  *  )(  Args  *  ...  )  >
+{
+};
+
+template  <  class R, typename  ... Args  >
+struct invoke2r :  invoke  <  R (  *  )(  Args  &&  ...  )  >
 {
 };

--- a/tests/expected/cpp/31601-parameter-packs.cpp
+++ b/tests/expected/cpp/31601-parameter-packs.cpp
@@ -4,7 +4,7 @@ struct foo1 : foo1<A..., (sizeof...(A)+B)...>
 	foo1() {
 		int x = sizeof...(A);
 	}
-}
+};
 
 template<int... X> int bar1()
 {
@@ -14,17 +14,36 @@ template<int... X> int bar1()
 }
 
 template<class R, typename ... Args>
-struct invoke1<R(fp*)(FArgs...)>
+void call1v(R (*fp)(Args...));
+
+template<class R, typename ... Args>
+void call1p(R (*fp)(Args*...));
+
+template<class R, typename ... Args>
+void call1r(R (*fp)(Args&&...));
+
+template<class R, typename ... Args>
+struct invoke1v : invoke<R (*)(Args...)>
+{
+};
+
+template<class R, typename ... Args>
+struct invoke1p : invoke<R (*)(Args*...)>
+{
+};
+
+template<class R, typename ... Args>
+struct invoke1r : invoke<R (*)(Args&&...)>
 {
 };
 
 template  <  typename  ... A, int  ... B  >
-struct foo2 :  foo2<  A  ..., (  sizeof  ...  (  A  )  +  B  )...  >
+struct foo2 :  foo2  <  A  ..., (  sizeof  ...  (  A  )  +  B  )...  >
 {
 	foo2() {
 		int x = sizeof  ...  (  A  );
 	}
-}
+};
 
 template  <  int  ... X  > int bar2()
 {
@@ -34,6 +53,25 @@ template  <  int  ... X  > int bar2()
 }
 
 template  <  class R, typename  ... Args  >
-struct invoke2  <  R  (  fp*  )  (  FArgs  ...  )  >
+void call2v(  R (  *fp  )(  Args  ...  )  );
+
+template  <  class R, typename  ... Args  >
+void call2p(  R (  *fp  )(  Args  *  ...  )  );
+
+template  <  class R, typename  ... Args  >
+void call2r(  R (  *fp  )(  Args  &&  ...  )  );
+
+template  <  class R, typename  ... Args  >
+struct invoke2v :  invoke  <  R (  *  )(  Args  ...  )  >
+{
+};
+
+template  <  class R, typename  ... Args  >
+struct invoke2p :  invoke  <  R (  *  )(  Args  *  ...  )  >
+{
+};
+
+template  <  class R, typename  ... Args  >
+struct invoke2r :  invoke  <  R (  *  )(  Args  &&  ...  )  >
 {
 };

--- a/tests/expected/cpp/31602-parameter-packs.cpp
+++ b/tests/expected/cpp/31602-parameter-packs.cpp
@@ -4,7 +4,7 @@ struct foo1 : foo1<A..., (sizeof ...(A)+B)...>
 	foo1() {
 		int x = sizeof ...(A);
 	}
-}
+};
 
 template<int... X> int bar1()
 {
@@ -14,17 +14,36 @@ template<int... X> int bar1()
 }
 
 template<class R, typename ... Args>
-struct invoke1<R(fp*)(FArgs...)>
+void call1v(R (*fp)(Args...));
+
+template<class R, typename ... Args>
+void call1p(R (*fp)(Args*...));
+
+template<class R, typename ... Args>
+void call1r(R (*fp)(Args&&...));
+
+template<class R, typename ... Args>
+struct invoke1v : invoke<R (*)(Args...)>
+{
+};
+
+template<class R, typename ... Args>
+struct invoke1p : invoke<R (*)(Args*...)>
+{
+};
+
+template<class R, typename ... Args>
+struct invoke1r : invoke<R (*)(Args&&...)>
 {
 };
 
 template  <  typename  ... A, int  ... B  >
-struct foo2 :  foo2<  A  ..., (  sizeof ...  (  A  )  +  B  )  ...  >
+struct foo2 :  foo2  <  A  ..., (  sizeof ...  (  A  )  +  B  )  ...  >
 {
 	foo2() {
 		int x = sizeof ...  (  A  );
 	}
-}
+};
 
 template  <  int  ... X  > int bar2()
 {
@@ -34,6 +53,25 @@ template  <  int  ... X  > int bar2()
 }
 
 template  <  class R, typename  ... Args  >
-struct invoke2  <  R  (  fp*  )  (  FArgs  ...  )  >
+void call2v(  R (  *fp  )(  Args  ...  )  );
+
+template  <  class R, typename  ... Args  >
+void call2p(  R (  *fp  )(  Args  *  ...  )  );
+
+template  <  class R, typename  ... Args  >
+void call2r(  R (  *fp  )(  Args  &&  ...  )  );
+
+template  <  class R, typename  ... Args  >
+struct invoke2v :  invoke  <  R (  *  )(  Args  ...  )  >
+{
+};
+
+template  <  class R, typename  ... Args  >
+struct invoke2p :  invoke  <  R (  *  )(  Args  *  ...  )  >
+{
+};
+
+template  <  class R, typename  ... Args  >
+struct invoke2r :  invoke  <  R (  *  )(  Args  &&  ...  )  >
 {
 };

--- a/tests/expected/cpp/31603-parameter-packs.cpp
+++ b/tests/expected/cpp/31603-parameter-packs.cpp
@@ -4,7 +4,7 @@ struct foo1 : foo1<A..., (sizeof...(A)+B)...>
 	foo1() {
 		int x = sizeof...(A);
 	}
-}
+};
 
 template<int... X> int bar1()
 {
@@ -14,17 +14,36 @@ template<int... X> int bar1()
 }
 
 template<class R, typename ... Args>
-struct invoke1<R(fp*)(FArgs...)>
+void call1v(R (*fp)(Args...));
+
+template<class R, typename ... Args>
+void call1p(R (*fp)(Args*...));
+
+template<class R, typename ... Args>
+void call1r(R (*fp)(Args&&...));
+
+template<class R, typename ... Args>
+struct invoke1v : invoke<R (*)(Args...)>
+{
+};
+
+template<class R, typename ... Args>
+struct invoke1p : invoke<R (*)(Args*...)>
+{
+};
+
+template<class R, typename ... Args>
+struct invoke1r : invoke<R (*)(Args&&...)>
 {
 };
 
 template  <  typename  ... A, int  ... B  >
-struct foo2 :  foo2<  A  ..., (  sizeof...  (  A  )  +  B  )  ...  >
+struct foo2 :  foo2  <  A  ..., (  sizeof...  (  A  )  +  B  )  ...  >
 {
 	foo2() {
 		int x = sizeof...  (  A  );
 	}
-}
+};
 
 template  <  int  ... X  > int bar2()
 {
@@ -34,6 +53,25 @@ template  <  int  ... X  > int bar2()
 }
 
 template  <  class R, typename  ... Args  >
-struct invoke2  <  R  (  fp*  )  (  FArgs  ...  )  >
+void call2v(  R (  *fp  )(  Args  ...  )  );
+
+template  <  class R, typename  ... Args  >
+void call2p(  R (  *fp  )(  Args  *  ...  )  );
+
+template  <  class R, typename  ... Args  >
+void call2r(  R (  *fp  )(  Args  &&  ...  )  );
+
+template  <  class R, typename  ... Args  >
+struct invoke2v :  invoke  <  R (  *  )(  Args  ...  )  >
+{
+};
+
+template  <  class R, typename  ... Args  >
+struct invoke2p :  invoke  <  R (  *  )(  Args  *  ...  )  >
+{
+};
+
+template  <  class R, typename  ... Args  >
+struct invoke2r :  invoke  <  R (  *  )(  Args  &&  ...  )  >
 {
 };

--- a/tests/expected/cpp/31604-parameter-packs.cpp
+++ b/tests/expected/cpp/31604-parameter-packs.cpp
@@ -4,7 +4,7 @@ struct foo1 : foo1<A..., (sizeof...(A)+B)...>
 	foo1() {
 		int x = sizeof...(A);
 	}
-}
+};
 
 template<int... X> int bar1()
 {
@@ -14,17 +14,36 @@ template<int... X> int bar1()
 }
 
 template<class R, typename ... Args>
-struct invoke1<R(fp*)(FArgs...)>
+void call1v(R (*fp)(Args...));
+
+template<class R, typename ... Args>
+void call1p(R (*fp)(Args*...));
+
+template<class R, typename ... Args>
+void call1r(R (*fp)(Args&&...));
+
+template<class R, typename ... Args>
+struct invoke1v : invoke<R (*)(Args...)>
+{
+};
+
+template<class R, typename ... Args>
+struct invoke1p : invoke<R (*)(Args*...)>
+{
+};
+
+template<class R, typename ... Args>
+struct invoke1r : invoke<R (*)(Args&&...)>
 {
 };
 
 template  <  typename ... A, int  ... B  >
-struct foo2 :  foo2<  A  ..., (  sizeof  ...  (  A  )  +  B  )  ...  >
+struct foo2 :  foo2  <  A  ..., (  sizeof  ...  (  A  )  +  B  )  ...  >
 {
 	foo2() {
 		int x = sizeof  ...  (  A  );
 	}
-}
+};
 
 template  <  int  ... X  > int bar2()
 {
@@ -34,6 +53,25 @@ template  <  int  ... X  > int bar2()
 }
 
 template  <  class R, typename ... Args  >
-struct invoke2  <  R  (  fp*  )  (  FArgs  ...  )  >
+void call2v(  R (  *fp  )(  Args  ...  )  );
+
+template  <  class R, typename ... Args  >
+void call2p(  R (  *fp  )(  Args  *  ...  )  );
+
+template  <  class R, typename ... Args  >
+void call2r(  R (  *fp  )(  Args  &&  ...  )  );
+
+template  <  class R, typename ... Args  >
+struct invoke2v :  invoke  <  R (  *  )(  Args  ...  )  >
+{
+};
+
+template  <  class R, typename ... Args  >
+struct invoke2p :  invoke  <  R (  *  )(  Args  *  ...  )  >
+{
+};
+
+template  <  class R, typename ... Args  >
+struct invoke2r :  invoke  <  R (  *  )(  Args  &&  ...  )  >
 {
 };

--- a/tests/expected/cpp/31605-parameter-packs.cpp
+++ b/tests/expected/cpp/31605-parameter-packs.cpp
@@ -4,7 +4,7 @@ struct foo1 : foo1<A..., (sizeof...(A)+B)...>
 	foo1() {
 		int x = sizeof...(A);
 	}
-}
+};
 
 template<int... X> int bar1()
 {
@@ -14,17 +14,36 @@ template<int... X> int bar1()
 }
 
 template<class R, typename... Args>
-struct invoke1<R(fp*)(FArgs...)>
+void call1v(R (*fp)(Args...));
+
+template<class R, typename... Args>
+void call1p(R (*fp)(Args*...));
+
+template<class R, typename... Args>
+void call1r(R (*fp)(Args&&...));
+
+template<class R, typename... Args>
+struct invoke1v : invoke<R (*)(Args...)>
+{
+};
+
+template<class R, typename... Args>
+struct invoke1p : invoke<R (*)(Args*...)>
+{
+};
+
+template<class R, typename... Args>
+struct invoke1r : invoke<R (*)(Args&&...)>
 {
 };
 
 template  <  typename... A, int  ... B  >
-struct foo2 :  foo2<  A  ..., (  sizeof  ...  (  A  )  +  B  )  ...  >
+struct foo2 :  foo2  <  A  ..., (  sizeof  ...  (  A  )  +  B  )  ...  >
 {
 	foo2() {
 		int x = sizeof  ...  (  A  );
 	}
-}
+};
 
 template  <  int  ... X  > int bar2()
 {
@@ -34,6 +53,25 @@ template  <  int  ... X  > int bar2()
 }
 
 template  <  class R, typename... Args  >
-struct invoke2  <  R  (  fp*  )  (  FArgs  ...  )  >
+void call2v(  R (  *fp  )(  Args  ...  )  );
+
+template  <  class R, typename... Args  >
+void call2p(  R (  *fp  )(  Args  *  ...  )  );
+
+template  <  class R, typename... Args  >
+void call2r(  R (  *fp  )(  Args  &&  ...  )  );
+
+template  <  class R, typename... Args  >
+struct invoke2v :  invoke  <  R (  *  )(  Args  ...  )  >
+{
+};
+
+template  <  class R, typename... Args  >
+struct invoke2p :  invoke  <  R (  *  )(  Args  *  ...  )  >
+{
+};
+
+template  <  class R, typename... Args  >
+struct invoke2r :  invoke  <  R (  *  )(  Args  &&  ...  )  >
 {
 };

--- a/tests/expected/cpp/31606-parameter-packs.cpp
+++ b/tests/expected/cpp/31606-parameter-packs.cpp
@@ -4,7 +4,7 @@ struct foo1 : foo1<A ..., (sizeof...(A)+B)...>
 	foo1() {
 		int x = sizeof...(A);
 	}
-}
+};
 
 template<int ... X> int bar1()
 {
@@ -14,17 +14,36 @@ template<int ... X> int bar1()
 }
 
 template<class R, typename ... Args>
-struct invoke1<R(fp*)(FArgs ...)>
+void call1v(R (*fp)(Args ...));
+
+template<class R, typename ... Args>
+void call1p(R (*fp)(Args* ...));
+
+template<class R, typename ... Args>
+void call1r(R (*fp)(Args&& ...));
+
+template<class R, typename ... Args>
+struct invoke1v : invoke<R (*)(Args ...)>
+{
+};
+
+template<class R, typename ... Args>
+struct invoke1p : invoke<R (*)(Args* ...)>
+{
+};
+
+template<class R, typename ... Args>
+struct invoke1r : invoke<R (*)(Args&& ...)>
 {
 };
 
 template  <  typename  ... A, int ... B  >
-struct foo2 :  foo2<  A ..., (  sizeof  ...  (  A  )  +  B  )  ...  >
+struct foo2 :  foo2  <  A ..., (  sizeof  ...  (  A  )  +  B  )  ...  >
 {
 	foo2() {
 		int x = sizeof  ...  (  A  );
 	}
-}
+};
 
 template  <  int ... X  > int bar2()
 {
@@ -34,6 +53,25 @@ template  <  int ... X  > int bar2()
 }
 
 template  <  class R, typename  ... Args  >
-struct invoke2  <  R  (  fp*  )  (  FArgs ...  )  >
+void call2v(  R (  *fp  )(  Args ...  )  );
+
+template  <  class R, typename  ... Args  >
+void call2p(  R (  *fp  )(  Args  * ...  )  );
+
+template  <  class R, typename  ... Args  >
+void call2r(  R (  *fp  )(  Args  && ...  )  );
+
+template  <  class R, typename  ... Args  >
+struct invoke2v :  invoke  <  R (  *  )(  Args ...  )  >
+{
+};
+
+template  <  class R, typename  ... Args  >
+struct invoke2p :  invoke  <  R (  *  )(  Args  * ...  )  >
+{
+};
+
+template  <  class R, typename  ... Args  >
+struct invoke2r :  invoke  <  R (  *  )(  Args  && ...  )  >
 {
 };

--- a/tests/expected/cpp/31607-parameter-packs.cpp
+++ b/tests/expected/cpp/31607-parameter-packs.cpp
@@ -4,7 +4,7 @@ struct foo1 : foo1<A..., (sizeof...(A)+B)...>
 	foo1() {
 		int x = sizeof...(A);
 	}
-}
+};
 
 template<int... X> int bar1()
 {
@@ -14,17 +14,36 @@ template<int... X> int bar1()
 }
 
 template<class R, typename ... Args>
-struct invoke1<R(fp*)(FArgs...)>
+void call1v(R (*fp)(Args...));
+
+template<class R, typename ... Args>
+void call1p(R (*fp)(Args*...));
+
+template<class R, typename ... Args>
+void call1r(R (*fp)(Args&&...));
+
+template<class R, typename ... Args>
+struct invoke1v : invoke<R (*)(Args...)>
+{
+};
+
+template<class R, typename ... Args>
+struct invoke1p : invoke<R (*)(Args*...)>
+{
+};
+
+template<class R, typename ... Args>
+struct invoke1r : invoke<R (*)(Args&&...)>
 {
 };
 
 template  <  typename  ... A, int... B  >
-struct foo2 :  foo2<  A..., (  sizeof  ...  (  A  )  +  B  )  ...  >
+struct foo2 :  foo2  <  A..., (  sizeof  ...  (  A  )  +  B  )  ...  >
 {
 	foo2() {
 		int x = sizeof  ...  (  A  );
 	}
-}
+};
 
 template  <  int... X  > int bar2()
 {
@@ -34,6 +53,25 @@ template  <  int... X  > int bar2()
 }
 
 template  <  class R, typename  ... Args  >
-struct invoke2  <  R  (  fp*  )  (  FArgs...  )  >
+void call2v(  R (  *fp  )(  Args...  )  );
+
+template  <  class R, typename  ... Args  >
+void call2p(  R (  *fp  )(  Args  *...  )  );
+
+template  <  class R, typename  ... Args  >
+void call2r(  R (  *fp  )(  Args  &&...  )  );
+
+template  <  class R, typename  ... Args  >
+struct invoke2v :  invoke  <  R (  *  )(  Args...  )  >
+{
+};
+
+template  <  class R, typename  ... Args  >
+struct invoke2p :  invoke  <  R (  *  )(  Args  *...  )  >
+{
+};
+
+template  <  class R, typename  ... Args  >
+struct invoke2r :  invoke  <  R (  *  )(  Args  &&...  )  >
 {
 };

--- a/tests/expected/cpp/31608-parameter-packs.cpp
+++ b/tests/expected/cpp/31608-parameter-packs.cpp
@@ -4,7 +4,7 @@ struct foo1 : foo1<A..., (sizeof... (A)+B)...>
 	foo1() {
 		int x = sizeof... (A);
 	}
-}
+};
 
 template<int... X> int bar1()
 {
@@ -14,17 +14,36 @@ template<int... X> int bar1()
 }
 
 template<class R, typename ... Args>
-struct invoke1<R(fp*)(FArgs...)>
+void call1v(R (*fp)(Args...));
+
+template<class R, typename ... Args>
+void call1p(R (*fp)(Args*...));
+
+template<class R, typename ... Args>
+void call1r(R (*fp)(Args&&...));
+
+template<class R, typename ... Args>
+struct invoke1v : invoke<R (*)(Args...)>
+{
+};
+
+template<class R, typename ... Args>
+struct invoke1p : invoke<R (*)(Args*...)>
+{
+};
+
+template<class R, typename ... Args>
+struct invoke1r : invoke<R (*)(Args&&...)>
 {
 };
 
 template  <  typename  ... A, int  ... B  >
-struct foo2 :  foo2<  A  ..., (  sizeof  ... (  A  )  +  B  )  ...  >
+struct foo2 :  foo2  <  A  ..., (  sizeof  ... (  A  )  +  B  )  ...  >
 {
 	foo2() {
 		int x = sizeof  ... (  A  );
 	}
-}
+};
 
 template  <  int  ... X  > int bar2()
 {
@@ -34,6 +53,25 @@ template  <  int  ... X  > int bar2()
 }
 
 template  <  class R, typename  ... Args  >
-struct invoke2  <  R  (  fp*  )  (  FArgs  ...  )  >
+void call2v(  R (  *fp  )(  Args  ...  )  );
+
+template  <  class R, typename  ... Args  >
+void call2p(  R (  *fp  )(  Args  *  ...  )  );
+
+template  <  class R, typename  ... Args  >
+void call2r(  R (  *fp  )(  Args  &&  ...  )  );
+
+template  <  class R, typename  ... Args  >
+struct invoke2v :  invoke  <  R (  *  )(  Args  ...  )  >
+{
+};
+
+template  <  class R, typename  ... Args  >
+struct invoke2p :  invoke  <  R (  *  )(  Args  *  ...  )  >
+{
+};
+
+template  <  class R, typename  ... Args  >
+struct invoke2r :  invoke  <  R (  *  )(  Args  &&  ...  )  >
 {
 };

--- a/tests/expected/cpp/31609-parameter-packs.cpp
+++ b/tests/expected/cpp/31609-parameter-packs.cpp
@@ -4,7 +4,7 @@ struct foo1 : foo1<A..., (sizeof...(A)+B)...>
 	foo1() {
 		int x = sizeof...(A);
 	}
-}
+};
 
 template<int... X> int bar1()
 {
@@ -14,17 +14,36 @@ template<int... X> int bar1()
 }
 
 template<class R, typename ... Args>
-struct invoke1<R(fp*)(FArgs...)>
+void call1v(R (*fp)(Args...));
+
+template<class R, typename ... Args>
+void call1p(R (*fp)(Args*...));
+
+template<class R, typename ... Args>
+void call1r(R (*fp)(Args&&...));
+
+template<class R, typename ... Args>
+struct invoke1v : invoke<R (*)(Args...)>
+{
+};
+
+template<class R, typename ... Args>
+struct invoke1p : invoke<R (*)(Args*...)>
+{
+};
+
+template<class R, typename ... Args>
+struct invoke1r : invoke<R (*)(Args&&...)>
 {
 };
 
 template  <  typename  ... A, int  ... B  >
-struct foo2 :  foo2<  A  ..., (  sizeof  ...(  A  )  +  B  )  ...  >
+struct foo2 :  foo2  <  A  ..., (  sizeof  ...(  A  )  +  B  )  ...  >
 {
 	foo2() {
 		int x = sizeof  ...(  A  );
 	}
-}
+};
 
 template  <  int  ... X  > int bar2()
 {
@@ -34,6 +53,25 @@ template  <  int  ... X  > int bar2()
 }
 
 template  <  class R, typename  ... Args  >
-struct invoke2  <  R  (  fp*  )  (  FArgs  ...  )  >
+void call2v(  R (  *fp  )(  Args  ...  )  );
+
+template  <  class R, typename  ... Args  >
+void call2p(  R (  *fp  )(  Args  *  ...  )  );
+
+template  <  class R, typename  ... Args  >
+void call2r(  R (  *fp  )(  Args  &&  ...  )  );
+
+template  <  class R, typename  ... Args  >
+struct invoke2v :  invoke  <  R (  *  )(  Args  ...  )  >
+{
+};
+
+template  <  class R, typename  ... Args  >
+struct invoke2p :  invoke  <  R (  *  )(  Args  *  ...  )  >
+{
+};
+
+template  <  class R, typename  ... Args  >
+struct invoke2r :  invoke  <  R (  *  )(  Args  &&  ...  )  >
 {
 };

--- a/tests/input/cpp/parameter-packs.cpp
+++ b/tests/input/cpp/parameter-packs.cpp
@@ -4,7 +4,7 @@ struct foo1:foo1<A..., (sizeof...(A)+B)...>
 	foo1() {
 		int x = sizeof...(A);
 	}
-}
+};
 
 template<int...X> int bar1()
 {
@@ -14,17 +14,36 @@ template<int...X> int bar1()
 }
 
 template<class R, typename...Args>
-struct invoke1<R(fp*)(FArgs...)>
+void call1v(R(*fp)(Args...));
+
+template<class R, typename...Args>
+void call1p(R(*fp)(Args*...));
+
+template<class R, typename...Args>
+void call1r(R(*fp)(Args&&...));
+
+template<class R, typename...Args>
+struct invoke1v : invoke<R(*)(Args...)>
+{
+};
+
+template<class R, typename...Args>
+struct invoke1p : invoke<R(*)(Args*...)>
+{
+};
+
+template<class R, typename...Args>
+struct invoke1r : invoke<R(*)(Args&&...)>
 {
 };
 
 template  <  typename  ...  A  , int  ...  B  >
-struct foo2  :  foo2<  A  ...  , (  sizeof  ...  (  A  )  +  B  )  ...  >
+struct foo2  :  foo2  <  A  ...  , (  sizeof  ...  (  A  )  +  B  )  ...  >
 {
 	foo2() {
 		int x = sizeof  ...  (  A  );
 	}
-}
+};
 
 template  <  int  ...  X  > int bar2()
 {
@@ -34,6 +53,25 @@ template  <  int  ...  X  > int bar2()
 }
 
 template  <  class R  , typename  ...  Args  >
-struct invoke2  <  R  (  fp*  )  (  FArgs  ...  )  >
+void call2v(  R  (  *fp  )  (  Args  ...  )  );
+
+template  <  class R  , typename  ...  Args  >
+void call2p(  R  (  *fp  )  (  Args  *  ...  )  );
+
+template  <  class R  , typename  ...  Args  >
+void call2r(  R  (  *fp  )  (  Args  &&  ...  )  );
+
+template  <  class R  , typename  ...  Args  >
+struct invoke2v  :  invoke  <  R  (  *  )  (  Args  ...  )  >
+{
+};
+
+template  <  class R  , typename  ...  Args  >
+struct invoke2p  :  invoke  <  R  (  *  )  (  Args  *  ...  )  >
+{
+};
+
+template  <  class R  , typename  ...  Args  >
+struct invoke2r  :  invoke  <  R  (  *  )  (  Args  &&  ...  )  >
 {
 };


### PR DESCRIPTION
Modify how `sp_type_ellipsis` is applied to also apply it between an indirection (`CT_PTR_TYPE` or `CT_BYREF`) and an ellipsis. This corrects some formatting issues and is consistent with e.g. how `sp_type_func` is applied.

Also, fix some issues in the test cases which were not valid C++ code and were causing uncrustify to parse the code in a manner other than what was intended. This should make the tests more robust. (Note that, considering the manner in which the test code was wrong, uncrustify's parsing is actually reasonable.)

Fixes #2394.