### PR TITLE
Use enum flags type for token flags

### DIFF
--- a/src/ParseFrame.cpp
+++ b/src/ParseFrame.cpp
@@ -167,7 +167,7 @@ void ParseFrame::push(chunk_t *pc, brace_stage_e stage)
    new_entry.indent_cont = top().indent_cont;
    new_entry.stage       = stage;
 
-   new_entry.in_preproc = (pc->flags & PCF_IN_PREPROC);
+   new_entry.in_preproc = pc->flags.test(PCF_IN_PREPROC);
    new_entry.non_vardef = false;
    new_entry.ip         = top().ip;
 

--- a/src/align_assign.cpp
+++ b/src/align_assign.cpp
@@ -151,10 +151,10 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
          var_def_cnt = 0;
          equ_count   = 0;
       }
-      else if (  (pc->flags & PCF_VAR_DEF)
-              && !(pc->flags & PCF_IN_CONST_ARGS) // Issue #1717
-              && !(pc->flags & PCF_IN_FCN_DEF)    // Issue #1717
-              && !(pc->flags & PCF_IN_FCN_CALL))  // Issue #1717
+      else if (  pc->flags.test(PCF_VAR_DEF)
+              && !pc->flags.test(PCF_IN_CONST_ARGS) // Issue #1717
+              && !pc->flags.test(PCF_IN_FCN_DEF)    // Issue #1717
+              && !pc->flags.test(PCF_IN_FCN_CALL))  // Issue #1717
       {
          LOG_FMT(LALASS, "%s(%d): log_pcf_flags pc->flags:\n   ", __func__, __LINE__);
          log_pcf_flags(LALASS, pc->flags);
@@ -166,7 +166,7 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
          vdas.Reset();
       }
       else if (  equ_count == 0                      // indent only if first '=' in line
-              && (pc->flags & PCF_IN_TEMPLATE) == 0  // and it is not inside a template #999
+              && !pc->flags.test(PCF_IN_TEMPLATE)    // and it is not inside a template #999
               && (  chunk_is_token(pc, CT_ASSIGN)
                  || chunk_is_token(pc, CT_ASSIGN_DEFAULT_ARG)
                  || chunk_is_token(pc, CT_ASSIGN_FUNC_PROTO)))

--- a/src/align_func_params.cpp
+++ b/src/align_func_params.cpp
@@ -54,7 +54,7 @@ chunk_t *align_func_param(chunk_t *start)
       {
          break;
       }
-      else if (!did_this_line && (pc->flags & PCF_VAR_DEF))
+      else if (!did_this_line && pc->flags.test(PCF_VAR_DEF))
       {
          if (chunk_count > 1)
          {

--- a/src/align_func_proto.cpp
+++ b/src/align_func_proto.cpp
@@ -62,7 +62,7 @@ void align_func_proto(size_t span)
       }
       else if (  look_bro
               && chunk_is_token(pc, CT_BRACE_OPEN)
-              && (pc->flags & PCF_ONE_LINER))
+              && pc->flags.test(PCF_ONE_LINER))
       {
          as_br.Add(pc);
          look_bro = false;

--- a/src/align_left_shift.cpp
+++ b/src/align_left_shift.cpp
@@ -87,7 +87,7 @@ void align_left_shift(void)
             {
                indent_to_column(pc, pc->column_indent + options::indent_columns());
                pc->column_indent = pc->column;
-               pc->flags        |= PCF_DONT_INDENT;
+               chunk_flags_set(pc, PCF_DONT_INDENT);
             }
 
             // first one can be anywhere
@@ -114,7 +114,7 @@ void align_left_shift(void)
          {
             indent_to_column(pc, pc->column_indent + options::indent_columns());
             pc->column_indent = pc->column;
-            pc->flags        |= PCF_DONT_INDENT;
+            chunk_flags_set(pc, PCF_DONT_INDENT);
          }
       }
 

--- a/src/align_left_shift.cpp
+++ b/src/align_left_shift.cpp
@@ -65,7 +65,8 @@ void align_left_shift(void)
          as.Flush();
          start = nullptr;
       }
