### PR TITLE
Fix double indentation after `{` ObjC dictionary

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1661,7 +1661,8 @@ void indent_text(void)
             }
             else
             {
-               frm.top().indent = frm.prev().indent_tmp + indent_size;
+               frm.top().indent     = frm.prev().indent_tmp + indent_size;
+               frm.top().indent_tab = frm.top().indent;
             }
             log_indent();
          }
@@ -3387,8 +3388,7 @@ static bool is_end_of_assignment(chunk_t *pc, const ParseFrame &frm)
             || frm.top().type == CT_ASSIGN)
          && (  chunk_is_semicolon(pc)
             || chunk_is_token(pc, CT_COMMA)
-            || (  chunk_is_token(pc, CT_BRACE_OPEN)
-               && pc->parent_type != CT_OC_AT)
+            || chunk_is_token(pc, CT_BRACE_OPEN)
             || chunk_is_token(pc, CT_SPAREN_CLOSE)
             || (  chunk_is_token(pc, CT_SQUARE_OPEN)
                && pc->parent_type == CT_ASSIGN))

--- a/tests/config/double-indent-objc-dict.cfg
+++ b/tests/config/double-indent-objc-dict.cfg
@@ -1,0 +1,4 @@
+indent_align_assign = false
+indent_single_after_return = false
+indent_continue = 0
+use_indent_continue_only_once = true

--- a/tests/expected/oc/10021-double-indent-objc-dict.m
+++ b/tests/expected/oc/10021-double-indent-objc-dict.m
@@ -1,0 +1,17 @@
+id a = @{
+	@"a": @1,
+	@"b": @2,
+};
+
+struct foo_t b = {
+	1,
+	2,
+};
+
+SomeObject *build()
+{
+	return @{
+		@"a": @1,
+		@"b": @2,
+	};
+}

--- a/tests/input/oc/double-indent-objc-dict.m
+++ b/tests/input/oc/double-indent-objc-dict.m
@@ -1,0 +1,17 @@
+id a = @{
+  @"a": @1,
+  @"b": @2,
+};
+
+struct foo_t b = {
+  1,
+  2,
+};
+
+SomeObject *build()
+{
+  return @{
+    @"a": @1,
+    @"b": @2,
+  };
+}

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -146,3 +146,4 @@
 10018  empty.cfg                            oc/delete-space-oc.mm
 10019  empty.cfg                            oc/func-param-wrap-oc.mm
 10020  align-objc-like-xcode.cfg            oc/align-objc-like-xcode.m
+10021  double-indent-objc-dict.cfg          oc/double-indent-objc-dict.m


### PR DESCRIPTION
`@{}` Objective C maps are indented incorrectly.

This fixes #2496.