### PR TITLE
Add indent_sparen_extra to adjust indent in ctrl statements

### DIFF
--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1309,6 +1309,10 @@ indent_off_after_return_new     = false    # true/false
 # If true, the tokens after return are indented with regular single indentation. By default (false) the indentation is after the return token.
 indent_single_after_return      = false    # true/false
 
+# When opening a paren for a control statement (if, for, while, etc), increase
+# the indent level by this value. Negative values decrease the indent level.
+indent_sparen_extra             = 0        # number
+
 # Whether to ignore indent and alignment for 'asm' blocks (i.e. assume they
 # have their own indentation).
 indent_ignore_asm_block         = false    # true/false

--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -40,6 +40,7 @@ indent_cpp_lambda_only_once               = true
 indent_first_bool_expr                    = true
 indent_macro_brace                        = true
 indent_member                             = 3
+indent_sparen_extra                       = 0
 indent_with_tabs                          = 0
 
 # Newline adding and removing options

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2398,6 +2398,13 @@ void indent_text(void)
                   frm.top().indent = calc_indent_continue(frm);
                   log_indent();
                   frm.top().indent_cont = true;
+
+                  if (  chunk_is_token(pc, CT_SPAREN_OPEN)
+                     && options::indent_sparen_extra() != 0)
+                  {
+                     frm.top().indent += options::indent_sparen_extra();
+                     log_indent();
+                  }
                }
             }
          }

--- a/src/options.h
+++ b/src/options.h
@@ -1375,6 +1375,11 @@ indent_member_single;
 extern BoundedOption<unsigned, 0, 16>
 indent_sing_line_comments;
 
+// When opening a paren for a control statement (if, for, while, etc), increase
+// the indent level by this value. Negative values decrease the indent level.
+extern BoundedOption<signed, -16, 16>
+indent_sparen_extra;
+
 // Whether to indent trailing single line ('//') comments relative to the code
 // instead of trying to keep the same absolute column.
 extern Option<bool>

--- a/tests/c.test
+++ b/tests/c.test
@@ -389,3 +389,7 @@
 10009  empty.cfg                            c/return-compound-literal.c
 10010  indent_compound_literal_return-false.cfg c/return-compound-literal.c
 10011  indent_compound_literal_return-true.cfg c/return-compound-literal.c
+
+10012  indent_sparen_extra-8.cfg            c/sparen-indent.c
+10013  empty.cfg                            c/sparen-indent.c
+10014  indent_continue-8.cfg                c/sparen-indent.c

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -284,6 +284,7 @@ indent_macro_brace              = true
 indent_member                   = 0
 indent_member_single            = false
 indent_sing_line_comments       = 0
+indent_sparen_extra             = 0
 indent_relative_single_line_comments = false
 indent_switch_case              = 0
 indent_switch_break_with_case   = false

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1113,6 +1113,10 @@ indent_member_single            = false    # true/false
 # Spaces to indent single line ('//') comments on lines before code.
 indent_sing_line_comments       = 0        # unsigned number
 
+# When opening a paren for a control statement (if, for, while, etc), increase
+# the indent level by this value. Negative values decrease the indent level.
+indent_sparen_extra             = 0        # number
+
 # Whether to indent trailing single line ('//') comments relative to the code
 # instead of trying to keep the same absolute column.
 indent_relative_single_line_comments = false    # true/false

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -284,6 +284,7 @@ indent_macro_brace              = true
 indent_member                   = 0
 indent_member_single            = false
 indent_sing_line_comments       = 0
+indent_sparen_extra             = 0
 indent_relative_single_line_comments = false
 indent_switch_case              = 0
 indent_switch_break_with_case   = false

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1113,6 +1113,10 @@ indent_member_single            = false    # true/false
 # Spaces to indent single line ('//') comments on lines before code.
 indent_sing_line_comments       = 0        # unsigned number
 
