### PR TITLE
Add option `indent_compound_literal_return`

### DIFF
--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1284,6 +1284,13 @@ indent_token_after_brace        = true     # true/false
 # Whether to indent the body of a C++11 lambda.
 indent_cpp_lambda_body          = false    # true/false
 
+# How to indent compound literals that are being returned.
+# true: add both the indent from return & the compound literal open brace (ie:
+#       2 indent levels)
+# false: only indent 1 level, don't add the indent for the open brace, only add
+#        the indent for the return.
+indent_compound_literal_return  = true     # true/false
+
 # (C#) Whether to indent a 'using' block if no braces are used.
 #
 # Default: true

--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -35,6 +35,7 @@ align_var_struct_span                     = 3
 indent_bool_paren                         = true
 indent_class                              = true
 indent_columns                            = 3
+indent_compound_literal_return            = false
 indent_cpp_lambda_only_once               = true
 indent_first_bool_expr                    = true
 indent_macro_brace                        = true

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1666,9 +1666,12 @@ void indent_text(void)
             }
             log_indent();
          }
-         else if (  pc->parent_type == CT_BRACED_INIT_LIST
+         else if (  (  pc->parent_type == CT_BRACED_INIT_LIST
+                    || (!options::indent_compound_literal_return() && pc->parent_type == CT_C_CAST))
                  && frm.prev().type == CT_RETURN)
          {
+            // we're returning either a c compound literal (CT_C_CAST) or a
+            // C++11 initialization list (CT_BRACED_INIT_LIST), use indent from the return.
             if (frm.prev().indent_cont)
             {
                frm.top().indent = frm.prev().indent_tmp;

--- a/src/options.h
+++ b/src/options.h
@@ -1570,6 +1570,14 @@ indent_token_after_brace; // = true
 extern Option<bool>
 indent_cpp_lambda_body;
 
+// How to indent compound literals that are being returned.
+// true: add both the indent from return & the compound literal open brace (ie:
+//       2 indent levels)
+// false: only indent 1 level, don't add the indent for the open brace, only add
+//        the indent for the return.
+extern Option<bool>
+indent_compound_literal_return; // = true
+
 // (C#) Whether to indent a 'using' block if no braces are used.
 extern Option<bool>
 indent_using_block; // = true

--- a/tests/c.test
+++ b/tests/c.test
@@ -385,3 +385,7 @@
 
 10007  indent_macro_brace-true.cfg          c/indent-macro-brace.c
 10008  indent_macro_brace-false.cfg         c/indent-macro-brace.c
+
+10009  empty.cfg                            c/return-compound-literal.c
+10010  indent_compound_literal_return-false.cfg c/return-compound-literal.c
+10011  indent_compound_literal_return-true.cfg c/return-compound-literal.c

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -322,6 +322,7 @@ indent_min_vbrace_open          = 0
 indent_vbrace_open_on_tabstop   = false
 indent_token_after_brace        = true
 indent_cpp_lambda_body          = false
+indent_compound_literal_return  = true
 indent_using_block              = true
 indent_ternary_operator         = 0
 indent_off_after_return_new     = false

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1284,6 +1284,15 @@ indent_token_after_brace        = true     # true/false
 # Whether to indent the body of a C++11 lambda.
 indent_cpp_lambda_body          = false    # true/false
 
+# How to indent compound literals that are being returned.
+# true: add both the indent from return & the compound literal open brace (ie:
+#       2 indent levels)
+# false: only indent 1 level, don't add the indent for the open brace, only add
+#        the indent for the return.
+#
+# Default: true
+indent_compound_literal_return  = true     # true/false
+
 # (C#) Whether to indent a 'using' block if no braces are used.
 #
 # Default: true

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -322,6 +322,7 @@ indent_min_vbrace_open          = 0
 indent_vbrace_open_on_tabstop   = false
 indent_token_after_brace        = true
 indent_cpp_lambda_body          = false
+indent_compound_literal_return  = true
 indent_using_block              = true
 indent_ternary_operator         = 0
 indent_off_after_return_new     = false

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1284,6 +1284,15 @@ indent_token_after_brace        = true     # true/false
 # Whether to indent the body of a C++11 lambda.
 indent_cpp_lambda_body          = false    # true/false
 
+# How to indent compound literals that are being returned.
+# true: add both the indent from return & the compound literal open brace (ie:
+#       2 indent levels)
+# false: only indent 1 level, don't add the indent for the open brace, only add
+#        the indent for the return.
+#
+# Default: true
+indent_compound_literal_return  = true     # true/false
+
 # (C#) Whether to indent a 'using' block if no braces are used.
 #
 # Default: true

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1284,6 +1284,15 @@ indent_token_after_brace        = true     # true/false
 # Whether to indent the body of a C++11 lambda.
 indent_cpp_lambda_body          = false    # true/false
 
+# How to indent compound literals that are being returned.
+# true: add both the indent from return & the compound literal open brace (ie:
+#       2 indent levels)
+# false: only indent 1 level, don't add the indent for the open brace, only add
+#        the indent for the return.
+#
+# Default: true
+indent_compound_literal_return  = true     # true/false
+
 # (C#) Whether to indent a 'using' block if no braces are used.
 #
 # Default: true

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2881,6 +2881,14 @@ EditorType=boolean
 TrueFalse=indent_cpp_lambda_body=true|indent_cpp_lambda_body=false
 ValueDefault=false
 
+[Indent Compound Literal Return]
+Category=2
+Description="<html>How to indent compound literals that are being returned.<br/>true: add both the indent from return &amp; the compound literal open brace (ie:<br/>      2 indent levels)<br/>false: only indent 1 level, don't add the indent for the open brace, only add<br/>       the indent for the return.<br/><br/>Default: true</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=indent_compound_literal_return=true|indent_compound_literal_return=false
+ValueDefault=true
+
 [Indent Using Block]
 Category=2
 Description="<html>(C#) Whether to indent a 'using' block if no braces are used.<br/><br/>Default: true</html>"

--- a/tests/config/indent_compound_literal_return-false.cfg
+++ b/tests/config/indent_compound_literal_return-false.cfg
@@ -1,0 +1,1 @@
+indent_compound_literal_return = false

--- a/tests/config/indent_compound_literal_return-true.cfg
+++ b/tests/config/indent_compound_literal_return-true.cfg
@@ -1,0 +1,1 @@
+indent_compound_literal_return = true

--- a/tests/expected/c/10009-return-compound-literal.c
+++ b/tests/expected/c/10009-return-compound-literal.c
@@ -1,0 +1,5 @@
+struct f z(void) {
+	return (struct f){
+		       .z = 1,
+	};
+}

--- a/tests/expected/c/10010-return-compound-literal.c
+++ b/tests/expected/c/10010-return-compound-literal.c
@@ -1,0 +1,5 @@
+struct f z(void) {
+	return (struct f){
+	        .z = 1,
+	};
+}

--- a/tests/expected/c/10011-return-compound-literal.c
+++ b/tests/expected/c/10011-return-compound-literal.c
@@ -1,0 +1,5 @@
+struct f z(void) {
+	return (struct f){
+		       .z = 1,
+	};
+}

--- a/tests/input/c/return-compound-literal.c
+++ b/tests/input/c/return-compound-literal.c
@@ -1,0 +1,5 @@
+struct f z(void) {
+return (struct f){
+.z = 1,
+};
+}


### PR DESCRIPTION
Setting this to `false` (default is `true`) makes indent treat returned
compound literals like c++ init lists.

Previously, we'd apply an indent from both the `return` and the brace
when returning a compound literal.

Now, we can treat them like just c++ initializers lists (and avoid the
extra indent level).

indent_compound_literal_return = true (current default):

	struct f z(void) {
		return (struct f){
				.z = 1,
		};
	}

indent_compound_literal_return = false:

	struct f z(void) {
		return (struct f){
			.z = 1,
		};
	}

For uncrustify, we've set this to `false` to match the behavior with c++
initializer lists.
