### PR TITLE
Introduce a new option used by typedef.

### DIFF
--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -222,6 +222,7 @@ sp_func_call_paren                        = remove
 sp_func_def_paren                         = remove
 sp_func_proto_paren_empty                 = remove
 sp_func_proto_paren                       = remove
+sp_func_type_paren                        = remove
 sp_incdec                                 = remove
 sp_inside_angle_empty                     = remove
 sp_inside_angle                           = remove

--- a/src/options.h
+++ b/src/options.h
@@ -639,7 +639,7 @@ sp_func_proto_paren_empty;
 extern Option<iarf_e>
 sp_func_type_paren;
 
-// Add or remove space between function name and '(' on function definition.
+// Add or remove space between alias name and '(' of a non-pointer function type typedef.
 extern Option<iarf_e>
 sp_func_def_paren;
 

--- a/src/options.h
+++ b/src/options.h
@@ -635,6 +635,10 @@ sp_func_proto_paren;
 extern Option<iarf_e>
 sp_func_proto_paren_empty;
 
+// Add or remove space between function name and '(' with a typedef specifier.
+extern Option<iarf_e>
+sp_func_type_paren;
+
 // Add or remove space between function name and '(' on function definition.
 extern Option<iarf_e>
 sp_func_def_paren;

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1500,6 +1500,14 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       log_rule("sp_func_proto_paren");
       return(options::sp_func_proto_paren());
    }
