### PR TITLE
Add option indent_inside_ternary_operator to fix several issues with ternary operator

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -1307,6 +1307,9 @@ indent_using_block              = true     # true/false
 # 2: When the `:` is a continuation, indent it under `?`
 indent_ternary_operator         = 0        # unsigned number
 
+# Whether to indent the statments inside ternary operator.
+indent_inside_ternary_operator  = false    # true/false
+
 # If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.
 indent_off_after_return         = false    # true/false
 

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -1307,6 +1307,9 @@ indent_using_block              = true     # true/false
 # 2: When the `:` is a continuation, indent it under `?`
 indent_ternary_operator         = 0        # unsigned number
 
+# Whether to indent the statments inside ternary operator.
+indent_inside_ternary_operator  = false    # true/false
+
 # If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.
 indent_off_after_return         = false    # true/false
 

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1314,6 +1314,9 @@ indent_using_block              = true     # true/false
 # 2: When the `:` is a continuation, indent it under `?`
 indent_ternary_operator         = 0        # unsigned number
 
+# Whether to indent the statments inside ternary operator.
+indent_inside_ternary_operator  = false    # true/false
+
 # If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.
 indent_off_after_return         = false    # true/false
 

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -2924,6 +2924,14 @@ MinVal=0
 MaxVal=2
 ValueDefault=0
 
+[Indent Inside Ternary Operator]
+Category=2
+Description="<html>Whether to indent the statments inside ternary operator.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=indent_inside_ternary_operator=true|indent_inside_ternary_operator=false
+ValueDefault=false
+
 [Indent Off After Return]
 Category=2
 Description="<html>If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.</html>"

--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -44,6 +44,7 @@ indent_sparen_extra                       = 0
 indent_with_tabs                          = 0
 indent_oc_inside_msg_sel                  = false
 indent_off_after_assign                   = false
+indent_inside_ternary_operator            = false
 
 # Newline adding and removing options
 nl_after_access_spec                      = 1

--- a/src/options.h
+++ b/src/options.h
@@ -1611,6 +1611,10 @@ indent_using_block; // = true
 extern BoundedOption<unsigned, 0, 2>
 indent_ternary_operator;
 
+// Whether to indent the statments inside ternary operator.
+extern Option<bool>
+indent_inside_ternary_operator; // false
+
 // If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.
 extern Option<bool>
 indent_off_after_return;

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -329,6 +329,7 @@ indent_cpp_lambda_body          = false
 indent_compound_literal_return  = true
 indent_using_block              = true
 indent_ternary_operator         = 0
+indent_inside_ternary_operator  = false
 indent_off_after_return         = false
 indent_off_after_return_new     = false
 indent_single_after_return      = false

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1320,6 +1320,9 @@ indent_using_block              = true     # true/false
 # 2: When the `:` is a continuation, indent it under `?`
 indent_ternary_operator         = 0        # unsigned number
 
+# Whether to indent the statments inside ternary operator.
+indent_inside_ternary_operator  = false    # true/false
+
 # If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.
 indent_off_after_return         = false    # true/false
 

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -329,6 +329,7 @@ indent_cpp_lambda_body          = false
 indent_compound_literal_return  = true
 indent_using_block              = true
 indent_ternary_operator         = 0
+indent_inside_ternary_operator  = false
 indent_off_after_return         = false
 indent_off_after_return_new     = false
 indent_single_after_return      = false

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1320,6 +1320,9 @@ indent_using_block              = true     # true/false
 # 2: When the `:` is a continuation, indent it under `?`
 indent_ternary_operator         = 0        # unsigned number
 
+# Whether to indent the statments inside ternary operator.
+indent_inside_ternary_operator  = false    # true/false
+
 # If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.
 indent_off_after_return         = false    # true/false
 

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1320,6 +1320,9 @@ indent_using_block              = true     # true/false
 # 2: When the `:` is a continuation, indent it under `?`
 indent_ternary_operator         = 0        # unsigned number
 
+# Whether to indent the statments inside ternary operator.
+indent_inside_ternary_operator  = false    # true/false
+
 # If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.
 indent_off_after_return         = false    # true/false
 

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2942,6 +2942,14 @@ MinVal=0
 MaxVal=2
 ValueDefault=0
 
