### PR TITLE
Inject version into uncrustify.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,11 @@ function(py_gen OUTPUT SCRIPT INPUT)
   set(deps "${PROJECT_SOURCE_DIR}/src/${INPUT}")
   get_filename_component(outdir "${out}" DIRECTORY)
   foreach(arg IN LISTS ARGN)
-    list(APPEND deps "${PROJECT_SOURCE_DIR}/src/${arg}")
+    if (IS_ABSOLUTE "${arg}")
+      list(APPEND deps "${arg}")
+    else()
+      list(APPEND deps "${PROJECT_SOURCE_DIR}/src/${arg}")
+    endif()
   endforeach()
 
   add_custom_command(
@@ -214,6 +218,7 @@ py_gen(option_enum.cpp
 py_gen(../etc/uncrustify.xml
   make_katehl.py
   ../etc/uncrustify.xml.in
+  "${PROJECT_BINARY_DIR}/uncrustify_version.h"
   options.h
   option.h
   token_enum.h

--- a/etc/uncrustify.xml.in
+++ b/etc/uncrustify.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE language SYSTEM "language.dtd">
-<language name="Uncrustify Configuration" section="Configuration" extensions="uncrustify.cfg;uncrustify.conf;.uncrustify.cfg;.uncrustify.conf" mimetype="" version="0.69.0" kateversion="2.0" author="Matthew Woehlke (mwoehlke.floss@gmail.com)" license="LGPL">
+<language name="Uncrustify Configuration" section="Configuration" extensions="uncrustify.cfg;uncrustify.conf;.uncrustify.cfg;.uncrustify.conf" mimetype="" version="##VERSION##" kateversion="2.0" author="Matthew Woehlke (mwoehlke.floss@gmail.com)" license="LGPL">
 
   <highlighting>
     <list name="options">


### PR DESCRIPTION
Modify how we generate the katepart syntax highlighting file (`uncrustify.xml`) to inject the version number, rather than having it hard-coded.

Fixes #2515.