### PR TITLE
Do not remove semicolon at the end of '?' operator

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1451,6 +1451,8 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
          || chunk_is_token(pc, CT_SQUARE_CLOSE)
          || chunk_is_token(pc, CT_TSQUARE)
          || chunk_is_token(pc, CT_FPAREN_OPEN)
+         || chunk_is_token(pc, CT_QUESTION)
+         || chunk_is_token(pc, CT_COLON)
          || (  chunk_is_token(pc, CT_BRACE_OPEN)
             && (  pc->parent_type == CT_NONE
                || pc->parent_type == CT_BRACED_INIT_LIST)))

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -804,3 +804,4 @@
 60046  align_continuation_left_shift.cfg    cpp/align_continuation_left_shift.cpp
 60047  align_default_after_override.cfg     cpp/align_default_after_override.cpp
 60048  bug_2322.cfg                         cpp/bug_2322.cpp
+60050  mod_remove_extra_semicolon-t.cfg     cpp/semicolon-removal-after-ternary-operator.cpp

--- a/tests/expected/cpp/60050-semicolon-removal-after-ternary-operator.cpp
+++ b/tests/expected/cpp/60050-semicolon-removal-after-ternary-operator.cpp
@@ -1,0 +1,9 @@
+std::string StrGet()
+{
+	return IsConnected() ? "Connected" : {};
+}
+
+std::string StrGet2()
+{
+	return !IsConnected() ? {} : "Connected";
+}

--- a/tests/input/cpp/semicolon-removal-after-ternary-operator.cpp
+++ b/tests/input/cpp/semicolon-removal-after-ternary-operator.cpp
@@ -1,0 +1,9 @@
+std::string StrGet()
+{
+	return IsConnected() ? "Connected" : {};
+}
+
+std::string StrGet2()
+{
+	return !IsConnected() ? {} : "Connected";
+}


### PR DESCRIPTION
Ternary operator is often used to return some value from function conditionally. From C++11 one can instantiate object using initializer list, so `{}` is valid value for either branch of ternary operator and
must be treated as such.

This fixes #2404.