### PR TITLE
Don't put stack memory in ParseFrame

### DIFF
--- a/src/ParseFrame.cpp
+++ b/src/ParseFrame.cpp
@@ -144,17 +144,11 @@ const ContainerType &ParseFrame::top() const
 }
 
 
-void ParseFrame::push(chunk_t &pc, brace_stage_e stage)
-{
-   push(&pc, stage);
-}
-
-
 void ParseFrame::push(std::nullptr_t, brace_stage_e stage)
 {
    static chunk_t dummy;
 
-   push(dummy, stage);
+   push(&dummy, stage);
    top().pc = nullptr;
 }
 

--- a/src/ParseFrame.cpp
+++ b/src/ParseFrame.cpp
@@ -146,19 +146,34 @@ const ContainerType &ParseFrame::top() const
 
 void ParseFrame::push(chunk_t &pc, brace_stage_e stage)
 {
+   push(&pc, stage);
+}
+
+
+void ParseFrame::push(std::nullptr_t, brace_stage_e stage)
+{
+   static chunk_t dummy;
+
+   push(dummy, stage);
+   top().pc = nullptr;
+}
+
+
+void ParseFrame::push(chunk_t *pc, brace_stage_e stage)
+{
    LOG_FUNC_ENTRY();
 
    ContainerType new_entry = {};
-   new_entry.type      = pc.type;
-   new_entry.level     = pc.level;
-   new_entry.open_line = pc.orig_line;
-   new_entry.pc        = &pc;
+   new_entry.type      = pc->type;
+   new_entry.level     = pc->level;
+   new_entry.open_line = pc->orig_line;
+   new_entry.pc        = pc;
 
    new_entry.indent_tab  = top().indent_tab;
    new_entry.indent_cont = top().indent_cont;
    new_entry.stage       = stage;
 
-   new_entry.in_preproc = (pc.flags & PCF_IN_PREPROC);
+   new_entry.in_preproc = (pc->flags & PCF_IN_PREPROC);
    new_entry.non_vardef = false;
    new_entry.ip         = top().ip;
 
@@ -166,9 +181,9 @@ void ParseFrame::push(chunk_t &pc, brace_stage_e stage)
 
    LOG_FMT(LINDPSE, "ParseFrame::%s(%d): orig_line is %zu, orig_col is %zu, type is %s, brace_level is %zu, "
            "level is %zu, pse_tos: %zu -> %zu\n",
-           __func__, __LINE__, pc.orig_line, pc.orig_col,
-           get_token_name(pc.type), pc.brace_level, pc.level, (pse.size() - 2),
-           (pse.size() - 1));
+           __func__, __LINE__, pc->orig_line, pc->orig_col,
+           get_token_name(pc->type), pc->brace_level, pc->level,
+           (pse.size() - 2), (pse.size() - 1));
 }
 
 

--- a/src/ParseFrame.h
+++ b/src/ParseFrame.h
@@ -43,7 +43,6 @@ private:
    std::vector<paren_stack_entry_t> pse;
    paren_stack_entry_t              last_poped;
 
-   void push(chunk_t *pc, brace_stage_e stage);
    void clear();
 
 public:
@@ -74,7 +73,7 @@ public:
 
    const paren_stack_entry_t &poped() const;
 
-   void push(chunk_t &pc, brace_stage_e stage    = brace_stage_e::NONE);
+   void push(chunk_t *pc, brace_stage_e stage    = brace_stage_e::NONE);
    void push(std::nullptr_t, brace_stage_e stage = brace_stage_e::NONE);
    void pop();
 

--- a/src/ParseFrame.h
+++ b/src/ParseFrame.h
@@ -43,6 +43,7 @@ private:
    std::vector<paren_stack_entry_t> pse;
    paren_stack_entry_t              last_poped;
 
+   void push(chunk_t *pc, brace_stage_e stage);
    void clear();
 
 public:
@@ -73,7 +74,8 @@ public:
 
    const paren_stack_entry_t &poped() const;
 
-   void push(chunk_t &pc, brace_stage_e stage = brace_stage_e::NONE);
+   void push(chunk_t &pc, brace_stage_e stage    = brace_stage_e::NONE);
+   void push(std::nullptr_t, brace_stage_e stage = brace_stage_e::NONE);
    void pop();
 
    size_t size() const;

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -143,8 +143,7 @@ static size_t preproc_start(ParseFrame &frm, chunk_t *pc)
    frm.brace_level = 1;
 
    // TODO: not sure about the next 3 lines
-   chunk_t tmp{};
-   frm.push(tmp);
+   frm.push(nullptr);
    frm.top().type = CT_PP_DEFINE;
 
    return(pp_level);

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -655,7 +655,7 @@ static void parse_cleanup(ParseFrame &frm, chunk_t *pc)
                     __func__, __LINE__, frm.brace_level);
          }
       }
