### PR TITLE
Fix braces removal for list initializer

### DIFF
--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -1391,6 +1391,7 @@ static void process_if_chain(chunk_t *br_start)
          const auto brace = *itc;
 
          if (  (chunk_is_token(brace, CT_BRACE_OPEN) || chunk_is_token(brace, CT_BRACE_CLOSE))
+            && (brace->parent_type != CT_BRACED_INIT_LIST)
             && (multiline_block ? !paren_multiline_before_brace(brace) : true))
          {
             LOG_FMT(LBRCH, "%s(%d): brace->orig_line is %zu, brace->orig_col is %zu\n",

--- a/tests/config/bug_2322.cfg
+++ b/tests/config/bug_2322.cfg
@@ -1,0 +1,11 @@
+indent_columns = 4
+output_tab_size = 4
+indent_with_tabs = 0
+
+mod_full_brace_if_chain = true
+
+mod_full_brace_for   = remove
+mod_full_brace_if    = remove
+mod_full_brace_do    = remove
+mod_full_brace_while = remove
+mod_full_brace_using = remove

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -793,3 +793,4 @@
 60045  align_asterisk_after_type_cast.cfg   cpp/align_asterisk_after_type_cast.cpp
 60046  align_continuation_left_shift.cfg    cpp/align_continuation_left_shift.cpp
 60047  align_default_after_override.cfg     cpp/align_default_after_override.cpp
+60048  bug_2322.cfg                         cpp/bug_2322.cpp

--- a/tests/expected/cpp/60048-bug_2322.cpp
+++ b/tests/expected/cpp/60048-bug_2322.cpp
@@ -1,0 +1,12 @@
+void main()
+{
+    if (foo()) bar();
+    else if (baz({ rick, morty })) anime();
+    else if (a) while (true) amime2();
+    else if (b) do amime3(); while (false);
+    else if (c) for(;;) amime5();
+    else if (d) while(true) {}
+    else if (e) do {} while (false);
+    else if (f) for(;;) {}
+    else amime6();
+}

--- a/tests/input/cpp/bug_2322.cpp
+++ b/tests/input/cpp/bug_2322.cpp
@@ -1,0 +1,12 @@
+void main()
+{
+    if (foo()) { bar(); }
+    else if (baz({ rick, morty })) { anime(); }
+    else if (a) while (true) { amime2(); }
+    else if (b) do { amime3(); } while(false);
+    else if (c) for(;;) { amime5(); }
+    else if (d) while(true) {}
+    else if (e) do {} while(false);
+    else if (f) for(;;) {}
+    else { amime6(); }
+}


### PR DESCRIPTION
Braces around list initializer are removed in case if it's used as a parameter to function inside `if`'s condition.

This fixes #2322.