### PR TITLE
use xenial for ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 matrix:
   include:
     - os: linux
-      dist: trusty
+      dist: xenial
       env: BADGE=linux BUILD_TYPE=debug
       addons:
         apt:
@@ -13,7 +13,7 @@ matrix:
             - ninja-build
 
     - os: linux
-      dist: trusty
+      dist: xenial
       env: BADGE=linux BUILD_TYPE=release
       addons:
         apt:
@@ -22,12 +22,12 @@ matrix:
             - ninja-build
 
     - os: linux
-      dist: trusty
+      dist: xenial
       env: BADGE=linux BUILD_TYPE=release NO_MACRO_VARARG=1
 
     # GCC 6
     - os: linux
-      dist: trusty
+      dist: xenial
       env: BADGE=linux C_COMPILER=gcc-6 CXX_COMPILER=g++-6
       addons:
         apt:
@@ -41,7 +41,7 @@ matrix:
 
     # Clang 3.8 address sanitizer
     - os: linux
-      dist: trusty
+      dist: xenial
       env: BADGE=linux BUILD_TYPE=asan C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8
       addons:
         apt:
@@ -53,7 +53,7 @@ matrix:
 
     # mingw-w64 Win64 cross-compile
     - os: linux
-      dist: trusty
+      dist: xenial
       env: BADGE=linux BUILD_TYPE=cross C_COMPILER=x86_64-w64-mingw32-gcc CXX_COMPILER=x86_64-w64-mingw32-g++
       addons:
         apt:
@@ -76,7 +76,7 @@ matrix:
       env: BADGE=osx BUILD_TYPE=release
 
     - os: linux
-      dist: trusty
+      dist: xenial
       env: BUILD_TYPE=coverage COVERALLS_TOKEN="Dy94SOU3ajc1VbIy1wnWaNaeIUzfgdtEg"
       compiler: gcc
 
@@ -89,7 +89,7 @@ before_install:
     if [ "x${BUILD_TYPE}" == "xcoverage" ]; then
       sudo apt-get update
       sudo apt-get install -qy python3-pip lcov
-      pip3 install --user --upgrade 'setuptools<44.0.0'
+      pip3 install --user --upgrade setuptools
       pip3 install --user --upgrade pip
       pip3 install --user PyYAML
       pip3 install --user --upgrade cpp-coveralls


### PR DESCRIPTION
ubuntu trusty ~~is eol~~ has reached _End of Standard Support_  and the ci needs python 3.5.x for pip and setuptools

ref: #2597