### PR TITLE
Fix issue 2623 with nested template syntax

### DIFF
--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -58,7 +58,7 @@ static void check_template_args(chunk_t *start, chunk_t *end);
  *
  * @param start  chunk to start check at
  */
-static void check_template(chunk_t *start);
+static void check_template(chunk_t *start, bool in_type_cast);
 
 
 /**
@@ -482,7 +482,7 @@ void tokenize_cleanup(void)
          if (language_is_set(LANG_OC | LANG_CPP | LANG_CS | LANG_JAVA | LANG_VALA))
          {
             // bug #663
-            check_template(pc);
+            check_template(pc, in_type_cast);
          }
          else
          {
@@ -1097,7 +1097,7 @@ void tokenize_cleanup(void)
 } // tokenize_cleanup
 
 
-static void check_template(chunk_t *start)
+static void check_template(chunk_t *start, bool in_type_cast)
 {
    LOG_FMT(LTEMPL, "%s(%d): orig_line %zu, orig_col %zu:\n",
            __func__, __LINE__, start->orig_line, start->orig_col);
@@ -1257,7 +1257,7 @@ static void check_template(chunk_t *start)
             && (pc->len() > 1)
             && (  options::tok_split_gte()
                || (  (chunk_is_str(pc, ">>", 2) || chunk_is_str(pc, ">>>", 3))
-                  && num_tokens >= 2)))
+                  && (num_tokens >= 2 || (num_tokens >= 1 && in_type_cast)))))
          {
             LOG_FMT(LTEMPL, "%s(%d): {split '%s' at orig_line %zu, orig_col %zu}\n",
                     __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col);

--- a/tests/config/issue_2623_1.cfg
+++ b/tests/config/issue_2623_1.cfg
@@ -1,0 +1,4 @@
+tok_split_gte = false
+sp_permit_cpp11_shift = true
+sp_angle_shift = remove
+sp_inside_angle = remove

--- a/tests/config/issue_2623_2.cfg
+++ b/tests/config/issue_2623_2.cfg
@@ -1,0 +1,4 @@
+tok_split_gte = false
+sp_permit_cpp11_shift = true
+sp_angle_shift = force
+sp_inside_angle = force

--- a/tests/config/issue_2623_3.cfg
+++ b/tests/config/issue_2623_3.cfg
@@ -1,0 +1,4 @@
+tok_split_gte = false
+sp_permit_cpp11_shift = true
+sp_angle_shift = ignore
+sp_inside_angle = ignore

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -763,6 +763,9 @@
 34319  align_func_proto_thresh_4.cfg        cpp/align_func_proto_thresh2.cpp
 34320  align_func_proto_thresh_5.cfg        cpp/align_func_proto_thresh2.cpp
 34321  bug_2285.cfg                         cpp/bug_2285.cpp
+34322  issue_2623_1.cfg                     cpp/issue_2623.cpp
+34323  issue_2623_2.cfg                     cpp/issue_2623.cpp
+34324  issue_2623_3.cfg                     cpp/issue_2623.cpp
 
 # Adopt some UT tests
 10000  empty.cfg                            cpp/621_this-spacing.cpp

--- a/tests/expected/cpp/34322-issue_2623.cpp
+++ b/tests/expected/cpp/34322-issue_2623.cpp
@@ -1,0 +1,30 @@
+void child() {
+	static_cast<id<Mountable>> ( object);
+}
+
+assert(x<0 && y>=3);
+assert(y <0&&z> 2);
+assert(a>>1);
+
+std::unique_ptr<Interface<T>> GetProjectionAdapter(const std::string& model_name);
+
+auto c = a< b>>c;
+auto c = a << b >>c;
+
+if (Something<a> == c) {
+}
+
+if (id<Something<a>> == c) {
+}
+
+const std::vector<Eigen::Matrix<T, A, B>> & P_c;
+
+const unsigned int wl = w>> lvl;
+
+using Poly = Model<P, Poly<Dx,Dy, Dz>>;
+
+void Compute(
+	Image<E::Matrix<SType, Dim,Int>> const& src,
+	Image<E::Matrix<TType,Dim, std::string>>& dst);
+
+Opt<std::vector <std::unordered_set<FrameId>>> partition;

--- a/tests/expected/cpp/34323-issue_2623.cpp
+++ b/tests/expected/cpp/34323-issue_2623.cpp
@@ -1,0 +1,30 @@
+void child() {
+	static_cast< id< Mountable > > ( object);
+}
+
+assert(x<0 && y>=3);
+assert(y <0&&z> 2);
+assert(a>>1);
+
+std::unique_ptr< Interface< T > > GetProjectionAdapter(const std::string& model_name);
+
+auto c = a< b>>c;
+auto c = a << b >>c;
+
+if (Something< a > == c) {
+}
+
+if (id< Something< a > > == c) {
+}
+
+const std::vector< Eigen::Matrix< T, A, B > > & P_c;
+
+const unsigned int wl = w>> lvl;
+
+using Poly = Model< P, Poly< Dx,Dy, Dz > >;
+
+void Compute(
+	Image< E::Matrix< SType, Dim,Int > > const& src,
+	Image< E::Matrix< TType,Dim, std::string > >& dst);
+
+Opt< std::vector < std::unordered_set< FrameId > > > partition;

--- a/tests/expected/cpp/34324-issue_2623.cpp
+++ b/tests/expected/cpp/34324-issue_2623.cpp
@@ -1,0 +1,30 @@
+void child() {
+	static_cast< id<Mountable >> ( object);
+}
+
+assert(x<0 && y>=3);
+assert(y <0&&z> 2);
+assert(a>>1);
+
+std::unique_ptr<Interface< T >> GetProjectionAdapter(const std::string& model_name);
+
+auto c = a< b>>c;
+auto c = a << b >>c;
+
+if (Something<a> == c) {
+}
+
+if (id< Something<a >> == c) {
+}
+
+const std::vector< Eigen::Matrix<T, A, B >> & P_c;
+
+const unsigned int wl = w>> lvl;
+
+using Poly = Model<P, Poly<Dx,Dy, Dz>>;
+
+void Compute(
+	Image<E::Matrix< SType, Dim,Int >> const& src,
+	Image< E::Matrix<  TType,Dim, std::string> >& dst);
+
+Opt<std::vector < std::unordered_set<FrameId> >> partition;

--- a/tests/input/cpp/issue_2623.cpp
+++ b/tests/input/cpp/issue_2623.cpp
@@ -1,0 +1,30 @@
+void child() {
+ static_cast< id<Mountable >> ( object);
+}
+
+assert(x<0 && y>=3);
+assert(y <0&&z> 2);
+assert(a>>1);
+
+std::unique_ptr<Interface< T >> GetProjectionAdapter(const std::string& model_name);
+
+auto c = a< b>>c;
+auto c = a << b >>c;
+
+if (Something<a> == c) {
+}
+
+if (id< Something<a >> == c) {
+}
+
+const std::vector< Eigen::Matrix<T, A, B >> & P_c;
+
+const unsigned int wl = w>> lvl;
+
+using Poly = Model<P, Poly<Dx,Dy, Dz>>;
+
+void Compute(
+    Image<E::Matrix< SType, Dim,Int >> const& src,
+    Image< E::Matrix<  TType,Dim, std::string> >& dst);
+
+Opt<std::vector < std::unordered_set<FrameId> >> partition;


### PR DESCRIPTION
The template token parsing logic has a bug when `static_cast` is present. `static_cast` already takes care of the angle_close token, hence during the check for template we need to take one less angle_close into account.

`tok_split_gte` option is added as a hack to parse nested template syntax like `Class1<Class2<Class3>>>`, but it breaks the simple syntax `assert(x<0 && y>=3)`. This commit correctly fixes the template parsing logic, hence the option `tok_split_gte` option may become obsolete and can be removed.