### PR TITLE
Add option nl_func_call_multi_line_ignore_closures to configure newline for closure syntax in function calls

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -1748,6 +1748,9 @@ nl_func_call_args_multi_line    = false    # true/false
 # different lines.
 nl_func_call_end_multi_line     = false    # true/false
 
+# Whether to respect nl_func_call_XXX option incase of closure args.
+nl_func_call_args_multi_line_ignore_closures = false # true/false
+
 # Whether to add a newline after '<' of a template parameter list.
 nl_template_start               = false    # true/false
 

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -1748,6 +1748,9 @@ nl_func_call_args_multi_line    = false    # true/false
 # different lines.
 nl_func_call_end_multi_line     = false    # true/false
 
+# Whether to respect nl_func_call_XXX option incase of closure args.
+nl_func_call_args_multi_line_ignore_closures = false # true/false
+
 # Whether to add a newline after '<' of a template parameter list.
 nl_template_start               = false    # true/false
 

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -4014,6 +4014,14 @@ EditorType=boolean
 TrueFalse=nl_func_call_end_multi_line=true|nl_func_call_end_multi_line=false
 ValueDefault=false
 
+[Nl Func Call Multi Line Trailing Closure]
+Category=3
+Description="<html>Whether to respect nl_func_call_XXX option incase of closure args.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=nl_func_call_args_multi_line_ignore_closures=true|nl_func_call_args_multi_line_ignore_closures=false
+ValueDefault=false
+
 [Nl Template Start]
 Category=3
 Description="<html>Whether to add a newline after '&lt;' of a template parameter list.</html>"

--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -446,6 +446,7 @@ nl_func_def_args                          = ignore
 # nl_unittest_brace
 # nl_using_brace
 # nl_version_brace
+# nl_func_call_args_multi_line_ignore_closures
 
 # NOT yet used indent_xx options
 # indent_off_after_return

--- a/src/options.h
+++ b/src/options.h
@@ -2181,6 +2181,10 @@ nl_func_call_args_multi_line;
 extern Option<bool>
 nl_func_call_end_multi_line;
 
+// Whether to respect nl_func_call_XXX option incase of closure args.
+extern Option<bool>
+nl_func_call_args_multi_line_ignore_closures; // false
+
 // Whether to add a newline after '<' of a template parameter list.
 extern Option<bool>
 nl_template_start;

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -454,6 +454,7 @@ nl_func_call_start              = ignore
 nl_func_call_start_multi_line   = false
 nl_func_call_args_multi_line    = false
 nl_func_call_end_multi_line     = false
+nl_func_call_args_multi_line_ignore_closures = false
 nl_template_start               = false
 nl_template_args                = false
 nl_template_end                 = false

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1764,6 +1764,9 @@ nl_func_call_args_multi_line    = false    # true/false
 # different lines.
 nl_func_call_end_multi_line     = false    # true/false
 
+# Whether to respect nl_func_call_XXX option incase of closure args.
+nl_func_call_args_multi_line_ignore_closures = false # true/false
+
 # Whether to add a newline after '<' of a template parameter list.
 nl_template_start               = false    # true/false
 

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -454,6 +454,7 @@ nl_func_call_start              = ignore
 nl_func_call_start_multi_line   = false
 nl_func_call_args_multi_line    = false
 nl_func_call_end_multi_line     = false
+nl_func_call_args_multi_line_ignore_closures = false
 nl_template_start               = false
 nl_template_args                = false
 nl_template_end                 = false

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1764,6 +1764,9 @@ nl_func_call_args_multi_line    = false    # true/false
 # different lines.
 nl_func_call_end_multi_line     = false    # true/false
 
+# Whether to respect nl_func_call_XXX option incase of closure args.
+nl_func_call_args_multi_line_ignore_closures = false # true/false
+
 # Whether to add a newline after '<' of a template parameter list.
 nl_template_start               = false    # true/false
 

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1764,6 +1764,9 @@ nl_func_call_args_multi_line    = false    # true/false
 # different lines.
 nl_func_call_end_multi_line     = false    # true/false
 
+# Whether to respect nl_func_call_XXX option incase of closure args.
+nl_func_call_args_multi_line_ignore_closures = false # true/false
+
 # Whether to add a newline after '<' of a template parameter list.
 nl_template_start               = false    # true/false
 

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -4041,6 +4041,14 @@ EditorType=boolean
 TrueFalse=nl_func_call_end_multi_line=true|nl_func_call_end_multi_line=false
 ValueDefault=false
 
+[Nl Func Call Multi Line Trailing Closure]
+Category=3
+Description="<html>Whether to respect nl_func_call_XXX option incase of closure args.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=nl_func_call_args_multi_line_ignore_closures=true|nl_func_call_args_multi_line_ignore_closures=false
+ValueDefault=false
+
 [Nl Template Start]
 Category=3
 Description="<html>Whether to add a newline after '&lt;' of a template parameter list.</html>"

