### PR TITLE
Fix issue with OC property sorting where `class` keyword is dropped

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -28,8 +28,8 @@
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
+#include <limits>
 #include <map>
-
 
 using namespace std;
 using namespace uncrustify;
@@ -6898,6 +6898,7 @@ static void handle_oc_property_decl(chunk_t *os)
       std::vector<ChunkGroup> getter_chunks;      // getter
       std::vector<ChunkGroup> setter_chunks;      // setter
       std::vector<ChunkGroup> nullability_chunks; // nonnull, nullable, null_unspecified, null_resettable
+      std::vector<ChunkGroup> other_chunks;       // any words other than above
 
       if (chunk_is_token(next, CT_PAREN_OPEN))
       {
@@ -6996,6 +6997,27 @@ static void handle_oc_property_decl(chunk_t *os)
                   chunkGroup.push_back(next);
                   class_chunks.push_back(chunkGroup);
                }
+               else
+               {
+                  ChunkGroup chunkGroup;
+                  chunkGroup.push_back(next);
+                  other_chunks.push_back(chunkGroup);
+               }
+            }
+            else if (chunk_is_word(next))
+            {
+               if (chunk_is_str(next, "class", 5))
+               {
+                  ChunkGroup chunkGroup;
+                  chunkGroup.push_back(next);
+                  class_chunks.push_back(chunkGroup);
+               }
+               else
+               {
+                  ChunkGroup chunkGroup;
+                  chunkGroup.push_back(next);
+                  other_chunks.push_back(chunkGroup);
+               }
             }
             next = chunk_get_next(next);
          }
@@ -7023,6 +7045,7 @@ static void handle_oc_property_decl(chunk_t *os)
          sorted_chunk_map.insert(pair<int, std::vector<ChunkGroup> >(getter_w, getter_chunks));
          sorted_chunk_map.insert(pair<int, std::vector<ChunkGroup> >(setter_w, setter_chunks));
          sorted_chunk_map.insert(pair<int, std::vector<ChunkGroup> >(nullability_w, nullability_chunks));
+         sorted_chunk_map.insert(pair<int, std::vector<ChunkGroup> >(std::numeric_limits<int>::min(), other_chunks));
 
          chunk_t *curr_chunk = open_paren;
 

--- a/tests/config/obj-c-properties.cfg
+++ b/tests/config/obj-c-properties.cfg
@@ -5,3 +5,4 @@ mod_sort_oc_property_readwrite_weight = 5
 mod_sort_oc_property_reference_weight = 4
 mod_sort_oc_property_getter_weight = 2
 mod_sort_oc_property_nullability_weight = 3
+mod_sort_oc_property_class_weight = 7

--- a/tests/expected/oc/50800-properties.m
+++ b/tests/expected/oc/50800-properties.m
@@ -1,8 +1,12 @@
+#define nonnull_strong nonnull, strong
+#define myatomic nonatomic
 @interface UCTestClass ()
 
 @property (nonatomic,readonly,strong,null_unspecified) NSString* test1;
 @property (nonatomic,readonly,strong,nullable) NSString* test2;
 @property (nonatomic,readonly,strong,nonnull,getter=test2Getter) NSString* test3;
 @property (nonatomic,readonly,strong,null_resettable,getter=test2Getter,setter=test2Setter:) NSString* test4;
+@property (class,nonatomic,readonly,assign,nonnull,getter=test5Getter) NSString* test5;
+@property (class,assign,getter=test5Getter,myatomic,nonnull_strong) NSString* test6;
 
 @end

--- a/tests/input/oc/properties.m
+++ b/tests/input/oc/properties.m
@@ -1,8 +1,12 @@
+#define nonnull_strong nonnull, strong
+#define myatomic nonatomic
 @interface UCTestClass ()
 
 @property (nonatomic, strong, null_unspecified, readonly) NSString* test1;
 @property (strong, readonly, nonatomic, nullable) NSString* test2;
 @property (strong, readonly, getter=test2Getter, nonatomic, nonnull) NSString* test3;
 @property (strong, readonly, getter=test2Getter, nonatomic, setter=test2Setter:, null_resettable) NSString* test4;
+@property (class, readonly, getter=test5Getter, nonatomic, nonnull, assign) NSString* test5;
+@property (class, assign, getter=test5Getter, myatomic, nonnull_strong) NSString* test6;
 
 @end


### PR DESCRIPTION
OC property sorting logic has a bad bug where `class` keyword is being dropped. The logic also doesn't handle cases when there are other words other than the OC keywords.