-      else if (  (!(pc->flags & PCF_IN_ENUM) && !(pc->flags & PCF_IN_TYPEDEF))
+      else if (  !pc->flags.test(PCF_IN_ENUM)
+              && !pc->flags.test(PCF_IN_TYPEDEF)
               && chunk_is_str(pc, "<<", 2))
       {
          if (pc->parent_type == CT_OPERATOR)

--- a/src/align_trailing_comments.cpp
+++ b/src/align_trailing_comments.cpp
@@ -66,7 +66,7 @@ chunk_t *align_trailing_comments(chunk_t *start)
    while (  pc != nullptr
          && (nl_count < options::align_right_cmt_span()))
    {
-      if ((pc->flags & PCF_RIGHT_COMMENT) && pc->column > 1)
+      if (pc->flags.test(PCF_RIGHT_COMMENT) && pc->column > 1)
       {
          if (same_level && pc->brace_level != lvl)
          {
@@ -197,7 +197,7 @@ void align_right_comments(void)
    chunk_t *pc = chunk_get_head();
    while (pc != nullptr)
    {
-      if (pc->flags & PCF_RIGHT_COMMENT)
+      if (pc->flags.test(PCF_RIGHT_COMMENT))
       {
          pc = align_trailing_comments(pc);
       }

--- a/src/align_typedefs.cpp
+++ b/src/align_typedefs.cpp
@@ -36,7 +36,7 @@ void align_typedefs(size_t span)
       }
       else if (c_typedef != nullptr)
       {
-         if (pc->flags & PCF_ANCHOR)
+         if (pc->flags.test(PCF_ANCHOR))
          {
             as.Add(pc);
             LOG_FMT(LALTD, "%s(%d): typedef @ %zu:%zu, tag '%s' @ %zu:%zu\n",

--- a/src/align_var_def_brace.cpp
+++ b/src/align_var_def_brace.cpp
@@ -63,11 +63,9 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
    LOG_FMT(LAVDB, "%s(%d): start->text() '%s', type is %s, on orig_line %zu\n",
            __func__, __LINE__, start->text(), get_token_name(start->type), start->orig_line);
 
-   UINT64 align_mask = PCF_IN_FCN_DEF | PCF_VAR_1ST;
-   if (!options::align_var_def_inline())
-   {
-      align_mask |= PCF_VAR_INLINE;
-   }
+   auto const align_mask =
+      PCF_IN_FCN_DEF | PCF_VAR_1ST |
+      (options::align_var_def_inline() ? PCF_NONE : PCF_VAR_INLINE);
 
    // Set up the variable/prototype/definition aligner
    AlignStack as;

--- a/src/align_var_def_brace.cpp
+++ b/src/align_var_def_brace.cpp
@@ -117,7 +117,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
          continue;
       }
 
-      if (fp_active && !(pc->flags & PCF_IN_CLASS_BASE))
+      if (fp_active && !pc->flags.test(PCF_IN_CLASS_BASE))
       {
          // WARNING: Duplicate from the align_func_proto()
          if (  chunk_is_token(pc, CT_FUNC_PROTO)
@@ -143,7 +143,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
          }
          else if (  fp_look_bro
                  && chunk_is_token(pc, CT_BRACE_OPEN)
-                 && (pc->flags & PCF_ONE_LINER))
+                 && pc->flags.test(PCF_ONE_LINER))
          {
             as_br.Add(pc);
             fp_look_bro = false;
@@ -213,7 +213,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
       }
 
       // If this is a variable def, update the max_col
-      if (  !(pc->flags & PCF_IN_CLASS_BASE)
+      if (  !pc->flags.test(PCF_IN_CLASS_BASE)
          && pc->type != CT_FUNC_CLASS_DEF
          && pc->type != CT_FUNC_CLASS_PROTO
          && ((pc->flags & align_mask) == PCF_VAR_1ST)

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -351,7 +351,7 @@ static void parse_cleanup(ParseFrame &frm, chunk_t *pc)
       && !chunk_is_str(pc, ")", 1)
       && !chunk_is_str(pc, "]", 1))
    {
-      chunk_flags_set(pc, PCF_EXPR_START | ((frm.stmt_count == 0) ? PCF_STMT_START : 0));
+      chunk_flags_set(pc, PCF_EXPR_START | ((frm.stmt_count == 0) ? PCF_STMT_START : PCF_NONE));
       LOG_FMT(LSTMT, "%s(%d): orig_line is %zu, 1.marked '%s' as %s, start stmt_count is %zu, expr_count is %zu\n",
               __func__, __LINE__, pc->orig_line, pc->text(),
               (pc->flags & PCF_STMT_START) ? "stmt" : "expr", frm.stmt_count,

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -958,7 +958,7 @@ static bool check_complex_statements(ParseFrame &frm, chunk_t *pc)
          frm.expr_count = 0;
          LOG_FMT(LTOK, "%s(%d): frm.stmt_count is %zu, frm.expr_count is %zu\n",
                  __func__, __LINE__, frm.stmt_count, frm.expr_count);
-         pc->flags     |= PCF_STMT_START | PCF_EXPR_START;
+         chunk_flags_set(pc, PCF_STMT_START | PCF_EXPR_START);
          frm.stmt_count = 1;
          frm.expr_count = 1;
          LOG_FMT(LSTMT, "%s(%d): orig_line is %zu, 2.marked '%s' as stmt start\n",

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -193,7 +193,7 @@ void brace_cleanup(void)
    while (pc != nullptr)
    {
       // Check for leaving a #define body
-      if (cpd.in_preproc != CT_NONE && (pc->flags & PCF_IN_PREPROC) == 0)
+      if (cpd.in_preproc != CT_NONE && !pc->flags.test(PCF_IN_PREPROC))
       {
          if (cpd.in_preproc == CT_PP_DEFINE)
          {
@@ -255,13 +255,13 @@ static bool maybe_while_of_do(chunk_t *pc)
    LOG_FUNC_ENTRY();
 
    chunk_t *prev = chunk_get_prev_ncnl(pc);
-   if (prev == nullptr || !(prev->flags & PCF_IN_PREPROC))
+   if (prev == nullptr || !prev->flags.test(PCF_IN_PREPROC))
    {
       return(false);
    }
 
    // Find the chunk before the preprocessor
-   while (prev != nullptr && (prev->flags & PCF_IN_PREPROC))
+   while (prev != nullptr && prev->flags.test(PCF_IN_PREPROC))
    {
       prev = chunk_get_prev_ncnl(prev);
    }
@@ -354,7 +354,7 @@ static void parse_cleanup(ParseFrame &frm, chunk_t *pc)
       chunk_flags_set(pc, PCF_EXPR_START | ((frm.stmt_count == 0) ? PCF_STMT_START : PCF_NONE));
       LOG_FMT(LSTMT, "%s(%d): orig_line is %zu, 1.marked '%s' as %s, start stmt_count is %zu, expr_count is %zu\n",
               __func__, __LINE__, pc->orig_line, pc->text(),
-              (pc->flags & PCF_STMT_START) ? "stmt" : "expr", frm.stmt_count,
+              pc->flags.test(PCF_STMT_START) ? "stmt" : "expr", frm.stmt_count,
               frm.expr_count);
    }
    frm.stmt_count++;
@@ -921,7 +921,7 @@ static bool check_complex_statements(ParseFrame &frm, chunk_t *pc)
    // Insert a CT_VBRACE_OPEN, if needed
    // but not in a preprocessor
    if (  pc->type != CT_BRACE_OPEN
-      && !(pc->flags & PCF_IN_PREPROC)
+      && !pc->flags.test(PCF_IN_PREPROC)
       && (  (frm.top().stage == brace_stage_e::BRACE2)
          || (frm.top().stage == brace_stage_e::BRACE_DO)))
    {
@@ -1180,7 +1180,7 @@ static chunk_t *insert_vbrace(chunk_t *pc, bool after, const ParseFrame &frm)
       return(nullptr);
    }
 
-   if ((ref->flags & PCF_IN_PREPROC) == 0)
+   if (!ref->flags.test(PCF_IN_PREPROC))
    {
       chunk.flags &= ~PCF_IN_PREPROC;
    }
@@ -1197,12 +1197,12 @@ static chunk_t *insert_vbrace(chunk_t *pc, bool after, const ParseFrame &frm)
    }
 
    // Don't back into a preprocessor
-   if (  (pc->flags & PCF_IN_PREPROC) == 0
-      && (ref->flags & PCF_IN_PREPROC) != 0)
+   if (  !pc->flags.test(PCF_IN_PREPROC)
+      && ref->flags.test(PCF_IN_PREPROC))
    {
       if (chunk_is_token(ref, CT_PREPROC_BODY))
       {
-         while (ref != nullptr && (ref->flags & PCF_IN_PREPROC))
+         while (ref != nullptr && ref->flags.test(PCF_IN_PREPROC))
          {
             ref = chunk_get_prev(ref);
          }

--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -247,7 +247,7 @@ static void examine_braces(void)
       auto prev = chunk_get_prev_type(pc, CT_BRACE_OPEN, -1);
 
       if (  chunk_is_token(pc, CT_BRACE_OPEN)
-         && ((pc->flags & PCF_IN_PREPROC) == 0)
+         && !pc->flags.test(PCF_IN_PREPROC)
          && (  (  (  pc->parent_type == CT_IF
                   || pc->parent_type == CT_ELSE
                   || pc->parent_type == CT_ELSEIF)
@@ -318,7 +318,7 @@ static bool can_remove_braces(chunk_t *bopen)
            __func__, __LINE__, bopen->orig_line);
 
    // Cannot remove braces inside a preprocessor
-   if (bopen->flags & PCF_IN_PREPROC)
+   if (bopen->flags.test(PCF_IN_PREPROC))
    {
       return(false);
    }
@@ -346,7 +346,7 @@ static bool can_remove_braces(chunk_t *bopen)
    {
       LOG_FMT(LBRDEL, "%s(%d): test token '%s', orig_line is %zu, orig_col is %zu\n",
               __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col);
-      if (pc->flags & PCF_IN_PREPROC)
+      if (pc->flags.test(PCF_IN_PREPROC))
       {
          // Cannot remove braces that contain a preprocessor
          return(false);
@@ -493,7 +493,7 @@ static void examine_brace(chunk_t *bopen)
          LOG_FMT(LBRDEL, "%s(%d): orig_line is %zu, orig_col is %zu, text() '%s'\n",
                  __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text());
       }
-      if (pc->flags & PCF_IN_PREPROC)
+      if (pc->flags.test(PCF_IN_PREPROC))
       {
          // Cannot remove braces that contain a preprocessor
          LOG_FMT(LBRDEL, "%s(%d):  PREPROC\n", __func__, __LINE__);
@@ -697,7 +697,7 @@ static void convert_brace(chunk_t *br)
 {
    LOG_FUNC_ENTRY();
    if (  br == nullptr
-      || (br->flags & PCF_KEEP_BRACE))
+      || br->flags.test(PCF_KEEP_BRACE))
    {
       return;
    }
@@ -732,7 +732,7 @@ static void convert_brace(chunk_t *br)
    {
       if (tmp->nl_count > 1)
       {
-         if ((br->flags & PCF_ONE_LINER) == 0) // Issue #2232
+         if (!br->flags.test(PCF_ONE_LINER)) // Issue #2232
          {
             if (tmp->nl_count == 0)
             {
@@ -838,7 +838,7 @@ static void convert_vbrace_to_brace(void)
          continue;
       }
 
-      bool in_preproc = (pc->flags & PCF_IN_PREPROC);
+      auto const in_preproc = pc->flags.test(PCF_IN_PREPROC);
 
       if (  (  (  pc->parent_type == CT_IF
                || pc->parent_type == CT_ELSE
@@ -861,7 +861,7 @@ static void convert_vbrace_to_brace(void)
          chunk_t *tmp = pc;
          while ((tmp = chunk_get_next(tmp)) != nullptr)
          {
-            if (in_preproc && ((tmp->flags & PCF_IN_PREPROC) == 0))
+            if (in_preproc && !tmp->flags.test(PCF_IN_PREPROC))
             {
                // Can't leave a preprocessor
                break;
@@ -993,7 +993,7 @@ void add_long_closebrace_comment(void)
          cl_pc = pc;
       }
 
-      if (pc->type != CT_BRACE_OPEN || (pc->flags & PCF_IN_PREPROC))
+      if (pc->type != CT_BRACE_OPEN || pc->flags.test(PCF_IN_PREPROC))
       {
          continue;
       }
@@ -1159,7 +1159,7 @@ static chunk_t *mod_case_brace_remove(chunk_t *br_open)
         tmp_pc != br_close;
         tmp_pc = chunk_get_next_ncnl(tmp_pc, scope_e::PREPROC))
    {
-      if (tmp_pc->level == (br_open->level + 1) && (tmp_pc->flags & PCF_VAR_DEF))
+      if (tmp_pc->level == (br_open->level + 1) && tmp_pc->flags.test(PCF_VAR_DEF))
       {
          LOG_FMT(LMCB, "%s(%d):  - vardef on line %zu: '%s'\n",
                  __func__, __LINE__, tmp_pc->orig_line, pc->text());

--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -817,16 +817,21 @@ void set_chunk_parent_real(chunk_t *pc, c_token_t pt)
 }
 
 
-void chunk_flags_set_real(chunk_t *pc, UINT64 clr_bits, UINT64 set_bits)
+void chunk_flags_set_real(chunk_t *pc, pcf_flags_t clr_bits, pcf_flags_t set_bits)
 {
    if (pc != nullptr)
    {
       LOG_FUNC_ENTRY();
-      UINT64 nflags = (pc->flags & ~clr_bits) | set_bits;
+      auto const nflags = (pc->flags & ~clr_bits) | set_bits;
       if (pc->flags != nflags)
       {
-         LOG_FMT(LSETFLG, "%s(%d): %016" PRIx64 "^%016" PRIx64 "=%016" PRIx64 " orig_line is %zu, orig_col is %zu, text() '%s', type is %s, ",
-                 __func__, __LINE__, pc->flags, pc->flags ^ nflags, nflags,
+         LOG_FMT(LSETFLG,
+                 "%s(%d): %016llx^%016llx=%016llx "
+                 "orig_line is %zu, orig_col is %zu, text() '%s', type is %s, ",
+                 __func__, __LINE__,
+                 static_cast<pcf_flags_t::int_t>(pc->flags),
+                 static_cast<pcf_flags_t::int_t>(pc->flags ^ nflags),
+                 static_cast<pcf_flags_t::int_t>(nflags),
                  pc->orig_line, pc->orig_col, pc->text(),
                  get_token_name(pc->type));
          LOG_FMT(LSETFLG, "parent_type is %s",

--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -341,7 +341,7 @@ static chunk_t *chunk_search(chunk_t *cur, const check_t check_fct, const scope_
 
 static chunk_t *chunk_ppa_search(chunk_t *cur, const check_t check_fct, const bool cond)
 {
-   if (cur && !(cur->flags & PCF_IN_PREPROC))
+   if (cur && !cur->flags.test(PCF_IN_PREPROC))
    {
       // if not in preprocessor, do a regular search
       return(chunk_search(cur, check_fct, scope_e::ALL,
@@ -352,7 +352,7 @@ static chunk_t *chunk_ppa_search(chunk_t *cur, const check_t check_fct, const bo
 
    while (pc != nullptr && (pc = pc->next) != nullptr)
    {
-      if (!(pc->flags & PCF_IN_PREPROC))
+      if (!pc->flags.test(PCF_IN_PREPROC))
       {
          // Bail if we run off the end of the preprocessor directive, but
          // return the next token, NOT nullptr, because the caller may need to
@@ -394,17 +394,17 @@ chunk_t *chunk_get_next(chunk_t *cur, scope_e scope)
    {
       return(pc);
    }
-   if (cur->flags & PCF_IN_PREPROC)
+   if (cur->flags.test(PCF_IN_PREPROC))
    {
       // If in a preproc, return nullptr if trying to leave
-      if ((pc->flags & PCF_IN_PREPROC) == 0)
+      if (!pc->flags.test(PCF_IN_PREPROC))
       {
          return(nullptr);
       }
       return(pc);
    }
    // Not in a preproc, skip any preproc
-   while (pc != nullptr && (pc->flags & PCF_IN_PREPROC))
+   while (pc != nullptr && pc->flags.test(PCF_IN_PREPROC))
    {
       pc = g_cl.GetNext(pc);
    }
@@ -423,17 +423,17 @@ chunk_t *chunk_get_prev(chunk_t *cur, scope_e scope)
    {
       return(pc);
    }
-   if (cur->flags & PCF_IN_PREPROC)
+   if (cur->flags.test(PCF_IN_PREPROC))
    {
       // If in a preproc, return NULL if trying to leave
-      if ((pc->flags & PCF_IN_PREPROC) == 0)
+      if (!pc->flags.test(PCF_IN_PREPROC))
       {
          return(nullptr);
       }
       return(pc);
    }
    // Not in a preproc, skip any preproc
-   while (pc != nullptr && (pc->flags & PCF_IN_PREPROC))
+   while (pc != nullptr && pc->flags.test(PCF_IN_PREPROC))
    {
       pc = g_cl.GetPrev(pc);
    }

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -610,7 +610,7 @@ static inline bool chunk_is_balanced_square(chunk_t *pc)
 
 static inline bool chunk_is_preproc(chunk_t *pc)
 {
-   return(pc != nullptr && (pc->flags & PCF_IN_PREPROC));
+   return(pc != nullptr && pc->flags.test(PCF_IN_PREPROC));
 }
 
 
@@ -721,7 +721,7 @@ static inline bool chunk_is_addr(chunk_t *pc)
    {
       chunk_t *prev = chunk_get_prev(pc);
 
-      if (  (pc->flags & PCF_IN_TEMPLATE)
+      if (  pc->flags.test(PCF_IN_TEMPLATE)
          && (chunk_is_token(prev, CT_COMMA) || chunk_is_token(prev, CT_ANGLE_OPEN)))
       {
          return(false);

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -870,7 +870,7 @@ void set_chunk_parent_real(chunk_t *pc, c_token_t tt);
 } while (false)
 
 
-void chunk_flags_set_real(chunk_t *pc, UINT64 clr_bits, UINT64 set_bits);
+void chunk_flags_set_real(chunk_t *pc, pcf_flags_t clr_bits, pcf_flags_t set_bits);
 
 
 #define chunk_flags_upd(pc, cc, ss)    do {   \
@@ -880,12 +880,12 @@ void chunk_flags_set_real(chunk_t *pc, UINT64 clr_bits, UINT64 set_bits);
 
 #define chunk_flags_set(pc, ss)        do { \
       LOG_FUNC_CALL();                      \
-      chunk_flags_set_real((pc), 0, (ss));  \
+      chunk_flags_set_real((pc), {}, (ss)); \
 } while (false)
 
 #define chunk_flags_clr(pc, cc)        do { \
       LOG_FUNC_CALL();                      \
-      chunk_flags_set_real((pc), (cc), 0);  \
+      chunk_flags_set_real((pc), (cc), {}); \
 } while (false)
 
 

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2204,7 +2204,7 @@ void fix_symbols(void)
 
                if (chunk_is_token(tmp, CT_WORD))
                {
-                  tmp->flags |= PCF_STMT_START | PCF_EXPR_START;
+                  chunk_flags_set(tmp, PCF_STMT_START | PCF_EXPR_START);
                   break;
                }
 
@@ -2218,7 +2218,7 @@ void fix_symbols(void)
          chunk_t *tmp = skip_attribute_next(pc);
          if (chunk_is_token(tmp, CT_WORD))
          {
-            tmp->flags |= PCF_STMT_START | PCF_EXPR_START;
+            chunk_flags_set(tmp, PCF_STMT_START | PCF_EXPR_START);
          }
       }
 
@@ -4985,7 +4985,7 @@ static pcf_flags_t mark_where_chunk(chunk_t *pc, c_token_t parent_type, pcf_flag
 
    if (flags.test(PCF_IN_WHERE_SPEC))
    {
-      pc->flags |= PCF_IN_WHERE_SPEC;
+      chunk_flags_set(pc, PCF_IN_WHERE_SPEC);
    }
 
    return(flags);

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -261,7 +261,7 @@ static chunk_t *process_return(chunk_t *pc);
  * TODO: add doc cmt
  *
  */
-static UINT64 mark_where_chunk(chunk_t *pc, c_token_t parent_type, UINT64 flags);
+static pcf_flags_t mark_where_chunk(chunk_t *pc, c_token_t parent_type, pcf_flags_t flags);
 
 
 /**
@@ -386,7 +386,7 @@ static void handle_oc_available(chunk_t *pc);
  *
  * @return the chunk after the type
  */
-static chunk_t *handle_oc_md_type(chunk_t *paren_open, c_token_t ptype, UINT64 flags, bool &did_it);
+static chunk_t *handle_oc_md_type(chunk_t *paren_open, c_token_t ptype, pcf_flags_t flags, bool &did_it);
 
 /**
  * Process an C# [] thingy:
@@ -519,7 +519,7 @@ void make_type(chunk_t *pc)
 }
 
 
-void flag_series(chunk_t *start, chunk_t *end, UINT64 set_flags, UINT64 clr_flags, scope_e nav)
+void flag_series(chunk_t *start, chunk_t *end, pcf_flags_t set_flags, pcf_flags_t clr_flags, scope_e nav)
 {
    LOG_FUNC_ENTRY();
    while (start != nullptr && start != end)
@@ -836,7 +836,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       && prev->parent_type != CT_CS_PROPERTY
       && (chunk_is_token(pc, CT_GETSET) || chunk_is_token(pc, CT_GETSET_EMPTY)))
    {
-      flag_parens(prev, 0, CT_NONE, CT_GETSET, false);
+      flag_parens(prev, PCF_NONE, CT_NONE, CT_GETSET, false);
    }
 
    if (chunk_is_token(pc, CT_ASM))
@@ -1062,7 +1062,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
    {
       if (chunk_is_paren_open(next))
       {
-         tmp = flag_parens(next, 0, CT_NONE, CT_EXTERN, true);
+         tmp = flag_parens(next, PCF_NONE, CT_NONE, CT_EXTERN, true);
          if (chunk_is_token(tmp, CT_BRACE_OPEN))
          {
             set_paren_parent(tmp, CT_EXTERN);
@@ -1101,7 +1101,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
 
    if (chunk_is_token(pc, CT_SQUARE_CLOSE) && chunk_is_token(next, CT_PAREN_OPEN))
    {
-      flag_parens(next, 0, CT_FPAREN_OPEN, CT_NONE, false);
+      flag_parens(next, PCF_NONE, CT_FPAREN_OPEN, CT_NONE, false);
    }
 
    if (chunk_is_token(pc, CT_TYPE_CAST))
@@ -1269,7 +1269,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       {
          if (chunk_is_paren_open(tmp))
          {
-            tmp = flag_parens(tmp, 0, CT_FPAREN_OPEN, pc->type, false);
+            tmp = flag_parens(tmp, PCF_NONE, CT_FPAREN_OPEN, pc->type, false);
             if (tmp != nullptr)
             {
                if (chunk_is_token(tmp, CT_BRACE_OPEN))
@@ -1333,7 +1333,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
    {
       if (language_is_set(LANG_D))
       {
-         flag_parens(next, 0, CT_FPAREN_OPEN, CT_FUNC_CALL, false);
+         flag_parens(next, PCF_NONE, CT_FPAREN_OPEN, CT_FUNC_CALL, false);
       }
       else
       {
@@ -1603,7 +1603,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
    {
       if (chunk_is_token(next, CT_PAREN_OPEN))
       {
-         flag_parens(next, 0, CT_FPAREN_OPEN, pc->type, false);
+         flag_parens(next, PCF_NONE, CT_FPAREN_OPEN, pc->type, false);
       }
    }
 
@@ -2109,7 +2109,7 @@ void fix_symbols(void)
          chunk_t *next = chunk_get_next_ncnl(pc, scope_e::PREPROC);
          if (next != nullptr && chunk_is_token(next, CT_PAREN_OPEN))
          {
-            flag_parens(next, 0, CT_FPAREN_OPEN, CT_ATTRIBUTE, false);
+            flag_parens(next, PCF_NONE, CT_FPAREN_OPEN, CT_ATTRIBUTE, false);
          }
       }
    }
@@ -2561,7 +2561,7 @@ static bool mark_function_type(chunk_t *pc)
    }
    else if (chunk_is_token(aft, CT_BRACE_OPEN))
    {
-      flag_parens(aft, 0, CT_NONE, pt, false);
+      flag_parens(aft, PCF_NONE, CT_NONE, pt, false);
    }
 
    // Step backwards to the previous open paren and mark everything a
@@ -2603,7 +2603,7 @@ nogo_exit:
    {
       LOG_FMT(LFTYPE, "%s(%d): setting FUNC_CALL on orig_line is %zu, orig_col is %zu\n",
               __func__, __LINE__, tmp->orig_line, tmp->orig_col);
-      flag_parens(tmp, 0, CT_FPAREN_OPEN, CT_FUNC_CALL, false);
+      flag_parens(tmp, PCF_NONE, CT_FPAREN_OPEN, CT_FUNC_CALL, false);
    }
    return(false);
 } // mark_function_type
@@ -3127,10 +3127,10 @@ static void fix_type_cast(chunk_t *start)
 static void fix_enum_struct_union(chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *next;
-   chunk_t *prev        = nullptr;
-   size_t  flags        = PCF_VAR_1ST_DEF;
-   size_t  in_fcn_paren = pc->flags & PCF_IN_FCN_DEF;
+   chunk_t     *next;
+   chunk_t     *prev        = nullptr;
+   pcf_flags_t flags        = PCF_VAR_1ST_DEF;
+   auto const  in_fcn_paren = pc->flags & PCF_IN_FCN_DEF;
 
    // Make sure this wasn't a cast
    if (pc->parent_type == CT_C_CAST)
@@ -3339,7 +3339,7 @@ static void fix_typedef(chunk_t *start)
    if (  last_op != nullptr
       && !(language_is_set(LANG_OC) && last_op->parent_type == CT_ENUM))
    {
-      flag_parens(last_op, 0, CT_FPAREN_OPEN, CT_TYPEDEF, false);
+      flag_parens(last_op, PCF_NONE, CT_FPAREN_OPEN, CT_TYPEDEF, false);
       fix_fcn_def_params(last_op);
 
       the_type = chunk_get_prev_ncnlni(last_op, scope_e::PREPROC);   // Issue #2279
@@ -3786,8 +3786,8 @@ static chunk_t *mark_variable_definition(chunk_t *start)
       return(nullptr);
    }
 
-   chunk_t *pc   = start;
-   size_t  flags = PCF_VAR_1ST_DEF;
+   chunk_t     *pc   = start;
+   pcf_flags_t flags = PCF_VAR_1ST_DEF;
 
    LOG_FMT(LVARDEF, "%s(%d): orig_line %zu, orig_col %zu, text() '%s', type is %s\n",
            __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(),
@@ -3799,7 +3799,7 @@ static chunk_t *mark_variable_definition(chunk_t *start)
    {
       if (chunk_is_token(pc, CT_WORD) || chunk_is_token(pc, CT_FUNC_CTOR_VAR))
       {
-         UINT64 flg = pc->flags;
+         auto const orig_flags = pc->flags;
          if ((pc->flags & PCF_IN_ENUM) == 0)
          {
             chunk_flags_set(pc, flags);
@@ -3808,9 +3808,13 @@ static chunk_t *mark_variable_definition(chunk_t *start)
          LOG_FMT(LVARDEF, "%s(%d): orig_line is %zu, orig_col is %zu, text() '%s', set PCF_VAR_1ST\n",
                  __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text());
 
-         LOG_FMT(LVARDEF, "%s(%d): orig_line is %zu, marked text() '%s'[%s] in orig_col %zu, flags: %#" PRIx64 " -> %#" PRIx64 "\n",
+         LOG_FMT(LVARDEF,
+                 "%s(%d): orig_line is %zu, marked text() '%s'[%s] "
+                 "in orig_col %zu, flags: %#llx -> %#llx\n",
                  __func__, __LINE__, pc->orig_line, pc->text(),
-                 get_token_name(pc->type), pc->orig_col, flg, pc->flags);
+                 get_token_name(pc->type), pc->orig_col,
+                 static_cast<pcf_flags_t::int_t>(orig_flags),
+                 static_cast<pcf_flags_t::int_t>(pc->flags));
       }
       else if (chunk_is_star(pc) || chunk_is_msref(pc))
       {
@@ -4146,7 +4150,7 @@ static void mark_function(chunk_t *pc)
       {
          return;
       }
-      flag_parens(next, 0, CT_FPAREN_OPEN, pc->type, true);
+      flag_parens(next, PCF_NONE, CT_FPAREN_OPEN, pc->type, true);
       return;
    }
 
@@ -4228,7 +4232,7 @@ static void mark_function(chunk_t *pc)
             LOG_FMT(LFCN, "%s(%d): orig_line is %zu, orig_col is %zu, function variable '%s', changing '%s' into a type\n",
                     __func__, __LINE__, pc->orig_line, pc->orig_col, tmp2->text(), pc->text());
             set_chunk_type(tmp2, CT_FUNC_VAR);
-            flag_parens(paren_open, 0, CT_PAREN_OPEN, CT_FUNC_VAR, false);
+            flag_parens(paren_open, PCF_NONE, CT_PAREN_OPEN, CT_FUNC_VAR, false);
 
             LOG_FMT(LFCN, "%s(%d): paren open @ orig_line %zu, orig_col %zu\n",
                     __func__, __LINE__, paren_open->orig_line, paren_open->orig_col);
@@ -4241,7 +4245,7 @@ static void mark_function(chunk_t *pc)
             {
                set_chunk_type(tmp2, CT_FUNC_TYPE);
             }
-            flag_parens(paren_open, 0, CT_PAREN_OPEN, CT_FUNC_TYPE, false);
+            flag_parens(paren_open, PCF_NONE, CT_PAREN_OPEN, CT_FUNC_TYPE, false);
          }
 
          set_chunk_type(pc, CT_TYPE);
@@ -4251,7 +4255,7 @@ static void mark_function(chunk_t *pc)
          {
             chunk_flags_set(tmp2, PCF_VAR_1ST_DEF);
          }
-         flag_parens(tmp, 0, CT_FPAREN_OPEN, CT_FUNC_PROTO, false);
+         flag_parens(tmp, PCF_NONE, CT_FPAREN_OPEN, CT_FUNC_PROTO, false);
          fix_fcn_def_params(tmp);
          return;
       }
@@ -4830,7 +4834,7 @@ static void mark_function(chunk_t *pc)
       && ((chunk_is_token(pc, CT_FUNC_DEF)) || (chunk_is_token(pc, CT_FUNC_PROTO))))
    {
       tmp = chunk_get_next_ncnl(paren_close);
-      int in_where_spec_flags = 0;
+      pcf_flags_t in_where_spec_flags = PCF_NONE;
       while (  (tmp != nullptr)
             && (tmp->type != CT_BRACE_OPEN) && (tmp->type != CT_SEMICOLON))
       {
@@ -4951,7 +4955,7 @@ static void mark_cpp_constructor(chunk_t *pc)
 } // mark_cpp_constructor
 
 
-static UINT64 mark_where_chunk(chunk_t *pc, c_token_t parent_type, UINT64 flags)
+static pcf_flags_t mark_where_chunk(chunk_t *pc, c_token_t parent_type, pcf_flags_t flags)
 {
    /* TODO: should have options to control spacing around the ':' as well as newline ability for the
     * constraint clauses (should it break up a 'where A : B where C : D' on the same line? wrap? etc.) */
@@ -5091,7 +5095,7 @@ static void mark_class_ctor(chunk_t *start)
    }
 
    // Find the open brace, abort on semicolon
-   size_t flags = 0;
+   pcf_flags_t flags = PCF_NONE;
    while (pc != nullptr && pc->type != CT_BRACE_OPEN)
    {
       LOG_FMT(LFTOR, " [%s]", pc->text());
@@ -6140,7 +6144,7 @@ static void handle_oc_block_type(chunk_t *pc)
 } // handle_oc_block_type
 
 
-static chunk_t *handle_oc_md_type(chunk_t *paren_open, c_token_t ptype, UINT64 flags, bool &did_it)
+static chunk_t *handle_oc_md_type(chunk_t *paren_open, c_token_t ptype, pcf_flags_t flags, bool &did_it)
 {
    chunk_t *paren_close;
 

--- a/src/combine.h
+++ b/src/combine.h
@@ -49,7 +49,7 @@ void mark_comments(void);
 void make_type(chunk_t *pc);
 
 
-void flag_series(chunk_t *start, chunk_t *end, UINT64 set_flags, UINT64 clr_flags = 0, scope_e nav = scope_e::ALL);
+void flag_series(chunk_t *start, chunk_t *end, pcf_flags_t set_flags, pcf_flags_t clr_flags = {}, scope_e nav = scope_e::ALL);
 
 
 /**

--- a/src/combine_labels.cpp
+++ b/src/combine_labels.cpp
@@ -96,7 +96,7 @@ void combine_labels(void)
                  __func__, __LINE__, next->orig_line, next->orig_col, next->text());
       }
 
-      if (  !(next->flags & PCF_IN_OC_MSG)  // filter OC case of [self class] msg send
+      if (  !next->flags.test(PCF_IN_OC_MSG) // filter OC case of [self class] msg send
          && (  chunk_is_token(next, CT_CLASS)
             || chunk_is_token(next, CT_OC_CLASS)
             || chunk_is_token(next, CT_TEMPLATE)))
@@ -126,7 +126,7 @@ void combine_labels(void)
          }
       }
 
-      if ((chunk_is_token(next, CT_QUESTION)) && ((next->flags & PCF_IN_TEMPLATE) == 0))
+      if (chunk_is_token(next, CT_QUESTION) && !next->flags.test(PCF_IN_TEMPLATE))
       {
          cs.Push_Back(next);
       }
@@ -171,7 +171,7 @@ void combine_labels(void)
                }
             }
          }
-         else if (cur->flags & PCF_IN_WHERE_SPEC)
+         else if (cur->flags.test(PCF_IN_WHERE_SPEC))
          {
             /* leave colons in where-constraint clauses alone */
          }
@@ -214,15 +214,15 @@ void combine_labels(void)
                   }
                }
             }
-            else if (next->flags & PCF_IN_ARRAY_ASSIGN)
+            else if (next->flags.test(PCF_IN_ARRAY_ASSIGN))
             {
                set_chunk_type(next, CT_D_ARRAY_COLON);
             }
-            else if (next->flags & PCF_IN_FOR)
+            else if (next->flags.test(PCF_IN_FOR))
             {
                set_chunk_type(next, CT_FOR_COLON);
             }
-            else if (next->flags & PCF_OC_BOXED)
+            else if (next->flags.test(PCF_OC_BOXED))
             {
                set_chunk_type(next, CT_OC_DICT_COLON);
             }
@@ -237,7 +237,7 @@ void combine_labels(void)
                LOG_FMT(LFCN, "%s(%d): orig_line is %zu, orig_col is %zu, tmp '%s': ",
                        __func__, __LINE__, tmp->orig_line, tmp->orig_col, (tmp->type == CT_NEWLINE) ? "<Newline>" : tmp->text());
                log_pcf_flags(LGUY, tmp->flags);
-               if (next->flags & PCF_IN_FCN_CALL)
+               if (next->flags.test(PCF_IN_FCN_CALL))
                {
                   // Must be a macro thingy, assume some sort of label
                   set_chunk_type(next, CT_LABEL_COLON);
@@ -247,7 +247,7 @@ void combine_labels(void)
                           && tmp->type != CT_DECLTYPE
                           && tmp->type != CT_SIZEOF
                           && tmp->parent_type != CT_SIZEOF
-                          && !(tmp->flags & (PCF_IN_STRUCT | PCF_IN_CLASS)))
+                          && !tmp->flags.test_any(PCF_IN_STRUCT | PCF_IN_CLASS))
                        || chunk_is_token(tmp, CT_NEWLINE))
                {
                   /*
@@ -277,7 +277,7 @@ void combine_labels(void)
                      set_chunk_type(next, CT_LABEL_COLON);
                   }
                }
-               else if (next->flags & (PCF_IN_STRUCT | PCF_IN_CLASS | PCF_IN_TYPEDEF))
+               else if (next->flags.test_any(PCF_IN_STRUCT | PCF_IN_CLASS | PCF_IN_TYPEDEF))
                {
                   set_chunk_type(next, CT_BIT_COLON);
 

--- a/src/detect.cpp
+++ b/src/detect.cpp
@@ -172,7 +172,7 @@ static void detect_space_options(void)
       }
       if (chunk_is_token(pc, CT_ASSIGN))
       {
-         if ((pc->flags & PCF_IN_ENUM) == 0)
+         if (!pc->flags.test(PCF_IN_ENUM))
          {
             vote_sp_before_assign.vote(prev, pc);
             vote_sp_after_assign.vote(pc, next);

--- a/src/enum_cleanup.cpp
+++ b/src/enum_cleanup.cpp
@@ -53,7 +53,7 @@ void enum_cleanup(void)
                comma.orig_line = prev->orig_line;
                comma.orig_col  = prev->orig_col + 1;
                comma.nl_count  = 0;
-               comma.flags     = 0;
+               comma.flags     = PCF_NONE;
                comma.type      = CT_COMMA;
                comma.str       = ",";
                chunk_add_after(&comma, prev);

--- a/src/enum_flags.h
+++ b/src/enum_flags.h
@@ -18,7 +18,7 @@
 #endif
 
 #define UNC_DECLARE_FLAGS(flag_type, enum_type) \
-   using flag_type = flags<enum_type>
+   using flag_type = ::uncrustify::flags<enum_type>
 
 #define UNC_DECLARE_OPERATORS_FOR_FLAGS(flag_type)                        \
    inline flag_type operator&(flag_type::enum_t f1, flag_type::enum_t f2) \

--- a/src/enum_flags.h
+++ b/src/enum_flags.h
@@ -9,6 +9,8 @@
 #ifndef ENUM_FLAGS_H_INCLUDED
 #define ENUM_FLAGS_H_INCLUDED
 
+#include <type_traits>
+
 #if __GNUC__ == 4 && !defined (__clang__)
 #pragma GCC diagnostic push
 #if __GNUC_MINOR__ < 9 || __GNUC_PATCHLEVEL__ < 2
@@ -37,53 +39,68 @@ template<typename Enum> class flags
 {
 public:
    using enum_t = Enum;
+   using int_t  = typename std::underlying_type<enum_t>::type;
+
+   template<typename T> using integral =
+      typename std::enable_if<std::is_integral<T>::value, bool>::type;
 
    inline flags() = default;
    inline flags(Enum flag)
-      : m_i{static_cast<int>(flag)} {}
+      : m_i{static_cast<int_t>(flag)} {}
 
-   inline flags &operator&=(int mask)
-   { m_i &= mask; return(*this); }
-   inline flags &operator&=(unsigned int mask)
-   { m_i &= mask; return(*this); }
+   inline bool operator==(Enum const &other)
+   { return(m_i == static_cast<int_t>(other)); }
+   inline bool operator==(flags const &other)
+   { return(m_i == other.m_i); }
+   inline bool operator!=(Enum const &other)
+   { return(m_i != static_cast<int_t>(other)); }
+   inline bool operator!=(flags const &other)
+   { return(m_i != other.m_i); }
+
+   template<typename T, integral<T> = true>
+   inline flags &operator&=(T mask)
+   { m_i &= static_cast<int_t>(mask); return(*this); }
 
    inline flags &operator|=(flags f)
-   { m_i |= f.i; return(*this); }
+   { m_i |= f.m_i; return(*this); }
    inline flags &operator|=(Enum f)
    { m_i |= f; return(*this); }
 
    inline flags &operator^=(flags f)
-   { m_i ^= f.i; return(*this); }
+   { m_i ^= f.m_i; return(*this); }
    inline flags &operator^=(Enum f)
    { m_i ^= f; return(*this); }
 
-   inline operator int() const { return(m_i); }
+   inline operator int_t() const { return(m_i); }
    inline operator enum_t() const { return(static_cast<enum_t>(m_i)); }
 
    inline flags operator&(Enum f) const
-   { flags g; g.m_i = m_i & static_cast<int>(f); return(g); }
-   inline flags operator&(int mask) const
-   { flags g; g.m_i = m_i & mask; return(g); }
-   inline flags operator&(unsigned int mask) const
-   { flags g; g.m_i = m_i & mask; return(g); }
+   { flags g; g.m_i = m_i & static_cast<int_t>(f); return(g); }
+   inline flags operator&(flags f) const
+   { flags g; g.m_i = m_i & static_cast<int_t>(f); return(g); }
+
+   template<typename T, integral<T> = true>
+   inline flags operator&(T mask) const
+   { flags g; g.m_i = m_i & static_cast<int_t>(mask); return(g); }
 
    inline flags operator|(flags f) const
    { flags g; g.m_i = m_i | f.m_i; return(g); }
    inline flags operator|(Enum f) const
-   { flags g; g.m_i = m_i | static_cast<int>(f); return(g); }
+   { flags g; g.m_i = m_i | static_cast<int_t>(f); return(g); }
 
    inline flags operator^(flags f) const
    { flags g; g.m_i = m_i ^ f.m_i; return(g); }
    inline flags operator^(Enum f) const
-   { flags g; g.m_i = m_i ^ static_cast<int>(f); return(g); }
+   { flags g; g.m_i = m_i ^ static_cast<int_t>(f); return(g); }
 
-   inline int operator~() const
+   inline int_t operator~() const
    { return(~m_i); }
 
+   inline operator bool() const { return(m_i); }
    inline bool operator!() const { return(!m_i); }
 
 protected:
-   int m_i = 0;
+   int_t m_i = 0;
 };
 
 } // namespace uncrustify

--- a/src/enum_flags.h
+++ b/src/enum_flags.h
@@ -99,6 +99,12 @@ public:
    inline operator bool() const { return(m_i); }
    inline bool operator!() const { return(!m_i); }
 
+   inline bool test(flags f) const { return((*this & f) == f); }
+   inline bool test(Enum f) const { return((*this & f) == f); }
+
+   inline bool test_any() const { return(m_i != 0); }
+   inline bool test_any(flags f) const { return((*this & f).test_any()); }
+
 protected:
    int_t m_i = 0;
 };

--- a/src/flag_parens.cpp
+++ b/src/flag_parens.cpp
@@ -9,7 +9,7 @@
 #include "uncrustify.h"
 
 
-chunk_t *flag_parens(chunk_t *po, UINT64 flags, c_token_t opentype, c_token_t parenttype, bool parent_all)
+chunk_t *flag_parens(chunk_t *po, pcf_flags_t flags, c_token_t opentype, c_token_t parenttype, bool parent_all)
 {
    LOG_FUNC_ENTRY();
    chunk_t *paren_close;
@@ -35,7 +35,7 @@ chunk_t *flag_parens(chunk_t *po, UINT64 flags, c_token_t opentype, c_token_t pa
    chunk_t *after_paren_close = chunk_get_next(paren_close);
    if (po != paren_close)
    {
-      if (  flags != 0
+      if (  flags != PCF_NONE
          || (parent_all && parenttype != CT_NONE))
       {
          chunk_t *pc;

--- a/src/flag_parens.h
+++ b/src/flag_parens.h
@@ -22,7 +22,7 @@
  *
  * @return The token after the close paren
  */
-chunk_t *flag_parens(chunk_t *po, UINT64 flags, c_token_t opentype, c_token_t parenttype, bool parent_all);
+chunk_t *flag_parens(chunk_t *po, pcf_flags_t flags, c_token_t opentype, c_token_t parenttype, bool parent_all);
 
 
 #endif /* FLAG_PARENS_H_INCLUDED */

--- a/src/frame_list.cpp
+++ b/src/frame_list.cpp
@@ -175,7 +175,7 @@ int fl_check(ParseFrame &frm, chunk_t *pc)
    const size_t    b4_cnt   = cpd.frames.size();
 
    const char      *txt = nullptr;
-   if (pc->flags & PCF_IN_PREPROC)
+   if (pc->flags.test(PCF_IN_PREPROC))
    {
       LOG_FMT(LPF, " <In> ");
       fl_log(LPF, frm);

--- a/src/lang_pawn.cpp
+++ b/src/lang_pawn.cpp
@@ -149,7 +149,7 @@ static bool pawn_continued(chunk_t *pc, size_t br_level)
       || pc->parent_type == CT_WHILE
       || pc->parent_type == CT_FUNC_DEF
       || pc->parent_type == CT_ENUM
-      || (pc->flags & (PCF_IN_ENUM | PCF_IN_STRUCT))
+      || pc->flags.test_any(PCF_IN_ENUM | PCF_IN_STRUCT)
       || chunk_is_str(pc, ":", 1)
       || chunk_is_str(pc, "+", 1)
       || chunk_is_str(pc, "-", 1))
@@ -300,8 +300,8 @@ void pawn_add_virtual_semicolons(void)
          }
 
          // we just hit a newline and we have a previous token
-         if (  ((prev->flags & PCF_IN_PREPROC) == 0)
-            && ((prev->flags & (PCF_IN_ENUM | PCF_IN_STRUCT)) == 0)
+         if (  !prev->flags.test(PCF_IN_PREPROC)
+            && !prev->flags.test_any(PCF_IN_ENUM | PCF_IN_STRUCT)
             && prev->type != CT_VSEMICOLON
             && prev->type != CT_SEMICOLON
             && !pawn_continued(prev, prev->brace_level))
@@ -415,7 +415,7 @@ static chunk_t *pawn_process_func_def(chunk_t *pc)
               __func__, pc->orig_line, pc->text(), get_token_name(last->type));
 
       // do not insert a vbrace before a preproc
-      if (last->flags & PCF_IN_PREPROC)
+      if (last->flags.test(PCF_IN_PREPROC))
       {
          return(last);
       }
@@ -487,7 +487,7 @@ chunk_t *pawn_check_vsemicolon(chunk_t *pc)
    chunk_t *prev = chunk_get_prev_ncnl(pc);
    if (  prev == nullptr
       || prev == vb_open
-      || (prev->flags & PCF_IN_PREPROC)
+      || prev->flags.test(PCF_IN_PREPROC)
       || pawn_continued(prev, vb_open->level + 1))
    {
       if (prev != nullptr)

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -583,11 +583,11 @@ static void newline_end_newline(chunk_t *br_close)
 }
 
 
-static void newline_min_after(chunk_t *ref, size_t count, UINT64 flag)
+static void newline_min_after(chunk_t *ref, size_t count, pcf_flag_e flag)
 {
    LOG_FUNC_ENTRY();
 
-   LOG_FMT(LNEWLINE, "%s(%d): '%s' line %zu - count=%zu flg=0x%" PRIx64 ":",
+   LOG_FMT(LNEWLINE, "%s(%d): '%s' line %zu - count=%zu flg=0x%llx:",
            __func__, __LINE__, ref->text(), ref->orig_line, count, flag);
    log_func_stack_inline(LNEWLINE);
 
@@ -722,8 +722,8 @@ void newline_del_between(chunk_t *start, chunk_t *end)
            __func__, __LINE__, start->text(), start->orig_line, start->orig_col);
    LOG_FMT(LNEWLINE, "%s(%d): and end->text() is '%s', orig_line is %zu, orig_col is %zu: preproc=%d/%d\n",
            __func__, __LINE__, end->text(), end->orig_line, end->orig_col,
-           ((start->flags & PCF_IN_PREPROC) != 0),
-           ((end->flags & PCF_IN_PREPROC) != 0));
+           static_cast<bool>(start->flags & PCF_IN_PREPROC),
+           static_cast<bool>(end->flags & PCF_IN_PREPROC));
    log_func_stack_inline(LNEWLINE);
 
    // Can't remove anything if the preproc status differs
@@ -2798,8 +2798,8 @@ static void newline_oc_msg(chunk_t *start)
    }
 
    // we don't use the 1-liner flag, but set it anyway
-   UINT64 flags = one_liner ? PCF_ONE_LINER : 0;
-   flag_series(start, sq_c, flags, flags ^ PCF_ONE_LINER);
+   auto const flags = one_liner ? PCF_ONE_LINER : PCF_NONE;
+   flag_series(start, sq_c, flags, PCF_ONE_LINER);
 
    if (options::nl_oc_msg_leave_one_liner() && one_liner)
    {
@@ -2823,9 +2823,9 @@ static void newline_oc_msg(chunk_t *start)
 static bool one_liner_nl_ok(chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
-   LOG_FMT(LNL1LINE, "%s(%d): check type is %s, parent is %s, flag is %" PRIx64 ", orig_line is %zu, orig_col is %zu\n",
+   LOG_FMT(LNL1LINE, "%s(%d): check type is %s, parent is %s, flag is %llx, orig_line is %zu, orig_col is %zu\n",
            __func__, __LINE__, get_token_name(pc->type), get_token_name(pc->parent_type),
-           pc->flags, pc->orig_line, pc->orig_col);
+           static_cast<pcf_flags_t::int_t>(pc->flags), pc->orig_line, pc->orig_col);
 
 
    if (!(pc->flags & PCF_ONE_LINER))

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -335,8 +335,7 @@ static bool can_increase_nl(chunk_t *nl)
          && next->parent_type == CT_PP_ENDIF
          && (next->level > 0 || options::nl_squeeze_ifdef_top_level()))
       {
-         bool rv = ifdef_over_whole_file()
-                   && (next->flags & PCF_WF_ENDIF);
+         bool rv = ifdef_over_whole_file() && next->flags.test(PCF_WF_ENDIF);
          LOG_FMT(LBLANKD, "%s(%d): nl_squeeze_ifdef %zu (next) pp_lvl=%zu rv=%d\n",
                  __func__, __LINE__, nl->orig_line, nl->pp_level, rv);
          return(rv);
@@ -444,12 +443,12 @@ static void setup_newline_add(chunk_t *prev, chunk_t *nl, chunk_t *next)
    nl->flags       = (prev->flags & PCF_COPY_FLAGS) & ~PCF_IN_PREPROC;
    nl->orig_col    = prev->orig_col_end;
    nl->column      = prev->orig_col;
-   if (  (prev->flags & PCF_IN_PREPROC)
-      && (next->flags & PCF_IN_PREPROC))
+   if (  prev->flags.test(PCF_IN_PREPROC)
+      && next->flags.test(PCF_IN_PREPROC))
    {
       chunk_flags_set(nl, PCF_IN_PREPROC);
    }
-   if (nl->flags & PCF_IN_PREPROC)
+   if (nl->flags.test(PCF_IN_PREPROC))
    {
       set_chunk_type(nl, CT_NL_CONT);
       nl->str = "\\\n";
@@ -559,13 +558,13 @@ static void newline_end_newline(chunk_t *br_close)
       nl.orig_col  = br_close->orig_col;
       nl.nl_count  = 1;
       nl.flags     = (br_close->flags & PCF_COPY_FLAGS) & ~PCF_IN_PREPROC;
-      if (  (br_close->flags & PCF_IN_PREPROC)
+      if (  br_close->flags.test(PCF_IN_PREPROC)
          && next != nullptr
-         && (next->flags & PCF_IN_PREPROC))
+         && next->flags.test(PCF_IN_PREPROC))
       {
          nl.flags |= PCF_IN_PREPROC;
       }
-      if (nl.flags & PCF_IN_PREPROC)
+      if (nl.flags.test(PCF_IN_PREPROC))
       {
          nl.type = CT_NL_CONT;
          nl.str  = "\\\n";
@@ -720,10 +719,10 @@ void newline_del_between(chunk_t *start, chunk_t *end)
 
    LOG_FMT(LNEWLINE, "%s(%d): start->text() is '%s', orig_line is %zu, orig_col is %zu\n",
            __func__, __LINE__, start->text(), start->orig_line, start->orig_col);
-   LOG_FMT(LNEWLINE, "%s(%d): and end->text() is '%s', orig_line is %zu, orig_col is %zu: preproc=%d/%d\n",
+   LOG_FMT(LNEWLINE, "%s(%d): and end->text() is '%s', orig_line is %zu, orig_col is %zu: preproc=%c/%c\n",
            __func__, __LINE__, end->text(), end->orig_line, end->orig_col,
-           static_cast<bool>(start->flags & PCF_IN_PREPROC),
-           static_cast<bool>(end->flags & PCF_IN_PREPROC));
+           start->flags.test(PCF_IN_PREPROC) ? 'y' : 'n',
+           end->flags.test(PCF_IN_PREPROC) ? 'y' : 'n');
    log_func_stack_inline(LNEWLINE);
 
    // Can't remove anything if the preproc status differs
@@ -833,7 +832,7 @@ static bool newlines_if_for_while_switch(chunk_t *start, iarf_e nl_opt)
    LOG_FUNC_ENTRY();
 
    if (  nl_opt == IARF_IGNORE
-      || (  (start->flags & PCF_IN_PREPROC)
+      || (  start->flags.test(PCF_IN_PREPROC)
          && !options::nl_define_macro()))
    {
       return(false);
@@ -899,7 +898,7 @@ static void newlines_if_for_while_switch_pre_blank_lines(chunk_t *start, iarf_e 
    LOG_FUNC_ENTRY();
 
    if (  nl_opt == IARF_IGNORE
-      || (  (start->flags & PCF_IN_PREPROC)
+      || (  start->flags.test(PCF_IN_PREPROC)
          && !options::nl_define_macro()))
    {
       return;
@@ -926,7 +925,7 @@ static void newlines_if_for_while_switch_pre_blank_lines(chunk_t *start, iarf_e 
          if (pc->nl_count > 1 || chunk_is_newline(chunk_get_prev_nvb(pc)))
          {
             // need to remove
-            if ((nl_opt & IARF_REMOVE) && ((pc->flags & PCF_VAR_DEF) == 0))
+            if ((nl_opt & IARF_REMOVE) && !pc->flags.test(PCF_VAR_DEF))
             {
                // if we're also adding, take care of that here
                size_t nl_count = do_add ? 2 : 1;
@@ -1274,7 +1273,7 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, iarf_e
    LOG_FMT(LNEWLINE, "%s(%d): start->text() is '%s', type is %s, orig_line is %zu, orig_column is %zu\n",
            __func__, __LINE__, start->text(), get_token_name(start->type), start->orig_line, start->orig_col);
    if (  nl_opt == IARF_IGNORE
-      || (  (start->flags & PCF_IN_PREPROC)
+      || (  start->flags.test(PCF_IN_PREPROC)
          && !options::nl_define_macro()))
    {
       return;
@@ -1367,7 +1366,7 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, iarf_e
          remove_next_newlines(pc);
       }
       else if (  (chunk_is_newline(next = chunk_get_next_nvb(pc)))
-              && !(next->flags & PCF_VAR_DEF))
+              && !next->flags.test(PCF_VAR_DEF))
       {
          // otherwise just deal with newlines after brace
          if (next->nl_count != 1)
@@ -1493,7 +1492,7 @@ static void newlines_struct_union(chunk_t *start, iarf_e nl_opt, bool leave_trai
    chunk_t *pc;
 
    if (  nl_opt == IARF_IGNORE
-      || (  (start->flags & PCF_IN_PREPROC)
+      || (  start->flags.test(PCF_IN_PREPROC)
          && !options::nl_define_macro()))
    {
       return;
@@ -1557,7 +1556,7 @@ static void newlines_enum(chunk_t *start)
    chunk_t *pcType2;
    iarf_e  nl_opt;
 
-   if ((start->flags & PCF_IN_PREPROC) && !options::nl_define_macro())
+   if (start->flags.test(PCF_IN_PREPROC) && !options::nl_define_macro())
    {
       return;
    }
@@ -1644,7 +1643,7 @@ static void newlines_namespace(chunk_t *start)
    // Add or remove newline between 'namespace' and '{'.
 
    if (  nl_opt == IARF_IGNORE
-      || (  (start->flags & PCF_IN_PREPROC)
+      || (  start->flags.test(PCF_IN_PREPROC)
          && !options::nl_define_macro()))
    {
       return;
@@ -1653,7 +1652,7 @@ static void newlines_namespace(chunk_t *start)
    LOG_FMT(LNEWLINE, "%s(%d): braceOpen->orig_line is %zu, orig_col is %zu, text() is '%s'\n",
            __func__, __LINE__, braceOpen->orig_line, braceOpen->orig_col, braceOpen->text());
    log_pcf_flags(LNEWLINE, braceOpen->flags);
-   if ((braceOpen->flags & PCF_ONE_LINER) != 0)
+   if (braceOpen->flags.test(PCF_ONE_LINER))
    {
       LOG_FMT(LNEWLINE, "%s(%d): is one_liner\n",
               __func__, __LINE__);
@@ -1673,7 +1672,7 @@ static void newlines_cuddle_uncuddle(chunk_t *start, iarf_e nl_opt)
    LOG_FUNC_ENTRY();
    chunk_t *br_close;
 
-   if ((start->flags & PCF_IN_PREPROC) && !options::nl_define_macro())
+   if (start->flags.test(PCF_IN_PREPROC) && !options::nl_define_macro())
    {
       return;
    }
@@ -1692,7 +1691,7 @@ static void newlines_do_else(chunk_t *start, iarf_e nl_opt)
    chunk_t *next;
 
    if (  nl_opt == IARF_IGNORE
-      || (  (start->flags & PCF_IN_PREPROC)
+      || (  start->flags.test(PCF_IN_PREPROC)
          && !options::nl_define_macro()))
    {
       return;
@@ -1986,7 +1985,7 @@ static void newlines_brace_pair(chunk_t *br_open)
 {
    LOG_FUNC_ENTRY();
 
-   if ((br_open->flags & PCF_IN_PREPROC) && !options::nl_define_macro())
+   if (br_open->flags.test(PCF_IN_PREPROC) && !options::nl_define_macro())
    {
       return;
    }
@@ -2201,7 +2200,7 @@ static void newlines_brace_pair(chunk_t *br_open)
       || br_open->parent_type == CT_CPP_LAMBDA)
    {
       // Need to force a newline before the close brace, if not in a class body
-      if ((br_open->flags & PCF_IN_CLASS) == 0)
+      if (!br_open->flags.test(PCF_IN_CLASS))
       {
          nl_close_brace = true;
       }
@@ -2412,7 +2411,7 @@ static void newline_iarf_pair(chunk_t *before, chunk_t *after, iarf_e av, bool c
    {
       if (  check_nl_assign_leave_one_liners
          && options::nl_assign_leave_one_liners()
-         && (after->flags & PCF_ONE_LINER))
+         && after->flags.test(PCF_ONE_LINER))
       {
          return;
       }
@@ -2634,7 +2633,7 @@ static void newline_func_def_or_call(chunk_t *start)
             iarf_e a = (is_proto) ?
                        options::nl_func_proto_type_name() :
                        options::nl_func_type_name();
-            if (  (tmp->flags & PCF_IN_CLASS)
+            if (  tmp->flags.test(PCF_IN_CLASS)
                && (options::nl_func_type_name_class() != IARF_IGNORE))
             {
                a = options::nl_func_type_name_class();
@@ -2828,7 +2827,7 @@ static bool one_liner_nl_ok(chunk_t *pc)
            static_cast<pcf_flags_t::int_t>(pc->flags), pc->orig_line, pc->orig_col);
 
 
-   if (!(pc->flags & PCF_ONE_LINER))
+   if (!pc->flags.test(PCF_ONE_LINER))
    {
       LOG_FMT(LNL1LINE, "%s(%d): true (not 1-liner), a new line may be added\n", __func__, __LINE__);
       return(true);
@@ -2845,7 +2844,7 @@ static bool one_liner_nl_ok(chunk_t *pc)
    else
    {
       while (  br_open
-            && (br_open->flags & PCF_ONE_LINER)
+            && br_open->flags.test(PCF_ONE_LINER)
             && !chunk_is_opening_brace(br_open)
             && !chunk_is_closing_brace(br_open))
       {
@@ -2853,15 +2852,15 @@ static bool one_liner_nl_ok(chunk_t *pc)
       }
    }
    pc = br_open;
-   if (  pc
-      && (pc->flags & PCF_ONE_LINER)
+   if (  pc != nullptr
+      && pc->flags.test(PCF_ONE_LINER)
       && (  chunk_is_token(pc, CT_BRACE_OPEN)
          || chunk_is_token(pc, CT_BRACE_CLOSE)
          || chunk_is_token(pc, CT_VBRACE_OPEN)
          || chunk_is_token(pc, CT_VBRACE_CLOSE)))
    {
       if (  options::nl_class_leave_one_liners()
-         && (pc->flags & PCF_IN_CLASS))
+         && pc->flags.test(PCF_IN_CLASS))
       {
          LOG_FMT(LNL1LINE, "%s(%d): false (class)\n", __func__, __LINE__);
          return(false);
@@ -2919,7 +2918,7 @@ static bool one_liner_nl_ok(chunk_t *pc)
       }
 
       if (  options::nl_oc_msg_leave_one_liner()
-         && (pc->flags & PCF_IN_OC_MSG))
+         && pc->flags.test(PCF_IN_OC_MSG))
       {
          LOG_FMT(LNL1LINE, "%s(%d): false (message)\n", __func__, __LINE__);
          return(false);
@@ -2957,7 +2956,7 @@ void undo_one_liner(chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
 
-   if (pc && (pc->flags & PCF_ONE_LINER))
+   if (pc != nullptr && pc->flags.test(PCF_ONE_LINER))
    {
       LOG_FMT(LNL1LINE, "%s(%d): pc->text() '%s', orig_line is %zu, orig_col is %zu",
               __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col);
@@ -2968,7 +2967,7 @@ void undo_one_liner(chunk_t *pc)
       chunk_t *tmp = pc;
       while ((tmp = chunk_get_prev(tmp)) != nullptr)
       {
-         if (!(tmp->flags & PCF_ONE_LINER))
+         if (!tmp->flags.test(PCF_ONE_LINER))
          {
             LOG_FMT(LNL1LINE, "%s(%d): tmp->text() '%s', orig_line is %zu, orig_col is %zu, --> break\n",
                     __func__, __LINE__, tmp->text(), tmp->orig_line, tmp->orig_col);
@@ -2985,7 +2984,7 @@ void undo_one_liner(chunk_t *pc)
       LOG_FMT(LNL1LINE, "%s(%d): - \n", __func__, __LINE__);
       while ((tmp = chunk_get_next(tmp)) != nullptr)
       {
-         if (!(tmp->flags & PCF_ONE_LINER))
+         if (!tmp->flags.test(PCF_ONE_LINER))
          {
             LOG_FMT(LNL1LINE, "%s(%d): tmp->text() '%s', orig_line is %zu, orig_col is %zu, --> break\n",
                     __func__, __LINE__, tmp->text(), tmp->orig_line, tmp->orig_col);
@@ -3048,7 +3047,7 @@ void newlines_remove_newlines(void)
    while (pc != nullptr)
    {
       // Remove all newlines not in preproc
-      if (!(pc->flags & PCF_IN_PREPROC))
+      if (!pc->flags.test(PCF_IN_PREPROC))
       {
          next = pc->next;
          prev = pc->prev;
@@ -3339,7 +3338,8 @@ void newlines_cleanup_braces(bool first)
                   LOG_FMT(LNL1LINE, "a new line may NOT be added\n");
                   // no change - preserve one liner body
                }
-               else if (pc->flags & (PCF_IN_ARRAY_ASSIGN | PCF_IN_PREPROC))
+               else if (  pc->flags.test(PCF_IN_ARRAY_ASSIGN)
+                       || pc->flags.test(PCF_IN_PREPROC))
                {
                   // no change - don't break up array assignments or preprocessors
                }
@@ -3444,7 +3444,7 @@ void newlines_cleanup_braces(bool first)
                     || pc->parent_type == CT_STRUCT
                     || pc->parent_type == CT_UNION))
          {
-            if ((pc->flags & PCF_ONE_LINER) == 0)
+            if (!pc->flags.test(PCF_ONE_LINER))
             {
                // Make sure the brace is preceded by two newlines
                prev = chunk_get_prev(pc);
@@ -3489,9 +3489,10 @@ void newlines_cleanup_braces(bool first)
                && next->type != CT_FPAREN_CLOSE
                && next->type != CT_PAREN_CLOSE
                && next->type != CT_WHILE_OF_DO
-               && next->type != CT_VBRACE_CLOSE                                    // Issue #666
-               && (next->type != CT_BRACE_CLOSE || !(next->flags & PCF_ONE_LINER)) // #1258
-               && (pc->flags & (PCF_IN_ARRAY_ASSIGN | PCF_IN_TYPEDEF)) == 0
+               && next->type != CT_VBRACE_CLOSE                                      // Issue #666
+               && (next->type != CT_BRACE_CLOSE || !next->flags.test(PCF_ONE_LINER)) // #1258
+               && !pc->flags.test(PCF_IN_ARRAY_ASSIGN)
+               && !pc->flags.test(PCF_IN_TYPEDEF)
                && !chunk_is_newline(next)
                && !chunk_is_comment(next))
             {
@@ -3557,7 +3558,7 @@ void newlines_cleanup_braces(bool first)
             || (  pc->parent_type == CT_WHILE
                && options::nl_split_while_one_liner()))
          {
-            if (pc->flags & PCF_ONE_LINER)
+            if (pc->flags.test(PCF_ONE_LINER))
             {
                // split one-liner
                chunk_t *end = chunk_get_next(chunk_get_next_type(pc->next, CT_SEMICOLON, -1));
@@ -3659,7 +3660,8 @@ void newlines_cleanup_braces(bool first)
       }
       else if (chunk_is_token(pc, CT_SEMICOLON))
       {
-         if (  ((pc->flags & (PCF_IN_SPAREN | PCF_IN_PREPROC)) == 0)
+         if (  !pc->flags.test(PCF_IN_SPAREN)
+            && !pc->flags.test(PCF_IN_PREPROC)
             && options::nl_after_semicolon())
          {
             next = chunk_get_next(pc);
@@ -3799,8 +3801,7 @@ void newlines_cleanup_braces(bool first)
       }
       else if (chunk_is_token(pc, CT_SQUARE_OPEN))
       {
-         if (  pc->parent_type == CT_ASSIGN
-            && ((pc->flags & PCF_ONE_LINER) == 0))
+         if (pc->parent_type == CT_ASSIGN && !pc->flags.test(PCF_ONE_LINER))
          {
             tmp = chunk_get_prev_ncnlni(pc);   // Issue #2279
             newline_iarf(tmp, options::nl_assign_square());
@@ -3861,7 +3862,7 @@ void newlines_cleanup_braces(bool first)
       }
       else if (  first
               && (options::nl_remove_extra_newlines() == 1)
-              && !(pc->flags & PCF_IN_PREPROC))
+              && !pc->flags.test(PCF_IN_PREPROC))
       {
          newline_iarf(pc, IARF_REMOVE);
       }
@@ -3947,11 +3948,11 @@ static bool is_class_one_liner(chunk_t *pc)
 {
    if (  (  chunk_is_token(pc, CT_FUNC_CLASS_DEF)
          || chunk_is_token(pc, CT_FUNC_DEF))
-      && (pc->flags & PCF_IN_CLASS))
+      && pc->flags.test(PCF_IN_CLASS))
    {
       // Find opening brace
       pc = chunk_get_next_type(pc, CT_BRACE_OPEN, pc->level);
-      return(pc && (pc->flags & PCF_ONE_LINER));
+      return(pc != nullptr && pc->flags.test(PCF_ONE_LINER));
    }
    return(false);
 }
@@ -4301,7 +4302,7 @@ void newlines_chunk_pos(c_token_t chunk_type, token_pos_e mode)
             LOG_FMT(LNEWLINE, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s', type is %s\n   ",
                     __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(), get_token_name(pc->type));
             log_pcf_flags(LNEWLINE, pc->flags);
-            if ((pc->flags & PCF_IN_CONST_ARGS) != 0)                          // Issue #2250
+            if (pc->flags.test(PCF_IN_CONST_ARGS)) // Issue #2250
             {
                continue;
             }
@@ -4311,12 +4312,12 @@ void newlines_chunk_pos(c_token_t chunk_type, token_pos_e mode)
              * BUT we must take care of options::pos_class_comma()
              * TODO and options::pos_constr_comma()
              */
-            if (pc->flags & PCF_IN_CLASS_BASE)
+            if (pc->flags.test(PCF_IN_CLASS_BASE))
             {
                // change mode
                mode_local = options::pos_class_comma();
             }
-            else if (pc->flags & PCF_IN_ENUM)
+            else if (pc->flags.test(PCF_IN_ENUM))
             {
                mode_local = options::pos_enum_comma();
             }
@@ -4441,8 +4442,8 @@ void newlines_chunk_pos(c_token_t chunk_type, token_pos_e mode)
                        __func__, __LINE__, prev->orig_line, prev->orig_col, prev->text());
                if (  prev != nullptr
                   && !chunk_is_newline(prev)
-                  && !(prev->flags & PCF_IN_PREPROC)
-                  && !(prev->flags & PCF_IN_OC_MSG))
+                  && !prev->flags.test(PCF_IN_PREPROC)
+                  && !prev->flags.test(PCF_IN_OC_MSG))
                {
                   chunk_move_after(pc, prev);
                }
@@ -4665,17 +4666,17 @@ bool is_func_proto_group(chunk_t *pc, c_token_t one_liner_type)
 {
    if (  pc && options::nl_class_leave_one_liner_groups()
       && (pc->type == one_liner_type || pc->parent_type == one_liner_type)
-      && (pc->flags & PCF_IN_CLASS))
+      && pc->flags.test(PCF_IN_CLASS))
    {
       if (pc->type == CT_BRACE_CLOSE)
       {
-         return((pc->flags & PCF_ONE_LINER) != 0); // forcing value to bool
+         return(pc->flags.test(PCF_ONE_LINER));
       }
       else
       {
          // Find opening brace
          pc = chunk_get_next_type(pc, CT_BRACE_OPEN, pc->level);
-         return(pc && (pc->flags & PCF_ONE_LINER));
+         return(pc != nullptr && pc->flags.test(PCF_ONE_LINER));
       }
    }
    return(false);
@@ -4863,7 +4864,7 @@ void do_blank_lines(void)
             || prev->parent_type == CT_OC_MSG_DECL
             || prev->parent_type == CT_ASSIGN))
       {
-         if (prev->flags & PCF_ONE_LINER)
+         if (prev->flags.test(PCF_ONE_LINER))
          {
             if (options::nl_after_func_body_one_liner() > pc->nl_count)
             {
@@ -4872,7 +4873,7 @@ void do_blank_lines(void)
          }
          else
          {
-            if (  (prev->flags & PCF_IN_CLASS)
+            if (  prev->flags.test(PCF_IN_CLASS)
                && (options::nl_after_func_body_class() > 0))
             {
                if (options::nl_after_func_body_class() != pc->nl_count)
@@ -4954,7 +4955,7 @@ void do_blank_lines(void)
                {
                   LOG_FMT(LBLANK, "%s(%d): %zu:%zu token is '%s'\n",
                           __func__, __LINE__, tmp->orig_line, tmp->orig_col, tmp->text());
-                  if (tmp->flags & PCF_VAR_DEF)
+                  if (tmp->flags.test(PCF_VAR_DEF))
                   {
                      is_var_def = true;
                   }
@@ -5031,7 +5032,7 @@ void do_blank_lines(void)
             blank_line_set(pc, options::nl_around_cs_property);
          }
          else if (  next->parent_type == CT_CS_PROPERTY
-                 && (next->flags & PCF_STMT_START))
+                 && next->flags.test(PCF_STMT_START))
          {
             blank_line_set(pc, options::nl_around_cs_property);
          }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -452,8 +452,8 @@ void output_parsed(FILE *pfile)
               get_token_name(pc->parent_type),
               pc->column, pc->orig_col, pc->orig_col_end, pc->orig_prev_sp,
               pc->brace_level, pc->level, pc->pp_level);
-      fprintf(pfile, "[%10" PRIx64 "]",
-              pc->flags);
+      fprintf(pfile, "[%10llx]",
+              static_cast<pcf_flags_t::int_t>(pc->flags));
       fprintf(pfile, "[%zu-%d]",
               pc->nl_count, pc->after_tab);
 #endif // ifdef WIN32

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -528,7 +528,7 @@ void output_text(FILE *pfile)
       else if (chunk_is_token(pc, CT_NL_CONT))
       {
          // FIXME: this really shouldn't be done here!
-         if ((pc->flags & PCF_WAS_ALIGNED) == 0)
+         if (!pc->flags.test(PCF_WAS_ALIGNED))
          {
             // Add or remove space before a backslash-newline at the end of a line.
             if (options::sp_before_nl_cont() & IARF_REMOVE)
@@ -693,7 +693,7 @@ void output_text(FILE *pfile)
             // not the first item on a line
             chunk_t *prev = chunk_get_prev(pc);
             allow_tabs = (  options::align_with_tabs()
-                         && (pc->flags & PCF_WAS_ALIGNED)
+                         && pc->flags.test(PCF_WAS_ALIGNED)
                          && ((prev->column + prev->len() + 1) != pc->column));
             if (options::align_keep_tabs())
             {
@@ -1047,7 +1047,7 @@ static void output_cmt_start(cmt_reflow &cmt, chunk_t *pc)
    cmt.cont_text.clear();
    cmt.reflow = false;
 
-   if ((pc->flags & PCF_INSERTED))
+   if (pc->flags.test(PCF_INSERTED))
    {
       do_kw_subst(pc);
    }
@@ -1066,7 +1066,7 @@ static void output_cmt_start(cmt_reflow &cmt, chunk_t *pc)
    {
       if (  !options::indent_col1_comment()
          && pc->orig_col == 1
-         && !(pc->flags & PCF_INSERTED))
+         && !pc->flags.test(PCF_INSERTED))
       {
          cmt.column    = 1;
          cmt.base_col  = 1;
@@ -1470,7 +1470,7 @@ static void output_comment_multi(chunk_t *pc)
             if (  prev_nonempty_line < 0
                && !unc_isspace(line[nwidx])
                && line[nwidx] != '*'    // block comment: skip '*' at end of line
-               && ((pc->flags & PCF_IN_PREPROC)
+               && (pc->flags.test(PCF_IN_PREPROC)
                    ? (  line[nwidx] != '\\'
                      || (line[nwidx + 1] != 'r' && line[nwidx + 1] != '\n'))
                    : true))
@@ -1490,7 +1490,7 @@ static void output_comment_multi(chunk_t *pc)
                && !unc_isspace(pc->str[nxt_len])
                && pc->str[nxt_len] != '*'
                && (  nxt_len == remaining
-                  || ((pc->flags & PCF_IN_PREPROC)
+                  || (pc->flags.test(PCF_IN_PREPROC)
                       ? (  pc->str[nxt_len] != '\\'
                         || (  pc->str[nxt_len + 1] != 'r'  // TODO: should this be \r ?
                            && pc->str[nxt_len + 1] != '\n'))
@@ -1561,7 +1561,7 @@ static void output_comment_multi(chunk_t *pc)
          {
             nl_end = true;
             line.pop_back();
-            cmt_trim_whitespace(line, pc->flags & PCF_IN_PREPROC);
+            cmt_trim_whitespace(line, pc->flags.test(PCF_IN_PREPROC));
          }
 
          // LOG_FMT(LSYS, "[%3d]%s\n", ccol, line);
@@ -1977,7 +1977,7 @@ static bool kw_fcn_fclass(chunk_t *cmt, unc_text &out_txt)
    {
       return(false);
    }
-   if (fcn->flags & PCF_IN_CLASS)
+   if (fcn->flags.test(PCF_IN_CLASS))
    {
       // if inside a class, we need to find to the class name
       chunk_t *tmp = chunk_get_prev_type(fcn, CT_BRACE_OPEN, fcn->level - 1);
@@ -2236,7 +2236,7 @@ void add_long_preprocessor_conditional_block_comment(void)
          continue;
       }
 #if 0
-      if (pc->flags & PCF_IN_PREPROC)
+      if (pc->flags.test(PCF_IN_PREPROC))
       {
          continue;
       }

--- a/src/parens.cpp
+++ b/src/parens.cpp
@@ -140,7 +140,7 @@ static void check_bool_parens(chunk_t *popen, chunk_t *pclose, int nest)
    chunk_t *pc = popen;
    while ((pc = chunk_get_next_ncnl(pc)) != nullptr && pc != pclose)
    {
-      if (pc->flags & PCF_IN_PREPROC)
+      if (pc->flags.test(PCF_IN_PREPROC))
       {
          LOG_FMT(LPARADD2, " -- bail on PP %s [%s] at line %zu col %zu, level %zu\n",
                  get_token_name(pc->type),

--- a/src/quick_align_again.cpp
+++ b/src/quick_align_again.cpp
@@ -20,7 +20,7 @@ void quick_align_again(void)
    {
       LOG_FMT(LALAGAIN, "%s(%d): pc->orig_line is %zu, pc->orig_col is %zu, pc->text() '%s'\n",
               __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text());
-      if (pc->align.next != nullptr && (pc->flags & PCF_ALIGN_START))
+      if (pc->align.next != nullptr && pc->flags.test(PCF_ALIGN_START))
       {
          AlignStack as;
          as.Start(100, 0);

--- a/src/semicolons.cpp
+++ b/src/semicolons.cpp
@@ -53,7 +53,7 @@ void remove_extra_semicolons(void)
       chunk_t *next = chunk_get_next_ncnl(pc);
       chunk_t *prev;
       if (  chunk_is_token(pc, CT_SEMICOLON)
-         && !(pc->flags & PCF_IN_PREPROC)
+         && !pc->flags.test(PCF_IN_PREPROC)
          && (prev = chunk_get_prev_ncnl(pc)) != nullptr)
       {
          LOG_FMT(LSCANSEMI, "%s(%d): Semi orig_line is %zu, orig_col is %zu, parent is %s, prev = '%s' [%s/%s]\n",

--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -270,7 +270,7 @@ void sort_imports(void)
          if (  p_imp != nullptr
             && p_last != nullptr
             && (  chunk_is_token(p_last, CT_SEMICOLON)
-               || (p_imp->flags & PCF_IN_PREPROC)))
+               || p_imp->flags.test(PCF_IN_PREPROC)))
          {
             if (num_chunks < MAX_NUMBER_TO_SORT)
             {

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -178,7 +178,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       return(options::sp_pp_stringify());
    }
    if (  chunk_is_token(second, CT_POUND)
-      && (second->flags & PCF_IN_PREPROC)
+      && second->flags.test(PCF_IN_PREPROC)
       && first->parent_type != CT_MACRO_FUNC)
    {
       // Add or remove space before preprocessor '#' stringify operator
@@ -716,7 +716,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       }
 
       // non-punc followed by a ellipsis
-      if (  ((first->flags & PCF_PUNCTUATOR) == 0)
+      if (  !first->flags.test(PCF_PUNCTUATOR)
          && (options::sp_before_ellipsis() != IARF_IGNORE))
       {
          // Add or remove space before the variadic '...' when preceded by a
@@ -914,7 +914,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    if (chunk_is_token(second, CT_ASSIGN))
    {
-      if (second->flags & PCF_IN_ENUM)
+      if (second->flags.test(PCF_IN_ENUM))
       {
          // Add or remove space before assignment '=' in enum.
          // Overrides sp_enum_assign.
@@ -966,7 +966,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    if (chunk_is_token(first, CT_ASSIGN))
    {
-      if (first->flags & PCF_IN_ENUM)
+      if (first->flags.test(PCF_IN_ENUM))
       {
          // Add or remove space after assignment '=' in enum.
          // Overrides sp_enum_assign.
@@ -1031,7 +1031,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    if (chunk_is_token(first, CT_BIT_COLON))
    {
-      if (first->flags & PCF_IN_ENUM)
+      if (first->flags.test(PCF_IN_ENUM))
       {
          // Add or remove space around assignment ':' in enum.
          log_rule("sp_enum_colon");
@@ -1041,7 +1041,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    if (chunk_is_token(second, CT_BIT_COLON))
    {
-      if (second->flags & PCF_IN_ENUM)
+      if (second->flags.test(PCF_IN_ENUM))
       {
          // Add or remove space around assignment ':' in enum.
          log_rule("sp_enum_colon");
@@ -1103,7 +1103,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          && second->parent_type != CT_CS_SQ_STMT
          && second->parent_type != CT_CPP_LAMBDA))
    {
-      if (((second->flags & PCF_IN_SPAREN) != 0) && (chunk_is_token(first, CT_IN)))
+      if (second->flags.test(PCF_IN_SPAREN) && (chunk_is_token(first, CT_IN)))
       {
          return(IARF_FORCE);
       }
@@ -1527,7 +1527,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_func_class_paren");
       return(options::sp_func_class_paren());
    }
-   if (chunk_is_token(first, CT_CLASS) && !(first->flags & PCF_IN_OC_MSG))
+   if (chunk_is_token(first, CT_CLASS) && !first->flags.test(PCF_IN_OC_MSG))
    {
       log_rule("FORCE");
       return(IARF_FORCE);
@@ -1868,7 +1868,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    if (chunk_is_token(first, CT_PAREN_CLOSE))
    {
-      if (  (first->flags & PCF_OC_RTYPE)  // == CT_OC_RTYPE)
+      if (  first->flags.test(PCF_OC_RTYPE) // == CT_OC_RTYPE)
          && (  first->parent_type == CT_OC_MSG_DECL
             || first->parent_type == CT_OC_MSG_SPEC))
       {
@@ -2427,7 +2427,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
 
    if (  chunk_is_token(first, CT_BRACE_CLOSE)
-      && (first->flags & PCF_IN_TYPEDEF)
+      && first->flags.test(PCF_IN_TYPEDEF)
       && (  first->parent_type == CT_ENUM
          || first->parent_type == CT_STRUCT
          || first->parent_type == CT_UNION))
@@ -2570,7 +2570,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    }
    if (chunk_is_token(first, CT_OC_COLON))
    {
-      if (first->flags & PCF_IN_OC_MSG)
+      if (first->flags.test(PCF_IN_OC_MSG))
       {
          // (OC) Add or remove space after the colon in message specs,
          // i.e. '[object setValue:1];' vs. '[object setValue: 1];'.
@@ -2584,7 +2584,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    }
    if (chunk_is_token(second, CT_OC_COLON))
    {
-      if (  (first->flags & PCF_IN_OC_MSG)
+      if (  first->flags.test(PCF_IN_OC_MSG)
          && (chunk_is_token(first, CT_OC_MSG_FUNC) || chunk_is_token(first, CT_OC_MSG_NAME)))
       {
          // (OC) Add or remove space before the colon in message specs,
@@ -2722,7 +2722,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
 static iarf_e ensure_force_space(chunk_t *first, chunk_t *second, iarf_e av)
 {
-   if (first->flags & PCF_FORCE_SPACE)
+   if (first->flags.test(PCF_FORCE_SPACE))
    {
       LOG_FMT(LSPACE, " <force between '%s' and '%s'>",
               first->text(), second->text());

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -1810,7 +1810,7 @@ static bool parse_next(tok_ctx &ctx, chunk_t &pc)
    pc.orig_col  = ctx.c.col;
    pc.type      = CT_NONE;
    pc.nl_count  = 0;
-   pc.flags     = 0;
+   pc.flags     = PCF_NONE;
 
    // If it is turned off, we put everything except newlines into CT_UNKNOWN
    if (cpd.unc_off)

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -2332,7 +2332,7 @@ void tokenize(const deque<int> &data, chunk_t *ref)
             && (rprev == nullptr || chunk_is_token(rprev, CT_NEWLINE)))
          {
             set_chunk_type(pc, CT_PREPROC);
-            pc->flags     |= PCF_IN_PREPROC;
+            chunk_flags_set(pc, PCF_IN_PREPROC);
             cpd.in_preproc = CT_PREPROC;
          }
       }

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -206,7 +206,7 @@ void tokenize_cleanup(void)
          }
       }
       if (  chunk_is_token(pc, CT_SEMICOLON)
-         && (pc->flags & PCF_IN_PREPROC)
+         && pc->flags.test(PCF_IN_PREPROC)
          && !chunk_get_next_ncnl(pc, scope_e::PREPROC))
       {
          LOG_FMT(LNOTE, "%s(%d): %s:%zu Detected a macro that ends with a semicolon. Possible failures if used.\n",
@@ -522,7 +522,7 @@ void tokenize_cleanup(void)
             set_chunk_type(next, CT_OPERATOR_VAL);
             chunk_del(tmp2);
          }
-         else if (next->flags & PCF_PUNCTUATOR)
+         else if (next->flags.test(PCF_PUNCTUATOR))
          {
             set_chunk_type(next, CT_OPERATOR_VAL);
          }
@@ -907,7 +907,7 @@ void tokenize_cleanup(void)
          if (chunk_is_token(prev, CT_TYPE))
          {
             // Issue # 1002
-            if ((pc->flags & PCF_IN_TEMPLATE) == 0)
+            if (!pc->flags.test(PCF_IN_TEMPLATE))
             {
                set_chunk_type(pc, CT_BYREF);
             }

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1533,7 +1533,7 @@ static void add_func_header(c_token_t type, file_mem &fm)
       {
          continue;
       }
-      if (  (pc->flags & PCF_IN_CLASS)
+      if (  pc->flags.test(PCF_IN_CLASS)
          && !options::cmt_insert_before_inlines())
       {
          continue;
@@ -1605,7 +1605,7 @@ static void add_func_header(c_token_t type, file_mem &fm)
          }
 
          // Bail if we hit a preprocessor and cmt_insert_before_preproc is false
-         if (ref->flags & PCF_IN_PREPROC)
+         if (ref->flags.test(PCF_IN_PREPROC))
          {
             tmp = chunk_get_prev_type(ref, CT_PREPROC, ref->level);
             if (tmp != nullptr && tmp->parent_type == CT_PP_IF)
@@ -1626,7 +1626,7 @@ static void add_func_header(c_token_t type, file_mem &fm)
          }
 
          if (  ref->level == pc->level
-            && (  (ref->flags & PCF_IN_PREPROC)
+            && (  ref->flags.test(PCF_IN_PREPROC)
                || chunk_is_token(ref, CT_SEMICOLON)
                || chunk_is_token(ref, CT_BRACE_CLOSE)))
          {
@@ -1686,7 +1686,7 @@ static void add_msg_header(c_token_t type, file_mem &fm)
          }
 
          // Bail if we hit a preprocessor and cmt_insert_before_preproc is false
-         if (ref->flags & PCF_IN_PREPROC)
+         if (ref->flags.test(PCF_IN_PREPROC))
          {
             tmp = chunk_get_prev_type(ref, CT_PREPROC, ref->level);
             if (tmp != nullptr && tmp->parent_type == CT_PP_IF)
@@ -1700,7 +1700,7 @@ static void add_msg_header(c_token_t type, file_mem &fm)
             }
          }
          if (  ref->level == pc->level
-            && ((ref->flags & PCF_IN_PREPROC) || chunk_is_token(ref, CT_OC_SCOPE)))
+            && (ref->flags.test(PCF_IN_PREPROC) || chunk_is_token(ref, CT_OC_SCOPE)))
          {
             ref = chunk_get_prev(ref);
             if (ref != nullptr)

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -491,7 +491,7 @@ int main(int argc, char *argv[])
       size_t idx = 1;
       while ((p_arg = arg.Unused(idx)) != nullptr)
       {
-         log_pcf_flags(LSYS, strtoul(p_arg, nullptr, 16));
+         log_pcf_flags(LSYS, static_cast<pcf_flag_e>(strtoul(p_arg, nullptr, 16)));
       }
       return(EXIT_SUCCESS);
    }
@@ -2362,19 +2362,19 @@ static size_t language_flags_from_filename(const char *filename)
 }
 
 
-void log_pcf_flags(log_sev_t sev, UINT64 flags)
+void log_pcf_flags(log_sev_t sev, pcf_flags_t flags)
 {
    if (!log_sev_on(sev))
    {
       return;
    }
 
-   log_fmt(sev, "[0x%" PRIx64 ":", flags);
+   log_fmt(sev, "[0x%llx:", static_cast<pcf_flags_t::int_t>(flags));
 
    const char *tolog = nullptr;
    for (size_t i = 0; i < ARRAY_SIZE(pcf_names); i++)
    {
-      if (flags & (1ULL << i))
+      if (flags & static_cast<pcf_flag_e>(pcf_bit(i)))
       {
          if (tolog != nullptr)
          {

--- a/src/uncrustify.h
+++ b/src/uncrustify.h
@@ -46,7 +46,7 @@ const char *language_name_from_flags(size_t lang);
 c_token_t find_token_name(const char *text);
 
 
-void log_pcf_flags(log_sev_t sev, UINT64 flags);
+void log_pcf_flags(log_sev_t sev, pcf_flags_t flags);
 
 
 /**

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -258,7 +258,7 @@ struct chunk_t
       orig_col      = 0;
       orig_col_end  = 0;
       orig_prev_sp  = 0;
-      flags         = 0;
+      flags         = PCF_NONE;
       column        = 0;
       column_indent = 0;
       nl_count      = 0;

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -187,7 +187,7 @@ static const char *pcf_names[] =
    "IN_NAMESPACE",      // 12
    "IN_FOR",            // 13
    "IN_OC_MSG",         // 14
-   "#15",               // 15
+   "IN_WHERE_SPEC",     // 15
    "FORCE_SPACE",       // 16
    "STMT_START",        // 17
    "EXPR_START",        // 18

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -11,6 +11,7 @@
 #define UNCRUSTIFY_TYPES_H_INCLUDED
 
 #include "base_types.h"
+#include "enum_flags.h"
 #include "log_levels.h"
 #include "logger.h"
 #include "option_enum.h"
@@ -106,56 +107,67 @@ struct indent_ptr_t
 };
 
 
-#define PCF_BIT(b)    (1ULL << b)
+constexpr auto pcf_bit(size_t b)->decltype(0ULL)
+{
+   return(1ULL << b);
+}
 
+
+enum pcf_flag_e : decltype(0ULL)
+{
 // Copy flags are in the lower 16 bits
-#define PCF_COPY_FLAGS         0x0000ffff
-#define PCF_IN_PREPROC         PCF_BIT(0)  //! in a preprocessor
-#define PCF_IN_STRUCT          PCF_BIT(1)  //! in a struct
-#define PCF_IN_ENUM            PCF_BIT(2)  //! in enum
-#define PCF_IN_FCN_DEF         PCF_BIT(3)  //! inside function def parens
-#define PCF_IN_FCN_CALL        PCF_BIT(4)  //! inside function call parens
-#define PCF_IN_SPAREN          PCF_BIT(5)  //! inside for/if/while/switch parens
-#define PCF_IN_TEMPLATE        PCF_BIT(6)
-#define PCF_IN_TYPEDEF         PCF_BIT(7)
-#define PCF_IN_CONST_ARGS      PCF_BIT(8)
-#define PCF_IN_ARRAY_ASSIGN    PCF_BIT(9)
-#define PCF_IN_CLASS           PCF_BIT(10)
-#define PCF_IN_CLASS_BASE      PCF_BIT(11)
-#define PCF_IN_NAMESPACE       PCF_BIT(12)
-#define PCF_IN_FOR             PCF_BIT(13)
-#define PCF_IN_OC_MSG          PCF_BIT(14)
-#define PCF_IN_WHERE_SPEC      PCF_BIT(15)  /* inside C# 'where' constraint clause on class or function def */
+   PCF_NONE            = 0ULL,
+   PCF_COPY_FLAGS      = 0x0000ffffULL,
+   PCF_IN_PREPROC      = pcf_bit(0),  //! in a preprocessor
+   PCF_IN_STRUCT       = pcf_bit(1),  //! in a struct
+   PCF_IN_ENUM         = pcf_bit(2),  //! in enum
+   PCF_IN_FCN_DEF      = pcf_bit(3),  //! inside function def parens
+   PCF_IN_FCN_CALL     = pcf_bit(4),  //! inside function call parens
+   PCF_IN_SPAREN       = pcf_bit(5),  //! inside for/if/while/switch parens
+   PCF_IN_TEMPLATE     = pcf_bit(6),
+   PCF_IN_TYPEDEF      = pcf_bit(7),
+   PCF_IN_CONST_ARGS   = pcf_bit(8),
+   PCF_IN_ARRAY_ASSIGN = pcf_bit(9),
+   PCF_IN_CLASS        = pcf_bit(10),
+   PCF_IN_CLASS_BASE   = pcf_bit(11),
+   PCF_IN_NAMESPACE    = pcf_bit(12),
+   PCF_IN_FOR          = pcf_bit(13),
+   PCF_IN_OC_MSG       = pcf_bit(14),
+   PCF_IN_WHERE_SPEC   = pcf_bit(15),  /* inside C# 'where' constraint clause on class or function def */
 
 // Non-Copy flags are in the upper 48 bits
-#define PCF_FORCE_SPACE        PCF_BIT(16)  //! must have a space after this token
-#define PCF_STMT_START         PCF_BIT(17)  //! marks the start of a statement
-#define PCF_EXPR_START         PCF_BIT(18)
-#define PCF_DONT_INDENT        PCF_BIT(19)  //! already aligned!
-#define PCF_ALIGN_START        PCF_BIT(20)
-#define PCF_WAS_ALIGNED        PCF_BIT(21)
-#define PCF_VAR_TYPE           PCF_BIT(22)  //! part of a variable def type
-#define PCF_VAR_DEF            PCF_BIT(23)  //! variable name in a variable def
-#define PCF_VAR_1ST            PCF_BIT(24)  //! 1st variable def in a statement
-#define PCF_VAR_1ST_DEF        (PCF_VAR_DEF | PCF_VAR_1ST)
-#define PCF_VAR_INLINE         PCF_BIT(25)  //! type was an inline struct/enum/union
-#define PCF_RIGHT_COMMENT      PCF_BIT(26)
-#define PCF_OLD_FCN_PARAMS     PCF_BIT(27)
-#define PCF_LVALUE             PCF_BIT(28)  //! left of assignment
-#define PCF_ONE_LINER          PCF_BIT(29)
-#define PCF_ONE_CLASS          (PCF_ONE_LINER | PCF_IN_CLASS)
-#define PCF_EMPTY_BODY         PCF_BIT(30)
-#define PCF_ANCHOR             PCF_BIT(31)  //! aligning anchor
-#define PCF_PUNCTUATOR         PCF_BIT(32)
-#define PCF_INSERTED           PCF_BIT(33)  //! chunk was inserted from another file
-#define PCF_LONG_BLOCK         PCF_BIT(34)  //! the block is 'long' by some measure
-#define PCF_OC_BOXED           PCF_BIT(35)  //! inside OC boxed expression
-#define PCF_KEEP_BRACE         PCF_BIT(36)  //! do not remove brace
-#define PCF_OC_RTYPE           PCF_BIT(37)  //! inside OC return type
-#define PCF_OC_ATYPE           PCF_BIT(38)  //! inside OC arg type
-#define PCF_WF_ENDIF           PCF_BIT(39)  //! #endif for whole file ifdef
-#define PCF_IN_QT_MACRO        PCF_BIT(40)  //! in a QT-macro, i.e. SIGNAL, SLOT
-#define PCF_IN_FCN_CTOR        PCF_BIT(41)  //! inside function constructor
+   PCF_FORCE_SPACE    = pcf_bit(16),   //! must have a space after this token
+   PCF_STMT_START     = pcf_bit(17),   //! marks the start of a statement
+   PCF_EXPR_START     = pcf_bit(18),
+   PCF_DONT_INDENT    = pcf_bit(19),   //! already aligned!
+   PCF_ALIGN_START    = pcf_bit(20),
+   PCF_WAS_ALIGNED    = pcf_bit(21),
+   PCF_VAR_TYPE       = pcf_bit(22),   //! part of a variable def type
+   PCF_VAR_DEF        = pcf_bit(23),   //! variable name in a variable def
+   PCF_VAR_1ST        = pcf_bit(24),   //! 1st variable def in a statement
+   PCF_VAR_1ST_DEF    = (PCF_VAR_DEF | PCF_VAR_1ST),
+   PCF_VAR_INLINE     = pcf_bit(25),   //! type was an inline struct/enum/union
+   PCF_RIGHT_COMMENT  = pcf_bit(26),
+   PCF_OLD_FCN_PARAMS = pcf_bit(27),
+   PCF_LVALUE         = pcf_bit(28),   //! left of assignment
+   PCF_ONE_LINER      = pcf_bit(29),
+   PCF_ONE_CLASS      = (PCF_ONE_LINER | PCF_IN_CLASS),
+   PCF_EMPTY_BODY     = pcf_bit(30),
+   PCF_ANCHOR         = pcf_bit(31),   //! aligning anchor
+   PCF_PUNCTUATOR     = pcf_bit(32),
+   PCF_INSERTED       = pcf_bit(33),   //! chunk was inserted from another file
+   PCF_LONG_BLOCK     = pcf_bit(34),   //! the block is 'long' by some measure
+   PCF_OC_BOXED       = pcf_bit(35),   //! inside OC boxed expression
+   PCF_KEEP_BRACE     = pcf_bit(36),   //! do not remove brace
+   PCF_OC_RTYPE       = pcf_bit(37),   //! inside OC return type
+   PCF_OC_ATYPE       = pcf_bit(38),   //! inside OC arg type
+   PCF_WF_ENDIF       = pcf_bit(39),   //! #endif for whole file ifdef
+   PCF_IN_QT_MACRO    = pcf_bit(40),   //! in a QT-macro, i.e. SIGNAL, SLOT
+   PCF_IN_FCN_CTOR    = pcf_bit(41),   //! inside function constructor
+};
+
+UNC_DECLARE_FLAGS(pcf_flags_t, pcf_flag_e);
+UNC_DECLARE_OPERATORS_FOR_FLAGS(pcf_flags_t);
 
 #ifdef DEFINE_PCF_NAMES
 static const char *pcf_names[] =
@@ -282,7 +294,7 @@ struct chunk_t
    size_t       orig_col;         //! column where chunk started in the input file, is always > 0
    size_t       orig_col_end;     //! column where chunk ended in the input file, is always > 1
    UINT32       orig_prev_sp;     //! whitespace before this token
-   UINT64       flags;            //! see PCF_xxx
+   pcf_flags_t  flags;            //! see PCF_xxx
    size_t       column;           //! column of chunk
    size_t       column_indent;    /** if 1st on a line, set to the 'indent'
                                    * column, which may be less than the real

--- a/src/width.cpp
+++ b/src/width.cpp
@@ -332,11 +332,11 @@ static bool split_line(chunk_t *start)
    log_pcf_flags(LSPLIT, start->flags);
    LOG_FMT(LSPLIT, "   start->parent_type %s, (PCF_IN_FCN_DEF is %s), (PCF_IN_FCN_CALL is %s)\n",
            get_token_name(start->parent_type),
-           ((start->flags & (PCF_IN_FCN_DEF)) != 0) ? "TRUE" : "FALSE",
-           ((start->flags & (PCF_IN_FCN_CALL)) != 0) ? "TRUE" : "FALSE");
+           start->flags.test((PCF_IN_FCN_DEF)) ? "TRUE" : "FALSE",
+           start->flags.test((PCF_IN_FCN_CALL)) ? "TRUE" : "FALSE");
 
    // break at maximum line length if ls_code_width is true
-   if (start->flags & PCF_ONE_LINER)
+   if (start->flags.test(PCF_ONE_LINER))
    {
       LOG_FMT(LSPLIT, "%s(%d): ** ONCE LINER SPLIT **\n", __func__, __LINE__);
       undo_one_liner(start);
@@ -351,7 +351,7 @@ static bool split_line(chunk_t *start)
    {
    }
    // Check to see if we are in a for statement
-   else if (start->flags & PCF_IN_FOR)
+   else if (start->flags.test(PCF_IN_FOR))
    {
       LOG_FMT(LSPLIT, " ** FOR SPLIT **\n");
       split_for_stmt(start);
@@ -366,10 +366,10 @@ static bool split_line(chunk_t *start)
     * If this is in a function call or prototype, split on commas or right
     * after the open parenthesis
     */
-   else if (  (start->flags & PCF_IN_FCN_DEF)
+   else if (  start->flags.test(PCF_IN_FCN_DEF)
            || start->parent_type == CT_FUNC_PROTO            // Issue #1169
            || (  (start->level == (start->brace_level + 1))
-              && (start->flags & PCF_IN_FCN_CALL)))
+              && start->flags.test(PCF_IN_FCN_CALL)))
    {
       LOG_FMT(LSPLIT, " ** FUNC SPLIT **\n");
 
@@ -388,7 +388,7 @@ static bool split_line(chunk_t *start)
    /*
     * If this is in a template, split on commas, Issue #1170
     */
-   else if (start->flags & PCF_IN_TEMPLATE)
+   else if (start->flags.test(PCF_IN_TEMPLATE))
    {
       LOG_FMT(LSPLIT, " ** TEMPLATE SPLIT **\n");
       split_template(start);
@@ -557,7 +557,7 @@ static void split_for_stmt(chunk_t *start)
    // first scan backwards for the semicolons
    while (  (count < static_cast<int>(max_cnt))
          && ((pc = chunk_get_prev(pc)) != nullptr)
-         && (pc->flags & PCF_IN_SPAREN))
+         && pc->flags.test(PCF_IN_SPAREN))
    {
       if (chunk_is_token(pc, CT_SEMICOLON) && pc->parent_type == CT_FOR)
       {
@@ -569,7 +569,7 @@ static void split_for_stmt(chunk_t *start)
    pc = start;
    while (  (count < static_cast<int>(max_cnt))
          && ((pc = chunk_get_next(pc)) != nullptr)
-         && (pc->flags & PCF_IN_SPAREN))
+         && pc->flags.test(PCF_IN_SPAREN))
    {
       if (chunk_is_token(pc, CT_SEMICOLON) && pc->parent_type == CT_FOR)
       {


### PR DESCRIPTION
Replace `PCF_*` preprocessor defines with an enumeration. Use a proper flags type for dealing with these flags, rather than a bare integer type.

Also, fix several bugs in our flags helper type that this uncovered. (With these changes, we are exercising the flags helper type much more than before.)