### PR TITLE
Fix ptr type in trailing return syntax to correctly apply rules

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1788,6 +1788,16 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
             //    using AbstractLinkPtrPtr = AbstractLink**;
             set_chunk_type(pc, CT_PTR_TYPE);
          }
+         else if (  (  get_chunk_parent_type(pc) == CT_FUNC_DEF
+                    && (chunk_is_opening_brace(next) || chunk_is_star(pc->next)))
+                 || (next->type == CT_QUALIFIER))               // Issue #2648
+         {
+            // example:
+            // auto getComponent(Color *color) -> Component * {
+            // auto getComponent(Color *color) -> Component ** {
+            // auto getComponent(Color *color) -> Component * _Nonnull
+            set_chunk_type(pc, CT_PTR_TYPE);
+         }
          else if (  chunk_is_token(pc->next, CT_SEMICOLON)      // Issue #2319
                  || (  chunk_is_token(pc->next, CT_STAR)
                     && chunk_is_token(pc->next->next, CT_STAR)))

--- a/tests/expected/cpp/30805-ptr-star.cpp
+++ b/tests/expected/cpp/30805-ptr-star.cpp
@@ -48,3 +48,23 @@ struct X
 
 int* const i;
 int* static i;
+
+static auto Func1(Model* model) -> Color*;
+static auto Func1(Model* model) -> Color* {
+	return nullptr;
+}
+
+auto Func2(Model* model) -> Color* const;
+auto Func2(Model* model) -> Color* const {
+	return nullptr;
+}
+
+auto Func3(Model* model) -> Color**;
+auto Func3(Model* model) -> Color** {
+	return nullptr;
+}
+
+auto Func4(Model* model) -> Color** const;
+auto Func4(Model* model) -> Color** const {
+	return nullptr;
+}

--- a/tests/expected/cpp/30806-ptr-star.cpp
+++ b/tests/expected/cpp/30806-ptr-star.cpp
@@ -48,3 +48,23 @@ struct X
 
 int *const i;
 int *static i;
+
+static auto Func1(Model *model) -> Color *;
+static auto Func1(Model *model) -> Color * {
+	return nullptr;
+}
+
+auto Func2(Model *model) -> Color *const;
+auto Func2(Model *model) -> Color *const {
+	return nullptr;
+}
+
+auto Func3(Model *model) -> Color **;
+auto Func3(Model *model) -> Color ** {
+	return nullptr;
+}
+
+auto Func4(Model *model) -> Color**const;
+auto Func4(Model *model) -> Color **const {
+	return nullptr;
+}

--- a/tests/expected/cpp/30807-ptr-star.cpp
+++ b/tests/expected/cpp/30807-ptr-star.cpp
@@ -48,3 +48,23 @@ struct X
 
 int*const i;
 int*static i;
+
+static auto Func1(Model *model) -> Color*;
+static auto Func1(Model *model) -> Color* {
+	return nullptr;
+}
+
+auto Func2(Model *model) -> Color*const;
+auto Func2(Model *model) -> Color* const {
+	return nullptr;
+}
+
+auto Func3(Model *model) -> Color**;
+auto Func3(Model *model) -> Color** {
+	return nullptr;
+}
+
+auto Func4(Model *model) -> Color**const;
+auto Func4(Model *model) -> Color** const {
+	return nullptr;
+}

--- a/tests/expected/cpp/30808-ptr-star.cpp
+++ b/tests/expected/cpp/30808-ptr-star.cpp
@@ -48,3 +48,23 @@ struct X
 
 int * const i;
 int * static i;
+
+static auto Func1(Model *model) -> Color*;
+static auto Func1(Model *model) -> Color* {
+	return nullptr;
+}
+
+auto Func2(Model *model) -> Color* const;
+auto Func2(Model *model) -> Color* const {
+	return nullptr;
+}
+
+auto Func3(Model *model) -> Color**;
+auto Func3(Model *model) -> Color** {
+	return nullptr;
+}
+
+auto Func4(Model *model) -> Color** const;
+auto Func4(Model *model) -> Color** const {
+	return nullptr;
+}

--- a/tests/expected/cpp/30810-ptr-star.cpp
+++ b/tests/expected/cpp/30810-ptr-star.cpp
@@ -50,3 +50,27 @@ struct X
 
 int *const  i;
 int *static i;
+
+static auto Func1(Model *model) -> Color *;
+static auto Func1(Model *model) -> Color *
+{
+   return(nullptr);
+}
+
+auto Func2(Model *model) -> Color *const;
+auto Func2(Model *model) -> Color *const
+{
+   return(nullptr);
+}
+
+auto Func3(Model *model) -> Color **;
+auto Func3(Model *model) -> Color **
+{
+   return(nullptr);
+}
+
+auto Func4(Model *model) -> Color**const;
+auto Func4(Model *model) -> Color **const
+{
+   return(nullptr);
+}

--- a/tests/input/cpp/ptr-star.cpp
+++ b/tests/input/cpp/ptr-star.cpp
@@ -48,3 +48,23 @@ return  *  c ;  // 11:8
 
 int *const i;
 int *static i;
+
+static auto Func1(Model *model) -> Color*;
+static auto Func1(Model *model) -> Color* {
+  return nullptr;
+}
+
+auto Func2(Model *model) -> Color* const;
+auto Func2(Model *model) -> Color* const {
+  return nullptr;
+}
+
+auto Func3(Model *model) -> Color**;
+auto Func3(Model *model) -> Color** {
+  return nullptr;
+}
+
+auto Func4(Model *model) -> Color** const;
+auto Func4(Model *model) -> Color** const {
+  return nullptr;
+}


### PR DESCRIPTION
The `STAR` is not correctly tagged as `PTR_TYPE` in trailing return syntax. This causes several rules in config related to ptr not apply.