### PR TITLE
Fix issue using NoGitVersionString option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ set(CURRENT_VERSION "Uncrustify-0.70.0_f")
 option(NoGitVersionString "Do not use make_version.py and git to build a version string" OFF)
 if(NoGitVersionString)
   configure_file(src/uncrustify_version.h.in uncrustify_version.h @ONLY)
+  add_custom_target(generate_version_header) # Dummy target
 else()
   # Add target to generate version header;
   # do this every build to ensure git SHA is up to date


### PR DESCRIPTION
When the CMake option `NoGitVersionString` is enabled, create a dummy `generate_version_header` target that does nothing, so that when we later try to add a dependency on this target (which, when `NoGitVersionString` is `OFF`, would generate the version header), CMake doesn't complain about there being no such target.

(n.b. When `NoGitVersionString` is `ON`, the header is generated at configure time instead using the version hard-coded into our `CMakeLists.txt`.)

(Yes, we could also just make the dependency conditional, but IMHO this produces slightly cleaner CMake code for negligible cost.)