### PR TITLE
Add option sp_before_oc_proto_list

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -604,6 +604,10 @@ sp_catch_paren                  = ignore   # ignore/add/remove/force
 # in '@catch (something) { }'. If set to ignore, sp_catch_paren is used.
 sp_oc_catch_paren               = ignore   # ignore/add/remove/force
 
+# (OC) Add or remove space before Objective-C protocol list
+# as in '@protocol Protocol<here><Protocol_A>' or '@interface MyClass : NSObject<here><MyProtocol>'.
+sp_before_oc_proto_list         = ignore   # ignore/add/remove/force
+
 # (OC) Add or remove space between class name and '('
 # in '@interface className(categoryName)<ProtocolName>:BaseClass'
 sp_oc_classname_paren           = ignore   # ignore/add/remove/force

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -604,6 +604,10 @@ sp_catch_paren                  = ignore   # ignore/add/remove/force
 # in '@catch (something) { }'. If set to ignore, sp_catch_paren is used.
 sp_oc_catch_paren               = ignore   # ignore/add/remove/force
 
+# (OC) Add or remove space before Objective-C protocol list
+# as in '@protocol Protocol<here><Protocol_A>' or '@interface MyClass : NSObject<here><MyProtocol>'.
+sp_before_oc_proto_list         = ignore   # ignore/add/remove/force
+
 # (OC) Add or remove space between class name and '('
 # in '@interface className(categoryName)<ProtocolName>:BaseClass'
 sp_oc_classname_paren           = ignore   # ignore/add/remove/force

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -604,6 +604,10 @@ sp_catch_paren                  = ignore   # ignore/add/remove/force
 # in '@catch (something) { }'. If set to ignore, sp_catch_paren is used.
 sp_oc_catch_paren               = ignore   # ignore/add/remove/force
 
+# (OC) Add or remove space before Objective-C protocol list
+# as in '@protocol Protocol<here><Protocol_A>' or '@interface MyClass : NSObject<here><MyProtocol>'.
+sp_before_oc_proto_list         = ignore   # ignore/add/remove/force
+
 # (OC) Add or remove space between class name and '('
 # in '@interface className(categoryName)<ProtocolName>:BaseClass'
 sp_oc_classname_paren           = ignore   # ignore/add/remove/force

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -1452,6 +1452,15 @@ Choices=sp_oc_catch_paren=ignore|sp_oc_catch_paren=add|sp_oc_catch_paren=remove|
 ChoicesReadable="Ignore Sp Oc Catch Paren|Add Sp Oc Catch Paren|Remove Sp Oc Catch Paren|Force Sp Oc Catch Paren"
 ValueDefault=ignore
 
+[Sp Before Oc Proto List]
+Category=1
+Description="<html>(OC) Add or remove space before Objective-C protocol list<br/>as in '@protocol Protocol<here><Protocol_A>' or '@interface MyClass : NSObject<here><MyProtocol>'.</html>"
+Enabled=false
+EditorType=multiple
+Choices=sp_before_oc_proto_list=ignore|sp_before_oc_proto_list=add|sp_before_oc_proto_list=remove|sp_before_oc_proto_list=force
+ChoicesReadable="Ignore Sp Before Oc Proto List|Add Sp Before Oc Proto List|Remove Sp Before Oc Proto List|Force Sp Before Oc Proto List"
+ValueDefault=ignore
+
 [Sp Oc Classname Paren]
 Category=1
 Description="<html>(OC) Add or remove space between class name and '('<br/>in '@interface className(categoryName)&lt;ProtocolName&gt;:BaseClass'</html>"

--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -352,6 +352,7 @@ nl_func_def_args                          = ignore
 # sp_before_oc_block_caret
 # sp_before_oc_colon
 # sp_before_oc_dict_colon
+# sp_before_oc_proto_list
 # sp_before_pp_stringify
 # sp_before_send_oc_colon
 # sp_before_square_asm_block

--- a/src/options.h
+++ b/src/options.h
@@ -774,6 +774,11 @@ sp_catch_paren;
 extern Option<iarf_e>
 sp_oc_catch_paren;
 
