### PR TITLE
Fix wrongly tagged parent type for braces inside OC_CLASS

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -6254,13 +6254,15 @@ static void handle_oc_class(chunk_t *pc)
          }
       }
 
-      if (chunk_is_token(tmp, CT_BRACE_OPEN))
+      if (  chunk_is_token(tmp, CT_BRACE_OPEN)
+         && get_chunk_parent_type(tmp) != CT_ASSIGN)
       {
          as = angle_state_e::CLOSE;
          set_chunk_parent(tmp, CT_OC_CLASS);
          tmp = chunk_get_next_type(tmp, CT_BRACE_CLOSE, tmp->level);
 
-         if (tmp != nullptr)
+         if (  tmp != nullptr
+            && get_chunk_parent_type(tmp) != CT_ASSIGN)
          {
             set_chunk_parent(tmp, CT_OC_CLASS);
          }

--- a/tests/expected/oc/50062-issue_2631.m
+++ b/tests/expected/oc/50062-issue_2631.m
@@ -1,0 +1,17 @@
+@protocol SomeProtocol
+Props Method(const Contents& options = {});
+@end
+
+@interface SomeClass
+Props Method1(const Contents& options = {});
+@end
+
+
+@implementation SomeClass
+Props Method1(const Contents options = {});
+@end
+
+void Method2(const Contents options = {}) {
+}
+
+void Method3(const Contents& options = { .text = 10 });

--- a/tests/input/oc/issue_2631.m
+++ b/tests/input/oc/issue_2631.m
@@ -1,0 +1,17 @@
+@protocol SomeProtocol
+Props Method(const Contents &options = {});
+@end
+
+@interface SomeClass
+Props Method1(const Contents &options = {});
+@end
+
+
+@implementation SomeClass
+Props Method1(const Contents options = {});
+@end
+
+void Method2(const Contents options = {}) {
+}
+
+void Method3(const Contents &options = { .text = 10 });

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -40,6 +40,8 @@
 50060  align_oc_msg_colon_span-1.cfg        oc/oc-split.m
 50061  bug_167.cfg                          oc/bug_167.m
 
+50062  aet.cfg                              oc/issue_2631.m
+
 50070  blocks.cfg                           oc/blocks.m
 50071  sp_before_oc_block_caret_force.cfg   oc/blocks.m
 50072  sp_before_oc_block_caret_remove.cfg  oc/blocks.m


### PR DESCRIPTION
Open and Close braces are wrongly tagged with parent type `OC_CLASS` incase of parent type `ASSIGN`. This should fix the issue 2631.