### PR TITLE
Bump minimum CMake version, fix warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.2)
 
 project(uncrustify)
 
@@ -139,17 +139,19 @@ else()
   # Add target to generate version header;
   # do this every build to ensure git SHA is up to date
   add_custom_target(generate_version_header
-    ${CMAKE_COMMAND}
-    -D PYTHON_EXECUTABLE:STRING=${PYTHON_EXECUTABLE}
-    -D SOURCE_DIR:PATH="${PROJECT_SOURCE_DIR}"
-    -D INPUT:PATH="${PROJECT_SOURCE_DIR}/src/uncrustify_version.h.in"
-    -D OUTPUT:PATH="${PROJECT_BINARY_DIR}/uncrustify_version.h"
-    -D UNCRUSTIFY_VERSION:STRING="${UNCRUSTIFY_VERSION}"
-    -P ${PROJECT_SOURCE_DIR}/cmake/GenerateVersionHeader.cmake
+    BYPRODUCTS "${PROJECT_BINARY_DIR}/uncrustify_version.h"
+    COMMAND
+      ${CMAKE_COMMAND}
+      -D PYTHON_EXECUTABLE:STRING=${PYTHON_EXECUTABLE}
+      -D SOURCE_DIR:PATH="${PROJECT_SOURCE_DIR}"
+      -D INPUT:PATH="${PROJECT_SOURCE_DIR}/src/uncrustify_version.h.in"
+      -D OUTPUT:PATH="${PROJECT_BINARY_DIR}/uncrustify_version.h"
+      -D UNCRUSTIFY_VERSION:STRING="${UNCRUSTIFY_VERSION}"
+      -P ${PROJECT_SOURCE_DIR}/cmake/GenerateVersionHeader.cmake
     COMMENT "Generating version header"
   )
   set_source_files_properties(
-    "${CMAKE_CURRENT_BINARY_DIR}/uncrustify_version.h"
+    "${PROJECT_BINARY_DIR}/uncrustify_version.h"
     PROPERTIES GENERATED TRUE
   )
 endif()


### PR DESCRIPTION
Increase the minimum required CMake version to 3.2. List `uncrustify_version.h` as a `BYPRODUCT` of the rule that generates it, which is relevant for generating a proper build graph for some tools (notably Ninja) and fixes a CMake warning to such effect.

Note that support for `BYPRODUCTS` was introduced in CMake 3.2, which is why these changes are being combined. (In a very real sense, fixing the warning is the driver for increasing the minimum version, which in turn is a more significant change than silencing a configure warning.)

Fixes #2541. (Well, "accomplishes", but use the keyword that GitHub recognizes...)