### PR TITLE
Fix FUNC_PROTO not tokenized when function params has OC blocks

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -4167,7 +4167,8 @@ static bool can_be_full_param(chunk_t *start, chunk_t *end)
       else if (  (word_count == 1 || (word_count == type_count))
               && chunk_is_token(pc, CT_PAREN_OPEN))
       {
-         // Check for func proto param 'void (*name)' or 'void (*name)(params)'
+         // Check for func proto param 'void (*name)' or 'void (*name)(params)' or 'void (^name)(params)'
+         // <name> can be optional
          chunk_t *tmp1 = chunk_get_next_ncnl(pc, scope_e::PREPROC);
 
          if (tmp1 == nullptr)
@@ -4180,7 +4181,7 @@ static bool can_be_full_param(chunk_t *start, chunk_t *end)
          {
             return(false);
          }
-         chunk_t *tmp3 = chunk_get_next_ncnl(tmp2, scope_e::PREPROC);
+         chunk_t *tmp3 = (chunk_is_str(tmp2, ")", 1)) ? tmp2 : chunk_get_next_ncnl(tmp2, scope_e::PREPROC);
 
          if (tmp3 == nullptr)
          {
@@ -4188,8 +4189,8 @@ static bool can_be_full_param(chunk_t *start, chunk_t *end)
          }
 
          if (  !chunk_is_str(tmp3, ")", 1)
-            || !chunk_is_str(tmp1, "*", 1)
-            || tmp2->type != CT_WORD)
+            || !(chunk_is_str(tmp1, "*", 1) || chunk_is_str(tmp1, "^", 1)) // Issue #2656
+            || !(tmp2->type == CT_WORD || chunk_is_str(tmp2, ")", 1)))
          {
             LOG_FMT(LFPARAM, " <== [%s] not fcn type!\n", get_token_name(pc->type));
             return(false);

--- a/tests/config/issue_2656.cfg
+++ b/tests/config/issue_2656.cfg
@@ -1,0 +1,2 @@
+sp_after_ptr_star = remove
+sp_before_ptr_star = force

--- a/tests/expected/oc/50086-block_in_method.m
+++ b/tests/expected/oc/50086-block_in_method.m
@@ -1,4 +1,7 @@
 
+void Events1(NSString *    identifier, void (^handler)());
+
+void Events2(NSString *    identifier, void (^)());
 
 @implementation NSArray (WWDC)
 - (NSArray *)map:(id (^)(id))xform {

--- a/tests/expected/oc/50091-block_in_method.m
+++ b/tests/expected/oc/50091-block_in_method.m
@@ -1,7 +1,7 @@
 
-void Events1(NSString *    identifier, void (^handler)());
+void Events1(NSString *identifier, void (^handler)());
 
-void Events2(NSString *    identifier, void (^)());
+void Events2(NSString *identifier, void (^)());
 
 @implementation NSArray (WWDC)
 - (NSArray *)map:(id (^)(id))xform {
@@ -11,7 +11,6 @@ void Events2(NSString *    identifier, void (^)());
 	return result;
 }
 
-
 - (NSArray *)collect:(BOOL ( ^ )(id))predicate {
 	id result = [NSMutableArray array];
 	for (id elem in self)
@@ -20,23 +19,21 @@ void Events2(NSString *    identifier, void (^)());
 	return result;
 }
 
-
 - (void)each:(void (^)(id object))block {
 	[self enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-	     block(obj);
+	         block(obj);
 	 }];
 }
 
-
 // corner case: block literal in use with return type
 id longLines = [allLines collect: ^ BOOL (id item) {
-                    return [item length] > 20;
-				}];
+                        return [item length] > 20;
+		}];
 
 // corner case: block literal in use with return type
-id longLines = [allLines collect: ^ BOOL* (id item) {
-                    return [item length] > 20;
-				}];
+id longLines = [allLines collect: ^ BOOL * (id item) {
+                        return [item length] > 20;
+		}];
 
 @end
 

--- a/tests/input/oc/block_in_method.m
+++ b/tests/input/oc/block_in_method.m
@@ -1,4 +1,7 @@
 
+void Events1(NSString *    identifier, void (^handler)());
+
+void Events2(NSString *    identifier, void (^)());
 
 @implementation NSArray (WWDC)
 - (NSArray *)map:(id (^)(id))xform {

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -62,6 +62,7 @@
 50086  issue_2643.cfg                       oc/block_in_method.m
 
 50090  oc12.cfg                             oc/kw.m
+50091  issue_2656.cfg                       oc/block_in_method.m
 
 50095  oc13.cfg                             oc/box.m
 50100  bug_340.cfg                          oc/bug_340.m


### PR DESCRIPTION
Issue 2656. `FUNC_PROTO` are incorrectly tokenized as `FUNC_CTOR_VAR ` when function params has OC blocks.