--- a/tests/config/nl_func_call_args_multi_line_ignore_closures.cfg
+++ b/tests/config/nl_func_call_args_multi_line_ignore_closures.cfg
@@ -1,0 +1,4 @@
+nl_func_call_start_multi_line = true
+nl_func_call_args_multi_line = true
+nl_func_call_end_multi_line = true
+nl_func_call_args_multi_line_ignore_closures = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -682,6 +682,8 @@
 34165  sp_before_type_brace_init_lst_close-f.cfg  cpp/type_brace_init_lst.cpp
 34166  sp_before_type_brace_init_lst_close-r.cfg  cpp/type_brace_init_lst.cpp
 
+34167 nl_func_call_args_multi_line_ignore_closures.cfg cpp/nl_func_call_args_multi_line_ignore_closures.cpp
+
 34170  empty.cfg                            cpp/i1082.cpp
 34171  empty.cfg                            cpp/i1181.cpp
 34172  space_indent_columns-4.cfg           cpp/i1165.cpp

--- a/tests/expected/cpp/34167-nl_func_call_args_multi_line_ignore_closures.cpp
+++ b/tests/expected/cpp/34167-nl_func_call_args_multi_line_ignore_closures.cpp
@@ -1,0 +1,75 @@
+methodCall([] {
+	Log();
+});
+
+funcCall(
+	match ( [ & ]( const ContentProps &props)  {
+	return PairingCmpnt()
+})
+	);
+
+match( [ & ]( const ContentProps &props)  {
+	return PairingCmpnt()
+});
+
+
+outerMethodCall(
+	methodCall(^{
+	// action
+}, x)
+	);
+
+outerMethodCall(
+	x,
+	methodCall(^{
+	// action
+}, y)
+	);
+
+options({
+	.cornerRadius = CGFLOAT_MAX,
+});
+
+mapToPtr([&](const LeftAddOn::Props &addOnProps) {
+	FSTheme *const theme = AK::getTheme();
+});
+
+mapToPtr(x, [&](const Props &addOnProps) {
+	FSTheme *const theme = AK::getTheme();
+});
+
+mapToPtr([&](const Props &addOnProps) {
+	FSTheme *const theme = AK::getTheme();
+});
+
+methodCall(
+	arg1,
+	arg2,
+	arg3
+	);
+
+methodCall(arg1, arg2, arg3);
+
+methodCall(
+	arg1, [] {
+	variant.action.send(Cmpnt);
+}, arg3
+	);
+
+methodCall(
+	arg1, {
+	.x = 10,
+},
+	arg3
+	);
+
+methodCall({
+	.x = 10,
+},
+           arg3);
+
+methodCall(
+	arg1, {
+	.x = 10,
+}
+	);

--- a/tests/expected/oc/50630-nl_func_call_args_multi_line_ignore_closures.m
+++ b/tests/expected/oc/50630-nl_func_call_args_multi_line_ignore_closures.m
@@ -1,0 +1,103 @@
+mapToPtr(^(const LeftAddOn::Props &addOnProps) {
+	FSTheme *const theme = AK::getTheme();
+});
+
+mapToPtr( x, ^ (const Props &addOnProps) {
+	FSTheme *const theme = AK::getTheme();
+});
+
+mapToPtr( ^ (const Props &addOnProps) {
+	FSTheme *const theme = AK::getTheme();
+});
+
+mapToPtr(
+	arg1, ^ ( NSString * ) (const Props &addOnProps) {
+	FSTheme *const theme = AK::getTheme();
+}, arg2
+	);
+
+mapToPtr(arg1, ^ ( NSString *) (const Props &addOnProps) {
+	FSTheme *const theme = AK::getTheme();
+});
+
+mapToPtr( ^()(const Props &addOnProps) {
+	FSTheme *const theme = AK::getTheme();
+}, arg2);
+
+
+
+methodCall(^{
+	variant.action.send(Cmpnt);
+});
+
+methodCall(
+	^{
+	variant.action.send(Cmpnt);
+}, x);
+
+
+methodCall(  x, ^id (Cmpnt *c) {
+	NSLog(@"Something");
+});
+
+methodCall(  ^id (Cmpnt *c) {
+	NSLog(@"Something");
+});
+
+methodCall(  ^(Cmpnt *c) {
+	NSLog(@"Something");
+});
+
+methodCall(
+	^ (Cmpnt *c) {
+	NSLog(@"Something");
+}, y);
+
+methodCall(
+	x,  ^(Cmpnt *c) {
+	NSLog(@"Something");
+}, y
+	);
+
+
+methodCall(
+	arg1,
+	arg2,
+	arg3
+	);
+
+methodCall(arg1, arg2, arg3);
+
+methodCall(
+	arg1,
+	arg2, {
+	.x = 10,
+}
+	);
+
+methodCall(
+	arg1, {
+	.x = 10,
+},
+	arg2
+	);
+
+methodCall({
+	.x = 10,
+},
+           arg2);
+
+
+outerMethodCall(
+	methodCall(^{
+	// action
+},
+	           x)
+	);
+
+outerMethodCall(
+	methodCall(^{
+	variant.action.send(Cmpnt);
+},
+	           x)
+	);

