### PR TITLE
Add option indent_oc_inside_msg_sel to indent code inside OC message selectors

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -1233,6 +1233,9 @@ indent_off_after_assign         = false    # true/false
 # Default: true
 indent_align_paren              = true     # true/false
 
+# (OC) Whether to indent Objective-C code inside message selectors.
+indent_oc_inside_msg_sel        = false    # true/false
+
 # (OC) Whether to indent Objective-C blocks at brace level instead of usual
 # rules.
 indent_oc_block                 = false    # true/false

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -1233,6 +1233,9 @@ indent_off_after_assign         = false    # true/false
 # Default: true
 indent_align_paren              = true     # true/false
 
+# (OC) Whether to indent Objective-C code inside message selectors.
+indent_oc_inside_msg_sel        = false    # true/false
+
 # (OC) Whether to indent Objective-C blocks at brace level instead of usual
 # rules.
 indent_oc_block                 = false    # true/false

--- a/documentation/htdocs/options_Indenting.html
+++ b/documentation/htdocs/options_Indenting.html
@@ -123,6 +123,7 @@ indent_oc_block_msg_from_keyword<br>
 indent_oc_block_msg_from_colon<br>
 indent_oc_block_msg_from_caret<br>
 indent_oc_block_msg_from_brace<br>
+indent_oc_inside_msg_sel<br>
 
 </body>
 </html>

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1233,6 +1233,9 @@ indent_off_after_assign         = false    # true/false
 # Default: true
 indent_align_paren              = true     # true/false
 
+# (OC) Whether to indent Objective-C code inside message selectors.
+indent_oc_inside_msg_sel        = false    # true/false
+
 # (OC) Whether to indent Objective-C blocks at brace level instead of usual
 # rules.
 indent_oc_block                 = false    # true/false

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -2788,6 +2788,14 @@ EditorType=boolean
 TrueFalse=indent_align_paren=true|indent_align_paren=false
 ValueDefault=true
 
+[Indent Oc Inside Msg Sel]
+Category=2
+Description="<html>(OC) Whether to indent Objective-C code inside message selectors.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=indent_oc_inside_msg_sel=true|indent_oc_inside_msg_sel=false
+ValueDefault=false
+
 [Indent Oc Block]
 Category=2
 Description="<html>(OC) Whether to indent Objective-C blocks at brace level instead of usual<br/>rules.</html>"

--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -42,6 +42,7 @@ indent_macro_brace                        = true
 indent_member                             = 3
 indent_sparen_extra                       = 0
 indent_with_tabs                          = 0
+indent_oc_inside_msg_sel                  = false
 indent_off_after_assign                   = false
 
 # Newline adding and removing options

--- a/src/options.h
+++ b/src/options.h
@@ -1519,6 +1519,10 @@ indent_off_after_assign; // = false
 extern Option<bool>
 indent_align_paren; // = true
 
+// (OC) Whether to indent Objective-C code inside message selectors.
+extern Option<bool>
+indent_oc_inside_msg_sel; // = false
+
 // (OC) Whether to indent Objective-C blocks at brace level instead of usual
 // rules.
 extern Option<bool>

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -312,6 +312,7 @@ indent_preserve_sql             = false
 indent_align_assign             = true
 indent_off_after_assign         = false
 indent_align_paren              = true
+indent_oc_inside_msg_sel        = false
 indent_oc_block                 = false
 indent_oc_block_msg             = 0
 indent_oc_msg_colon             = 0

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1237,6 +1237,9 @@ indent_off_after_assign         = false    # true/false
 # Default: true
 indent_align_paren              = true     # true/false
 
+# (OC) Whether to indent Objective-C code inside message selectors.
+indent_oc_inside_msg_sel        = false    # true/false
+
 # (OC) Whether to indent Objective-C blocks at brace level instead of usual
 # rules.
 indent_oc_block                 = false    # true/false

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -312,6 +312,7 @@ indent_preserve_sql             = false
 indent_align_assign             = true
 indent_off_after_assign         = false
 indent_align_paren              = true
+indent_oc_inside_msg_sel        = false
 indent_oc_block                 = false
 indent_oc_block_msg             = 0
 indent_oc_msg_colon             = 0

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1237,6 +1237,9 @@ indent_off_after_assign         = false    # true/false
 # Default: true
 indent_align_paren              = true     # true/false
 
+# (OC) Whether to indent Objective-C code inside message selectors.
+indent_oc_inside_msg_sel        = false    # true/false
+
 # (OC) Whether to indent Objective-C blocks at brace level instead of usual
 # rules.
 indent_oc_block                 = false    # true/false

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1237,6 +1237,9 @@ indent_off_after_assign         = false    # true/false
 # Default: true
 indent_align_paren              = true     # true/false
 
+# (OC) Whether to indent Objective-C code inside message selectors.
+indent_oc_inside_msg_sel        = false    # true/false
+
 # (OC) Whether to indent Objective-C blocks at brace level instead of usual
 # rules.
 indent_oc_block                 = false    # true/false

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2798,6 +2798,14 @@ EditorType=boolean
 TrueFalse=indent_align_paren=true|indent_align_paren=false
 ValueDefault=true
 
+[Indent Oc Inside Msg Sel]
+Category=2
+Description="<html>(OC) Whether to indent Objective-C code inside message selectors.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=indent_oc_inside_msg_sel=true|indent_oc_inside_msg_sel=false
+ValueDefault=false
+
 [Indent Oc Block]
 Category=2
 Description="<html>(OC) Whether to indent Objective-C blocks at brace level instead of usual<br/>rules.</html>"

