### PR TITLE
Fix OC_BLOCK_EXPR parent tag not recognized for OC blocks inside C method calls

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -6481,6 +6481,12 @@ static void handle_oc_block_type(chunk_t *pc)
          return(handle_oc_block_literal(pc));
       }
 
+      // Check apo is '(' or else this might be a block literal. Issue 2643.
+      if (!chunk_is_paren_open(apo))
+      {
+         return(handle_oc_block_literal(pc));
+      }
+
       if (chunk_is_paren_close(apc))
       {
          chunk_t   *aft = chunk_get_next_ncnl(apc);

--- a/tests/config/issue_2643.cfg
+++ b/tests/config/issue_2643.cfg
@@ -1,0 +1,4 @@
+sp_before_oc_block_caret        = remove
+sp_after_oc_block_caret         = force
+indent_oc_block                 = true
+indent_oc_block_msg_from_caret  = true

--- a/tests/expected/oc/50086-block_in_method.m
+++ b/tests/expected/oc/50086-block_in_method.m
@@ -8,7 +8,6 @@
 	return result;
 }
 
-
 - (NSArray *)collect:(BOOL ( ^ )(id))predicate {
 	id result = [NSMutableArray array];
 	for (id elem in self)
@@ -17,46 +16,44 @@
 	return result;
 }
 
-
 - (void)each:(void (^)(id object))block {
-	[self enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-	     block(obj);
-	 }];
+	[self enumerateObjectsUsingBlock:^ (id obj, NSUInteger idx, BOOL *stop) {
+	                                         block(obj);
+					 }];
 }
 
+// corner case: block literal in use with return type
+id longLines = [allLines collect:^ BOOL (id item) {
+        return [item length] > 20;
+}];
 
 // corner case: block literal in use with return type
-id longLines = [allLines collect: ^ BOOL (id item) {
-                    return [item length] > 20;
-				}];
-
-// corner case: block literal in use with return type
-id longLines = [allLines collect: ^ BOOL* (id item) {
-                    return [item length] > 20;
-				}];
+id longLines = [allLines collect:^ BOOL* (id item) {
+        return [item length] > 20;
+}];
 
 @end
 
-nestedMethodCall(methodCall( ^ BOOL * (id item) {
+nestedMethodCall(methodCall(^ BOOL * (id item) {
 	NSLog(@"methodCall")
 }));
 
 nestedMethodCall(
 	arg1,
-	methodCall(  ^ NSString * (id item) {
+	methodCall(^ NSString * (id item) {
 	NSLog(@"methodCall")
 }));
 
 nestedMethodCall(
 	arg1,
-	methodCall(  ^ {
+	methodCall(^ {
 	NSLog(@"methodCall")
 },
-	             arg2)
+	           arg2)
 	);
 
 nestedMethodCall(
-	methodCall(  ^ {
+	methodCall(^ {
 	NSLog(@"methodCall")
 })
 	);

--- a/tests/input/oc/block_in_method.m
+++ b/tests/input/oc/block_in_method.m
@@ -34,6 +34,30 @@ id longLines = [allLines collect: ^ BOOL* (id item) {
 
 @end
 
+nestedMethodCall(methodCall( ^ BOOL * (id item) {
+  NSLog(@"methodCall")
+}));
+
+nestedMethodCall(
+    arg1,
+    methodCall(  ^ NSString * (id item) {
+        NSLog(@"methodCall")
+    }));
+
+nestedMethodCall(
+    arg1,
+    methodCall(  ^ {
+        NSLog(@"methodCall")
+    },
+    arg2)
+);
+
+nestedMethodCall(
+    methodCall(  ^ {
+        NSLog(@"methodCall")
+    })
+);
+
 // 1. block literal: ^{ ... };
 // 2. block declaration: return_t (^name) (int arg1, int arg2, ...) NB: return_t is optional and name is also optional
 // 3. block inline call ^ return_t (int arg) { ... }; NB: return_t is optional

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -59,6 +59,7 @@
 50083  sp_before_oc_block_caret_remove.cfg  oc/more_blocks.m
 50084  nl_brace_square.cfg                  oc/more_blocks.m
 50085  nl_after_func_body-3.cfg             oc/block_in_method.m
+50086  issue_2643.cfg                       oc/block_in_method.m
 
 50090  oc12.cfg                             oc/kw.m
 


### PR DESCRIPTION
When OC block is used as a param inside C function calls, they are not recognized as OC_BLOCK_EXPR. This can cause the rules around OC block fail. This fixes the issue 2643.