--- a/tests/input/cpp/nl_func_call_args_multi_line_ignore_closures.cpp
+++ b/tests/input/cpp/nl_func_call_args_multi_line_ignore_closures.cpp
@@ -1,0 +1,58 @@
+methodCall([] {
+                             Log();
+                           });
+
+funcCall(match ( [ & ]( const ContentProps &props)  {
+        return PairingCmpnt()
+      }));
+
+match( [ & ]( const ContentProps &props)  {
+        return PairingCmpnt()
+      });
+
+
+outerMethodCall(methodCall(^{
+  // action
+}, x)
+);
+
+outerMethodCall(x, methodCall(^{
+  // action
+}, y));
+
+options({
+          .cornerRadius = CGFLOAT_MAX,
+        });
+
+mapToPtr([&](const LeftAddOn::Props &addOnProps) {
+      FSTheme *const theme = AK::getTheme();
+});
+
+mapToPtr(x, [&](const Props &addOnProps) {
+      FSTheme *const theme = AK::getTheme();
+});
+
+mapToPtr([&](const Props &addOnProps) {
+      FSTheme *const theme = AK::getTheme();
+});
+
+methodCall(arg1, arg2,
+arg3);
+
+methodCall(arg1, arg2, arg3);
+
+methodCall(arg1, []{
+              variant.action.send(Cmpnt);
+      }, arg3);
+
+methodCall(arg1, {
+              .x = 10,
+      }, arg3);
+
+methodCall({
+              .x = 10,
+      }, arg3);
+
+methodCall(arg1, {
+              .x = 10,
+      });

--- a/tests/input/oc/nl_func_call_args_multi_line_ignore_closures.m
+++ b/tests/input/oc/nl_func_call_args_multi_line_ignore_closures.m
@@ -1,0 +1,85 @@
+mapToPtr(^(const LeftAddOn::Props &addOnProps) {
+      FSTheme *const theme = AK::getTheme();
+});
+
+mapToPtr( x, ^ (const Props &addOnProps) {
+      FSTheme *const theme = AK::getTheme();
+});
+
+mapToPtr( ^ (const Props &addOnProps) {
+      FSTheme *const theme = AK::getTheme();
+});
+
+mapToPtr( arg1, ^ ( NSString * ) (const Props &addOnProps) {
+      FSTheme *const theme = AK::getTheme();
+}, arg2);
+
+mapToPtr(arg1, ^ ( NSString *) (const Props &addOnProps) {
+      FSTheme *const theme = AK::getTheme();
+});
+
+mapToPtr( ^() (const Props &addOnProps) {
+      FSTheme *const theme = AK::getTheme();
+}, arg2);
+
+
+
+methodCall(^{
+              variant.action.send(Cmpnt);
+      });
+
+      methodCall(
+        ^{
+              variant.action.send(Cmpnt);
+      }, x);
+
+
+methodCall(  x, ^id (Cmpnt *c) {
+                                NSLog(@"Something");
+                              });
+
+methodCall(  ^id (Cmpnt *c) {
+                                NSLog(@"Something");
+                              });
+
+methodCall(  ^(Cmpnt *c) {
+                             NSLog(@"Something");
+                           });
+
+methodCall(
+  ^ (Cmpnt *c) {
+                             NSLog(@"Something");
+                           }, y);
+
+  methodCall(x,  ^(Cmpnt *c) {
+                             NSLog(@"Something");
+                           }, y);
+
+
+methodCall(arg1,
+arg2, arg3);
+
+methodCall(arg1, arg2, arg3);
+
+methodCall(arg1, arg2, {
+  .x = 10,
+});
+
+methodCall(arg1, {
+  .x = 10,
+}, arg2);
+
+methodCall({
+  .x = 10,
+}, arg2);
+
+
+outerMethodCall(methodCall(^{
+  // action
+},
+                           x));
+
+outerMethodCall(methodCall(^{
+  variant.action.send(Cmpnt);
+},
+           x));

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -127,6 +127,8 @@
 50628  aet.cfg                              oc/macro-close-brace.m
 50629  aet.cfg                              oc/pp_bool.m
 
+50630 nl_func_call_args_multi_line_ignore_closures.cfg oc/nl_func_call_args_multi_line_ignore_closures.m
+
 50700  cmt_insert-0.cfg                     oc/cmt_insert.m
 50701  cmt_insert-0.cfg                     oc/cmt_insert2.m
 


### PR DESCRIPTION
Currently there is no option to configure newline for closure syntax formatting in function calls. `nl_func_call_multi_line_ignore_closures` let people configure if newlines around closure syntax has to be handled in function calls. In general people prefer to use trailing closure syntax whenever available this option helps in achieving that formatting.