### PR TITLE
Lambda

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2695,7 +2695,17 @@ void indent_text(void)
                     || !options::indent_align_assign())
             {
                log_rule_B("indent_align_assign");
-               frm.top().indent = frm.prev().indent_tmp + indent_size;
+               chunk_t *L_next = chunk_get_next(pc); // Issue #2591
+
+               if (  chunk_is_token(L_next, CT_SQUARE_OPEN)
+                  && L_next->parent_type == CT_CPP_LAMBDA)
+               {
+                  frm.top().indent = frm.prev().indent_tmp;
+               }
+               else
+               {
+                  frm.top().indent = frm.prev().indent_tmp + indent_size;
+               }
                log_indent();
 
                if (chunk_is_token(pc, CT_ASSIGN) && chunk_is_newline(next))

--- a/tests/config/Issue_2591.cfg
+++ b/tests/config/Issue_2591.cfg
@@ -1,0 +1,2 @@
+indent_columns      = 2
+indent_align_assign = false

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -272,6 +272,7 @@
 30761  out-668-F.cfg                        cpp/out-668.cpp
 30762  out-668-T.cfg                        cpp/out-668.cpp
 30763  Issue_2166.cfg                       cpp/Issue_2166.cpp
+30764  Issue_2591.cfg                       cpp/Issue_2591.cpp
 
 30770 sp_cpp_lambda_square_paren-r.cfg      cpp/lambda.cpp
 30771 sp_cpp_lambda_square_paren-f.cfg      cpp/lambda.cpp

--- a/tests/expected/cpp/30764-Issue_2591.cpp
+++ b/tests/expected/cpp/30764-Issue_2591.cpp
@@ -1,0 +1,3 @@
+const auto lambda = [this](int arg) {
+  doSomething();
+};

--- a/tests/input/cpp/Issue_2591.cpp
+++ b/tests/input/cpp/Issue_2591.cpp
@@ -1,0 +1,3 @@
+const auto lambda = [this](int arg) {
+  doSomething();
+};


### PR DESCRIPTION
When an assignment continuation contains a lambda, it should be possible to remove the extra level of indentation.

Ref. #2591