### PR TITLE
Teach indent the `indent_macro_brace` option

### DIFF
--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1087,6 +1087,14 @@ indent_func_const               = 0        # unsigned number
 # prototype.
 indent_func_throw               = 0        # unsigned number
 
+# How to indent within a macro followed by a brace on the same line.
+# This allows reducing the indent in macros that have (for example)
+# `do { ... } while (0)` blocks bracketing them.
+#
+# true:  add an indent for the brace on the same line as the macro
+# false: do not add an indent for the brace on the same line as the macro
+indent_macro_brace              = true     # true/false
+
 # The number of spaces to indent a continued '->' or '.'.
 # Usually set to 0, 1, or indent_columns.
 indent_member                   = 0        # unsigned number

--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -37,6 +37,7 @@ indent_class                              = true
 indent_columns                            = 3
 indent_cpp_lambda_only_once               = true
 indent_first_bool_expr                    = true
+indent_macro_brace                        = true
 indent_member                             = 3
 indent_with_tabs                          = 0
 

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1412,8 +1412,14 @@ void indent_text(void)
                  __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text());
          frm.push(pc);
 
-         if (  options::indent_cpp_lambda_body()
-            && pc->parent_type == CT_CPP_LAMBDA)
+         if (  !options::indent_macro_brace()
+            && frm.prev().type == CT_PP_DEFINE
+            && frm.prev().open_line == frm.top().open_line)
+         {
+            LOG_FMT(LINDENT2, "%s(%d): indent_macro_brace\n", __func__, __LINE__);
+         }
+         else if (  options::indent_cpp_lambda_body()
+                 && pc->parent_type == CT_CPP_LAMBDA)
          {
             frm.top().brace_indent = frm.prev().indent;
             indent_column_set(frm.top().brace_indent);

--- a/src/options.h
+++ b/src/options.h
@@ -1352,6 +1352,15 @@ indent_func_const;
 extern BoundedOption<unsigned, 0, 41>
 indent_func_throw;
 
+// How to indent within a macro followed by a brace on the same line
+// This allows reducing the indent in macros that have (for example)
+// `do { ... } while (0)` blocks bracketing them.
+//
+// true:  add an indent for the brace on the same line as the macro
+// false: do not add an indent for the brace on the same line as the macro
+extern Option<bool>
+indent_macro_brace; // = true
+
 // The number of spaces to indent a continued '->' or '.'.
 // Usually set to 0, 1, or indent_columns.
 extern BoundedOption<unsigned, 0, 16>

--- a/tests/c.test
+++ b/tests/c.test
@@ -382,3 +382,6 @@
 10005  empty.cfg                            c/i1270.c
 
 10006  bug_2331.cfg                         c/bug_2331.c
+
+10007  indent_macro_brace-true.cfg          c/indent-macro-brace.c
+10008  indent_macro_brace-false.cfg         c/indent-macro-brace.c

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -280,6 +280,7 @@ indent_template_param           = false
 indent_func_param_double        = false
 indent_func_const               = 0
 indent_func_throw               = 0
+indent_macro_brace              = true
 indent_member                   = 0
 indent_member_single            = false
 indent_sing_line_comments       = 0

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1092,6 +1092,16 @@ indent_func_const               = 0        # unsigned number
 # prototype.
 indent_func_throw               = 0        # unsigned number
 
+# How to indent within a macro followed by a brace on the same line
+# This allows reducing the indent in macros that have (for example)
+# `do { ... } while (0)` blocks bracketing them.
+#
+# true:  add an indent for the brace on the same line as the macro
+# false: do not add an indent for the brace on the same line as the macro
+#
+# Default: true
+indent_macro_brace              = true     # true/false
+
 # The number of spaces to indent a continued '->' or '.'.
 # Usually set to 0, 1, or indent_columns.
 indent_member                   = 0        # unsigned number

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -280,6 +280,7 @@ indent_template_param           = false
 indent_func_param_double        = false
 indent_func_const               = 0
 indent_func_throw               = 0
+indent_macro_brace              = true
 indent_member                   = 0
 indent_member_single            = false
 indent_sing_line_comments       = 0

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1092,6 +1092,16 @@ indent_func_const               = 0        # unsigned number
 # prototype.
 indent_func_throw               = 0        # unsigned number
 
+# How to indent within a macro followed by a brace on the same line
+# This allows reducing the indent in macros that have (for example)
+# `do { ... } while (0)` blocks bracketing them.
+#
+# true:  add an indent for the brace on the same line as the macro
+# false: do not add an indent for the brace on the same line as the macro
+#
+# Default: true
+indent_macro_brace              = true     # true/false
+
 # The number of spaces to indent a continued '->' or '.'.
 # Usually set to 0, 1, or indent_columns.
 indent_member                   = 0        # unsigned number

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1092,6 +1092,16 @@ indent_func_const               = 0        # unsigned number
 # prototype.
 indent_func_throw               = 0        # unsigned number
 
+# How to indent within a macro followed by a brace on the same line
+# This allows reducing the indent in macros that have (for example)
+# `do { ... } while (0)` blocks bracketing them.
+#
+# true:  add an indent for the brace on the same line as the macro
+# false: do not add an indent for the brace on the same line as the macro
+#
+# Default: true
+indent_macro_brace              = true     # true/false
+
 # The number of spaces to indent a continued '->' or '.'.
 # Usually set to 0, 1, or indent_columns.
 indent_member                   = 0        # unsigned number

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2523,6 +2523,14 @@ MinVal=0
 MaxVal=41
 ValueDefault=0
 
+[Indent Macro Brace]
+Category=2
+Description="<html>How to indent within a macro followed by a brace on the same line<br/>This allows reducing the indent in macros that have (for example)<br/>`do { ... } while ` blocks bracketing them.<br/><br/>true:  add an indent for the brace on the same line as the macro<br/>false: do not add an indent for the brace on the same line as the macro<br/><br/>Default: true</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=indent_macro_brace=true|indent_macro_brace=false
+ValueDefault=true
+
 [Indent Member]
 Category=2
 Description="<html>The number of spaces to indent a continued '-&gt;' or '.'.<br/>Usually set to 0, 1, or indent_columns.</html>"

--- a/tests/config/indent_macro_brace-false.cfg
+++ b/tests/config/indent_macro_brace-false.cfg
@@ -1,0 +1,1 @@
+indent_macro_brace = false

--- a/tests/config/indent_macro_brace-true.cfg
+++ b/tests/config/indent_macro_brace-true.cfg
@@ -1,0 +1,1 @@
+indent_macro_brace = true

--- a/tests/expected/c/10007-indent-macro-brace.c
+++ b/tests/expected/c/10007-indent-macro-brace.c
@@ -1,0 +1,8 @@
+#define X do { \
+		a; \
+		b; \
+} while (0)
+
+#define X \
+	y; \
+	z

--- a/tests/expected/c/10008-indent-macro-brace.c
+++ b/tests/expected/c/10008-indent-macro-brace.c
@@ -1,0 +1,8 @@
+#define X do { \
+	a; \
+	b; \
+} while (0)
+
+#define X \
+	y; \
+	z

--- a/tests/input/c/indent-macro-brace.c
+++ b/tests/input/c/indent-macro-brace.c
@@ -1,0 +1,8 @@
+#define X do {\
+a; \
+b; \
+} while (0)
+
+#define X\
+y; \
+z


### PR DESCRIPTION
Allows controlling the indent effect of an initial `{` in a macro.
Setting `indent_macro_brace` false removes 1 level (the brace level)
indent when the brace is opened on the same line as the macro.

true:

	#define X() do { \
			bar(); \
			baz(); \
	} while (0)

false:

	#define X() do { \
		bar(); \
		baz(); \
	} while (0)

Default is set to `true` to match current behavior.