### PR TITLE
Add LANG_OC for handling option sp_angle_shift

### DIFF
--- a/src/space.cpp
+++ b/src/space.cpp
@@ -3557,7 +3557,7 @@ void space_text(void)
                      // that sp_angle_shift cannot remove the space without this option.
                      if (  (  (  language_is_set(LANG_CPP)
                               && options::sp_permit_cpp11_shift())
-                           || (language_is_set(LANG_JAVA | LANG_CS | LANG_VALA)))
+                           || (language_is_set(LANG_JAVA | LANG_CS | LANG_VALA | LANG_OC)))
                         && chunk_is_token(pc, CT_ANGLE_CLOSE)
                         && chunk_is_token(next, CT_ANGLE_CLOSE))
                      {

--- a/tests/config/double_angle_space_1.cfg
+++ b/tests/config/double_angle_space_1.cfg
@@ -1,0 +1,8 @@
+# (C++11) Permit removal of the space between '>>' in 'foo<bar<int> >'. Note
+# that sp_angle_shift cannot remove the space without this option.
+sp_permit_cpp11_shift           = true     # true/false
+
+# Add or remove space between '>' and '>' in '>>' (template stuff).
+#
+# Default: add
+sp_angle_shift                  = remove   # ignore/add/remove/force

--- a/tests/config/double_angle_space_2.cfg
+++ b/tests/config/double_angle_space_2.cfg
@@ -1,0 +1,8 @@
+# (C++11) Permit removal of the space between '>>' in 'foo<bar<int> >'. Note
+# that sp_angle_shift cannot remove the space without this option.
+sp_permit_cpp11_shift           = true     # true/false
+
+# Add or remove space between '>' and '>' in '>>' (template stuff).
+#
+# Default: add
+sp_angle_shift                  = add   # ignore/add/remove/force

--- a/tests/config/double_angle_space_3.cfg
+++ b/tests/config/double_angle_space_3.cfg
@@ -1,0 +1,8 @@
+# (C++11) Permit removal of the space between '>>' in 'foo<bar<int> >'. Note
+# that sp_angle_shift cannot remove the space without this option.
+sp_permit_cpp11_shift           = true     # true/false
+
+# Add or remove space between '>' and '>' in '>>' (template stuff).
+#
+# Default: add
+sp_angle_shift                  = ignore   # ignore/add/remove/force

--- a/tests/expected/oc/50904-double_angle_space.m
+++ b/tests/expected/oc/50904-double_angle_space.m
@@ -1,0 +1,25 @@
+static const NSArray< id< NSObject>> **controllers = nil;
+
+NSArray< id< BlockController>> *someMethod();
+
+@interface Fraction : NSObject
+	void Compute(
+		Image< E::Matrix<SType, Dim,1>> const& src,
+		Image<E::Matrix<TType,Dim,1>>& dst);
+@end
+@implementation SomeClass
+- (void)initializeControllers:( NSArray< id< BlockController>> *)hybridContollers {
+	if (index < children.count) {
+		const unsigned int wl = w>>lvl;
+
+		assert(x<0 && y>=3);
+		assert(y <0&&z> 2);
+		assert(a>>1);
+		assert(b >>1);
+
+		return static_cast< id <CKMountable>>(children[index]);
+	}
+
+	NSArray<id< BlockController>> *controllers = hybridContollers;
+}
+@end

--- a/tests/expected/oc/50905-double_angle_space.m
+++ b/tests/expected/oc/50905-double_angle_space.m
@@ -1,0 +1,25 @@
+static const NSArray< id< NSObject> > **controllers = nil;
+
+NSArray< id< BlockController> > *someMethod();
+
+@interface Fraction : NSObject
+	void Compute(
+		Image< E::Matrix<SType, Dim,1> > const& src,
+		Image<E::Matrix<TType,Dim,1> >& dst);
+@end
+@implementation SomeClass
+- (void)initializeControllers:( NSArray< id< BlockController> > *)hybridContollers {
+	if (index < children.count) {
+		const unsigned int wl = w>>lvl;
+
+		assert(x<0 && y>=3);
+		assert(y <0&&z> 2);
+		assert(a>>1);
+		assert(b >>1);
+
+		return static_cast< id <CKMountable> >(children[index]);
+	}
+
+	NSArray<id< BlockController> > *controllers = hybridContollers;
+}
+@end

--- a/tests/expected/oc/50906-double_angle_space.m
+++ b/tests/expected/oc/50906-double_angle_space.m
@@ -1,0 +1,25 @@
+static const NSArray< id< NSObject> > **controllers = nil;
+
+NSArray< id< BlockController> > *someMethod();
+
+@interface Fraction : NSObject
+	void Compute(
+		Image< E::Matrix<SType, Dim,1> > const& src,
+		Image<E::Matrix<TType,Dim,1> >& dst);
+@end
+@implementation SomeClass
+- (void)initializeControllers:( NSArray< id< BlockController> > *)hybridContollers {
+	if (index < children.count) {
+		const unsigned int wl = w>>lvl;
+
+		assert(x<0 && y>=3);
+		assert(y <0&&z> 2);
+		assert(a>>1);
+		assert(b >>1);
+
+		return static_cast< id <CKMountable>>(children[index]);
+	}
+
+	NSArray<id< BlockController> > *controllers = hybridContollers;
+}
+@end

--- a/tests/input/oc/double_angle_space.m
+++ b/tests/input/oc/double_angle_space.m
@@ -1,0 +1,25 @@
+static const NSArray< id< NSObject> > **controllers = nil;
+
+NSArray< id< BlockController> > *someMethod();
+
+@interface Fraction : NSObject
+void Compute(
+    Image< E::Matrix<SType, Dim,1> > const& src,
+    Image<E::Matrix<TType,Dim,1> >& dst);
+@end
+@implementation SomeClass
+- (void)initializeControllers:( NSArray< id< BlockController> > *)hybridContollers {
+    if (index < children.count) {
+        const unsigned int wl = w>>lvl;
+
+        assert(x<0 && y>=3);
+assert(y <0&&z> 2);
+assert(a>>1);
+assert(b >>1);
+
+    return static_cast< id <CKMountable>>(children[index]);
+  }
+
+NSArray<id< BlockController> > *controllers = hybridContollers;
+}
+@end

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -141,6 +141,10 @@
 50902  empty.cfg                            oc/Issue_2289.m
 50903  Issue_681.cfg                        oc/Issue_681.oc
 
+50904  double_angle_space_1.cfg             oc/double_angle_space.m
+50905  double_angle_space_2.cfg             oc/double_angle_space.m
+50906  double_angle_space_3.cfg             oc/double_angle_space.m
+
 #
 # adopt tests from UT
 10018  empty.cfg                            oc/delete-space-oc.mm


### PR DESCRIPTION
Space inside angle shifts are correctly handled in `LANG_JAVA`, `LANG_CS` and `LANG_CPP` with option `sp_permit_cpp11_shift`. ObjectiveC language also need to support this option.