+// (OC) Add or remove space before Objective-C protocol list
+// as in '@protocol Protocol<here><Protocol_A>' or '@interface MyClass : NSObject<here><MyProtocol>'.
+extern Option<iarf_e>
+sp_before_oc_proto_list;
+
 // (OC) Add or remove space between class name and '('
 // in '@interface className(categoryName)<ProtocolName>:BaseClass'
 extern Option<iarf_e>

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -785,6 +785,18 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    }
 
    if (  language_is_set(LANG_OC)
+      && (chunk_is_token(first, CT_PAREN_CLOSE) || chunk_is_token(first, CT_OC_CLASS) || chunk_is_token(first, CT_WORD))
+      && chunk_is_token(second, CT_ANGLE_OPEN)
+      && (get_chunk_parent_type(second) == CT_OC_PROTO_LIST || get_chunk_parent_type(second) == CT_OC_GENERIC_SPEC)
+      && (options::sp_before_oc_proto_list() != IARF_IGNORE))
+   {
+      // (OC) Add or remove space before Objective-C protocol list
+      // as in '@protocol Protocol<here><Protocol_A>' or '@interface MyClass : NSObject<here><MyProtocol>'.
+      log_rule("sp_before_oc_proto_list");
+      return(options::sp_before_oc_proto_list());
+   }
+
+   if (  language_is_set(LANG_OC)
       && chunk_is_token(first, CT_OC_CLASS)
       && chunk_is_token(second, CT_PAREN_OPEN)
       && (options::sp_oc_classname_paren() != IARF_IGNORE))

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -159,6 +159,7 @@ sp_throw_paren                  = ignore
 sp_after_throw                  = ignore
 sp_catch_paren                  = ignore
 sp_oc_catch_paren               = ignore
+sp_before_oc_proto_list         = ignore
 sp_oc_classname_paren           = ignore
 sp_version_paren                = ignore
 sp_scope_paren                  = ignore

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -606,6 +606,10 @@ sp_catch_paren                  = ignore   # ignore/add/remove/force
 # in '@catch (something) { }'. If set to ignore, sp_catch_paren is used.
 sp_oc_catch_paren               = ignore   # ignore/add/remove/force
 
+# (OC) Add or remove space before Objective-C protocol list
+# as in '@protocol Protocol<here><Protocol_A>' or '@interface MyClass : NSObject<here><MyProtocol>'.
+sp_before_oc_proto_list         = ignore   # ignore/add/remove/force
+
 # (OC) Add or remove space between class name and '('
 # in '@interface className(categoryName)<ProtocolName>:BaseClass'
 sp_oc_classname_paren           = ignore   # ignore/add/remove/force

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -159,6 +159,7 @@ sp_throw_paren                  = ignore
 sp_after_throw                  = ignore
 sp_catch_paren                  = ignore
 sp_oc_catch_paren               = ignore
+sp_before_oc_proto_list         = ignore
 sp_oc_classname_paren           = ignore
 sp_version_paren                = ignore
 sp_scope_paren                  = ignore

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -606,6 +606,10 @@ sp_catch_paren                  = ignore   # ignore/add/remove/force
 # in '@catch (something) { }'. If set to ignore, sp_catch_paren is used.
 sp_oc_catch_paren               = ignore   # ignore/add/remove/force
 
+# (OC) Add or remove space before Objective-C protocol list
+# as in '@protocol Protocol<here><Protocol_A>' or '@interface MyClass : NSObject<here><MyProtocol>'.
+sp_before_oc_proto_list         = ignore   # ignore/add/remove/force
+
 # (OC) Add or remove space between class name and '('
 # in '@interface className(categoryName)<ProtocolName>:BaseClass'
 sp_oc_classname_paren           = ignore   # ignore/add/remove/force

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -606,6 +606,10 @@ sp_catch_paren                  = ignore   # ignore/add/remove/force
 # in '@catch (something) { }'. If set to ignore, sp_catch_paren is used.
 sp_oc_catch_paren               = ignore   # ignore/add/remove/force
 
+# (OC) Add or remove space before Objective-C protocol list
+# as in '@protocol Protocol<here><Protocol_A>' or '@interface MyClass : NSObject<here><MyProtocol>'.
+sp_before_oc_proto_list         = ignore   # ignore/add/remove/force
+
 # (OC) Add or remove space between class name and '('
 # in '@interface className(categoryName)<ProtocolName>:BaseClass'
 sp_oc_classname_paren           = ignore   # ignore/add/remove/force

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -1452,6 +1452,15 @@ Choices=sp_oc_catch_paren=ignore|sp_oc_catch_paren=add|sp_oc_catch_paren=remove|
 ChoicesReadable="Ignore Sp Oc Catch Paren|Add Sp Oc Catch Paren|Remove Sp Oc Catch Paren|Force Sp Oc Catch Paren"
 ValueDefault=ignore
 
+[Sp Before Oc Proto List]
+Category=1
+Description="<html>(OC) Add or remove space before Objective-C protocol list<br/>as in '@protocol Protocol&lt;here&gt;&lt;Protocol_A&gt;' or '@interface MyClass : NSObject&lt;here&gt;&lt;MyProtocol&gt;'.</html>"
+Enabled=false
+EditorType=multiple
+Choices=sp_before_oc_proto_list=ignore|sp_before_oc_proto_list=add|sp_before_oc_proto_list=remove|sp_before_oc_proto_list=force
+ChoicesReadable="Ignore Sp Before Oc Proto List|Add Sp Before Oc Proto List|Remove Sp Before Oc Proto List|Force Sp Before Oc Proto List"
+ValueDefault=ignore
+
 [Sp Oc Classname Paren]
 Category=1
 Description="<html>(OC) Add or remove space between class name and '('<br/>in '@interface className(categoryName)&lt;ProtocolName&gt;:BaseClass'</html>"

