### PR TITLE
Fix parsing using alias in #define

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1952,6 +1952,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
    {
       // look for CT_ASSIGN before CT_SEMICOLON at the end of the statement
       bool    assign_found = false;
+      bool    is_preproc   = (pc->flags & PCF_IN_PREPROC);
       chunk_t *temp;
       for (temp = pc; temp != nullptr; temp = chunk_get_next_ncnl(temp))
       {
@@ -1962,7 +1963,10 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
             assign_found = true;
             break;
          }
-         if (chunk_is_token(temp, CT_SEMICOLON))
+         if (  chunk_is_token(temp, CT_SEMICOLON)
+            || (  is_preproc
+               && (  !(temp->flags & PCF_IN_PREPROC)
+                  || chunk_is_token(temp, CT_PREPROC))))
          {
             break;
          }
@@ -1976,7 +1980,10 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
             {
                set_chunk_parent(temp, CT_USING_ALIAS);
             }
-            if (chunk_is_token(temp, CT_SEMICOLON))
+            if (  chunk_is_token(temp, CT_SEMICOLON)
+               || (  is_preproc
+                  && (  !(temp->flags & PCF_IN_PREPROC)
+                     || chunk_is_token(temp, CT_PREPROC))))
             {
                break;
             }

--- a/src/enum_flags.h
+++ b/src/enum_flags.h
@@ -22,8 +22,7 @@
 
 #define UNC_DECLARE_OPERATORS_FOR_FLAGS(flag_type)                        \
    inline flag_type operator&(flag_type::enum_t f1, flag_type::enum_t f2) \
-   { return(flag_type { f1 }                                              \
-            &f2); }                                                       \
+   { return(flag_type{ f1 } & f2); }                                      \
    inline flag_type operator|(flag_type::enum_t f1, flag_type::enum_t f2) \
    { return(flag_type{ f1 } | f2); }                                      \
    inline flag_type operator|(flag_type::enum_t f1, flag_type f2)         \

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -395,6 +395,7 @@
 30971  Issue_2224.cfg                       cpp/Issue_2224.cpp
 30972  Issue_2229.cfg                       cpp/Issue_2229.cpp
 30973  Issue_2236.cfg                       cpp/Issue_2236.cpp
+30974  empty.cfg                            cpp/using-alias-in-define.cpp
 
 31000  empty.cfg                            cpp/digraph.cpp
 31001  ben_030.cfg                          cpp/digraph.cpp

--- a/tests/expected/cpp/30974-using-alias-in-define.cpp
+++ b/tests/expected/cpp/30974-using-alias-in-define.cpp
@@ -1,0 +1,6 @@
+#define UNC_DECLARE_FLAGS(flag_type, enum_type) \
+	using flag_type = flags<enum_type>
+
+#define UNC_DECLARE_OPERATORS_FOR_FLAGS(flag_type)                        \
+	inline flag_type operator&(flag_type::enum_t f1, flag_type::enum_t f2) \
+	{ return(flag_type { f1 } & f2); }

--- a/tests/input/cpp/using-alias-in-define.cpp
+++ b/tests/input/cpp/using-alias-in-define.cpp
@@ -1,0 +1,6 @@
+#define UNC_DECLARE_FLAGS(flag_type, enum_type) \
+   using flag_type = flags<enum_type>
+
+#define UNC_DECLARE_OPERATORS_FOR_FLAGS(flag_type)                        \
+   inline flag_type operator&(flag_type::enum_t f1, flag_type::enum_t f2) \
+   { return(flag_type { f1 } & f2); }


### PR DESCRIPTION
Fix parsing of C++11 `using` type aliases that appear in a `#define` to not mark stuff past the macro definition if said definition ends before the terminating semicolon of the type alias is found.

This fixes a formatting bug in our own [`enum_flags.h`](../tree/master/src/enum_flags.h).