### PR TITLE
nl_xx options should not be used with the value ignore if possible

### DIFF
--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -45,28 +45,46 @@ nl_after_access_spec                      = 1
 nl_after_brace_close                      = true
 nl_after_brace_open                       = true
 nl_after_case                             = true
+nl_after_do                               = force
+nl_after_for                              = force
 nl_after_func_proto                       = 1
 nl_after_func_proto_group                 = 2
+nl_after_if                               = force
 nl_after_return                           = true
 nl_after_semicolon                        = true
+nl_after_switch                           = force
 nl_after_vbrace_open                      = true
+nl_after_while                            = force
 nl_assign_brace                           = add
 nl_assign_leave_one_liners                = true
 nl_before_case                            = true
+nl_before_do                              = force
 nl_before_func_body_def                   = 3
+nl_before_if                              = force
 nl_before_if_closing_paren                = remove
+nl_before_for                             = force
+nl_before_switch                          = force
+nl_before_while                           = force
+nl_brace_catch                            = force
 nl_brace_else                             = add
+nl_brace_fparen                           = remove
 nl_brace_while                            = remove
 nl_case_colon_brace                       = force
 nl_catch_brace                            = add
+nl_class_brace                            = force
+nl_class_colon                            = remove
 nl_class_leave_one_liner_groups           = true
 nl_class_leave_one_liners                 = true
 nl_comment_func_def                       = 1
 nl_constr_colon                           = force
 nl_constr_init_args                       = force
+nl_cpp_ldef_brace                         = force
 nl_do_brace                               = add
 nl_else_brace                             = add
+nl_else_if                                = remove
 nl_elseif_brace                           = add
+nl_end_of_file                            = force
+nl_end_of_file_min                        = 1
 nl_enum_brace                             = force
 nl_enum_class_identifier                  = remove
 nl_enum_class                             = remove
@@ -77,19 +95,30 @@ nl_fcall_brace                            = add
 nl_fdef_brace                             = force
 nl_finally_brace                          = add
 nl_for_brace                              = add
+nl_func_call_empty                        = remove
 nl_func_call_paren                        = remove
+nl_func_call_paren_empty                  = remove
+nl_func_class_scope                       = remove
 nl_func_decl_args                         = remove
+nl_func_decl_empty                        = remove
 nl_func_decl_end                          = remove
 nl_func_decl_end_single                   = remove
 nl_func_decl_start                        = remove
 nl_func_decl_start_single                 = remove
+nl_func_def_args                          = force
+nl_func_def_empty                         = remove
 nl_func_def_end                           = remove
 nl_func_def_end_single                    = remove
 nl_func_def_paren                         = remove
+nl_func_def_paren_empty                   = remove
 nl_func_def_start                         = remove
 nl_func_def_start_single                  = remove
 nl_func_paren                             = remove
+nl_func_paren_empty                       = remove
+nl_func_proto_type_name                   = remove
+nl_func_scope_name                        = remove
 nl_func_type_name                         = remove
+nl_func_type_name_class                   = remove
 nl_func_var_def_blk                       = 1
 nl_getset_leave_one_liners                = true
 nl_if_brace                               = add
@@ -101,6 +130,9 @@ nl_squeeze_ifdef                          = true
 nl_struct_brace                           = add
 nl_switch_brace                           = add
 nl_try_brace                              = add
+nl_type_brace_init_lst                    = force
+nl_type_brace_init_lst_close              = force
+nl_type_brace_init_lst_open               = force
 nl_union_brace                            = add
 nl_while_brace                            = add
 
@@ -350,3 +382,33 @@ sp_cmt_cpp_start                          = ignore
 # sp_version_paren
 # sp_word_brace_ns
 # sp_word_brace
+
+# NOT yet used nl_xx options
+# nl_after_annotation
+# nl_after_square_assign
+# nl_after_synchronized
+# nl_assign_square
+# nl_before_synchronized
+# nl_before_throw
+# nl_between_annotation
+# nl_brace_brace
+# nl_brace_finally
+# nl_brace_square
+# nl_brace_struct_var
+# nl_class_init_args
+# nl_getset_brace
+# nl_oc_block_brace
+# nl_oc_brace_catch
+# nl_oc_catch_brace
+# nl_oc_implementation_brace
+# nl_oc_interface_brace
+# nl_oc_mdef_brace
+# nl_paren_dbrace_open
+# nl_property_brace
+# nl_scope_brace
+# nl_start_of_file
+# nl_synchronized_brace
+# nl_tsquare_brace
+# nl_unittest_brace
+# nl_using_brace
+# nl_version_brace

--- a/src/ChunkStack.cpp
+++ b/src/ChunkStack.cpp
@@ -13,11 +13,13 @@
 void ChunkStack::Set(const ChunkStack &cs)
 {
    m_cse.resize(cs.m_cse.size());
+
    for (size_t idx = 0; idx < m_cse.size(); idx++)
    {
       m_cse[idx].m_pc     = cs.m_cse[idx].m_pc;
       m_cse[idx].m_seqnum = cs.m_cse[idx].m_seqnum;
    }
+
    m_seqnum = cs.m_seqnum;
 }
 
@@ -28,6 +30,7 @@ const ChunkStack::Entry *ChunkStack::Top() const
    {
       return(&m_cse[m_cse.size() - 1]);
    }
+
    return(nullptr);
 }
 
@@ -38,6 +41,7 @@ const ChunkStack::Entry *ChunkStack::Get(size_t idx) const
    {
       return(&m_cse[idx]);
    }
+
    return(nullptr);
 }
 
@@ -48,6 +52,7 @@ chunk_t *ChunkStack::GetChunk(size_t idx) const
    {
       return(m_cse[idx].m_pc);
    }
+
    return(nullptr);
 }
 
@@ -61,6 +66,7 @@ chunk_t *ChunkStack::Pop_Front()
       pc = m_cse[0].m_pc;
       m_cse.pop_front();
    }
+
    return(pc);
 }
 
@@ -74,13 +80,16 @@ chunk_t *ChunkStack::Pop_Back()
       pc = m_cse[m_cse.size() - 1].m_pc;
       m_cse.pop_back();
    }
+
    return(pc);
 }
 
 
-void ChunkStack::Push_Back(chunk_t *pc, size_t seqnum)
+void ChunkStack::Push_Back(chunk_t *pc,
+                           size_t  seqnum)
 {
    m_cse.push_back(Entry(seqnum, pc));
+
    if (m_seqnum < seqnum)
    {
       m_seqnum = seqnum;
@@ -110,8 +119,10 @@ void ChunkStack::Collapse()
             m_cse[wr_idx].m_pc     = m_cse[rd_idx].m_pc;
             m_cse[wr_idx].m_seqnum = m_cse[rd_idx].m_seqnum;
          }
+
          wr_idx++;
       }
    }
+
    m_cse.resize(wr_idx);
 }

--- a/src/ChunkStack.h
+++ b/src/ChunkStack.h
@@ -30,7 +30,8 @@ public:
       }
 
 
-      Entry(size_t sn, chunk_t *pc)
+      Entry(size_t  sn,
+            chunk_t *pc)
          : m_seqnum(sn)
          , m_pc(pc)
       {

--- a/src/ListManager.h
+++ b/src/ListManager.h
@@ -111,18 +111,22 @@ public:
          {
             first = obj->next;
          }
+
          if (last == obj)
          {
             last = obj->prev;
          }
+
          if (obj->next != NULL)
          {
             obj->next->prev = obj->prev;
          }
+
          if (obj->prev != NULL)
          {
             obj->prev->next = obj->next;
          }
+
          obj->next = NULL;
          obj->prev = NULL;
       }
@@ -130,7 +134,8 @@ public:
 
 
    //! swap two elements of a list
-   void Swap(T *obj1, T *obj2)
+   void Swap(T *obj1,
+             T *obj2)
    {
       if (obj1 != NULL && obj2 != NULL)
       {
@@ -165,13 +170,15 @@ public:
     * @param obj  new element to add to list
     * @param ref  chunk after which to insert new object
     */
-   void AddAfter(T *obj, T *ref)
+   void AddAfter(T *obj,
+                 T *ref)
    {
       if (obj != NULL && ref != NULL)
       {
          Pop(obj); // TODO: is this necessary?
          obj->next = ref->next;
          obj->prev = ref;
+
          if (ref->next != NULL)
          {
             ref->next->prev = obj;
@@ -180,6 +187,7 @@ public:
          {
             last = obj;
          }
+
          ref->next = obj;
       }
    }
@@ -191,13 +199,15 @@ public:
     * @param obj  new element to add to list
     * @param ref  chunk before to insert new object
     */
-   void AddBefore(T *obj, T *ref)
+   void AddBefore(T *obj,
+                  T *ref)
    {
       if (obj != NULL && ref != NULL)
       {
          Pop(obj);
          obj->next = ref;
          obj->prev = ref->prev;
+
          if (ref->prev != NULL)
          {
             ref->prev->next = obj;
@@ -206,6 +216,7 @@ public:
          {
             first = obj;
          }
+
          ref->prev = obj;
       }
    }
@@ -220,6 +231,7 @@ public:
    {
       obj->next = NULL;
       obj->prev = last;
+
       if (last == NULL)
       {
          last  = obj;
@@ -229,6 +241,7 @@ public:
       {
          last->next = obj;
       }
+
       last = obj;
    }
 
@@ -242,6 +255,7 @@ public:
    {
       obj->next = first;
       obj->prev = NULL;
+
       if (first == NULL)
       {
          last  = obj;
@@ -251,6 +265,7 @@ public:
       {
          first->prev = obj;
       }
+
       first = obj;
    }
 };

--- a/src/ParseFrame.cpp
+++ b/src/ParseFrame.cpp
@@ -96,6 +96,7 @@ ContainerType &ParseFrame::prev(size_t idx)
       throw invalid_argument(string(__FILE__) + ":" + to_string(__LINE__)
                              + " idx can't be zero");
    }
+
    if (idx >= pse.size())
    {
       LOG_FMT(LINDPSE, "%s(%d): idx is %zu, size is %zu\n",
@@ -103,6 +104,7 @@ ContainerType &ParseFrame::prev(size_t idx)
       throw invalid_argument(string(__FILE__) + ":" + to_string(__LINE__)
                              + " idx can't be >= size()");
    }
+
    return(*std::prev(std::end(pse), idx + 1));
 }
 
@@ -116,6 +118,7 @@ const ContainerType &ParseFrame::prev(size_t idx) const
       throw invalid_argument(string(__FILE__) + ":" + to_string(__LINE__)
                              + " idx can't be zero or >= size()");
    }
+
    return(*std::prev(std::end(pse), idx + 1));
 }
 
@@ -144,7 +147,8 @@ const ContainerType &ParseFrame::top() const
 }
 
 
-void ParseFrame::push(chunk_t &pc, brace_stage_e stage)
+void ParseFrame::push(chunk_t       &pc,
+                      brace_stage_e stage)
 {
    LOG_FUNC_ENTRY();
 

--- a/src/ParseFrame.h
+++ b/src/ParseFrame.h
@@ -38,7 +38,8 @@ struct paren_stack_entry_t
    chunk_t       *pop_pc;
 };
 
-class ParseFrame {
+class ParseFrame
+{
 private:
    std::vector<paren_stack_entry_t> pse;
    paren_stack_entry_t              last_poped;

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -115,6 +115,7 @@ using namespace uncrustify;
 void align_all(void)
 {
    LOG_FUNC_ENTRY();
+
    if (options::align_typedef_span() > 0)
    {
       align_typedefs(options::align_typedef_span());
@@ -189,6 +190,7 @@ void align_all(void)
    {
       align_same_func_call_params();
    }
+
    // Just in case something was aligned out of order... do it again
    quick_align_again();
 } // align_all

--- a/src/align_add.cpp
+++ b/src/align_add.cpp
@@ -11,12 +11,15 @@
 #include "uncrustify.h"
 
 
-void align_add(ChunkStack &cs, chunk_t *pc, size_t &max_col)
+void align_add(ChunkStack &cs,
+               chunk_t    *pc,
+               size_t     &max_col)
 {
    LOG_FUNC_ENTRY();
 
    size_t  min_col;
    chunk_t *prev = chunk_get_prev(pc);
+
    if (prev == nullptr || chunk_is_newline(prev))
    {
       min_col = 1;
@@ -33,6 +36,7 @@ void align_add(ChunkStack &cs, chunk_t *pc, size_t &max_col)
       {
          min_col = prev->column + prev->len() + 1;
       }
+
       LOG_FMT(LALADD, "%s(%d): pc->orig_line=%zu, pc->col=%zu max_col=%zu min_col=%zu multi:%s prev->col=%zu prev->len()=%zu %s\n",
               __func__, __LINE__, pc->orig_line, pc->column, max_col, min_col, (chunk_is_token(prev, CT_COMMENT_MULTI)) ? "Y" : "N",
               (chunk_is_token(prev, CT_COMMENT_MULTI)) ? prev->orig_col_end : (UINT32)prev->column, prev->len(), get_token_name(prev->type));
@@ -44,6 +48,7 @@ void align_add(ChunkStack &cs, chunk_t *pc, size_t &max_col)
    }
 
    cs.Push_Back(pc);
+
    if (min_col > max_col)
    {
       max_col = min_col;

--- a/src/align_asm_colon.cpp
+++ b/src/align_asm_colon.cpp
@@ -22,6 +22,7 @@ void align_asm_colon(void)
    cas.Start(4);
 
    chunk_t *pc = chunk_get_head();
+
    while (pc != nullptr)
    {
       if (pc->type != CT_ASM_COLON)
@@ -35,6 +36,7 @@ void align_asm_colon(void)
       pc = chunk_get_next_ncnl(pc, scope_e::PREPROC);
       size_t level = pc ? pc->level : 0;
       did_nl = true;
+
       while (pc && pc->level >= level)
       {
          if (chunk_is_newline(pc))
@@ -52,8 +54,10 @@ void align_asm_colon(void)
             did_nl = false;
             cas.Add(pc);
          }
+
          pc = chunk_get_next_nc(pc, scope_e::PREPROC);
       }
+
       cas.End();
    }
 } // align_asm_colon

--- a/src/align_assign.cpp
+++ b/src/align_assign.cpp
@@ -14,7 +14,10 @@
 using namespace uncrustify;
 
 
-chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_count)
+chunk_t *align_assign(chunk_t *first,
+                      size_t  span,
+                      size_t  thresh,
+                      size_t  *p_nl_count)
 {
    LOG_FUNC_ENTRY();
 
@@ -24,6 +27,7 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
       // see https://en.wikipedia.org/wiki/Robustness_principle
       return(nullptr);
    }
+
    size_t my_level = first->level;
 
    LOG_FMT(LALASS, "%s(%d): [my_level is %zu]: start checking with '%s', on orig_line %zu, span is %zu, thresh is %zu\n",
@@ -50,6 +54,7 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
    size_t  equ_count   = 0;
    size_t  tmp;
    chunk_t *pc = first;
+
    while (pc != nullptr)
    {
       LOG_FMT(LALASS, "%s(%d): orig_line is %zu, check pc->text() '%s', type is %s, parent_type is %s\n",
@@ -65,6 +70,7 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
                  __func__, __LINE__, get_token_name(pc->type));
          tmp = pc->orig_line;
          pc  = chunk_skip_to_match(pc);
+
          if (pc != nullptr)
          {
             as.NewLines(pc->orig_line - tmp);
@@ -72,9 +78,9 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
             fcnDefault.NewLines(pc->orig_line - tmp);
             fcnProto.NewLines(pc->orig_line - tmp);
          }
+
          continue;
       }
-
 
       // Recurse if a brace set is found
       if (chunk_is_token(pc, CT_BRACE_OPEN) || chunk_is_token(pc, CT_VBRACE_OPEN))
@@ -96,17 +102,20 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
          }
 
          pc = align_assign(chunk_get_next_ncnl(pc), myspan, mythresh, &sub_nl_count);
+
          if (sub_nl_count > 0)
          {
             as.NewLines(sub_nl_count);
             vdas.NewLines(sub_nl_count);
             fcnDefault.NewLines(sub_nl_count);
             fcnProto.NewLines(sub_nl_count);
+
             if (p_nl_count != nullptr)
             {
                *p_nl_count += sub_nl_count;
             }
          }
+
          continue;
       }
 
@@ -116,7 +125,6 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
          pc = chunk_get_next(pc);
          break;
       }
-
 
       if (chunk_is_newline(pc))
       {
@@ -157,6 +165,7 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
          {
             equ_count++;
          }
+
          LOG_FMT(LALASS, "%s(%d): align_assign_decl_func() is %d\n",
                  __func__, __LINE__, options::align_assign_decl_func());
          LOG_FMT(LALASS, "%s(%d): log_pcf_flags pc->flags: ", __func__, __LINE__);

--- a/src/align_func_params.cpp
+++ b/src/align_func_params.cpp
@@ -21,6 +21,7 @@ chunk_t *align_func_param(chunk_t *start)
    size_t myspan   = 2;
    size_t mythresh = 0;
    size_t mygap    = 0;
+
    // Override, if the align_func_params_span > 0
    if (options::align_func_params_span() > 0)
    {
@@ -40,9 +41,11 @@ chunk_t *align_func_param(chunk_t *start)
    size_t  chunk_count   = 0;
 
    chunk_t *pc = start;
+
    while ((pc = chunk_get_next(pc)) != nullptr)
    {
       chunk_count++;
+
       if (chunk_is_newline(pc))
       {
          did_this_line = false;
@@ -60,6 +63,7 @@ chunk_t *align_func_param(chunk_t *start)
          {
             as.Add(pc);
          }
+
          did_this_line = true;
       }
       else if (comma_count > 0)
@@ -73,6 +77,7 @@ chunk_t *align_func_param(chunk_t *start)
       else if (chunk_is_token(pc, CT_COMMA))
       {
          chunk_t *tmp_prev = chunk_get_prev_nc(pc);
+
          if (!chunk_is_newline(tmp_prev))  // don't count leading commas
          {
             comma_count++;
@@ -93,6 +98,7 @@ void align_func_params(void)
 {
    LOG_FUNC_ENTRY();
    chunk_t *pc = chunk_get_head();
+
    while ((pc = chunk_get_next(pc)) != nullptr)
    {
       if (  pc->type != CT_FPAREN_OPEN

--- a/src/align_func_proto.cpp
+++ b/src/align_func_proto.cpp
@@ -56,6 +56,7 @@ void align_func_proto(size_t span)
          {
             toadd = pc;
          }
+
          as.Add(step_back_over_member(toadd));
          look_bro = (chunk_is_token(pc, CT_FUNC_DEF))
                     && options::align_single_line_brace();
@@ -68,6 +69,7 @@ void align_func_proto(size_t span)
          look_bro = false;
       }
    }
+
    as.End();
    as_br.End();
 } // align_func_proto

--- a/src/align_init_brace.cpp
+++ b/src/align_init_brace.cpp
@@ -32,6 +32,7 @@ void align_init_brace(chunk_t *start)
 
    chunk_t *pc       = chunk_get_next_ncnl(start);
    chunk_t *pcSingle = scan_ib_line(pc, true);
+
    if (  pcSingle == nullptr
       || (chunk_is_token(pcSingle, CT_BRACE_CLOSE) && pcSingle->parent_type == CT_ASSIGN))
    {
@@ -39,6 +40,7 @@ void align_init_brace(chunk_t *start)
       LOG_FMT(LALBR, "%s(%d): single line - nothing to do\n", __func__, __LINE__);
       return;
    }
+
    LOG_FMT(LALBR, "%s(%d): is not a single line\n", __func__, __LINE__);
 
    do
@@ -68,35 +70,43 @@ void align_init_brace(chunk_t *start)
 
    pc = chunk_get_next(start);
    size_t idx = 0;
+
    do
    {
       chunk_t *tmp;
+
       if (idx == 0 && ((tmp = skip_c99_array(pc)) != nullptr))
       {
          pc = tmp;
+
          if (pc != nullptr)
          {
             LOG_FMT(LALBR, " -%zu- skipped '[] =' to %s\n",
                     pc->orig_line, get_token_name(pc->type));
          }
+
          continue;
       }
 
       chunk_t *next = pc;
+
       if (idx < cpd.al_cnt)
       {
          LOG_FMT(LALBR, " (%zu) check %s vs %s -- ",
                  idx, get_token_name(pc->type), get_token_name(cpd.al[idx].type));
+
          if (pc->type == cpd.al[idx].type)
          {
             if (idx == 0 && cpd.al_c99_array)
             {
                chunk_t *prev = chunk_get_prev(pc);
+
                if (chunk_is_newline(prev))
                {
                   chunk_flags_set(pc, PCF_DONT_INDENT);
                }
             }
+
             LOG_FMT(LALBR, " [%s] to col %zu\n", pc->text(), cpd.al[idx].col);
 
             if (num_token != nullptr)
@@ -116,6 +126,7 @@ void align_init_brace(chunk_t *start)
             if (chunk_is_token(pc, CT_COMMA))
             {
                next = chunk_get_next(pc);
+
                if (next != nullptr && !chunk_is_newline(next))
                {
                   //LOG_FMT(LSYS, "-= %zu =- indent [%s] col=%d len=%d\n",
@@ -154,6 +165,7 @@ void align_init_brace(chunk_t *start)
                   && options::align_number_right())
                {
                   next = chunk_get_next(pc);
+
                   if (  next != nullptr
                      && !chunk_is_newline(next)
                      && (  chunk_is_token(next, CT_NUMBER_FP)
@@ -166,6 +178,7 @@ void align_init_brace(chunk_t *start)
                   }
                }
             }
+
             idx++;
          }
          else
@@ -173,10 +186,12 @@ void align_init_brace(chunk_t *start)
             LOG_FMT(LALBR, " no match\n");
          }
       }
+
       if (chunk_is_newline(pc) || chunk_is_newline(next))
       {
          idx = 0;
       }
+
       pc = chunk_get_next(pc);
    } while (pc != nullptr && pc->level > start->level);
 } // align_init_brace

--- a/src/align_left_shift.cpp
+++ b/src/align_left_shift.cpp
@@ -27,6 +27,7 @@ void align_left_shift(void)
    as.Start(255);
 
    chunk_t *pc = chunk_get_head();
+
    while (pc != nullptr)
    {
       if (chunk_is_newline(pc))
@@ -38,6 +39,7 @@ void align_left_shift(void)
          LOG_FMT(LAVDB, "%s(%d): orig_line is %zu, orig_col is %zu, pc->text() '%s'\n",
                  __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text());
       }
+
       if (  start != nullptr
          && ((pc->flags & PCF_IN_PREPROC) != (start->flags & PCF_IN_PREPROC)))
       {
@@ -82,6 +84,7 @@ void align_left_shift(void)
              *          << "something";
              */
             chunk_t *prev = chunk_get_prev(pc);
+
             if (prev != nullptr && chunk_is_newline(prev))
             {
                indent_to_column(pc, pc->column_indent + options::indent_columns());
@@ -109,6 +112,7 @@ void align_left_shift(void)
           *          "something";
           */
          chunk_t *prev = chunk_get_prev(pc);
+
          if (prev != nullptr && chunk_is_newline(prev))
          {
             indent_to_column(pc, pc->column_indent + options::indent_columns());
@@ -119,5 +123,6 @@ void align_left_shift(void)
 
       pc = chunk_get_next(pc);
    }
+
    as.End();
 } // align_left_shift

--- a/src/align_log_al.cpp
+++ b/src/align_log_al.cpp
@@ -11,18 +11,21 @@
 #include "uncrustify.h"
 
 
-void align_log_al(log_sev_t sev, size_t line)
+void align_log_al(log_sev_t sev,
+                  size_t    line)
 {
    if (log_sev_on(sev))
    {
       log_fmt(sev, "%s(%d): line %zu, cpd.al_cnt is %zu\n",
               __func__, __LINE__, line, cpd.al_cnt);
+
       for (size_t idx = 0; idx < cpd.al_cnt; idx++)
       {
          log_fmt(sev, "   cpd.al[%2.1zu].col is %2.1zu, cpd.al[%2.1zu].len is %zu, type is %s\n",
                  idx, cpd.al[idx].col, idx, cpd.al[idx].len,
                  get_token_name(cpd.al[idx].type));
       }
+
       log_fmt(sev, "\n");
    }
 } // align_log_al

--- a/src/align_nl_cont.cpp
+++ b/src/align_nl_cont.cpp
@@ -25,6 +25,7 @@ chunk_t *align_nl_cont(chunk_t *start)
    ChunkStack cs;
    size_t     max_col = 0;
    chunk_t    *pc     = start;
+
    while (  pc != nullptr
          && pc->type != CT_NEWLINE
          && pc->type != CT_COMMENT_MULTI)
@@ -33,11 +34,13 @@ chunk_t *align_nl_cont(chunk_t *start)
       {
          align_add(cs, pc, max_col);
       }
+
       pc = chunk_get_next(pc);
    }
 
    // NL_CONT is always the last thing on a line
    chunk_t *tmp;
+
    while ((tmp = cs.Pop_Back()) != nullptr)
    {
       chunk_flags_set(tmp, PCF_WAS_ALIGNED);
@@ -52,6 +55,7 @@ void align_backslash_newline(void)
 {
    LOG_FUNC_ENTRY();
    chunk_t *pc = chunk_get_head();
+
    while (pc != nullptr)
    {
       if (pc->type != CT_NL_CONT)
@@ -59,6 +63,7 @@ void align_backslash_newline(void)
          pc = chunk_get_next_type(pc, CT_NL_CONT, -1);
          continue;
       }
+
       pc = align_nl_cont(pc);
    }
 } // align_backslash_newline

--- a/src/align_oc_decl_colon.cpp
+++ b/src/align_oc_decl_colon.cpp
@@ -29,6 +29,7 @@ void align_oc_decl_colon(void)
    nas.m_right_align = !options::align_on_tabstop();
 
    chunk_t *pc = chunk_get_head();
+
    while (pc != nullptr)
    {
       if (pc->type != CT_OC_SCOPE)
@@ -79,10 +80,13 @@ void align_oc_decl_colon(void)
             {
                nas.Add(tmp);
             }
+
             did_line = true;
          }
+
          pc = chunk_get_next(pc, scope_e::PREPROC);
       }
+
       nas.End();
       cas.End();
    }

--- a/src/align_oc_msg_colons.cpp
+++ b/src/align_oc_msg_colons.cpp
@@ -44,6 +44,7 @@ void align_oc_msg_colon(chunk_t *so)
          {
             ++lcnt;
          }
+
          did_line  = false;
          has_colon = !has_colon;
       }
@@ -54,14 +55,17 @@ void align_oc_msg_colon(chunk_t *so)
          has_colon = true;
          cas.Add(pc);
          chunk_t *tmp = chunk_get_prev(pc);
+
          if (  tmp != nullptr
             && (chunk_is_token(tmp, CT_OC_MSG_FUNC) || chunk_is_token(tmp, CT_OC_MSG_NAME)))
          {
             nas.Add(tmp);
             chunk_flags_set(tmp, PCF_DONT_INDENT);
          }
+
          did_line = true;
       }
+
       pc = chunk_get_next(pc, scope_e::PREPROC);
    }
 
@@ -74,20 +78,25 @@ void align_oc_msg_colon(chunk_t *so)
    chunk_t *longest  = nullptr;
 
    size_t  len = nas.m_aligned.Len();
+
    for (size_t idx = 0; idx < len; idx++)
    {
       chunk_t *tmp = nas.m_aligned.GetChunk(idx);
+
       if (tmp != nullptr)
       {
          size_t tlen = tmp->str.size();
+
          if (tlen > mlen)
          {
             mlen = tlen;
+
             if (idx != 0)
             {
                longest = tmp;
             }
          }
+
          if (idx == 0)
          {
             first_len = tlen + 1;
@@ -99,6 +108,7 @@ void align_oc_msg_colon(chunk_t *so)
    len = options::indent_oc_msg_colon();
    size_t len_diff    = mlen - first_len;
    size_t indent_size = options::indent_columns();
+
    // Align with first colon if possible by removing spaces
    if (  longest
       && options::indent_oc_msg_prioritize_first_colon()
@@ -127,6 +137,7 @@ void align_oc_msg_colon(chunk_t *so)
 
       chunk_add_before(&chunk, longest);
    }
+
    nas.End();
    cas.End();
 } // align_oc_msg_colon

--- a/src/align_oc_msg_spec.cpp
+++ b/src/align_oc_msg_spec.cpp
@@ -31,5 +31,6 @@ void align_oc_msg_spec(size_t span)
          as.Add(pc);
       }
    }
+
    as.End();
 } // void align_oc_msg_spec

--- a/src/align_preprocessor.cpp
+++ b/src/align_preprocessor.cpp
@@ -29,6 +29,7 @@ void align_preprocessor(void)
    asf.m_gap = options::align_pp_define_gap();
 
    chunk_t *pc = chunk_get_head();
+
    while (pc != nullptr)
    {
       // Note: not counting back-slash newline combos
@@ -47,6 +48,7 @@ void align_preprocessor(void)
 
       // step past the 'define'
       pc = chunk_get_next_nc(pc);
+
       if (pc == nullptr)
       {
          // coveralls will complain here. There are no example for that.
@@ -58,6 +60,7 @@ void align_preprocessor(void)
               __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col);
 
       cur_as = &as;
+
       if (chunk_is_token(pc, CT_MACRO_FUNC))
       {
          if (!options::align_pp_define_together())
@@ -75,6 +78,7 @@ void align_preprocessor(void)
 
       // step to the value past the close parenthesis or the macro name
       pc = chunk_get_next(pc);
+
       if (pc == nullptr)
       {
          // coveralls will complain here. There are no example for that.

--- a/src/align_same_func_call_params.cpp
+++ b/src/align_same_func_call_params.cpp
@@ -53,6 +53,7 @@ void align_same_func_call_params(void)
             {
                as_v.NewLines(pc->nl_count);
             }
+
             fcn_as.NewLines(pc->nl_count);
          }
          else
@@ -64,37 +65,46 @@ void align_same_func_call_params(void)
 
                // Flush it all!
                fcn_as.Flush();
+
                for (auto &as_v : as)
                {
                   as_v.Flush();
                }
+
                align_root = nullptr;
             }
          }
+
          continue;
       }
 
       // Only align function calls that are right after a newline
       chunk_t *prev = chunk_get_prev(pc);
+
       while (  chunk_is_token(prev, CT_MEMBER)
             || chunk_is_token(prev, CT_DC_MEMBER))
       {
          chunk_t *tprev = chunk_get_prev(prev);
+
          if (!chunk_is_token(tprev, CT_TYPE))
          {
             prev = tprev;
             break;
          }
+
          prev = chunk_get_prev(tprev);
       }
+
       if (!chunk_is_newline(prev))
       {
          continue;
       }
+
       prev      = chunk_get_next(prev);
       align_fcn = prev;
       align_fcn_name.clear();
       LOG_FMT(LASFCP, "%s(%d): align_fnc_name '%s'\n", __func__, __LINE__, align_fcn_name.c_str());
+
       while (prev != pc)
       {
          LOG_FMT(LASFCP, "%s(%d): align_fnc_name '%s'\n", __func__, __LINE__, align_fcn_name.c_str());
@@ -102,6 +112,7 @@ void align_same_func_call_params(void)
          LOG_FMT(LASFCP, "%s(%d): align_fnc_name '%s'\n", __func__, __LINE__, align_fcn_name.c_str());
          prev = chunk_get_next(prev);
       }
+
       LOG_FMT(LASFCP, "%s(%d): align_fnc_name '%s'\n", __func__, __LINE__, align_fcn_name.c_str());
       align_fcn_name += pc->str;
       LOG_FMT(LASFCP, "%s(%d): align_fnc_name '%s'\n", __func__, __LINE__, align_fcn_name.c_str());
@@ -111,6 +122,7 @@ void align_same_func_call_params(void)
               align_fcn_name.c_str());
 
       add_str = nullptr;
+
       if (align_root != nullptr)
       {
          // Issue # 1395
@@ -132,10 +144,12 @@ void align_same_func_call_params(void)
 
             // Flush it all!
             fcn_as.Flush();
+
             for (auto &as_v : as)
             {
                as_v.Flush();
             }
+
             align_root = nullptr;
          }
       }
@@ -160,10 +174,12 @@ void align_same_func_call_params(void)
          for (size_t idx = 0; idx < chunks.size(); idx++)
          {
             LOG_FMT(LASFCP, " [%s]", chunks[idx]->text());
+
             if (idx >= as.size())
             {
                as.resize(idx + 1);
                as[idx].Start(span, thresh);
+
                if (!options::align_number_right())
                {
                   if (  chunk_is_token(chunks[idx], CT_NUMBER_FP)
@@ -175,8 +191,10 @@ void align_same_func_call_params(void)
                   }
                }
             }
+
             as[idx].Add(chunks[idx]);
          }
+
          LOG_FMT(LASFCP, "\n");
       }
    }
@@ -185,6 +203,7 @@ void align_same_func_call_params(void)
    {
       LOG_FMT(LASFCP, "  ++ Ended with %zu fcns\n", align_len);
       fcn_as.End();
+
       for (auto &as_v : as)
       {
          as_v.End();
@@ -193,7 +212,8 @@ void align_same_func_call_params(void)
 } // align_same_func_call_params
 
 
-void align_params(chunk_t *start, deque<chunk_t *> &chunks)
+void align_params(chunk_t          *start,
+                  deque<chunk_t *> &chunks)
 {
    LOG_FUNC_ENTRY();
 
@@ -201,6 +221,7 @@ void align_params(chunk_t *start, deque<chunk_t *> &chunks)
 
    bool    hit_comma = true;
    chunk_t *pc       = chunk_get_next_type(start, CT_FPAREN_OPEN, start->level);
+
    while ((pc = chunk_get_next(pc)) != nullptr)
    {
       if (  chunk_is_newline(pc)

--- a/src/align_struct_initializers.cpp
+++ b/src/align_struct_initializers.cpp
@@ -17,15 +17,18 @@ void align_struct_initializers(void)
 {
    LOG_FUNC_ENTRY();
    chunk_t *pc = chunk_get_head();
+
    while (pc != nullptr)
    {
       chunk_t *prev = chunk_get_prev_ncnl(pc);
+
       if (  chunk_is_token(prev, CT_ASSIGN)
          && (  chunk_is_token(pc, CT_BRACE_OPEN)
             || (language_is_set(LANG_D) && chunk_is_token(pc, CT_SQUARE_OPEN))))
       {
          align_init_brace(pc);
       }
+
       pc = chunk_get_next_type(pc, CT_BRACE_OPEN, -1);
    }
 } // align_struct_initializers

--- a/src/align_tab_column.cpp
+++ b/src/align_tab_column.cpp
@@ -29,9 +29,11 @@ size_t align_tab_column(size_t col)
    {
       col = 1;
    }
+
    if ((col % uncrustify::options::output_tab_size()) != 1)
    {
       col = next_tab_column(col);
    }
+
    return(col);
 }

--- a/src/align_tools.cpp
+++ b/src/align_tools.cpp
@@ -24,11 +24,13 @@ chunk_t *skip_c99_array(chunk_t *sq_open)
          return(chunk_get_next_nc(tmp));
       }
    }
+
    return(nullptr);
 } // skip_c99_array
 
 
-chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
+chunk_t *scan_ib_line(chunk_t *start,
+                      bool    first_pass)
 {
    UNUSED(first_pass);
    LOG_FUNC_ENTRY();
@@ -37,12 +39,14 @@ chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
 
    // Skip past C99 "[xx] =" stuff
    chunk_t *tmp = skip_c99_array(start);
+
    if (tmp != nullptr)
    {
       set_chunk_parent(start, CT_TSQUARE);
       start            = tmp;
       cpd.al_c99_array = true;
    }
+
    chunk_t *pc = start;
 
    if (pc != nullptr)
@@ -59,6 +63,7 @@ chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
       //        pc->text(), pc->column, pc->orig_col, pc->orig_line);
 
       chunk_t *next = chunk_get_next(pc);
+
       if (next == nullptr || chunk_is_comment(next))
       {
          // do nothing
@@ -79,12 +84,14 @@ chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
             {
                LOG_FMT(LSIB, "%s(%d): Prepare the 'idx's\n", __func__, __LINE__);
             }
+
             LOG_FMT(LSIB, "%s(%d):   New idx is %2.1zu, pc->column is %2.1zu, text() '%s', token_width is %zu, type is %s\n",
                     __func__, __LINE__, idx, pc->column, pc->text(), token_width, get_token_name(pc->type));
             cpd.al[cpd.al_cnt].type = pc->type;
             cpd.al[cpd.al_cnt].col  = pc->column;
             cpd.al[cpd.al_cnt].len  = token_width;
             cpd.al_cnt++;
+
             if (cpd.al_cnt == AL_SIZE)
             {
                fprintf(stderr, "Number of 'entry' to be aligned is too big for the current value %d,\n", AL_SIZE);
@@ -93,6 +100,7 @@ chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
                log_flush(true);
                exit(EX_SOFTWARE);
             }
+
             idx++;
          }
          else
@@ -121,6 +129,7 @@ chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
                           __func__, __LINE__, prev_match->text(), prev_match->orig_line, prev_match->orig_col);
                   int min_col_diff = pc->column - prev_match->column;
                   int cur_col_diff = cpd.al[idx].col - cpd.al[idx - 1].col;
+
                   if (cur_col_diff < min_col_diff)
                   {
                      LOG_FMT(LSIB, "%s(%d):   pc->orig_line is %zu\n",
@@ -128,20 +137,25 @@ chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
                      ib_shift_out(idx, min_col_diff - cur_col_diff);
                   }
                }
+
                LOG_FMT(LSIB, "%s(%d): at ende of the loop: now is col %zu, len is %zu\n",
                        __func__, __LINE__, cpd.al[idx].col, cpd.al[idx].len);
                idx++;
             }
          }
+
          prev_match = pc;
       }
+
       pc = chunk_get_next_nc(pc);
    }
+
    return(pc);
 } // scan_ib_line
 
 
-void ib_shift_out(size_t idx, size_t num)
+void ib_shift_out(size_t idx,
+                  size_t num)
 {
    while (idx < cpd.al_cnt)
    {
@@ -162,5 +176,6 @@ chunk_t *step_back_over_member(chunk_t *pc)
       // TODO: verify that we are pointing at something sane?
       pc = chunk_get_prev_ncnl(tmp);
    }
+
    return(pc);
 } // step_back_over_member

--- a/src/align_trailing_comments.cpp
+++ b/src/align_trailing_comments.cpp
@@ -17,7 +17,10 @@
 using namespace uncrustify;
 
 
-void align_stack(ChunkStack &cs, size_t col, bool align_single, log_sev_t sev)
+void align_stack(ChunkStack &cs,
+                 size_t     col,
+                 bool       align_single,
+                 log_sev_t  sev)
 {
    LOG_FUNC_ENTRY();
 
@@ -31,6 +34,7 @@ void align_stack(ChunkStack &cs, size_t col, bool align_single, log_sev_t sev)
    {
       LOG_FMT(sev, "%s(%d): max_col=%zu\n", __func__, __LINE__, col);
       chunk_t *pc;
+
       while ((pc = cs.Pop_Back()) != nullptr)
       {
          align_to_column(pc, col);
@@ -40,6 +44,7 @@ void align_stack(ChunkStack &cs, size_t col, bool align_single, log_sev_t sev)
                  __func__, __LINE__, pc->text(), pc->orig_line, pc->column);
       }
    }
+
    cs.Reset();
 } // align_stack
 
@@ -81,44 +86,54 @@ chunk_t *align_trailing_comments(chunk_t *start)
             LOG_FMT(LALADD, "%s(%d): line=%zu min_col=%zu pc->col=%zu pc->len=%zu %s\n",
                     __func__, __LINE__, pc->orig_line, min_col, pc->column, pc->len(),
                     get_token_name(pc->type));
+
             if (min_orig == 0 || min_orig > pc->column)
             {
                min_orig = pc->column;
             }
+
             align_add(cs, pc, min_col); // (intended_col < col));
             nl_count = 0;
          }
       }
+
       if (chunk_is_newline(pc))
       {
          nl_count += pc->nl_count;
       }
+
       pc = chunk_get_next(pc);
    }
 
    // Start with the minimum original column
    col = min_orig;
+
    // fall back to the intended column
    if (intended_col > 0 && col > intended_col)
    {
       col = intended_col;
    }
+
    // if less than allowed, bump it out
    if (col < min_col)
    {
       col = min_col;
    }
+
    // bump out to the intended column
    if (col < intended_col)
    {
       col = intended_col;
    }
+
    LOG_FMT(LALADD, "%s(%d):  -- min_orig=%zu intended_col=%zu min_allowed=%zu ==> col=%zu\n",
            __func__, __LINE__, min_orig, intended_col, min_col, col);
+
    if (cpd.frag_cols > 0 && cpd.frag_cols <= col)
    {
       col -= cpd.frag_cols;
    }
+
    align_stack(cs, col, (intended_col != 0), LALTC);
 
    return(chunk_get_next(pc));
@@ -145,6 +160,7 @@ comment_align_e get_comment_align_type(chunk_t *cmt)
          }
       }
    }
+
    return(cmt_type);
 } // get_comment_align_type
 
@@ -195,6 +211,7 @@ void align_right_comments(void)
    }
 
    chunk_t *pc = chunk_get_head();
+
    while (pc != nullptr)
    {
       if (pc->flags & PCF_RIGHT_COMMENT)

--- a/src/align_typedefs.cpp
+++ b/src/align_typedefs.cpp
@@ -27,6 +27,7 @@ void align_typedefs(size_t span)
 
    chunk_t *c_typedef = nullptr;
    chunk_t *pc        = chunk_get_head();
+
    while (pc != nullptr)
    {
       if (chunk_is_newline(pc))

--- a/src/align_var_def_brace.cpp
+++ b/src/align_var_def_brace.cpp
@@ -16,7 +16,9 @@
 using namespace uncrustify;
 
 
-chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
+chunk_t *align_var_def_brace(chunk_t *start,
+                             size_t  span,
+                             size_t  *p_nl_count)
 {
    LOG_FUNC_ENTRY();
 
@@ -51,6 +53,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
 
    // can't be any variable definitions in a "= {" block
    chunk_t *prev = chunk_get_prev_ncnl(start);
+
    if (chunk_is_token(prev, CT_ASSIGN))
    {
       LOG_FMT(LAVDB, "%s(%d): start->text() '%s', type is %s, on orig_line %zu (abort due to assign)\n",
@@ -64,6 +67,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
            __func__, __LINE__, start->text(), get_token_name(start->type), start->orig_line);
 
    UINT64 align_mask = PCF_IN_FCN_DEF | PCF_VAR_1ST;
+
    if (!options::align_var_def_inline())
    {
       align_mask |= PCF_VAR_INLINE;
@@ -93,6 +97,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
    bool    did_this_line = false;
    bool    fp_active     = options::align_mix_var_proto();
    chunk_t *pc           = chunk_get_next(start);
+
    while (  pc != nullptr
          && (pc->level >= start->level || pc->level == 0))
    {
@@ -106,6 +111,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
          LOG_FMT(LAVDB, "%s(%d): orig_line is %zu, orig_col is %zu, text() '%s', type is %s\n",
                  __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(), get_token_name(pc->type));
       }
+
       if (chunk_is_comment(pc))
       {
          if (pc->nl_count > 0)
@@ -115,6 +121,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
             as_at.NewLines(pc->nl_count);
             as_br.NewLines(pc->nl_count);
          }
+
          pc = chunk_get_next(pc);
          continue;
       }
@@ -130,6 +137,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
                     __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col, pc->level);
 
             chunk_t *toadd;
+
             if (  pc->parent_type == CT_OPERATOR
                && options::align_on_operator())
             {
@@ -139,6 +147,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
             {
                toadd = pc;
             }
+
             as.Add(step_back_over_member(toadd));
             fp_look_bro = (chunk_is_token(pc, CT_FUNC_DEF))
                           && options::align_single_line_brace();
@@ -158,6 +167,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
          size_t sub_nl_count = 0;
 
          pc = align_var_def_brace(pc, span, &sub_nl_count);
+
          if (sub_nl_count > 0)
          {
             fp_look_bro   = false;
@@ -166,11 +176,13 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
             as_bc.NewLines(sub_nl_count);
             as_at.NewLines(sub_nl_count);
             as_br.NewLines(sub_nl_count);
+
             if (p_nl_count != nullptr)
             {
                *p_nl_count += sub_nl_count;
             }
          }
+
          continue;
       }
 
@@ -189,6 +201,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
          as_bc.NewLines(pc->nl_count);
          as_at.NewLines(pc->nl_count);
          as_br.NewLines(pc->nl_count);
+
          if (p_nl_count != nullptr)
          {
             *p_nl_count += pc->nl_count;
@@ -197,16 +210,19 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
 
       LOG_FMT(LAVDB, "%s(%d): pc->text() is '%s', level is %zu, pc->brace_level is %zu\n",
               __func__, __LINE__, chunk_is_newline(pc) ? "Newline" : pc->text(), pc->level, pc->brace_level);
+
       if (!chunk_is_newline(pc))
       {
          LOG_FMT(LAVDB, "%s(%d): pc->orig_line is %zu, orig_col is %zu, text() '%s', type is %s\n",
                  __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(), get_token_name(pc->type));
+
          if (!chunk_is_token(pc, CT_IGNORED))
          {
             LOG_FMT(LAVDB, "   ");
             log_pcf_flags(LAVDB, pc->flags);
          }
       }
+
       // don't align stuff inside parenthesis/squares/angles
       if (pc->level > pc->brace_level)
       {
@@ -228,6 +244,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
                  __func__, __LINE__, did_this_line ? "TRUE" : "FALSE");
          LOG_FMT(LAVDB, "%s(%d): text() is '%s', orig_line is %zu, orig_col is %zu, level is %zu\n",
                  __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col, pc->level);
+
          if (!did_this_line)
          {
             if (  start->parent_type == CT_STRUCT
@@ -235,6 +252,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
             {
                // we must look after the previous token
                chunk_t *prev_local = pc->prev;
+
                while (  chunk_is_token(prev_local, CT_PTR_TYPE)
                      || chunk_is_token(prev_local, CT_ADDR))
                {
@@ -242,8 +260,10 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
                           __func__, __LINE__, prev_local->text(), get_token_name(prev_local->type));
                   prev_local = prev_local->prev;
                }
+
                pc = prev_local->next;
             }
+
             LOG_FMT(LAVDB, "%s(%d): add = '%s', orig_line is %zu, orig_col is %zu, level is %zu\n",
                     __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col, pc->level);
 
@@ -252,14 +272,17 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
             if (options::align_var_def_colon())
             {
                next = chunk_get_next_nc(pc);
+
                if (chunk_is_token(next, CT_BIT_COLON))
                {
                   as_bc.Add(next);
                }
             }
+
             if (options::align_var_def_attribute())
             {
                next = pc;
+
                while ((next = chunk_get_next_nc(next)) != nullptr)
                {
                   if (chunk_is_token(next, CT_ATTRIBUTE))
@@ -267,6 +290,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
                      as_at.Add(next);
                      break;
                   }
+
                   if (chunk_is_token(next, CT_SEMICOLON) || chunk_is_newline(next))
                   {
                      break;
@@ -274,6 +298,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
                }
             }
          }
+
          did_this_line = true;
       }
       else if (chunk_is_token(pc, CT_BIT_COLON))
@@ -284,6 +309,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
             did_this_line = true;
          }
       }
+
       pc = chunk_get_next(pc);
    }
 

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -11,12 +11,14 @@
 
 #include <cstring>
 
-Args::Args(int argc, char **argv)
+Args::Args(int  argc,
+           char **argv)
 {
    m_count  = argc;
    m_values = argv;
    size_t len = (argc >> 3) + 1;
    m_used = new UINT8[len];
+
    if (m_used != nullptr)
    {
       memset(m_used, 0, len);
@@ -31,6 +33,7 @@ Args::~Args()
       delete[] m_used;
       m_used = nullptr;
    }
+
    m_count = 0;
 }
 
@@ -48,6 +51,7 @@ bool Args::Present(const char *token)
          }
       }
    }
+
    return(false);
 }
 
@@ -60,7 +64,8 @@ const char *Args::Param(const char *token)
 }
 
 
-const char *Args::Params(const char *token, size_t &index)
+const char *Args::Params(const char *token,
+                         size_t     &index)
 {
    if (token == nullptr)
    {
@@ -79,22 +84,27 @@ const char *Args::Params(const char *token, size_t &index)
          && (memcmp(token, m_values[idx], token_len) == 0))
       {
          SetUsed(idx);
+
          if (arg_len > token_len)
          {
             if (m_values[idx][token_len] == '=')
             {
                token_len++;
             }
+
             index = idx + 1;
             return(&m_values[idx][token_len]);
          }
+
          idx++;
          index = idx + 1;
+
          if (idx < m_count)
          {
             SetUsed(idx);
             return(m_values[idx]);
          }
+
          return("");
       }
    }
@@ -111,6 +121,7 @@ bool Args::GetUsed(size_t idx)
    {
       return((m_used[idx >> 3] & (1 << (idx & 0x07))) != 0);
    }
+
    return(false);
 }
 
@@ -141,12 +152,15 @@ const char *Args::Unused(size_t &index)
          return(m_values[idx]);
       }
    }
+
    index = m_count;
    return(nullptr);
 }
 
 
-size_t Args::SplitLine(char *text, char *args[], size_t num_args)
+size_t Args::SplitLine(char   *text,
+                       char   *args[],
+                       size_t num_args)
 {
    if (text == nullptr || num_args == 0)
    {
@@ -202,6 +216,7 @@ size_t Args::SplitLine(char *text, char *args[], size_t num_args)
             *dest = 0;
             dest++;
             in_arg = false;
+
             if (argc == num_args)
             {
                break; // all arguments found, we can stop
@@ -213,8 +228,10 @@ size_t Args::SplitLine(char *text, char *args[], size_t num_args)
             dest++;
          }
       }
+
       text++; // go on with next character
    }
+
    *dest = 0;
 
    return(argc);

--- a/src/backup.cpp
+++ b/src/backup.cpp
@@ -39,7 +39,8 @@
 using namespace std;
 
 
-int backup_copy_file(const char *filename, const vector<UINT8> &data)
+int backup_copy_file(const char          *filename,
+                     const vector<UINT8> &data)
 {
    char  newpath[1024];
    char  md5_str_in[33];
@@ -60,9 +61,11 @@ int backup_copy_file(const char *filename, const vector<UINT8> &data)
    snprintf(newpath, sizeof(newpath), "%s%s", filename, UNC_BACKUP_MD5_SUFFIX);
 
    FILE *thefile = fopen(newpath, "rb");
+
    if (thefile != nullptr)
    {
       char buffer[128];
+
       if (fgets(buffer, sizeof(buffer), thefile) != nullptr)
       {
          for (int i = 0; buffer[i] != 0; i++)
@@ -78,6 +81,7 @@ int backup_copy_file(const char *filename, const vector<UINT8> &data)
             }
          }
       }
+
       fclose(thefile);
    }
 
@@ -94,6 +98,7 @@ int backup_copy_file(const char *filename, const vector<UINT8> &data)
    snprintf(newpath, sizeof(newpath), "%s%s", filename, UNC_BACKUP_SUFFIX);
 
    thefile = fopen(newpath, "wb");
+
    if (thefile != nullptr)
    {
       size_t retval   = fwrite(&data[0], data.size(), 1, thefile);
@@ -105,6 +110,7 @@ int backup_copy_file(const char *filename, const vector<UINT8> &data)
       {
          return(EX_OK);
       }
+
       LOG_FMT(LERR, "fwrite(%s) failed: %s (%d)\n",
               newpath, strerror(my_errno), my_errno);
       cpd.error_count++;
@@ -115,6 +121,7 @@ int backup_copy_file(const char *filename, const vector<UINT8> &data)
               newpath, strerror(errno), errno);
       cpd.error_count++;
    }
+
    return(EX_IOERR);
 } // backup_copy_file
 
@@ -131,6 +138,7 @@ void backup_create_md5_file(const char *filename)
    md5.Init();
 
    thefile = fopen(filename, "rb");
+
    if (thefile == nullptr)
    {
       LOG_FMT(LERR, "%s: fopen(%s) failed: %s (%d)\n",
@@ -151,6 +159,7 @@ void backup_create_md5_file(const char *filename)
    snprintf(newpath, sizeof(newpath), "%s%s", filename, UNC_BACKUP_MD5_SUFFIX);
 
    thefile = fopen(newpath, "wb");
+
    if (thefile != nullptr)
    {
       fprintf(thefile,

--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -231,19 +231,22 @@ static search_t select_search_fct(const direction_e dir)
 }
 
 
-chunk_t *chunk_search_prev_cat(chunk_t *pc, const c_token_t cat)
+chunk_t *chunk_search_prev_cat(chunk_t         *pc,
+                               const c_token_t cat)
 {
    return(chunk_search_type(pc, cat, scope_e::ALL, direction_e::BACKWARD));
 }
 
 
-chunk_t *chunk_search_next_cat(chunk_t *pc, const c_token_t cat)
+chunk_t *chunk_search_next_cat(chunk_t         *pc,
+                               const c_token_t cat)
 {
    return(chunk_search_type(pc, cat, scope_e::ALL, direction_e::FORWARD));
 }
 
 
-bool are_chunks_in_same_line(chunk_t *start, chunk_t *end)
+bool are_chunks_in_same_line(chunk_t *start,
+                             chunk_t *end)
 {
    chunk_t *tmp;
 
@@ -255,20 +258,25 @@ bool are_chunks_in_same_line(chunk_t *start, chunk_t *end)
    {
       return(false);
    }
+
    while (tmp != nullptr && tmp != end)
    {
       if (chunk_is_token(tmp, CT_NEWLINE))
       {
          return(false);
       }
+
       tmp = chunk_get_next(tmp);
    }
+
    return(true);
 }
 
 
-static chunk_t *chunk_search_type(chunk_t *cur, const c_token_t type,
-                                  const scope_e scope, const direction_e dir)
+static chunk_t *chunk_search_type(chunk_t           *cur,
+                                  const c_token_t   type,
+                                  const scope_e     scope,
+                                  const direction_e dir)
 {
    /*
     * Depending on the parameter dir the search function searches
@@ -282,11 +290,16 @@ static chunk_t *chunk_search_type(chunk_t *cur, const c_token_t type,
       pc = search_function(pc, scope); // in either direction while
    } while (  pc != nullptr            // the end of the list was not reached yet
            && pc->type != type);       // and the demanded chunk was not found either
+
    return(pc);                         // the latest chunk is the searched one
 }
 
 
-static chunk_t *chunk_search_typelevel(chunk_t *cur, c_token_t type, scope_e scope, direction_e dir, int level)
+static chunk_t *chunk_search_typelevel(chunk_t     *cur,
+                                       c_token_t   type,
+                                       scope_e     scope,
+                                       direction_e dir,
+                                       int         level)
 {
    /*
     * Depending on the parameter dir the search function searches
@@ -300,11 +313,17 @@ static chunk_t *chunk_search_typelevel(chunk_t *cur, c_token_t type, scope_e sco
       pc = search_function(pc, scope); // in either direction while
    } while (  pc != nullptr            // the end of the list was not reached yet
            && (is_expected_type_and_level(pc, type, level) == false));
+
    return(pc);                         // the latest chunk is the searched one
 }
 
 
-static chunk_t *chunk_search_str(chunk_t *cur, const char *str, size_t len, scope_e scope, direction_e dir, int level)
+static chunk_t *chunk_search_str(chunk_t     *cur,
+                                 const char  *str,
+                                 size_t      len,
+                                 scope_e     scope,
+                                 direction_e dir,
+                                 int         level)
 {
    /*
     * Depending on the parameter dir the search function searches
@@ -317,12 +336,16 @@ static chunk_t *chunk_search_str(chunk_t *cur, const char *str, size_t len, scop
       pc = search_function(pc, scope); // in either direction while
    } while (  pc != nullptr            // the end of the list was not reached yet
            && (is_expected_string_and_level(pc, str, level, len) == false));
+
    return(pc);                         // the latest chunk is the searched one
 }
 
 
-static chunk_t *chunk_search(chunk_t *cur, const check_t check_fct, const scope_e scope,
-                             const direction_e dir, const bool cond)
+static chunk_t *chunk_search(chunk_t           *cur,
+                             const check_t     check_fct,
+                             const scope_e     scope,
+                             const direction_e dir,
+                             const bool        cond)
 {
    /*
     * Depending on the parameter dir the search function searches
@@ -335,11 +358,14 @@ static chunk_t *chunk_search(chunk_t *cur, const check_t check_fct, const scope_
       pc = search_function(pc, scope);  // in either direction while
    } while (  pc != nullptr             // the end of the list was not reached yet
            && (check_fct(pc) != cond)); // and the demanded chunk was not found either
+
    return(pc);                          // the latest chunk is the searched one
 }
 
 
-static chunk_t *chunk_ppa_search(chunk_t *cur, const check_t check_fct, const bool cond)
+static chunk_t *chunk_ppa_search(chunk_t       *cur,
+                                 const check_t check_fct,
+                                 const bool    cond)
 {
    if (cur && !(cur->flags & PCF_IN_PREPROC))
    {
@@ -383,17 +409,21 @@ static chunk_t *chunk_ppa_search(chunk_t *cur, const check_t check_fct, const bo
  * into a common function However this should be done with the preprocessor
  * to avoid addition check conditions that would be evaluated in the
  * while loop of the calling function */
-chunk_t *chunk_get_next(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next(chunk_t *cur,
+                        scope_e scope)
 {
    if (cur == nullptr)
    {
       return(nullptr);
    }
+
    chunk_t *pc = g_cl.GetNext(cur);
+
    if (pc == nullptr || scope == scope_e::ALL)
    {
       return(pc);
    }
+
    if (cur->flags & PCF_IN_PREPROC)
    {
       // If in a preproc, return nullptr if trying to leave
@@ -401,28 +431,35 @@ chunk_t *chunk_get_next(chunk_t *cur, scope_e scope)
       {
          return(nullptr);
       }
+
       return(pc);
    }
+
    // Not in a preproc, skip any preproc
    while (pc != nullptr && (pc->flags & PCF_IN_PREPROC))
    {
       pc = g_cl.GetNext(pc);
    }
+
    return(pc);
 }
 
 
-chunk_t *chunk_get_prev(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev(chunk_t *cur,
+                        scope_e scope)
 {
    if (cur == nullptr)
    {
       return(nullptr);
    }
+
    chunk_t *pc = g_cl.GetPrev(cur);
+
    if (pc == nullptr || scope == scope_e::ALL)
    {
       return(pc);
    }
+
    if (cur->flags & PCF_IN_PREPROC)
    {
       // If in a preproc, return NULL if trying to leave
@@ -430,13 +467,16 @@ chunk_t *chunk_get_prev(chunk_t *cur, scope_e scope)
       {
          return(nullptr);
       }
+
       return(pc);
    }
+
    // Not in a preproc, skip any preproc
    while (pc != nullptr && (pc->flags & PCF_IN_PREPROC))
    {
       pc = g_cl.GetPrev(pc);
    }
+
    return(pc);
 }
 
@@ -462,10 +502,13 @@ chunk_t *chunk_dup(const chunk_t *pc_in)
 }
 
 
-static void chunk_log_msg(chunk_t *chunk, const log_sev_t log, const char *str)
+static void chunk_log_msg(chunk_t         *chunk,
+                          const log_sev_t log,
+                          const char      *str)
 {
    LOG_FMT(log, "%s orig_line is %zu, orig_col is %zu, ",
            str, chunk->orig_line, chunk->orig_col);
+
    if (chunk_is_token(chunk, CT_NEWLINE))
    {
       LOG_FMT(log, "<Newline>,");
@@ -485,7 +528,8 @@ static void chunk_log_msg(chunk_t *chunk, const log_sev_t log, const char *str)
 }
 
 
-static void chunk_log(chunk_t *pc, const char *text)
+static void chunk_log(chunk_t    *pc,
+                      const char *text)
 {
    if (  pc != nullptr
       && (cpd.unc_stage != unc_stage_e::TOKENIZE)
@@ -510,6 +554,7 @@ static void chunk_log(chunk_t *pc, const char *text)
       {
          chunk_log_msg(prev, log, " @ after");
       }
+
       LOG_FMT(log, " stage is %s",
               get_unc_stage_name(cpd.unc_stage));
       log_func_stack_inline(log);
@@ -517,13 +562,15 @@ static void chunk_log(chunk_t *pc, const char *text)
 }
 
 
-chunk_t *chunk_add_after(const chunk_t *pc_in, chunk_t *ref)
+chunk_t *chunk_add_after(const chunk_t *pc_in,
+                         chunk_t       *ref)
 {
    return(chunk_add(pc_in, ref, direction_e::FORWARD));
 }
 
 
-chunk_t *chunk_add_before(const chunk_t *pc_in, chunk_t *ref)
+chunk_t *chunk_add_before(const chunk_t *pc_in,
+                          chunk_t       *ref)
 {
    return(chunk_add(pc_in, ref, direction_e::BACKWARD));
 }
@@ -537,7 +584,8 @@ void chunk_del(chunk_t *pc)
 }
 
 
-void chunk_move_after(chunk_t *pc_in, chunk_t *ref)
+void chunk_move_after(chunk_t *pc_in,
+                      chunk_t *ref)
 {
    LOG_FUNC_ENTRY();
    g_cl.Pop(pc_in);
@@ -550,37 +598,43 @@ void chunk_move_after(chunk_t *pc_in, chunk_t *ref)
 }
 
 
-chunk_t *chunk_get_next_nl(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next_nl(chunk_t *cur,
+                           scope_e scope)
 {
    return(chunk_search(cur, chunk_is_newline, scope, direction_e::FORWARD, true));
 }
 
 
-chunk_t *chunk_get_prev_nl(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_nl(chunk_t *cur,
+                           scope_e scope)
 {
    return(chunk_search(cur, chunk_is_newline, scope, direction_e::BACKWARD, true));
 }
 
 
-chunk_t *chunk_get_next_nnl(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next_nnl(chunk_t *cur,
+                            scope_e scope)
 {
    return(chunk_search(cur, chunk_is_newline, scope, direction_e::FORWARD, false));
 }
 
 
-chunk_t *chunk_get_prev_nnl(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_nnl(chunk_t *cur,
+                            scope_e scope)
 {
    return(chunk_search(cur, chunk_is_newline, scope, direction_e::BACKWARD, false));
 }
 
 
-chunk_t *chunk_get_next_ncnl(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next_ncnl(chunk_t *cur,
+                             scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment_or_newline, scope, direction_e::FORWARD, false));
 }
 
 
-chunk_t *chunk_get_next_ncnlnp(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next_ncnlnp(chunk_t *cur,
+                               scope_e scope)
 {
    return(chunk_get_ncnlnp(cur, scope, direction_e::FORWARD));
 }
@@ -592,79 +646,102 @@ chunk_t *chunk_ppa_get_next_ncnl(chunk_t *cur)
 }
 
 
-chunk_t *chunk_get_prev_ncnlnp(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_ncnlnp(chunk_t *cur,
+                               scope_e scope)
 {
    return(chunk_get_ncnlnp(cur, scope, direction_e::BACKWARD));
 }
 
 
-chunk_t *chunk_get_next_nblank(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next_nblank(chunk_t *cur,
+                               scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment_newline_or_blank, scope, direction_e::FORWARD, false));
 }
 
 
-chunk_t *chunk_get_prev_nblank(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_nblank(chunk_t *cur,
+                               scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment_newline_or_blank, scope, direction_e::BACKWARD, false));
 }
 
 
-chunk_t *chunk_get_next_nc(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next_nc(chunk_t *cur,
+                           scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment, scope, direction_e::FORWARD, false));
 }
 
 
-chunk_t *chunk_get_next_nisq(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next_nisq(chunk_t *cur,
+                             scope_e scope)
 {
    return(chunk_search(cur, chunk_is_balanced_square, scope, direction_e::FORWARD, false));
 }
 
 
-chunk_t *chunk_get_prev_ncnl(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_ncnl(chunk_t *cur,
+                             scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment_or_newline, scope, direction_e::BACKWARD, false));
 }
 
 
-chunk_t *chunk_get_prev_ncnlni(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_ncnlni(chunk_t *cur,
+                               scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment_or_newline_or_ignored, scope, direction_e::BACKWARD, false));
 }
 
 
-chunk_t *chunk_get_prev_nc(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_nc(chunk_t *cur,
+                           scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment, scope, direction_e::BACKWARD, false));
 }
 
 
-chunk_t *chunk_get_next_type(chunk_t *cur, c_token_t type, int level, scope_e scope)
+chunk_t *chunk_get_next_type(chunk_t   *cur,
+                             c_token_t type,
+                             int       level,
+                             scope_e   scope)
 {
    return(chunk_search_typelevel(cur, type, scope, direction_e::FORWARD, level));
 }
 
 
-chunk_t *chunk_get_next_str(chunk_t *cur, const char *str, size_t len, int level, scope_e scope)
+chunk_t *chunk_get_next_str(chunk_t    *cur,
+                            const char *str,
+                            size_t     len,
+                            int        level,
+                            scope_e    scope)
 {
    return(chunk_search_str(cur, str, len, scope, direction_e::FORWARD, level));
 }
 
 
-chunk_t *chunk_get_prev_type(chunk_t *cur, c_token_t type, int level, scope_e scope)
+chunk_t *chunk_get_prev_type(chunk_t   *cur,
+                             c_token_t type,
+                             int       level,
+                             scope_e   scope)
 {
    return(chunk_search_typelevel(cur, type, scope, direction_e::BACKWARD, level));
 }
 
 
-chunk_t *chunk_get_prev_str(chunk_t *cur, const char *str, size_t len, int level, scope_e scope)
+chunk_t *chunk_get_prev_str(chunk_t    *cur,
+                            const char *str,
+                            size_t     len,
+                            int        level,
+                            scope_e    scope)
 {
    return(chunk_search_str(cur, str, len, scope, direction_e::BACKWARD, level));
 }
 
 
-bool chunk_is_newline_between(chunk_t *start, chunk_t *end)
+bool chunk_is_newline_between(chunk_t *start,
+                              chunk_t *end)
 {
    for (chunk_t *pc = start; pc != end; pc = chunk_get_next(pc))
    {
@@ -673,11 +750,13 @@ bool chunk_is_newline_between(chunk_t *start, chunk_t *end)
          return(true);
       }
    }
+
    return(false);
 }
 
 
-void chunk_swap(chunk_t *pc1, chunk_t *pc2)
+void chunk_swap(chunk_t *pc1,
+                chunk_t *pc2)
 {
    g_cl.Swap(pc1, pc2);
 }
@@ -709,6 +788,7 @@ bool chunk_is_last_on_line(chunk_t &pc)  //TODO: pc should be const here
 
    // if the next chunk is a newline then pc is the last chunk on its line
    const auto *next = chunk_get_next(&pc);
+
    if (chunk_is_token(next, CT_NEWLINE))
    {
       return(true);
@@ -719,7 +799,8 @@ bool chunk_is_last_on_line(chunk_t &pc)  //TODO: pc should be const here
 
 
 // TODO: this function needs some cleanup
-void chunk_swap_lines(chunk_t *pc1, chunk_t *pc2)
+void chunk_swap_lines(chunk_t *pc1,
+                      chunk_t *pc2)
 {
    // to swap lines we need to find the first chunk of the lines
    pc1 = chunk_first_on_line(pc1);
@@ -759,6 +840,7 @@ void chunk_swap_lines(chunk_t *pc1, chunk_t *pc2)
    {
       chunk_t *tmp = chunk_get_next(pc1);
       g_cl.Pop(pc1);
+
       if (ref2 != nullptr)
       {
          g_cl.AddAfter(pc1, ref2);
@@ -767,6 +849,7 @@ void chunk_swap_lines(chunk_t *pc1, chunk_t *pc2)
       {
          g_cl.AddHead(pc1);
       }
+
       ref2 = pc1;
       pc1  = tmp;
    }
@@ -793,36 +876,43 @@ void chunk_swap_lines(chunk_t *pc1, chunk_t *pc2)
 } // chunk_swap_lines
 
 
-chunk_t *chunk_get_next_nvb(chunk_t *cur, const scope_e scope)
+chunk_t *chunk_get_next_nvb(chunk_t       *cur,
+                            const scope_e scope)
 {
    return(chunk_search(cur, chunk_is_vbrace, scope, direction_e::FORWARD, false));
 }
 
 
-chunk_t *chunk_get_prev_nvb(chunk_t *cur, const scope_e scope)
+chunk_t *chunk_get_prev_nvb(chunk_t       *cur,
+                            const scope_e scope)
 {
    return(chunk_search(cur, chunk_is_vbrace, scope, direction_e::BACKWARD, false));
 }
 
 
-void set_chunk_type_real(chunk_t *pc, c_token_t tt)
+void set_chunk_type_real(chunk_t   *pc,
+                         c_token_t tt)
 {
    set_chunk_real(pc, tt, LSETTYP);
 }
 
 
-void set_chunk_parent_real(chunk_t *pc, c_token_t pt)
+void set_chunk_parent_real(chunk_t   *pc,
+                           c_token_t pt)
 {
    set_chunk_real(pc, pt, LSETPAR);
 }
 
 
-void chunk_flags_set_real(chunk_t *pc, UINT64 clr_bits, UINT64 set_bits)
+void chunk_flags_set_real(chunk_t *pc,
+                          UINT64  clr_bits,
+                          UINT64  set_bits)
 {
    if (pc != nullptr)
    {
       LOG_FUNC_ENTRY();
       UINT64 nflags = (pc->flags & ~clr_bits) | set_bits;
+
       if (pc->flags != nflags)
       {
          LOG_FMT(LSETFLG, "%s(%d): %016" PRIx64 "^%016" PRIx64 "=%016" PRIx64 " orig_line is %zu, orig_col is %zu, text() '%s', type is %s, ",
@@ -838,7 +928,9 @@ void chunk_flags_set_real(chunk_t *pc, UINT64 clr_bits, UINT64 set_bits)
 }
 
 
-void set_chunk_real(chunk_t *pc, c_token_t token, log_sev_t what)
+void set_chunk_real(chunk_t   *pc,
+                    c_token_t token,
+                    log_sev_t what)
 {
    LOG_FUNC_ENTRY();
 
@@ -868,6 +960,7 @@ void set_chunk_real(chunk_t *pc, c_token_t token, log_sev_t what)
    {
       LOG_FMT(what, "%s(%d): orig_line is %zu, orig_col is %zu, pc->text() ",
               __func__, __LINE__, pc->orig_line, pc->orig_col);
+
       if (*type == CT_NEWLINE)
       {
          LOG_FMT(what, "<Newline>\n");
@@ -877,6 +970,7 @@ void set_chunk_real(chunk_t *pc, c_token_t token, log_sev_t what)
          LOG_FMT(what, "'%s'\n",
                  pc->text());
       }
+
       LOG_FMT(what, "   pc->type is %s, pc->parent_type is %s => *type is %s, *parent_type is %s",
               get_token_name(pc->type), get_token_name(pc->parent_type),
               get_token_name(*type), get_token_name(*parent_type));
@@ -886,7 +980,9 @@ void set_chunk_real(chunk_t *pc, c_token_t token, log_sev_t what)
 } // set_chunk_real
 
 
-static chunk_t *chunk_get_ncnlnp(chunk_t *cur, const scope_e scope, const direction_e dir)
+static chunk_t *chunk_get_ncnlnp(chunk_t           *cur,
+                                 const scope_e     scope,
+                                 const direction_e dir)
 {
    chunk_t *pc = cur;
 
@@ -897,7 +993,9 @@ static chunk_t *chunk_get_ncnlnp(chunk_t *cur, const scope_e scope, const direct
 }
 
 
-static chunk_t *chunk_add(const chunk_t *pc_in, chunk_t *ref, const direction_e pos)
+static chunk_t *chunk_add(const chunk_t     *pc_in,
+                          chunk_t           *ref,
+                          const direction_e pos)
 {
 #ifdef DEBUG
    if (pc_in->orig_line == 0)
@@ -907,6 +1005,7 @@ static chunk_t *chunk_add(const chunk_t *pc_in, chunk_t *ref, const direction_e 
       log_flush(true);
       exit(EX_SOFTWARE);
    }
+
    if (pc_in->orig_col == 0)
    {
       fprintf(stderr, "%s(%d): no column number\n", __func__, __LINE__);
@@ -928,8 +1027,10 @@ static chunk_t *chunk_add(const chunk_t *pc_in, chunk_t *ref, const direction_e 
       {
          (pos == direction_e::FORWARD) ? g_cl.AddHead(pc) : g_cl.AddTail(pc);
       }
+
       chunk_log(pc, "chunk_add(A):");
    }
+
    return(pc);
 }
 
@@ -942,8 +1043,10 @@ chunk_t *chunk_get_next_ssq(chunk_t *cur)
       {
          cur = chunk_skip_to_match(cur);
       }
+
       cur = chunk_get_next_ncnl(cur);
    }
+
    return(cur);
 }
 
@@ -956,16 +1059,21 @@ chunk_t *chunk_get_prev_ssq(chunk_t *cur)
       {
          cur = chunk_skip_to_match_rev(cur);
       }
+
       cur = chunk_get_prev_ncnl(cur);
    }
+
    return(cur);
 }
 
 
 //! skip to the final word/type in a :: chain
-static chunk_t *chunk_skip_dc_member(chunk_t *start, scope_e scope, direction_e dir)
+static chunk_t *chunk_skip_dc_member(chunk_t     *start,
+                                     scope_e     scope,
+                                     direction_e dir)
 {
    LOG_FUNC_ENTRY();
+
    if (start == nullptr)
    {
       return(nullptr);
@@ -976,26 +1084,32 @@ static chunk_t *chunk_skip_dc_member(chunk_t *start, scope_e scope, direction_e 
 
    chunk_t *pc   = start;
    chunk_t *next = chunk_is_token(pc, CT_DC_MEMBER) ? pc : step_fcn(pc, scope);
+
    while (chunk_is_token(next, CT_DC_MEMBER))
    {
       pc = step_fcn(next, scope);
+
       if (pc == nullptr)
       {
          return(nullptr);
       }
+
       next = step_fcn(pc, scope);
    }
+
    return(pc);
 }
 
 
-chunk_t *chunk_skip_dc_member(chunk_t *start, scope_e scope)
+chunk_t *chunk_skip_dc_member(chunk_t *start,
+                              scope_e scope)
 {
    return(chunk_skip_dc_member(start, scope, direction_e::FORWARD));
 }
 
 
-chunk_t *chunk_skip_dc_member_rev(chunk_t *start, scope_e scope)
+chunk_t *chunk_skip_dc_member_rev(chunk_t *start,
+                                  scope_e scope)
 {
    return(chunk_skip_dc_member(start, scope, direction_e::BACKWARD));
 }

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -461,7 +461,9 @@ bool are_chunks_in_same_line(chunk_t *start, chunk_t *end);
  * The compiler should know how to optimize the code itself.
  * To clarify do a profiling run with and without inline
  */
-static inline bool is_expected_type_and_level(chunk_t *pc, c_token_t type, int level)
+static inline bool is_expected_type_and_level(chunk_t   *pc,
+                                              c_token_t type,
+                                              int       level)
 {
    // we don't care about the level (if it is negative) or it is as expected
    // and the type is as expected
@@ -470,7 +472,10 @@ static inline bool is_expected_type_and_level(chunk_t *pc, c_token_t type, int l
 }
 
 
-static inline bool is_expected_string_and_level(chunk_t *pc, const char *str, int level, size_t len)
+static inline bool is_expected_string_and_level(chunk_t    *pc,
+                                                const char *str,
+                                                int        level,
+                                                size_t     len)
 {
    // we don't care about the level (if it is negative) or it is as expected
    return(  (level < 0 || pc->level == static_cast<size_t>(level))
@@ -479,13 +484,15 @@ static inline bool is_expected_string_and_level(chunk_t *pc, const char *str, in
 }
 
 
-static inline bool chunk_is_token(const chunk_t *pc, c_token_t c_token)
+static inline bool chunk_is_token(const chunk_t *pc,
+                                  c_token_t     c_token)
 {
    return(pc != nullptr && pc->type == c_token);
 }
 
 
-static inline bool chunk_is_not_token(const chunk_t *pc, c_token_t c_token)
+static inline bool chunk_is_not_token(const chunk_t *pc,
+                                      c_token_t     c_token)
 {
    return(pc != nullptr && pc->type != c_token);
 }
@@ -499,7 +506,8 @@ static inline bool chunk_is_not_token(const chunk_t *pc, c_token_t c_token)
  *
  * @return nullptr or the matching paren/brace/square
  */
-static inline chunk_t *chunk_skip_to_match(chunk_t *cur, scope_e scope = scope_e::ALL)
+static inline chunk_t *chunk_skip_to_match(chunk_t *cur,
+                                           scope_e scope = scope_e::ALL)
 {
    if (  chunk_is_token(cur, CT_PAREN_OPEN)
       || chunk_is_token(cur, CT_SPAREN_OPEN)
@@ -512,11 +520,13 @@ static inline chunk_t *chunk_skip_to_match(chunk_t *cur, scope_e scope = scope_e
    {
       return(chunk_get_next_type(cur, (c_token_t)(cur->type + 1), cur->level, scope));
    }
+
    return(cur);
 }
 
 
-static inline chunk_t *chunk_skip_to_match_rev(chunk_t *cur, scope_e scope = scope_e::ALL)
+static inline chunk_t *chunk_skip_to_match_rev(chunk_t *cur,
+                                               scope_e scope = scope_e::ALL)
 {
    if (  chunk_is_token(cur, CT_PAREN_CLOSE)
       || chunk_is_token(cur, CT_SPAREN_CLOSE)
@@ -529,6 +539,7 @@ static inline chunk_t *chunk_skip_to_match_rev(chunk_t *cur, scope_e scope = sco
    {
       return(chunk_get_prev_type(cur, (c_token_t)(cur->type - 1), cur->level, scope));
    }
+
    return(cur);
 }
 
@@ -642,13 +653,16 @@ static inline bool chunk_is_Doxygen_comment(chunk_t *pc)
    {
       return(false);
    }
+
    // check the third character
    const char   *sComment = pc->text();
    const size_t len       = strlen(sComment);
+
    if (len < 3)
    {
       return(false);
    }
+
    return(  (sComment[2] == '/')
          || (sComment[2] == '!')
          || (sComment[2] == '@'));
@@ -668,7 +682,9 @@ static inline bool chunk_is_type(chunk_t *pc)
 }
 
 
-static inline bool chunk_is_str(chunk_t *pc, const char *str, size_t len)
+static inline bool chunk_is_str(chunk_t    *pc,
+                                const char *str,
+                                size_t     len)
 {
    return(  pc != nullptr                         // valid pc pointer
          && (pc->len() == len)                    // token size equals size parameter
@@ -681,7 +697,9 @@ static inline bool chunk_is_str(chunk_t *pc, const char *str, size_t len)
 }
 
 
-static inline bool chunk_is_str_case(chunk_t *pc, const char *str, size_t len)
+static inline bool chunk_is_str_case(chunk_t    *pc,
+                                     const char *str,
+                                     size_t     len)
 {
    return(  pc != nullptr
          && (pc->len() == len)
@@ -797,7 +815,8 @@ static inline bool chunk_is_paren_close(chunk_t *pc)
  * Returns true if either chunk is null or both have the same preproc flags.
  * If this is true, you can remove a newline/nl_cont between the two.
  */
-static inline bool chunk_same_preproc(chunk_t *pc1, chunk_t *pc2)
+static inline bool chunk_same_preproc(chunk_t *pc1,
+                                      chunk_t *pc2)
 {
    return(  pc1 == nullptr
          || pc2 == nullptr
@@ -818,6 +837,7 @@ static inline bool chunk_safe_to_del_nl(chunk_t *nl)
    {
       return(false);
    }
+
    return(chunk_same_preproc(chunk_get_prev(nl), chunk_get_next(nl)));
 }
 
@@ -834,21 +854,25 @@ static inline bool chunk_is_forin(chunk_t *pc)
       && chunk_is_token(pc, CT_SPAREN_OPEN))
    {
       chunk_t *prev = chunk_get_prev_ncnl(pc);
+
       if (chunk_is_token(prev, CT_FOR))
       {
          chunk_t *next = pc;
+
          while (  next != nullptr
                && next->type != CT_SPAREN_CLOSE
                && next->type != CT_IN)
          {
             next = chunk_get_next_ncnl(next);
          }
+
          if (chunk_is_token(next, CT_IN))
          {
             return(true);
          }
       }
    }
+
    return(false);
 }
 

--- a/src/combine_labels.cpp
+++ b/src/combine_labels.cpp
@@ -13,7 +13,8 @@
 #include "uncrustify.h"
 
 
-chunk_t *chunk_get_next_local(chunk_t *pc, scope_e scope = scope_e::ALL)
+chunk_t *chunk_get_next_local(chunk_t *pc,
+                              scope_e scope = scope_e::ALL)
 {
    chunk_t *tmp = pc;
 
@@ -28,7 +29,8 @@ chunk_t *chunk_get_next_local(chunk_t *pc, scope_e scope = scope_e::ALL)
 }
 
 
-chunk_t *chunk_get_prev_local(chunk_t *pc, scope_e scope = scope_e::ALL)
+chunk_t *chunk_get_prev_local(chunk_t *pc,
+                              scope_e scope = scope_e::ALL)
 {
    chunk_t *tmp = pc;
 
@@ -60,15 +62,19 @@ void combine_labels(void)
    ChunkStack cs;
 
    prev = chunk_get_head();
+
    if (prev == nullptr)
    {
       return;
    }
+
    cur = chunk_get_next_nc(prev);
+
    if (cur == nullptr)
    {
       return;
    }
+
    next = chunk_get_next_nc(cur);
 
    // unlikely that the file will start with a label...
@@ -103,6 +109,7 @@ void combine_labels(void)
       {
          hit_class = true;
       }
+
       if (chunk_is_semicolon(next) || chunk_is_token(next, CT_BRACE_OPEN))
       {
          hit_class = false;
@@ -119,6 +126,7 @@ void combine_labels(void)
          {
             chunk_t *t2 = cs.Top()->m_pc;
             cs.Pop_Back();
+
             if (chunk_is_token(t2, CT_SQUARE_OPEN))
             {
                break;
@@ -151,6 +159,7 @@ void combine_labels(void)
             set_chunk_type(cur, CT_CASE);
             hit_case = true;
          }
+
          if (cs_top_is_question(cs, next->level))
          {
             set_chunk_type(next, CT_COND_COLON);
@@ -161,10 +170,12 @@ void combine_labels(void)
             hit_case = false;
             set_chunk_type(next, CT_CASE_COLON);
             tmp = chunk_get_next_ncnlnp(next);                // Issue #2150
+
             if (chunk_is_token(tmp, CT_BRACE_OPEN))
             {
                set_chunk_parent(tmp, CT_CASE);
                tmp = chunk_get_next_type(tmp, CT_BRACE_CLOSE, tmp->level);
+
                if (tmp != nullptr)
                {
                   set_chunk_parent(tmp, CT_CASE);
@@ -184,10 +195,12 @@ void combine_labels(void)
             LOG_FMT(LFCN, "%s(%d): next->text() is '%s', orig_line is %zu, orig_col is %zu\n\n",
                     __func__, __LINE__, next->text(), next->orig_line, next->orig_col);
             chunk_t *nextprev = chunk_get_prev_local(next);   // Issue #2279
+
             if (nextprev == nullptr)
             {
                return;
             }
+
             if (language_is_set(LANG_PAWN))
             {
                if (chunk_is_token(cur, CT_WORD) || chunk_is_token(cur, CT_BRACE_CLOSE))
@@ -195,10 +208,12 @@ void combine_labels(void)
                   c_token_t new_type = CT_TAG;
 
                   tmp = chunk_get_next_nc(next);
+
                   if (tmp == nullptr)
                   {
                      return;
                   }
+
                   if (chunk_is_newline(prev) && chunk_is_newline(tmp))
                   {
                      new_type = CT_LABEL;
@@ -208,6 +223,7 @@ void combine_labels(void)
                   {
                      set_chunk_type(next, CT_TAG_COLON);
                   }
+
                   if (chunk_is_token(cur, CT_WORD))
                   {
                      set_chunk_type(cur, new_type);
@@ -229,14 +245,17 @@ void combine_labels(void)
             else if (chunk_is_token(cur, CT_WORD))
             {
                tmp = chunk_get_next_nc(next, scope_e::PREPROC);
+
                // Issue #1187
                if (tmp == nullptr)
                {
                   return;
                }
+
                LOG_FMT(LFCN, "%s(%d): orig_line is %zu, orig_col is %zu, tmp '%s': ",
                        __func__, __LINE__, tmp->orig_line, tmp->orig_col, (tmp->type == CT_NEWLINE) ? "<Newline>" : tmp->text());
                log_pcf_flags(LGUY, tmp->flags);
+
                if (next->flags & PCF_IN_FCN_CALL)
                {
                   // Must be a macro thingy, assume some sort of label
@@ -261,10 +280,12 @@ void combine_labels(void)
                      && (!language_is_set(LANG_OC)))
                   {
                      chunk_t *labelPrev = prev;
+
                      if (chunk_is_token(labelPrev, CT_NEWLINE))
                      {
                         labelPrev = chunk_get_prev_ncnlni(prev);   // Issue #2279
                      }
+
                      if (labelPrev->type != CT_FPAREN_CLOSE)
                      {
                         set_chunk_type(cur, CT_LABEL);
@@ -282,16 +303,19 @@ void combine_labels(void)
                   set_chunk_type(next, CT_BIT_COLON);
 
                   tmp = chunk_get_next(next);
+
                   if (tmp == nullptr)
                   {
                      return;
                   }
+
                   while ((tmp = chunk_get_next(tmp)) != nullptr)
                   {
                      if (chunk_is_token(tmp, CT_SEMICOLON))
                      {
                         break;
                      }
+
                      if (chunk_is_token(tmp, CT_COLON))
                      {
                         set_chunk_type(tmp, CT_BIT_COLON);
@@ -307,6 +331,7 @@ void combine_labels(void)
                LOG_FMT(LFCN, "%s(%d): next->text() is '%s', orig_line is %zu, orig_col is %zu, type is %s\n",
                        __func__, __LINE__, next->text(), next->orig_line, next->orig_col,
                        get_token_name(next->type));
+
                // Issue #2172
                if (next->parent_type == CT_FUNC_DEF)
                {
@@ -355,6 +380,7 @@ void combine_labels(void)
             else
             {
                tmp = chunk_get_next_ncnl(next);
+
                //tmp = chunk_get_next_local(next);
                if (tmp != nullptr)
 
@@ -362,6 +388,7 @@ void combine_labels(void)
                   LOG_FMT(LFCN, "%s(%d): tmp->text() is '%s', orig_line is %zu, orig_col is %zu, type is %s\n",
                           __func__, __LINE__, tmp->text(), tmp->orig_line, tmp->orig_col,
                           get_token_name(tmp->type));
+
                   if (chunk_is_token(tmp, CT_BASE) || chunk_is_token(tmp, CT_THIS))
                   {
                      // ignore it, as it is a C# base thingy

--- a/src/compat_posix.cpp
+++ b/src/compat_posix.cpp
@@ -12,7 +12,8 @@
 #include <string>
 
 
-bool unc_getenv(const char *name, std::string &str)
+bool unc_getenv(const char  *name,
+                std::string &str)
 {
    const char *val = getenv(name);
 
@@ -21,6 +22,7 @@ bool unc_getenv(const char *name, std::string &str)
       str = val;
       return(true);
    }
+
    return(false);
 }
 

--- a/src/compat_win32.cpp
+++ b/src/compat_win32.cpp
@@ -15,7 +15,8 @@
 #include <string>
 
 
-bool unc_getenv(const char *name, std::string &str)
+bool unc_getenv(const char  *name,
+                std::string &str)
 {
    DWORD len = GetEnvironmentVariableA(name, NULL, 0);
    char  *buf;
@@ -29,10 +30,12 @@ bool unc_getenv(const char *name, std::string &str)
    }
 
    buf = (char *)malloc(len);
+
    if (buf)
    {
       len = GetEnvironmentVariableA(name, buf, len);
    }
+
    buf[len] = 0;
 
    str = buf;
@@ -49,16 +52,20 @@ bool unc_homedir(std::string &home)
    {
       return(true);
    }
+
    if (unc_getenv("USERPROFILE", home))
    {
       return(true);
    }
+
    std::string hd, hp;
+
    if (unc_getenv("HOMEDRIVE", hd) && unc_getenv("HOMEPATH", hp))
    {
       home = hd + hp;
       return(true);
    }
+
    return(false);
 }
 

--- a/src/cs_top_is_question.cpp
+++ b/src/cs_top_is_question.cpp
@@ -11,7 +11,8 @@
 #include "chunk_list.h"
 
 
-bool cs_top_is_question(ChunkStack &cs, size_t level)
+bool cs_top_is_question(ChunkStack &cs,
+                        size_t     level)
 {
    chunk_t *pc = cs.Empty() ? nullptr : cs.Top()->m_pc;
 

--- a/src/detect.cpp
+++ b/src/detect.cpp
@@ -44,7 +44,8 @@ public:
 };
 
 
-void sp_votes::vote(chunk_t *first, chunk_t *second)
+void sp_votes::vote(chunk_t *first,
+                    chunk_t *second)
 {
    if (  first == nullptr
       || chunk_is_newline(first)
@@ -55,6 +56,7 @@ void sp_votes::vote(chunk_t *first, chunk_t *second)
    }
 
    int col_dif = second->column - (first->column + first->len());
+
    if (col_dif == 0)
    {
       m_remove++;
@@ -160,6 +162,7 @@ static void detect_space_options(void)
    while (pc != nullptr)
    {
       next = chunk_get_next(pc);
+
       if (next == nullptr)
       {
          break;
@@ -170,6 +173,7 @@ static void detect_space_options(void)
          vote_sp_arith.vote(pc, next);
          vote_sp_arith.vote(prev, pc);
       }
+
       if (chunk_is_token(pc, CT_ASSIGN))
       {
          if ((pc->flags & PCF_IN_ENUM) == 0)
@@ -183,46 +187,56 @@ static void detect_space_options(void)
             vote_sp_enum_after_assign.vote(pc, next);
          }
       }
+
       if (chunk_is_token(pc, CT_SQUARE_OPEN))
       {
          vote_sp_before_square.vote(prev, pc);
          vote_sp_inside_square.vote(pc, next);
       }
+
       if (chunk_is_token(pc, CT_SQUARE_CLOSE))
       {
          vote_sp_inside_square.vote(prev, pc);
       }
+
       if (chunk_is_token(pc, CT_TSQUARE))
       {
          vote_sp_before_squares.vote(prev, pc);
       }
+
       if (chunk_is_token(pc, CT_BOOL))
       {
          vote_sp_bool.vote(prev, pc);
          vote_sp_bool.vote(pc, next);
       }
+
       if (chunk_is_token(pc, CT_COMPARE))
       {
          vote_sp_compare.vote(prev, pc);
          vote_sp_compare.vote(pc, next);
       }
+
       if (chunk_is_token(pc, CT_PAREN_CLOSE))
       {
          vote_sp_inside_paren.vote(prev, pc);
       }
+
       if (chunk_is_token(pc, CT_PAREN_OPEN))
       {
          vote_sp_inside_paren.vote(pc, next);
       }
+
       if (  (chunk_is_paren_open(pc) && chunk_is_paren_open(next))
          || (chunk_is_paren_close(pc) && chunk_is_paren_close(next)))
       {
          vote_sp_paren_paren.vote(pc, next);
       }
+
       if (chunk_is_paren_close(pc) && chunk_is_token(next, CT_BRACE_OPEN))
       {
          vote_sp_paren_brace.vote(pc, next);
       }
+
       if (chunk_is_token(pc, CT_PTR_TYPE))
       {
          if (chunk_is_token(prev, CT_PTR_TYPE))
@@ -237,11 +251,13 @@ static void detect_space_options(void)
          {
             vote_sp_before_ptr_star.vote(prev, pc);
          }
+
          if (CharTable::IsKw1(next->str[0]))
          {
             vote_sp_after_ptr_star.vote(pc, next);
          }
       }
+
       if (chunk_is_token(pc, CT_BYREF))
       {
          if (next->type != CT_WORD)
@@ -252,16 +268,20 @@ static void detect_space_options(void)
          {
             vote_sp_before_byref.vote(prev, pc);
          }
+
          vote_sp_after_byref.vote(pc, next);
       }
+
       if (  pc->type != CT_PTR_TYPE
          && (chunk_is_token(prev, CT_QUALIFIER) || chunk_is_token(prev, CT_TYPE)))
       {
          vote_sp_after_type.vote(prev, pc);
       }
+
       if (chunk_is_token(pc, CT_ANGLE_OPEN))
       {
          vote_sp_inside_angle.vote(pc, next);
+
          if (chunk_is_token(prev, CT_TEMPLATE))
          {
             vote_sp_template_angle.vote(prev, pc);
@@ -271,9 +291,11 @@ static void detect_space_options(void)
             vote_sp_before_angle.vote(prev, pc);
          }
       }
+
       if (chunk_is_token(pc, CT_ANGLE_CLOSE))
       {
          vote_sp_inside_angle.vote(prev, pc);
+
          if (chunk_is_paren_open(next))
          {
             vote_sp_angle_paren.vote(prev, pc);
@@ -293,9 +315,11 @@ static void detect_space_options(void)
          vote_sp_before_sparen.vote(prev, pc);
          vote_sp_inside_sparen.vote(pc, next);
       }
+
       if (chunk_is_token(pc, CT_SPAREN_CLOSE))
       {
          vote_sp_inside_sparen.vote(prev, pc);
+
          if (chunk_is_token(next, CT_BRACE_OPEN))
          {
             vote_sp_sparen_brace.vote(pc, next);
@@ -305,6 +329,7 @@ static void detect_space_options(void)
             vote_sp_after_sparen.vote(pc, next);
          }
       }
+
       if (chunk_is_token(pc, CT_SEMICOLON))
       {
          if (pc->parent_type == CT_FOR)
@@ -341,16 +366,19 @@ static void detect_space_options(void)
             vote_sp_before_semi.vote(prev, pc);
          }
       }
+
       if (chunk_is_token(pc, CT_COMMA))
       {
          vote_sp_before_comma.vote(prev, pc);
          vote_sp_after_comma.vote(pc, next);
       }
+
       if (chunk_is_token(pc, CT_CLASS_COLON))
       {
          vote_sp_before_class_colon.vote(prev, pc);
          vote_sp_after_class_colon.vote(pc, next);
       }
+
       if (chunk_is_token(pc, CT_BRACE_OPEN))
       {
          if (chunk_is_token(prev, CT_ELSE))
@@ -373,6 +401,7 @@ static void detect_space_options(void)
          {
             vote_sp_catch_brace.vote(prev, pc);
          }
+
          if (chunk_is_token(next, CT_BRACE_CLOSE))
          {
             vote_sp_inside_braces_empty.vote(pc, next);
@@ -382,9 +411,11 @@ static void detect_space_options(void)
             vote_sp_inside_braces.vote(pc, next);
          }
       }
+
       if (chunk_is_token(pc, CT_BRACE_CLOSE))
       {
          vote_sp_inside_braces.vote(prev, pc);
+
          if (chunk_is_token(next, CT_ELSE))
          {
             vote_sp_brace_else.vote(pc, next);

--- a/src/enum_cleanup.cpp
+++ b/src/enum_cleanup.cpp
@@ -27,6 +27,7 @@ void enum_cleanup(void)
    }
 
    chunk_t *pc = chunk_get_head();  // Issue #858
+
    while (pc != nullptr)
    {
       if (  pc->parent_type == CT_ENUM
@@ -35,6 +36,7 @@ void enum_cleanup(void)
          LOG_FMT(LTOK, "%s(%d): orig_line is %zu, type is %s\n",
                  __func__, __LINE__, pc->orig_line, get_token_name(pc->type));
          chunk_t *prev = chunk_get_prev_ncnlnp(pc);
+
          // test of (prev == nullptr) is not necessary
          if (chunk_is_token(prev, CT_COMMA))
          {
@@ -60,6 +62,7 @@ void enum_cleanup(void)
             }
          }
       }
+
       pc = chunk_get_next(pc);
    }
 } // enum_cleanup

--- a/src/flag_parens.cpp
+++ b/src/flag_parens.cpp
@@ -9,12 +9,17 @@
 #include "uncrustify.h"
 
 
-chunk_t *flag_parens(chunk_t *po, UINT64 flags, c_token_t opentype, c_token_t parenttype, bool parent_all)
+chunk_t *flag_parens(chunk_t   *po,
+                     UINT64    flags,
+                     c_token_t opentype,
+                     c_token_t parenttype,
+                     bool      parent_all)
 {
    LOG_FUNC_ENTRY();
    chunk_t *paren_close;
 
    paren_close = chunk_skip_to_match(po, scope_e::PREPROC);
+
    if (paren_close == nullptr)
    {
       LOG_FMT(LERR, "%s(%d): no match for '%s' at [%zu:%zu]",
@@ -33,17 +38,20 @@ chunk_t *flag_parens(chunk_t *po, UINT64 flags, c_token_t opentype, c_token_t pa
 
    // the last chunk must be also modified. Issue #2149
    chunk_t *after_paren_close = chunk_get_next(paren_close);
+
    if (po != paren_close)
    {
       if (  flags != 0
          || (parent_all && parenttype != CT_NONE))
       {
          chunk_t *pc;
+
          for (pc = chunk_get_next(po, scope_e::PREPROC);
               pc != nullptr && pc != after_paren_close;
               pc = chunk_get_next(pc, scope_e::PREPROC))
          {
             chunk_flags_set(pc, flags);
+
             if (parent_all)
             {
                set_chunk_parent(pc, parenttype);
@@ -63,5 +71,6 @@ chunk_t *flag_parens(chunk_t *po, UINT64 flags, c_token_t opentype, c_token_t pa
          set_chunk_parent(paren_close, parenttype);
       }
    }
+
    return(chunk_get_next_ncnl(paren_close, scope_e::PREPROC));
 } // flag_parens

--- a/src/frame_list.cpp
+++ b/src/frame_list.cpp
@@ -49,22 +49,27 @@ static void fl_trash_tos(void);
 
 
 //! Logs one parse frame
-static void fl_log(log_sev_t logsev, const ParseFrame &frm)
+static void fl_log(log_sev_t        logsev,
+                   const ParseFrame &frm)
 {
    LOG_FMT(logsev, "[%s] BrLevel=%zu Level=%zu PseTos=%zu\n",
            get_token_name(frm.in_ifdef), frm.brace_level, frm.level, frm.size() - 1);
 
    LOG_FMT(logsev, " *");
+
    for (size_t idx = 1; idx < frm.size(); idx++)
    {
       LOG_FMT(logsev, " [%s-%u]", get_token_name(frm.at(idx).type),
               static_cast<unsigned int>(frm.at(idx).stage));
    }
+
    LOG_FMT(logsev, "\n");
 }
 
 
-static void fl_log_frms(log_sev_t logsev, const char *txt, const ParseFrame &frm)
+static void fl_log_frms(log_sev_t        logsev,
+                        const char       *txt,
+                        const ParseFrame &frm)
 {
    LOG_FMT(logsev, "%s Parse Frames(%zu):", txt, cpd.frames.size());
 
@@ -88,6 +93,7 @@ static void fl_log_all(log_sev_t logsev)
 
       fl_log(logsev, cpd.frames.at(idx));
    }
+
    LOG_FMT(logsev, "##=-\n");
 }
 
@@ -98,6 +104,7 @@ static void fl_copy_tos(ParseFrame &pf)
    {
       pf = *std::prev(std::end(cpd.frames));
    }
+
    LOG_FMT(LPF, "%s(%d): frame_count is %zu\n", __func__, __LINE__, cpd.frames.size());
 }
 
@@ -108,6 +115,7 @@ static void fl_copy_2nd_tos(ParseFrame &pf)
    {
       pf = *std::prev(std::end(cpd.frames), 2);
    }
+
    LOG_FMT(LPF, "%s(%d): frame_count is %zu\n", __func__, __LINE__, cpd.frames.size());
 }
 
@@ -118,6 +126,7 @@ static void fl_trash_tos(void)
    {
       cpd.frames.pop_back();
    }
+
    LOG_FMT(LPF, "%s(%d): frame_count is %zu\n", __func__, __LINE__, cpd.frames.size());
 }
 
@@ -143,7 +152,8 @@ void fl_pop(ParseFrame &pf)
 }
 
 
-int fl_check(ParseFrame &frm, chunk_t *pc)
+int fl_check(ParseFrame &frm,
+             chunk_t    *pc)
 {
    if (pc->type != CT_PREPROC)
    {
@@ -151,6 +161,7 @@ int fl_check(ParseFrame &frm, chunk_t *pc)
    }
 
    chunk_t *next = chunk_get_next(pc);
+
    if (next == nullptr)
    {
       return(cpd.pp_level);
@@ -174,6 +185,7 @@ int fl_check(ParseFrame &frm, chunk_t *pc)
    const size_t    b4_cnt   = cpd.frames.size();
 
    const char      *txt = nullptr;
+
    if (pc->flags & PCF_IN_PREPROC)
    {
       LOG_FMT(LPF, " <In> ");
@@ -204,6 +216,7 @@ int fl_check(ParseFrame &frm, chunk_t *pc)
             fl_push(frm);
             frm.in_ifdef = CT_PP_ELSE;
          }
+
          // we have [...] [base] [if]-[else], copy [base] over [else]
          fl_copy_2nd_tos(frm);
          frm.in_ifdef = CT_PP_ELSE;
@@ -233,6 +246,7 @@ int fl_check(ParseFrame &frm, chunk_t *pc)
                log_flush(true);
                exit(EX_SOFTWARE);
             }
+
             frm.in_ifdef = cpd.frames[cpd.frames.size() - 2].in_ifdef;
             fl_trash_tos();       // [...] [base]-[if]
             fl_trash_tos();       // [...]-[if]

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -196,13 +196,16 @@ static bool single_line_comment_indent_rule_applies(chunk_t *start);
 static bool is_end_of_assignment(chunk_t *pc, const ParseFrame &frm);
 
 
-void indent_to_column(chunk_t *pc, size_t column)
+void indent_to_column(chunk_t *pc,
+                      size_t  column)
 {
    LOG_FUNC_ENTRY();
+
    if (column < pc->column)
    {
       column = pc->column;
    }
+
    reindent_line(pc, column);
 }
 
@@ -215,9 +218,11 @@ enum class align_mode_e : unsigned int
 };
 
 
-void align_to_column(chunk_t *pc, size_t column)
+void align_to_column(chunk_t *pc,
+                     size_t  column)
 {
    LOG_FUNC_ENTRY();
+
    if (pc == nullptr || column == pc->column)
    {
       return;
@@ -231,9 +236,11 @@ void align_to_column(chunk_t *pc, size_t column)
    size_t     min_col   = column;
 
    pc->column = column;
+
    do
    {
       auto *next = chunk_get_next(pc);
+
       if (next == nullptr)
       {
          break;
@@ -246,6 +253,7 @@ void align_to_column(chunk_t *pc, size_t column)
       pc = next;
 
       auto almod = align_mode_e::SHIFT;
+
       if (chunk_is_comment(pc) && pc->parent_type != CT_COMMENT_EMBED)
       {
          almod = (  chunk_is_single_line_comment(pc)
@@ -274,6 +282,7 @@ void align_to_column(chunk_t *pc, size_t column)
                       ? pc->column + col_delta : 0;
          pc->column = max(pc->column, min_col);
       }
+
       LOG_FMT(LINDLINED, "%s(%d):   %s set column of '%s', type is %s, orig_line is %zu, to col %zu (orig_col was %zu)\n",
               __func__, __LINE__,
               (almod == align_mode_e::KEEP_ABS) ? "abs" :
@@ -283,7 +292,8 @@ void align_to_column(chunk_t *pc, size_t column)
 } // align_to_column
 
 
-void reindent_line(chunk_t *pc, size_t column)
+void reindent_line(chunk_t *pc,
+                   size_t  column)
 {
    LOG_FUNC_ENTRY();
    LOG_FMT(LINDLINE, "%s(%d): orig_line is %zu, orig_col is %zu, on '%s' [%s/%s] => %zu\n",
@@ -301,6 +311,7 @@ void reindent_line(chunk_t *pc, size_t column)
    auto min_col   = column;
 
    pc->column = column;
+
    do
    {
       if (QT_SIGNAL_SLOT_found)
@@ -325,6 +336,7 @@ void reindent_line(chunk_t *pc, size_t column)
       }
 
       chunk_t *next = chunk_get_next(pc);
+
       if (next == nullptr)
       {
          break;
@@ -335,6 +347,7 @@ void reindent_line(chunk_t *pc, size_t column)
          min_col   = 0;
          col_delta = 0;
       }
+
       min_col += space_col_align(pc, next);
       pc       = next;
 
@@ -357,6 +370,7 @@ void reindent_line(chunk_t *pc, size_t column)
          pc->column = max(tmp_col, static_cast<int>(min_col));
 
          LOG_FMT(LINDLINED, "   set column of ");
+
          if (chunk_is_token(pc, CT_NEWLINE))
          {
             LOG_FMT(LINDLINED, "<Newline>");
@@ -365,6 +379,7 @@ void reindent_line(chunk_t *pc, size_t column)
          {
             LOG_FMT(LINDLINED, "'%s'", pc->text());
          }
+
          LOG_FMT(LINDLINED, " to %zu (orig %zu)\n", pc->column, pc->orig_col);
       }
    } while (pc != nullptr && pc->nl_count == 0);
@@ -410,7 +425,8 @@ static size_t token_indent(c_token_t type)
    } while (false)
 
 
-static size_t calc_indent_continue(const ParseFrame &frm, size_t pse_tos)
+static size_t calc_indent_continue(const ParseFrame &frm,
+                                   size_t           pse_tos)
 {
    const int ic = options::indent_continue();
 
@@ -429,9 +445,11 @@ static size_t calc_indent_continue(const ParseFrame &frm)
 }
 
 
-static chunk_t *oc_msg_block_indent(chunk_t *pc, bool from_brace,
-                                    bool from_caret, bool from_colon,
-                                    bool from_keyword)
+static chunk_t *oc_msg_block_indent(chunk_t *pc,
+                                    bool    from_brace,
+                                    bool    from_caret,
+                                    bool    from_colon,
+                                    bool    from_keyword)
 {
    LOG_FUNC_ENTRY();
    chunk_t *tmp = chunk_get_prev_nc(pc);
@@ -445,35 +463,44 @@ static chunk_t *oc_msg_block_indent(chunk_t *pc, bool from_brace,
    {
       tmp = chunk_get_prev_nc(chunk_skip_to_match_rev(tmp));
    }
+
    if (tmp == nullptr || tmp->type != CT_OC_BLOCK_CARET)
    {
       return(nullptr);
    }
+
    if (from_caret)
    {
       return(tmp);
    }
+
    tmp = chunk_get_prev_nc(tmp);
+
    if (tmp == nullptr || tmp->type != CT_OC_COLON)
    {
       return(nullptr);
    }
+
    if (from_colon)
    {
       return(tmp);
    }
+
    tmp = chunk_get_prev_nc(tmp);
+
    if (  tmp == nullptr
       || (tmp->type != CT_OC_MSG_NAME && tmp->type != CT_OC_MSG_FUNC))
    {
       return(nullptr);
    }
+
    if (from_keyword)
    {
       return(tmp);
    }
 
    tmp = chunk_first_on_line(tmp);
+
    if (chunk_is_token(tmp, CT_SQUARE_OPEN))
    {
       return(tmp);
@@ -494,7 +521,9 @@ static chunk_t *oc_msg_prev_colon(chunk_t *pc)
    } while (false)
 
 
-static void _log_indent(const char *func, const uint32_t line, const ParseFrame &frm)
+static void _log_indent(const char       *func,
+                        const uint32_t   line,
+                        const ParseFrame &frm)
 {
    LOG_FMT(LINDLINE, "%s(%d): frm.pse_tos is %zu, ...indent is %zu\n",
            func, line, frm.size() - 1, frm.top().indent);
@@ -506,7 +535,9 @@ static void _log_indent(const char *func, const uint32_t line, const ParseFrame 
    } while (false)
 
 
-static void _log_prev_indent(const char *func, const uint32_t line, const ParseFrame &frm)
+static void _log_prev_indent(const char       *func,
+                             const uint32_t   line,
+                             const ParseFrame &frm)
 {
    LOG_FMT(LINDLINE, "%s(%d): frm.pse_tos is %zu, prev....indent is %zu\n",
            func, line, frm.size() - 1, frm.prev().indent);
@@ -518,7 +549,9 @@ static void _log_prev_indent(const char *func, const uint32_t line, const ParseF
    } while (false)
 
 
-static void _log_indent_tmp(const char *func, const uint32_t line, const ParseFrame &frm)
+static void _log_indent_tmp(const char       *func,
+                            const uint32_t   line,
+                            const ParseFrame &frm)
 {
    LOG_FMT(LINDLINE, "%s(%d): frm.pse_tos is %zu, ...indent_tmp is %zu\n",
            func, line, frm.size() - 1, frm.top().indent_tmp);
@@ -537,6 +570,7 @@ static void quick_indent_again(void)
       }
 
       chunk_t *tmp = chunk_get_prev(pc);
+
       if (!chunk_is_newline(tmp))
       {
          continue;
@@ -580,6 +614,7 @@ void indent_text(void)
          && options::indent_col1_multi_string_literal())
       {
          string str = pc->text();
+
          if ((str[0] == '@') && (chunk_get_prev(pc)->type == CT_NEWLINE))
          {
             indent_column_set(1);
@@ -614,7 +649,6 @@ void indent_text(void)
                  __func__, __LINE__, pc->orig_line, get_token_name(pc->type));
       }
 
-
       // Handle preprocessor transitions
       const size_t parent_token_indent = (options::indent_brace_parent())
                                          ? token_indent(pc->parent_type) : 0;
@@ -625,6 +659,7 @@ void indent_text(void)
          if (!in_func_def)
          {
             chunk_t *next = chunk_get_next_ncnl(pc);
+
             if (  pc->parent_type == CT_FUNC_DEF
                || (  chunk_is_token(pc, CT_COMMENT)
                   && next != nullptr
@@ -640,6 +675,7 @@ void indent_text(void)
          else
          {
             chunk_t *prev = chunk_get_prev(pc);
+
             if (  chunk_is_token(prev, CT_BRACE_CLOSE)
                && prev->parent_type == CT_FUNC_DEF)
             {
@@ -653,6 +689,7 @@ void indent_text(void)
 
       // Clean up after a #define, etc
       const bool in_preproc = (pc->flags & PCF_IN_PREPROC);
+
       if (!in_preproc)
       {
          while (!frm.empty() && frm.top().in_preproc)
@@ -694,6 +731,7 @@ void indent_text(void)
             && pc->parent_type == CT_PP_REGION)
          {
             chunk_t *next = chunk_get_next(pc);
+
             if (next == nullptr)
             {
                break;
@@ -721,10 +759,12 @@ void indent_text(void)
             frm.push(*pc);
             LOG_FMT(LINDPC, "%s(%d): frm.top().indent is %zu, indent_size is %zu\n",
                     __func__, __LINE__, frm.top().indent, indent_size);
+
             if (frm.top().indent >= indent_size)
             {
                frm.prev().indent = frm.top().indent - indent_size;
             }
+
             log_prev_indent();
          }
 
@@ -734,6 +774,7 @@ void indent_text(void)
                || pc->parent_type == CT_PP_ELSE))
          {
             chunk_t *next = chunk_get_next(pc);
+
             if (next == nullptr)
             {
                break;
@@ -759,8 +800,10 @@ void indent_text(void)
                   should_indent_preproc = false;
                   break;
                }
+
                preproc_next = chunk_get_next(preproc_next);
             }
+
             if (should_indent_preproc)
             {
                // Hack to get the logs to look right
@@ -797,6 +840,7 @@ void indent_text(void)
                   && frm.top().pc != frmbkup.top().pc)
                {
                   chunk_t *tmp = chunk_get_next_ncnlnp(pc);
+
                   if (tmp != nullptr)
                   {
                      if (chunk_is_token(tmp, CT_WORD) || chunk_is_token(tmp, CT_TYPE))
@@ -806,11 +850,13 @@ void indent_text(void)
                      else if (chunk_is_token(tmp, CT_FUNC_CALL) || chunk_is_token(tmp, CT_FPAREN_OPEN))
                      {
                         tmp = chunk_get_next_type(tmp, CT_FPAREN_CLOSE, tmp->level);
+
                         if (tmp != nullptr)
                         {
                            tmp = chunk_get_next_ncnlnp(pc);
                         }
                      }
+
                      if (tmp != nullptr)
                      {
                         frm.top().pop_pc = tmp;
@@ -827,12 +873,15 @@ void indent_text(void)
                }
             }
          }
+
          // Transition into a preproc by creating a dummy indent
          chunk_t *pp_next = chunk_get_next(pc);
+
          if (pp_next == nullptr)
          {
             return;
          }
+
          frm.push(*pp_next);
 
          if (pc->parent_type == CT_PP_DEFINE || pc->parent_type == CT_PP_UNDEF)
@@ -869,10 +918,12 @@ void indent_text(void)
                frm.top().indent = frm.prev().indent;
                log_indent();
             }
+
             log_indent();
 
 
             auto val = 0;
+
             if (  pc->parent_type == CT_PP_REGION
                || pc->parent_type == CT_PP_ENDREGION)
             {
@@ -886,6 +937,7 @@ void indent_text(void)
                val = options::pp_indent_if();
                log_indent();
             }
+
             if (val != 0)
             {
                auto &indent = frm.top().indent;
@@ -924,6 +976,7 @@ void indent_text(void)
 
       bool   token_used = false;
       size_t old_frm_size;
+
       do
       {
          old_frm_size = frm.size();
@@ -948,6 +1001,7 @@ void indent_text(void)
                        __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(), get_token_name(pc->type));
                frm.pop();
                pc = chunk_get_next(pc);
+
                if (pc == nullptr)
                {
                   // need to break out of both the do and while loops
@@ -971,6 +1025,7 @@ void indent_text(void)
                   LOG_FMT(LINDLINE, "%s(%d): prev_ncnl is NOT comma\n", __func__, __LINE__);
                }
             }
+
             // End any assign operations with a semicolon on the same level
             if (is_end_of_assignment(pc, frm))
             {
@@ -1013,6 +1068,7 @@ void indent_text(void)
                        __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(), get_token_name(pc->type));
                frm.pop();
             }
+
             // End ObjC class colon stuff inside of generic definition (like Test<T1: id<T3>>)
             if (  (frm.top().type == CT_CLASS_COLON)
                && chunk_is_token(pc, CT_ANGLE_CLOSE)
@@ -1022,6 +1078,7 @@ void indent_text(void)
                        __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(), get_token_name(pc->type));
                frm.pop();
             }
+
             // End Objc nested message and boxed array
             // TODO: ideally formatting would know which opens occurred on a line and group closes in the same manor
             if (  language_is_set(LANG_OC)
@@ -1031,6 +1088,7 @@ void indent_text(void)
             {
                size_t  count = 1;
                chunk_t *next = chunk_get_next_nc(pc);
+
                while (  next
                      && (  (chunk_is_token(next, CT_BRACE_CLOSE) && next->parent_type == CT_OC_AT)
                         || (chunk_is_token(next, CT_SQUARE_CLOSE) && next->parent_type == CT_OC_AT)
@@ -1041,6 +1099,7 @@ void indent_text(void)
                }
 
                count = std::min(count, frm.size());
+
                if (count > 0)
                {
                   while (count-- > 0)
@@ -1049,10 +1108,12 @@ void indent_text(void)
                      {
                         frm.paren_count--;
                      }
+
                      LOG_FMT(LINDLINE, "%s(%d): pc->orig_line is %zu, orig_col is %zu, text() is '%s', type is %s\n",
                              __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(), get_token_name(pc->type));
                      frm.pop();
                   }
+
                   if (next)
                   {
                      // End any assign operations with a semicolon on the same level
@@ -1063,6 +1124,7 @@ void indent_text(void)
                         frm.pop();
                      }
                   }
+
                   // Indent the brace to match outer most brace/square
                   indent_column_set(frm.top().indent_tmp);
                   continue;
@@ -1085,6 +1147,7 @@ void indent_text(void)
                        __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(), get_token_name(pc->type));
                frm.pop();
             }
+
             if (  (frm.top().type == CT_LAMBDA)
                && (  chunk_is_token(pc, CT_SEMICOLON)
                   || chunk_is_token(pc, CT_COMMA)
@@ -1191,6 +1254,7 @@ void indent_text(void)
          LOG_FMT(LINDPC, "%s(%d):\n", __func__, __LINE__);
          LOG_FMT(LINDPC, "   -=[ pc->orig_line is %zu, orig_col is %zu %s ]=-, frm.size() is %zu\n",
                  pc->orig_line, pc->orig_col, pc->text(), frm.size());
+
          for (size_t ttidx = frm.size() - 1; ttidx > 0; ttidx--)
          {
             LOG_FMT(LINDPC, "     [%zu %zu:%zu %s %s/%s tmp=%zu ind=%zu bri=%zu tab=%zu cont=%d lvl=%zu blvl=%zu]\n",
@@ -1209,6 +1273,7 @@ void indent_text(void)
                     frm.at(ttidx).pc->brace_level);
          }
       }
+
       LOG_FMT(LINDENT2, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s'\n",
               __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text());
 
@@ -1263,6 +1328,7 @@ void indent_text(void)
             {
                size_t  count = 1;
                chunk_t *next = chunk_get_next_nc(pc);
+
                while (  next
                      && (  (chunk_is_token(next, CT_BRACE_CLOSE) && next->parent_type == CT_OC_AT)
                         || (chunk_is_token(next, CT_SQUARE_CLOSE) && next->parent_type == CT_OC_AT)
@@ -1271,6 +1337,7 @@ void indent_text(void)
                   count++;
                   next = chunk_get_next_nc(next);
                }
+
                count = std::min(count, frm.size());
 
                // End Objc nested boxed dictionary
@@ -1349,15 +1416,19 @@ void indent_text(void)
          frm.push(*pc);
 
          size_t iMinIndent = options::indent_min_vbrace_open();
+
          if (indent_size > iMinIndent)
          {
             iMinIndent = indent_size;
          }
+
          size_t iNewIndent = frm.prev().indent + iMinIndent;
+
          if (options::indent_vbrace_open_on_tabstop())
          {
             iNewIndent = next_tab_column(iNewIndent);
          }
+
          frm.top().indent = iNewIndent;
          log_indent();
          frm.top().indent_tmp = frm.top().indent;
@@ -1428,11 +1499,13 @@ void indent_text(void)
                     || pc->parent_type == CT_DELEGATE))
          {
             frm.top().brace_indent = frm.prev().indent;
+
             // Issue # 1620, UNI-24090.cs
             if (are_chunks_in_same_line(frm.prev().pc, chunk_get_prev_ncnlnp(frm.top().pc)))
             {
                frm.top().brace_indent -= indent_size;
             }
+
             indent_column_set(frm.top().brace_indent);
             frm.top().indent = indent_column + indent_size;
             log_indent();
@@ -1546,6 +1619,7 @@ void indent_text(void)
                                                      indent_from_caret,
                                                      indent_from_colon,
                                                      indent_from_keyword);
+
                   if (ref)
                   {
                      frm.top().indent = indent_size + ref->column;
@@ -1554,6 +1628,7 @@ void indent_text(void)
                   {
                      frm.top().indent = 1 + ((pc->brace_level + 1) * indent_size);
                   }
+
                   log_indent();
                   indent_column_set(frm.top().indent - indent_size);
                }
@@ -1575,6 +1650,7 @@ void indent_text(void)
                {
                   frm.top().indent = frm.prev().indent_tmp + indent_size;
                }
+
                log_indent();
             }
             // Issue # 1620, UNI-24090.cs
@@ -1619,6 +1695,7 @@ void indent_text(void)
             {
                frm.top().indent = frm.prev().indent_tmp + indent_size;
             }
+
             log_indent();
          }
          else if (  pc->parent_type == CT_BRACED_INIT_LIST
@@ -1632,6 +1709,7 @@ void indent_text(void)
             {
                frm.top().indent = frm.prev().indent_tmp + indent_size;
             }
+
             log_indent();
          }
          else
@@ -1701,6 +1779,7 @@ void indent_text(void)
             else if (pc->parent_type == CT_NAMESPACE)
             {
                frm.top().ns_cnt = frm.prev().ns_cnt + 1;
+
                if (  options::indent_namespace()
                   && options::indent_namespace_single_indent())
                {
@@ -1710,6 +1789,7 @@ void indent_text(void)
                      frm.top().indent -= indent_size;
                      log_indent();
                   }
+
                   indent_column_set(frm.prev(frm.top().ns_cnt).indent);
                }
                else if (  (pc->flags & PCF_LONG_BLOCK)
@@ -1759,11 +1839,14 @@ void indent_text(void)
              *   b--; };
              */
             chunk_t *next = chunk_get_next_ncnl(pc);
+
             if (next == nullptr)
             {
                break;
             }
+
             chunk_t *prev = chunk_get_prev(pc);
+
             if (pc->parent_type == CT_BRACED_INIT_LIST && chunk_is_token(prev, CT_BRACE_OPEN) && prev->parent_type == CT_BRACED_INIT_LIST)
             {
                indent_column = frm.prev().brace_indent;
@@ -1778,6 +1861,7 @@ void indent_text(void)
                frm.top().indent = next->column;
                log_indent();
             }
+
             frm.top().indent_tmp = frm.top().indent;
             frm.top().open_line  = pc->orig_line;
             log_indent_tmp();
@@ -1853,10 +1937,12 @@ void indent_text(void)
 
          // comments before 'case' need to be aligned with the 'case'
          chunk_t *pct = pc;
+
          while (  ((pct = chunk_get_prev_nnl(pct)) != nullptr)
                && chunk_is_comment(pct))
          {
             chunk_t *t2 = chunk_get_prev(pct);
+
             if (chunk_is_newline(t2))
             {
                pct->column        = frm.top().indent_tmp;
@@ -1867,14 +1953,17 @@ void indent_text(void)
       else if (chunk_is_token(pc, CT_BREAK))
       {
          chunk_t *prev = chunk_get_prev_ncnl(pc);
+
          if (  chunk_is_token(prev, CT_BRACE_CLOSE)
             && prev->parent_type == CT_CASE)
          {
             // issue #663 + issue #1366
             chunk_t *prev_newline = chunk_get_prev_nl(pc);
+
             if (prev_newline != nullptr)
             {
                chunk_t *prev_prev_newline = chunk_get_prev_nl(prev_newline);
+
                if (prev_prev_newline != nullptr)
                {
                   // This only affects the 'break', so no need for a stack entry
@@ -1930,10 +2019,12 @@ void indent_text(void)
             // Issue 1161
             // comments before 'access specifier' need to be aligned with the 'access specifier'
             chunk_t *pct = pc;
+
             while (  ((pct = chunk_get_prev_nnl(pct)) != nullptr)
                   && chunk_is_comment(pct))
             {
                chunk_t *t2 = chunk_get_prev(pct);
+
                if (chunk_is_newline(t2))
                {
                   pct->column        = frm.top().indent_tmp;
@@ -1945,6 +2036,7 @@ void indent_text(void)
          {
             // Access spec labels get sent to the left or backed up
             const auto val = options::indent_access_spec();
+
             if (val > 0)
             {
                indent_column_set(val);
@@ -1984,6 +2076,7 @@ void indent_text(void)
             else
             {
                chunk_t *next = chunk_get_next(pc);
+
                if (next != nullptr && !chunk_is_newline(next))
                {
                   frm.top().indent = next->column;
@@ -1995,6 +2088,7 @@ void indent_text(void)
                  && chunk_is_token(pc, CT_CONSTR_COLON))
          {
             chunk_t *prev = chunk_get_prev(pc);
+
             if (chunk_is_newline(prev))
             {
                frm.top().indent += options::indent_ctor_init_leading();
@@ -2025,6 +2119,7 @@ void indent_text(void)
             else
             {
                chunk_t *next = chunk_get_next(pc);
+
                if (next != nullptr && !chunk_is_newline(next))
                {
                   frm.top().indent = next->column;
@@ -2041,6 +2136,7 @@ void indent_text(void)
          chunk_t *tmp = chunk_skip_to_match(pc);
 
          int     move = 0;
+
          if (  chunk_is_newline(chunk_get_prev(pc))
             && pc->column != indent_column)
          {
@@ -2056,6 +2152,7 @@ void indent_text(void)
             pc->column = pc->orig_col + move;
             pc         = chunk_get_next(pc);
          } while (pc != tmp);
+
          reindent_line(pc, indent_column);
       }
       else if (  chunk_is_token(pc, CT_PAREN_OPEN)
@@ -2069,6 +2166,7 @@ void indent_text(void)
           * unless right after a newline.
           */
          frm.push(*pc);
+
          if (  chunk_is_newline(chunk_get_prev(pc))
             && pc->column != indent_column
             && !(pc->flags & PCF_DONT_INDENT))
@@ -2077,6 +2175,7 @@ void indent_text(void)
                     __func__, __LINE__, pc->orig_line, indent_column, pc->text());
             reindent_line(pc, indent_column);
          }
+
          frm.top().indent = pc->column + pc->len();
          log_indent();
 
@@ -2086,6 +2185,7 @@ void indent_text(void)
          }
 
          bool skipped = false;
+
          if (  (chunk_is_token(pc, CT_FPAREN_OPEN) || chunk_is_token(pc, CT_ANGLE_OPEN))
             && (  (  options::indent_func_call_param()
                   && (  pc->parent_type == CT_FUNC_CALL
@@ -2105,6 +2205,7 @@ void indent_text(void)
          {
             // Skip any continuation indents
             size_t idx = (!frm.empty()) ? frm.size() - 2 : 0;
+
             while (  (  (  idx > 0
                         && frm.at(idx).type != CT_BRACE_OPEN
                         && frm.at(idx).type != CT_VBRACE_OPEN
@@ -2125,6 +2226,7 @@ void indent_text(void)
                idx--;
                skipped = true;
             }
+
             // PR#381
             if (options::indent_param() != 0)
             {
@@ -2136,12 +2238,14 @@ void indent_text(void)
                frm.top().indent = frm.at(idx).indent + indent_size;
                log_indent();
             }
+
             if (options::indent_func_param_double())
             {
                // double is: Use both values of the options indent_columns and indent_param
                frm.top().indent += indent_size;
                log_indent();
             }
+
             frm.top().indent_tab = frm.top().indent;
          }
          else if (  chunk_is_token(pc, CT_PAREN_OPEN)
@@ -2150,11 +2254,13 @@ void indent_text(void)
                  && !(pc->flags & PCF_IN_SPAREN))
          {
             int idx = static_cast<int>(frm.size()) - 2;
+
             while (idx > 0 && are_chunks_in_same_line(frm.at(idx).pc, frm.top().pc))
             {
                idx--;
                skipped = true;
             }
+
             frm.top().indent = frm.at(idx).indent + indent_size;
             log_indent();
 
@@ -2169,36 +2275,44 @@ void indent_text(void)
                     && !options::indent_square_nl()))
          {
             chunk_t *next = chunk_get_next_nc(pc);
+
             if (next == nullptr)
             {
                break;
             }
+
             if (  chunk_is_newline(next)
                && !options::indent_paren_after_func_def()
                && !options::indent_paren_after_func_decl()
                && !options::indent_paren_after_func_call())
             {
                size_t sub = 2;
+
                if (  (frm.prev().type == CT_ASSIGN)
                   || (frm.prev().type == CT_RETURN))
                {
                   sub = 3;
                }
+
                sub = static_cast<int>(frm.size()) - sub;
+
                if (!options::indent_align_paren())
                {
                   sub = static_cast<int>(frm.size()) - 2;
+
                   while (sub > 0 && are_chunks_in_same_line(frm.at(sub).pc, frm.top().pc))
                   {
                      sub--;
                      skipped = true;
                   }
+
                   if (  (frm.at(sub + 1).type == CT_CLASS_COLON || frm.at(sub + 1).type == CT_CONSTR_COLON)
                      && (chunk_is_token(frm.at(sub + 1).pc->prev, CT_NEWLINE)))
                   {
                      sub = sub + 1;
                   }
                }
+
                frm.top().indent = frm.at(sub).indent + indent_size;
                log_indent();
 
@@ -2212,11 +2326,13 @@ void indent_text(void)
                   if (chunk_is_token(next, CT_SPACE))
                   {
                      next = chunk_get_next_nc(next);
+
                      if (next == nullptr)
                      {
                         break;
                      }
                   }
+
                   if (chunk_is_comment(next->prev))
                   {
                      // Issue #2099
@@ -2226,6 +2342,7 @@ void indent_text(void)
                   {
                      frm.top().indent = next->column;
                   }
+
                   log_indent();
                }
             }
@@ -2249,6 +2366,7 @@ void indent_text(void)
 
             indent_column_set(frm.top().indent);
          }
+
          if (  pc->parent_type != CT_OC_AT
             && options::indent_continue() != 0
             && !skipped)
@@ -2296,6 +2414,7 @@ void indent_text(void)
                }
             }
          }
+
          frm.top().indent_tmp = frm.top().indent;
          log_indent_tmp();
 
@@ -2310,6 +2429,7 @@ void indent_text(void)
          {
             frm.push(*pc);
             chunk_t *tmp = chunk_get_prev_ncnlnp(frm.top().pc);
+
             if (are_chunks_in_same_line(frm.prev().pc, tmp))
             {
                frm.top().indent = frm.prev().indent;
@@ -2318,18 +2438,22 @@ void indent_text(void)
             {
                frm.top().indent = frm.prev().indent + indent_size;
             }
+
             log_indent();
             frm.top().indent_tmp = frm.top().indent;
             log_indent_tmp();
          }
+
          if (chunk_is_newline(chunk_get_prev(pc)))
          {
             indent_column_set(frm.top().indent);
             reindent_line(pc, indent_column);
             did_newline = false;
          }
+
          //check for the series of CT_member chunks else pop it.
          chunk_t *tmp = chunk_get_next_ncnlnp(pc);
+
          if (tmp != nullptr)
          {
             if (chunk_is_token(tmp, CT_FUNC_CALL))
@@ -2341,6 +2465,7 @@ void indent_text(void)
                tmp = chunk_get_next_ncnlnp(tmp);
             }
          }
+
          if (  tmp != nullptr
             && (  (strcmp(tmp->text(), ".") != 0)
                || tmp->type != CT_MEMBER))
@@ -2349,10 +2474,12 @@ void indent_text(void)
             {
                tmp = chunk_get_prev_ncnlnp(tmp);
             }
+
             if (tmp != nullptr && chunk_is_newline(tmp->prev))
             {
                tmp = chunk_get_next_nl(chunk_get_prev_ncnlnp(tmp));
             }
+
             if (tmp != nullptr)
             {
                frm.top().pop_pc = tmp;
@@ -2378,6 +2505,7 @@ void indent_text(void)
             {
                frm.top().indent_tmp = frm.top().indent + indent_size;
             }
+
             log_indent_tmp();
 
             indent_column_set(frm.top().indent_tmp);
@@ -2387,6 +2515,7 @@ void indent_text(void)
          }
 
          chunk_t *next = chunk_get_next(pc);
+
          if (next != nullptr)
          {
             /*
@@ -2401,6 +2530,7 @@ void indent_text(void)
                        __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(), get_token_name(pc->type));
                frm.pop();
             }
+
             frm.push(*pc);
 
             if (chunk_is_token(pc, CT_ASSIGN) && chunk_is_newline(chunk_get_prev(pc)))
@@ -2453,6 +2583,7 @@ void indent_text(void)
                frm.top().indent = pc->column + pc->len() + 1;
                log_indent();
             }
+
             frm.top().indent_tmp = frm.top().indent;
             log_indent_tmp();
          }
@@ -2464,6 +2595,7 @@ void indent_text(void)
          if (pc->level == pc->brace_level)
          {
             chunk_t *next = chunk_get_next(pc);
+
             // Avoid indentation on return token if the next token is a new token
             // to properly indent object initializers returned by functions.
             if (  !options::indent_off_after_return_new()
@@ -2471,6 +2603,7 @@ void indent_text(void)
                || next->type != CT_NEW)
             {
                frm.push(*pc);
+
                if (  chunk_is_newline(next)
                   || (  chunk_is_token(pc, CT_RETURN)
                      && options::indent_single_after_return()))
@@ -2483,10 +2616,12 @@ void indent_text(void)
                   // indent after the return token
                   frm.top().indent = frm.prev().indent + pc->len() + 1;
                }
+
                log_indent();
                frm.top().indent_tmp = frm.prev().indent;
                log_indent_tmp();
             }
+
             log_indent();
          }
       }
@@ -2501,6 +2636,7 @@ void indent_text(void)
          frm.top().indent_tmp = frm.top().indent;
          LOG_FMT(LINDLINE, "%s(%d): .indent is %zu, .indent_tmp is %zu\n",
                  __func__, __LINE__, frm.top().indent, frm.top().indent_tmp);
+
          if (options::indent_continue() != 0)
          {
             frm.top().indent = calc_indent_continue(frm, frm.size() - 2);
@@ -2536,6 +2672,7 @@ void indent_text(void)
          frm.push(*pc);
          frm.top().indent = frm.prev().indent;
          log_indent();
+
          if (chunk_is_newline(chunk_get_prev_nc(pc)) && !are_chunks_in_same_line(frm.prev().pc, chunk_get_prev_ncnl(pc)))
          {
             frm.top().indent = frm.prev().indent + indent_size;
@@ -2547,6 +2684,7 @@ void indent_text(void)
          {
             frm.top().indent = frm.prev().indent + indent_size;
          }
+
          log_indent();
          frm.top().indent_tmp = frm.top().indent;
          log_indent_tmp();
@@ -2558,6 +2696,7 @@ void indent_text(void)
 
       // Handle shift expression continuation indenting
       size_t shiftcontcol = 0;
+
       if (  options::indent_shift()
          && !(pc->flags & PCF_IN_ENUM)
          && pc->parent_type != CT_OPERATOR
@@ -2573,6 +2712,7 @@ void indent_text(void)
 
          // Are we in such an expression? Go both forwards and backwards.
          chunk_t *tmp = pc;
+
          do
          {
             if (  tmp != nullptr
@@ -2583,6 +2723,7 @@ void indent_text(void)
                        __func__, __LINE__);
 
                tmp = chunk_get_prev_ncnl(tmp);
+
                if (chunk_is_token(tmp, CT_OPERATOR))
                {
                   is_operator = true;
@@ -2590,6 +2731,7 @@ void indent_text(void)
 
                break;
             }
+
             tmp = chunk_get_prev_ncnl(tmp);
          } while (  !in_shift
                  && tmp != nullptr
@@ -2601,9 +2743,11 @@ void indent_text(void)
                  && tmp->type != CT_SPAREN_CLOSE);
 
          tmp = pc;
+
          do
          {
             tmp = chunk_get_next_ncnl(tmp);
+
             if (  tmp != nullptr
                && (chunk_is_str(tmp, "<<", 2) || chunk_is_str(tmp, ">>", 2)))
             {
@@ -2612,6 +2756,7 @@ void indent_text(void)
                        __func__, __LINE__);
 
                tmp = chunk_get_prev_ncnl(tmp);
+
                if (chunk_is_token(tmp, CT_OPERATOR))
                {
                   is_operator = true;
@@ -2648,6 +2793,7 @@ void indent_text(void)
 
          LOG_FMT(LINDENT2, "%s(%d): in_shift is %s\n",
                  __func__, __LINE__, in_shift ? "TRUE" : "FALSE");
+
          if (chunk_is_token(prev2, CT_NEWLINE) && in_shift)
          {
             shiftcontcol = calc_indent_continue(frm);
@@ -2659,6 +2805,7 @@ void indent_text(void)
             // Work around the doubly increased indent in RETURNs and assignments
             bool   need_workaround = false;
             size_t sub             = 0;
+
             for (int i = frm.size() - 1; i >= 0; i--)
             {
                if (frm.at(i).type == CT_RETURN || frm.at(i).type == CT_ASSIGN)
@@ -2700,6 +2847,7 @@ void indent_text(void)
             vardefcol = pc->column;
             // need to skip backward over any '*'
             chunk_t *tmp = chunk_get_prev_nc(pc);
+
             while (chunk_is_token(tmp, CT_PTR_TYPE))
             {
                vardefcol = tmp->column;
@@ -2707,6 +2855,7 @@ void indent_text(void)
             }
          }
       }
+
       if (  chunk_is_semicolon(pc)
          || (chunk_is_token(pc, CT_BRACE_OPEN) && pc->parent_type == CT_FUNCTION))
       {
@@ -2740,6 +2889,7 @@ void indent_text(void)
          auto next  = chunk_get_next_ncnl(pc);
 
          bool do_vardefcol = false;
+
          if (  vardefcol > 0
             && pc->level == pc->brace_level
             && (  chunk_is_token(prev, CT_COMMA)
@@ -2748,10 +2898,12 @@ void indent_text(void)
                || chunk_is_token(prev, CT_WORD)))
          {
             chunk_t *tmp = pc;
+
             while (chunk_is_token(tmp, CT_PTR_TYPE))
             {
                tmp = chunk_get_next_ncnl(tmp);
             }
+
             if (  (tmp->flags & PCF_VAR_DEF)
                && (chunk_is_token(tmp, CT_WORD) || chunk_is_token(tmp, CT_FUNC_CTOR_VAR)))
             {
@@ -2868,6 +3020,7 @@ void indent_text(void)
                      LOG_FMT(LINDLINE, "%s(%d): [%zu:%zu] indent_column set to %zu\n",
                              __func__, __LINE__, ck2->orig_line, ck2->orig_col, indent_column);
                      pc->column_indent = frm.poped().indent_tab;
+
                      if (options::indent_paren_close() == 1)
                      {
                         LOG_FMT(LINDLINE, "%s(%d): [%zu:%zu] indent_paren_close is 1\n",
@@ -2882,28 +3035,34 @@ void indent_text(void)
                      // 2
                      LOG_FMT(LINDLINE, "%s(%d): [%zu:%zu] indent_paren_close is 2\n",
                              __func__, __LINE__, ck2->orig_line, ck2->orig_col);
+
                      if (chunk_get_prev(pc)->type == CT_NEWLINE)
                      {
                         chunk_t *search = pc;
+
                         while (chunk_is_paren_close(chunk_get_next(search)))
                         {
                            search = chunk_get_next(search);
                         }
+
                         if (  chunk_get_next(search)->type == CT_SEMICOLON
                            || chunk_get_next(search)->type == CT_NEWLINE)
                         {
                            search = chunk_skip_to_match_rev(search);
                            search = chunk_get_next(chunk_get_prev_nl(search));
+
                            if (search == nullptr)
                            {
                               search = chunk_get_head();
                            }
+
                            indent_column_set(search->column);
                         }
                      }
                   }
                }
             }
+
             LOG_FMT(LINDENT, "%s(%d): %zu] cl paren => %zu [%s]\n",
                     __func__, __LINE__, pc->orig_line, indent_column, pc->text());
             reindent_line(pc, indent_column);
@@ -2915,6 +3074,7 @@ void indent_text(void)
             {
                indent_column_set(frm.top().pc->column);
             }
+
             LOG_FMT(LINDENT, "%s(%d): %zu] comma => %zu [%s]\n",
                     __func__, __LINE__, pc->orig_line, indent_column, pc->text());
             reindent_line(pc, indent_column);
@@ -2990,9 +3150,11 @@ void indent_text(void)
                     || chunk_is_token(pc, CT_PAREN_OPEN)))
          {
             chunk_t *tmp = chunk_get_prev_type(prev, CT_QUESTION, -1);
+
             if (tmp != nullptr)
             {
                tmp = chunk_get_next_ncnl(tmp);
+
                if (tmp != nullptr)
                {
                   LOG_FMT(LINDENT, "%s: %zu] ternarydefcol => %zu [%s]\n",
@@ -3005,6 +3167,7 @@ void indent_text(void)
                  && chunk_is_token(pc, CT_COND_COLON))
          {
             chunk_t *tmp = chunk_get_prev_type(pc, CT_QUESTION, -1);
+
             if (tmp != nullptr)
             {
                LOG_FMT(LINDENT, "%s: %zu] ternarydefcol => %zu [%s]\n",
@@ -3016,13 +3179,16 @@ void indent_text(void)
          {
             bool         use_indent = true;
             const size_t ttidx      = frm.size() - 1;
+
             if (ttidx > 0)
             {
                LOG_FMT(LINDPC, "%s(%d): (frm.at(ttidx).pc)->parent_type is %s\n",
                        __func__, __LINE__, get_token_name((frm.at(ttidx).pc)->parent_type));
+
                if ((frm.at(ttidx).pc)->parent_type == CT_FUNC_CALL)
                {
                   LOG_FMT(LINDPC, "FUNC_CALL OK [%d]\n", __LINE__);
+
                   if (options::use_indent_func_call_param())
                   {
                      LOG_FMT(LINDPC, "use is true [%d]\n", __LINE__);
@@ -3034,8 +3200,10 @@ void indent_text(void)
                   }
                }
             }
+
             LOG_FMT(LINDENT, "%s(%d): pc->line is %zu, pc->column is %zu, pc->text() is '%s, indent_column is %zu\n",
                     __func__, __LINE__, pc->orig_line, pc->column, pc->text(), indent_column);
+
             if (pc->column != indent_column)
             {
                if (use_indent && pc->type != CT_PP_IGNORE) // Leave indentation alone for PP_IGNORE tokens
@@ -3063,6 +3231,7 @@ void indent_text(void)
                }
             }
          }
+
          did_newline = false;
 
          if (  chunk_is_token(pc, CT_SQL_EXEC)
@@ -3080,6 +3249,7 @@ void indent_text(void)
                && (frm.top().type == CT_BRACE_OPEN))
             {
                const auto val = options::indent_var_def_blk();
+
                if (val != 0)
                {
                   auto indent = indent_column;
@@ -3135,6 +3305,7 @@ void indent_text(void)
          {
             xml_indent = pc->column;
          }
+
          xml_indent += options::indent_xml_string();
       }
 
@@ -3158,6 +3329,7 @@ void indent_text(void)
 
       pc = chunk_get_next(pc);
    }
+
 null_pc:
 
    // Throw out any stuff inside a preprocessor - no need to warn
@@ -3193,6 +3365,7 @@ null_pc:
 static bool single_line_comment_indent_rule_applies(chunk_t *start)
 {
    LOG_FUNC_ENTRY();
+
    if (!chunk_is_single_line_comment(start))
    {
       return(false);
@@ -3209,6 +3382,7 @@ static bool single_line_comment_indent_rule_applies(chunk_t *start)
          {
             return(false);
          }
+
          nl_count++;
       }
       else if (chunk_is_single_line_comment(pc))
@@ -3233,7 +3407,8 @@ static bool single_line_comment_indent_rule_applies(chunk_t *start)
 } // single_line_comment_indent_rule_applies
 
 
-static bool is_end_of_assignment(chunk_t *pc, const ParseFrame &frm)
+static bool is_end_of_assignment(chunk_t          *pc,
+                                 const ParseFrame &frm)
 {
    return(  (  frm.top().type == CT_ASSIGN_NL
             || frm.top().type == CT_MEMBER
@@ -3264,12 +3439,14 @@ static size_t calc_comment_next_col_diff(chunk_t *pc)
       chunk_t *newline_token = chunk_get_next(next);
       LOG_FMT(LCMTIND, "%s(%d): newline_token->text() is '%s', orig_line is %zu, orig_col is %zu\n",
               __func__, __LINE__, newline_token->text(), newline_token->orig_line, newline_token->orig_col);
+
       if (newline_token == nullptr || newline_token->nl_count > 1)
       {
          return(5000);  // FIXME: Max thresh magic number 5000
       }
 
       next = chunk_get_next(newline_token);
+
       if (next != nullptr)
       {
          LOG_FMT(LCMTIND, "%s(%d): next->text() is '%s', orig_line is %zu, orig_col is %zu\n",
@@ -3288,10 +3465,11 @@ static size_t calc_comment_next_col_diff(chunk_t *pc)
    return(next->orig_col > pc->orig_col
           ? next->orig_col - pc->orig_col
           : pc->orig_col - next->orig_col);
-}
+} // calc_comment_next_col_diff
 
 
-static void indent_comment(chunk_t *pc, size_t col)
+static void indent_comment(chunk_t *pc,
+                           size_t  col)
 {
    LOG_FUNC_ENTRY();
    LOG_FMT(LCMTIND, "%s(%d): pc->text() is '%s', orig_line %zu, orig_col %zu, level %zu\n",
@@ -3308,6 +3486,7 @@ static void indent_comment(chunk_t *pc, size_t col)
    }
 
    chunk_t *nl = chunk_get_prev(pc);
+
    if (nl != nullptr)
    {
       LOG_FMT(LCMTIND, "%s(%d): nl->text() is '%s', orig_line %zu, orig_col %zu, level %zu\n",
@@ -3327,15 +3506,18 @@ static void indent_comment(chunk_t *pc, size_t col)
 
    // TODO: Add an indent_comment_align_thresh option?
    const size_t indent_comment_align_thresh = 3;
+
    if (pc->orig_col > 1)
    {
       chunk_t *prev = chunk_get_prev(nl);
+
       if (prev != nullptr)
       {
          LOG_FMT(LCMTIND, "%s(%d): prev->text() is '%s', orig_line %zu, orig_col %zu, level %zu\n",
                  __func__, __LINE__, prev->text(), prev->orig_line, prev->orig_col, prev->level);
          log_pcf_flags(LCMTIND, prev->flags);
       }
+
       if (chunk_is_comment(prev) && nl->nl_count == 1)
       {
          const size_t prev_col_diff = (prev->orig_col > pc->orig_col)
@@ -3354,11 +3536,13 @@ static void indent_comment(chunk_t *pc, size_t col)
                     __func__, __LINE__, prev->text(), chunk_is_Doxygen_comment(prev) ? "TRUE" : "FALSE");
             LOG_FMT(LCMTIND, "%s(%d): pc->text() is '%s', Doxygen_comment(pc) is %s\n",
                     __func__, __LINE__, pc->text(), chunk_is_Doxygen_comment(pc) ? "TRUE" : "FALSE");
+
             if (chunk_is_Doxygen_comment(prev) == chunk_is_Doxygen_comment(pc))
             {
                const size_t next_col_diff = calc_comment_next_col_diff(pc);
                LOG_FMT(LCMTIND, "%s(%d): next_col_diff is %zu\n",
                        __func__, __LINE__, next_col_diff);
+
                // Align to the previous comment or to the next token?
                if (  prev_col_diff <= next_col_diff
                   || next_col_diff == 5000) // FIXME: Max thresh magic number 5000
@@ -3392,6 +3576,7 @@ static void indent_comment(chunk_t *pc, size_t col)
 bool ifdef_over_whole_file(void)
 {
    LOG_FUNC_ENTRY();
+
    // the results for this file are cached
    if (cpd.ifdef_over_whole_file)
    {
@@ -3415,11 +3600,14 @@ bool ifdef_over_whole_file(void)
          {
             break;
          }
+
          chunk_t *next = chunk_get_next(pc);
+
          if (next == nullptr || next->type != CT_PP_IF)
          {
             break;
          }
+
          stage = 1;
       }
       else if (stage == 1)
@@ -3430,6 +3618,7 @@ bool ifdef_over_whole_file(void)
             stage  = 2;
             end_pp = pc;
          }
+
          continue;
       }
       else if (stage == 2)
@@ -3444,10 +3633,12 @@ bool ifdef_over_whole_file(void)
    }
 
    cpd.ifdef_over_whole_file = (stage == 2) ? 1 : -1;
+
    if (cpd.ifdef_over_whole_file > 0)
    {
       chunk_flags_set(end_pp, PCF_WF_ENDIF);
    }
+
    LOG_FMT(LNOTE, "The whole file is%s covered by a #IF\n",
            (cpd.ifdef_over_whole_file > 0) ? "" : " NOT");
    return(cpd.ifdef_over_whole_file > 0);
@@ -3469,6 +3660,7 @@ void indent_preproc(void)
       }
 
       chunk_t *next = chunk_get_next_ncnl(pc);
+
       if (next == nullptr)
       {
          break;

--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -373,6 +373,7 @@ void init_keywords()
       {
          int               lang_flags = LANG_OC;
          const chunk_tag_t *probe     = kw_static_match(tag, lang_flags);
+
          if (probe == NULL)
          {
             tag->lang_flags |= lang_flags;
@@ -380,6 +381,7 @@ void init_keywords()
 
          lang_flags = LANG_CPP;
          probe      = kw_static_match(tag, lang_flags);
+
          if (probe == NULL)
          {
             tag->lang_flags |= lang_flags;
@@ -389,7 +391,8 @@ void init_keywords()
 }
 
 
-static int kw_compare(const void *p1, const void *p2)
+static int kw_compare(const void *p1,
+                      const void *p2)
 {
    const chunk_tag_t *t1 = static_cast<const chunk_tag_t *>(p1);
    const chunk_tag_t *t2 = static_cast<const chunk_tag_t *>(p2);
@@ -418,7 +421,8 @@ bool keywords_are_sorted(void)
 }
 
 
-void add_keyword(const std::string &tag, c_token_t type)
+void add_keyword(const std::string &tag,
+                 c_token_t         type)
 {
    // See if the keyword has already been added
    dkwmap::iterator it = dkwm.find(tag);
@@ -450,11 +454,13 @@ static const chunk_tag_t *kw_static_first(const chunk_tag_t *tag)
       tag = prev;
       prev--;
    }
+
    return(tag);
 }
 
 
-static const chunk_tag_t *kw_static_match(const chunk_tag_t *tag, int lang_flags)
+static const chunk_tag_t *kw_static_match(const chunk_tag_t *tag,
+                                          int               lang_flags)
 {
    bool in_pp = (  cpd.in_preproc != CT_NONE
                 && cpd.in_preproc != CT_PP_DEFINE);
@@ -464,6 +470,7 @@ static const chunk_tag_t *kw_static_match(const chunk_tag_t *tag, int lang_flags
         iter++)
    {
       bool pp_iter = (iter->lang_flags & FLAG_PP) != 0; // forcing value to bool
+
       if (  (strcmp(iter->tag, tag->tag) == 0)
          && language_is_set(iter->lang_flags)
          && (lang_flags & iter->lang_flags)
@@ -472,11 +479,13 @@ static const chunk_tag_t *kw_static_match(const chunk_tag_t *tag, int lang_flags
          return(iter);
       }
    }
+
    return(nullptr);
 }
 
 
-c_token_t find_keyword_type(const char *word, size_t len)
+c_token_t find_keyword_type(const char *word,
+                            size_t     len)
 {
    if (len <= 0)
    {
@@ -486,6 +495,7 @@ c_token_t find_keyword_type(const char *word, size_t len)
    // check the dynamic word list first
    string           ss(word, len);
    dkwmap::iterator it = dkwm.find(ss);
+
    if (it != dkwm.end())
    {
       return((*it).second);
@@ -504,8 +514,10 @@ c_token_t find_keyword_type(const char *word, size_t len)
       {
          cpd.in_preproc = CT_PREPROC;
       }
+
       p_ret = kw_static_match(p_ret, cpd.lang_flags);
    }
+
    return((p_ret != nullptr) ? p_ret->type : CT_WORD);
 }
 
@@ -536,6 +548,7 @@ int load_keyword_file(const char *filename)
 
       // remove comments after '#' sign
       char *ptr;
+
       if ((ptr = strchr(buf, '#')) != nullptr)
       {
          *ptr = 0; // set string end where comment begins
@@ -572,6 +585,7 @@ void print_keywords(FILE *pfile)
    for (const auto &keyword_pair : dkwm)
    {
       c_token_t tt = keyword_pair.second;
+
       if (tt == CT_TYPE)
       {
          fprintf(pfile, "type %*.s%s\n",

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -24,7 +24,8 @@
 
 struct log_fcn_info
 {
-   log_fcn_info(const char *name_, int line_)
+   log_fcn_info(const char *name_,
+                int        line_)
       : name(name_)
       , line(line_)
    {
@@ -107,7 +108,8 @@ bool log_sev_on(log_sev_t sev)
 }
 
 
-void log_set_sev(log_sev_t sev, bool value)
+void log_set_sev(log_sev_t sev,
+                 bool      value)
 {
    logmask_set_sev(g_log.mask, sev, value);
 }
@@ -134,7 +136,9 @@ void log_flush(bool force_nl)
          g_log.bufX[g_log.buf_len++] = '\n';
          g_log.bufX[g_log.buf_len]   = 0;
       }
+
       size_t retlength = fwrite(&g_log.bufX[0], g_log.buf_len, 1, g_log.log_file);
+
       if (retlength != 1)
       {
          // maybe we should log something to complain... =)
@@ -153,6 +157,7 @@ static size_t log_start(log_sev_t sev)
       {
          log_flush(true);
       }
+
       g_log.sev    = sev;
       g_log.in_log = false;
    }
@@ -172,6 +177,7 @@ static size_t log_start(log_sev_t sev)
 static void log_end(void)
 {
    g_log.in_log = (g_log.bufX[g_log.buf_len - 1] != '\n');
+
    if (  !g_log.in_log
       || (g_log.buf_len > (g_log.bufX.size() / 2)))
    {
@@ -180,7 +186,9 @@ static void log_end(void)
 }
 
 
-void log_str(log_sev_t sev, const char *str, size_t len)
+void log_str(log_sev_t  sev,
+             const char *str,
+             size_t     len)
 {
    if (  str == nullptr
       || len == 0
@@ -190,21 +198,26 @@ void log_str(log_sev_t sev, const char *str, size_t len)
    }
 
    size_t cap = log_start(sev);
+
    if (cap > 0)
    {
       if (len > cap)
       {
          len = cap;
       }
+
       memcpy(&g_log.bufX[g_log.buf_len], str, len);
       g_log.buf_len            += len;
       g_log.bufX[g_log.buf_len] = 0;
    }
+
    log_end();
 }
 
 
-void log_fmt(log_sev_t sev, const char *fmt, ...)
+void log_fmt(log_sev_t  sev,
+             const char *fmt,
+             ...)
 {
    if (fmt == nullptr || !log_sev_on(sev))
    {
@@ -221,6 +234,7 @@ void log_fmt(log_sev_t sev, const char *fmt, ...)
    char         buf[BUFFERLENGTH];
    // it MUST be a 'unsigned int' variable to be runable under windows
    unsigned int length = strlen(fmt);
+
    if (length >= BUFFERLENGTH)
    {
       fprintf(stderr, "FATAL: The variable 'buf' is not big enought:\n");
@@ -228,6 +242,7 @@ void log_fmt(log_sev_t sev, const char *fmt, ...)
       fprintf(stderr, "Please make a report.\n");
       exit(EX_SOFTWARE);
    }
+
    memcpy(buf, fmt, length);
    buf[length] = 0;
    convert_log_zu2lu(buf);
@@ -273,7 +288,9 @@ void log_fmt(log_sev_t sev, const char *fmt, ...)
 } // log_fmt
 
 
-void log_hex(log_sev_t sev, const void *vdata, size_t len)
+void log_hex(log_sev_t  sev,
+             const void *vdata,
+             size_t     len)
 {
    if (vdata == nullptr || !log_sev_on(sev))
    {
@@ -284,6 +301,7 @@ void log_hex(log_sev_t sev, const void *vdata, size_t len)
    char        buf[MAX_BUF];
    const UINT8 *dat = static_cast<const UINT8 *>(vdata);
    size_t      idx  = 0;
+
    while (len-- > 0)
    {
       buf[idx++] = to_hex_char(*dat >> 4);
@@ -307,7 +325,9 @@ void log_hex(log_sev_t sev, const void *vdata, size_t len)
 }
 
 
-void log_hex_blk(log_sev_t sev, const void *data, size_t len)
+void log_hex_blk(log_sev_t  sev,
+                 const void *data,
+                 size_t     len)
 {
    if (data == nullptr || !log_sev_on(sev))
    {
@@ -327,6 +347,7 @@ void log_hex_blk(log_sev_t sev, const void *data, size_t len)
    // Loop through the data of the current iov
    int count = 0;
    int total = 0;
+
    for (size_t idx = 0; idx < len; idx++)
    {
       if (count == 0)
@@ -349,6 +370,7 @@ void log_hex_blk(log_sev_t sev, const void *data, size_t len)
 
       total++;
       count++;
+
       if (count >= 16)
       {
          count = 0;
@@ -370,12 +392,14 @@ void log_hex_blk(log_sev_t sev, const void *data, size_t len)
 
          count++;
       }
+
       log_str(sev, buf, 73);
    }
 } // log_hex_blk
 
 
-log_func::log_func(const char *name, int line)
+log_func::log_func(const char *name,
+                   int        line)
 {
    g_fq.push_back(log_fcn_info(name, line));
 }
@@ -397,7 +421,10 @@ void log_func_call(int line)
 }
 
 
-void log_func_stack(log_sev_t sev, const char *prefix, const char *suffix, size_t skip_cnt)
+void log_func_stack(log_sev_t  sev,
+                    const char *prefix,
+                    const char *suffix,
+                    size_t     skip_cnt)
 {
    UNUSED(skip_cnt);
 
@@ -405,23 +432,28 @@ void log_func_stack(log_sev_t sev, const char *prefix, const char *suffix, size_
    {
       LOG_FMT(sev, "%s", prefix);
    }
+
 #ifdef DEBUG
    const char *sep      = "";
    size_t     g_fq_size = g_fq.size();
    size_t     begin_with;
+
    if (g_fq_size > (skip_cnt + 1))
    {
       begin_with = g_fq_size - (skip_cnt + 1);
+
       for (size_t idx = begin_with; idx != 0; idx--)
       {
          LOG_FMT(sev, "%s %s:%d", sep, g_fq[idx].name, g_fq[idx].line);
          sep = ",";
       }
+
       LOG_FMT(sev, "%s %s:%d", sep, g_fq[0].name, g_fq[0].line);
    }
 #else
    LOG_FMT(sev, "-DEBUG NOT SET-");
 #endif
+
    if (suffix)
    {
       LOG_FMT(sev, "%s", suffix);

--- a/src/logmask.cpp
+++ b/src/logmask.cpp
@@ -24,7 +24,9 @@
  * Don't worry about unsed lines for the functions:
  *   logmask_to_str
  */
-char *logmask_to_str(const log_mask_t &mask, char *buf, int size)
+char *logmask_to_str(const log_mask_t &mask,
+                     char             *buf,
+                     int              size)
 {
    if (buf == nullptr || size <= 0)
    {
@@ -47,6 +49,7 @@ char *logmask_to_str(const log_mask_t &mask, char *buf, int size)
          {
             is_range = true;
          }
+
          last_sev = sev;
       }
       else
@@ -57,6 +60,7 @@ char *logmask_to_str(const log_mask_t &mask, char *buf, int size)
             len         += snprintf(&buf[len], size - len, "%d,", last_sev);
             is_range     = false;
          }
+
          last_sev = -1;
       }
    }
@@ -83,7 +87,8 @@ char *logmask_to_str(const log_mask_t &mask, char *buf, int size)
 #endif /* DEVELOP_ONLY */
 
 
-void logmask_from_string(const char *str, log_mask_t &mask)
+void logmask_from_string(const char *str,
+                         log_mask_t &mask)
 {
    if (str == nullptr)
    {
@@ -102,6 +107,7 @@ void logmask_from_string(const char *str, log_mask_t &mask)
    char *ptmp;
    bool was_dash   = false;
    int  last_level = -1;
+
    while (*str != 0)         // check string until termination character
    {
       if (unc_isspace(*str)) // ignore spaces and go on with next character
@@ -116,12 +122,14 @@ void logmask_from_string(const char *str, log_mask_t &mask)
          str = ptmp;
 
          logmask_set_sev(mask, static_cast<log_sev_t>(level), true);
+
          if (was_dash)
          {
             for (int idx = last_level + 1; idx < level; idx++)
             {
                logmask_set_sev(mask, static_cast<log_sev_t>(idx), true);
             }
+
             was_dash = false;
          }
 

--- a/src/logmask.h
+++ b/src/logmask.h
@@ -36,7 +36,8 @@ typedef std::bitset<256> log_mask_t;
  *
  * @return true (is set) or false (not set)
  */
-static inline bool logmask_test(const log_mask_t &mask, log_sev_t sev)
+static inline bool logmask_test(const log_mask_t &mask,
+                                log_sev_t        sev)
 {
    return(mask.test(sev));
 }
@@ -49,7 +50,9 @@ static inline bool logmask_test(const log_mask_t &mask, log_sev_t sev)
  * @param sev    The severity to check
  * @param value  true (set bit) or false (clear bit)
  */
-static inline void logmask_set_sev(log_mask_t &mask, log_sev_t sev, bool value)
+static inline void logmask_set_sev(log_mask_t &mask,
+                                   log_sev_t  sev,
+                                   bool       value)
 {
    mask.set(sev, value);
 }
@@ -61,7 +64,8 @@ static inline void logmask_set_sev(log_mask_t &mask, log_sev_t sev, bool value)
  * @param mast   log mask to operate on
  * @param value  true (set bit) or false (clear bit)
  */
-static inline void logmask_set_all(log_mask_t &mask, bool value)
+static inline void logmask_set_all(log_mask_t &mask,
+                                   bool       value)
 {
    if (value)
    {

--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -21,7 +21,8 @@
 #include <string.h>
 
 
-void MD5::reverse_u32(UINT8 *buf, int n_u32)
+void MD5::reverse_u32(UINT8 *buf,
+                      int   n_u32)
 {
    UINT8 tmp;
 
@@ -92,7 +93,8 @@ void MD5::Init()
 
 
 //! Update context to reflect the concatenation of another buffer full of bytes.
-void MD5::Update(const void *data, UINT32 len)
+void MD5::Update(const void *data,
+                 UINT32     len)
 {
    const UINT8 *buf = (const UINT8 *)data;
 
@@ -102,6 +104,7 @@ void MD5::Update(const void *data, UINT32 len)
    {
       m_bits[1]++;   // Carry from low to high
    }
+
    m_bits[1] += len >> 29;
 
    t = (t >> 3) & 0x3f;   // Bytes already in shsInfo->data
@@ -112,16 +115,20 @@ void MD5::Update(const void *data, UINT32 len)
       UINT8 *p = m_in8 + t;
 
       t = 64 - t;
+
       if (len < t)
       {
          memcpy(p, buf, len);
          return;
       }
+
       memcpy(p, buf, t);
+
       if (m_need_byteswap)
       {
          reverse_u32(m_in8, 16);
       }
+
       Transform(m_buf, m_in32);
       buf += t;
       len -= t;
@@ -131,10 +138,12 @@ void MD5::Update(const void *data, UINT32 len)
    while (len >= 64)
    {
       memcpy(m_in32, buf, 64);
+
       if (m_need_byteswap)
       {
          reverse_u32(m_in8, 16);
       }
+
       Transform(m_buf, m_in32);
       buf += 64;  // TODO: possible creation of out-of-bounds pointer 64 beyond end of data
       len -= 64;
@@ -166,10 +175,12 @@ void MD5::Final(UINT8 digest[16])
    {
       // Two lots of padding:  Pad the first block to 64 bytes
       memset(p, 0, count);
+
       if (m_need_byteswap)
       {
          reverse_u32(m_in8, 16);
       }
+
       Transform(m_buf, m_in32);
 
       // Now fill the next block with 56 bytes
@@ -180,6 +191,7 @@ void MD5::Final(UINT8 digest[16])
       // Pad block to 56 bytes
       memset(p, 0, count - 8);
    }
+
    if (m_need_byteswap)
    {
       reverse_u32(m_in8, 14);
@@ -190,10 +202,12 @@ void MD5::Final(UINT8 digest[16])
    memcpy(m_in8 + 60, &m_bits[1], 4);
 
    Transform(m_buf, m_in32);
+
    if (m_need_byteswap)
    {
       reverse_u32((UINT8 *)m_buf, 4);
    }
+
    memcpy(digest, m_buf, 16);
 } // MD5::Final
 
@@ -211,7 +225,8 @@ void MD5::Final(UINT8 digest[16])
    ((w) += f((x), (y), (z)) + (data), (w) = (w) << (s) | (w) >> (32 - (s)), (w) += (x))
 
 
-void MD5::Transform(UINT32 buf[4], UINT32 in_data[16])
+void MD5::Transform(UINT32 buf[4],
+                    UINT32 in_data[16])
 {
    UINT32 a = buf[0];
    UINT32 b = buf[1];
@@ -293,7 +308,9 @@ void MD5::Transform(UINT32 buf[4], UINT32 in_data[16])
 } // MD5::Transform
 
 
-void MD5::Calc(const void *data, UINT32 length, UINT8 digest[16])
+void MD5::Calc(const void *data,
+               UINT32     length,
+               UINT8      digest[16])
 {
    MD5 md5;
 

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -94,7 +94,8 @@ std::unordered_map<std::string, GenericOption *> option_map;
 
 
 //-----------------------------------------------------------------------------
-constexpr int option_level(int major, int minor)
+constexpr int option_level(int major,
+                           int minor)
 {
    return((major << 16) | (minor << 0));
 }
@@ -127,7 +128,8 @@ using std::to_string;
 
 
 //-----------------------------------------------------------------------------
-std::string to_lower(const char *in, std::string::size_type size = 0)
+std::string to_lower(const char             *in,
+                     std::string::size_type size = 0)
 {
    std::string out;
 
@@ -135,6 +137,7 @@ std::string to_lower(const char *in, std::string::size_type size = 0)
    {
       out.reserve(size);
    }
+
    while (*in)
    {
       out += static_cast<char>(std::tolower(*in));
@@ -167,8 +170,9 @@ bool is_varg_sep(int ch)
 
 
 //-----------------------------------------------------------------------------
-std::vector<std::string> split_args(std::string in, const char *filename,
-                                    bool (*is_sep)(int))
+std::vector<std::string> split_args(std::string in,
+                                    const char  *filename,
+                                    bool (      *is_sep)(int))
 {
    std::vector<std::string> out;
    std::string::size_type   n = 0;
@@ -193,6 +197,7 @@ std::vector<std::string> split_args(std::string in, const char *filename,
       if (const auto *quote = strchr("\'\"`", in[n]))
       {
          const auto start = ++n;
+
          for ((void)n; in[n] != *quote; ++n)
          {
             if (n < k && in[n] == '\\')
@@ -200,6 +205,7 @@ std::vector<std::string> split_args(std::string in, const char *filename,
                in.erase(n, 1);
                --k;
             }
+
             if (n >= k)
             {
                OptionWarning w{ filename };
@@ -207,18 +213,22 @@ std::vector<std::string> split_args(std::string in, const char *filename,
                return{};
             }
          }
+
          out.push_back(in.substr(start, n - start));
+
          if (++n < k && !is_sep(in[n]))
          {
             OptionWarning w{ filename };
             w("unexpected text following quoted-string");
             return{};
          }
+
          continue;
       }
 
       // Extract anything else
       const auto start = n;
+
       for ((void)n; n < k && !is_sep(in[n]); ++n)
       {
          if (in[n] == '\\')
@@ -226,6 +236,7 @@ std::vector<std::string> split_args(std::string in, const char *filename,
             in.erase(n, 1);
             --k;
          }
+
          if (n >= k)
          {
             OptionWarning w{ filename };
@@ -233,6 +244,7 @@ std::vector<std::string> split_args(std::string in, const char *filename,
             return{};
          }
       }
+
       out.push_back(in.substr(start, n - start));
    }
 
@@ -268,8 +280,9 @@ bool is_path_relative(const std::string &path)
 
 
 //-----------------------------------------------------------------------------
-void print_description(FILE *pfile, std::string description,
-                       const char *eol_marker)
+void print_description(FILE        *pfile,
+                       std::string description,
+                       const char  *eol_marker)
 {
    // Descriptions always start with a '\n', so skip the first character
    for (std::string::size_type start = 1, length = description.length();
@@ -317,12 +330,14 @@ bool process_option_line_compat_0_68(const std::string              &cmd,
 
 
 //-----------------------------------------------------------------------------
-OptionWarning::OptionWarning(const char *filename, Severity severity)
+OptionWarning::OptionWarning(const char *filename,
+                             Severity   severity)
 {
    if (severity != MINOR)
    {
       ++cpd.error_count;
    }
+
    if (cpd.line_number != 0)
    {
       fprintf(stderr, "%s:%u: ", filename, cpd.line_number);
@@ -335,12 +350,14 @@ OptionWarning::OptionWarning(const char *filename, Severity severity)
 
 
 //-----------------------------------------------------------------------------
-OptionWarning::OptionWarning(const GenericOption *opt, Severity severity)
+OptionWarning::OptionWarning(const GenericOption *opt,
+                             Severity            severity)
 {
    if (severity != MINOR)
    {
       ++cpd.error_count;
    }
+
    fprintf(stderr, "Option<%s>: at %s:%d: ", to_string(opt->type()),
            cpd.filename.c_str(), cpd.line_number);
 }
@@ -355,7 +372,8 @@ OptionWarning::~OptionWarning()
 
 
 //-----------------------------------------------------------------------------
-void OptionWarning::operator()(const char *fmt, ...)
+void OptionWarning::operator()(const char *fmt,
+                               ...)
 {
    va_list args;
 
@@ -379,15 +397,18 @@ void GenericOption::warnUnexpectedValue(const char *actual) const
    else
    {
       w("Expected one of ");
+
       while (*values)
       {
          w("'%s'", *values);
+
          if (*(++values))
          {
             w(", ");
          }
       }
    }
+
    w(", for '%s'; got '%s'", name(), actual);
 }
 
@@ -404,7 +425,8 @@ void GenericOption::warnIncompatibleReference(const GenericOption *ref) const
 
 //-----------------------------------------------------------------------------
 template<typename T>
-bool read_enum(const char *in, Option<T> &out)
+bool read_enum(const char *in,
+               Option<T>  &out)
 {
    assert(in);
 
@@ -433,7 +455,8 @@ bool read_enum(const char *in, Option<T> &out)
 
 //-----------------------------------------------------------------------------
 template<typename T>
-bool read_number(const char *in, Option<T> &out)
+bool read_number(const char *in,
+                 Option<T>  &out)
 {
    assert(in);
 
@@ -447,6 +470,7 @@ bool read_number(const char *in, Option<T> &out)
    }
 
    bool invert = false;
+
    if (strchr("-", in[0]))
    {
       invert = true;
@@ -461,6 +485,7 @@ bool read_number(const char *in, Option<T> &out)
                  to_string(opt->type()), opt->name());
 
       long tval;
+
       if (opt->type() == OT_NUM)
       {
          auto &sopt = *static_cast<const Option<signed> *>(opt);
@@ -478,11 +503,13 @@ bool read_number(const char *in, Option<T> &out)
       }
 
       const auto rval = (invert ? -tval : tval);
+
       if (out.validate(rval))
       {
          out.m_val = static_cast<T>(rval);
          return(true);
       }
+
       return(false);
    }
 
@@ -552,6 +579,7 @@ bool Option<bool>::read(const char *in)
    }
 
    bool invert = false;
+
    if (strchr("~!-", in[0]))
    {
       invert = true;
@@ -797,6 +825,7 @@ uncrustify::GenericOption *find_option(const char *name)
    {
       return(iter->second);
    }
+
    return(nullptr);
 }
 
@@ -808,6 +837,7 @@ OptionGroup *get_option_group(size_t i)
    {
       return(nullptr);
    }
+
    return(&option_groups[i]);
 }
 
@@ -820,7 +850,8 @@ size_t get_option_count()
 
 
 //-----------------------------------------------------------------------------
-void process_option_line(const std::string &config_line, const char *filename)
+void process_option_line(const std::string &config_line,
+                         const char        *filename)
 {
    // Compatibility level; by default, we are compatible with everything
    static auto compat_level = 0;
@@ -835,6 +866,7 @@ void process_option_line(const std::string &config_line, const char *filename)
 
    // Check for necessary arguments
    const auto &cmd = to_lower(args.front());
+
    if (cmd == "set" || cmd == "file_ext")
    {
       if (args.size() < 3)
@@ -876,15 +908,18 @@ void process_option_line(const std::string &config_line, const char *filename)
    else if (cmd == "set")
    {
       const auto token = find_token_name(args[1].c_str());
+
       if (token != CT_NONE)
       {
          LOG_FMT(LNOTE, "%s:%d set '%s':",
                  filename, cpd.line_number, args[1].c_str());
+
          for (size_t i = 2; i < args.size(); ++i)
          {
             LOG_FMT(LNOTE, " '%s'", args[i].c_str());
             add_keyword(args[i], token);
          }
+
          LOG_FMT(LNOTE, "\n");
       }
       else
@@ -893,6 +928,7 @@ void process_option_line(const std::string &config_line, const char *filename)
          w("%s: unknown type '%s'", cmd.c_str(), args[1].c_str());
       }
    }
+
 #ifndef EMSCRIPTEN
    else if (cmd == "include")
    {
@@ -924,9 +960,11 @@ void process_option_line(const std::string &config_line, const char *filename)
    else if (cmd == "file_ext")
    {
       auto *const lang_arg = args[1].c_str();
+
       for (size_t i = 2; i < args.size(); ++i)
       {
          auto *const lang_name = extension_add(args[i].c_str(), lang_arg);
+
          if (lang_name)
          {
             LOG_FMT(LNOTE, "%s:%d file_ext '%s' => '%s'\n",
@@ -943,6 +981,7 @@ void process_option_line(const std::string &config_line, const char *filename)
    else if (cmd == "using")
    {
       auto vargs = split_args(args[1], filename, is_varg_sep);
+
       if (vargs.size() != 2)
       {
          OptionWarning w{ filename };
@@ -964,6 +1003,7 @@ void process_option_line(const std::string &config_line, const char *filename)
       }
 
       const auto oi = option_map.find(cmd);
+
       if (oi == option_map.end())
       {
          OptionWarning w{ filename };
@@ -992,6 +1032,7 @@ bool load_option_file(const char *filename)
 
    std::ifstream in;
    in.open(filename, std::ifstream::in);
+
    if (!in.good())
    {
       OptionWarning w{ filename };
@@ -1002,11 +1043,13 @@ bool load_option_file(const char *filename)
 
    // Read in the file line by line
    std::string line;
+
    while (std::getline(in, line))
    {
       ++cpd.line_number;
       process_option_line(line, filename);
    }
+
    return(true);
 }
 
@@ -1028,7 +1071,9 @@ const char *get_eol_marker()
 
 
 //-----------------------------------------------------------------------------
-void save_option_file(FILE *pfile, bool with_doc, bool minimal)
+void save_option_file(FILE *pfile,
+                      bool with_doc,
+                      bool minimal)
 {
    int        non_default_values = 0;
    const char *eol_marker        = get_eol_marker();
@@ -1071,12 +1116,14 @@ void save_option_file(FILE *pfile, bool with_doc, bool minimal)
             print_description(pfile, option->description(), eol_marker);
 
             const auto ds = option->defaultStr();
+
             if (!ds.empty())
             {
                fprintf(pfile, "#%s# Default: %s%s",
                        eol_marker, ds.c_str(), eol_marker);
             }
          }
+
          first = false;
 
          const int name_len = static_cast<int>(strlen(option->name()));
@@ -1093,15 +1140,18 @@ void save_option_file(FILE *pfile, bool with_doc, bool minimal)
          {
             fprintf(pfile, "%s", val.c_str());
          }
+
          if (with_doc)
          {
             const int val_len = static_cast<int>(val.length());
             fprintf(pfile, "%*.s # ", 8 - val_len, " ");
+
             for (auto pv = option->possibleValues(); *pv; ++pv)
             {
                fprintf(pfile, "%s%s", *pv, pv[1] ? "/" : "");
             }
          }
+
          fputs(eol_marker, pfile);
       }
    }

--- a/src/option.h
+++ b/src/option.h
@@ -108,7 +108,8 @@ UNC_DECLARE_OPERATORS_FOR_FLAGS(token_pos_flags_t);
 class GenericOption
 {
 public:
-   GenericOption(const char *opt_name, const char *opt_desc)
+   GenericOption(const char *opt_name,
+                 const char *opt_desc)
       : m_name{opt_name}
       , m_desc{opt_desc} {}
 
@@ -170,7 +171,9 @@ template<typename T>
 class Option : public GenericOption
 {
 public:
-   Option(const char *opt_name, const char *opt_desc, T opt_val = T{})
+   Option(const char *opt_name,
+          const char *opt_desc,
+          T          opt_val = T{})
       : GenericOption{opt_name, opt_desc}
       , m_val{opt_val}
       , m_default{opt_val} {}
@@ -204,7 +207,9 @@ template<typename T, T min, T max>
 class BoundedOption : public Option<T>
 {
 public:
-   BoundedOption(const char *opt_name, const char *opt_desc, T opt_val = T{})
+   BoundedOption(const char *opt_name,
+                 const char *opt_desc,
+                 T          opt_val = T{})
       : Option<T>{opt_name, opt_desc, opt_val}
    {
       assert(opt_val >= min && opt_val <= max);
@@ -224,6 +229,7 @@ protected:
            val, this->name(), static_cast<long>(min));
          return(false);
       }
+
       if (val > static_cast<long>(max))
       {
          OptionWarning w{ this };
@@ -232,6 +238,7 @@ protected:
            val, this->name(), static_cast<long>(max));
          return(false);
       }
+
       return(true);
    }
 };

--- a/src/options_for_QT.cpp
+++ b/src/options_for_QT.cpp
@@ -58,21 +58,19 @@ void temporary_iarf_option::restore()
 }
 
 //-----------------------------------------------------------------------------
-temporary_iarf_option for_qt_options[] = {
+temporary_iarf_option for_qt_options[] =
+{
    { &options::sp_inside_fparen           },
-// Issue #481
-// connect( timer,SIGNAL( timeout() ),this,SLOT( timeoutImage() ) );
+// Issue #481: connect( timer,SIGNAL( timeout() ),this,SLOT( timeoutImage() ) );
    { &options::sp_inside_fparens          },
    { &options::sp_paren_paren             },
    { &options::sp_before_comma            },
    { &options::sp_after_comma             },
-// Bug #654
-// connect(&mapper, SIGNAL(mapped(QString &)), this, SLOT(onSomeEvent(QString &)));
+// Issue #654: connect(&mapper, SIGNAL(mapped(QString &)), this, SLOT(onSomeEvent(QString &)));
    { &options::sp_before_byref            },
    { &options::sp_before_unnamed_byref    },
    { &options::sp_after_type              },
-// Issue #1969
-// connect( a, SIGNAL(b(c *)), this, SLOT(d(e *)) );
+// Issue #1969: connect( a, SIGNAL(b(c *)), this, SLOT(d(e *)) );
    { &options::sp_before_ptr_star         },
    { &options::sp_before_unnamed_ptr_star },
 // connect( a, SIGNAL(b(c< d >)), this, SLOT(e(f< g >)) );
@@ -90,10 +88,12 @@ void save_set_options_for_QT(size_t level)
    LOG_FMT(LGUY, "save values, level=%zu\n", level);
    // save the values
    QT_SIGNAL_SLOT_level = level;
+
    for (auto &opt : for_qt_options)
    {
       opt.save_and_override();
    }
+
    QT_SIGNAL_SLOT_found = true;
 }
 
@@ -106,10 +106,12 @@ void restore_options_for_QT(void)
    LOG_FMT(LGUY, "restore values\n");
    // restore the values we had before SIGNAL/SLOT
    QT_SIGNAL_SLOT_level = 0;
+
    for (auto &opt : for_qt_options)
    {
       opt.restore();
    }
+
    QT_SIGNAL_SLOT_found = false;
    restoreValues        = false;
 }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -241,7 +241,8 @@ static void add_spaces()
 }
 
 
-static void add_char(UINT32 ch, bool is_literal)
+static void add_char(UINT32 ch,
+                     bool   is_literal)
 {
    // If we did a '\r' and it isn't followed by a '\n', then output a newline
    if ((cpd.last_char == '\r') && (ch != '\n'))
@@ -271,10 +272,12 @@ static void add_char(UINT32 ch, bool is_literal)
    else if ((ch == '\t') && cpd.output_tab_as_space)
    {
       size_t endcol = next_tab_column(cpd.column);
+
       while (cpd.column < endcol)
       {
          add_char(' ');
       }
+
       return;
    }
    else
@@ -285,10 +288,12 @@ static void add_char(UINT32 ch, bool is_literal)
          if (options::indent_with_tabs() == 0)
          {
             size_t endcol = next_tab_column(cpd.column);
+
             while (cpd.column < endcol)
             {
                add_char(' ');
             }
+
             return;
          }
       }
@@ -302,6 +307,7 @@ static void add_char(UINT32 ch, bool is_literal)
       {
          add_spaces();
          write_char(ch);
+
          if (ch == '\t')
          {
             cpd.column = next_tab_column(cpd.column);
@@ -312,6 +318,7 @@ static void add_char(UINT32 ch, bool is_literal)
          }
       }
    }
+
    cpd.last_char = ch;
 } // add_char
 
@@ -328,11 +335,14 @@ static void add_text(const char *ascii_text)
 }
 
 
-static void add_text(const unc_text &text, bool is_ignored = false, bool is_literal = false)
+static void add_text(const unc_text &text,
+                     bool           is_ignored = false,
+                     bool           is_literal = false)
 {
    for (size_t idx = 0; idx < text.size(); idx++)
    {
       int ch = text[idx];
+
       if (is_ignored)
       {
          write_char(ch);
@@ -345,7 +355,8 @@ static void add_text(const unc_text &text, bool is_ignored = false, bool is_lite
 }
 
 
-static bool next_word_exceeds_limit(const unc_text &text, size_t idx)
+static bool next_word_exceeds_limit(const unc_text &text,
+                                    size_t         idx)
 {
    size_t length = 0;
 
@@ -362,6 +373,7 @@ static bool next_word_exceeds_limit(const unc_text &text, size_t idx)
       idx++;
       length++;
    }
+
    return((cpd.column + length - 1) > options::cmt_width());
 }
 
@@ -372,19 +384,23 @@ static bool next_word_exceeds_limit(const unc_text &text, size_t idx)
  *
  * @param column  The column to advance to
  */
-static void output_to_column(size_t column, bool allow_tabs)
+static void output_to_column(size_t column,
+                             bool   allow_tabs)
 {
    cpd.did_newline = 0;
+
    if (allow_tabs)
    {
       // tab out as far as possible and then use spaces
       size_t next_column = next_tab_column(cpd.column);
+
       while (next_column <= column)
       {
          add_text("\t");
          next_column = next_tab_column(cpd.column);
       }
    }
+
    // space out the final bit
    while (cpd.column < column)
    {
@@ -393,7 +409,9 @@ static void output_to_column(size_t column, bool allow_tabs)
 }
 
 
-static void cmt_output_indent(size_t brace_col, size_t base_col, size_t column)
+static void cmt_output_indent(size_t brace_col,
+                              size_t base_col,
+                              size_t column)
 {
    size_t iwt = options::indent_cmt_with_tabs() ? 2 :
                 (options::indent_with_tabs() ? 1 : 0);
@@ -404,6 +422,7 @@ static void cmt_output_indent(size_t brace_col, size_t base_col, size_t column)
    //        __func__, brace_col, base_col, column, iwt, tab_col, cpd.column);
 
    cpd.did_newline = 0;
+
    if (  iwt == 2
       || (cpd.column == 1 && iwt == 1))
    {
@@ -438,6 +457,7 @@ void output_parsed(FILE *pfile)
 #else // not WIN32
    fprintf(pfile, "# Line                Tag              Parent          Columns Br/Lvl/pp     Flag   Nl  Text");
 #endif // ifdef WIN32
+
    for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next(pc))
    {
 #ifdef WIN32
@@ -463,6 +483,7 @@ void output_parsed(FILE *pfile)
          {
             fprintf(pfile, " ");
          }
+
          if (pc->type != CT_NL_CONT)
          {
             fprintf(pfile, "%s", pc->text());
@@ -473,6 +494,7 @@ void output_parsed(FILE *pfile)
          }
       }
    }
+
    fprintf(pfile, "%s# -=====-%s", eol_marker, eol_marker);
    fflush(pfile);
 } // output_parsed
@@ -490,6 +512,7 @@ void output_text(FILE *pfile)
    }
 
    chunk_t *pc;
+
    if (cpd.frag_cols > 0)
    {
       size_t indent = cpd.frag_cols - 1;
@@ -500,6 +523,7 @@ void output_text(FILE *pfile)
          pc->column        += indent;
          pc->column_indent += indent;
       }
+
       cpd.frag_cols = 0;
    }
 
@@ -510,6 +534,7 @@ void output_text(FILE *pfile)
               __func__, __LINE__, pc->text(), get_token_name(pc->type), pc->orig_col, pc->column, pc->nl_count);
       cpd.output_tab_as_space = (  options::cmt_convert_tab_to_spaces()
                                 && chunk_is_comment(pc));
+
       if (chunk_is_token(pc, CT_NEWLINE))
       {
          for (size_t cnt = 0; cnt < pc->nl_count; cnt++)
@@ -518,8 +543,10 @@ void output_text(FILE *pfile)
             {
                output_to_column(pc->nl_column, (options::indent_with_tabs() == 2));
             }
+
             add_char('\n');
          }
+
          cpd.did_newline = 1;
          cpd.column      = 1;
          LOG_FMT(LOUTIND, " xx\n");
@@ -561,6 +588,7 @@ void output_text(FILE *pfile)
                   if (prev != NULL && prev->nl_count == 0)
                   {
                      int orig_sp = (pc->orig_col - prev->orig_col_end);
+
                      if ((int)(cpd.column + orig_sp) < 0)
                      {
 #ifdef WIN32
@@ -573,7 +601,9 @@ void output_text(FILE *pfile)
                         log_flush(true);
                         exit(EX_SOFTWARE);
                      }
+
                      pc->column = cpd.column + orig_sp;
+
                      // Add or remove space before a backslash-newline at the end of a line.
                      if (  (options::sp_before_nl_cont() != IARF_IGNORE)
                         && (pc->column < (cpd.column + 1)))
@@ -583,12 +613,14 @@ void output_text(FILE *pfile)
                   }
                }
             }
+
             output_to_column(pc->column, false);
          }
          else
          {
             output_to_column(pc->column, (options::indent_with_tabs() == 2));
          }
+
          add_char('\\');
          add_char('\n');
          cpd.did_newline = 1;
@@ -639,12 +671,14 @@ void output_text(FILE *pfile)
       {
          bool allow_tabs;
          cpd.output_trailspace = (chunk_is_token(pc, CT_STRING_MULTI));
+
          // indent to the 'level' first
          if (cpd.did_newline)
          {
             if (options::indent_with_tabs() == 1)
             {
                size_t lvlcol;
+
                /*
                 * FIXME: it would be better to properly set column_indent in
                 * indent_text(), but this hack for '}' and '#' seems to work.
@@ -658,6 +692,7 @@ void output_text(FILE *pfile)
                else
                {
                   lvlcol = pc->column_indent;
+
                   if (lvlcol > pc->column)
                   {
                      lvlcol = pc->column;
@@ -669,6 +704,7 @@ void output_text(FILE *pfile)
                   output_to_column(lvlcol, true);
                }
             }
+
             allow_tabs = (options::indent_with_tabs() == 2)
                          || (  chunk_is_comment(pc)
                             && options::indent_with_tabs() != 0);
@@ -694,16 +730,19 @@ void output_text(FILE *pfile)
             allow_tabs = (  options::align_with_tabs()
                          && (pc->flags & PCF_WAS_ALIGNED)
                          && ((prev->column + prev->len() + 1) != pc->column));
+
             if (options::align_keep_tabs())
             {
                allow_tabs |= pc->after_tab;
             }
+
             LOG_FMT(LOUTIND, "%s(%d): at column %zu(%s)\n",
                     __func__, __LINE__, pc->column, (allow_tabs ? "true" : "FALSE"));
          }
 
          output_to_column(pc->column, allow_tabs);
          add_text(pc->str, false, chunk_is_token(pc, CT_STRING));
+
          if (chunk_is_token(pc, CT_PP_DEFINE))  // Issue #876
          {
             if (options::force_tab_after_define())
@@ -711,6 +750,7 @@ void output_text(FILE *pfile)
                add_char('\t');
             }
          }
+
          cpd.did_newline       = chunk_is_newline(pc);
          cpd.output_trailspace = false;
       }
@@ -718,7 +758,8 @@ void output_text(FILE *pfile)
 } // output_text
 
 
-static size_t cmt_parse_lead(const unc_text &line, bool is_last)
+static size_t cmt_parse_lead(const unc_text &line,
+                             bool           is_last)
 {
    size_t len = 0;
 
@@ -728,20 +769,24 @@ static size_t cmt_parse_lead(const unc_text &line, bool is_last)
       {
          // ignore combined comments
          size_t tmp = len + 1;
+
          while (tmp < line.size() && unc_isspace(line[tmp]))
          {
             tmp++;
          }
+
          if (tmp < line.size() && line[tmp] == '/')
          {
             return(1);
          }
+
          break;
       }
       else if (strchr("*|\\#+", line[len]) == nullptr)
       {
          break;  // none of the characters '*|\#+' found in line
       }
+
       len++;
    }
 
@@ -765,11 +810,13 @@ static size_t cmt_parse_lead(const unc_text &line, bool is_last)
    {
       return(len);
    }
+
    return(0);
 } // cmt_parse_lead
 
 
-static void calculate_comment_body_indent(cmt_reflow &cmt, const unc_text &str)
+static void calculate_comment_body_indent(cmt_reflow     &cmt,
+                                          const unc_text &str)
 {
    cmt.xtra_indent = 0;
 
@@ -781,6 +828,7 @@ static void calculate_comment_body_indent(cmt_reflow &cmt, const unc_text &str)
    size_t idx      = 0;
    size_t len      = str.size();
    size_t last_len = 0;
+
    if (options::cmt_multi_check_last())
    {
       // find the last line length
@@ -789,11 +837,13 @@ static void calculate_comment_body_indent(cmt_reflow &cmt, const unc_text &str)
          if (str[idx] == '\n' || str[idx] == '\r')
          {
             idx++;
+
             while (  idx < len
                   && (str[idx] == ' ' || str[idx] == '\t'))
             {
                idx++;
             }
+
             last_len = len - idx;
             break;
          }
@@ -802,11 +852,13 @@ static void calculate_comment_body_indent(cmt_reflow &cmt, const unc_text &str)
 
    // find the first line length
    size_t first_len = 0;
+
    for (idx = 0; idx < len; idx++)
    {
       if (str[idx] == '\n' || str[idx] == '\r')
       {
          first_len = idx;
+
          while (str[first_len - 1] == ' ' || str[first_len - 1] == '\t')
          {
             first_len--;
@@ -817,6 +869,7 @@ static void calculate_comment_body_indent(cmt_reflow &cmt, const unc_text &str)
          {
             idx++;
          }
+
          idx++;
          break;
       }
@@ -824,6 +877,7 @@ static void calculate_comment_body_indent(cmt_reflow &cmt, const unc_text &str)
 
    // Scan the second line
    size_t width = 0;
+
    for ( ; idx < len - 1; idx++)
    {
       if (str[idx] == ' ' || str[idx] == '\t')
@@ -832,8 +886,10 @@ static void calculate_comment_body_indent(cmt_reflow &cmt, const unc_text &str)
          {
             break;
          }
+
          continue;
       }
+
       if (str[idx] == '\n' || str[idx] == '\r')
       {
          break;  // Done with second line
@@ -854,6 +910,7 @@ static void calculate_comment_body_indent(cmt_reflow &cmt, const unc_text &str)
          {
             width = 0;
          }
+
          break;
       }
    }
@@ -891,6 +948,7 @@ static chunk_t *get_next_function(chunk_t *pc)
          return(pc);
       }
    }
+
    return(nullptr);
 }
 
@@ -919,7 +977,9 @@ static chunk_t *get_prev_oc_class(chunk_t *pc)
 }
 
 
-static int next_up(const unc_text &text, size_t idx, unc_text &tag)
+static int next_up(const unc_text &text,
+                   size_t         idx,
+                   unc_text       &tag)
 {
    size_t offs = 0;
 
@@ -933,12 +993,14 @@ static int next_up(const unc_text &text, size_t idx, unc_text &tag)
    {
       return(offs);
    }
+
    return(-1);
 }
 
 
 static void add_comment_text(const unc_text &text,
-                             cmt_reflow &cmt, bool esc_close)
+                             cmt_reflow     &cmt,
+                             bool           esc_close)
 {
    bool   was_star  = false;
    bool   was_slash = false;
@@ -953,6 +1015,7 @@ static void add_comment_text(const unc_text &text,
    {
       add_text("//");
       idx += 2;
+
       while (unc_isspace(text[idx]))
       {
          add_char(text[idx++]);
@@ -967,6 +1030,7 @@ static void add_comment_text(const unc_text &text,
          in_word = false;
          add_char('\n');
          cmt_output_indent(cmt.brace_col, cmt.base_col, cmt.column);
+
          if (cmt.xtra_indent > 0)
          {
             add_char(' ');
@@ -974,6 +1038,7 @@ static void add_comment_text(const unc_text &text,
 
          // hack to get escaped newlines to align and not duplicate the leading '//'
          int tmp = next_up(text, idx + 1, cmt.cont_text);
+
          if (tmp < 0)
          {
             add_text(cmt.cont_text);
@@ -982,6 +1047,7 @@ static void add_comment_text(const unc_text &text,
          {
             idx += tmp;
          }
+
          ch_cnt = 0;
       }
       else if (  cmt.reflow
@@ -993,6 +1059,7 @@ static void add_comment_text(const unc_text &text,
          in_word = false;
          add_char('\n');
          cmt_output_indent(cmt.brace_col, cmt.base_col, cmt.column);
+
          if (cmt.xtra_indent > 0)
          {
             add_char(' ');
@@ -1013,10 +1080,12 @@ static void add_comment_text(const unc_text &text,
          {
             add_char(' ');
          }
+
          if (!in_word && !unc_isspace(text[idx]))
          {
             cmt.word_count++;
          }
+
          in_word = !unc_isspace(text[idx]);
 
          add_char(text[idx]);
@@ -1028,7 +1097,8 @@ static void add_comment_text(const unc_text &text,
 } // add_comment_text
 
 
-static void output_cmt_start(cmt_reflow &cmt, chunk_t *pc)
+static void output_cmt_start(cmt_reflow &cmt,
+                             chunk_t    *pc)
 {
    cmt.pc          = pc;
    cmt.column      = pc->column;
@@ -1076,6 +1146,7 @@ static void output_cmt_start(cmt_reflow &cmt, chunk_t *pc)
       //        __func__, pc->orig_line, pc->column, cmt.column);
       pc->column = cmt.column;
    }
+
    cmt.base_col = cmt.column;
 
    // LOG_FMT(LSYS, "%s: -- brace=%d base=%d col=%d\n",
@@ -1086,7 +1157,8 @@ static void output_cmt_start(cmt_reflow &cmt, chunk_t *pc)
 } // output_cmt_start
 
 
-static bool can_combine_comment(chunk_t *pc, cmt_reflow &cmt)
+static bool can_combine_comment(chunk_t    *pc,
+                                cmt_reflow &cmt)
 {
    // We can't combine if there is something other than a newline next
    if (pc->parent_type == CT_COMMENT_START)
@@ -1096,10 +1168,12 @@ static bool can_combine_comment(chunk_t *pc, cmt_reflow &cmt)
 
    // next is a newline for sure, make sure it is a single newline
    chunk_t *next = chunk_get_next(pc);
+
    if (next != nullptr && next->nl_count == 1)
    {
       // Make sure the comment is the same type at the same column
       next = chunk_get_next(next);
+
       if (  chunk_is_token(next, pc->type)
          && (  (next->column == 1 && pc->column == 1)
             || (next->column == cmt.base_col && pc->column == cmt.base_col)
@@ -1108,6 +1182,7 @@ static bool can_combine_comment(chunk_t *pc, cmt_reflow &cmt)
          return(true);
       }
    }
+
    return(false);
 } // can_combine_comment
 
@@ -1133,17 +1208,21 @@ static chunk_t *output_comment_c(chunk_t *first)
    LOG_CONTTEXT();
 
    add_text("/*");
+
    if (options::cmt_c_nl_start())
    {
       add_comment_text("\n", cmt, false);
    }
+
    chunk_t  *pc = first;
    unc_text tmp;
+
    while (can_combine_comment(pc, cmt))
    {
       LOG_FMT(LCONTTEXT, "%s(%d): text() is '%s'\n",
               __func__, __LINE__, pc->text());
       tmp.set(pc->str, 2, pc->len() - 4);
+
       if (  cpd.last_char == '*'
          && (  tmp[0] == '/'
             || tmp[0] != ' '))                 // Issue #1908
@@ -1151,6 +1230,7 @@ static chunk_t *output_comment_c(chunk_t *first)
          LOG_FMT(LCONTTEXT, "%s(%d): add_text a " "\n", __func__, __LINE__);
          add_text(" ");
       }
+
       // In case of reflow, original comment could contain trailing spaces before closing the comment, we don't need them after reflow
       LOG_FMT(LCONTTEXT, "%s(%d): trim\n", __func__, __LINE__);
       cmt_trim_whitespace(tmp, false);
@@ -1163,20 +1243,25 @@ static chunk_t *output_comment_c(chunk_t *first)
       pc = chunk_get_next(pc);
       pc = chunk_get_next(pc);
    }
+
    tmp.set(pc->str, 2, pc->len() - 4);
+
    if (cpd.last_char == '*' && tmp[0] == '/')
    {
       add_text(" ");
    }
+
    // In case of reflow, original comment could contain trailing spaces before closing the comment, we don't need them after reflow
    cmt_trim_whitespace(tmp, false);
    add_comment_text(tmp, cmt, false);
+
    if (options::cmt_c_nl_end())
    {
       cmt.cont_text = " ";
       LOG_CONTTEXT();
       add_comment_text("\n", cmt, false);
    }
+
    add_comment_text("*/", cmt, false);
    return(pc);
 } // output_comment_c
@@ -1190,6 +1275,7 @@ static chunk_t *output_comment_cpp(chunk_t *first)
    cmt.reflow = (options::cmt_reflow_mode() != 1);
 
    unc_text leadin = "//";             // default setting to keep previous behaviour
+
    // If true, space is added with sp_cmt_cpp_start will be added after doxygen
    // sequences like '///', '///<', '//!' and '//!<'.
    if (options::sp_cmt_cpp_doxygen())  // special treatment for doxygen style comments (treat as unity)
@@ -1197,9 +1283,11 @@ static chunk_t *output_comment_cpp(chunk_t *first)
       const char *sComment = first->text();
       bool       grouping  = (sComment[2] == '@');
       size_t     brace     = 3;
+
       if (sComment[2] == '/' || sComment[2] == '!') // doxygen style found!
       {
          leadin += sComment[2];                     // at least one additional char (either "///" or "//!")
+
          if (sComment[3] == '<')                    // and a further one (either "///<" or "//!<")
          {
             leadin += '<';
@@ -1210,6 +1298,7 @@ static chunk_t *output_comment_cpp(chunk_t *first)
             brace    = 4;
          }
       }
+
       if (  grouping
          && (sComment[brace] == '{' || sComment[brace] == '}'))
       {
@@ -1224,6 +1313,7 @@ static chunk_t *output_comment_cpp(chunk_t *first)
    if (options::sp_cmt_cpp_qttr())
    {
       const int c = first->str[2];
+
       if (  c == ':'
          || c == '='
          || c == '~')
@@ -1232,17 +1322,18 @@ static chunk_t *output_comment_cpp(chunk_t *first)
       }
    }
 
-
    // CPP comments can't be grouped unless they are converted to C comments
    if (!options::cmt_cpp_to_c())
    {
       cmt.cont_text = leadin;
+
       // Add or remove space after the opening of a C++ comment,
       // i.e. '// A' vs. '//A'.
       if (options::sp_cmt_cpp_start() != IARF_REMOVE)
       {
          cmt.cont_text += ' ';
       }
+
       LOG_CONTTEXT();
 
       // Add or remove space after the opening of a C++ comment,
@@ -1268,6 +1359,7 @@ static chunk_t *output_comment_cpp(chunk_t *first)
                tmp.pop_front();
             }
          }
+
          if (tmp.size() > 0)
          {
             // Add or remove space after the opening of a C++ comment,
@@ -1279,6 +1371,7 @@ static chunk_t *output_comment_cpp(chunk_t *first)
                   add_comment_text(" ", cmt, false);
                }
             }
+
             add_comment_text(tmp, cmt, false);
          }
       }
@@ -1291,11 +1384,13 @@ static chunk_t *output_comment_cpp(chunk_t *first)
    LOG_CONTTEXT();
 
    unc_text tmp;
+
    // See if we can combine this comment with the next comment
    if (!options::cmt_cpp_group() || !can_combine_comment(first, cmt))
    {
       // nothing to group: just output a single line
       add_text("/*");
+
       // patch # 32, 2012-03-23
       // Add or remove space after the opening of a C++ comment,
       // i.e. '// A' vs. '//A'.
@@ -1304,6 +1399,7 @@ static chunk_t *output_comment_cpp(chunk_t *first)
       {
          add_char(' ');
       }
+
       tmp.set(first->str, 2, first->len() - 2);
       add_comment_text(tmp, cmt, true);
       add_text(" */");
@@ -1311,6 +1407,7 @@ static chunk_t *output_comment_cpp(chunk_t *first)
    }
 
    add_text("/*");
+
    if (options::cmt_cpp_nl_start())
    {
       add_comment_text("\n", cmt, false);
@@ -1319,6 +1416,7 @@ static chunk_t *output_comment_cpp(chunk_t *first)
    {
       add_text(" ");
    }
+
    chunk_t *pc = first;
    int     offs;
 
@@ -1326,29 +1424,35 @@ static chunk_t *output_comment_cpp(chunk_t *first)
    {
       offs = unc_isspace(pc->str[2]) ? 1 : 0;
       tmp.set(pc->str, 2 + offs, pc->len() - (2 + offs));
+
       if (cpd.last_char == '*' && tmp[0] == '/')
       {
          add_text(" ");
       }
+
       add_comment_text(tmp, cmt, true);
       add_comment_text("\n", cmt, false);
       pc = chunk_get_next(chunk_get_next(pc));
    }
+
    offs = unc_isspace(pc->str[2]) ? 1 : 0;
    tmp.set(pc->str, 2 + offs, pc->len() - (2 + offs));
    add_comment_text(tmp, cmt, true);
+
    if (options::cmt_cpp_nl_end())
    {
       cmt.cont_text = "";
       LOG_CONTTEXT();
       add_comment_text("\n", cmt, false);
    }
+
    add_comment_text(" */", cmt, false);
    return(pc);
 } // output_comment_cpp
 
 
-static void cmt_trim_whitespace(unc_text &line, bool in_preproc)
+static void cmt_trim_whitespace(unc_text &line,
+                                bool     in_preproc)
 {
    // Remove trailing whitespace on the line
    while (  line.size() > 0
@@ -1366,16 +1470,19 @@ static void cmt_trim_whitespace(unc_text &line, bool in_preproc)
 
       // If there was any space before the backslash, change it to 1 space
       line.pop_back();
+
       while (  line.size() > 0
             && (line.back() == ' ' || line.back() == '\t'))
       {
          do_space = true;
          line.pop_back();
       }
+
       if (do_space)
       {
          line.append(' ');
       }
+
       line.append('\\');
    }
 } // cmt_trim_whitespace
@@ -1408,6 +1515,7 @@ static void output_comment_multi(chunk_t *pc)
    bool     nl_end     = false;
    unc_text line;
    line.clear();
+
    while (cmt_idx < pc->len())
    {
       int ch = pc->str[cmt_idx++];
@@ -1416,6 +1524,7 @@ static void output_comment_multi(chunk_t *pc)
       if (ch == '\r')
       {
          ch = '\n';
+
          if (cmt_idx < pc->len() && pc->str[cmt_idx] == '\n')
          {
             cmt_idx++;
@@ -1426,6 +1535,7 @@ static void output_comment_multi(chunk_t *pc)
       if (line.size() == 0)
       {
          nl_end = false;
+
          if (ch == ' ')
          {
             ccol++;
@@ -1459,6 +1569,7 @@ static void output_comment_multi(chunk_t *pc)
          while (nwidx > 0)
          {
             nwidx--;
+
             if (  prev_nonempty_line < 0
                && !unc_isspace(line[nwidx])
                && line[nwidx] != '*'    // block comment: skip '*' at end of line
@@ -1472,6 +1583,7 @@ static void output_comment_multi(chunk_t *pc)
          }
 
          size_t remaining = pc->len() - cmt_idx;
+
          for (size_t nxt_len = 0;
               (  nxt_len <= remaining
               && pc->str[nxt_len] != 'r'  // TODO: should this be \r ?
@@ -1562,6 +1674,7 @@ static void output_comment_multi(chunk_t *pc)
          {
             // this is the first line - add unchanged
             add_comment_text(line, cmt, false);
+
             if (nl_end)
             {
                add_char('\n');
@@ -1592,16 +1705,19 @@ static void output_comment_multi(chunk_t *pc)
                   // The number of spaces to insert at the start of subsequent comment lines.
                   cmt.column = cmt_col + options::cmt_sp_before_star_cont();
                   cmt_output_indent(cmt.brace_col, cmt.base_col, cmt.column);
+
                   if (cmt.xtra_indent > 0)
                   {
                      add_char(' ');
                   }
+
                   //Multiline comments with can have empty lines with some spaces in them for alignment
                   //While adding * symbol and alligning them we don't want to keep these trailing spaces
                   unc_text tmp = unc_text(cmt.cont_text);
                   cmt_trim_whitespace(tmp, false);
                   add_text(tmp);
                }
+
                add_char('\n');
             }
             else
@@ -1624,10 +1740,12 @@ static void output_comment_multi(chunk_t *pc)
                   {
                      cmt.column = start_col;
                      cmt_output_indent(cmt.brace_col, cmt.base_col, cmt.column);
+
                      if (cmt.xtra_indent > 0)
                      {
                         add_char(' ');
                      }
+
                      add_text(cmt.cont_text);
                      // The number of spaces to insert after the star on subsequent comment lines.
                      output_to_column(ccol + options::cmt_sp_after_star_cont(),
@@ -1644,6 +1762,7 @@ static void output_comment_multi(chunk_t *pc)
                   // The number of spaces to insert at the start of subsequent comment lines.
                   cmt.column = cmt_col + options::cmt_sp_before_star_cont();
                   cmt_output_indent(cmt.brace_col, cmt.base_col, cmt.column);
+
                   if (cmt.xtra_indent > 0)
                   {
                      add_char(' ');
@@ -1654,11 +1773,13 @@ static void output_comment_multi(chunk_t *pc)
                   // Checks for and updates the lead chars.
                   // @return 0=not present, >0=number of chars that are part of the lead
                   idx = cmt_parse_lead(line, (cmt_idx == pc->len()));
+
                   if (idx > 0)
                   {
                      // >0=number of chars that are part of the lead
                      cmt.cont_text.set(line, 0, idx);
                      LOG_CONTTEXT();
+
                      if (  (line.size() >= 2)
                         && (line[0] == '*')
                         && unc_isalnum(line[1]))
@@ -1678,12 +1799,14 @@ static void output_comment_multi(chunk_t *pc)
                }
 
                add_comment_text(line, cmt, false);
+
                if (nl_end)
                {
                   add_text("\n");
                }
             }
          }
+
          line.clear();
          ccol = 1;
       }
@@ -1691,7 +1814,8 @@ static void output_comment_multi(chunk_t *pc)
 } // output_comment_multi
 
 
-static bool kw_fcn_filename(chunk_t *cmt, unc_text &out_txt)
+static bool kw_fcn_filename(chunk_t  *cmt,
+                            unc_text &out_txt)
 {
    UNUSED(cmt);
    out_txt.append(path_basename(cpd.filename.c_str()));
@@ -1699,13 +1823,15 @@ static bool kw_fcn_filename(chunk_t *cmt, unc_text &out_txt)
 }
 
 
-static bool kw_fcn_class(chunk_t *cmt, unc_text &out_txt)
+static bool kw_fcn_class(chunk_t  *cmt,
+                         unc_text &out_txt)
 {
    chunk_t *tmp = nullptr;
 
    if (language_is_set(LANG_CPP | LANG_OC))
    {
       chunk_t *fcn = get_next_function(cmt);
+
       if (chunk_is_token(fcn, CT_OC_MSG_DECL))
       {
          tmp = get_prev_oc_class(cmt);
@@ -1719,6 +1845,7 @@ static bool kw_fcn_class(chunk_t *cmt, unc_text &out_txt)
    {
       tmp = get_prev_oc_class(cmt);
    }
+
    if (tmp == nullptr)
    {
       tmp = get_next_class(cmt);
@@ -1727,26 +1854,32 @@ static bool kw_fcn_class(chunk_t *cmt, unc_text &out_txt)
    if (tmp != nullptr)
    {
       out_txt.append(tmp->str);
+
       while ((tmp = chunk_get_next(tmp)) != nullptr)
       {
          if (tmp->type != CT_DC_MEMBER)
          {
             break;
          }
+
          tmp = chunk_get_next(tmp);
+
          if (tmp != nullptr)
          {
             out_txt.append("::");
             out_txt.append(tmp->str);
          }
       }
+
       return(true);
    }
+
    return(false);
 } // kw_fcn_class
 
 
-static bool kw_fcn_message(chunk_t *cmt, unc_text &out_txt)
+static bool kw_fcn_message(chunk_t  *cmt,
+                           unc_text &out_txt)
 {
    chunk_t *fcn = get_next_function(cmt);
 
@@ -1759,12 +1892,14 @@ static bool kw_fcn_message(chunk_t *cmt, unc_text &out_txt)
 
    chunk_t *tmp  = chunk_get_next_ncnl(fcn);
    chunk_t *word = nullptr;
+
    while (tmp != nullptr)
    {
       if (chunk_is_token(tmp, CT_BRACE_OPEN) || chunk_is_token(tmp, CT_SEMICOLON))
       {
          break;
       }
+
       if (chunk_is_token(tmp, CT_OC_COLON))
       {
          if (word != nullptr)
@@ -1772,19 +1907,24 @@ static bool kw_fcn_message(chunk_t *cmt, unc_text &out_txt)
             out_txt.append(word->str);
             word = nullptr;
          }
+
          out_txt.append(":");
       }
+
       if (chunk_is_token(tmp, CT_WORD))
       {
          word = tmp;
       }
+
       tmp = chunk_get_next_ncnl(tmp);
    }
+
    return(true);
 } // kw_fcn_message
 
 
-static bool kw_fcn_category(chunk_t *cmt, unc_text &out_txt)
+static bool kw_fcn_category(chunk_t  *cmt,
+                            unc_text &out_txt)
 {
    chunk_t *category = get_prev_category(cmt);
 
@@ -1794,11 +1934,13 @@ static bool kw_fcn_category(chunk_t *cmt, unc_text &out_txt)
       out_txt.append(category->str);
       out_txt.append(')');
    }
+
    return(true);
 } // kw_fcn_category
 
 
-static bool kw_fcn_scope(chunk_t *cmt, unc_text &out_txt)
+static bool kw_fcn_scope(chunk_t  *cmt,
+                         unc_text &out_txt)
 {
    chunk_t *scope = get_next_scope(cmt);
 
@@ -1807,11 +1949,13 @@ static bool kw_fcn_scope(chunk_t *cmt, unc_text &out_txt)
       out_txt.append(scope->str);
       return(true);
    }
+
    return(false);
 } // kw_fcn_scope
 
 
-static bool kw_fcn_function(chunk_t *cmt, unc_text &out_txt)
+static bool kw_fcn_function(chunk_t  *cmt,
+                            unc_text &out_txt)
 {
    chunk_t *fcn = get_next_function(cmt);
 
@@ -1821,18 +1965,22 @@ static bool kw_fcn_function(chunk_t *cmt, unc_text &out_txt)
       {
          out_txt.append("operator ");
       }
+
       if (fcn->prev && fcn->prev->type == CT_DESTRUCTOR)
       {
          out_txt.append('~');
       }
+
       out_txt.append(fcn->str);
       return(true);
    }
+
    return(false);
 }
 
 
-static bool kw_fcn_javaparam(chunk_t *cmt, unc_text &out_txt)
+static bool kw_fcn_javaparam(chunk_t  *cmt,
+                             unc_text &out_txt)
 {
    chunk_t *fcn = get_next_function(cmt);
 
@@ -1850,6 +1998,7 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text &out_txt)
    {
       chunk_t *tmp = chunk_get_next_ncnl(fcn);
       has_param = false;
+
       while (tmp != nullptr)
       {
          if (chunk_is_token(tmp, CT_BRACE_OPEN) || chunk_is_token(tmp, CT_SEMICOLON))
@@ -1863,6 +2012,7 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text &out_txt)
             {
                out_txt.append("\n");
             }
+
             need_nl = true;
             out_txt.append("@param");
             out_txt.append(" ");
@@ -1871,22 +2021,28 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text &out_txt)
          }
 
          has_param = false;
+
          if (chunk_is_token(tmp, CT_PAREN_CLOSE))
          {
             has_param = true;
          }
+
          tmp = chunk_get_next_ncnl(tmp);
       }
+
       fpo = fpc = nullptr;
    }
    else
    {
       fpo = chunk_get_next_type(fcn, CT_FPAREN_OPEN, fcn->level);
+
       if (fpo == nullptr)
       {
          return(true);
       }
+
       fpc = chunk_get_next_type(fpo, CT_FPAREN_CLOSE, fcn->level);
+
       if (fpc == nullptr)
       {
          return(true);
@@ -1894,6 +2050,7 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text &out_txt)
    }
 
    chunk_t *tmp;
+
    // Check for 'foo()' and 'foo(void)'
    if (chunk_get_next_ncnl(fpo) == fpc)
    {
@@ -1902,6 +2059,7 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text &out_txt)
    else
    {
       tmp = chunk_get_next_ncnl(fpo);
+
       if ((tmp == chunk_get_prev_ncnl(fpc)) && chunk_is_str(tmp, "void", 4))
       {
          has_param = false;
@@ -1912,6 +2070,7 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text &out_txt)
    {
       chunk_t *prev = nullptr;
       tmp = fpo;
+
       while ((tmp = chunk_get_next(tmp)) != nullptr)
       {
          if (chunk_is_token(tmp, CT_COMMA) || tmp == fpc)
@@ -1920,20 +2079,25 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text &out_txt)
             {
                out_txt.append("\n");
             }
+
             need_nl = true;
             out_txt.append("@param");
+
             if (prev != nullptr)
             {
                out_txt.append(" ");
                out_txt.append(prev->str);
                out_txt.append(" TODO");
             }
+
             prev = nullptr;
+
             if (tmp == fpc)
             {
                break;
             }
          }
+
          if (chunk_is_token(tmp, CT_WORD))
          {
             prev = tmp;
@@ -1943,17 +2107,20 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text &out_txt)
 
    // Do the return stuff
    tmp = chunk_get_prev_ncnl(fcn);
+
    // For Objective-C we need to go to the previous chunk
    if (tmp != nullptr && tmp->parent_type == CT_OC_MSG_DECL && chunk_is_token(tmp, CT_PAREN_CLOSE))
    {
       tmp = chunk_get_prev_ncnl(tmp);
    }
+
    if (tmp != nullptr && !chunk_is_str(tmp, "void", 4))
    {
       if (need_nl)
       {
          out_txt.append("\n");
       }
+
       out_txt.append("@return TODO");
    }
 
@@ -1961,7 +2128,8 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text &out_txt)
 } // kw_fcn_javaparam
 
 
-static bool kw_fcn_fclass(chunk_t *cmt, unc_text &out_txt)
+static bool kw_fcn_fclass(chunk_t  *cmt,
+                          unc_text &out_txt)
 {
    chunk_t *fcn = get_next_function(cmt);
 
@@ -1969,12 +2137,14 @@ static bool kw_fcn_fclass(chunk_t *cmt, unc_text &out_txt)
    {
       return(false);
    }
+
    if (fcn->flags & PCF_IN_CLASS)
    {
       // if inside a class, we need to find to the class name
       chunk_t *tmp = chunk_get_prev_type(fcn, CT_BRACE_OPEN, fcn->level - 1);
       tmp = chunk_get_prev_type(tmp, CT_CLASS, tmp->level);
       tmp = chunk_get_next_ncnl(tmp);
+
       while (chunk_is_token(chunk_get_next_ncnl(tmp), CT_DC_MEMBER))
       {
          tmp = chunk_get_next_ncnl(tmp);
@@ -1991,10 +2161,12 @@ static bool kw_fcn_fclass(chunk_t *cmt, unc_text &out_txt)
    {
       // if outside a class, we expect "CLASS::METHOD(...)"
       chunk_t *tmp = chunk_get_prev_ncnl(fcn);
+
       if (chunk_is_token(tmp, CT_OPERATOR))
       {
          tmp = chunk_get_prev_ncnl(tmp);
       }
+
       if (  tmp != nullptr
          && (chunk_is_token(tmp, CT_DC_MEMBER) || chunk_is_token(tmp, CT_MEMBER)))
       {
@@ -2003,6 +2175,7 @@ static bool kw_fcn_fclass(chunk_t *cmt, unc_text &out_txt)
          return(true);
       }
    }
+
    return(false);
 } // kw_fcn_fclass
 
@@ -2032,6 +2205,7 @@ static void do_kw_subst(chunk_t *pc)
    for (const auto &kw : kw_subst_table)
    {
       int idx = pc->str.find(kw.tag);
+
       if (idx < 0)
       {
          continue;
@@ -2039,26 +2213,31 @@ static void do_kw_subst(chunk_t *pc)
 
       unc_text tmp_txt;
       tmp_txt.clear();
+
       if (kw.func(pc, tmp_txt))
       {
          // if the replacement contains '\n' we need to fix the lead
          if (tmp_txt.find("\n") >= 0)
          {
             size_t nl_idx = pc->str.rfind("\n", idx);
+
             if (nl_idx > 0)
             {
                // idx and nl_idx are both positive
                unc_text nl_txt;
                nl_txt.append("\n");
                nl_idx++;
+
                while (  (nl_idx < static_cast<size_t>(idx))
                      && !unc_isalnum(pc->str[nl_idx]))
                {
                   nl_txt.append(pc->str[nl_idx++]);
                }
+
                tmp_txt.replace("\n", nl_txt);
             }
          }
+
          pc->str.replace(kw.tag, tmp_txt);
       }
    }
@@ -2079,7 +2258,8 @@ static void output_comment_multi_simple(chunk_t *pc)
    // shifted all lines of the comment need to be shifter by the same amount.
    // Save the difference of initial and current position to apply it on every
    // line_column
-   const int col_diff = [pc]() {
+   const int col_diff = [pc]()
+   {
       int diff = 0;
 
       if (chunk_is_newline(chunk_get_prev(pc)))
@@ -2095,6 +2275,7 @@ static void output_comment_multi_simple(chunk_t *pc)
    size_t   line_count  = 0;
    size_t   line_column = pc->column;
    size_t   cmt_idx     = 0;
+
    while (cmt_idx < pc->len())
    {
       int ch = pc->str[cmt_idx];
@@ -2119,11 +2300,13 @@ static void output_comment_multi_simple(chunk_t *pc)
       if (ch == '\r')
       {
          ch = '\n';
+
          if ((cmt_idx < pc->len()) && (pc->str[cmt_idx] == '\n'))
          {
             cmt_idx++;
          }
       }
+
       line.append(ch);
 
       // If we just hit an end of line OR we just hit end-of-comment...
@@ -2159,6 +2342,7 @@ static void output_comment_multi_simple(chunk_t *pc)
                cmt.column = line_column;
                cmt_output_indent(cmt.brace_col, cmt.base_col, cmt.column);
             }
+
             add_text(line);
 
             line.clear();
@@ -2170,17 +2354,20 @@ static void output_comment_multi_simple(chunk_t *pc)
 } // output_comment_multi_simple
 
 
-static void generate_if_conditional_as_text(unc_text &dst, chunk_t *ifdef)
+static void generate_if_conditional_as_text(unc_text &dst,
+                                            chunk_t  *ifdef)
 {
    int column = -1;
 
    dst.clear();
+
    for (chunk_t *pc = ifdef; pc != nullptr; pc = chunk_get_next(pc))
    {
       if (column == -1)
       {
          column = pc->column;
       }
+
       if (  chunk_is_token(pc, CT_NEWLINE)
          || chunk_is_token(pc, CT_COMMENT_MULTI)
          || chunk_is_token(pc, CT_COMMENT_CPP))
@@ -2202,6 +2389,7 @@ static void generate_if_conditional_as_text(unc_text &dst, chunk_t *ifdef)
             dst += ' ';
             column++;
          }
+
          dst.append(pc->str);
          column += pc->len();
       }
@@ -2226,6 +2414,7 @@ void add_long_preprocessor_conditional_block_comment(void)
       {
          continue;
       }
+
 #if 0
       if (pc->flags & PCF_IN_PREPROC)
       {
@@ -2238,6 +2427,7 @@ void add_long_preprocessor_conditional_block_comment(void)
       size_t  nl_count = 0;
 
       chunk_t *tmp = pc;
+
       while ((tmp = chunk_get_next(tmp)) != nullptr)
       {
          // just track the preproc level:
@@ -2266,6 +2456,7 @@ void add_long_preprocessor_conditional_block_comment(void)
             LOG_FMT(LPPIF, "next item type %d (is %s)\n",
                     (tmp ? tmp->type : -1), (tmp ? chunk_is_newline(tmp) ? "newline"
                                              : chunk_is_comment(tmp) ? "comment" : "other" : "---"));
+
             if (tmp == nullptr || chunk_is_token(tmp, CT_NEWLINE))  // chunk_is_newline(tmp))
             {
                size_t nl_min;

--- a/src/parens.cpp
+++ b/src/parens.cpp
@@ -52,6 +52,7 @@ void do_parens(void)
    if (options::mod_full_paren_if_bool())
    {
       chunk_t *pc = chunk_get_head();
+
       while ((pc = chunk_get_next_ncnl(pc)) != nullptr)
       {
          if (  pc->type != CT_SPAREN_OPEN
@@ -64,6 +65,7 @@ void do_parens(void)
 
          // Grab the close sparen
          chunk_t *pclose = chunk_get_next_type(pc, CT_SPAREN_CLOSE, pc->level, scope_e::PREPROC);
+
          if (pclose != nullptr)
          {
             check_bool_parens(pc, pclose, 0);
@@ -74,7 +76,8 @@ void do_parens(void)
 }
 
 
-static void add_parens_between(chunk_t *first, chunk_t *last)
+static void add_parens_between(chunk_t *first,
+                               chunk_t *last)
 {
    LOG_FUNC_ENTRY();
 
@@ -85,6 +88,7 @@ static void add_parens_between(chunk_t *first, chunk_t *last)
 
    // Don't do anything if we have a bad sequence, ie "&& )"
    chunk_t *first_n = chunk_get_next_ncnl(first);
+
    if (first_n == last)
    {
       return;
@@ -120,11 +124,14 @@ static void add_parens_between(chunk_t *first, chunk_t *last)
    {
       tmp->level++;
    }
+
    last_p->level++;
 } // add_parens_between
 
 
-static void check_bool_parens(chunk_t *popen, chunk_t *pclose, int nest)
+static void check_bool_parens(chunk_t *popen,
+                              chunk_t *pclose,
+                              int     nest)
 {
    LOG_FUNC_ENTRY();
 
@@ -138,6 +145,7 @@ static void check_bool_parens(chunk_t *popen, chunk_t *pclose, int nest)
            popen->level);
 
    chunk_t *pc = popen;
+
    while ((pc = chunk_get_next_ncnl(pc)) != nullptr && pc != pclose)
    {
       if (pc->flags & PCF_IN_PREPROC)
@@ -156,14 +164,17 @@ static void check_bool_parens(chunk_t *popen, chunk_t *pclose, int nest)
          LOG_FMT(LPARADD2, " -- %s [%s] at line %zu col %zu, level %zu\n",
                  get_token_name(pc->type),
                  pc->text(), pc->orig_line, pc->orig_col, pc->level);
+
          if (hit_compare)
          {
             hit_compare = false;
+
             if (!language_is_set(LANG_CS))
             {
                add_parens_between(ref, pc);
             }
          }
+
          ref = pc;
       }
       else if (chunk_is_token(pc, CT_COMPARE))
@@ -175,6 +186,7 @@ static void check_bool_parens(chunk_t *popen, chunk_t *pclose, int nest)
       else if (chunk_is_paren_open(pc))
       {
          chunk_t *next = chunk_skip_to_match(pc);
+
          if (next != nullptr)
          {
             check_bool_parens(pc, next, nest + 1);

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -24,21 +24,26 @@
  * @param tabsize The tabsize
  * @return the next tabstop column
  */
-static inline size_t calc_next_tab_column(size_t col, size_t tabsize)
+static inline size_t calc_next_tab_column(size_t col,
+                                          size_t tabsize)
 {
    if (col == 0)
    {
       col = 1;
    }
+
    if (cpd.frag_cols > 0)
    {
       col += cpd.frag_cols - 1;
    }
+
    col = 1 + ((((col - 1) / tabsize) + 1) * tabsize);
+
    if (cpd.frag_cols > 0)
    {
       col -= cpd.frag_cols - 1;
    }
+
    return(col);
 }
 

--- a/src/punctuators.cpp
+++ b/src/punctuators.cpp
@@ -32,7 +32,8 @@ using namespace uncrustify;
 #include "punctuator_table.h"
 
 
-const chunk_tag_t *find_punctuator(const char *str, int lang_flags)
+const chunk_tag_t *find_punctuator(const char *str,
+                                   int        lang_flags)
 {
    if (str == nullptr || str[0] == '\0')
    {
@@ -55,6 +56,7 @@ const chunk_tag_t *find_punctuator(const char *str, int lang_flags)
    {
       // search for next parent node in all current child nodes
       parent = binary_find(parent, next(parent, parent->left_in_group), str[ch_idx]);
+
       if (parent == nullptr)
       {
          break; // no nodes found with the searched char
@@ -72,9 +74,11 @@ const chunk_tag_t *find_punctuator(const char *str, int lang_flags)
       {
          break;                               // no child nodes, leaf reached
       }
+
       parent = &punc_table[parent->next_idx]; // point at the first child node
       ch_idx++;
       continue;
    }
+
    return(match);
 } // find_punctuator

--- a/src/punctuators.h
+++ b/src/punctuators.h
@@ -29,7 +29,8 @@ struct lookup_entry_t
       }
 
       template<typename T1, typename T2>
-      bool operator()(T1 const &t1, T2 const &t2)
+      bool operator()(T1 const &t1,
+                      T2 const &t2)
       {
          return(get_char(t1) < get_char(t2));
       }

--- a/src/quick_align_again.cpp
+++ b/src/quick_align_again.cpp
@@ -16,10 +16,12 @@
 void quick_align_again(void)
 {
    LOG_FUNC_ENTRY();
+
    for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next(pc))
    {
       LOG_FMT(LALAGAIN, "%s(%d): pc->orig_line is %zu, pc->orig_col is %zu, pc->text() '%s'\n",
               __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text());
+
       if (pc->align.next != nullptr && (pc->flags & PCF_ALIGN_START))
       {
          AlignStack as;
@@ -33,6 +35,7 @@ void quick_align_again(void)
                  __func__, __LINE__, pc->text(), pc->orig_line);
          as.Add(pc->align.start);
          chunk_flags_set(pc, PCF_WAS_ALIGNED);
+
          for (chunk_t *tmp = pc->align.next; tmp != nullptr; tmp = tmp->align.next)
          {
             chunk_flags_set(tmp, PCF_WAS_ALIGNED);
@@ -40,6 +43,7 @@ void quick_align_again(void)
             LOG_FMT(LALAGAIN, "%s(%d):    => tmp->text() is '%s', orig_line is %zu\n",
                     __func__, __LINE__, tmp->text(), tmp->orig_line);
          }
+
          LOG_FMT(LALAGAIN, "\n");
          as.End();
       }

--- a/src/scan_ib_line.cpp
+++ b/src/scan_ib_line.cpp
@@ -16,7 +16,8 @@
 #include "uncrustify.h"
 
 
-chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
+chunk_t *scan_ib_line(chunk_t *start,
+                      bool    first_pass)
 {
    UNUSED(first_pass);
    LOG_FUNC_ENTRY();
@@ -25,12 +26,14 @@ chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
 
    // Skip past C99 "[xx] =" stuff
    chunk_t *tmp = skip_c99_array(start);
+
    if (tmp != nullptr)
    {
       set_chunk_parent(start, CT_TSQUARE);
       start            = tmp;
       cpd.al_c99_array = true;
    }
+
    chunk_t *pc = start;
 
    if (pc != nullptr)
@@ -47,6 +50,7 @@ chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
       //        pc->text(), pc->column, pc->orig_col, pc->orig_line);
 
       chunk_t *next = chunk_get_next(pc);
+
       if (next == nullptr || chunk_is_comment(next))
       {
          // do nothing
@@ -67,12 +71,14 @@ chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
             {
                LOG_FMT(LSIB, "%s(%d): Prepare the 'idx's\n", __func__, __LINE__);
             }
+
             LOG_FMT(LSIB, "%s(%d):   New idx is %2.1zu, pc->column is %2.1zu, text() '%s', token_width is %zu, type is %s\n",
                     __func__, __LINE__, idx, pc->column, pc->text(), token_width, get_token_name(pc->type));
             cpd.al[cpd.al_cnt].type = pc->type;
             cpd.al[cpd.al_cnt].col  = pc->column;
             cpd.al[cpd.al_cnt].len  = token_width;
             cpd.al_cnt++;
+
             if (cpd.al_cnt == AL_SIZE)
             {
                fprintf(stderr, "Number of 'entry' to be aligned is too big for the current value %d,\n", AL_SIZE);
@@ -81,6 +87,7 @@ chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
                log_flush(true);
                exit(EX_SOFTWARE);
             }
+
             idx++;
          }
          else
@@ -109,6 +116,7 @@ chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
                           __func__, __LINE__, prev_match->text(), prev_match->orig_line, prev_match->orig_col);
                   int min_col_diff = pc->column - prev_match->column;
                   int cur_col_diff = cpd.al[idx].col - cpd.al[idx - 1].col;
+
                   if (cur_col_diff < min_col_diff)
                   {
                      LOG_FMT(LSIB, "%s(%d):   pc->orig_line is %zu\n",
@@ -116,14 +124,18 @@ chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
                      ib_shift_out(idx, min_col_diff - cur_col_diff);
                   }
                }
+
                LOG_FMT(LSIB, "%s(%d): at ende of the loop: now is col %zu, len is %zu\n",
                        __func__, __LINE__, cpd.al[idx].col, cpd.al[idx].len);
                idx++;
             }
          }
+
          prev_match = pc;
       }
+
       pc = chunk_get_next_nc(pc);
    }
+
    return(pc);
 } // scan_ib_line

--- a/src/semicolons.cpp
+++ b/src/semicolons.cpp
@@ -48,10 +48,12 @@ void remove_extra_semicolons(void)
    LOG_FUNC_ENTRY();
 
    chunk_t *pc = chunk_get_head();
+
    while (pc != nullptr)
    {
       chunk_t *next = chunk_get_next_ncnl(pc);
       chunk_t *prev;
+
       if (  chunk_is_token(pc, CT_SEMICOLON)
          && !(pc->flags & PCF_IN_PREPROC)
          && (prev = chunk_get_prev_ncnl(pc)) != nullptr)
@@ -117,11 +119,13 @@ void remove_extra_semicolons(void)
 } // remove_extra_semicolons
 
 
-static void check_unknown_brace_close(chunk_t *semi, chunk_t *brace_close)
+static void check_unknown_brace_close(chunk_t *semi,
+                                      chunk_t *brace_close)
 {
    LOG_FUNC_ENTRY();
    chunk_t *pc = chunk_get_prev_type(brace_close, CT_BRACE_OPEN, brace_close->level);
    pc = chunk_get_prev_ncnl(pc);
+
    if (  pc != nullptr
       && pc->type != CT_RETURN
       && pc->type != CT_WORD

--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -64,6 +64,7 @@ static void prepare_categories()
    for (int i = 0; i < kIncludeCategoriesCount; ++i)
    {
       const auto &cat_pattern = (*include_category_options[i])();
+
       if (!cat_pattern.empty())
       {
          include_categories[i] = new include_category(cat_pattern);
@@ -114,22 +115,27 @@ static unc_text chunk_sort_str(chunk_t *pc)
    {
       return(unc_text{ pc->str, 0, pc->len() - 1 });
    }
+
    return(pc->str);
 }
 
 
 //! Compare two chunks
-static int compare_chunks(chunk_t *pc1, chunk_t *pc2, bool tcare)
+static int compare_chunks(chunk_t *pc1,
+                          chunk_t *pc2,
+                          bool    tcare)
 {
    LOG_FUNC_ENTRY();
    LOG_FMT(LSORT, "%s(%d): @begin pc1->len is %zu, line is %zu, column is %zu\n",
            __func__, __LINE__, pc1->len(), pc1->orig_line, pc1->orig_col);
    LOG_FMT(LSORT, "%s(%d): @begin pc2->len is %zu, line is %zu, column is %zu\n",
            __func__, __LINE__, pc2->len(), pc2->orig_line, pc2->orig_col);
+
    if (pc1 == pc2) // same chunk is always identical thus return 0 differences
    {
       return(0);
    }
+
    while (pc1 != nullptr && pc2 != nullptr)
    {
       int ppc1 = get_chunk_priority(pc1);
@@ -154,6 +160,7 @@ static int compare_chunks(chunk_t *pc1, chunk_t *pc2, bool tcare)
       {
          return(ret_val);
       }
+
       if (pc1->len() != pc2->len())
       {
          return(pc1->len() - pc2->len());
@@ -163,21 +170,25 @@ static int compare_chunks(chunk_t *pc1, chunk_t *pc2, bool tcare)
       pc1 = chunk_get_next(pc1);
       LOG_FMT(LSORT, "%s(%d): text is %s, pc1->len is %zu, line is %zu, column is %zu\n",
               __func__, __LINE__, pc1->text(), pc1->len(), pc1->orig_line, pc1->orig_col);
+
       if (chunk_is_token(pc1, CT_MEMBER))
       {
          pc1 = chunk_get_next(pc1);
          LOG_FMT(LSORT, "%s(%d): text is %s, pc1->len is %zu, line is %zu, column is %zu\n",
                  __func__, __LINE__, pc1->text(), pc1->len(), pc1->orig_line, pc1->orig_col);
       }
+
       pc2 = chunk_get_next(pc2);
       LOG_FMT(LSORT, "%s(%d): text is %s, pc2->len is %zu, line is %zu, column is %zu\n",
               __func__, __LINE__, pc2->text(), pc2->len(), pc2->orig_line, pc2->orig_col);
+
       if (chunk_is_token(pc2, CT_MEMBER))
       {
          pc2 = chunk_get_next(pc2);
          LOG_FMT(LSORT, "%s(%d): text is %s, pc2->len is %zu, line is %zu, column is %zu\n",
                  __func__, __LINE__, pc2->text(), pc2->len(), pc2->orig_line, pc2->orig_col);
       }
+
       LOG_FMT(LSORT, "%s(%d): >>>text is %s, pc1->len is %zu, line is %zu, column is %zu\n",
               __func__, __LINE__, pc1->text(), pc1->len(), pc1->orig_line, pc1->orig_col);
       LOG_FMT(LSORT, "%s(%d): >>>text is %s, pc2->len is %zu, line is %zu, column is %zu\n",
@@ -197,10 +208,12 @@ static int compare_chunks(chunk_t *pc1, chunk_t *pc2, bool tcare)
    {
       return(-1);
    }
+
    if (!chunk_is_newline(pc1))
    {
       return(1);
    }
+
    return(0);
 } // compare_chunks
 
@@ -210,24 +223,29 @@ static int compare_chunks(chunk_t *pc1, chunk_t *pc2, bool tcare)
  * We need to minimize the number of swaps, as those are expensive.
  * So, we do a min sort.
  */
-static void do_the_sort(chunk_t **chunks, size_t num_chunks)
+static void do_the_sort(chunk_t **chunks,
+                        size_t  num_chunks)
 {
    LOG_FUNC_ENTRY();
 
    LOG_FMT(LSORT, "%s(%d): %zu chunks:",
            __func__, __LINE__, num_chunks);
+
    for (size_t idx = 0; idx < num_chunks; idx++)
    {
       LOG_FMT(LSORT, " [%s]", chunks[idx]->text());
    }
+
    LOG_FMT(LSORT, "\n");
 
    size_t start_idx;
    bool   take_care = options::mod_sort_case_sensitive();                  // Issue #2091
+
    for (start_idx = 0; start_idx < (num_chunks - 1); start_idx++)
    {
       // Find the index of the minimum value
       size_t min_idx = start_idx;
+
       for (size_t idx = start_idx + 1; idx < num_chunks; idx++)
       {
          if (compare_chunks(chunks[idx], chunks[min_idx], take_care) < 0)  // Issue #2091
@@ -259,6 +277,7 @@ void sort_imports(void)
    prepare_categories();
 
    chunk_t *pc = chunk_get_head();
+
    while (pc != nullptr)
    {
       chunk_t *next = chunk_get_next(pc);
@@ -286,8 +305,10 @@ void sort_imports(void)
                cpd.error_count++;
                exit(2);
             }
+
             did_import = true;
          }
+
          if (  !did_import
             || pc->nl_count > 1
             || next == nullptr)
@@ -296,8 +317,10 @@ void sort_imports(void)
             {
                do_the_sort(chunks, num_chunks);
             }
+
             num_chunks = 0;
          }
+
          p_imp  = nullptr;
          p_last = nullptr;
       }
@@ -327,6 +350,7 @@ void sort_imports(void)
       {
          p_last = pc;
       }
+
       pc = next;
    }
 

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -125,9 +125,13 @@ const no_space_table_t no_space_table[] =
    } while (0)
 
 
-static void log_rule2(size_t line, const char *rule, chunk_t *first, chunk_t *second)
+static void log_rule2(size_t     line,
+                      const char *rule,
+                      chunk_t    *first,
+                      chunk_t    *second)
 {
    LOG_FUNC_ENTRY();
+
    if (second->type != CT_NEWLINE)
    {
       LOG_FMT(LSPACE, "%s(%d): Spacing: first->orig_line is %zu, first->orig_col is %zu, first->text() is '%s', [%s/%s] <===>\n",
@@ -145,7 +149,9 @@ static void log_rule2(size_t line, const char *rule, chunk_t *first, chunk_t *se
  * this function is called for every chunk in the input file.
  * Thus it is important to keep this function efficient
  */
-static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
+static iarf_e do_space(chunk_t *first,
+                       chunk_t *second,
+                       int     &min_sp)
 {
    LOG_FUNC_ENTRY();
 
@@ -153,23 +159,27 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
            __func__, __LINE__, first->orig_line, first->orig_col, first->text(), get_token_name(first->type));
 
    min_sp = 1;
+
    if (chunk_is_token(first, CT_IGNORED) || chunk_is_token(second, CT_IGNORED))
    {
       log_rule("IGNORED");
       return(IARF_REMOVE);
    }
+
    if (chunk_is_token(first, CT_PP_IGNORE) && chunk_is_token(second, CT_PP_IGNORE))
    {
       // Leave spacing alone between PP_IGNORE tokens as we don't want the default behavior (which is ADD).
       log_rule("PP_IGNORE");
       return(IARF_IGNORE);
    }
+
    if (chunk_is_token(first, CT_PP) || chunk_is_token(second, CT_PP))
    {
       // Add or remove space around preprocessor '##' concatenation operator.
       log_rule("sp_pp_concat");
       return(options::sp_pp_concat());
    }
+
    if (chunk_is_token(first, CT_POUND))
    {
       // Add or remove space after preprocessor '#' stringify operator.
@@ -177,6 +187,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_pp_stringify");
       return(options::sp_pp_stringify());
    }
+
    if (  chunk_is_token(second, CT_POUND)
       && (second->flags & PCF_IN_PREPROC)
       && first->parent_type != CT_MACRO_FUNC)
@@ -198,6 +209,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("Remove");
       return(IARF_REMOVE);
    }
+
    // there are not any data for this case, this block will never been reached
    //if (chunk_is_token(first, CT_PAREN_CLOSE) && first->parent_type == CT_DECLSPEC)
    //{
@@ -209,6 +221,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("REMOVE");
       return(IARF_REMOVE);
    }
+
    if (  chunk_is_token(first, CT_VBRACE_OPEN)
       && second->type != CT_NL_CONT
       && second->type != CT_SEMICOLON) // # Issue 1158
@@ -216,21 +229,25 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("FORCE");
       return(IARF_FORCE);
    }
+
    if (chunk_is_token(first, CT_VBRACE_CLOSE) && second->type != CT_NL_CONT)
    {
       log_rule("REMOVE");
       return(IARF_REMOVE);
    }
+
    if (chunk_is_token(second, CT_VSEMICOLON))
    {
       log_rule("REMOVE");
       return(IARF_REMOVE);
    }
+
    if (chunk_is_token(first, CT_MACRO_FUNC))
    {
       log_rule("REMOVE");
       return(IARF_REMOVE);
    }
+
    if (chunk_is_token(second, CT_NL_CONT))
    {
       // Add or remove space before a backslash-newline at the end of a line.
@@ -262,6 +279,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_after_for_colon");
       return(options::sp_after_for_colon());
    }
+
    if (chunk_is_token(second, CT_FOR_COLON))
    {
       // java
@@ -293,6 +311,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_cond_question_before");
          return(options::sp_cond_question_before());
       }
+
       if (  chunk_is_token(first, CT_QUESTION)
          && (options::sp_cond_question_after() != IARF_IGNORE))
       {
@@ -301,6 +320,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_cond_question_after");
          return(options::sp_cond_question_after());
       }
+
       if (options::sp_cond_question() != IARF_IGNORE)
       {
          // Add or remove space around the '?' in 'b ? t : f'.
@@ -319,6 +339,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_cond_colon_before");
          return(options::sp_cond_colon_before());
       }
+
       if (  chunk_is_token(first, CT_COND_COLON)
          && (options::sp_cond_colon_after() != IARF_IGNORE))
       {
@@ -327,6 +348,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_cond_colon_after");
          return(options::sp_cond_colon_after());
       }
+
       if (options::sp_cond_colon() != IARF_IGNORE)
       {
          // Add or remove space around the ':' in 'b ? t : f'.
@@ -373,6 +395,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("IGNORE");
          return(IARF_IGNORE);
       }
+
       log_rule("REMOVE");
       return(IARF_REMOVE);
    }
@@ -394,6 +417,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             log_rule("sp_before_semi_for_empty");
             return(options::sp_before_semi_for_empty());
          }
+
          if (options::sp_before_semi_for() != IARF_IGNORE)
          {
             // Add or remove space before ';' in non-empty 'for' statements.
@@ -403,6 +427,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       }
 
       iarf_e arg = options::sp_before_semi();
+
       if (  chunk_is_token(first, CT_SPAREN_CLOSE)
          && first->parent_type != CT_WHILE_OF_DO)
       {
@@ -415,6 +440,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          // Add or remove space before ';'.
          log_rule("sp_before_semi");
       }
+
       return(arg);
    }
 
@@ -474,6 +500,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             log_rule("sp_after_semi_for_empty");
             return(options::sp_after_semi_for_empty());
          }
+
          if (  (options::sp_after_semi_for() != IARF_IGNORE)
             && second->type != CT_SPAREN_CLOSE)  // Issue 1324
          {
@@ -488,6 +515,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_after_semi");
          return(options::sp_after_semi());
       }
+
       // Let the comment spacing rules handle this
    }
 
@@ -520,6 +548,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_return_brace");
          return(options::sp_return_brace());
       }
+
       // everything else requires a space
       log_rule("FORCE");
       return(IARF_FORCE);
@@ -534,12 +563,14 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_sizeof_paren");
          return(options::sp_sizeof_paren());
       }
+
       if (chunk_is_token(second, CT_ELLIPSIS))
       {
          // Add or remove space between 'sizeof' and '...'.
          log_rule("sp_sizeof_ellipsis");
          return(options::sp_sizeof_ellipsis());
       }
+
       log_rule("FORCE");
       return(IARF_FORCE);
    }
@@ -553,6 +584,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_decltype_paren");
          return(options::sp_decltype_paren());
       }
+
       log_rule("FORCE");
       return(IARF_FORCE);
    }
@@ -564,6 +596,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_after_dc");
       return(options::sp_after_dc());
    }
+
    // Issue #889
    // mapped_file_source abc((int) ::CW2A(sTemp));
    if (  chunk_is_token(first, CT_PAREN_CLOSE)
@@ -574,6 +607,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_after_cast");
       return(options::sp_after_cast());
    }
+
    if (chunk_is_token(second, CT_DC_MEMBER))
    {
       /* '::' at the start of an identifier is not member access, but global scope operator.
@@ -648,21 +682,25 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             log_rule("sp_between_mdatype_commas");
             return(options::sp_between_mdatype_commas());
          }
+
          // (C#) Add or remove space between ',' and ']' in multidimensional array type
          // like 'int[,,]'.
          log_rule("sp_after_mdatype_commas");
          return(options::sp_after_mdatype_commas());
       }
+
       // Fix for issue #1243
       // Don't add extra space after comma immediately followed by Angle close
       if (chunk_is_token(second, CT_ANGLE_CLOSE))
       {
          return(IARF_IGNORE);
       }
+
       // Add or remove space after ',', i.e. 'a,b' vs. 'a, b'.
       log_rule("sp_after_comma");
       return(options::sp_after_comma());
    }
+
    // test if we are within a SIGNAL/SLOT call
    if (QT_SIGNAL_SLOT_found)
    {
@@ -675,6 +713,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          }
       }
    }
+
    if (chunk_is_token(second, CT_COMMA))
    {
       if (chunk_is_token(first, CT_SQUARE_OPEN) && first->parent_type == CT_TYPE)
@@ -685,6 +724,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_before_mdatype_commas");
          return(options::sp_before_mdatype_commas());
       }
+
       if (  chunk_is_token(first, CT_PAREN_OPEN)
          && (options::sp_paren_comma() != IARF_IGNORE))
       {
@@ -693,6 +733,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_paren_comma");
          return(options::sp_paren_comma());
       }
+
       // Add or remove space before ','.
       log_rule("sp_before_comma");
       return(options::sp_before_comma());
@@ -702,11 +743,13 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    {
       // type followed by a ellipsis
       chunk_t *tmp = first;
+
       if (  chunk_is_token(tmp, CT_PTR_TYPE)
          || chunk_is_token(tmp, CT_BYREF))
       {
          tmp = chunk_get_prev_ncnl(tmp);
       }
+
       if (  chunk_is_token(tmp, CT_TYPE)
          || chunk_is_token(tmp, CT_QUALIFIER))
       {
@@ -739,6 +782,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          return(IARF_FORCE);
       }
    }
+
    if (chunk_is_token(first, CT_ELLIPSIS))
    {
       if (CharTable::IsKw1(second->str[0]))
@@ -746,6 +790,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("FORCE");
          return(IARF_FORCE);
       }
+
       if (  chunk_is_token(second, CT_PAREN_OPEN)
          && first->prev && chunk_is_token(first->prev, CT_SIZEOF))
       {
@@ -754,12 +799,14 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          return(options::sp_sizeof_ellipsis_paren());
       }
    }
+
    if (chunk_is_token(first, CT_TAG_COLON))
    {
       // (Pawn) Add or remove space after the tag keyword.
       log_rule("sp_after_tag");
       return(options::sp_after_tag());
    }
+
    if (chunk_is_token(second, CT_TAG_COLON))
    {
       log_rule("REMOVE");
@@ -923,10 +970,12 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             log_rule("sp_enum_before_assign");
             return(options::sp_enum_before_assign());
          }
+
          // Add or remove space around assignment '=' in enum.
          log_rule("sp_enum_assign");
          return(options::sp_enum_assign());
       }
+
       // Add or remove space around assignment operator '=' in a prototype.
       // If set to ignore, use sp_assign.
       if (  (options::sp_assign_default() != IARF_IGNORE)
@@ -935,6 +984,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_assign_default");
          return(options::sp_assign_default());
       }
+
       // Add or remove space before assignment operator '=', '+=', etc.
       // Overrides sp_assign.
       if (options::sp_before_assign() != IARF_IGNORE)
@@ -942,6 +992,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_before_assign");
          return(options::sp_before_assign());
       }
+
       // Add or remove space around assignment operator '=', '+=', etc.
       log_rule("sp_assign");
       return(options::sp_assign());
@@ -955,11 +1006,13 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_assign_default");
          return(options::sp_assign_default());
       }
+
       if (options::sp_before_assign() != IARF_IGNORE)
       {
          log_rule("sp_before_assign");
          return(options::sp_before_assign());
       }
+
       log_rule("sp_assign");
       return(options::sp_assign());
    }
@@ -975,16 +1028,19 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             log_rule("sp_enum_after_assign");
             return(options::sp_enum_after_assign());
          }
+
          // Add or remove space around assignment '=' in enum.
          log_rule("sp_enum_assign");
          return(options::sp_enum_assign());
       }
+
       if (  (options::sp_assign_default() != IARF_IGNORE)
          && first->parent_type == CT_FUNC_PROTO)
       {
          log_rule("sp_assign_default");
          return(options::sp_assign_default());
       }
+
       // Add or remove space after assignment operator '=', '+=', etc.
       // Overrides sp_assign.
       if (options::sp_after_assign() != IARF_IGNORE)
@@ -992,10 +1048,10 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_after_assign");
          return(options::sp_after_assign());
       }
+
       log_rule("sp_assign");
       return(options::sp_assign());
    }
-
 
    if (chunk_is_token(first, CT_TRAILING_RET_T))
    {
@@ -1018,6 +1074,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_assign_default");
          return(options::sp_assign_default());
       }
+
       // Add or remove space after assignment operator '=', '+=', etc.
       // Overrides sp_assign.
       if (options::sp_after_assign() != IARF_IGNORE)
@@ -1025,6 +1082,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_after_assign");
          return(options::sp_after_assign());
       }
+
       log_rule("sp_assign");
       return(options::sp_assign());
    }
@@ -1054,6 +1112,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("IGNORE");
       return(IARF_IGNORE);
    }
+
    if (chunk_is_token(second, CT_OC_BLOCK_CARET))
    {
       // (OC) Add or remove space before a block pointer caret,
@@ -1061,6 +1120,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_before_oc_block_caret");
       return(options::sp_before_oc_block_caret());
    }
+
    if (chunk_is_token(first, CT_OC_BLOCK_CARET))
    {
       // (OC) Add or remove space after a block pointer caret,
@@ -1068,6 +1128,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_after_oc_block_caret");
       return(options::sp_after_oc_block_caret());
    }
+
    if (chunk_is_token(second, CT_OC_MSG_FUNC))
    {
       if (  (options::sp_after_oc_msg_receiver() == IARF_REMOVE)
@@ -1077,6 +1138,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       {
          return(IARF_FORCE);
       }
+
       // (OC) Add or remove space between the receiver and selector in a message,
       // as in '[receiver selector ...]'.
       log_rule("sp_after_oc_msg_receiver");
@@ -1107,12 +1169,14 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       {
          return(IARF_FORCE);
       }
+
       if (chunk_is_token(first, CT_ASM_COLON))
       {
          // Add or remove space before '[' for asm block.
          log_rule("sp_before_square_asm_block");
          return(options::sp_before_square_asm_block());
       }
+
       // Add or remove space before '[' (except '[]').
       log_rule("sp_before_square");
       return(options::sp_before_square());
@@ -1159,8 +1223,10 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       {
          op = IARF_IGNORE;
       }
+
       return(op);
    }
+
    if (chunk_is_token(second, CT_ANGLE_OPEN))
    {
       if (  chunk_is_token(first, CT_TEMPLATE)
@@ -1171,6 +1237,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_template_angle");
          return(options::sp_template_angle());
       }
+
       if (first->type != CT_QUALIFIER)
       {
          // Add or remove space before '<'.
@@ -1178,6 +1245,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          return(options::sp_before_angle());
       }
    }
+
    if (chunk_is_token(first, CT_ANGLE_CLOSE))
    {
       if (chunk_is_token(second, CT_WORD) || CharTable::IsKw1(second->str[0]))
@@ -1190,9 +1258,11 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             return(options::sp_angle_word());
          }
       }
+
       if (chunk_is_token(second, CT_FPAREN_OPEN) || chunk_is_token(second, CT_PAREN_OPEN))
       {
          chunk_t *next = chunk_get_next_ncnl(second);
+
          if (chunk_is_token(next, CT_FPAREN_CLOSE))
          {
             // Add or remove space between '>' and '()' as found in 'new List<byte>();'.
@@ -1204,12 +1274,14 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_angle_paren");
          return(options::sp_angle_paren());
       }
+
       if (chunk_is_token(second, CT_DC_MEMBER))
       {
          // Add or remove space before the '::' operator.
          log_rule("sp_before_dc");
          return(options::sp_before_dc());
       }
+
       if (  second->type != CT_BYREF
          && second->type != CT_PTR_TYPE
          && second->type != CT_BRACE_OPEN
@@ -1222,6 +1294,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             log_rule("sp_angle_colon");
             return(options::sp_angle_colon());
          }
+
          if (  chunk_is_token(second, CT_FPAREN_CLOSE)
             && options::sp_inside_fparen() != IARF_IGNORE
             && options::use_sp_after_angle_always() == false)
@@ -1230,6 +1303,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             log_rule("sp_inside_fparen");
             return(options::sp_inside_fparen());
          }
+
          // Add or remove space after '>'.
          log_rule("sp_after_angle");
          return(options::sp_after_angle());
@@ -1268,6 +1342,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (options::sp_before_byref_func() != IARF_IGNORE)
       {
          chunk_t *next = chunk_get_next(second);
+
          if (  next != nullptr
             && (  next->parent_type == CT_FUNC_DEF
                || next->parent_type == CT_FUNC_PROTO))
@@ -1282,12 +1357,14 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (options::sp_before_unnamed_byref() != IARF_IGNORE)
       {
          chunk_t *next = chunk_get_next_nc(second);
+
          if (next != nullptr && next->type != CT_WORD)
          {
             log_rule("sp_before_unnamed_byref");
             return(options::sp_before_unnamed_byref());
          }
       }
+
       // Add or remove space before a reference sign '&'.
       log_rule("sp_before_byref");
       return(options::sp_before_byref());
@@ -1307,6 +1384,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
                log_rule("sp_oc_catch_brace");
                return(options::sp_oc_catch_brace());
             }
+
             if (options::sp_catch_brace() != IARF_IGNORE)
             {
                // Add or remove space before the '{' of a 'catch' statement, if the '{' and
@@ -1315,6 +1393,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
                return(options::sp_catch_brace());
             }
          }
+
          if (options::sp_sparen_brace() != IARF_IGNORE)
          {
             // Add or remove space between ')' and '{' of of control statements.
@@ -1322,6 +1401,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             return(options::sp_sparen_brace());
          }
       }
+
       if (  !chunk_is_comment(second)
          && (options::sp_after_sparen() != IARF_IGNORE))
       {
@@ -1330,6 +1410,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          return(options::sp_after_sparen());
       }
    }
+
    if (  chunk_is_token(first, CT_VBRACE_OPEN)
       && chunk_is_token(second, CT_SEMICOLON)) // Issue # 1158
    {
@@ -1346,6 +1427,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          && chunk_is_token(second, CT_FPAREN_OPEN))
       {
          chunk_t *next = chunk_get_next_ncnl(second);
+
          if (chunk_is_token(next, CT_FPAREN_CLOSE))
          {
             // Overrides sp_after_operator_sym when the operator has no arguments, as in
@@ -1354,6 +1436,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             return(options::sp_after_operator_sym_empty());
          }
       }
+
       // Add or remove space between the operator symbol and the open parenthesis, as
       // in 'operator ++('.
       log_rule("sp_after_operator_sym");
@@ -1385,6 +1468,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          && chunk_is_token(second, CT_FPAREN_OPEN))
       {
          chunk_t *next = chunk_get_next_ncnl(second);
+
          if (chunk_is_token(next, CT_FPAREN_CLOSE))
          {
             // Add or remove space between function name and '()' on function calls without
@@ -1393,10 +1477,12 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             return(options::sp_func_call_paren_empty());
          }
       }
+
       // Add or remove space between function name and '(' on function calls.
       log_rule("sp_func_call_paren");
       return(options::sp_func_call_paren());
    }
+
    if (chunk_is_token(first, CT_FUNC_CALL_USER))
    {
       // Add or remove space between the user function name and '(' on function
@@ -1406,18 +1492,21 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_func_call_user_paren");
       return(options::sp_func_call_user_paren());
    }
+
    if (chunk_is_token(first, CT_ATTRIBUTE) && chunk_is_paren_open(second))
    {
       // Add or remove space between '__attribute__' and '('.
       log_rule("sp_attribute_paren");
       return(options::sp_attribute_paren());
    }
+
    if (chunk_is_token(first, CT_FUNC_DEF))
    {
       if (  (options::sp_func_def_paren_empty() != IARF_IGNORE)
          && chunk_is_token(second, CT_FPAREN_OPEN))
       {
          chunk_t *next = chunk_get_next_ncnl(second);
+
          if (chunk_is_token(next, CT_FPAREN_CLOSE))
          {
             // Add or remove space between function name and '()' on function definition
@@ -1426,10 +1515,12 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             return(options::sp_func_def_paren_empty());
          }
       }
+
       // Add or remove space between function name and '(' on function definition.
       log_rule("sp_func_def_paren");
       return(options::sp_func_def_paren());
    }
+
    if (chunk_is_token(first, CT_CPP_CAST) || chunk_is_token(first, CT_TYPE_WRAP))
    {
       // Add or remove space between the type and open parenthesis in a C++ cast,
@@ -1488,6 +1579,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          && chunk_is_token(second, CT_FPAREN_OPEN))
       {
          chunk_t *next = chunk_get_next_ncnl(second);
+
          if (chunk_is_token(next, CT_FPAREN_CLOSE))
          {
             // Add or remove space between function name and '()' on function declaration
@@ -1496,16 +1588,19 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             return(options::sp_func_proto_paren_empty());
          }
       }
+
       // Add or remove space between function name and '(' on function declaration.
       log_rule("sp_func_proto_paren");
       return(options::sp_func_proto_paren());
    }
+
    if (chunk_is_token(first, CT_FUNC_CLASS_DEF) || chunk_is_token(first, CT_FUNC_CLASS_PROTO))
    {
       if (  (options::sp_func_class_paren_empty() != IARF_IGNORE)
          && chunk_is_token(second, CT_FPAREN_OPEN))
       {
          chunk_t *next = chunk_get_next_ncnl(second);
+
          if (chunk_is_token(next, CT_FPAREN_CLOSE))
          {
             // Add or remove space between a constructor without parameters or destructor
@@ -1514,11 +1609,13 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             return(options::sp_func_class_paren_empty());
          }
       }
+
       // Add or remove space between a constructor/destructor and the open
       // parenthesis.
       log_rule("sp_func_class_paren");
       return(options::sp_func_class_paren());
    }
+
    if (chunk_is_token(first, CT_CLASS) && !(first->flags & PCF_IN_OC_MSG))
    {
       log_rule("FORCE");
@@ -1538,6 +1635,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       && second->parent_type == CT_BRACED_INIT_LIST)
    {
       auto arg = iarf_flags_t{ options::sp_type_brace_init_lst() };
+
       if (arg || first->parent_type != CT_DECLTYPE)
       {
          // 'int{9}' vs 'int {9}'
@@ -1556,14 +1654,17 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_inside_braces_enum");
          return(options::sp_inside_braces_enum());
       }
+
       if (second->parent_type == CT_STRUCT || second->parent_type == CT_UNION)
       {
          // Fix for issue #1240  adding space in struct initializers
          chunk_t *tmp = chunk_get_prev_ncnl(chunk_skip_to_match_rev(second));
+
          if (chunk_is_token(tmp, CT_ASSIGN))
          {
             return(IARF_IGNORE);
          }
+
          // Add or remove space inside struct/union '{' and '}'.
          log_rule("sp_inside_braces_struct");
          return(options::sp_inside_braces_struct());
@@ -1586,6 +1687,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             log_rule("sp_brace_brace");
             return(options::sp_brace_brace());
          }
+
          if (options::sp_before_type_brace_init_lst_close() != IARF_IGNORE)
          {
             // Add or remove space before close brace in an unnamed temporary
@@ -1593,6 +1695,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             log_rule("sp_before_type_brace_init_lst_close");
             return(options::sp_before_type_brace_init_lst_close());
          }
+
          if (options::sp_inside_type_brace_init_lst() != IARF_IGNORE)
          {
             // Add or remove space inside an unnamed temporary direct-list-initialization.
@@ -1600,6 +1703,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             return(options::sp_inside_type_brace_init_lst());
          }
       }
+
       // Add or remove space inside '{' and '}'.
       log_rule("sp_inside_braces");
       return(options::sp_inside_braces());
@@ -1626,6 +1730,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_throw_paren");
          return(options::sp_throw_paren());
       }
+
       // Add or remove space between 'throw' and anything other than '(' as in
       // '@throw [...];'.
       log_rule("sp_after_throw");
@@ -1680,12 +1785,14 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_fparen_dbrace");
          return(options::sp_fparen_dbrace());
       }
+
       // To fix issue #1234
       // check for initializers and add space or ignore based on the option.
       if (first->parent_type == CT_FUNC_CALL)
       {
          chunk_t *tmp = chunk_get_prev_type(first, first->parent_type, first->level);
          tmp = chunk_get_prev_ncnl(tmp);
+
          if (chunk_is_token(tmp, CT_NEW))
          {
             // Add or remove space between ')' and '{' of s function call in object
@@ -1695,6 +1802,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             return(options::sp_fparen_brace_initializer());
          }
       }
+
       // Add or remove space between ')' and '{' of function.
       log_rule("sp_fparen_brace");
       return(options::sp_fparen_brace());
@@ -1748,6 +1856,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_word_brace_ns");
          return(options::sp_word_brace_ns());
       }
+
       if (first->parent_type == CT_NONE && second->parent_type == CT_NONE)
       {
          // Add or remove space between a variable and '{' for C++ uniform
@@ -1822,6 +1931,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_func_call_user_paren_paren");
          return(options::sp_func_call_user_paren_paren());
       }
+
       // Add or remove space between nested parentheses, i.e. '((' vs. ') )'.
       log_rule("sp_paren_paren");
       return(options::sp_paren_paren());
@@ -1838,12 +1948,14 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_func_call_user_inside_fparen");
          return(options::sp_func_call_user_inside_fparen());
       }
+
       if (chunk_is_token(first, CT_FPAREN_OPEN) && chunk_is_token(second, CT_FPAREN_CLOSE))
       {
          // Add or remove space inside empty function '()'.
          log_rule("sp_inside_fparens");
          return(options::sp_inside_fparens());
       }
+
       // Add or remove space inside function '(' and ')'.
       log_rule("sp_inside_fparen");
       return(options::sp_inside_fparen());
@@ -1929,6 +2041,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_inside_paren_cast");
          return(options::sp_inside_paren_cast());
       }
+
       if (first->parent_type == CT_NEW)
       {
          if (options::sp_inside_newop_paren_open() != IARF_IGNORE)
@@ -1939,6 +2052,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             log_rule("sp_inside_newop_paren_open");
             return(options::sp_inside_newop_paren_open());
          }
+
          if (options::sp_inside_newop_paren() != IARF_IGNORE)
          {
             // Add or remove space inside parenthesis of the new operator
@@ -1947,6 +2061,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             return(options::sp_inside_newop_paren());
          }
       }
+
       log_rule("sp_inside_paren");
       return(options::sp_inside_paren());
    }
@@ -1961,6 +2076,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_inside_paren_cast");
          return(options::sp_inside_paren_cast());
       }
+
       if (second->parent_type == CT_NEW)
       {
          if (options::sp_inside_newop_paren_close() != IARF_IGNORE)
@@ -1971,6 +2087,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             log_rule("sp_inside_newop_paren_close");
             return(options::sp_inside_newop_paren_close());
          }
+
          if (options::sp_inside_newop_paren() != IARF_IGNORE)
          {
             // Add or remove space inside parenthesis of the new operator
@@ -1979,6 +2096,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             return(options::sp_inside_newop_paren());
          }
       }
+
       // Add or remove space inside '(' and ')'.
       log_rule("sp_inside_paren");
       return(options::sp_inside_paren());
@@ -1997,10 +2115,12 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_inside_square_oc_array");
          return(options::sp_inside_square_oc_array());
       }
+
       // Add or remove space inside a non-empty '[' and ']'.
       log_rule("sp_inside_square");
       return(options::sp_inside_square());
    }
+
    if (chunk_is_token(first, CT_SQUARE_CLOSE) && chunk_is_token(second, CT_FPAREN_OPEN))
    {
       // Add or remove space between ']' and '(' when part of a function call.
@@ -2017,6 +2137,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_inside_sparen_close");
       return(options::sp_inside_sparen_close());
    }
+
    if (  chunk_is_token(first, CT_SPAREN_OPEN)
       && (options::sp_inside_sparen_open() != IARF_IGNORE))
    {
@@ -2025,6 +2146,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_inside_sparen_open");
       return(options::sp_inside_sparen_open());
    }
+
    if (chunk_is_token(first, CT_SPAREN_OPEN) || chunk_is_token(second, CT_SPAREN_CLOSE))
    {
       // Add or remove space inside '(' and ')' of control statements.
@@ -2054,6 +2176,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          return(options::sp_after_class_colon());
       }
    }
+
    if (chunk_is_token(second, CT_CLASS_COLON))
    {
       if (  second->parent_type == CT_OC_CLASS
@@ -2089,6 +2212,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_after_constr_colon");
       return(options::sp_after_constr_colon());
    }
+
    if (  (options::sp_before_constr_colon() != IARF_IGNORE)
       && chunk_is_token(second, CT_CONSTR_COLON))
    {
@@ -2110,6 +2234,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("REMOVE");
       return(IARF_REMOVE);
    }
+
    if (chunk_is_token(second, CT_DOT))
    {
       log_rule("ADD");
@@ -2134,6 +2259,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       {
          auto arith_char = (chunk_is_token(first, CT_ARITH) || chunk_is_token(first, CT_CARET))
                            ? first->str[0] : second->str[0];
+
          if (arith_char == '+' || arith_char == '-')
          {
             log_rule("sp_arith_additive");
@@ -2146,19 +2272,23 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_arith");
       return(options::sp_arith());
    }
+
    if (chunk_is_token(first, CT_BOOL) || chunk_is_token(second, CT_BOOL))
    {
       // Add or remove space around boolean operators '&&' and '||'.
       iarf_e arg = options::sp_bool();
+
       if (  (options::pos_bool() != TP_IGNORE)
          && first->orig_line != second->orig_line
          && arg != IARF_REMOVE)
       {
          arg = arg | IARF_ADD;
       }
+
       log_rule("sp_bool");
       return(arg);
    }
+
    if (chunk_is_token(first, CT_COMPARE) || chunk_is_token(second, CT_COMPARE))
    {
       // Add or remove space around compare operator '<', '>', '==', etc.
@@ -2206,6 +2336,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    if (chunk_is_token(first, CT_PTR_TYPE) && CharTable::IsKw1(second->str[0]))
    {
       chunk_t *prev = chunk_get_prev(first);
+
       if (chunk_is_token(prev, CT_IN))
       {
          // Add or remove space after the '*' (dereference) unary operator. This does
@@ -2253,12 +2384,14 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          min_sp = 0;
          return(IARF_REMOVE);
       }
+
       // Add or remove space before a pointer star '*', if followed by a function
       // prototype or function definition.
       if (options::sp_before_ptr_star_func() != IARF_IGNORE)
       {
          // Find the next non-'*' chunk
          chunk_t *next = second;
+
          do
          {
             next = chunk_get_next(next);
@@ -2276,16 +2409,19 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (options::sp_before_unnamed_ptr_star() != IARF_IGNORE)
       {
          chunk_t *next = chunk_get_next_nc(second);
+
          while (chunk_is_token(next, CT_PTR_TYPE))
          {
             next = chunk_get_next_nc(next);
          }
+
          if (next != nullptr && next->type != CT_WORD)
          {
             log_rule("sp_before_unnamed_ptr_star");
             return(options::sp_before_unnamed_ptr_star());
          }
       }
+
       // Add or remove space before pointer star '*'.
       if (options::sp_before_ptr_star() != IARF_IGNORE)
       {
@@ -2310,6 +2446,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_type_func|ADD");
          return(options::sp_type_func() | IARF_ADD);
       }
+
       // Add or remove space between return type and function name. A
       // minimum of 1 is forced except for pointer/reference return types.
       log_rule("sp_type_func");
@@ -2366,14 +2503,17 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_inside_braces_enum");
          return(options::sp_inside_braces_enum());
       }
+
       if (first->parent_type == CT_STRUCT || first->parent_type == CT_UNION)
       {
          // Fix for issue #1240  adding space in struct initializers
          chunk_t *tmp = chunk_get_prev_ncnl(first);
+
          if (chunk_is_token(tmp, CT_ASSIGN))
          {
             return(IARF_IGNORE);
          }
+
          // Add or remove space inside struct/union '{' and '}'.
          log_rule("sp_inside_braces_struct");
          return(options::sp_inside_braces_struct());
@@ -2385,6 +2525,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_inside_braces_oc_dict");
          return(options::sp_inside_braces_oc_dict());
       }
+
       if (first->parent_type == CT_BRACED_INIT_LIST)
       {
          // Add or remove space between nested braces, i.e. '{{' vs '{ {'.
@@ -2395,6 +2536,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             log_rule("sp_brace_brace");
             return(options::sp_brace_brace());
          }
+
          if (options::sp_after_type_brace_init_lst_open() != IARF_IGNORE)
          {
             // Add or remove space after open brace in an unnamed temporary
@@ -2402,6 +2544,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             log_rule("sp_after_type_brace_init_lst_open");
             return(options::sp_after_type_brace_init_lst_open());
          }
+
          if (options::sp_inside_type_brace_init_lst() != IARF_IGNORE)
          {
             // Add or remove space inside an unnamed temporary direct-list-initialization.
@@ -2409,6 +2552,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
             return(options::sp_inside_type_brace_init_lst());
          }
       }
+
       if (!chunk_is_comment(second))
       {
          // Add or remove space inside '{' and '}'.
@@ -2416,7 +2560,6 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          return(options::sp_inside_braces());
       }
    }
-
 
    if (  chunk_is_token(first, CT_BRACE_CLOSE)
       && (first->flags & PCF_IN_TYPEDEF)
@@ -2447,6 +2590,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_after_decltype");
          return(arg);
       }
+
       // Add or remove space between type and word.
       log_rule("sp_after_type");
       return(options::sp_after_type());
@@ -2460,6 +2604,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_type_question");
       return(options::sp_type_question());
    }
+
    if (  !chunk_is_token(second, CT_PTR_TYPE)
       && (chunk_is_token(first, CT_QUALIFIER) || chunk_is_token(first, CT_TYPE)))
    {
@@ -2479,6 +2624,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_func_call_paren");
          return(options::sp_func_call_paren());
       }
+
       log_rule("IGNORE");
       return(IARF_IGNORE);
    }
@@ -2496,12 +2642,14 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_not");
       return(options::sp_not());
    }
+
    if (chunk_is_token(first, CT_INV))
    {
       // Add or remove space after the '~' (invert) unary operator.
       log_rule("sp_inv");
       return(options::sp_inv());
    }
+
    if (chunk_is_token(first, CT_ADDR))
    {
       // Add or remove space after the '&' (address-of) unary operator. This does not
@@ -2509,6 +2657,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_addr");
       return(options::sp_addr());
    }
+
    if (chunk_is_token(first, CT_DEREF))
    {
       // Add or remove space after the '*' (dereference) unary operator. This does
@@ -2516,12 +2665,14 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_deref");
       return(options::sp_deref());
    }
+
    if (chunk_is_token(first, CT_POS) || chunk_is_token(first, CT_NEG))
    {
       // Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'.
       log_rule("sp_sign");
       return(options::sp_sign());
    }
+
    if (chunk_is_token(first, CT_INCDEC_BEFORE) || chunk_is_token(second, CT_INCDEC_AFTER))
    {
       // Add or remove space between '++' and '--' the word to which it is being
@@ -2529,16 +2680,19 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_incdec");
       return(options::sp_incdec());
    }
+
    if (chunk_is_token(second, CT_CS_SQ_COLON))
    {
       log_rule("REMOVE");
       return(IARF_REMOVE);
    }
+
    if (chunk_is_token(first, CT_CS_SQ_COLON))
    {
       log_rule("FORCE");
       return(IARF_FORCE);
    }
+
    if (chunk_is_token(first, CT_OC_SCOPE))
    {
       // (OC) Add or remove space after the scope '+' or '-', as in '-(void) foo;'
@@ -2546,6 +2700,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_after_oc_scope");
       return(options::sp_after_oc_scope());
    }
+
    if (chunk_is_token(first, CT_OC_DICT_COLON))
    {
       // (OC) Add or remove space after the colon in immutable dictionary expression
@@ -2553,6 +2708,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_after_oc_dict_colon");
       return(options::sp_after_oc_dict_colon());
    }
+
    if (chunk_is_token(second, CT_OC_DICT_COLON))
    {
       // (OC) Add or remove space before the colon in immutable dictionary expression
@@ -2560,6 +2716,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_before_oc_dict_colon");
       return(options::sp_before_oc_dict_colon());
    }
+
    if (chunk_is_token(first, CT_OC_COLON))
    {
       if (first->flags & PCF_IN_OC_MSG)
@@ -2569,11 +2726,13 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_after_send_oc_colon");
          return(options::sp_after_send_oc_colon());
       }
+
       // (OC) Add or remove space after the colon in message specs,
       // i.e. '-(int) f:(int) x;' vs. '-(int) f: (int) x;'.
       log_rule("sp_after_oc_colon");
       return(options::sp_after_oc_colon());
    }
+
    if (chunk_is_token(second, CT_OC_COLON))
    {
       if (  (first->flags & PCF_IN_OC_MSG)
@@ -2584,6 +2743,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_before_send_oc_colon");
          return(options::sp_before_send_oc_colon());
       }
+
       // (OC) Add or remove space before the colon in message specs,
       // i.e. '-(int) f: (int) x;' vs. '-(int) f : (int) x;'.
       log_rule("sp_before_oc_colon");
@@ -2609,6 +2769,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_between_new_paren");
       return(options::sp_between_new_paren());
    }
+
    if (  chunk_is_token(first, CT_NEW)
       || chunk_is_token(first, CT_DELETE)
       || (chunk_is_token(first, CT_TSQUARE) && first->parent_type == CT_DELETE))
@@ -2712,7 +2873,9 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 } // do_space
 
 
-static iarf_e ensure_force_space(chunk_t *first, chunk_t *second, iarf_e av)
+static iarf_e ensure_force_space(chunk_t *first,
+                                 chunk_t *second,
+                                 iarf_e  av)
 {
    if (first->flags & PCF_FORCE_SPACE)
    {
@@ -2725,7 +2888,9 @@ static iarf_e ensure_force_space(chunk_t *first, chunk_t *second, iarf_e av)
 }
 
 
-static iarf_e do_space_ensured(chunk_t *first, chunk_t *second, int &min_sp)
+static iarf_e do_space_ensured(chunk_t *first,
+                               chunk_t *second,
+                               int     &min_sp)
 {
    return(ensure_force_space(first, second, do_space(first, second, min_sp)));
 }
@@ -2736,6 +2901,7 @@ void space_text(void)
    LOG_FUNC_ENTRY();
 
    chunk_t *pc = chunk_get_head();
+
    if (pc == nullptr)
    {
       return;
@@ -2744,6 +2910,7 @@ void space_text(void)
    chunk_t *next;
    size_t  prev_column;
    size_t  column = pc->column;
+
    while (pc != nullptr)
    {
       if (chunk_is_token(pc, CT_NEWLINE))
@@ -2756,6 +2923,7 @@ void space_text(void)
          LOG_FMT(LSPACE, "%s(%d): orig_line is %zu, orig_col is %zu, '%s' type is %s\n",
                  __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(), get_token_name(pc->type));
       }
+
       if (  (options::use_options_overriding_for_qt_macros())
          && (  (strcmp(pc->text(), "SIGNAL") == 0)
             || (strcmp(pc->text(), "SLOT") == 0)))
@@ -2767,11 +2935,13 @@ void space_text(void)
          // save the values
          save_set_options_for_QT(pc->level);
       }
+
       // Bug # 637
       // If true, vbrace tokens are dropped to the previous token and skipped.
       if (options::sp_skip_vbrace_tokens())
       {
          next = chunk_get_next(pc);
+
          while (  chunk_is_blank(next)
                && !chunk_is_newline(next)
                && (chunk_is_token(next, CT_VBRACE_OPEN) || chunk_is_token(next, CT_VBRACE_CLOSE)))
@@ -2787,10 +2957,12 @@ void space_text(void)
       {
          next = pc->next;
       }
+
       if (!next)
       {
          break;
       }
+
       // Issue # 481
       // Whether to balance spaces inside nested parentheses.
       if ((QT_SIGNAL_SLOT_found) && (options::sp_balance_nested_parens()))
@@ -2822,6 +2994,7 @@ void space_text(void)
          {
             column = pc->orig_col_end;
          }
+
          prev_column = column;
 
          /*
@@ -2832,6 +3005,7 @@ void space_text(void)
           * They are always safe to not have a space after them.
           */
          chunk_flags_clr(pc, PCF_FORCE_SPACE);
+
          if (  (pc->len() > 0)
             && !chunk_is_str(pc, "[]", 2)
             && !chunk_is_str(pc, "{{", 2)
@@ -2841,6 +3015,7 @@ void space_text(void)
          {
             // Find the next non-empty chunk on this line
             chunk_t *tmp = next;
+
             // TODO: better use chunk_search here
             while (  tmp != nullptr
                   && (tmp->len() == 0)
@@ -2848,10 +3023,12 @@ void space_text(void)
             {
                tmp = chunk_get_next(tmp);
             }
+
             if (tmp != nullptr && tmp->len() > 0)
             {
                bool kw1 = CharTable::IsKw2(pc->str[pc->len() - 1]);
                bool kw2 = CharTable::IsKw1(next->str[0]);
+
                if (kw1 && kw2)
                {
                   // back-to-back words need a space
@@ -2873,6 +3050,7 @@ void space_text(void)
 
                   const chunk_tag_t *ct;
                   ct = find_punctuator(buf, cpd.lang_flags);
+
                   if (ct != nullptr && (strlen(ct->tag) != pc->len()))
                   {
                      // punctuator parsed to a different size..
@@ -2911,6 +3089,7 @@ void space_text(void)
                  __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(), get_token_name(pc->type));
          iarf_e av = do_space_ensured(pc, next, min_sp);
          min_sp = max(1, min_sp);
+
          switch (av)
          {
          case IARF_FORCE:
@@ -2920,15 +3099,18 @@ void space_text(void)
          case IARF_ADD:
          {
             int delta = min_sp;
+
             if (next->orig_col >= pc->orig_col_end && pc->orig_col_end != 0)
             {
                // Keep the same relative spacing, minimum 1
                delta = next->orig_col - pc->orig_col_end;
+
                if (delta < min_sp)
                {
                   delta = min_sp;
                }
             }
+
             column += delta;
             break;
          }
@@ -2938,6 +3120,7 @@ void space_text(void)
             break;
 
          case IARF_IGNORE:
+
             // Keep the same relative spacing, if possible
             if (next->orig_col >= pc->orig_col_end && pc->orig_col_end != 0)
             {
@@ -2952,6 +3135,7 @@ void space_text(void)
                   column = next->orig_col;
                }
             }
+
             break;
 
          default:
@@ -2991,14 +3175,17 @@ void space_text(void)
                    */
                   size_t col_min = pc->column + pc->len() + ((next->orig_prev_sp > 0) ? 1 : 0);
                   column = next->orig_col;
+
                   if (column < col_min)
                   {
                      column = col_min;
                   }
+
                   LOG_FMT(LSPACE, "%s(%d): <relative set>", __func__, __LINE__);
                }
             }
          }
+
          next->column = column;
 
          LOG_FMT(LSPACE, " rule = %s @ %zu => %zu\n",
@@ -3006,6 +3193,7 @@ void space_text(void)
                  (av == IARF_ADD) ? "ADD" :
                  (av == IARF_REMOVE) ? "REMOVE" : "FORCE",
                  column - prev_column, next->column);
+
          if (restoreValues)    // guy 2015-09-22
          {
             restore_options_for_QT();
@@ -3013,6 +3201,7 @@ void space_text(void)
       }
 
       pc = next;
+
       if (QT_SIGNAL_SLOT_found)
       {
          // flag the chunk for a second processing
@@ -3027,9 +3216,11 @@ void space_text_balance_nested_parens(void)
    LOG_FUNC_ENTRY();
 
    chunk_t *first = chunk_get_head();
+
    while (first != nullptr)
    {
       chunk_t *next = chunk_get_next(first);
+
       if (next == nullptr)
       {
          break;
@@ -3043,6 +3234,7 @@ void space_text_balance_nested_parens(void)
 
          // test after the closing parens   Issue #1703
          chunk_t *closing = chunk_get_next_type(first, (c_token_t)(first->type + 1), first->level);
+
          if (closing->orig_col == closing->prev->orig_col_end)
          {
             space_add_after(closing->prev, 1);
@@ -3055,6 +3247,7 @@ void space_text_balance_nested_parens(void)
 
          // test after the opening parens   Issue #1703
          chunk_t *opening = chunk_get_prev_type(next, (c_token_t)(next->type - 1), next->level);
+
          if (opening->orig_col_end == opening->next->orig_col)
          {
             space_add_after(opening, 1);
@@ -3066,12 +3259,14 @@ void space_text_balance_nested_parens(void)
 } // space_text_balance_nested_parens
 
 
-size_t space_needed(chunk_t *first, chunk_t *second)
+size_t space_needed(chunk_t *first,
+                    chunk_t *second)
 {
    LOG_FUNC_ENTRY();
    LOG_FMT(LSPACE, "%s(%d)\n", __func__, __LINE__);
 
    int min_sp;
+
    switch (do_space_ensured(first, second, min_sp))
    {
    case IARF_ADD:
@@ -3088,7 +3283,8 @@ size_t space_needed(chunk_t *first, chunk_t *second)
 }
 
 
-size_t space_col_align(chunk_t *first, chunk_t *second)
+size_t space_col_align(chunk_t *first,
+                       chunk_t *second)
 {
    LOG_FUNC_ENTRY();
 
@@ -3107,6 +3303,7 @@ size_t space_col_align(chunk_t *first, chunk_t *second)
 
    LOG_FMT(LSPACE, "%s(%d): av is %s\n", __func__, __LINE__, to_string(av));
    size_t coldiff;
+
    if (first->nl_count)
    {
       LOG_FMT(LSPACE, "%s(%d):    nl_count is %zu, orig_col_end is %zu\n", __func__, __LINE__, first->nl_count, first->orig_col_end);
@@ -3117,12 +3314,14 @@ size_t space_col_align(chunk_t *first, chunk_t *second)
       LOG_FMT(LSPACE, "%s(%d):    len is %zu\n", __func__, __LINE__, first->len());
       coldiff = first->len();
    }
+
    LOG_FMT(LSPACE, "%s(%d):    => coldiff is %zu\n", __func__, __LINE__, coldiff);
 
    LOG_FMT(LSPACE, "%s(%d):    => av is %s\n", __func__, __LINE__,
            (av == IARF_IGNORE) ? "IGNORE" :
            (av == IARF_ADD) ? "ADD" :
            (av == IARF_REMOVE) ? "REMOVE" : "FORCE");
+
    switch (av)
    {
    case IARF_ADD:
@@ -3141,23 +3340,27 @@ size_t space_col_align(chunk_t *first, chunk_t *second)
       LOG_FMT(LSPACE, "%s(%d):    => first->orig_col   is %zu\n", __func__, __LINE__, first->orig_col);
       LOG_FMT(LSPACE, "%s(%d):    => second->orig_col  is %zu\n", __func__, __LINE__, second->orig_col);
       LOG_FMT(LSPACE, "%s(%d):    => first->len()      is %zu\n", __func__, __LINE__, first->len());
+
       if (  first->orig_line == second->orig_line
          && second->orig_col > (first->orig_col + first->len()))
       {
          coldiff++;
       }
+
       break;
 
    default:
       // If we got here, something is wrong...
       break;
    }
+
    LOG_FMT(LSPACE, "%s(%d):    => coldiff is %zu\n", __func__, __LINE__, coldiff);
    return(coldiff);
 } // space_col_align
 
 
-void space_add_after(chunk_t *pc, size_t count)
+void space_add_after(chunk_t *pc,
+                     size_t  count)
 {
    LOG_FUNC_ENTRY();
 
@@ -3185,6 +3388,7 @@ void space_add_after(chunk_t *pc, size_t count)
             next->str.append(' ');
          }
       }
+
       return;
    }
 

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -38,13 +38,16 @@ static int getLogTextUtf8Len(unc_text::value_type &c0, size_t end);
 static int getLogTextUtf8Len(unc_text::value_type &c0, size_t start, size_t end);
 
 
-static int getLogTextUtf8Len(unc_text::value_type &c0, size_t start, size_t end)
+static int getLogTextUtf8Len(unc_text::value_type &c0,
+                             size_t               start,
+                             size_t               end)
 {
    size_t c1_idx = 0;
 
    for (size_t i = start; i < end; ++i)
    {
       auto ch = c0[i];
+
       if (ch == '\n')
       {
          ch = 0x2424;  // NL symbol
@@ -84,17 +87,20 @@ static int getLogTextUtf8Len(unc_text::value_type &c0, size_t start, size_t end)
                             + " - ch value too big, can't convert to utf8");
       }
    }
+
    return(c1_idx);
 } // getLogTextUTF8Len
 
 
-static int getLogTextUtf8Len(unc_text::value_type &c0, size_t end)
+static int getLogTextUtf8Len(unc_text::value_type &c0,
+                             size_t               end)
 {
    return(getLogTextUtf8Len(c0, 0, end));
 }
 
 
-static void toLogTextUtf8(int c, unc_text::log_type &container)
+static void toLogTextUtf8(int                c,
+                          unc_text::log_type &container)
 {
    if (c == '\n')
    {
@@ -104,11 +110,14 @@ static void toLogTextUtf8(int c, unc_text::log_type &container)
    {
       c = 0x240d; // CR symbol
    }
+
    encode_utf8(c, container);
 }
 
 
-static size_t fix_len_idx(size_t size, size_t idx, size_t len)
+static size_t fix_len_idx(size_t size,
+                          size_t idx,
+                          size_t len)
 {
    if (idx >= size)
    {
@@ -132,7 +141,9 @@ unc_text::unc_text(const unc_text &ref)
 }
 
 
-unc_text::unc_text(const unc_text &ref, size_t idx, size_t len)
+unc_text::unc_text(const unc_text &ref,
+                   size_t         idx,
+                   size_t         len)
 {
    set(ref, idx, len);
 }
@@ -150,7 +161,9 @@ unc_text::unc_text(const std::string &ascii_text)
 }
 
 
-unc_text::unc_text(const value_type &data, size_t idx, size_t len)
+unc_text::unc_text(const value_type &data,
+                   size_t           idx,
+                   size_t           len)
 {
    set(data, idx, len);
 }
@@ -277,15 +290,20 @@ void unc_text::update_logtext()
    // make a pessimistic guess at the size
    m_logtext.clear();
    m_logtext.reserve(m_chars.size() * 3);
+
    for (int m_char : m_chars)
    {
       toLogTextUtf8(m_char, m_logtext);
    }
+
    m_logtext.push_back(0);
 }
 
 
-int unc_text::compare(const unc_text &ref1, const unc_text &ref2, size_t len, bool tcare)
+int unc_text::compare(const unc_text &ref1,
+                      const unc_text &ref2,
+                      size_t         len,
+                      bool           tcare)
 {
    const size_t len1    = ref1.size();
    const size_t len2    = ref2.size();
@@ -301,6 +319,7 @@ int unc_text::compare(const unc_text &ref1, const unc_text &ref2, size_t len, bo
       }
 
       int diff;                                             // Issue #2091
+
       if (tcare)
       {
          diff = ref1.m_chars[idx] - ref2.m_chars[idx];
@@ -309,6 +328,7 @@ int unc_text::compare(const unc_text &ref1, const unc_text &ref2, size_t len, bo
       {
          diff = unc_tolower(ref1.m_chars[idx]) - unc_tolower(ref2.m_chars[idx]);
       }
+
       if (diff == 0)
       {
          /*
@@ -349,6 +369,7 @@ bool unc_text::equals(const unc_text &ref) const
          return(false);
       }
    }
+
    return(true);
 }
 
@@ -378,7 +399,9 @@ void unc_text::set(const unc_text &ref)
 }
 
 
-void unc_text::set(const unc_text &ref, size_t idx, size_t len)
+void unc_text::set(const unc_text &ref,
+                   size_t         idx,
+                   size_t         len)
 {
    const auto ref_size = ref.size();
 
@@ -392,13 +415,13 @@ void unc_text::set(const unc_text &ref, size_t idx, size_t len)
    m_chars.resize(len);
 
    len = fix_len_idx(ref_size, idx, len);
+
    for (size_t di = 0;
         len > 0;
         di++, idx++, len--)
    {
       m_chars[di] = ref.m_chars[idx];
    }
-
 
    update_logtext();
 }
@@ -409,11 +432,11 @@ void unc_text::set(const string &ascii_text)
    const size_t len = ascii_text.size();
 
    m_chars.resize(len);
+
    for (size_t idx = 0; idx < len; idx++)
    {
       m_chars[idx] = ascii_text[idx];
    }
-
 
    update_logtext();
 }
@@ -424,28 +447,30 @@ void unc_text::set(const char *ascii_text)
    const size_t len = strlen(ascii_text);
 
    m_chars.resize(len);
+
    for (size_t idx = 0; idx < len; idx++)
    {
       m_chars[idx] = *ascii_text++;
    }
 
-
    update_logtext();
 }
 
 
-void unc_text::set(const value_type &data, size_t idx, size_t len)
+void unc_text::set(const value_type &data,
+                   size_t           idx,
+                   size_t           len)
 {
    m_chars.resize(len);
 
    len = fix_len_idx(data.size(), idx, len);
+
    for (size_t di = 0;
         len > 0;
         di++, idx++, len--)
    {
       m_chars[di] = data[idx];
    }
-
 
    update_logtext();
 }
@@ -477,7 +502,8 @@ void unc_text::clear()
 }
 
 
-void unc_text::insert(size_t idx, int ch)
+void unc_text::insert(size_t idx,
+                      int    ch)
 {
    if (idx >= m_chars.size())
    {
@@ -500,12 +526,14 @@ void unc_text::insert(size_t idx, int ch)
 }
 
 
-void unc_text::insert(size_t idx, const unc_text &ref)
+void unc_text::insert(size_t         idx,
+                      const unc_text &ref)
 {
    if (ref.size() == 0)
    {
       return;
    }
+
    if (idx >= m_chars.size())
    {
       throw out_of_range(string(__func__) + ":" + to_string(__LINE__)
@@ -529,6 +557,7 @@ void unc_text::insert(size_t idx, const unc_text &ref)
 void unc_text::append(int ch)
 {
    m_logtext.pop_back();
+
    if (ch < 0x80 && ch != '\n' && ch != '\r')
    {
       m_logtext.push_back(ch);
@@ -542,6 +571,7 @@ void unc_text::append(int ch)
       m_logtext.insert(std::end(m_logtext),
                        std::begin(utf8converted), std::end(utf8converted));
    }
+
    m_logtext.push_back('\0');
 
 
@@ -580,7 +610,9 @@ void unc_text::append(const char *ascii_text)
 }
 
 
-void unc_text::append(const value_type &data, size_t idx, size_t len)
+void unc_text::append(const value_type &data,
+                      size_t           idx,
+                      size_t           len)
 {
    unc_text tmp(data, idx, len);
 
@@ -588,7 +620,8 @@ void unc_text::append(const value_type &data, size_t idx, size_t len)
 }
 
 
-bool unc_text::startswith(const char *text, size_t idx) const
+bool unc_text::startswith(const char *text,
+                          size_t     idx) const
 {
    const auto orig_idx = idx;
 
@@ -604,7 +637,8 @@ bool unc_text::startswith(const char *text, size_t idx) const
 }
 
 
-bool unc_text::startswith(const unc_text &text, size_t idx) const
+bool unc_text::startswith(const unc_text &text,
+                          size_t         idx) const
 {
    size_t     si       = 0;
    const auto orig_idx = idx;
@@ -621,7 +655,8 @@ bool unc_text::startswith(const unc_text &text, size_t idx) const
 }
 
 
-int unc_text::find(const char *search_txt, size_t start_idx) const
+int unc_text::find(const char *search_txt,
+                   size_t     start_idx) const
 {
    const size_t t_len = strlen(search_txt); // the length of 'text' we are looking for
    const size_t s_len = size();             // the length of the string we are looking in
@@ -633,9 +668,11 @@ int unc_text::find(const char *search_txt, size_t start_idx) const
    }
 
    const size_t end_idx = s_len - t_len;
+
    for (size_t idx = start_idx; idx <= end_idx; idx++)
    {
       bool match = true;
+
       for (size_t ii = 0; ii < t_len; ii++)
       {
          if (m_chars[idx + ii] != search_txt[ii])
@@ -644,16 +681,19 @@ int unc_text::find(const char *search_txt, size_t start_idx) const
             break;
          }
       }
+
       if (match) // 'text' found at position 'idx'
       {
          return(idx);
       }
    }
+
    return(-1);  //  'text' not found
 }
 
 
-int unc_text::rfind(const char *search_txt, size_t start_idx) const
+int unc_text::rfind(const char *search_txt,
+                    size_t     start_idx) const
 {
    const size_t t_len = strlen(search_txt); // the length of 'text' we are looking for
    const size_t s_len = size();             // the length of the string we are looking in
@@ -674,6 +714,7 @@ int unc_text::rfind(const char *search_txt, size_t start_idx) const
    for (auto idx = static_cast<int>(start_idx); idx >= 0; idx--)
    {
       bool match = true;
+
       for (size_t ii = 0; ii < t_len; ii++)
       {
          if (m_chars[idx + ii] != search_txt[ii])
@@ -682,22 +723,27 @@ int unc_text::rfind(const char *search_txt, size_t start_idx) const
             break;
          }
       }
+
       if (match)
       {
          return(idx);
       }
    }
+
    return(-1);
 }
 
 
-void unc_text::erase(size_t start_idx, size_t len)
+void unc_text::erase(size_t start_idx,
+                     size_t len)
 {
    if (len == 0)
    {
       return;
    }
+
    const size_t end_idx = start_idx + len - 1;
+
    if (end_idx >= m_chars.size())
    {
       throw out_of_range(string(__func__) + ":" + to_string(__LINE__)
@@ -718,7 +764,8 @@ void unc_text::erase(size_t start_idx, size_t len)
 }
 
 
-int unc_text::replace(const char *search_text, const unc_text &replace_text)
+int unc_text::replace(const char     *search_text,
+                      const unc_text &replace_text)
 {
    const size_t s_len = strlen(search_text);
    const size_t r_len = replace_text.size();
@@ -737,5 +784,6 @@ int unc_text::replace(const char *search_text, const unc_text &replace_text)
 
       fidx = find(search_text, static_cast<size_t>(fidx) + r_len);
    }
+
    return(rcnt);
 }

--- a/src/unc_tools.cpp
+++ b/src/unc_tools.cpp
@@ -39,20 +39,26 @@ static size_t tokenCounter;
 // log_pcf_flags(LSYS, pc->flags);
 // if partNumber is zero, all the tokens of the line are shown,
 // if partNumber is NOT zero, only the token with this partNumber is shown.
-void prot_the_line(const char *func_name, int theLine, unsigned int actual_line, size_t partNumber)
+void prot_the_line(const char   *func_name,
+                   int          theLine,
+                   unsigned int actual_line,
+                   size_t       partNumber)
 {
    counter++;
    tokenCounter = 0;
    LOG_FMT(LGUY, "Prot_the_line:(%s:%d)(%zu)\n", func_name, theLine, counter);
+
    for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = pc->next)
    {
       if (pc->orig_line == actual_line)
       {
          tokenCounter++;
+
          if (  partNumber == 0
             || partNumber == tokenCounter)
          {
             LOG_FMT(LGUY, " orig_line is %d, (%zu) ", actual_line, tokenCounter);
+
             if (chunk_is_token(pc, CT_VBRACE_OPEN))
             {
                LOG_FMT(LGUY, "<VBRACE_OPEN>, ");
@@ -81,8 +87,10 @@ void prot_the_line(const char *func_name, int theLine, unsigned int actual_line,
             {
                LOG_FMT(LGUY, "text() '%s', ", pc->text());
             }
+
             LOG_FMT(LGUY, " column is %zu, type is %s, parent_type is %s, orig_col is %zu,",
                     pc->column, get_token_name(pc->type), get_token_name(pc->parent_type), pc->orig_col);
+
             if (chunk_is_token(pc, CT_IGNORED))
             {
                LOG_FMT(LGUY, "\n");
@@ -95,6 +103,7 @@ void prot_the_line(const char *func_name, int theLine, unsigned int actual_line,
          }
       }
    }
+
    LOG_FMT(LGUY, "\n");
 } // prot_the_line
 
@@ -109,14 +118,18 @@ void prot_the_source(int theLine)
 
 // examples:
 //   examine_Data(__func__, __LINE__, n);
-void examine_Data(const char *func_name, int theLine, int what)
+void examine_Data(const char *func_name,
+                  int        theLine,
+                  int        what)
 {
    LOG_FMT(LGUY, "\n%s:", func_name);
 
    chunk_t *pc;
+
    switch (what)
    {
    case 1:
+
       for (pc = chunk_get_head(); pc != nullptr; pc = pc->next)
       {
          if (chunk_is_token(pc, CT_SQUARE_CLOSE) || chunk_is_token(pc, CT_TSQUARE))
@@ -126,10 +139,12 @@ void examine_Data(const char *func_name, int theLine, int what)
             LOG_FMT(LGUY, "%s, orig_col=%zu, orig_col_end=%zu\n", pc->text(), pc->orig_col, pc->orig_col_end);
          }
       }
+
       break;
 
    case 2:
       LOG_FMT(LGUY, "2:(%d)\n", theLine);
+
       for (pc = chunk_get_head(); pc != nullptr; pc = pc->next)
       {
          if (pc->orig_line == 7)
@@ -144,10 +159,12 @@ void examine_Data(const char *func_name, int theLine, int what)
             }
          }
       }
+
       break;
 
    case 3:
       LOG_FMT(LGUY, "3:(%d)\n", theLine);
+
       for (pc = chunk_get_head(); pc != nullptr; pc = pc->next)
       {
          if (chunk_is_token(pc, CT_NEWLINE))
@@ -159,10 +176,12 @@ void examine_Data(const char *func_name, int theLine, int what)
             LOG_FMT(LGUY, "(%zu)%s %s, col=%zu, column=%zu\n", pc->orig_line, pc->text(), get_token_name(pc->type), pc->orig_col, pc->column);
          }
       }
+
       break;
 
    case 4:
       LOG_FMT(LGUY, "4:(%d)\n", theLine);
+
       for (pc = chunk_get_head(); pc != nullptr; pc = pc->next)
       {
          if (pc->orig_line == 6)
@@ -177,6 +196,7 @@ void examine_Data(const char *func_name, int theLine, int what)
             }
          }
       }
+
       break;
 
    default:
@@ -197,7 +217,9 @@ void dump_out(unsigned int type)
    {
       sprintf(dumpFileName, "%s.%u", cpd.dumped_file, type);
    }
+
    FILE *D_file = fopen(dumpFileName, "w");
+
    if (D_file != nullptr)
    {
       for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = pc->next)
@@ -207,47 +229,58 @@ void dump_out(unsigned int type)
          fprintf(D_file, "  orig_line %zu\n", pc->orig_line);
          fprintf(D_file, "  orig_col %zu\n", pc->orig_col);
          fprintf(D_file, "  orig_col_end %zu\n", pc->orig_col_end);
+
          if (pc->orig_prev_sp != 0)
          {
             fprintf(D_file, "  orig_prev_sp %u\n", pc->orig_prev_sp);
          }
+
          if (pc->flags != 0)
          {
             fprintf(D_file, "  flags %" PRIu64 "\n", pc->flags);
          }
+
          if (pc->column != 0)
          {
             fprintf(D_file, "  column %zu\n", pc->column);
          }
+
          if (pc->column_indent != 0)
          {
             fprintf(D_file, "  column_indent %zu\n", pc->column_indent);
          }
+
          if (pc->nl_count != 0)
          {
             fprintf(D_file, "  nl_count %zu\n", pc->nl_count);
          }
+
          if (pc->level != 0)
          {
             fprintf(D_file, "  level %zu\n", pc->level);
          }
+
          if (pc->brace_level != 0)
          {
             fprintf(D_file, "  brace_level %zu\n", pc->brace_level);
          }
+
          if (pc->pp_level != 0)
          {
             fprintf(D_file, "  pp_level %zu\n", pc->pp_level);
          }
+
          if (pc->after_tab != 0)
          {
             fprintf(D_file, "  after_tab %d\n", pc->after_tab);
          }
+
          if (pc->type != CT_NEWLINE)
          {
             fprintf(D_file, "  text %s\n", pc->text());
          }
       }
+
       fclose(D_file);
    }
 } // dump_out
@@ -268,18 +301,22 @@ void dump_in(unsigned int type)
    {
       sprintf(dumpFileName, "%s.%u", cpd.dumped_file, type);
    }
+
    FILE *D_file = fopen(dumpFileName, "r");
 
    if (D_file != nullptr)
    {
       unsigned int lineNumber = 0;
+
       while (fgets(buffer, sizeof(buffer), D_file) != nullptr)
       {
          ++lineNumber;
+
          if (aNewChunkIsFound)
          {
             // look for the next chunk
             char first = buffer[0];
+
             if (first == '[')
             {
                aNewChunkIsFound = false;
@@ -289,12 +326,14 @@ void dump_in(unsigned int type)
                aNewChunkIsFound = true;
                continue;
             }
+
             // the line as the form
             // part value
             // Split the line
 #define NUMBER_OF_PARTS    3
             char *parts[NUMBER_OF_PARTS];
             int partCount = Args::SplitLine(buffer, parts, NUMBER_OF_PARTS - 1);
+
             if (partCount != 2)
             {
                exit(EX_SOFTWARE);
@@ -351,6 +390,7 @@ void dump_in(unsigned int type)
          {
             // look for a new chunk
             char first = buffer[0];
+
             if (first == '[')
             {
                aNewChunkIsFound = true;

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -197,12 +197,14 @@ const char *path_basename(const char *path)
    while ((ch = *path) != 0) // check for end of string
    {
       path++;
+
       // Check both slash types to support Linux and Windows
       if ((ch == '/') || (ch == '\\'))
       {
          last_path = path;
       }
    }
+
    return(last_path);
 }
 
@@ -213,6 +215,7 @@ int path_dirname_len(const char *filename)
    {
       return(0);
    }
+
    // subtracting addresses like this works only on big endian systems
    return(static_cast<int>(path_basename(filename) - filename));
 }
@@ -225,6 +228,7 @@ void usage_error(const char *msg)
       fprintf(stderr, "%s\n", msg);
       log_flush(true);
    }
+
    fprintf(stderr, "Try running with -h for usage information\n");
    log_flush(true);
 }
@@ -329,6 +333,7 @@ NODISCARD static int redir_stdout(const char *output_file)
    if (output_file != nullptr)
    {
       my_stdout = freopen(output_file, "wb", stdout);
+
       if (my_stdout == nullptr)
       {
          LOG_FMT(LERR, "Unable to open %s for write: %s (%d)\n",
@@ -337,8 +342,10 @@ NODISCARD static int redir_stdout(const char *output_file)
          usage_error();
          return(EX_IOERR);
       }
+
       LOG_FMT(LNOTE, "Redirecting output to %s\n", output_file);
    }
+
    return(EXIT_SUCCESS);
 }
 
@@ -393,7 +400,8 @@ void setup_crash_handling()
 #endif
 
 
-int main(int argc, char *argv[])
+int main(int  argc,
+         char *argv[])
 {
    // initialize the global data
    cpd.unc_off_used = false;
@@ -418,6 +426,7 @@ int main(int argc, char *argv[])
 #ifdef DEBUG
    // make sure we have 'name' not too big
 #define MAXLENGTHOFTHENAME    19
+
    // maxLengthOfTheName must be consider at the format line at the file
    // output.cpp, line 427: fprintf(pfile, "# Line              Tag                Parent...
    // and              430: ... fprintf(pfile, "%s# %3zu>%19.19s[%19.19s] ...
@@ -425,6 +434,7 @@ int main(int argc, char *argv[])
    for (size_t token = 0; token < ARRAY_SIZE(token_names); token++)
    {
       size_t lengthOfTheName = strlen(token_names[token]);
+
       if (lengthOfTheName > MAXLENGTHOFTHENAME)
       {
          fprintf(stderr, "%s(%d): The token name '%s' is too long (%zu)\n",
@@ -441,10 +451,12 @@ int main(int argc, char *argv[])
 #endif // DEBUG
 
    Args arg(argc, argv);
+
    if (arg.Present("--version") || arg.Present("-v"))
    {
       version_exit();
    }
+
    if (  arg.Present("--help")
       || arg.Present("-h")
       || arg.Present("--usage")
@@ -471,6 +483,7 @@ int main(int argc, char *argv[])
    // Init logging
    log_init(cpd.do_check ? stdout : stderr);
    log_mask_t mask;
+
    if (arg.Present("-q"))
    {
       logmask_from_string("", mask);
@@ -478,26 +491,31 @@ int main(int argc, char *argv[])
    }
 
    const char *p_arg;
+
    if (  ((p_arg = arg.Param("-L")) != nullptr)
       || ((p_arg = arg.Param("--log")) != nullptr))
    {
       logmask_from_string(p_arg, mask);
       log_set_mask(mask);
    }
+
    cpd.frag = arg.Present("--frag");
 
    if (arg.Present("--decode"))
    {
       size_t idx = 1;
+
       while ((p_arg = arg.Unused(idx)) != nullptr)
       {
          log_pcf_flags(LSYS, strtoul(p_arg, nullptr, 16));
       }
+
       return(EXIT_SUCCESS);
    }
 
    // Get the config file name
    string cfg_file;
+
    if (  ((p_arg = arg.Param("--config")) != nullptr)
       || ((p_arg = arg.Param("-c")) != nullptr))
    {
@@ -528,6 +546,7 @@ int main(int argc, char *argv[])
 
    // Get the parsed file name
    const char *parsed_file;
+
    if (  ((parsed_file = arg.Param("--parsed")) != nullptr)
       || ((parsed_file = arg.Param("-p")) != nullptr))
    {
@@ -549,6 +568,7 @@ int main(int argc, char *argv[])
 
    // Load type files
    size_t idx = 0;
+
    while ((p_arg = arg.Params("-t", idx)) != nullptr)
    {
       load_keyword_file(p_arg);
@@ -556,6 +576,7 @@ int main(int argc, char *argv[])
 
    // add types
    idx = 0;
+
    while ((p_arg = arg.Params("--type", idx)) != nullptr)
    {
       add_keyword(p_arg, CT_TYPE);
@@ -565,6 +586,7 @@ int main(int argc, char *argv[])
    if ((p_arg = arg.Param("-l")) != nullptr)
    {
       cpd.lang_flags = language_flags_from_name(p_arg);
+
       if (cpd.lang_flags == 0)
       {
          LOG_FMT(LWARN, "Ignoring unknown language: %s\n", p_arg);
@@ -577,6 +599,7 @@ int main(int argc, char *argv[])
 
    // Get the source file name
    const char *source_file;
+
    if (  ((source_file = arg.Param("--file")) == nullptr)
       && ((source_file = arg.Param("-f")) == nullptr))
    {
@@ -585,6 +608,7 @@ int main(int argc, char *argv[])
 
    // Get a source file list
    const char *source_list;
+
    if (  ((source_list = arg.Param("--files")) == nullptr)
       && ((source_list = arg.Param("-F")) == nullptr))
    {
@@ -643,6 +667,7 @@ int main(int argc, char *argv[])
             usage_error("Cannot use --replace with --prefix or --suffix");
             return(EX_NOINPUT);
          }
+
          if (source_file != nullptr || output_file != nullptr)
          {
             usage_error("Cannot use --replace with -f or -o");
@@ -666,11 +691,13 @@ int main(int argc, char *argv[])
    if (!cfg_file.empty())
    {
       cpd.filename = cfg_file;
+
       if (!load_option_file(cpd.filename.c_str()))
       {
          usage_error("Unable to load the config file");
          return(EX_IOERR);
       }
+
       // test if all options are compatible to each other
       if (options::nl_max() > 0)
       {
@@ -686,6 +713,7 @@ int main(int argc, char *argv[])
 
    // Set config options using command line arguments.
    idx = 0;
+
    while ((p_arg = arg.Params("--set", idx)) != nullptr)
    {
       size_t argLength = strlen(p_arg);
@@ -696,6 +724,7 @@ int main(int argc, char *argv[])
          log_flush(true);
          exit(EX_SOFTWARE);
       }
+
       char buffer[MAXLENGTHFORARG];
       strcpy(buffer, p_arg);
 
@@ -739,6 +768,7 @@ int main(int argc, char *argv[])
       if (output_file != nullptr)
       {
          pfile = fopen(output_file, "w");
+
          if (pfile == nullptr)
          {
             fprintf(stderr, "Unable to open %s for write: %s (%d)\n",
@@ -787,6 +817,7 @@ int main(int argc, char *argv[])
       {
          return(error);
       }
+
       save_option_file(stdout, update_config_wd);
       return(EXIT_SUCCESS);
    }
@@ -798,6 +829,7 @@ int main(int argc, char *argv[])
       {
          return(error);
       }
+
       save_option_file(stdout, update_config_wd);
       return(EXIT_SUCCESS);
    }
@@ -868,6 +900,7 @@ int main(int argc, char *argv[])
       }
 
       file_mem fm;
+
       if (!read_stdin(fm))
       {
          LOG_FMT(LERR, "Failed to read stdin\n");
@@ -897,11 +930,13 @@ int main(int argc, char *argv[])
          log_flush(true);
          exit(EX_CONFIG);
       }
+
       // Doing multiple files, TODO: multiple threads for parallel processing
       if (prefix != nullptr)
       {
          LOG_FMT(LSYS, "Output prefix: %s/\n", prefix);
       }
+
       if (suffix != nullptr)
       {
          LOG_FMT(LSYS, "Output suffix: %s\n", suffix);
@@ -909,6 +944,7 @@ int main(int argc, char *argv[])
 
       // Do the files on the command line first
       idx = 1;
+
       while ((p_arg = arg.Unused(idx)) != nullptr)
       {
          char outbuf[1024];
@@ -929,6 +965,7 @@ int main(int argc, char *argv[])
    {
       return(EXIT_FAILURE);
    }
+
    if (cpd.do_check && cpd.check_fail_cnt != 0)
    {
       return(EXIT_FAILURE);
@@ -939,8 +976,10 @@ int main(int argc, char *argv[])
 
 
 static void process_source_list(const char *source_list,
-                                const char *prefix, const char *suffix,
-                                bool no_backup, bool keep_mtime)
+                                const char *prefix,
+                                const char *suffix,
+                                bool       no_backup,
+                                bool       keep_mtime)
 {
    int  from_stdin = strcmp(source_list, "-") == 0;
    FILE *p_file    = from_stdin ? stdin : fopen(source_list, "r");
@@ -961,16 +1000,20 @@ static void process_source_list(const char *source_list,
       line++;
       char *fname = linebuf;
       int  len    = strlen(fname);
+
       while (len > 0 && unc_isspace(*fname))
       {
          fname++;
          len--;
       }
+
       while (len > 0 && unc_isspace(fname[len - 1]))
       {
          len--;
       }
+
       fname[len] = 0;
+
       while (len-- > 0)
       {
          if (fname[len] == '\\')
@@ -1009,6 +1052,7 @@ static bool read_stdin(file_mem &fm)
    while (!feof(stdin))
    {
       int len = fread(buf, 1, sizeof(buf), stdin);
+
       for (int idx = 0; idx < len; idx++)
       {
          dq.push_back(buf[idx]);
@@ -1048,6 +1092,7 @@ static void make_folders(const string &filename)
          {
             int status;    // Coverity CID 75999
             status = mkdir(outname, 0750);
+
             if (status != 0 && errno != EEXIST)
             {
                LOG_FMT(LERR, "%s: Unable to create %s: %s (%d)\n",
@@ -1056,6 +1101,7 @@ static void make_folders(const string &filename)
                return;
             }
          }
+
          outname[idx] = PATH_SEP; // reconstruct full path to search for next subpath
       }
 
@@ -1067,7 +1113,8 @@ static void make_folders(const string &filename)
 } // make_folders
 
 
-static int load_mem_file(const char *filename, file_mem &fm)
+static int load_mem_file(const char *filename,
+                         file_mem   &fm)
 {
    int         retval = -1;
    struct stat my_stat;
@@ -1090,12 +1137,14 @@ static int load_mem_file(const char *filename, file_mem &fm)
 
    // Try to read in the file
    p_file = fopen(filename, "rb");
+
    if (p_file == nullptr)
    {
       return(-1);
    }
 
    fm.raw.resize(my_stat.st_size);
+
    if (my_stat.st_size == 0) // check if file is empty
    {
       retval = 0;
@@ -1129,12 +1178,14 @@ static int load_mem_file(const char *filename, file_mem &fm)
          retval = 0;
       }
    }
+
    fclose(p_file);
    return(retval);
 } // load_mem_file
 
 
-static int load_mem_file_config(const std::string &filename, file_mem &fm)
+static int load_mem_file_config(const std::string &filename,
+                                file_mem          &fm)
 {
    int  retval;
    char buf[1024];
@@ -1143,15 +1194,18 @@ static int load_mem_file_config(const std::string &filename, file_mem &fm)
             path_dirname_len(cpd.filename.c_str()), cpd.filename.c_str(), filename.c_str());
 
    retval = load_mem_file(buf, fm);
+
    if (retval < 0)
    {
       retval = load_mem_file(filename.c_str(), fm);
+
       if (retval < 0)
       {
          LOG_FMT(LERR, "Failed to load (%s) or (%s)\n", buf, filename.c_str());
          cpd.error_count++;
       }
    }
+
    return(retval);
 }
 
@@ -1166,31 +1220,37 @@ int load_header_files()
       retval |= load_mem_file_config(options::cmt_insert_file_header(),
                                      cpd.file_hdr);
    }
+
    if (!options::cmt_insert_file_footer().empty())
    {
       retval |= load_mem_file_config(options::cmt_insert_file_footer(),
                                      cpd.file_ftr);
    }
+
    if (!options::cmt_insert_func_header().empty())
    {
       retval |= load_mem_file_config(options::cmt_insert_func_header(),
                                      cpd.func_hdr);
    }
+
    if (!options::cmt_insert_class_header().empty())
    {
       retval |= load_mem_file_config(options::cmt_insert_class_header(),
                                      cpd.class_hdr);
    }
+
    if (!options::cmt_insert_oc_msg_header().empty())
    {
       retval |= load_mem_file_config(options::cmt_insert_oc_msg_header(),
                                      cpd.oc_msg_hdr);
    }
+
    return(retval);
 }
 
 
-static const char *make_output_filename(char *buf, size_t buf_size,
+static const char *make_output_filename(char       *buf,
+                                        size_t     buf_size,
                                         const char *filename,
                                         const char *prefix,
                                         const char *suffix)
@@ -1209,7 +1269,8 @@ static const char *make_output_filename(char *buf, size_t buf_size,
 }
 
 
-static bool file_content_matches(const string &filename1, const string &filename2)
+static bool file_content_matches(const string &filename1,
+                                 const string &filename2)
 {
    struct stat st1, st2;
    int         fd1, fd2;
@@ -1226,6 +1287,7 @@ static bool file_content_matches(const string &filename1, const string &filename
    {
       return(false);
    }
+
    if ((fd2 = open(filename2.c_str(), O_RDONLY)) < 0)
    {
       close(fd1);
@@ -1238,26 +1300,32 @@ static bool file_content_matches(const string &filename1, const string &filename
    UINT8 buf2[1024];
    memset(buf1, 0, sizeof(buf1));
    memset(buf2, 0, sizeof(buf2));
+
    while (len1 >= 0 && len2 >= 0)
    {
       if (len1 == 0)
       {
          len1 = read(fd1, buf1, sizeof(buf1));
       }
+
       if (len2 == 0)
       {
          len2 = read(fd2, buf2, sizeof(buf2));
       }
+
       if (len1 <= 0 || len2 <= 0)
       {
          break; // reached end of either files
          // TODO: what is if one file is longer than the other, do we miss that ?
       }
+
       int minlen = (len1 < len2) ? len1 : len2;
+
       if (memcmp(buf1, buf2, minlen) != 0)
       {
          break; // found a difference
       }
+
       len1 -= minlen;
       len2 -= minlen;
    }
@@ -1276,17 +1344,20 @@ static string fix_filename(const char *filename)
 
    // Create 'outfile.uncrustify'
    tmp_file = new char[strlen(filename) + 16 + 1]; // + 1 for '//  + 1 for '/* + 1 for '\0' */' '
+
    if (tmp_file != nullptr)
    {
       sprintf(tmp_file, "%s.uncrustify", filename);
    }
+
    rv = tmp_file;
    delete[] tmp_file;
    return(rv);
 }
 
 
-static bool bout_content_matches(const file_mem &fm, bool report_status)
+static bool bout_content_matches(const file_mem &fm,
+                                 bool           report_status)
 {
    bool is_same = true;
 
@@ -1300,6 +1371,7 @@ static bool bout_content_matches(const file_mem &fm, bool report_status)
                  static_cast<int>(cpd.bout->size()));
          log_flush(true);
       }
+
       is_same = false;
    }
    else
@@ -1314,11 +1386,13 @@ static bool bout_content_matches(const file_mem &fm, bool report_status)
                        cpd.filename.c_str(), idx);
                log_flush(true);
             }
+
             is_same = false;
             break;
          }
       }
    }
+
    if (is_same && report_status)
    {
       fprintf(stdout, "PASS: %s (%u bytes)\n",
@@ -1326,7 +1400,7 @@ static bool bout_content_matches(const file_mem &fm, bool report_status)
    }
 
    return(is_same);
-}
+} // bout_content_matches
 
 
 static void do_source_file(const char *filename_in,
@@ -1375,6 +1449,7 @@ static void do_source_file(const char *filename_in,
        * to write it to a file (if it changed).
        */
       uncrustify_file(fm, nullptr, parsed_file, true);
+
       if (bout_content_matches(fm, false))
       {
          uncrustify_end();
@@ -1392,6 +1467,7 @@ static void do_source_file(const char *filename_in,
       {
          // If the out file is the same as the in file, then use a temp file
          filename_tmp = filename_out;
+
          if (strcmp(filename_in, filename_out) == 0)
          {
             // Create 'outfile.uncrustify'
@@ -1406,12 +1482,15 @@ static void do_source_file(const char *filename_in,
                   cpd.error_count++;
                   return;
                }
+
                need_backup = true;
             }
          }
+
          make_folders(filename_tmp);
 
          pfout = fopen(filename_tmp.c_str(), "wb");
+
          if (pfout == nullptr)
          {
             LOG_FMT(LERR, "%s: Unable to create %s: %s (%d)\n",
@@ -1419,6 +1498,7 @@ static void do_source_file(const char *filename_in,
             cpd.error_count++;
             return;
          }
+
          did_open = true;
          //LOG_FMT(LSYS, "Output file %s\n", filename_out);
       }
@@ -1430,6 +1510,7 @@ static void do_source_file(const char *filename_in,
       {
          fputc(*i, pfout);
       }
+
       uncrustify_end();
    }
    else
@@ -1506,21 +1587,25 @@ static void add_file_footer()
    {
       pc = chunk_get_prev(pc);
    }
+
    if (  pc != nullptr
       && (!chunk_is_comment(pc) || !chunk_is_newline(chunk_get_prev(pc))))
    {
       pc = chunk_get_tail();
+
       if (!chunk_is_newline(pc))
       {
          LOG_FMT(LSYS, "Adding a newline at the end of the file\n");
          newline_add_after(pc);
       }
+
       tokenize(cpd.file_ftr.data, nullptr);
    }
 }
 
 
-static void add_func_header(c_token_t type, file_mem &fm)
+static void add_func_header(c_token_t type,
+                            file_mem  &fm)
 {
    chunk_t *pc;
    chunk_t *ref;
@@ -1533,6 +1618,7 @@ static void add_func_header(c_token_t type, file_mem &fm)
       {
          continue;
       }
+
       if (  (pc->flags & PCF_IN_CLASS)
          && !options::cmt_insert_before_inlines())
       {
@@ -1547,11 +1633,13 @@ static void add_func_header(c_token_t type, file_mem &fm)
          && ref->next)
       {
          ref = ref->next;
+
          if (  chunk_is_token(ref, CT_TYPE)
             && ref->parent_type == type
             && ref->next)
          {
             ref = ref->next;
+
             if (chunk_is_token(ref, CT_SEMICOLON) && ref->parent_type == CT_NONE)
             {
                continue;
@@ -1567,6 +1655,7 @@ static void add_func_header(c_token_t type, file_mem &fm)
          && ref->next)
       {
          int found_brace = 0;                                 // Set if a close brace is found before a newline
+
          while (ref->type != CT_NEWLINE && (ref = ref->next)) // TODO: is the assignment of ref wanted here?, better move it to the loop
          {
             if (chunk_is_token(ref, CT_BRACE_CLOSE))
@@ -1575,6 +1664,7 @@ static void add_func_header(c_token_t type, file_mem &fm)
                break;
             }
          }
+
          if (found_brace)
          {
             continue;
@@ -1588,6 +1678,7 @@ static void add_func_header(c_token_t type, file_mem &fm)
        * the same level
        */
       ref = pc;
+
       while ((ref = chunk_get_prev(ref)) != nullptr)
       {
          // Bail if we change level or find an access specifier colon
@@ -1608,9 +1699,11 @@ static void add_func_header(c_token_t type, file_mem &fm)
          if (ref->flags & PCF_IN_PREPROC)
          {
             tmp = chunk_get_prev_type(ref, CT_PREPROC, ref->level);
+
             if (tmp != nullptr && tmp->parent_type == CT_PP_IF)
             {
                tmp = chunk_get_prev_nnl(tmp);
+
                if (  chunk_is_comment(tmp)
                   && !options::cmt_insert_before_preproc())
                {
@@ -1634,11 +1727,13 @@ static void add_func_header(c_token_t type, file_mem &fm)
             break;
          }
       }
+
       if (do_insert)
       {
          // Insert between after and ref
          chunk_t *after = chunk_get_next_ncnl(ref);
          tokenize(fm.data, after);
+
          for (tmp = chunk_get_next(ref); tmp != after; tmp = chunk_get_next(tmp))
          {
             tmp->level = after->level;
@@ -1648,7 +1743,8 @@ static void add_func_header(c_token_t type, file_mem &fm)
 } // add_func_header
 
 
-static void add_msg_header(c_token_t type, file_mem &fm)
+static void add_msg_header(c_token_t type,
+                           file_mem  &fm)
 {
    chunk_t *pc;
    chunk_t *ref;
@@ -1669,6 +1765,7 @@ static void add_msg_header(c_token_t type, file_mem &fm)
        * the same level
        */
       ref = pc;
+
       while ((ref = chunk_get_prev(ref)) != nullptr)
       {
          // ignore the CT_TYPE token that is the result type
@@ -1689,9 +1786,11 @@ static void add_msg_header(c_token_t type, file_mem &fm)
          if (ref->flags & PCF_IN_PREPROC)
          {
             tmp = chunk_get_prev_type(ref, CT_PREPROC, ref->level);
+
             if (tmp != nullptr && tmp->parent_type == CT_PP_IF)
             {
                tmp = chunk_get_prev_nnl(tmp);
+
                if (  chunk_is_comment(tmp)
                   && !options::cmt_insert_before_preproc())
                {
@@ -1699,10 +1798,12 @@ static void add_msg_header(c_token_t type, file_mem &fm)
                }
             }
          }
+
          if (  ref->level == pc->level
             && ((ref->flags & PCF_IN_PREPROC) || chunk_is_token(ref, CT_OC_SCOPE)))
          {
             ref = chunk_get_prev(ref);
+
             if (ref != nullptr)
             {
                // Ignore 'right' comments
@@ -1710,8 +1811,10 @@ static void add_msg_header(c_token_t type, file_mem &fm)
                {
                   break;
                }
+
                do_insert = true;
             }
+
             break;
          }
       }
@@ -1721,6 +1824,7 @@ static void add_msg_header(c_token_t type, file_mem &fm)
          // Insert between after and ref
          chunk_t *after = chunk_get_next_ncnl(ref);
          tokenize(fm.data, after);
+
          for (tmp = chunk_get_next(ref); tmp != after; tmp = chunk_get_next(tmp))
          {
             tmp->level = after->level;
@@ -1791,20 +1895,25 @@ static void uncrustify_start(const deque<int> &data)
 } // uncrustify_start
 
 
-void uncrustify_file(const file_mem &fm, FILE *pfout,
-                     const char *parsed_file, bool defer_uncrustify_end)
+void uncrustify_file(const file_mem &fm,
+                     FILE           *pfout,
+                     const char     *parsed_file,
+                     bool           defer_uncrustify_end)
 {
    const deque<int> &data = fm.data;
 
    // Save off the encoding and whether a BOM is required
    cpd.bom = fm.bom;
    cpd.enc = fm.enc;
+
    if (  options::utf8_force()
       || ((cpd.enc == char_encoding_e::e_BYTE) && options::utf8_byte()))
    {
       cpd.enc = char_encoding_e::e_UTF8;
    }
+
    iarf_e av;
+
    switch (cpd.enc)
    {
    case char_encoding_e::e_UTF8:
@@ -1820,6 +1929,7 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
       av = IARF_IGNORE;
       break;
    }
+
    if (av == IARF_REMOVE)
    {
       cpd.bom = false;
@@ -1832,6 +1942,7 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
    // Check for embedded 0's (represents a decoding failure or corrupt file)
    size_t count_line   = 1;
    size_t count_column = 1;
+
    for (int idx = 0; idx < static_cast<int>(data.size()) - 1; idx++)
    {
       if (data[idx] == 0)
@@ -1845,6 +1956,7 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
       }
 
       count_column++;
+
       if (data[idx] == '\n')
       {
          count_line++;
@@ -1865,15 +1977,18 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
       if (!cpd.func_hdr.data.empty())
       {
          add_func_header(CT_FUNC_DEF, cpd.func_hdr);
+
          if (options::cmt_insert_before_ctor_dtor())
          {
             add_func_header(CT_FUNC_CLASS_DEF, cpd.func_hdr);
          }
       }
+
       if (!cpd.class_hdr.data.empty())
       {
          add_func_header(CT_CLASS, cpd.class_hdr);
       }
+
       if (!cpd.oc_msg_hdr.data.empty())
       {
          add_msg_header(CT_OC_MSG_DECL, cpd.oc_msg_hdr);
@@ -1904,7 +2019,9 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
       {
          newlines_remove_newlines();
       }
+
       cpd.pass_count = 3;
+
       do
       {
          old_changes = cpd.changes;
@@ -1915,51 +2032,64 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
          newlines_cleanup_dup();
          newlines_sparens();
          newlines_cleanup_braces(first);
+
          if (options::nl_after_multiline_comment())
          {
             newline_after_multiline_comment();
          }
+
          if (options::nl_after_label_colon())
          {
             newline_after_label_colon();
          }
+
          newlines_insert_blank_lines();
+
          if (options::pos_bool() != TP_IGNORE)
          {
             newlines_chunk_pos(CT_BOOL, options::pos_bool());
          }
+
          if (options::pos_compare() != TP_IGNORE)
          {
             newlines_chunk_pos(CT_COMPARE, options::pos_compare());
          }
+
          if (options::pos_conditional() != TP_IGNORE)
          {
             newlines_chunk_pos(CT_COND_COLON, options::pos_conditional());
             newlines_chunk_pos(CT_QUESTION, options::pos_conditional());
          }
+
          if (options::pos_comma() != TP_IGNORE || options::pos_enum_comma() != TP_IGNORE)
          {
             newlines_chunk_pos(CT_COMMA, options::pos_comma());
          }
+
          if (options::pos_assign() != TP_IGNORE)
          {
             newlines_chunk_pos(CT_ASSIGN, options::pos_assign());
          }
+
          if (options::pos_arith() != TP_IGNORE)
          {
             newlines_chunk_pos(CT_ARITH, options::pos_arith());
             newlines_chunk_pos(CT_CARET, options::pos_arith());
          }
+
          newlines_class_colon_pos(CT_CLASS_COLON);
          newlines_class_colon_pos(CT_CONSTR_COLON);
+
          if (options::nl_squeeze_ifdef())
          {
             newlines_squeeze_ifdef();
          }
+
          if (options::nl_squeeze_paren_close())
          {
             newlines_squeeze_paren_close();
          }
+
          do_blank_lines();
          newlines_eat_start_end();
          newlines_functions_remove_extra_blank_lines();
@@ -2020,16 +2150,19 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
 
       // Align everything else, reindent and break at code_width
       first = true;
+
       do
       {
          align_all();
          indent_text();
          old_changes = cpd.changes;
+
          if (options::code_width() > 0)
          {
             LOG_FMT(LNEWLINE, "%s(%d): Code_width loop start: %d\n",
                     __func__, __LINE__, cpd.changes);
             do_code_width();
+
             if (old_changes != cpd.changes && first)
             {
                // retry line breaks caused by splitting 1-liners
@@ -2042,6 +2175,7 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
 
       // And finally, align the backslash newline stuff
       align_right_comments();
+
       if (options::align_nl_cont())
       {
          align_backslash_newline();
@@ -2055,6 +2189,7 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
    if (parsed_file != nullptr)
    {
       FILE *p_file;
+
       if (parsed_file[0] == '-' && !parsed_file[1])
       {
          p_file = stdout;
@@ -2063,9 +2198,11 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
       {
          p_file = fopen(parsed_file, "wb");
       }
+
       if (p_file != nullptr)
       {
          output_parsed(p_file);
+
          if (p_file != stdout)
          {
             fclose(p_file);
@@ -2132,6 +2269,7 @@ const char *get_token_name(c_token_t token)
    {
       return(token_names[token]);
    }
+
    return("???");
 }
 
@@ -2148,11 +2286,14 @@ c_token_t find_token_name(const char *text)
          }
       }
    }
+
    return(CT_NONE);
 }
 
 
-static bool ends_with(const char *filename, const char *tag, bool case_sensitive = true)
+static bool ends_with(const char *filename,
+                      const char *tag,
+                      bool       case_sensitive = true)
 {
    int len1 = strlen(filename);
    int len2 = strlen(tag);
@@ -2196,6 +2337,7 @@ static size_t language_flags_from_name(const char *name)
          return(language.lang);
       }
    }
+
    return(0);
 }
 
@@ -2219,6 +2361,7 @@ const char *language_name_from_flags(size_t lang)
          return(language_name.name);
       }
    }
+
    return("???");
 }
 
@@ -2268,6 +2411,7 @@ const char *get_file_extension(int &idx)
    {
       val = language_exts[idx].ext;
    }
+
    idx++;
    return(val);
 }
@@ -2283,7 +2427,8 @@ typedef std::map<string, string> extension_map_t;
 static extension_map_t g_ext_map;
 
 
-const char *extension_add(const char *ext_text, const char *lang_text)
+const char *extension_add(const char *ext_text,
+                          const char *lang_text)
 {
    size_t lang_flags = language_flags_from_name(lang_text);
 
@@ -2293,6 +2438,7 @@ const char *extension_add(const char *ext_text, const char *lang_text)
       g_ext_map[string(ext_text)] = lang_name;
       return(lang_name);
    }
+
    return(nullptr);
 }
 
@@ -2302,6 +2448,7 @@ void print_extensions(FILE *pfile)
    for (auto &language : language_names)
    {
       bool did_one = false;
+
       for (auto &extension_val : g_ext_map)
       {
          if (strcmp(extension_val.second.c_str(), language.name) == 0)
@@ -2311,6 +2458,7 @@ void print_extensions(FILE *pfile)
                fprintf(pfile, "file_ext %s", extension_val.second.c_str());
                did_one = true;
             }
+
             fprintf(pfile, " %s", extension_val.first.c_str());
          }
       }
@@ -2351,6 +2499,7 @@ static size_t language_flags_from_filename(const char *filename)
          return(language_flags_from_name(extension_val.second.c_str()));
       }
    }
+
    for (auto &lanugage : language_exts)
    {
       if (ends_with(filename, lanugage.ext, false))
@@ -2358,11 +2507,13 @@ static size_t language_flags_from_filename(const char *filename)
          return(language_flags_from_name(lanugage.name));
       }
    }
+
    return(LANG_C);
 }
 
 
-void log_pcf_flags(log_sev_t sev, UINT64 flags)
+void log_pcf_flags(log_sev_t sev,
+                   UINT64    flags)
 {
    if (!log_sev_on(sev))
    {
@@ -2372,6 +2523,7 @@ void log_pcf_flags(log_sev_t sev, UINT64 flags)
    log_fmt(sev, "[0x%" PRIx64 ":", flags);
 
    const char *tolog = nullptr;
+
    for (size_t i = 0; i < ARRAY_SIZE(pcf_names); i++)
    {
       if (flags & (1ULL << i))
@@ -2381,6 +2533,7 @@ void log_pcf_flags(log_sev_t sev, UINT64 flags)
             log_str(sev, tolog, strlen(tolog));
             log_str(sev, ",", 1);
          }
+
          tolog = pcf_names[i];
       }
    }

--- a/src/uncrustify_emscripten.cpp
+++ b/src/uncrustify_emscripten.cpp
@@ -102,6 +102,7 @@ int load_option_fileChar(char *configString)
    while (true)
    {
       delimPos = strchr(delimPos, '\n');
+
       if (delimPos == nullptr)
       {
          break;
@@ -115,6 +116,7 @@ int load_option_fileChar(char *configString)
       delimPos++;
       subStringStart = delimPos;
    }
+
    //get last line, expectation: ends with \0
    process_option_line(subStringStart, "");
 
@@ -128,13 +130,15 @@ int load_option_fileChar(char *configString)
  * @param tag:  keyword that is going to be added
  * @param type: type of the keyword
  */
-void _add_keyword(string tag, c_token_t type)
+void _add_keyword(string    tag,
+                  c_token_t type)
 {
    if (tag.empty())
    {
       LOG_FMT(LERR, "%s: input string is empty\n", __func__);
       return;
    }
+
    add_keyword(tag.c_str(), type);
 }
 
@@ -152,13 +156,15 @@ void clear_keywords()
  * @param tag:   tag string
  * @param value: value of the define
  */
-void add_define(string tag, string val)
+void add_define(string tag,
+                string val)
 {
    if (tag.empty())
    {
       LOG_FMT(LERR, "%s: tag string is empty\n", __func__);
       return;
    }
+
    if (val.empty())
    {
       LOG_FMT(LERR, "%s: val string is empty\n", __func__);
@@ -181,6 +187,7 @@ void add_define(string tag)
       LOG_FMT(LERR, "%s: tag string is empty\n", __func__);
       return;
    }
+
    add_define(tag.c_str(), nullptr);
 }
 
@@ -232,13 +239,15 @@ void set_quiet()
  * @param value: value that is going to be set
  * @return options enum value of the found option or -1 if option was not found
  */
-int set_option(string name, string value)
+int set_option(string name,
+               string value)
 {
    if (name.empty())
    {
       LOG_FMT(LERR, "%s: name string is empty\n", __func__);
       return(-1);
    }
+
    if (value.empty())
    {
       LOG_FMT(LERR, "%s: value string is empty\n", __func__);
@@ -264,6 +273,7 @@ string get_option(string name)
    }
 
    const auto option = unc_find_option(name.c_str());
+
    if (option == nullptr)
    {
       LOG_FMT(LWARN, "Option %s not found\n", name.c_str());
@@ -291,7 +301,6 @@ string show_options()
       return("");
    }
 
-
    print_options(stream);
    fflush(stream);
    fclose(stream);
@@ -312,7 +321,8 @@ string show_options()
  *                          true=containing only options with non default values
  * @return returns the config file string based on the current configuration
  */
-string show_config(bool withDoc, bool only_not_default)
+string show_config(bool withDoc,
+                   bool only_not_default)
 {
    char   *buf;
    size_t len;
@@ -398,7 +408,6 @@ int _loadConfig(intptr_t _cfg)
    // memory management is done in /emscripten/postfix_module.js
    char *cfg = reinterpret_cast<char *>(_cfg);
 
-
    if (load_option_fileChar(cfg) != EXIT_SUCCESS)
    {
       LOG_FMT(LERR, "unable to load the config\n");
@@ -437,7 +446,10 @@ map<uncrustify_groups, group_map_value> getGroupMap()
  *
  * @return pointer to the formatted file char* string
  */
-intptr_t _uncrustify(intptr_t _file, lang_flag_e langIDX, bool frag, bool defer)
+intptr_t _uncrustify(intptr_t    _file,
+                     lang_flag_e langIDX,
+                     bool        frag,
+                     bool        defer)
 {
    // Problem: uncrustify originally is not a lib and uses global vars such as
    // cpd.error_count for the whole program execution
@@ -445,6 +457,7 @@ intptr_t _uncrustify(intptr_t _file, lang_flag_e langIDX, bool frag, bool defer)
    cpd.error_count = 0;
    cpd.filename    = "stdin";
    cpd.frag        = frag;
+
    if (langIDX == 0)   // 0 == undefined
    {
       LOG_FMT(LWARN, "language of input file not defined, C++ will be assumed\n");
@@ -466,6 +479,7 @@ intptr_t _uncrustify(intptr_t _file, lang_flag_e langIDX, bool frag, bool defer)
    fm.raw = vector<UINT8>();
 
    char c;
+
    for (auto idx = 0; (c = file[idx]) != 0; ++idx)
    {
       fm.raw.push_back(c);
@@ -492,6 +506,7 @@ intptr_t _uncrustify(intptr_t _file, lang_flag_e langIDX, bool frag, bool defer)
    // apparently emscripten has its own implementation, if that is not working
    // see: stackoverflow.com/questions/10305095#answer-10341073
    FILE *stream = open_memstream(&buf, &len);
+
    if (stream == nullptr)
    {
       LOG_FMT(LERR, "Failed to open_memstream\n");
@@ -526,6 +541,7 @@ intptr_t _uncrustify(intptr_t _file, lang_flag_e langIDX, bool frag, bool defer)
    {
       return(0);
    }
+
    // buf is deleted inside js code
    return(reinterpret_cast<intptr_t>(buf));
 } // uncrustify
@@ -540,7 +556,9 @@ intptr_t _uncrustify(intptr_t _file, lang_flag_e langIDX, bool frag, bool defer)
  *
  * @return pointer to the formatted file char* string
  */
-intptr_t _uncrustify(intptr_t file, lang_flag_e langIDX, bool frag)
+intptr_t _uncrustify(intptr_t    file,
+                     lang_flag_e langIDX,
+                     bool        frag)
 {
    return(_uncrustify(file, langIDX, frag, false));
 }
@@ -554,7 +572,8 @@ intptr_t _uncrustify(intptr_t file, lang_flag_e langIDX, bool frag)
  *
  * @return pointer to the formatted file char* string
  */
-intptr_t _uncrustify(intptr_t file, lang_flag_e langIDX)
+intptr_t _uncrustify(intptr_t    file,
+                     lang_flag_e langIDX)
 {
    return(_uncrustify(file, langIDX, false, false));
 }
@@ -569,7 +588,9 @@ intptr_t _uncrustify(intptr_t file, lang_flag_e langIDX)
  *
  * @return pointer to the debug file char* string
  */
-intptr_t _debug(intptr_t _file, lang_flag_e langIDX, bool frag)
+intptr_t _debug(intptr_t    _file,
+                lang_flag_e langIDX,
+                bool        frag)
 {
    auto formatted_str_ptr = _uncrustify(_file, langIDX, frag, true);
    char *formatted_str    = reinterpret_cast<char *>(formatted_str_ptr);
@@ -582,11 +603,13 @@ intptr_t _debug(intptr_t _file, lang_flag_e langIDX, bool frag)
    char   *buf    = nullptr;
    size_t len     = 0;
    FILE   *stream = open_memstream(&buf, &len);
+
    if (stream == nullptr)
    {
       LOG_FMT(LERR, "Failed to open_memstream\n");
       return(0);
    }
+
    output_parsed(stream);
    fflush(stream);
    fclose(stream);
@@ -612,7 +635,8 @@ intptr_t _debug(intptr_t _file, lang_flag_e langIDX, bool frag)
  *
  * @return pointer to the debug file char* string
  */
-intptr_t _debug(intptr_t _file, lang_flag_e langIDX)
+intptr_t _debug(intptr_t    _file,
+                lang_flag_e langIDX)
 {
    return(_debug(_file, langIDX, false));
 }

--- a/src/uncrustify_types.cpp
+++ b/src/uncrustify_types.cpp
@@ -49,6 +49,7 @@ const char *get_brace_stage_name(brace_stage_e brace_stage)
    case brace_stage_e::CATCH_WHEN:
       return("CATCH_WHEN");
    }
+
    return("?????");
 } // get_brace_stage_name
 
@@ -84,5 +85,6 @@ const char *get_unc_stage_name(unc_stage_e unc_stage)
    case unc_stage_e::CLEANUP:
       return("CLEANUP");
    }
+
    return("?????");
 } // get_unc_stage_name

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -310,8 +310,8 @@ enum lang_flag_e
    LANG_PAWN = 0x0080,
    LANG_ECMA = 0x0100,     //! ECMA Script (JavaScript)
 
-   LANG_ALLC = 0x017f,     /** LANG_C    | LANG_CPP | LANG_D    | LANG_CS   |
-                            *  LANG_JAVA | LANG_OC  | LANG_VALA | LANG_ECMA   */
+   LANG_ALLC = 0x017f,     //  LANG_C    | LANG_CPP | LANG_D    | LANG_CS   |
+                           //  LANG_JAVA | LANG_OC  | LANG_VALA | LANG_ECMA
    LANG_ALL  = 0x0fff,     //! applies to all languages
 
    FLAG_HDR  = 0x2000,     /*<< Header file for C family languages */
@@ -323,22 +323,22 @@ enum lang_flag_e
 enum class pattern_class_e : unsigned int
 {
    NONE,
-   BRACED,   /** keyword + braced statement:
-              *    do, try, finally, body, unittest, unsafe, volatile
-              *    add, get, remove, set                                      */
-   PBRACED,  /** keyword + parens + braced statement:
-              *    if, elseif, switch, for, while, synchronized,
-              *    using, lock, with, version, CT_D_SCOPE_IF                  */
-   OPBRACED, /** keyword + optional parens + braced statement:
-              *    catch, version, debug                                      */
-   VBRACED,  /** keyword + value + braced statement:
-              *    namespace                                                  */
-   PAREN,    /** keyword + parens:
-              *    while-of-do                                                */
-   OPPAREN,  /** keyword + optional parens:
-              *    invariant (D lang)                                         */
-   ELSE,     /** Special case of pattern_class_e::BRACED for handling CT_IF
-              *    else                                                       */
+   BRACED,   //  keyword + braced statement:
+             //    do, try, finally, body, unittest, unsafe, volatile
+             //    add, get, remove, set
+   PBRACED,  //  keyword + parens + braced statement:
+             //    if, elseif, switch, for, while, synchronized,
+             //    using, lock, with, version, CT_D_SCOPE_IF
+   OPBRACED, //  keyword + optional parens + braced statement:
+             //    catch, version, debug
+   VBRACED,  //  keyword + value + braced statement:
+             //    namespace
+   PAREN,    //  keyword + parens:
+             //    while-of-do
+   OPPAREN,  //  keyword + optional parens:
+             //    invariant (D lang)
+   ELSE,     //  Special case of pattern_class_e::BRACED for handling CT_IF
+             //    else
 };
 
 //! used to link language keywords with some addition information

--- a/src/universalindentgui.cpp
+++ b/src/universalindentgui.cpp
@@ -38,10 +38,12 @@ std::vector<uncrustify::OptionGroup *> get_option_groups()
 }
 
 
-void print_option_choices(FILE *pfile, uncrustify::GenericOption *option,
-                          char const *key = "Choices")
+void print_option_choices(FILE                      *pfile,
+                          uncrustify::GenericOption *option,
+                          char const                *key = "Choices")
 {
    fprintf(pfile, "%s=", key);
+
    for (auto c = option->possibleValues(); *c; ++c)
    {
       fprintf(pfile, "%s=%s%c", option->name(), *c, c[1] ? '|' : '\n');
@@ -62,21 +64,27 @@ void print_universal_indent_cfg(FILE *pfile)
    // first run to get the first option number of each group/categorie
    size_t optionNumber         = 0;
    bool   firstOptionNumberSet = false;
+
    for (idx = 0; idx < groups.size(); ++idx)
    {
       const auto *p_grp = groups[idx];
+
       for (auto *const option : p_grp->options)
       {
          UNUSED(option);
+
          if (!firstOptionNumberSet)
          {
             allGroups[idx]       = optionNumber;
             firstOptionNumberSet = true;
          }
+
          optionNumber++;
       } // for (auto *const option : p_grp->options)
+
       firstOptionNumberSet = false;
    } // end of first run
+
 //#else
 //   UNUSED(allGroups);
 #endif // DEBUG
@@ -94,6 +102,7 @@ void print_universal_indent_cfg(FILE *pfile)
 #if defined (DEBUG) && !defined (WIN32)
    optionNumber = 0;
 #endif // DEBUG
+
    for (auto *const g : groups)
    {
       fputc(ch, pfile);
@@ -102,13 +111,16 @@ void print_universal_indent_cfg(FILE *pfile)
 #if defined (DEBUG) && !defined (WIN32)
       fprintf(pfile, "(%zu)", allGroups[idx]);
 #endif // DEBUG
+
       // Write description, stripping leading and trailing newlines
       for (auto dc = g->description + 1; *(dc + 1); ++dc)
       {
          fputc(*dc, pfile);
       }
+
       idx++;
    }
+
    fprintf(pfile, "\n");
 
    fprintf(pfile,
@@ -120,11 +132,13 @@ void print_universal_indent_cfg(FILE *pfile)
    ch = '=';
    int fileIdx = 0;
    fprintf(pfile, "fileTypes");
+
    while ((p_name = get_file_extension(fileIdx)) != nullptr)
    {
       fprintf(pfile, "%c*%s", ch, p_name);
       ch = '|';
    }
+
    fprintf(pfile, "\n");
 
    // Add the rest of the constant file header
@@ -145,10 +159,12 @@ void print_universal_indent_cfg(FILE *pfile)
    fprintf(pfile, "version=%s\n", UNCRUSTIFY_VERSION);
 
    ch = '=';
+
    // Now add each option
    for (idx = 0; idx < groups.size(); ++idx)
    {
       const auto *p_grp = groups[idx];
+
       for (auto *const option : p_grp->options)
       {
          /*
@@ -159,6 +175,7 @@ void print_universal_indent_cfg(FILE *pfile)
          strcpy(optionNameReadable, option->name());
 
          bool was_space = true;
+
          for (char *character = optionNameReadable; *character != 0; character++)
          {
             if (*character == '_')
@@ -210,17 +227,18 @@ void print_universal_indent_cfg(FILE *pfile)
             default:
                fputc(*tmp, pfile);
             }
+
             tmp++;
          }
 
          const auto ds = option->defaultStr();
+
          if (!ds.empty())
          {
             fprintf(pfile, "<br/><br/>Default: %s", ds.c_str());
          }
 
          fprintf(pfile, "</html>\"\n");
-
 
          // Handle some options independent of their type and most by their type.
          if (option == &uncrustify::options::indent_with_tabs)
@@ -244,6 +262,7 @@ void print_universal_indent_cfg(FILE *pfile)
             // All not specially handled options are created only dependent by
             // their type.
             fprintf(pfile, "Enabled=false\n");
+
             switch (option->type())
             {
             case uncrustify::OT_BOOL:
@@ -346,6 +365,7 @@ void print_universal_indent_cfg(FILE *pfile)
                break;
             } // switch
          }
+
 #if defined (DEBUG) && !defined (WIN32)
          optionNumber++;
 #endif // DEBUG


### PR DESCRIPTION
If a **nl_xx IARF** option produces some changes with one of the possible values, it should be present in the file  _forUncrustifySources.cfg_.
If not, it should be present as comment at the end of the configuration file.