-      frm.push(*pc);
+      frm.push(pc);
       frm.top().parent = parent;
       set_chunk_parent(pc, parent);
    }
@@ -669,8 +669,8 @@ static void parse_cleanup(ParseFrame &frm, chunk_t *pc)
     */
    if (patcls == pattern_class_e::BRACED)
    {
-      frm.push(*pc, (chunk_is_token(pc, CT_DO) ? brace_stage_e::BRACE_DO
-                     : brace_stage_e::BRACE2));
+      frm.push(pc, (chunk_is_token(pc, CT_DO) ? brace_stage_e::BRACE_DO
+                    : brace_stage_e::BRACE2));
       // "+ComplexBraced"
    }
    else if (patcls == pattern_class_e::PBRACED)
@@ -682,17 +682,17 @@ static void parse_cleanup(ParseFrame &frm, chunk_t *pc)
          set_chunk_type(pc, CT_WHILE_OF_DO);
          bs = brace_stage_e::WOD_PAREN;
       }
-      frm.push(*pc, bs);
+      frm.push(pc, bs);
       // "+ComplexParenBraced"
    }
    else if (patcls == pattern_class_e::OPBRACED)
    {
-      frm.push(*pc, brace_stage_e::OP_PAREN1);
+      frm.push(pc, brace_stage_e::OP_PAREN1);
       // "+ComplexOpParenBraced");
    }
    else if (patcls == pattern_class_e::ELSE)
    {
-      frm.push(*pc, brace_stage_e::ELSEIF);
+      frm.push(pc, brace_stage_e::ELSEIF);
       // "+ComplexElse");
    }
 
@@ -944,7 +944,7 @@ static bool check_complex_statements(ParseFrame &frm, chunk_t *pc)
                  __func__, __LINE__, frm.brace_level);
          log_pcf_flags(LBCSPOP, pc->flags);
 
