### PR TITLE
Fix space trailing return type for function definition

### DIFF
--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -259,7 +259,7 @@ void tokenize_trailing_return_types(void)
          }
 
          if (  chunk_is_token(tmp, CT_FPAREN_CLOSE)
-            && get_chunk_parent_type(tmp) == CT_FUNC_PROTO)
+            && (get_chunk_parent_type(tmp) == CT_FUNC_PROTO || get_chunk_parent_type(tmp) == CT_FUNC_DEF))
          {
             set_chunk_type(pc, CT_TRAILING_RET);
             LOG_FMT(LNOTE, "%s(%d): set trailing return type for text() is '%s'\n",

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -107,7 +107,7 @@ struct indent_ptr_t
 };
 
 
-constexpr auto pcf_bit(size_t b)->decltype(0ULL)
+constexpr auto pcf_bit(size_t b) -> decltype(0ULL)
 {
    return(1ULL << b);
 }

--- a/tests/expected/cpp/30218-trailing_return.cpp
+++ b/tests/expected/cpp/30218-trailing_return.cpp
@@ -40,3 +40,11 @@ void foo()
 		return n + 5;
 	});
 }
+
+static auto f25() -> bool {
+	return true;
+}
+
+static auto f26() const noexcept(true) -> bool {
+	return true;
+}

--- a/tests/expected/cpp/30219-trailing_return.cpp
+++ b/tests/expected/cpp/30219-trailing_return.cpp
@@ -40,3 +40,11 @@ void foo()
 		return n + 5;
 	});
 }
+
+static auto f25()->bool {
+	return true;
+}
+
+static auto f26() const noexcept(true)->bool {
+	return true;
+}

--- a/tests/input/cpp/trailing_return.cpp
+++ b/tests/input/cpp/trailing_return.cpp
@@ -34,3 +34,11 @@ void foo()
 	auto l = [](int n)  ->  x_t{ return n + 5; };
 	x([](int n)  ->  x_t{ return n + 5; });
 }
+
+static auto f25()  ->  bool {
+	return true;
+}
+
+static auto f26() const noexcept(true)  ->  bool {
+	return true;
+}


### PR DESCRIPTION
Currently setting `sp_trailing_return` doesn't work for function definition cases. Hence fixed the issue so that `->` is correctly spaced.