### PR TITLE
Don't apply sp_before_square to lambdas

### DIFF
--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1099,7 +1099,9 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    // "a [x]" vs "a[x]"
    if (  chunk_is_token(second, CT_SQUARE_OPEN)
-      && (second->parent_type != CT_OC_MSG && second->parent_type != CT_CS_SQ_STMT))
+      && (  second->parent_type != CT_OC_MSG
+         && second->parent_type != CT_CS_SQ_STMT
+         && second->parent_type != CT_CPP_LAMBDA))
    {
       if (((second->flags & PCF_IN_SPAREN) != 0) && (chunk_is_token(first, CT_IN)))
       {

--- a/tests/config/lambda_in_one_liner.cfg
+++ b/tests/config/lambda_in_one_liner.cfg
@@ -1,0 +1,4 @@
+sp_cpp_lambda_square_brace      = remove
+sp_before_square                = remove
+nl_func_leave_one_liners        = true
+nl_cpp_lambda_leave_one_liners  = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -268,6 +268,8 @@
 30776 sp_cpp_lambda_fparen-r.cfg            cpp/sp_cpp_lambda_fparen.cpp
 30777 sp_cpp_lambda_fparen-f.cfg            cpp/sp_cpp_lambda_fparen.cpp
 
+30780 lambda_in_one_liner.cfg               cpp/lambda_in_one_liner.cpp
+
 30800  star_pos-0.cfg                       cpp/align-star-amp-pos.cpp
 30801  star_pos-1.cfg                       cpp/align-star-amp-pos.cpp
 30802  star_pos-2.cfg                       cpp/align-star-amp-pos.cpp

--- a/tests/expected/cpp/30780-lambda_in_one_liner.cpp
+++ b/tests/expected/cpp/30780-lambda_in_one_liner.cpp
@@ -1,0 +1,6 @@
+void bar();
+
+struct foo
+{
+	foo() { []{ bar(); }(); }
+};

--- a/tests/input/cpp/lambda_in_one_liner.cpp
+++ b/tests/input/cpp/lambda_in_one_liner.cpp
@@ -1,0 +1,6 @@
+void bar();
+
+struct foo
+{
+	foo() { []{ bar(); }(); }
+};


### PR DESCRIPTION
Fix how `sp_before_square` is applied to avoid incorrectly applying it to lambdas. This can be seen in (arguably pathological) code where a freestanding lambda appears as something other than the start of a line. (This issue has likely gone unnoticed as it is incredibly unlikely to show up in "real" code. It was noticed while testing some other lambda-related issues in "test" code reduced to a bare minimum number of characters.)