### PR TITLE
Fix issue `FUNC_CALL` not tokenized in OC when first param starts with `CARET`

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1176,7 +1176,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
          handle_oc_block_type(tmp);
 
          // This is the case where a block literal is passed as the first argument of a C-style method invocation.
-         if (chunk_is_token(tmp, CT_OC_BLOCK_CARET) && chunk_is_token(pc, CT_WORD))
+         if ((chunk_is_token(tmp, CT_OC_BLOCK_CARET) || chunk_is_token(tmp, CT_CARET)) && chunk_is_token(pc, CT_WORD))
          {
             set_chunk_type(pc, CT_FUNC_CALL);
          }

--- a/tests/expected/oc/50804-issue_2629.m
+++ b/tests/expected/oc/50804-issue_2629.m
@@ -1,0 +1,18 @@
+@implementation SomeClass
+- (void)someMethod {
+    enumerateItems(
+        ^(NSInteger section) {
+    });
+}
+
+- (void)someOtherMethod {
+    items.enumerateItems(
+        ^(NSInteger section, NSInteger index, id<NSObject> object, BOOL *stop) {
+        enumerator(index, object, TypeInsert);
+    },
+        nil,
+        some_param
+        );
+}
+
+@end

--- a/tests/input/oc/issue_2629.m
+++ b/tests/input/oc/issue_2629.m
@@ -1,0 +1,20 @@
+@implementation SomeClass
+- (void)someMethod
+{
+	   enumerateItems     (
+  ^(  NSInteger   section) {
+   } );
+}
+
+- (void)someOtherMethod
+{
+	items.enumerateItems (
+    ^(NSInteger section, NSInteger index, id<NSObject> object, BOOL *stop) {
+      enumerator(index, object, TypeInsert);
+    },
+    nil,
+		some_param
+  );
+}
+@end
+

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -132,6 +132,8 @@
 50802  obj-c-available.cfg                  oc/available.m
 50803  indent_single_newline.cfg            oc/indent_single_newline.m
 
+50804  aet.cfg                              oc/issue_2629.m
+
 50810  bug_841.cfg                          oc/bug_841.m
 50811  oc_bug_1674.cfg                      oc/bug_1674.m
 50812  oc_bug_1683.cfg                      oc/bug_1683.m


### PR DESCRIPTION
This fixes the Issue 2629 where `FUNC_CALL` is not being recognized when first
param stars with a `^`.