### PR TITLE
Improve flag logging

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -3810,11 +3810,11 @@ static chunk_t *mark_variable_definition(chunk_t *start)
 
          LOG_FMT(LVARDEF,
                  "%s(%d): orig_line is %zu, marked text() '%s'[%s] "
-                 "in orig_col %zu, flags: %#llx -> %#llx\n",
+                 "in orig_col %zu, flags: %s -> %s\n",
                  __func__, __LINE__, pc->orig_line, pc->text(),
                  get_token_name(pc->type), pc->orig_col,
-                 static_cast<pcf_flags_t::int_t>(orig_flags),
-                 static_cast<pcf_flags_t::int_t>(pc->flags));
+                 pcf_flags_str(orig_flags).c_str(),
+                 pcf_flags_str(pc->flags).c_str());
       }
       else if (chunk_is_star(pc) || chunk_is_msref(pc))
       {

--- a/src/logger.h
+++ b/src/logger.h
@@ -75,28 +75,6 @@ void log_get_mask(log_mask_t &mask);
 
 
 /**
- * Logs a string of known length
- *
- * @param sev  The severity
- * @param str  The pointer to the string
- * @param len  The length of the string from strlen(str)
- *
- * TODO call strlen internally instead of providing len
- */
-void log_str(log_sev_t sev, const char *str, size_t len);
-
-
-#define LOG_STR(sev, str, len)                           \
-   do { if (log_sev_on(sev)) { log_str(sev, str, len); } \
-   } while (0)
-
-
-#define LOG_STRING(sev, str)                                     \
-   do { if (log_sev_on(sev)) { log_str(sev, str, strlen(str)); } \
-   } while (0)
-
-
-/**
  * Logs a formatted string -- similar to printf()
  *
  * @param sev  The severity
@@ -135,58 +113,6 @@ void log_flush(bool force_nl);
 #else
 #define D_LOG_FMT(sev, ...)    ((void)0) //forces semicolon after macro
 #endif
-
-
-/**
- * Dumps hex characters inline, no newlines inserted
- *
- * @param sev     The severity
- * @param data    The data to log
- * @param len     The number of bytes to log
- */
-void log_hex(log_sev_t sev, const void *vdata, size_t len);
-
-
-#define LOG_HEX(sev, ptr, len)                           \
-   do { if (log_sev_on(sev)) { log_hex(sev, ptr, len); } \
-   } while (0)
-
-
-/**
- * Logs a block of data in a pretty hex format
- * Numbers on the left, characters on the right, just like I like it.
- *
- * "nnn | XX XX XX XX XX XX XX XX XX XX XX XX XX XX XX XX | ................"
- *  0     ^6                                            54^ ^56           72^
- *
- *  nnn is the line number or index/16
- *
- * @param sev   The severity
- * @param data  The data to log
- * @param len   The number of bytes to log
- */
-void log_hex_blk(log_sev_t sev, const void *data, size_t len);
-
-
-#define LOG_HEX_BLK(sev, ptr, len)                           \
-   do { if (log_sev_on(sev)) { log_hex_blk(sev, ptr, len); } \
-   } while (0)
-
-
-/**
- * Returns the HEX digit for a low nibble in a number
- *
- * @param nibble  The nibble
- *
- * @return '0', '1', '2', '3', '4', '5', '6', '7','8', '9',
- *         'a', 'b', 'c', 'd', 'e', or 'f'
- */
-static inline char to_hex_char(int nibble)
-{
-   const char *hex_string = "0123456789abcdef";
-
-   return(hex_string[nibble & 0x0F]);
-}
 
 
 #ifdef DEBUG

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -586,8 +586,9 @@ static void newline_min_after(chunk_t *ref, size_t count, pcf_flag_e flag)
 {
    LOG_FUNC_ENTRY();
 
-   LOG_FMT(LNEWLINE, "%s(%d): '%s' line %zu - count=%zu flg=0x%llx:",
-           __func__, __LINE__, ref->text(), ref->orig_line, count, flag);
+   LOG_FMT(LNEWLINE, "%s(%d): '%s' line %zu - count=%zu flg=%s:",
+           __func__, __LINE__, ref->text(), ref->orig_line, count,
+           pcf_flags_str(flag).c_str());
    log_func_stack_inline(LNEWLINE);
 
    chunk_t *pc = ref;
@@ -2822,9 +2823,9 @@ static void newline_oc_msg(chunk_t *start)
 static bool one_liner_nl_ok(chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
-   LOG_FMT(LNL1LINE, "%s(%d): check type is %s, parent is %s, flag is %llx, orig_line is %zu, orig_col is %zu\n",
+   LOG_FMT(LNL1LINE, "%s(%d): check type is %s, parent is %s, flag is %s, orig_line is %zu, orig_col is %zu\n",
            __func__, __LINE__, get_token_name(pc->type), get_token_name(pc->parent_type),
-           static_cast<pcf_flags_t::int_t>(pc->flags), pc->orig_line, pc->orig_col);
+           pcf_flags_str(pc->flags).c_str(), pc->orig_line, pc->orig_col);
 
 
    if (!pc->flags.test(PCF_ONE_LINER))

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -2362,6 +2362,37 @@ static size_t language_flags_from_filename(const char *filename)
 }
 
 
+std::string pcf_flags_str(pcf_flags_t flags)
+{
+   char buffer[64];
+
+   // Generate hex representation first
+   snprintf(buffer, 63, "[0x%llx:", static_cast<pcf_flags_t::int_t>(flags));
+
+   // Add human-readable names
+   auto out   = std::string{ buffer };
+   auto first = true;
+   for (size_t i = 0; i < ARRAY_SIZE(pcf_names); ++i)
+   {
+      if (flags & static_cast<pcf_flag_e>(pcf_bit(i)))
+      {
+         if (first)
+         {
+            first = false;
+         }
+         else
+         {
+            out += ',';
+         }
+         out += pcf_names[i];
+      }
+   }
+
+   out += ']';
+   return(out);
+}
+
+
 void log_pcf_flags(log_sev_t sev, pcf_flags_t flags)
 {
    if (!log_sev_on(sev))
@@ -2369,26 +2400,5 @@ void log_pcf_flags(log_sev_t sev, pcf_flags_t flags)
       return;
    }
 
-   log_fmt(sev, "[0x%llx:", static_cast<pcf_flags_t::int_t>(flags));
-
-   const char *tolog = nullptr;
-   for (size_t i = 0; i < ARRAY_SIZE(pcf_names); i++)
-   {
-      if (flags & static_cast<pcf_flag_e>(pcf_bit(i)))
-      {
-         if (tolog != nullptr)
-         {
-            log_str(sev, tolog, strlen(tolog));
-            log_str(sev, ",", 1);
-         }
-         tolog = pcf_names[i];
-      }
-   }
-
-   if (tolog != nullptr)
-   {
-      log_str(sev, tolog, strlen(tolog));
-   }
-
-   log_str(sev, "]\n", 2);
+   log_fmt(sev, "%s\n", pcf_flags_str(flags).c_str());
 }

--- a/src/uncrustify.h
+++ b/src/uncrustify.h
@@ -45,6 +45,8 @@ const char *language_name_from_flags(size_t lang);
  */
 c_token_t find_token_name(const char *text);
 
+std::string pcf_flags_str(pcf_flags_t flags);
+
 
 void log_pcf_flags(log_sev_t sev, pcf_flags_t flags);
 


### PR DESCRIPTION
Add a new helper function to convert `pcf_flags_t` to a human-readable string. Use this in some places that were previously only logging the raw value.

Besides being more human-readable, one of the changes avoids a bug in GCC < 8.x where the enum type is accepted as variadic argument, but is incorrectly converted to an `unsigned long`, which does not match the format specifier (`unsigned long long`), resulting in a compiler warning.