+# When opening a paren for a control statement (if, for, while, etc), increase
+# the indent level by this value. Negative values decrease the indent level.
+indent_sparen_extra             = 0        # number
+
 # Whether to indent trailing single line ('//') comments relative to the code
 # instead of trying to keep the same absolute column.
 indent_relative_single_line_comments = false    # true/false

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1113,6 +1113,10 @@ indent_member_single            = false    # true/false
 # Spaces to indent single line ('//') comments on lines before code.
 indent_sing_line_comments       = 0        # unsigned number
 
+# When opening a paren for a control statement (if, for, while, etc), increase
+# the indent level by this value. Negative values decrease the indent level.
+indent_sparen_extra             = 0        # number
+
 # Whether to indent trailing single line ('//') comments relative to the code
 # instead of trying to keep the same absolute column.
 indent_relative_single_line_comments = false    # true/false

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2559,6 +2559,16 @@ MinVal=0
 MaxVal=16
 ValueDefault=0
 
+[Indent Sparen Extra]
+Category=2
+Description="<html>When opening a paren for a control statement (if, for, while, etc), increase<br/>the indent level by this value. Negative values decrease the indent level.</html>"
+Enabled=false
+EditorType=numeric
+CallName="indent_sparen_extra="
+MinVal=-16
+MaxVal=16
+ValueDefault=0
+
 [Indent Relative Single Line Comments]
 Category=2
 Description="<html>Whether to indent trailing single line ('//') comments relative to the code<br/>instead of trying to keep the same absolute column.</html>"

--- a/tests/config/indent_sparen_extra-8.cfg
+++ b/tests/config/indent_sparen_extra-8.cfg
@@ -1,0 +1,2 @@
+indent_sparen_extra = 8
+indent_continue = 8

--- a/tests/expected/c/10012-sparen-indent.c
+++ b/tests/expected/c/10012-sparen-indent.c
@@ -1,0 +1,19 @@
+void f(void) {
+
+	if (a
+	                && b) {
+		h();
+	}
+
+	for (a = b;
+	                c;
+	                d++) {
+		h();
+	}
+
+	while (z
+	                && w) {
+		h();
+	}
+
+}

--- a/tests/expected/c/10013-sparen-indent.c
+++ b/tests/expected/c/10013-sparen-indent.c
@@ -1,0 +1,19 @@
+void f(void) {
+
+	if (a
+	    && b) {
+		h();
+	}
+
+	for (a = b;
+	     c;
+	     d++) {
+		h();
+	}
+
+	while (z
+	       && w) {
+		h();
+	}
+
+}

--- a/tests/expected/c/10014-sparen-indent.c
+++ b/tests/expected/c/10014-sparen-indent.c
@@ -1,0 +1,19 @@
+void f(void) {
+
+	if (a
+	        && b) {
+		h();
+	}
+
+	for (a = b;
+	        c;
+	        d++) {
+		h();
+	}
+
+	while (z
+	        && w) {
+		h();
+	}
+
+}

--- a/tests/input/c/sparen-indent.c
+++ b/tests/input/c/sparen-indent.c
@@ -1,0 +1,19 @@
+void f(void) {
+
+if (a
+&& b) {
+h();
+}
+
+for (a = b;
+c;
+d++) {
+h();
+}
+
+while (z
+&& w) {
+h();
+}
+
+}


### PR DESCRIPTION
When using `indent_continue` set to the same value as `indent_columns`
(I'll use `indent_continue = 8` in examples here), allow adjusting the
indent added due to a SPAREN_OPEN.

In otherwords, when we have a control statement, allow adding (or
removing) indent to continuations.

Existing:

	// indent_continue = 8 // non-default
	// indent_sparen_extra = 0 // default

	void f(void) {
	if (long__________________________x
		&& longger______x) {
		h();
	}

With this change:

	// indent_continue = 8 // non-default
	// indent_sparen_extra = 8 // non-default

	void f(void) {
	if (long__________________________x
			&& longger______x) {
		h();
	}