--- a/tests/config/indent_oc_inside_msg_sel.cfg
+++ b/tests/config/indent_oc_inside_msg_sel.cfg
@@ -1,0 +1,5 @@
+indent_oc_inside_msg_sel        = true
+indent_with_tabs                = 0
+indent_align_paren              = false
+align_oc_msg_colon_span         = 1
+

--- a/tests/config/nl_after_func_body-3.cfg
+++ b/tests/config/nl_after_func_body-3.cfg
@@ -1,3 +1,4 @@
 output_tab_size                 = 4
 indent_columns                  = 4
 nl_after_func_body              = 3
+indent_oc_inside_msg_sel        = true

--- a/tests/expected/oc/50087-indent_oc_inside_msg_sel.m
+++ b/tests/expected/oc/50087-indent_oc_inside_msg_sel.m
@@ -1,0 +1,71 @@
+[NSPasteboardItem pasteboardItemWithProvider:self
+                                    forTypes:@[ NSPasteboardTypePDF ]
+                                     andData:@[
+         kNSUTIExportedAgaroseGel,
+         [NSKeyedArchiver archivedDataWithRootObject:self.selectedIndexes.count != 0 ?[self.gels objectsAtIndexes:self.selectedIndexes] : self.gels]
+ ]];
+
+[ViewController simple_First:firstArg
+                  simple_Two:secondArg
+                    simple_3:thirdArg];
+
+
+[ViewController preFirst:(
+                        pre_1_arg
+                        )];
+
+[ViewController firstSelectorOne:arg1 preFirst:(
+                                              pre_1_arg
+                                              )];
+
+[ViewController preFirst:^{
+         return arg4;
+ }
+        firstSelectorOne:arg1];
+
+[ViewController firstSelectorOne:arg1 preFirst:^{
+         return arg4;
+ }];
+
+[ViewController firstSelectorOne:(flag
+                  ? arg5_1
+                  : arg5_2
+                        ) toolbox:_toolbox];
+
+[ViewController preFirst:(
+                        pre_1_arg
+                        )
+        firstSelectorOne:
+ arg1
+            selector_two:(
+                    arg2
+                    )
+              Selector_3:{
+                      .arg3 = 1
+              }
+         fourth_Selector:^{
+         return arg4;
+ }
+       selector_number_5:(flag
+         ? arg5_1
+         : arg5_2
+               )
+       selector_number_5:(flag
+         ? arg5_1
+         : arg5_2
+               )
+                  sixSel:(flag
+                    ?: arg6_1)
+        seventh_selector:(
+                arg7
+                )
+              toolboxSel:toolboxArg];
+
+[[ViewController alloc] strategy:(strategy
+                          ? [QuestionMarkStmt new]
+                          : [ColonStmt new])
+                         toolbox:_one];
+
+[[ViewController alloc] strategy:(strategy
+                          ?: [SourceStrategy new])
+                         toolbox:_two];

--- a/tests/input/oc/indent_oc_inside_msg_sel.m
+++ b/tests/input/oc/indent_oc_inside_msg_sel.m
@@ -1,0 +1,71 @@
+[NSPasteboardItem pasteboardItemWithProvider:self
+		                      forTypes:@[ NSPasteboardTypePDF ]
+		                       andData:@[
+					   kNSUTIExportedAgaroseGel,
+					   [NSKeyedArchiver archivedDataWithRootObject:self.selectedIndexes.count != 0 ?[self.gels objectsAtIndexes:self.selectedIndexes] : self.gels]
+		    ]];
+
+[ViewController simple_First:firstArg
+simple_Two:secondArg
+simple_3:thirdArg];
+
+
+[ViewController preFirst:(
+                  pre_1_arg
+                )];
+
+[ViewController firstSelectorOne:arg1 preFirst:(
+                                        pre_1_arg
+                                      )];
+
+[ViewController preFirst:^{
+                  return arg4;
+                }
+        firstSelectorOne:arg1];
+
+[ViewController firstSelectorOne:arg1 preFirst:^{
+  return arg4;
+}];
+
+[ViewController firstSelectorOne:(flag
+                  ? arg5_1
+                  : arg5_2
+                ) toolbox:_toolbox];
+
+[ViewController preFirst:(
+                  pre_1_arg
+                )
+        firstSelectorOne:
+        arg1
+            selector_two:(
+              arg2
+            )
+              Selector_3:{
+                .arg3 = 1
+              }
+         fourth_Selector:^{
+           return arg4;
+         }
+       selector_number_5:(flag
+         ? arg5_1
+         : arg5_2
+       )
+       selector_number_5:(flag
+         ? arg5_1
+         : arg5_2
+       )
+                  sixSel:(flag
+                    ?: arg6_1)
+        seventh_selector:(
+          arg7
+        )
+              toolboxSel:toolboxArg];
+
+[[ViewController alloc] strategy:(strategy
+                          ? [QuestionMarkStmt new]
+                          : [ColonStmt new])
+                         toolbox:_one];
+
+[[ViewController alloc] strategy:(strategy
+                          ?: [SourceStrategy new])
+                         toolbox:_two];

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -60,6 +60,7 @@
 50084  nl_brace_square.cfg                  oc/more_blocks.m
 50085  nl_after_func_body-3.cfg             oc/block_in_method.m
 50086  issue_2643.cfg                       oc/block_in_method.m
+50087  indent_oc_inside_msg_sel.cfg         oc/indent_oc_inside_msg_sel.m
 
 50090  oc12.cfg                             oc/kw.m
 


### PR DESCRIPTION
The indentation inside OC messages is not correctly handled currently. We need to correctly indent the statements inside OC message or else option `align_oc_msg_colon_span` will make the indentation of code inside OC message selectors look off. This is because there is no parse frame maintained for OC messages. Added optional configuration option to enable indentation inside OC message selectors. Issue 2658.