### PR TITLE
Improve release process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,6 @@ endif()
 # Generate uncrustify_version.h
 #
 
-# FIXME: the version number should be automatically integrated
 set(CURRENT_VERSION "Uncrustify-0.69.0_f")
 
 option(NoGitVersionString "Do not use make_version.py and git to build a version string" OFF)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 A source code beautifier for C, C++, C#, ObjectiveC, D, Java, Pawn and VALA
 
 ## Features
-* highly configurable - 671 configurable options as of version 0.69.0
+* Highly configurable - 671 configurable options as of version 0.69.0
 - <details><summary>add/remove spaces</summary>
 
   - `sp_before_sparen`: _Add or remove space before '(' of 'if', 'for', 'switch', 'while', etc._

--- a/man/uncrustify.1.in
+++ b/man/uncrustify.1.in
@@ -95,6 +95,9 @@ Print this message and exit
 \fB\-\-version\fR
 Print the version and exit
 .TP
+\fB\-\-count\-options\fR
+Print the number of available options and exit
+.TP
 \fB\-\-show\-config\fR
 Print out option documentation and exit
 .TP

--- a/scripts/release_tool.py
+++ b/scripts/release_tool.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python
+
+'''
+This script attempts to extract what options have been added since the
+specified revision (usually a tag, but any revision that git recognizes may be
+provided). It accepts an optional second revision to use as the cut-off. The
+default is your LOCAL "master". Thus, you should ensure that this is up to date
+before running this script.
+
+This script works by extracting the set of options before and after every
+commit that affected ':src/options.h' and computing the differences. It should,
+therefore, be fairly robust (for example, options that moved around won't show
+up). However, if an option is removed and subsequently re-added, or if an
+option was added and subsequently removed, the resulting records will need to
+be reconciled manually.
+'''
+
+import argparse
+import git
+import os
+import re
+import sys
+
+if sys.version_info[0] < 3:
+    input = raw_input
+
+re_desc = re.compile(r'^uncrustify[-]([0-9]+[.][0-9]+[.][0-9]+)')
+re_version = re.compile(r'^[0-9]+[.][0-9]+[.][0-9]+$')
+re_option_count = re.compile(r'There are currently ([0-9]+) options')
+
+
+# -----------------------------------------------------------------------------
+def fatal(msg, code=1):
+    sys.stderr.write(msg + '\n')
+    sys.exit(code)
+
+
+# -----------------------------------------------------------------------------
+def get_version_str(repo, required=True):
+    d = repo.git.describe('HEAD')
+    m = re_desc.match(d)
+    if m:
+        return m.group(1)
+
+    if required:
+        fatal('Unable to determine current version')
+
+    return None
+
+
+# -----------------------------------------------------------------------------
+def get_version_info(repo, required=True):
+    return tuple(map(int, get_version_str(repo, required).split('.')))
+
+
+# -----------------------------------------------------------------------------
+def get_option_count(executable):
+    import subprocess
+
+    out = subprocess.check_output([executable, '--count-options'])
+    m = re_option_count.match(out.decode('utf-8'))
+    if m is None:
+        fatal('Failed to get option count from \'{}\''.format(executable))
+
+    return int(m.group(1))
+
+
+# -----------------------------------------------------------------------------
+def alter(repo, path, old, new):
+    p = os.path.join(repo.working_tree_dir, path)
+    with open(p, 'r') as f:
+        content = f.read()
+        content = re.sub(old, new, content)
+    with open(p, 'w') as f:
+        f.write(content)
+    print(path)
+
+
+# -----------------------------------------------------------------------------
+def cmd_init(repo, args):
+    v = args.version
+    if v is None:
+        c = get_version_info(repo, required=False)
+        if c:
+            n = list(c)
+            n[1] += 1
+            n = '.'.join(map(str, n))
+            v = input('Version to be created? [{}] '.format(n))
+            if len(v) == 0:
+                v = n
+
+        else:
+            v = input('Version to be created? ')
+
+    if not re_version.match(v):
+        fatal('Bad version number, \'{}\''.format(v))
+
+    tag_message = 'Prepare Uncrustify v{} release'.format(v)
+    repo.git.tag('-a', 'uncrustify-{}'.format(v), '-m', tag_message)
+
+
+# -----------------------------------------------------------------------------
+def cmd_update(repo, args):
+    v = get_version_str(repo)
+    if hasattr(args, 'count'):
+        c = args.count
+    else:
+        c = get_option_count(args.executable)
+
+    alter(repo, 'CMakeLists.txt',
+          r'(set *[(] *CURRENT_VERSION +"Uncrustify)[-][0-9.]+',
+          r'\g<1>-{}'.format(v))
+    alter(repo, 'package.json',
+          r'("version" *): *"[0-9.]+"',
+          r'\g<1>: "{}"'.format(v))
+    alter(repo, 'README.md',
+          r'[0-9]+ configurable options',
+          r'{} configurable options'.format(c))
+    alter(repo, 'documentation/htdocs/index.html',
+          r'[0-9]+ configurable options',
+          r'{} configurable options'.format(c))
+
+
+# -----------------------------------------------------------------------------
+def cmd_commit(repo, args):
+    v = get_version_str(repo)
+    message = 'Create Uncrustify v{} release'.format(v)
+
+    extra_args = []
+    if args.amend:
+        extra_args += ['--amend', '--date=now']
+
+    repo.git.commit('-m', message, *extra_args)
+    repo.git.tag('-a', 'uncrustify-{}'.format(v), '-m', message, '--force')
+
+
+# -----------------------------------------------------------------------------
+def cmd_push(repo, args):
+    v = get_version_str(repo)
+    tag = 'uncrustify-{}'.format(v)
+
+    if args.ssh:
+        s = 'git@{}:'.format(args.server)
+    else:
+        s = 'https://{}/'.format(args.server)
+    r = '{}{}/{}.git'.format(s, args.organization, args.project)
+
+    extra_args = []
+    if args.force:
+        extra_args.append('--force-with-lease')
+
+    repo.git.push(r, 'HEAD:master', tag, *extra_args)
+
+
+# -----------------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser(
+        description='Perform release-related actions')
+
+    root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    parser.add_argument('--repo', type=str, default=root,
+                        help='path to uncrustify git repository')
+
+    subparsers = parser.add_subparsers(title='subcommands',
+                                       help='action to perform')
+
+    parser_init = subparsers.add_parser(
+        'init', help='initialize new version')
+    parser_init.set_defaults(func=cmd_init)
+    parser_init.add_argument('-v', '--version',
+                             help='version number for release')
+
+    parser_update = subparsers.add_parser(
+        'update', help='update version information')
+    parser_update.set_defaults(func=cmd_update)
+    group_update = parser_update.add_mutually_exclusive_group(required=True)
+    group_update.add_argument('-c', '--options', type=int,
+                              help='number of available options')
+    group_update.add_argument('-x', '--executable',
+                              help='path to uncrustify executable')
+
+    parser_commit = subparsers.add_parser(
+        'commit', help='commit changes for new version')
+    parser_commit.set_defaults(func=cmd_commit)
+    parser_commit.add_argument('--amend', action='store_true',
+                               help='amend a previous release commit')
+
+    parser_push = subparsers.add_parser(
+        'push', help='push release to github')
+    parser_push.set_defaults(func=cmd_push)
+    parser_push.add_argument('--ssh', action='store_true',
+                             help='use ssh (instead of HTTPS) to push')
+    parser_push.add_argument('-s', '--server', default='github.com',
+                             help='push to specified server')
+    parser_push.add_argument('-o', '--organization', default='uncrustify',
+                             help='push to specified user or organization')
+    parser_push.add_argument('-p', '--project', default='uncrustify',
+                             help='push to specified project')
+    parser_push.add_argument('-f', '--force', action='store_true',
+                             help='force push')
+
+    args = parser.parse_args()
+    repo = git.Repo(args.repo)
+    args.func(repo, args)
+
+    return 0
+
+
+# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -230,6 +230,14 @@ void usage_error(const char *msg)
 }
 
 