+   // Issue #2437
+   if (  chunk_is_token(first, CT_FUNC_TYPE)
+      && chunk_is_token(second, CT_FPAREN_OPEN))
+   {
+      // Add or remove space between function name and '(' with a typedef specifier.
+      log_rule("sp_func_type_paren");
+      return(options::sp_func_type_paren());
+   }
    if (chunk_is_token(first, CT_FUNC_CLASS_DEF) || chunk_is_token(first, CT_FUNC_CLASS_PROTO))
    {
       if (  (options::sp_func_class_paren_empty() != IARF_IGNORE)

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -129,6 +129,7 @@ sp_type_func                    = ignore
 sp_type_brace_init_lst          = ignore
 sp_func_proto_paren             = ignore
 sp_func_proto_paren_empty       = ignore
+sp_func_type_paren              = ignore
 sp_func_def_paren               = ignore
 sp_func_def_paren_empty         = ignore
 sp_inside_fparens               = ignore

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -495,6 +495,9 @@ sp_func_proto_paren             = ignore   # ignore/add/remove/force
 # without parameters.
 sp_func_proto_paren_empty       = ignore   # ignore/add/remove/force
 
+# Add or remove space between function name and '(' with a typedef specifier.
+sp_func_type_paren              = ignore   # ignore/add/remove/force
+
 # Add or remove space between function name and '(' on function definition.
 sp_func_def_paren               = ignore   # ignore/add/remove/force
 

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -498,7 +498,7 @@ sp_func_proto_paren_empty       = ignore   # ignore/add/remove/force
 # Add or remove space between function name and '(' with a typedef specifier.
 sp_func_type_paren              = ignore   # ignore/add/remove/force
 
-# Add or remove space between function name and '(' on function definition.
+# Add or remove space between alias name and '(' of a non-pointer function type typedef.
 sp_func_def_paren               = ignore   # ignore/add/remove/force
 
 # Add or remove space between function name and '()' on function definition

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -129,6 +129,7 @@ sp_type_func                    = ignore
 sp_type_brace_init_lst          = ignore
 sp_func_proto_paren             = ignore
 sp_func_proto_paren_empty       = ignore
+sp_func_type_paren              = ignore
 sp_func_def_paren               = ignore
 sp_func_def_paren_empty         = ignore
 sp_inside_fparens               = ignore

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -495,6 +495,9 @@ sp_func_proto_paren             = ignore   # ignore/add/remove/force
 # without parameters.
 sp_func_proto_paren_empty       = ignore   # ignore/add/remove/force
 
+# Add or remove space between function name and '(' with a typedef specifier.
+sp_func_type_paren              = ignore   # ignore/add/remove/force
+
 # Add or remove space between function name and '(' on function definition.
 sp_func_def_paren               = ignore   # ignore/add/remove/force
 

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -498,7 +498,7 @@ sp_func_proto_paren_empty       = ignore   # ignore/add/remove/force
 # Add or remove space between function name and '(' with a typedef specifier.
 sp_func_type_paren              = ignore   # ignore/add/remove/force
 
-# Add or remove space between function name and '(' on function definition.
+# Add or remove space between alias name and '(' of a non-pointer function type typedef.
 sp_func_def_paren               = ignore   # ignore/add/remove/force
 
 # Add or remove space between function name and '()' on function definition

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -495,6 +495,9 @@ sp_func_proto_paren             = ignore   # ignore/add/remove/force
 # without parameters.
 sp_func_proto_paren_empty       = ignore   # ignore/add/remove/force
 
+# Add or remove space between function name and '(' with a typedef specifier.
+sp_func_type_paren              = ignore   # ignore/add/remove/force
+
 # Add or remove space between function name and '(' on function definition.
 sp_func_def_paren               = ignore   # ignore/add/remove/force
 

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -498,7 +498,7 @@ sp_func_proto_paren_empty       = ignore   # ignore/add/remove/force
 # Add or remove space between function name and '(' with a typedef specifier.
 sp_func_type_paren              = ignore   # ignore/add/remove/force
 
-# Add or remove space between function name and '(' on function definition.
+# Add or remove space between alias name and '(' of a non-pointer function type typedef.
 sp_func_def_paren               = ignore   # ignore/add/remove/force
 
 # Add or remove space between function name and '()' on function definition

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -1182,6 +1182,15 @@ Choices=sp_func_proto_paren_empty=ignore|sp_func_proto_paren_empty=add|sp_func_p
 ChoicesReadable="Ignore Sp Func Proto Paren Empty|Add Sp Func Proto Paren Empty|Remove Sp Func Proto Paren Empty|Force Sp Func Proto Paren Empty"
 ValueDefault=ignore
 
+[Sp Func Type Paren]
+Category=1
+Description="<html>Add or remove space between function name and '(' with a typedef specifier.</html>"
+Enabled=false
+EditorType=multiple
+Choices=sp_func_type_paren=ignore|sp_func_type_paren=add|sp_func_type_paren=remove|sp_func_type_paren=force
+ChoicesReadable="Ignore Sp Func Type Paren|Add Sp Func Type Paren|Remove Sp Func Type Paren|Force Sp Func Type Paren"
+ValueDefault=ignore
+
 [Sp Func Def Paren]
 Category=1
 Description="<html>Add or remove space between function name and '(' on function definition.</html>"

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -1193,7 +1193,7 @@ ValueDefault=ignore
 
 [Sp Func Def Paren]
 Category=1
-Description="<html>Add or remove space between function name and '(' on function definition.</html>"
+Description="<html>Add or remove space between alias name and '(' of a non-pointer function type typedef.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_func_def_paren=ignore|sp_func_def_paren=add|sp_func_def_paren=remove|sp_func_def_paren=force

--- a/tests/config/Issue_2437.cfg
+++ b/tests/config/Issue_2437.cfg
@@ -1,0 +1,2 @@
+sp_func_proto_paren = remove
+sp_func_type_paren  = remove

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -736,6 +736,7 @@
 34310  issue_2209.cfg                       cpp/issue_2209-2.cpp
 34311  Issue_2250.cfg                       cpp/Issue_2250.cpp
 34312  Issue_2101.cfg                       cpp/Issue_2101.cpp
+34313  Issue_2437.cfg                       cpp/Issue_2437.cpp
 
 34315  align_func_proto_thresh_1.cfg        cpp/align_func_proto_thresh.cpp
 34316  align_func_proto_thresh_2.cfg        cpp/align_func_proto_thresh.cpp

--- a/tests/expected/cpp/34313-Issue_2437.cpp
+++ b/tests/expected/cpp/34313-Issue_2437.cpp
@@ -1,0 +1,2 @@
+void timer_cb1(struct timer_node *n);
+typedef void timer_cb(struct timer_node *n);

--- a/tests/input/cpp/Issue_2437.cpp
+++ b/tests/input/cpp/Issue_2437.cpp
@@ -1,0 +1,2 @@
+void timer_cb1(struct timer_node *n);
+typedef void timer_cb(struct timer_node *n);


### PR DESCRIPTION
To control the space before the parenthesis:
`typedef void timer_cb(struct timer_node *n);`
Ref. #2437 