### PR TITLE
Don't scare user if make_version.py fails

### DIFF
--- a/cmake/GenerateVersionHeader.cmake
+++ b/cmake/GenerateVersionHeader.cmake
@@ -15,8 +15,22 @@ execute_process(
 )
 
 if (make_version_error)
-  message(STATUS "scripts/make_version.py exited with code ${make_version_error}: ${make_version_output}\n"
-                  "As a fallback, version '${UNCRUSTIFY_VERSION}' will be used.")
+  # It's normal for make_version.py to fail when building from a tarball, so we
+  # want to avoid anything that looks too much like a scary error. Thus, report
+  # the error in an innocuous-looking fashion.
+  #
+  # If make_version.py is failing unexpectedly and needs to be debugged,
+  # uncomment the next few lines.
+  # string(STRIP "${make_version_output}" make_version_output)
+  # message(STATUS
+  #   "scripts/make_version.py exited with code ${make_version_error}: "
+  #   "${make_version_output}")
+
+  message(STATUS
+    "Unable to determine version from source tree; "
+    "fallback version '${UNCRUSTIFY_VERSION}' will be used")
+  message(STATUS
+    "(This is normal if you are building from a zip / tarball)")
 else()
   string(STRIP ${make_version_output} UNCRUSTIFY_VERSION)
   message(STATUS "Version: '${UNCRUSTIFY_VERSION}'")


### PR DESCRIPTION
Change how `GenerateVersionHeader.cmake` reports failures of `make_version.py` to look less scary. A failure is normal and expected when building from a source package as opposed to a repository clone, and the old reporting, even though it was non-fatal, was easy to mistake as an actual problem. Hopefully the new wording will make it more obvious that nothing is actually wrong.

The new output looks like:
```
$ cm
-- Unable to determine version from source tree; fallback version 'Uncrustify-0.70.0_f' will be used
-- (This is normal if you are building from a zip / tarball)
```

As a reminder, the old output looked like:
```
-- scripts/make_version.py exited with code 64: Unknown version control system in '/tmp/uncrustify'.

As a fallback, version 'Uncrustify-0.70.0_f' will be used.
```