### PR TITLE
nl_func_leave_one_liners may overwrite nl_func_type_name

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -2786,7 +2786,8 @@ static void newline_func_def_or_call(chunk_t *start)
                               || tmp->parent_type == CT_FUNC_CLASS_PROTO);
             iarf_e a = (is_proto) ?
                        options::nl_func_proto_type_name() :
-                       options::nl_func_type_name();
+                       (options::nl_func_leave_one_liners()) ?                 // Issue #1511
+                       IARF_IGNORE : options::nl_func_type_name();
 
             if (  tmp->flags.test(PCF_IN_CLASS)
                && (options::nl_func_type_name_class() != IARF_IGNORE))

--- a/src/options.h
+++ b/src/options.h
@@ -1621,6 +1621,7 @@ extern Option<bool>
 nl_cs_property_leave_one_liners;
 
 // Don't split one-line function definitions, as in 'int foo() { return 0; }'.
+// night modify nl_func_type_name
 extern Option<bool>
 nl_func_leave_one_liners;
 
@@ -1989,6 +1990,7 @@ nl_enum_own_lines;
 
 // Add or remove newline between return type and function name in a function
 // definition.
+// might be modified by nl_func_leave_one_liners
 extern Option<iarf_e>
 nl_func_type_name;
 

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1326,6 +1326,7 @@ nl_getset_leave_one_liners      = false    # true/false
 nl_cs_property_leave_one_liners = false    # true/false
 
 # Don't split one-line function definitions, as in 'int foo() { return 0; }'.
+# night modify nl_func_type_name
 nl_func_leave_one_liners        = false    # true/false
 
 # Don't split one-line C++11 lambdas, as in '[]() { return 0; }'.
@@ -1613,6 +1614,7 @@ nl_enum_own_lines               = ignore   # ignore/add/remove/force
 
 # Add or remove newline between return type and function name in a function
 # definition.
+# might be modified by nl_func_leave_one_liners
 nl_func_type_name               = ignore   # ignore/add/remove/force
 
 # Add or remove newline between return type and function name inside a class

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1326,6 +1326,7 @@ nl_getset_leave_one_liners      = false    # true/false
 nl_cs_property_leave_one_liners = false    # true/false
 
 # Don't split one-line function definitions, as in 'int foo() { return 0; }'.
+# night modify nl_func_type_name
 nl_func_leave_one_liners        = false    # true/false
 
 # Don't split one-line C++11 lambdas, as in '[]() { return 0; }'.
@@ -1613,6 +1614,7 @@ nl_enum_own_lines               = ignore   # ignore/add/remove/force
 
 # Add or remove newline between return type and function name in a function
 # definition.
+# might be modified by nl_func_leave_one_liners
 nl_func_type_name               = ignore   # ignore/add/remove/force
 
 # Add or remove newline between return type and function name inside a class

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1326,6 +1326,7 @@ nl_getset_leave_one_liners      = false    # true/false
 nl_cs_property_leave_one_liners = false    # true/false
 
 # Don't split one-line function definitions, as in 'int foo() { return 0; }'.
+# night modify nl_func_type_name
 nl_func_leave_one_liners        = false    # true/false
 
 # Don't split one-line C++11 lambdas, as in '[]() { return 0; }'.
@@ -1613,6 +1614,7 @@ nl_enum_own_lines               = ignore   # ignore/add/remove/force
 
 # Add or remove newline between return type and function name in a function
 # definition.
+# might be modified by nl_func_leave_one_liners
 nl_func_type_name               = ignore   # ignore/add/remove/force
 
 # Add or remove newline between return type and function name inside a class

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2965,7 +2965,7 @@ ValueDefault=false
 
 [Nl Func Leave One Liners]
 Category=3
-Description="<html>Don't split one-line function definitions, as in 'int foo() { return 0; }'.</html>"
+Description="<html>Don't split one-line function definitions, as in 'int foo() { return 0; }'.<br/>night modify nl_func_type_name</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_func_leave_one_liners=true|nl_func_leave_one_liners=false
@@ -3686,7 +3686,7 @@ ValueDefault=ignore
 
 [Nl Func Type Name]
 Category=3
-Description="<html>Add or remove newline between return type and function name in a function<br/>definition.</html>"
+Description="<html>Add or remove newline between return type and function name in a function<br/>definition.<br/>might be modified by nl_func_leave_one_liners</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_type_name=ignore|nl_func_type_name=add|nl_func_type_name=remove|nl_func_type_name=force

--- a/tests/config/Issue_1511.cfg
+++ b/tests/config/Issue_1511.cfg
@@ -1,0 +1,2 @@
+nl_func_type_name        = force
+nl_func_leave_one_liners = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -95,6 +95,7 @@
 30084  Issue_1184.cfg                       cpp/Issue_1184.cpp
 30085  nSolve.cfg                           cpp/align_class.cpp
 30086  align_class-constr.cfg               cpp/align_class-constr.cpp
+30087  Issue_1511.cfg                       cpp/Issue_1511.cpp
 
 30090  bug_488.cfg                          cpp/bug_488.cpp
 30091  bug_472.cfg                          cpp/bug_472.cpp

--- a/tests/expected/cpp/30087-Issue_1511.cpp
+++ b/tests/expected/cpp/30087-Issue_1511.cpp
@@ -1,0 +1,1 @@
+int getFoo() { return foo; }

--- a/tests/input/cpp/Issue_1511.cpp
+++ b/tests/input/cpp/Issue_1511.cpp
@@ -1,0 +1,1 @@
+int getFoo() { return foo; }


### PR DESCRIPTION
Ref. #1511