### PR TITLE
Add option indent_off_after_return to turn off indent similar to indent_off_after_return_new

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -1300,6 +1300,9 @@ indent_using_block              = true     # true/false
 # 2: When the `:` is a continuation, indent it under `?`
 indent_ternary_operator         = 0        # unsigned number
 
+# If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.
+indent_off_after_return         = false    # true/false
+
 # If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.
 indent_off_after_return_new     = false    # true/false
 

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -1300,6 +1300,9 @@ indent_using_block              = true     # true/false
 # 2: When the `:` is a continuation, indent it under `?`
 indent_ternary_operator         = 0        # unsigned number
 
+# If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.
+indent_off_after_return         = false    # true/false
+
 # If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.
 indent_off_after_return_new     = false    # true/false
 

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1307,6 +1307,9 @@ indent_using_block              = true     # true/false
 # 2: When the `:` is a continuation, indent it under `?`
 indent_ternary_operator         = 0        # unsigned number
 
+# If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.
+indent_off_after_return         = false    # true/false
+
 # If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.
 indent_off_after_return_new     = false    # true/false
 

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -2908,6 +2908,14 @@ MinVal=0
 MaxVal=2
 ValueDefault=0
 
+[Indent Off After Return]
+Category=2
+Description="<html>If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=indent_off_after_return=true|indent_off_after_return=false
+ValueDefault=false
+
 [Indent Off After Return New]
 Category=2
 Description="<html>If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.</html>"

--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -445,3 +445,6 @@ nl_func_def_args                          = ignore
 # nl_unittest_brace
 # nl_using_brace
 # nl_version_brace
+
+# NOT yet used indent_xx options
+# indent_off_after_return

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2721,13 +2721,19 @@ void indent_text(void)
          {
             chunk_t *next = chunk_get_next(pc);
 
+            // Avoid indentation on return token set by the option.
+            log_rule_B("indent_off_after_return");
+
             // Avoid indentation on return token if the next token is a new token
             // to properly indent object initializers returned by functions.
             log_rule_B("indent_off_after_return_new");
+            bool indent_after_return = (  next != nullptr
+                                       && next->type == CT_NEW)
+                                       ? !options::indent_off_after_return_new()
+                                       : !options::indent_off_after_return();
 
-            if (  !options::indent_off_after_return_new()
-               || next == nullptr
-               || next->type != CT_NEW)
+            if (  indent_after_return
+               || next == nullptr)
             {
                frm.push(pc, __func__, __LINE__);
 

--- a/src/options.h
+++ b/src/options.h
@@ -1602,6 +1602,10 @@ indent_using_block; // = true
 extern BoundedOption<unsigned, 0, 2>
 indent_ternary_operator;
 
+// If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.
+extern Option<bool>
+indent_off_after_return;
+
 // If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.
 extern Option<bool>
 indent_off_after_return_new;

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -327,6 +327,7 @@ indent_cpp_lambda_body          = false
 indent_compound_literal_return  = true
 indent_using_block              = true
 indent_ternary_operator         = 0
+indent_off_after_return         = false
 indent_off_after_return_new     = false
 indent_single_after_return      = false
 indent_ignore_asm_block         = false

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1313,6 +1313,9 @@ indent_using_block              = true     # true/false
 # 2: When the `:` is a continuation, indent it under `?`
 indent_ternary_operator         = 0        # unsigned number
 
+# If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.
+indent_off_after_return         = false    # true/false
+
 # If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.
 indent_off_after_return_new     = false    # true/false
 

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -327,6 +327,7 @@ indent_cpp_lambda_body          = false
 indent_compound_literal_return  = true
 indent_using_block              = true
 indent_ternary_operator         = 0
+indent_off_after_return         = false
 indent_off_after_return_new     = false
 indent_single_after_return      = false
 indent_ignore_asm_block         = false

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1313,6 +1313,9 @@ indent_using_block              = true     # true/false
 # 2: When the `:` is a continuation, indent it under `?`
 indent_ternary_operator         = 0        # unsigned number
 
+# If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.
+indent_off_after_return         = false    # true/false
+
 # If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.
 indent_off_after_return_new     = false    # true/false
 

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1313,6 +1313,9 @@ indent_using_block              = true     # true/false
 # 2: When the `:` is a continuation, indent it under `?`
 indent_ternary_operator         = 0        # unsigned number
 
+# If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.
+indent_off_after_return         = false    # true/false
+
 # If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.
 indent_off_after_return_new     = false    # true/false
 

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2926,6 +2926,14 @@ MinVal=0
 MaxVal=2
 ValueDefault=0
 
+[Indent Off After Return]
+Category=2
+Description="<html>If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=indent_off_after_return=true|indent_off_after_return=false
+ValueDefault=false
+
 [Indent Off After Return New]
 Category=2
 Description="<html>If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.</html>"

--- a/tests/config/indent_off_after_return.cfg
+++ b/tests/config/indent_off_after_return.cfg
@@ -1,0 +1,2 @@
+indent_off_after_return = true
+indent_off_after_return_new = false

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -229,6 +229,8 @@
 30324  mod_paren_on_return-a.cfg            cpp/returns.cpp
 30325  mod_paren_on_return-r.cfg            cpp/returns.cpp
 
+30326  indent_off_after_return.cfg          cpp/indent_off_after_return.cpp
+
 30400  attribute_specifier_seqs.cfg         cpp/attribute_specifier_seqs.cpp
 30401  Issue_2570.cfg                       cpp/Issue_2570.cpp
 

--- a/tests/expected/cpp/30326-indent_off_after_return.cpp
+++ b/tests/expected/cpp/30326-indent_off_after_return.cpp
@@ -1,0 +1,38 @@
+int foo1()
+{
+	return std::pair<int, int>{
+		1, 2
+	}.first;
+}
+
+int foo2()
+{
+	return
+	int{3} & 2;
+}
+
+int foo3()
+{
+	constexpr static int x = 3;
+	return
+	decltype(x) {x} & 2;
+}
+
+int foo4()
+{
+	return
+	new Type();
+}
+
+int foo5()
+{
+	return
+	veryLongMethodCall(
+		arg1,
+		longMethodCall(
+			methodCall(
+				arg2, arg3
+				), arg4
+			)
+		);
+}

--- a/tests/input/cpp/indent_off_after_return.cpp
+++ b/tests/input/cpp/indent_off_after_return.cpp
@@ -1,0 +1,38 @@
+int foo1()
+{
+	return std::pair<int, int>{
+		1, 2
+		}.first;
+}
+
+int foo2()
+{
+	return
+	 int{3} & 2;
+}
+
+int foo3()
+{
+	constexpr static int x = 3;
+	return
+	 decltype(x){x} & 2;
+}
+
+int foo4()
+{
+	return
+	new Type();
+}
+
+int foo5()
+{
+	return
+	veryLongMethodCall(
+		arg1,
+		longMethodCall(
+			methodCall(
+				arg2, arg3
+			), arg4
+		)
+	);
+}


### PR DESCRIPTION
The added option will help turn off indentation after 'return' expression. This is how Xcode does formatting by default. Hence this option would provide a great value in staying close to regular formatting rules which most people use.