### PR TITLE
limit setuptools to version below 44

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ before_install:
     if [ "x${BUILD_TYPE}" == "xcoverage" ]; then
       sudo apt-get update
       sudo apt-get install -qy python3-pip lcov
-      pip3 install --user --upgrade setuptools
+      pip3 install --user --upgrade 'setuptools<44.0.0'
       pip3 install --user --upgrade pip
       pip3 install --user PyYAML
       pip3 install --user --upgrade cpp-coveralls


### PR DESCRIPTION
See [history.html](https://setuptools.readthedocs.io/en/latest/history.html). Ubuntu 14.04 seems to only have python3 up to 3.4. We should consider upgrading the CI to 16.04 / 18.04.