+[Indent Inside Ternary Operator]
+Category=2
+Description="<html>Whether to indent the statments inside ternary operator.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=indent_inside_ternary_operator=true|indent_inside_ternary_operator=false
+ValueDefault=false
+
 [Indent Off After Return]
 Category=2
 Description="<html>If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.</html>"

--- a/tests/config/indent_inside_ternary_operator.cfg
+++ b/tests/config/indent_inside_ternary_operator.cfg
@@ -1,4 +1,5 @@
 indent_align_paren              = false
 pos_conditional                 = lead
+nl_func_call_args_multi_line_ignore_closures = true
 indent_ternary_operator         = 0
 indent_inside_ternary_operator  = true

--- a/tests/config/indent_inside_ternary_operator.cfg
+++ b/tests/config/indent_inside_ternary_operator.cfg
@@ -1,0 +1,4 @@
+indent_align_paren              = false
+pos_conditional                 = lead
+indent_ternary_operator         = 0
+indent_inside_ternary_operator  = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -203,6 +203,8 @@
 30275  empty.cfg                            cpp/bug_1321.cpp
 30278  bug_1439.cfg                         cpp/bug_1439.cpp
 
+30279  indent_inside_ternary_operator.cfg   cpp/indent-inside-ternary-operator.cpp
+
 30280  sp_dc.cfg                            cpp/sf557.cpp
 30281  Issue_2478.cfg                       cpp/Issue_2478.cpp
 

--- a/tests/expected/cpp/30279-indent-inside-ternary-operator.cpp
+++ b/tests/expected/cpp/30279-indent-inside-ternary-operator.cpp
@@ -1,0 +1,125 @@
+(tmp
+	? chunk_is_newline(tmp)
+		? "newline"
+		: chunk_is_comment(tmp)
+			? "comment"
+			: "other"
+	: chunk_is_newline(tmp)
+		? "newline"
+		: chunk_is_comment(tmp)
+			? "comment"
+			: "other");
+
+a
+? b
+	+ c
+: d
+	+ e;
+
+return
+        outerFlag
+	? RadioButton
+	: innerFlag
+		? Badge
+		: nil;
+
+x = outerFlag
+    ? RadioButton(
+		    arg1
+		    )
+    : Checkbutton
+	    .arg2;
+
+Builder
+.child(
+	outerFlag
+	? RadioButton(
+			buttonArg
+			)
+	: innerFlag
+		? Badge
+			.component(
+				LabelText)
+		: nil
+	);
+
+
+accessoryType
+? ConKSC1{}
+: flag == false
+	? ConKSC2{}
+		.build()
+	: flag == true
+		? ConKSC3{}
+			.build()
+		: ConKSC4{}
+			.build();
+
+options.meta == nil
+? metaCmpnt
+:  CBuilder()
+	.spacing(4)
+	.subCmpnt(
+		CBuilder()
+		.build());
+
+options.meta == nil
+? CBuilder()
+	.spacing(4)
+	.subCmpnt(
+		CBuilder()
+		.build()
+		)
+: Builder
+	.spacing;
+
+options == nil ? CBuilder()
+	.spacing(6)
+: Builder
+	.spacing;
+
+options == nil ? CBuilder()
+	.spacing(6) : Builder
+	.spacing;
+
+flag
+? isChild
+	? TypeBack
+	: TypeCancel
+: nil;
+
+
+func something() {
+	if (flag) {
+		x == flag
+		? Builder
+			.spacing
+		: Builder
+			.spacing;
+	}
+}
+
+
+flag1
+?   ( flag2
+		? ( flag3
+				?   result1
+				:  result2 )
+		:   ( result3  )
+		)
+:  (  flag5
+		? ( flag
+				? result4
+				: result5)
+		:   (  flag6
+				? result6
+				: ( result7   )
+				)
+		);
+
+
+flag1
+?   result1
+:  (
+		flag5
+		);

--- a/tests/expected/oc/50018-indent-inside-ternary-operator.m
+++ b/tests/expected/oc/50018-indent-inside-ternary-operator.m
@@ -76,3 +76,27 @@ flag1
 :  (
 		flag5
 		);
