### PR TITLE
test: add test for issue #2440.

### DIFF
--- a/tests/config/Issue_2440.cfg
+++ b/tests/config/Issue_2440.cfg
@@ -1,0 +1,1 @@
+pp_region_indent_code           = true    # true/false

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -608,10 +608,11 @@
 34116  nl_before_func_body_def-2.cfg        cpp/issue_2000.cpp
 34117  extern_func.cfg                      cpp/extern_func.cpp
 34118  Issue_2163.cfg                       cpp/Issue_2163.cpp
-34119  Issue_2440.cfg                       cpp/Issue_2440.cpp
 
 34120  align_assign_span-1.cfg              cpp/bug_i_999.cpp
 34121  bug_1717.cfg                         cpp/bug_1717.cpp
+34122  Issue_2440.cfg                       cpp/Issue_2440.cpp
+34123  Issue_2440+nl.cfg                    cpp/Issue_2440+nl.cpp
 
 34130  nl_brace_fparen-f.cfg                cpp/bug_i_1000.cpp
 34131  nl_brace_fparen-r.cfg                cpp/bug_i_1000.cpp

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -608,6 +608,7 @@
 34116  nl_before_func_body_def-2.cfg        cpp/issue_2000.cpp
 34117  extern_func.cfg                      cpp/extern_func.cpp
 34118  Issue_2163.cfg                       cpp/Issue_2163.cpp
+34119  Issue_2440.cfg                       cpp/Issue_2440.cpp
 
 34120  align_assign_span-1.cfg              cpp/bug_i_999.cpp
 34121  bug_1717.cfg                         cpp/bug_1717.cpp

--- a/tests/expected/cpp/Issue_2440+nl.cpp
+++ b/tests/expected/cpp/Issue_2440+nl.cpp
@@ -1,0 +1,2 @@
+#pragma region
+#pragma endregion

--- a/tests/expected/cpp/Issue_2440.cpp
+++ b/tests/expected/cpp/Issue_2440.cpp
@@ -1,0 +1,2 @@
+#pragma region
+#pragma endregion

--- a/tests/input/cpp/Issue_2440+nl.cpp
+++ b/tests/input/cpp/Issue_2440+nl.cpp
@@ -1,0 +1,2 @@
+#pragma region
+#pragma endregion

--- a/tests/input/cpp/Issue_2440.cpp
+++ b/tests/input/cpp/Issue_2440.cpp
@@ -1,0 +1,2 @@
+#pragma region
+#pragma endregion


### PR DESCRIPTION
### Local output
Output of local tests run on 32a055c2d4a61d871a79638992563649d73a405e:
```.log
1>------ Build started: Project: RUN_TESTS, Configuration: Release x64 ------
1>Test project D:/Documents/Visual Studio 2017/Projects/uncrustify/uncrustify/build
1>      Start  1: c-sharp
1> 1/14 Test  #1: c-sharp ..........................   Passed    8.80 sec
1>      Start  2: c
1> 2/14 Test  #2: c ................................   Passed   55.53 sec
1>      Start  3: cpp
1> 3/14 Test  #3: cpp ..............................***Failed   80.42 sec
1>      Start  4: d
1> 4/14 Test  #4: d ................................   Passed   21.31 sec
1>      Start  5: ecma
1> 5/14 Test  #5: ecma .............................   Passed    0.11 sec
1>      Start  6: imported
1> 6/14 Test  #6: imported .........................   Passed    0.06 sec
1>      Start  7: java
1> 7/14 Test  #7: java .............................   Passed    2.21 sec
1>      Start  8: objective-c
1> 8/14 Test  #8: objective-c ......................   Passed   12.46 sec
1>      Start  9: pawn
1> 9/14 Test  #9: pawn .............................   Passed    1.18 sec
1>      Start 10: vala
1>10/14 Test #10: vala .............................   Passed    0.83 sec
1>      Start 11: staging
1>11/14 Test #11: staging ..........................   Passed    0.13 sec
1>      Start 12: sources_format
1>12/14 Test #12: sources_format ...................   Passed  111.14 sec
1>      Start 13: cli_options
1>13/14 Test #13: cli_options ......................   Passed    0.28 sec
1>      Start 14: sanity
1>14/14 Test #14: sanity ...........................   Passed    0.01 sec
1>
1>93% tests passed, 1 tests failed out of 14
1>
1>Total Test time (real) = 294.50 sec
1>
1>The following tests FAILED:
1>	  3 - cpp (Failed)
1>Errors while running CTest
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(148,5): error MSB3073: The command "setlocal
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(148,5): error MSB3073: D:\Apps\CMake\bin\ctest.exe --force-new-ctest-process -C Release
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(148,5): error MSB3073: if %errorlevel% neq 0 goto :cmEnd
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(148,5): error MSB3073: :cmEnd
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(148,5): error MSB3073: endlocal & call :cmErrorLevel %errorlevel% & goto :cmDone
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(148,5): error MSB3073: :cmErrorLevel
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(148,5): error MSB3073: exit /b %1
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(148,5): error MSB3073: :cmDone
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(148,5): error MSB3073: if %errorlevel% neq 0 goto :VCEnd
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(148,5): error MSB3073: :VCEnd" exited with code 8.
1>Done building project "RUN_TESTS.vcxproj" -- FAILED.
========== Build: 0 succeeded, 1 failed, 1 up-to-date, 0 skipped ==========
```