+static void tease()
+{
+   fprintf(stdout,
+           "There are currently %zu options and minimal documentation.\n"
+           "Try UniversalIndentGUI and good luck.\n", get_option_count());
+}
+
+
 void usage(const char *argv0)
 {
    fprintf(stdout,
@@ -279,6 +287,7 @@ void usage(const char *argv0)
            "Config/Help Options:\n"
            " -h -? --help --usage     : Print this message and exit.\n"
            " --version                : Print the version and exit.\n"
+           " --count-options          : Print the number of available options and exit.\n"
            " --show-config            : Print out option documentation and exit.\n"
            " --update-config          : Output a new config file. Use with -o FILE.\n"
            " --update-config-with-doc : Output a new config file. Use with -o FILE.\n"
@@ -307,11 +316,9 @@ void usage(const char *argv0)
            "      processing of parts of the source file (these can be overridden with\n"
            "      enable_processing_cmt and disable_processing_cmt).\n"
            "\n"
-           "There are currently %d options and minimal documentation.\n"
-           "Try UniversalIndentGUI and good luck.\n"
-           "\n"
            ,
-           path_basename(argv0), (int)get_option_count());
+           path_basename(argv0));
+   tease();
 } // usage
 
 
@@ -454,6 +461,12 @@ int main(int argc, char *argv[])
       || arg.Present("-?"))
    {
       usage(argv[0]);
+      return(EXIT_SUCCESS);
+   }
+
+   if (arg.Present("--count-options"))
+   {
+      tease();
       return(EXIT_SUCCESS);
    }
 

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -41,6 +41,7 @@ Basic Options:
 Config/Help Options:
  -h -? --help --usage     : Print this message and exit.
  --version                : Print the version and exit.
+ --count-options          : Print the number of available options and exit.
  --show-config            : Print out option documentation and exit.
  --update-config          : Output a new config file. Use with -o FILE.
  --update-config-with-doc : Output a new config file. Use with -o FILE.
@@ -71,4 +72,3 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
 
 There are currently x options and minimal documentation.
 Try UniversalIndentGUI and good luck.
-


### PR DESCRIPTION
Create a new script to help perform several of the actions related to creating a new release. In particular, this automates several file changes that previously needed to be done by hand. (It isn't a "one button" script, but it should at least cut down on the number of details that need to be remembered.)

~~Also, replace the existing `release-steps.txt` with an updated reST document that also explains how to use the recently added `gen_changelog.py`.~~ (The documentation is still a WIP; will add it ASAP. This *could* be merged in its current state, but feel free to wait for the documentation.)

This has been tested locally and by pushing to my fork rather than the main repo.