### PR TITLE
The type of the token "class" was changed if an attribute was present.

### DIFF
--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -471,7 +471,8 @@ void tokenize_cleanup(void)
       }
 
       // Change angle open/close to CT_COMPARE, if not a template thingy
-      if (chunk_is_token(pc, CT_ANGLE_OPEN) && pc->parent_type != CT_TYPE_CAST)
+      if (  chunk_is_token(pc, CT_ANGLE_OPEN)
+         && pc->parent_type != CT_TYPE_CAST)
       {
          /*
           * pretty much all languages except C use <> for something other than
@@ -489,7 +490,8 @@ void tokenize_cleanup(void)
          }
       }
 
-      if (chunk_is_token(pc, CT_ANGLE_CLOSE) && pc->parent_type != CT_TEMPLATE)
+      if (  chunk_is_token(pc, CT_ANGLE_CLOSE)
+         && pc->parent_type != CT_TEMPLATE)
       {
          if (in_type_cast)
          {
@@ -584,7 +586,8 @@ void tokenize_cleanup(void)
       if (  chunk_is_token(pc, CT_CLASS)
          && !CharTable::IsKw1(next->str[0]))
       {
-         if (chunk_is_not_token(next, CT_DC_MEMBER))
+         if (  chunk_is_not_token(next, CT_DC_MEMBER)
+            && chunk_is_not_token(next, CT_ATTRIBUTE))                       // Issue #2570
          {
             set_chunk_type(pc, CT_WORD);
          }

--- a/tests/config/Issue_2570.cfg
+++ b/tests/config/Issue_2570.cfg
@@ -1,0 +1,1 @@
+mod_remove_extra_semicolon = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -225,6 +225,7 @@
 30325  mod_paren_on_return-r.cfg            cpp/returns.cpp
 
 30400  attribute_specifier_seqs.cfg         cpp/attribute_specifier_seqs.cpp
+30401  Issue_2570.cfg                       cpp/Issue_2570.cpp
 
 # function def newlines
 30701  func-def-1.cfg                       cpp/function-def.cpp

--- a/tests/expected/cpp/30401-Issue_2570.cpp
+++ b/tests/expected/cpp/30401-Issue_2570.cpp
@@ -1,0 +1,3 @@
+class [[nodiscard]] CClass final
+{
+};

--- a/tests/input/cpp/Issue_2570.cpp
+++ b/tests/input/cpp/Issue_2570.cpp
@@ -1,0 +1,3 @@
+class [[nodiscard]] CClass final
+{
+};


### PR DESCRIPTION
This is not correct.

Ref. #2570