--- a/tests/config/sp_before_oc_proto_list_add.cfg
+++ b/tests/config/sp_before_oc_proto_list_add.cfg
@@ -1,0 +1,2 @@
+sp_before_oc_proto_list         = add
+sp_oc_classname_paren           = force

--- a/tests/config/sp_before_oc_proto_list_force.cfg
+++ b/tests/config/sp_before_oc_proto_list_force.cfg
@@ -1,0 +1,2 @@
+sp_before_oc_proto_list         = force
+sp_oc_classname_paren           = force

--- a/tests/config/sp_before_oc_proto_list_remove.cfg
+++ b/tests/config/sp_before_oc_proto_list_remove.cfg
@@ -1,0 +1,2 @@
+sp_before_oc_proto_list         = remove
+sp_oc_classname_paren           = force

--- a/tests/expected/oc/50813-sp_before_oc_proto_list.m
+++ b/tests/expected/oc/50813-sp_before_oc_proto_list.m
@@ -1,0 +1,25 @@
+@protocol ControllerDelegate <NSObject, Controller>
+@end
+
+@protocol Controller  <NSObject>
+@end
+
+@interface CollectionViewController ()  <DataSource> {
+}
+@end
+
+@interface CollectionViewController (Flow) <FlowDelegate> : NSObject
+{
+	NSDictionary <NSString *, NSString *> dict;
+}
+@end
+
+@interface MyClass : NSObject  <Protocol_A, Protocol_B>
+
+@end
+
+@implementation ViewController
+- (void)someMethod {
+	auto const *dict = [NSMutableDictionary  < NSString *, NSString * > new];
+}
+@end

--- a/tests/expected/oc/50814-sp_before_oc_proto_list.m
+++ b/tests/expected/oc/50814-sp_before_oc_proto_list.m
@@ -1,0 +1,25 @@
+@protocol ControllerDelegate <NSObject, Controller>
+@end
+
+@protocol Controller <NSObject>
+@end
+
+@interface CollectionViewController () <DataSource> {
+}
+@end
+
+@interface CollectionViewController (Flow) <FlowDelegate> : NSObject
+{
+	NSDictionary <NSString *, NSString *> dict;
+}
+@end
+
+@interface MyClass : NSObject <Protocol_A, Protocol_B>
+
+@end
+
+@implementation ViewController
+- (void)someMethod {
+	auto const *dict = [NSMutableDictionary  < NSString *, NSString * > new];
+}
+@end

--- a/tests/expected/oc/50815-sp_before_oc_proto_list.m
+++ b/tests/expected/oc/50815-sp_before_oc_proto_list.m
@@ -1,0 +1,25 @@
+@protocol ControllerDelegate<NSObject, Controller>
+@end
+
+@protocol Controller<NSObject>
+@end
+
+@interface CollectionViewController ()<DataSource> {
+}
+@end
+
+@interface CollectionViewController (Flow)<FlowDelegate> : NSObject
+{
+	NSDictionary <NSString *, NSString *> dict;
+}
+@end
+
+@interface MyClass : NSObject<Protocol_A, Protocol_B>
+
+@end
+
+@implementation ViewController
+- (void)someMethod {
+	auto const *dict = [NSMutableDictionary  < NSString *, NSString * > new];
+}
+@end

--- a/tests/input/oc/sp_before_oc_proto_list.m
+++ b/tests/input/oc/sp_before_oc_proto_list.m
@@ -1,0 +1,25 @@
+@protocol ControllerDelegate<NSObject, Controller>
+@end
+
+@protocol Controller  <NSObject>
+@end
+
+@interface CollectionViewController ()  <DataSource> {
+}
+@end
+
+@interface CollectionViewController (Flow)<FlowDelegate> : NSObject
+{
+  NSDictionary <NSString *, NSString *> dict;
+}
+@end
+
+@interface MyClass : NSObject  <Protocol_A, Protocol_B>
+
+@end
+
+@implementation ViewController
+- (void)someMethod {
+  auto const *dict = [NSMutableDictionary  < NSString *, NSString * > new];
+}
+@end

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -140,6 +140,10 @@
 50811  oc_bug_1674.cfg                      oc/bug_1674.m
 50812  oc_bug_1683.cfg                      oc/bug_1683.m
 
+50813  sp_before_oc_proto_list_add.cfg      oc/sp_before_oc_proto_list.m
+50814  sp_before_oc_proto_list_force.cfg    oc/sp_before_oc_proto_list.m
+50815  sp_before_oc_proto_list_remove.cfg   oc/sp_before_oc_proto_list.m
+
 50900  1927.cfg                             oc/1927.m
 50901  Issue_2172.cfg                       oc/Issue_2172.m
 50902  empty.cfg                            oc/Issue_2289.m


### PR DESCRIPTION
Added option `sp_before_oc_proto_list` to be able to control space before protocol list in OC language. With this option we can tune the config to match Apple style format for defining protocols and interface classes even with categories.