### PR TITLE
Fix macros and typedefs are wrongly indented inside OC interfaces

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1106,6 +1106,12 @@ void indent_text(void)
                   || chunk_is_token(pc, CT_OC_END)
                   || chunk_is_token(pc, CT_OC_SCOPE)
                   || chunk_is_token(pc, CT_OC_PROPERTY)
+                  || chunk_is_token(pc, CT_TYPEDEF) // Issue #2675
+                  || chunk_is_token(pc, CT_MACRO_OPEN)
+                  || chunk_is_token(pc, CT_MACRO_CLOSE)
+                  || (  language_is_set(LANG_OC)
+                     && chunk_is_token(pc, CT_COMMENT_CPP)
+                     && get_chunk_parent_type(pc) == CT_COMMENT_WHOLE) // Issue #2675
                   || chunk_is_semicolon(pc)))
             {
                LOG_FMT(LINDLINE, "%s(%d): pc->orig_line is %zu, orig_col is %zu, text() is '%s', type is %s\n",

--- a/tests/config/issue_2675.cfg
+++ b/tests/config/issue_2675.cfg
@@ -1,0 +1,4 @@
+input_tab_size = 2
+output_tab_size = input_tab_size
+macro-open SOME_MACRO_OPEN
+macro-close SOME_MACRO_CLOSE

--- a/tests/expected/oc/50816-issue_2675.m
+++ b/tests/expected/oc/50816-issue_2675.m
@@ -1,0 +1,50 @@
+@interface Example1 : NSObject
+typedef ObjectType0 X;
+typedef ObjectType1 _Nullable (^Handler1)(id<Fragment> fragment);
+typedef ObjectType2 _Nullable (^Handler2)(id<Fragment> fragment);
+@end
+
+@interface Example2 : NSObject
+typedef ObjectType1 _Nullable (^Handler1)(id<Fragment> fragment);
+typedef ObjectType2 _Nullable (^Handler2)(id<Fragment> fragment);
+@end
+
+@interface AnotherExample1 : NSObject
+SOME_MACRO_OPEN
+				- (instancetype)init;
+
+SOME_MACRO_CLOSE
+@end
+
+SOME_MACRO_OPEN
+				@interface AnotherExample2 : NSObject
+SOME_MACRO_CLOSE
+- (instancetype)init;
+
+@end
+
+@interface SomeInterface : NSObject
+
+// Some comment goes here
+@end
+
+@interface YetAnotherExample : NSObject
+
+// What about this comment
+// here
+- (instancetype)init;
+@end
+
+@interface YetOneAnotherExample : NSObject
+
+/// What about this comment
+/// here
+- (instancetype)init;
+@end
+
+@interface YetOneOtherExample : NSObject
+
+/// What about this comment
+/// here
+- (instancetype)init;
+@end

--- a/tests/input/oc/issue_2675.m
+++ b/tests/input/oc/issue_2675.m
@@ -1,0 +1,50 @@
+@interface Example1 : NSObject
+  typedef ObjectType0 X;
+typedef ObjectType1 _Nullable (^Handler1)(id<Fragment> fragment);
+typedef ObjectType2 _Nullable (^Handler2)(id<Fragment> fragment);
+@end
+
+@interface Example2 : NSObject
+  typedef ObjectType1 _Nullable (^Handler1)(id<Fragment> fragment);
+typedef ObjectType2 _Nullable (^Handler2)(id<Fragment> fragment);
+@end
+
+@interface AnotherExample1 : NSObject
+      SOME_MACRO_OPEN
+- (instancetype)init;
+
+SOME_MACRO_CLOSE
+@end
+
+SOME_MACRO_OPEN
+@interface AnotherExample2 : NSObject
+SOME_MACRO_CLOSE      
+- (instancetype)init;
+
+@end
+
+@interface SomeInterface : NSObject
+
+        // Some comment goes here
+@end
+
+@interface YetAnotherExample : NSObject
+
+      // What about this comment
+    // here
+- (instancetype)init;
+@end
+
+@interface YetOneAnotherExample : NSObject
+
+/// What about this comment
+/// here
+- (instancetype)init;
+@end
+
+@interface YetOneOtherExample : NSObject
+
+         /// What about this comment
+     /// here
+- (instancetype)init;
+@end

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -151,6 +151,8 @@
 50814  sp_before_oc_proto_list_force.cfg    oc/sp_before_oc_proto_list.m
 50815  sp_before_oc_proto_list_remove.cfg   oc/sp_before_oc_proto_list.m
 
+50816  issue_2675.cfg                       oc/issue_2675.m
+
 50900  1927.cfg                             oc/1927.m
 50901  Issue_2172.cfg                       oc/Issue_2172.m
 50902  empty.cfg                            oc/Issue_2289.m


### PR DESCRIPTION
Colon stack is not popped in cases where macros, typedefs & comments are used after. This fixes the issue #2675.