### PR TITLE
Align OC messages the way Xcode does

### DIFF
--- a/src/align_oc_msg_colons.cpp
+++ b/src/align_oc_msg_colons.cpp
@@ -28,9 +28,10 @@ void align_oc_msg_colon(chunk_t *so)
    size_t  level = so->level;
    chunk_t *pc   = chunk_get_next_ncnl(so, scope_e::PREPROC);
 
-   bool    did_line  = false;
-   bool    has_colon = false;
-   size_t  lcnt      = 0; // line count with no colon for span
+   bool    did_line   = false;
+   bool    has_colon  = false;
+   size_t  lcnt       = 0; // line count with no colon for span
+   bool    first_line = true;
 
    while (pc != nullptr && pc->level > level)
    {
@@ -44,8 +45,14 @@ void align_oc_msg_colon(chunk_t *so)
          {
             ++lcnt;
          }
-         did_line  = false;
-         has_colon = !has_colon;
+         did_line = false;
+
+         if (options::align_oc_msg_colon_xcode_like() && first_line && !has_colon)
+         {
+            span = 0;
+         }
+         has_colon  = !has_colon;
+         first_line = false;
       }
       else if (  !did_line
               && (lcnt < span + 1)

--- a/src/options.h
+++ b/src/options.h
@@ -3093,6 +3093,12 @@ align_oc_msg_colon_first;
 extern Option<bool>
 align_oc_decl_colon;
 
+// (OC) Whether to not align parameters in an Objectve-C message call if first
+// colon is not on next line of the message call (the same way Xcode does
+// aligment)
+extern Option<bool>
+align_oc_msg_colon_xcode_like;
+
 //END
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -625,6 +625,7 @@ align_asm_colon                 = false
 align_oc_msg_colon_span         = 0
 align_oc_msg_colon_first        = false
 align_oc_decl_colon             = false
+align_oc_msg_colon_xcode_like   = false
 cmt_width                       = 0
 cmt_reflow_mode                 = 0
 cmt_convert_tab_to_spaces       = false

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -2503,6 +2503,11 @@ align_oc_msg_colon_first        = false    # true/false
 # on the ':'.
 align_oc_decl_colon             = false    # true/false
 
+# (OC) Whether to not align parameters in an Objectve-C message call if first
+# colon is not on next line of the message call (the same way Xcode does
+# aligment)
+align_oc_msg_colon_xcode_like   = false    # true/false
+
 #
 # Comment modification options
 #

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -625,6 +625,7 @@ align_asm_colon                 = false
 align_oc_msg_colon_span         = 0
 align_oc_msg_colon_first        = false
 align_oc_decl_colon             = false
+align_oc_msg_colon_xcode_like   = false
 cmt_width                       = 0
 cmt_reflow_mode                 = 0
 cmt_convert_tab_to_spaces       = false

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -2503,6 +2503,11 @@ align_oc_msg_colon_first        = false    # true/false
 # on the ':'.
 align_oc_decl_colon             = false    # true/false
 
+# (OC) Whether to not align parameters in an Objectve-C message call if first
+# colon is not on next line of the message call (the same way Xcode does
+# aligment)
+align_oc_msg_colon_xcode_like   = false    # true/false
+
 #
 # Comment modification options
 #

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -2503,6 +2503,11 @@ align_oc_msg_colon_first        = false    # true/false
 # on the ':'.
 align_oc_decl_colon             = false    # true/false
 
+# (OC) Whether to not align parameters in an Objectve-C message call if first
+# colon is not on next line of the message call (the same way Xcode does
+# aligment)
+align_oc_msg_colon_xcode_like   = false    # true/false
+
 #
 # Comment modification options
 #

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -5604,6 +5604,14 @@ EditorType=boolean
 TrueFalse=align_oc_decl_colon=true|align_oc_decl_colon=false
 ValueDefault=false
 
+[Align Oc Msg Colon Xcode Like]
+Category=7
+Description="<html>(OC) Whether to not align parameters in an Objectve-C message call if first<br/>colon is not on next line of the message call (the same way Xcode does<br/>aligment)</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=align_oc_msg_colon_xcode_like=true|align_oc_msg_colon_xcode_like=false
+ValueDefault=false
+
 [Cmt Width]
 Category=8
 Description="<html>Try to wrap comments at N columns.</html>"

--- a/tests/config/align-objc-like-xcode.cfg
+++ b/tests/config/align-objc-like-xcode.cfg
@@ -1,0 +1,8 @@
+indent_columns = 2
+indent_oc_msg_prioritize_first_colon = false
+indent_oc_msg_colon = 0
+align_oc_msg_spec_span = 0
+align_oc_msg_colon_span = 1
+align_oc_msg_colon_first = true
+sp_after_send_oc_colon = true
+align_oc_msg_colon_xcode_like = true

--- a/tests/expected/oc/10020-align-objc-like-xcode.m
+++ b/tests/expected/oc/10020-align-objc-like-xcode.m
@@ -1,0 +1,8 @@
+- (void)foo {
+  [self dismissWithReason: DismissReason::Auto animated: TRUE];
+  [self dismissWithReason: DismissReason::Auto
+                 animated: TRUE];
+  [self
+   dismissWithReason: DismissReason::Auto
+   animated: TRUE];
+}

--- a/tests/input/oc/align-objc-like-xcode.m
+++ b/tests/input/oc/align-objc-like-xcode.m
@@ -1,0 +1,8 @@
+- (void)foo {
+[self dismissWithReason:DismissReason::Auto animated:TRUE];
+[self dismissWithReason:DismissReason::Auto
+animated:TRUE];
+[self
+dismissWithReason:DismissReason::Auto
+animated:TRUE];
+}

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -145,3 +145,4 @@
 # adopt tests from UT
 10018  empty.cfg                            oc/delete-space-oc.mm
 10019  empty.cfg                            oc/func-param-wrap-oc.mm
+10020  align-objc-like-xcode.cfg            oc/align-objc-like-xcode.m


### PR DESCRIPTION
Xcode doesn't align Objective C messages by colon if first colon is not
on the first line of the message.

New option `align_oc_msg_colon_xcode_like` was introduced to implement
this behavior.

This fixes #2508.