### PR TITLE
Update syntax highlighting template

### DIFF
--- a/etc/uncrustify.xml.in
+++ b/etc/uncrustify.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE language SYSTEM "language.dtd">
-<language name="Uncrustify Configuration" section="Configuration" extensions="uncrustify.cfg;uncrustify.conf;.uncrustify.cfg;.uncrustify.conf" mimetype="" version="0.68" kateversion="2.0" author="Matthew Woehlke (mwoehlke.floss@gmail.com)" license="LGPL">
+<language name="Uncrustify Configuration" section="Configuration" extensions="uncrustify.cfg;uncrustify.conf;.uncrustify.cfg;.uncrustify.conf" mimetype="" version="0.69.0" kateversion="2.0" author="Matthew Woehlke (mwoehlke.floss@gmail.com)" license="LGPL">
 
   <highlighting>
     <list name="options">
@@ -19,6 +19,7 @@
       <item>macro-else</item>
       <item>macro-open</item>
       <item>type</item>
+      <item>using</item>
     </list>
 
     <contexts>
@@ -26,7 +27,6 @@
         <WordDetect context="SetDirective" attribute="Directive" String="set" />
         <keyword context="Values" attribute="Directive" String="directives" />
         <keyword context="Values" attribute="Option" String="options" />
-        <keyword context="Values" attribute="Token" String="tokens" />
         <DetectChar context="Comment" attribute="Comment" char="#" />
       </context>
 


### PR DESCRIPTION
Add 'using' to the set of directives recognized by our katepart syntax highlighting XML. Remove tokens from the set of things that are recognized at the start of a line. (Not sure what I was thinking with that rule; AFAIK tokens are only allowed after a 'set' directive.)