### PR TITLE
Add option indent_off_after_assign to turn off indent similar to indent_off_after_return_new

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -1223,6 +1223,10 @@ indent_preserve_sql             = false    # true/false
 # Default: true
 indent_align_assign             = true     # true/false
 
+# If true, the indentation of the chunks after a '=' sequence will be set at
+# LHS token indentation column before '='.
+indent_off_after_assign         = false    # true/false
+
 # Whether to align continued statements at the '('. If false or the '(' is
 # followed by a newline, the next line indent is one tab.
 #

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -1223,6 +1223,10 @@ indent_preserve_sql             = false    # true/false
 # Default: true
 indent_align_assign             = true     # true/false
 
+# If true, the indentation of the chunks after a '=' sequence will be set at
+# LHS token indentation column before '='.
+indent_off_after_assign         = false    # true/false
+
 # Whether to align continued statements at the '('. If false or the '(' is
 # followed by a newline, the next line indent is one tab.
 #

--- a/documentation/htdocs/options_Indenting.html
+++ b/documentation/htdocs/options_Indenting.html
@@ -99,6 +99,7 @@ class Test
     <td><a href="#indent_square_nl">indent_square_nl</a></td>
     <td><a href="#indent_preserve_sql">indent_preserve_sql</a></td>
     <td><a href="#indent_align_assign">indent_align_assign</a></td>
+    <td><a href="#indent_off_after_assign">indent_off_after_assign</a></td>
 
     <td><a href="#indent_min_vbrace_open">indent_min_vbrace_open</a></td>
     <td><a href="#indent_vbrace_open_on_tabstop">indent_vbrace_open_on_tabstop</a></td>

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1223,6 +1223,10 @@ indent_preserve_sql             = false    # true/false
 # Default: true
 indent_align_assign             = true     # true/false
 
+# If true, the indentation of the chunks after a '=' sequence will be set at
+# LHS token indentation column before '='.
+indent_off_after_assign         = false    # true/false
+
 # Whether to align continued statements at the '('. If false or the '(' is
 # followed by a newline, the next line indent is one tab.
 #

--- a/etc/freebsd.cfg
+++ b/etc/freebsd.cfg
@@ -47,6 +47,7 @@ indent_bool_paren                        = false
 indent_square_nl                         = false
 indent_preserve_sql                      = false
 indent_align_assign                      = true
+indent_off_after_assign                  = false
 sp_arith                                 = ignore
 sp_assign                                = force
 sp_before_assign                         = ignore

--- a/etc/sun.cfg
+++ b/etc/sun.cfg
@@ -246,6 +246,10 @@ indent_preserve_sql                       = false    # false/true
 # If FALSE or the '=' is followed by a newline, the next line is indent one tab.
 indent_align_assign                       = false    # false/true
 
+# If true, the indentation of the chunks after a '=' sequence will be set at
+# LHS token indentation column before '='.
+indent_off_after_assign                   = false    # true/false
+
 # Indent OC blocks at brace level instead of usual rules.
 indent_oc_block                           = false    # false/true
 

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -2772,6 +2772,14 @@ EditorType=boolean
 TrueFalse=indent_align_assign=true|indent_align_assign=false
 ValueDefault=true
 
+[Indent Off After Assign]
+Category=2
+Description="<html>If true, the indentation of the chunks after a '=' sequence will be set at<br/>LHS token indentation column before '='.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=indent_off_after_assign=true|indent_off_after_assign=false
+ValueDefault=false
+
 [Indent Align Paren]
 Category=2
 Description="<html>Whether to align continued statements at the '('. If false or the '(' is<br/>followed by a newline, the next line indent is one tab.<br/><br/>Default: true</html>"

--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -42,6 +42,7 @@ indent_macro_brace                        = true
 indent_member                             = 3
 indent_sparen_extra                       = 0
 indent_with_tabs                          = 0