-         frm.push(*vbrace, brace_stage_e::NONE);
+         frm.push(vbrace, brace_stage_e::NONE);
          // "+VBrace");
 
          frm.top().parent = parent;

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -631,7 +631,7 @@ void indent_text(void)
                   && next->parent_type == CT_FUNC_DEF))
             {
                in_func_def = true;
-               frm.push(*pc);
+               frm.push(pc);
                frm.top().indent_tmp = 1;
                frm.top().indent     = 1;
                frm.top().indent_tab = 1;
@@ -701,7 +701,7 @@ void indent_text(void)
 
             // Hack to get the logs to look right
             set_chunk_type(next, CT_PP_REGION_INDENT);
-            frm.push(*next);
+            frm.push(next);
             set_chunk_type(next, CT_PP_REGION);
 
             // Indent one level
@@ -718,7 +718,7 @@ void indent_text(void)
          if (  frm.top().type == CT_CASE
             && !options::indent_switch_pp())
          {
-            frm.push(*pc);
+            frm.push(pc);
             LOG_FMT(LINDPC, "%s(%d): frm.top().indent is %zu, indent_size is %zu\n",
                     __func__, __LINE__, frm.top().indent, indent_size);
             if (frm.top().indent >= indent_size)
@@ -767,7 +767,7 @@ void indent_text(void)
 
                const c_token_t memtype = next->type;
                set_chunk_type(next, CT_PP_IF_INDENT);
-               frm.push(*next);
+               frm.push(next);
                set_chunk_type(next, memtype);
 
                // Indent one level except if the #if is a #include guard
@@ -833,7 +833,7 @@ void indent_text(void)
          {
             return;
          }
-         frm.push(*pp_next);
+         frm.push(pp_next);
 
          if (pc->parent_type == CT_PP_DEFINE || pc->parent_type == CT_PP_UNDEF)
          {
@@ -1346,7 +1346,7 @@ void indent_text(void)
       }
       else if (chunk_is_token(pc, CT_VBRACE_OPEN))
       {
-         frm.push(*pc);
+         frm.push(pc);
 
          size_t iMinIndent = options::indent_min_vbrace_open();
          if (indent_size > iMinIndent)
@@ -1372,7 +1372,7 @@ void indent_text(void)
       {
          LOG_FMT(LINDENT2, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s'\n",
                  __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text());
-         frm.push(*pc);
+         frm.push(pc);
 
          if (  options::indent_cpp_lambda_body()
             && pc->parent_type == CT_CPP_LAMBDA)
@@ -1808,7 +1808,7 @@ void indent_text(void)
               || chunk_is_token(pc, CT_MACRO_OPEN)
               || chunk_is_token(pc, CT_CLASS))
       {
-         frm.push(*pc);
+         frm.push(pc);
 
          frm.top().indent = frm.prev().indent + indent_size;
          log_indent();
@@ -1819,7 +1819,7 @@ void indent_text(void)
       }
       else if (chunk_is_token(pc, CT_SQL_EXEC))
       {
-         frm.push(*pc);
+         frm.push(pc);
 
          frm.top().indent = frm.prev().indent + indent_size;
          log_indent();
@@ -1839,7 +1839,7 @@ void indent_text(void)
          // Start a case - indent UO_indent_switch_case from the switch level
          const size_t tmp = frm.top().indent
                             + options::indent_switch_case();
-         frm.push(*pc);
+         frm.push(pc);
 
          frm.top().indent = tmp;
          log_indent();
@@ -1913,7 +1913,7 @@ void indent_text(void)
          if (options::indent_access_spec_body())
          {
             const size_t tmp = frm.top().indent + indent_size;
-            frm.push(*pc);
+            frm.push(pc);
 
             frm.top().indent = tmp;
             log_indent();
@@ -1962,7 +1962,7 @@ void indent_text(void)
               || chunk_is_token(pc, CT_CONSTR_COLON))
       {
          // just indent one level
-         frm.push(*pc);
+         frm.push(pc);
 
          frm.top().indent = frm.prev().indent_tmp + indent_size;
          log_indent();
@@ -2068,7 +2068,7 @@ void indent_text(void)
           * Open parenthesis and squares - never update indent_column,
           * unless right after a newline.
           */
-         frm.push(*pc);
+         frm.push(pc);
          if (  chunk_is_newline(chunk_get_prev(pc))
             && pc->column != indent_column
             && !(pc->flags & PCF_DONT_INDENT))
@@ -2308,7 +2308,7 @@ void indent_text(void)
       {
          if (frm.top().type != CT_MEMBER)
          {
-            frm.push(*pc);
+            frm.push(pc);
             chunk_t *tmp = chunk_get_prev_ncnlnp(frm.top().pc);
             if (are_chunks_in_same_line(frm.prev().pc, tmp))
             {
@@ -2401,7 +2401,7 @@ void indent_text(void)
                        __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(), get_token_name(pc->type));
                frm.pop();
             }
-            frm.push(*pc);
+            frm.push(pc);
 
             if (chunk_is_token(pc, CT_ASSIGN) && chunk_is_newline(chunk_get_prev(pc)))
             {
@@ -2470,7 +2470,7 @@ void indent_text(void)
                || next == nullptr
                || next->type != CT_NEW)
             {
-               frm.push(*pc);
+               frm.push(pc);
                if (  chunk_is_newline(next)
                   || (  chunk_is_token(pc, CT_RETURN)
                      && options::indent_single_after_return()))
@@ -2493,7 +2493,7 @@ void indent_text(void)
       else if (  chunk_is_token(pc, CT_OC_SCOPE)
               || chunk_is_token(pc, CT_TYPEDEF))
       {
-         frm.push(*pc);
+         frm.push(pc);
          // Issue #405
          frm.top().indent = frm.prev().indent;
          log_indent();
@@ -2533,7 +2533,7 @@ void indent_text(void)
               && chunk_get_next_ncnlnp(pc)->type != CT_BRACE_OPEN
               && options::indent_cs_delegate_body())
       {
-         frm.push(*pc);
+         frm.push(pc);
          frm.top().indent = frm.prev().indent;
          log_indent();
          if (chunk_is_newline(chunk_get_prev_nc(pc)) && !are_chunks_in_same_line(frm.prev().pc, chunk_get_prev_ncnl(pc)))
@@ -3146,7 +3146,7 @@ void indent_text(void)
       {
          LOG_FMT(LINDENT, "%s(%d): orig_line is %zu, CT_CLASS found and UO_indent_continue != 0, OPEN IT\n",
                  __func__, __LINE__, pc->orig_line);
-         frm.push(*pc);
+         frm.push(pc);
          frm.top().indent = options::indent_continue_class_head() + 1;
          log_indent();
 


### PR DESCRIPTION
Fix a logic error in `preproc_start`, which was adding an entry to the ParseFrame which pointed to stack memory (which immediately became invalid). This fixes a subtle error where any subsequent access of this entry would get garbage, because the token long since ceased to exist as such, but was not showing up in memory checkers because the stack address was still valid.

(This was discovered when unrelated changes perturbed things "just right" so that the bit of stack being referenced "just happened" to be flagged by ASAN, and thus finally triggered an error.)

Also, change `ParseFrame::push` to not take a reference, which will hopefully reduce the chances of this sort of thing happening again.

This should fix #2429 and doesn't cause any obvious issues (read: the tests still pass), however it would be good for someone more familiar with this bit of uncrustify (@CDanU?) to also take a look.