+
+
+
+showButton ? Action<>::actionFromBlock(^(Component *component) {
+	return nil;
+}) : nil;
+
+showButton
+? Action<>::actionFromBlock(^(Component *component) {
+	return nil;
+})
+: nil;
+
+showButton
+? Action<>::actionFromBlock(^(Component *component) {
+	return nil;
+}) : nil;
+
+
+showButton
+? Action<>::actionFromBlock([] (Component *component) {
+	return nil;
+})
+: nil;

--- a/tests/expected/oc/50018-indent-inside-ternary-operator.m
+++ b/tests/expected/oc/50018-indent-inside-ternary-operator.m
@@ -1,0 +1,78 @@
+flag
+? [Cmpnt Cmpnt:(isChildActionSheet ? TypeBack : TypeCancel)]
+: nil;
+
+
+[[BottomSheetItem alloc]
+ iconName:selected
+ ? g.re
+	 .at
+ : g
+	 .re
+	 .at
+ builder:nil
+ handler:^{
+ }
+]
+
+
+[[BottomSheetItem alloc]
+iconName: selected
+ ? iconName : g
+	 .re
+	 .at
+builder: nil
+handler: ^{
+	 }
+]
+
+        (event
+	?   [FSBottomSheetActionCellItemVariant
+	     action:AKAction<> :: actionFromSenderlessBlock(^{
+								    auto const strongSelf = weakSelf;
+							    })]
+	: nil);
+
+
+[[ViewController alloc] strategy: (strategy
+	? [QuestionMarkStmt new]
+	: [ColonStmt new])
+ toolbox: _one];
+
+[[ViewController alloc] strategy: (strategy
+	?: [SourceStrategy new])
+ toolbox: _two];
+
+
+
+flag1
+?   ( flag2
+		? ( flag3
+				?   [ViewController selector1:^{
+					     NSLog(@"selector1");
+				     }]
+				:  [ViewController selector2:^(){
+					    NSLog(@"selector2");
+				    }] )
+		:   ( result3  )
+		)
+:  (  flag5
+		? ( flag
+				? result4
+				: [ViewController preSelector:flag selector3:{
+					   .x = 10,
+				   }])
+		:   (  flag6
+				? [ViewController preSelector:flag selector3:^{
+					   NSLog(@"selector3");
+				   }]
+				: ( result7   )
+				)
+		);
+
+
+flag1
+?   result1
+:  (
+		flag5
+		);

--- a/tests/input/cpp/indent-inside-ternary-operator.cpp
+++ b/tests/input/cpp/indent-inside-ternary-operator.cpp
@@ -1,0 +1,125 @@
+(tmp
+            ? chunk_is_newline(tmp)
+? "newline"
+		: chunk_is_comment(tmp)
+                          ? "comment"
+						     : "other"
+						                    : chunk_is_newline(tmp)
+          ? "newline"
+                                                      : chunk_is_comment(tmp)
+                ? "comment"
+                                : "other");
+
+a
+? b
+    + c
+  : d
+    + e;
+
+    return
+    outerFlag
+                    ? RadioButton
+        : innerFlag
+  ? Badge
+                                    : nil;
+
+x = outerFlag
+                                ? RadioButton(
+              arg1
+        )
+    : Checkbutton
+  .arg2;
+
+    Builder
+    .child(
+      outerFlag
+      ? RadioButton(
+        buttonArg
+      )
+      : innerFlag
+        ? Badge
+          .component(
+        LabelText)
+        : nil
+    );
+
+
+accessoryType
+      ? ConKSC1{}
+    : flag == false
+        ? ConKSC2{}
+        .build()
+  : flag == true
+      ? ConKSC3{}
+      .build()
+  : ConKSC4{}
+  .build();
+
+options.meta == nil
+    ? metaCmpnt
+    :  CBuilder()
+.spacing(4)
+    .subCmpnt(
+  CBuilder()
+        .build());
+
+options.meta == nil
+    ? CBuilder()
+  .spacing(4)
+.subCmpnt(
+    CBuilder()
+.build()
+)
+: Builder
+      .spacing;
+
+      options == nil ? CBuilder()
+  .spacing(6)
+: Builder
+      .spacing;
+
+      options == nil ? CBuilder()
+  .spacing(6) : Builder
+      .spacing;
+
+flag
+       ? isChild
+    ? TypeBack
+: TypeCancel
+       : nil;
+
+
+func something() {
+  if (flag) {
+    x == flag
+    ? Builder
+          .spacing
+      : Builder
+      .spacing;
+  }
+}
+
+
+flag1
+?   ( flag2
+          ? ( flag3
+    ?   result1
+      :  result2 )
+    :   ( result3  )
+  )
+    :  (  flag5
+    ? ( flag
+            ? result4
+        : result5)
+    :   (  flag6
+      ? result6
+        : ( result7   )
+        )
+        );
+
+
+flag1
+?   result1
+            :  (
+              flag5
+    );

