### PR TITLE
Leading tabs for java lambda

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -940,6 +940,13 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       }
    }
 
+   if (  language_is_set(LANG_JAVA)
+      && chunk_is_token(pc, CT_LAMBDA)
+      && chunk_is_token(next, CT_BRACE_OPEN))
+   {
+      set_paren_parent(next, pc->type);
+   }
+
    if (chunk_is_token(pc, CT_NEW))
    {
       chunk_t *ts = nullptr;

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1449,7 +1449,7 @@ void indent_text(void)
             frm.prev().indent_tmp = frm.top().indent_tmp;
             log_indent_tmp();
          }
-         else if (  language_is_set(LANG_CS)
+         else if (  language_is_set(LANG_CS | LANG_JAVA)
                  && options::indent_cs_delegate_brace()
                  && (  pc->parent_type == CT_LAMBDA
                     || pc->parent_type == CT_DELEGATE))
@@ -1465,7 +1465,7 @@ void indent_text(void)
             frm.prev().indent_tmp = frm.top().indent_tmp;
             log_indent_tmp();
          }
-         else if (  language_is_set(LANG_CS)
+         else if (  language_is_set(LANG_CS | LANG_JAVA)
                  && !options::indent_cs_delegate_brace()
                  && !options::indent_align_paren()
                  && (  pc->parent_type == CT_LAMBDA
@@ -1648,6 +1648,11 @@ void indent_text(void)
             {
                // We are inside ({ ... }) -- indent one tab from the paren
                frm.top().indent = frm.prev().indent_tmp + indent_size;
+
+               if (!chunk_is_paren_open(frm.prev().pc))
+               {
+                  frm.top().indent_tab = frm.top().indent;
+               }
                log_indent();
             }
          }
@@ -2639,7 +2644,8 @@ void indent_text(void)
             indent_column_set(frm.top().indent + 4);
          }
       }
-      else if (  chunk_is_token(pc, CT_LAMBDA) && language_is_set(LANG_CS)
+      else if (  chunk_is_token(pc, CT_LAMBDA)
+              && (language_is_set(LANG_CS | LANG_JAVA))
               && chunk_get_next_ncnlnp(pc)->type != CT_BRACE_OPEN
               && options::indent_cs_delegate_body())
       {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -408,7 +408,7 @@ static void cmt_output_indent(size_t brace_col, size_t base_col, size_t column)
 
    size_t tab_col = (iwt == 0) ? 0 : ((iwt == 1) ? brace_col : base_col);
 
-   // LOG_FMT(LSYS, "%s(brace=%d base=%d col=%d iwt=%d) tab=%d cur=%d\n",
+   // LOG_FMT(LSYS, "%s(brace=%zd base=%zd col=%zd iwt=%zd) tab=%zd cur=%zd\n",
    //        __func__, brace_col, base_col, column, iwt, tab_col, cpd.column);
 
    cpd.did_newline = 0;
@@ -1083,7 +1083,7 @@ static void output_cmt_start(cmt_reflow &cmt, chunk_t *pc)
    {
       cmt.brace_col = 1 + (pc->brace_level * options::output_tab_size());
    }
-   // LOG_FMT(LSYS, "%s: line %d, brace=%d base=%d col=%d orig=%d aligned=%x\n",
+   // LOG_FMT(LSYS, "%s: line %zd, brace=%zd base=%zd col=%zd orig=%zd aligned=%x\n",
    //        __func__, pc->orig_line, cmt.brace_col, cmt.base_col, cmt.column, pc->orig_col,
    //        pc->flags & (PCF_WAS_ALIGNED | PCF_RIGHT_COMMENT));
 

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -2301,6 +2301,13 @@ void tokenize(const deque<int> &data, chunk_t *ref)
          break;
       }
 
+      if (  language_is_set(LANG_JAVA)
+         && chunk.type == CT_MEMBER
+         && !memcmp(chunk.text(), "->", 2))
+      {
+         chunk.type = CT_LAMBDA;
+      }
+
       // Don't create an entry for whitespace
       if (chunk.type == CT_WHITESPACE)
       {

--- a/tests/config/leading-tabs-for-java-lambda.cfg
+++ b/tests/config/leading-tabs-for-java-lambda.cfg
@@ -1,0 +1,4 @@
+indent_with_tabs = 1
+indent_class = true
+cmt_indent_multi = false
+indent_cs_delegate_body = true

--- a/tests/expected/java/80306-leading-tabs-for-java-lambda.java
+++ b/tests/expected/java/80306-leading-tabs-for-java-lambda.java
@@ -1,0 +1,29 @@
+class MyClass {
+	void foo(List<Integer> arr) {
+		arr.forEach(n -> {
+			// Okay: This line will be indented with only tabs.
+			if (cond1) { // Okay
+				// BAD1: This line will be indented with tabs up to lambda brace level, then spaces for the rest.
+				if (cond2) // BAD2
+					// Okay
+					bar(); // Okay
+				if (cond3) // BAD3
+				{ // BAD4
+					// BAD5
+					bar(); // BAD6
+				} // Okay
+			} // Okay
+			if (cond4) { // Okay
+				/*
+				BAD7: C-style comments will also be affected on all lines.
+				*/
+			} // Okay
+			if (cond5) // Okay
+			{ // Okay
+				bar(); // BAD8
+			} // Okay
+			if (cond6) // Okay
+				bar; // Okay
+		});
+	}
+}

--- a/tests/input/java/leading-tabs-for-java-lambda.java
+++ b/tests/input/java/leading-tabs-for-java-lambda.java
@@ -1,0 +1,29 @@
+class MyClass {
+	void foo(List<Integer> arr) {
+		arr.forEach(n -> {
+			// Okay: This line will be indented with only tabs.
+			if (cond1) { // Okay
+				// BAD1: This line will be indented with tabs up to lambda brace level, then spaces for the rest.
+				if (cond2) // BAD2
+					// Okay
+					bar(); // Okay
+				if (cond3) // BAD3
+				{ // BAD4
+					// BAD5
+					bar(); // BAD6
+				} // Okay
+			} // Okay
+			if (cond4) { // Okay
+				/*
+				BAD7: C-style comments will also be affected on all lines.
+				*/
+			} // Okay
+			if (cond5) // Okay
+			{ // Okay
+				bar(); // BAD8
+			} // Okay
+			if (cond6) // Okay
+				bar; // Okay
+		});
+	}
+}

--- a/tests/java.test
+++ b/tests/java.test
@@ -38,3 +38,4 @@
 80303  Issue_1122.cfg                       java/Issue_1122.java
 80304  Issue_1124-f.cfg                     java/Issue_1124.java
 80305  Issue_1124-r.cfg                     java/Issue_1124.java
+80306  leading-tabs-for-java-lambda.cfg     java/leading-tabs-for-java-lambda.java


### PR DESCRIPTION
- `->` was incorrectly recognized for Java as `CT_MEMBER`
- some cases related to delegates in C# are very similar to ones for Java labmdas
- some `printf` specifications for LOG messages (now commented out) are corrected

Also fixes #2414