### PR TITLE
Fix handling of `interface` keyword in C++

### DIFF
--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -582,10 +582,28 @@ void tokenize_cleanup(void)
        * likewise, 'class' may be a member name in Java.
        */
       if (  chunk_is_token(pc, CT_CLASS)
-         && !CharTable::IsKw1(next->str[0])
-         && pc->next->type != CT_DC_MEMBER)
+         && !CharTable::IsKw1(next->str[0]))
       {
-         set_chunk_type(pc, CT_WORD);
+         if (chunk_is_not_token(next, CT_DC_MEMBER))
+         {
+            set_chunk_type(pc, CT_WORD);
+         }
+         else if (  chunk_is_token(prev, CT_DC_MEMBER)
+                 || chunk_is_token(prev, CT_TYPE))
+         {
+            set_chunk_type(pc, CT_TYPE);
+         }
+         else if (chunk_is_token(next, CT_DC_MEMBER))
+         {
+            chunk_t *next2 = chunk_get_next_nblank(next);
+
+            if (  chunk_is_token(next2, CT_INV)      // CT_INV hasn't turned into CT_DESTRUCTOR just yet
+               || (  chunk_is_token(next2, CT_CLASS) // constructor isn't turned into CT_FUNC* just yet
+                  && !strcmp(pc->text(), next2->text())))
+            {
+               set_chunk_type(pc, CT_TYPE);
+            }
+         }
       }
 
       /*

--- a/tests/config/interface-keyword-in-cpp.cfg
+++ b/tests/config/interface-keyword-in-cpp.cfg
@@ -1,0 +1,2 @@
+sp_before_dc = remove
+sp_after_dc  = remove

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -820,3 +820,4 @@
 60051  bug_2371.cfg                         cpp/bug_2371.cpp
 60052  bug_2433_1.cfg                       cpp/bug_2433_1.cpp
 60053  bug_2433_2.cfg                       cpp/bug_2433_2.cpp
+60054  interface-keyword-in-cpp.cfg         cpp/interface-keyword-in-cpp.cpp

--- a/tests/expected/cpp/60054-interface-keyword-in-cpp.cpp
+++ b/tests/expected/cpp/60054-interface-keyword-in-cpp.cpp
@@ -1,0 +1,69 @@
+#include "sdkconfig.h"
+
+#include <fs/nvs_storage.hpp>
+#include <network/interface.hpp>
+
+extern "C" void app_main (void) {
+	fs::nvs_storage::initialize ();
+	network::interface::initialize ();
+}
+
+#include "sdkconfig.h"
+#include "esp_wifi.h"
+#include "network/interface.hpp"
+
+
+using namespace network;
+void interface::initialize () {
+	tcpip_adapter_init ();
+}
+
+// ----------------------------------------
+
+namespace A {
+class interface {
+public:
+interface() {
+}
+
+~interface() {
+}
+
+void foo() {
+}
+};
+}
+
+namespace B {
+class interface {
+public:
+interface();
+~interface();
+void foo();
+};
+
+inline interface::interface() {
+}
+inline interface::~interface() {
+}
+inline void interface::foo() {
+}
+}
+
+namespace C {
+class interface {
+public:
+interface();
+~interface();
+void foo();
+};
+
+interface::interface() {
+}
+interface::~interface() {
+}
+void interface::foo() {
+}
+}
+
+interface ::external_iterface;

--- a/tests/input/cpp/interface-keyword-in-cpp.cpp
+++ b/tests/input/cpp/interface-keyword-in-cpp.cpp
@@ -1,0 +1,62 @@
+#include "sdkconfig.h"
+
+#include <fs/nvs_storage.hpp>
+#include <network/interface.hpp>
+
+extern "C" void app_main (void) {
+  fs::nvs_storage ::initialize ();
+  network::interface ::initialize ();
+}
+
+#include "sdkconfig.h"
+#include "esp_wifi.h"
+#include "network/interface.hpp"
+
+
+using namespace network;
+void interface ::initialize () {
+  tcpip_adapter_init ();
+}
+
+// ----------------------------------------
+
+namespace A {
+    class interface {
+    public:
+        interface() {
+        }
+
+        ~interface() {
+        }
+
+        void foo() {}
+    };
+}
+
+namespace B {
+    class interface {
+    public:
+        interface();
+        ~interface();
+        void foo();
+    };
+
+    inline interface :: interface() {}
+    inline interface :: ~interface() {}
+    inline void interface :: foo() {}
+}
+
+namespace C {
+    class interface {
+    public:
+        interface();
+        ~interface();
+        void foo();
+    };
+
+    interface :: interface() {}
+    interface :: ~interface() {}
+    void interface :: foo() {}
+}
+
+interface :: external_iterface;


### PR DESCRIPTION
Microsoft uses `interface` as define to `struct`, so it must be handled the same way `struct`/`class`/`union` are treated.

However in certain cases it must be handled as regular type name.

This fixes #2550