### PR TITLE
Fix parsing error with anonymous, explicitly-typed enum if colon is on new line

### DIFF
--- a/src/combine_labels.cpp
+++ b/src/combine_labels.cpp
@@ -346,11 +346,9 @@ void combine_labels(void)
                // ignore it, as it is inside a paren
             }
             else if (  chunk_is_token(cur, CT_TYPE)
-                    || chunk_is_token(cur, CT_ENUM))   // Issue #2584
-            {
-               set_chunk_type(next, CT_BIT_COLON);
-            }
-            else if (chunk_is_token(nextprev, CT_TYPE))
+                    || chunk_is_token(cur, CT_ENUM)       // Issue #2584
+                    || chunk_is_token(nextprev, CT_TYPE)
+                    || chunk_is_token(nextprev, CT_ENUM)) // Issue #2584
             {
                set_chunk_type(next, CT_BIT_COLON);
             }

--- a/tests/expected/cpp/34211-anonymous_enum.cpp
+++ b/tests/expected/cpp/34211-anonymous_enum.cpp
@@ -16,8 +16,22 @@ enum Enum2 : int {
   E33 = 2
 };
 
-enum : int {
+enum Enum3
+: int {
   E41 = 0,
   E42 = 1,
   E43 = 2
+};
+
+enum : int {
+  E51 = 0,
+  E52 = 1,
+  E53 = 2
+};
+
+enum
+: int {
+  E61 = 0,
+  E62 = 1,
+  E63 = 2
 };

--- a/tests/input/cpp/anonymous_enum.cpp
+++ b/tests/input/cpp/anonymous_enum.cpp
@@ -16,8 +16,22 @@ enum Enum2:int {
   E33=2
 };
 
-enum:int {
+enum Enum3
+:int {
   E41=0,
   E42=1,
   E43=2
+};
+
+enum:int {
+  E51=0,
+  E52=1,
+  E53=2
+};
+
+enum
+:int {
+  E61=0,
+  E62=1,
+  E63=2
 };


### PR DESCRIPTION
Uncrustify currently handles
```C++
enum : int {
  E51 = 0,
  E52 = 1,
  E53 = 2
};
```

correctly but throws an error for

```C++
enum
: int {
  E51 = 0,
  E52 = 1,
  E53 = 2
};
```

This MR fixes that error and adds corresponding tests.