### PR TITLE
Increase limits for mon_add_long_* options

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -3167,32 +3167,32 @@ mod_remove_extra_semicolon;
 
 // If a function body exceeds the specified number of newlines and doesn't have
 // a comment after the close brace, a comment will be added.
-extern BoundedOption<unsigned, 0, 50>
+extern BoundedOption<unsigned, 0, 255>
 mod_add_long_function_closebrace_comment;
 
 // If a namespace body exceeds the specified number of newlines and doesn't
 // have a comment after the close brace, a comment will be added.
-extern BoundedOption<unsigned, 0, 16>
+extern BoundedOption<unsigned, 0, 255>
 mod_add_long_namespace_closebrace_comment;
 
 // If a class body exceeds the specified number of newlines and doesn't have a
 // comment after the close brace, a comment will be added.
-extern BoundedOption<unsigned, 0, 16>
+extern BoundedOption<unsigned, 0, 255>
 mod_add_long_class_closebrace_comment;
 
 // If a switch body exceeds the specified number of newlines and doesn't have a
 // comment after the close brace, a comment will be added.
-extern BoundedOption<unsigned, 0, 50>
+extern BoundedOption<unsigned, 0, 255>
 mod_add_long_switch_closebrace_comment;
 
 // If an #ifdef body exceeds the specified number of newlines and doesn't have
 // a comment after the #endif, a comment will be added.
-extern BoundedOption<unsigned, 0, 16>
+extern BoundedOption<unsigned, 0, 255>
 mod_add_long_ifdef_endif_comment;
 
 // If an #ifdef or #else body exceeds the specified number of newlines and
 // doesn't have a comment after the #else, a comment will be added.
-extern BoundedOption<unsigned, 0, 16>
+extern BoundedOption<unsigned, 0, 255>
 mod_add_long_ifdef_else_comment;
 
 // Whether to take care of the case by the mod_sort_xx options.

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -5667,7 +5667,7 @@ Enabled=false
 EditorType=numeric
 CallName="mod_add_long_function_closebrace_comment="
 MinVal=0
-MaxVal=50
+MaxVal=255
 ValueDefault=0
 
 [Mod Add Long Namespace Closebrace Comment]
@@ -5677,7 +5677,7 @@ Enabled=false
 EditorType=numeric
 CallName="mod_add_long_namespace_closebrace_comment="
 MinVal=0
-MaxVal=16
+MaxVal=255
 ValueDefault=0
 
 [Mod Add Long Class Closebrace Comment]
@@ -5687,7 +5687,7 @@ Enabled=false
 EditorType=numeric
 CallName="mod_add_long_class_closebrace_comment="
 MinVal=0
-MaxVal=16
+MaxVal=255
 ValueDefault=0
 
 [Mod Add Long Switch Closebrace Comment]
@@ -5697,7 +5697,7 @@ Enabled=false
 EditorType=numeric
 CallName="mod_add_long_switch_closebrace_comment="
 MinVal=0
-MaxVal=50
+MaxVal=255
 ValueDefault=0
 
 [Mod Add Long Ifdef Endif Comment]
@@ -5707,7 +5707,7 @@ Enabled=false
 EditorType=numeric
 CallName="mod_add_long_ifdef_endif_comment="
 MinVal=0
-MaxVal=16
+MaxVal=255
 ValueDefault=0
 
 [Mod Add Long Ifdef Else Comment]
@@ -5717,7 +5717,7 @@ Enabled=false
 EditorType=numeric
 CallName="mod_add_long_ifdef_else_comment="
 MinVal=0
-MaxVal=16
+MaxVal=255
 ValueDefault=0
 
 [Mod Sort Case Sensitive]


### PR DESCRIPTION
Limits for these options seem a little bit restrictive - vim on my rotated monitor being opened to full screen has 95 lines visible at once, so limits increased to 100.

This fixes #2379.