+indent_off_after_assign                   = false
 
 # Newline adding and removing options
 nl_after_access_spec                      = 1

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2695,7 +2695,15 @@ void indent_text(void)
                     || !options::indent_align_assign())
             {
                log_rule_B("indent_align_assign");
-               frm.top().indent = frm.prev().indent_tmp + indent_size;
+
+               if (options::indent_off_after_assign())
+               {
+                  frm.top().indent = frm.prev().indent_tmp;
+               }
+               else
+               {
+                  frm.top().indent = frm.prev().indent_tmp + indent_size;
+               }
                log_indent();
 
                if (chunk_is_token(pc, CT_ASSIGN) && chunk_is_newline(next))

--- a/src/options.h
+++ b/src/options.h
@@ -1509,6 +1509,11 @@ indent_preserve_sql;
 extern Option<bool>
 indent_align_assign; // = true
 
+// If true, the indentation of the chunks after a '=' sequence will be set at
+// LHS token indentation column before '='.
+extern Option<bool>
+indent_off_after_assign; // = false
+
 // Whether to align continued statements at the '('. If false or the '(' is
 // followed by a newline, the next line indent is one tab.
 extern Option<bool>

--- a/tests/c.test
+++ b/tests/c.test
@@ -202,6 +202,7 @@
 
 00620  ben_083.cfg                          c/indent-assign.c
 00621  nl_endif.cfg                         c/nl_endif.c
+00622  indent_assign.cfg                    c/indent-off-after-assign.c
 
 00631  nl_assign1.cfg                       c/nl_assign.c
 00632  nl_assign2.cfg                       c/nl_assign.c

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -310,6 +310,7 @@ indent_first_for_expr           = false
 indent_square_nl                = false
 indent_preserve_sql             = false
 indent_align_assign             = true
+indent_off_after_assign         = false
 indent_align_paren              = true
 indent_oc_block                 = false
 indent_oc_block_msg             = 0

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1227,6 +1227,10 @@ indent_preserve_sql             = false    # true/false
 # Default: true
 indent_align_assign             = true     # true/false
 
+# If true, the indentation of the chunks after a '=' sequence will be set at
+# LHS token indentation column before '='.
+indent_off_after_assign         = false    # true/false
+
 # Whether to align continued statements at the '('. If false or the '(' is
 # followed by a newline, the next line indent is one tab.
 #

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -310,6 +310,7 @@ indent_first_for_expr           = false
 indent_square_nl                = false
 indent_preserve_sql             = false
 indent_align_assign             = true
+indent_off_after_assign         = false
 indent_align_paren              = true
 indent_oc_block                 = false
 indent_oc_block_msg             = 0

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1227,6 +1227,10 @@ indent_preserve_sql             = false    # true/false
 # Default: true
 indent_align_assign             = true     # true/false
 
+# If true, the indentation of the chunks after a '=' sequence will be set at
+# LHS token indentation column before '='.
+indent_off_after_assign         = false    # true/false
+
 # Whether to align continued statements at the '('. If false or the '(' is
 # followed by a newline, the next line indent is one tab.
 #

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1227,6 +1227,10 @@ indent_preserve_sql             = false    # true/false
 # Default: true
 indent_align_assign             = true     # true/false
 
+# If true, the indentation of the chunks after a '=' sequence will be set at
+# LHS token indentation column before '='.
+indent_off_after_assign         = false    # true/false
+
 # Whether to align continued statements at the '('. If false or the '(' is
 # followed by a newline, the next line indent is one tab.
 #

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2782,6 +2782,14 @@ EditorType=boolean
 TrueFalse=indent_align_assign=true|indent_align_assign=false
 ValueDefault=true
 
+[Indent Off After Assign]
+Category=2
+Description="<html>If true, the indentation of the chunks after a '=' sequence will be set at<br/>LHS token indentation column before '='.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=indent_off_after_assign=true|indent_off_after_assign=false
+ValueDefault=false
+
 [Indent Align Paren]
 Category=2
 Description="<html>Whether to align continued statements at the '('. If false or the '(' is<br/>followed by a newline, the next line indent is one tab.<br/><br/>Default: true</html>"

--- a/tests/config/indent_assign.cfg
+++ b/tests/config/indent_assign.cfg
@@ -1,0 +1,2 @@
+indent_align_assign             = false
+indent_off_after_assign         = true

--- a/tests/expected/c/00622-indent-off-after-assign.c
+++ b/tests/expected/c/00622-indent-off-after-assign.c
@@ -1,0 +1,29 @@
+void foo(void)
+{
+	int a;
+	int b =
+	veryLongMethodCall(
+		arg1,
+		longMethodCall(
+			arg2,
+			methodCall(
+				arg3, arg4
+				)
+			)
+		);
+	junk(a =
+	     3);
+}
+
+void f()
+{
+	int x = size_t(1.0) +
+	2;
+	int y = (size_t(1.0) +
+	         5);
+
+	int z =
+	size_t(1.0)
+	+ 5
+	+ size_t(2.0);
+}

--- a/tests/input/c/indent-off-after-assign.c
+++ b/tests/input/c/indent-off-after-assign.c
@@ -1,0 +1,29 @@
+void foo(void)
+{
+   int a;
+   int b =
+   veryLongMethodCall(
+     arg1,
+     longMethodCall(
+       arg2,
+       methodCall(
+         arg3, arg4
+       )
+     )
+   );
+   junk(a =
+   3);
+}
+
+void f()
+{
+  int x = size_t(1.0) +
+    2;
+  int y = (size_t(1.0) +
+    5);
+
+  int z =
+  size_t(1.0)
+  + 5
+  + size_t(2.0);
+}


### PR DESCRIPTION
The added option will help turn off indentation after assign expression. This is how Xcode does formatting by default. Hence this option would provide a great value in staying close to regular formatting rules which most people use.