### PR TITLE
Tweak output of gen_changelog.py

### DIFF
--- a/scripts/gen_changelog.py
+++ b/scripts/gen_changelog.py
@@ -96,11 +96,11 @@ def main():
             changes.append(c)
 
     for c in changes:
-        print('{} ({})'.format(c.date, c.sha))
+        print(c.sha)
         for o in c.added_options:
-            print('  Added   : {}'.format(o))
+            print('  Added   : {:36} {}'.format(o, c.date))
         for o in c.removed_options:
-            print('  Removed : {}'.format(o))
+            print('  Removed : {:36} {}'.format(o, c.date))
 
     return 0
 


### PR DESCRIPTION
Adjust the output of `gen_changelog.py` so that it is easier to convert to the desired final format. I think this strikes a good balance between minimal additional tweaking needed while still usefully providing the information that helps a human sort out things like renamed or transient options that need manual tweaking.