### PR TITLE
Fix generating version when no repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ else()
     -D SOURCE_DIR:PATH="${PROJECT_SOURCE_DIR}"
     -D INPUT:PATH="${PROJECT_SOURCE_DIR}/src/uncrustify_version.h.in"
     -D OUTPUT:PATH="${PROJECT_BINARY_DIR}/uncrustify_version.h"
-    -D CURRENT_VERSION:STRING="CURRENT_VERSION"
+    -D CURRENT_VERSION:STRING="${CURRENT_VERSION}"
     -P ${PROJECT_SOURCE_DIR}/cmake/GenerateVersionHeader.cmake
     COMMENT "Generating version header"
   )


### PR DESCRIPTION
Fix how we invoke the script(s) to generate `uncrustify_version.h` to correctly pass the fallback version, which was inadvertently passing the literal string `"CURRENT_VERSION"` rather than the value of the variable of that name. (This broke in e01c919d3b86.)

Fixes #2530.