### PR TITLE
don't split >= in a template

### DIFF
--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -1127,9 +1127,17 @@ static void check_template(chunk_t *start)
 
          if ((pc->str[0] == '>') && (pc->len() > 1))
          {
-            LOG_FMT(LTEMPL, "%s(%d): {split '%s' at orig_line %zu, orig_col %zu}\n",
-                    __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col);
-            split_off_angle_close(pc);
+            if (pc->str[1] == '=')                         // Issue #1462 and #2565
+            {
+               LOG_FMT(LTEMPL, "%s(%d): do not split '%s' at orig_line %zu, orig_col %zu\n",
+                       __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col);
+            }
+            else
+            {
+               LOG_FMT(LTEMPL, "%s(%d): {split '%s' at orig_line %zu, orig_col %zu}\n",
+                       __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col);
+               split_off_angle_close(pc);
+            }
          }
 
          if (pc->type == CT_PAREN_OPEN)

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -134,6 +134,7 @@
 30124  sp_after_angle-1.cfg                 cpp/sp_after_angle.cpp
 30125  sp_after_angle-2.cfg                 cpp/sp_after_angle.cpp
 30126  sp_after_angle-3.cfg                 cpp/sp_after_angle.cpp
+30127  empty.cfg                            cpp/Issue_2565.cpp
 
 30200  bug_1862.cfg                         cpp/bug_1862.cpp
 30201  cmt_indent-1.cfg                     cpp/cmt_indent.cpp

--- a/tests/expected/cpp/30114-bug_1462.cpp
+++ b/tests/expected/cpp/30114-bug_1462.cpp
@@ -2,7 +2,7 @@
 
 template <
 	typename ... Args,
-	typename E = typename std::enable_if<(sizeof...(Args) > = 1), bool>::type
+	typename E = typename std::enable_if<(sizeof...(Args) >= 1), bool>::type
 	>
 void fun1(Args&& ... args)
 {

--- a/tests/expected/cpp/30127-Issue_2565.cpp
+++ b/tests/expected/cpp/30127-Issue_2565.cpp
@@ -1,0 +1,3 @@
+template
+<bool = (sizeof(unsigned long) >= sizeof(size_t))>
+struct LongFitsIntoSizeTMinusOne { ... }

--- a/tests/input/cpp/Issue_2565.cpp
+++ b/tests/input/cpp/Issue_2565.cpp
@@ -1,0 +1,3 @@
+template
+<bool = (sizeof(unsigned long) >= sizeof(size_t))>
+struct LongFitsIntoSizeTMinusOne { ... }


### PR DESCRIPTION
Ref. #1462 and #2565 