### PR TITLE
Fix #2411 - preserve leading tabs after brace level in multiline C-style comments when comment formatting is disabled

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -2101,7 +2101,8 @@ static void output_comment_multi_simple(chunk_t *pc)
       cmt_idx++;
 
       // 1: step through leading tabs and spaces to find the start column
-      if (line.size() == 0 && (line_column < cmt.base_col || options::cmt_convert_tab_to_spaces()))
+      if (  line.size() == 0
+         && (line_column < cmt.base_col || options::cmt_convert_tab_to_spaces()))
       {
          if (ch == ' ')
          {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -2101,7 +2101,7 @@ static void output_comment_multi_simple(chunk_t *pc)
       cmt_idx++;
 
       // 1: step through leading tabs and spaces to find the start column
-      if (line.size() == 0)
+      if (line.size() == 0 && (line_column < cmt.base_col || options::cmt_convert_tab_to_spaces()))
       {
          if (ch == ' ')
          {

--- a/tests/c.test
+++ b/tests/c.test
@@ -377,6 +377,7 @@
 09616  enum_comma_ifdef.cfg                 c/enum_comma_ifdef.c
 09617  Issue_2360-a.cfg                     c/Issue_2360.c
 09618  Issue_2360-b.cfg                     c/Issue_2360.c
+09619  Issue_2411.cfg                       c/Issue_2411.c
 
 10005  empty.cfg                            c/i1270.c
 

--- a/tests/config/Issue_2411.cfg
+++ b/tests/config/Issue_2411.cfg
@@ -1,0 +1,3 @@
+indent_with_tabs = 1
+cmt_convert_tab_to_spaces = false
+cmt_indent_multi = false

--- a/tests/expected/c/09619-Issue_2411.c
+++ b/tests/expected/c/09619-Issue_2411.c
@@ -1,0 +1,5 @@
+void foo() {
+	/*
+		hello world
+	*/
+}

--- a/tests/input/c/Issue_2411.c
+++ b/tests/input/c/Issue_2411.c
@@ -1,0 +1,5 @@
+void foo() {
+	/*
+		hello world
+	*/
+}


### PR DESCRIPTION
Fix #2411

In multiline c-comment, when cmt_indent_multi and cmt_convert_tab_to_spaces are false, don't change leading whitespace after brace level.

This only addresses that particular use case. I'm not going to attempt to change the case where cmt_indent_multi=true, since this is already way out of my expertise.