### PR TITLE
"Fix" how release_tool.py obtains the branch

### DIFF
--- a/scripts/release_tool.py
+++ b/scripts/release_tool.py
@@ -24,7 +24,7 @@ def fatal(msg):
 # -----------------------------------------------------------------------------
 def get_version_str(repo, candidate=True, required=True):
     if candidate:
-        b = repo.git.branch('--show-current')
+        b = repo.git.symbolic_ref('-q', '--short', 'HEAD')
         m = re_branch.match(b)
         if m:
             return m.group(1)


### PR DESCRIPTION
Use a different method to obtain the name of the current branch; apparently, `git branch --show-current` is a very recent addition, and thus is not guaranteed to be available yet.

Fixes #2518.