--- a/tests/input/oc/indent-inside-ternary-operator.m
+++ b/tests/input/oc/indent-inside-ternary-operator.m
@@ -1,0 +1,78 @@
+flag
+       ? [Cmpnt Cmpnt:(isChildActionSheet ? TypeBack : TypeCancel)]
+       : nil;
+
+
+[[BottomSheetItem alloc]
+ iconName:selected
+ ? g.re
+          .at
+          : g
+          .re
+          .at
+   builder:nil
+      handler:^{
+   }
+]
+
+
+[[BottomSheetItem alloc]
+ iconName:selected
+ ? iconName : g
+          .re
+          .at
+   builder:nil
+      handler:^{
+   }
+]
+
+(event
+  ?   [FSBottomSheetActionCellItemVariant
+        action:AKAction<> :: actionFromSenderlessBlock(^{
+  auto const strongSelf = weakSelf;
+})]
+  : nil);
+
+
+[[ViewController alloc] strategy: (strategy
+   ? [QuestionMarkStmt new]
+   : [ColonStmt new])
+toolbox: _one];
+
+[[ViewController alloc] strategy: (strategy
+   ?: [SourceStrategy new])
+toolbox: _two];
+
+
+
+flag1
+?   ( flag2
+          ? ( flag3
+             ?   [ViewController selector1:^{
+  NSLog(@"selector1");
+}]
+             :  [ViewController selector2:^(){
+  NSLog(@"selector2");
+}] )
+    :   ( result3  )
+  )
+    :  (  flag5
+    ? ( flag
+            ? result4
+        : [ViewController preSelector:flag selector3:{
+          .x = 10,
+        }])
+    :   (  flag6
+         ? [ViewController preSelector:flag selector3:^{
+        NSLog(@"selector3");
+      }]
+        : ( result7   )
+        )
+        );
+
+
+flag1
+?   result1
+            :  (
+              flag5
+    );

--- a/tests/input/oc/indent-inside-ternary-operator.m
+++ b/tests/input/oc/indent-inside-ternary-operator.m
@@ -76,3 +76,27 @@ flag1
             :  (
               flag5
     );
+
+
+
+showButton ? Action<>::actionFromBlock(^(Component *component) {
+          return nil;
+        }) : nil;
+
+showButton
+? Action<>::actionFromBlock(^(Component *component) {
+          return nil;
+        })
+         : nil;
+
+         showButton
+? Action<>::actionFromBlock(^(Component *component) {
+          return nil;
+        }) : nil;
+
+
+showButton
+    ? Action<>::actionFromBlock([](Component *component) {
+          return nil;
+        })
+    : nil;

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -24,6 +24,8 @@
 50016  oc11.cfg                             oc/ternary.m
 50017  ternary_short.cfg                    oc/ternary.m
 
+50018  indent_inside_ternary_operator.cfg   oc/indent-inside-ternary-operator.m
+
 50020  sp_after_oc_at_sel_add.cfg           oc/selector.m
 50021  sp_after_oc_at_sel_force.cfg         oc/selector.m
 50022  sp_after_oc_at_sel_remove.cfg        oc/selector.m


### PR DESCRIPTION
Indentation of statements inside ternary operators are not handled which caused many issues related to them. Added many edge cases as tests that fix the issues. Issues #1130, #1715, #2545 should be fixed after this.