### PR TITLE
Improve class/struct/union/enum attributes support

### DIFF
--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -395,23 +395,25 @@ void tokenize_cleanup(void)
       }
 
       if (  chunk_is_token(pc, CT_ENUM)
-         && chunk_is_token(next, CT_CLASS))
+         && (chunk_is_token(next, CT_STRUCT) || chunk_is_token(next, CT_CLASS)))
       {
          set_chunk_type(next, CT_ENUM_CLASS);
       }
+      chunk_t *next_non_attr = language_is_set(LANG_CPP) ? skip_attribute_next(next) : next;
 
       /*
-       * Change CT_WORD after CT_ENUM, CT_UNION, or CT_STRUCT to CT_TYPE
+       * Change CT_WORD after CT_ENUM, CT_UNION, CT_STRUCT, or CT_CLASS to CT_TYPE
        * Change CT_WORD before CT_WORD to CT_TYPE
        */
-      if (chunk_is_token(next, CT_WORD))
+      if (chunk_is_token(next_non_attr, CT_WORD))
       {
          if (  chunk_is_token(pc, CT_ENUM)
             || chunk_is_token(pc, CT_ENUM_CLASS)
             || chunk_is_token(pc, CT_UNION)
-            || chunk_is_token(pc, CT_STRUCT))
+            || chunk_is_token(pc, CT_STRUCT)
+            || chunk_is_token(pc, CT_CLASS))
          {
-            set_chunk_type(next, CT_TYPE);
+            set_chunk_type(next_non_attr, CT_TYPE);
          }
 
          if (chunk_is_token(pc, CT_WORD))

--- a/tests/expected/cpp/30301-enum_class.h
+++ b/tests/expected/cpp/30301-enum_class.h
@@ -5,6 +5,13 @@ enum class A
 
 }
 
+enum struct D
+{
+    a,
+    b
+
+}
+
 class B {
 private:
 int x;

--- a/tests/expected/cpp/30400-attribute_specifier_seqs.cpp
+++ b/tests/expected/cpp/30400-attribute_specifier_seqs.cpp
@@ -61,6 +61,23 @@ int k() [[expects: x > 0]];
 int x;
 };
 
+class [[foo, bar("baz")]] /**/ Y : private Foo, Bar {
+public:
+int v(int &x) {
+	return x;
+}
+};
+
+class
+	[[foo]]
+	[[bar("baz")]]
+	Z : Foo, public Bar {
+public:
+int v(int * x) {
+	return *x;
+}
+};
+
 int g(int* p) [[ensures: p != nullptr]]
 {
 	*p = 42;
@@ -73,3 +90,40 @@ void i(int& x) [[ensures: meow(x)]]
 {
 	++x;
 }
+
+enum Enum {
+	a, b
+};
+enum class [[foo]] Enum {
+	a, b
+};
+enum struct [[foo]] /**/ [[bar("baz")]] Enum {
+	a, b
+};
+enum [[foo]]
+Enum {
+	a, b
+};
+enum class [[foo]] //
+[[bar("baz")]] Enum {
+	a, b
+};
+enum struct //
+[[bar("baz")]] Enum {
+	a, b
+};
+enum
+[[foo]] [[bar("baz")]] /**/ Enum {
+	a, b
+};
+enum class /**/ [[foo]] [[bar("baz")]]
+Enum {
+	a, b
+};
+enum //
+struct
+[[foo]]
+[[bar("baz")]]
+Enum {
+	a, b
+};

--- a/tests/input/cpp/attribute_specifier_seqs.cpp
+++ b/tests/input/cpp/attribute_specifier_seqs.cpp
@@ -59,6 +59,19 @@ int k() [[expects: x > 0]];
 int x;
 };
 
+class [[foo, bar("baz")]] /**/ Y :private Foo, Bar {
+public:
+int v(int &x) { return x; }
+};
+
+class
+[[foo]]
+[[bar("baz")]]
+Z:Foo, public Bar {
+public:
+int v(int * x) { return *x; }
+};
+
 int g(int* p) [[ensures: p != nullptr]]
 {
 *p = 42;
@@ -69,3 +82,31 @@ void i(int& x) [[ensures: meow(x)]]
 {
 ++x;
 }
+
+enum Enum {
+a, b };
+enum class [[foo]] Enum {
+a, b };
+enum struct [[foo]] /**/ [[bar("baz")]] Enum {
+a, b };
+enum [[foo]]
+Enum {
+a, b };
+enum class [[foo]] //
+[[bar("baz")]] Enum {
+a, b };
+enum struct //
+[[bar("baz")]] Enum {
+a, b };
+enum
+[[foo]] [[bar("baz")]] /**/ Enum {
+a, b };
+enum class /**/ [[foo]] [[bar("baz")]]
+Enum {
+a, b };
+enum //
+struct
+[[foo]]
+[[bar("baz")]]
+Enum {
+a, b };

--- a/tests/input/cpp/enum_class.h
+++ b/tests/input/cpp/enum_class.h
@@ -4,6 +4,12 @@ a,
 b
 }
 
+enum struct D
+{
+a,
+b
+}
+
 class B {
 private:
    int x;


### PR DESCRIPTION
C++ attributes support is missing out on class attributes. Adding an attribute between `class` and its name leads to bad formatting, mostly due to wrong tokenization. Address this by skipping attributes in a number of places, but only when formatting C++.

It's also possible to add more than one attribute where supported, which leads to further issues as only a single attribute is expected at each particular place. Address this by skipping all the attributes instead of just one when looking for the next non-attribute chunk.

Categorize WORD following `class` as TYPE during tokenization cleanup, in addition to previously supported enums, enum classes, unions, and structs.

Categorize `struct` following `enum` as ENUM_CLASS, same way `class` following `enum` is.

<details><summary>Example of bad formatting</summary>

Input:
```cpp
class [[deprecated("")]] // ...
A : public B, public C
{
public:
    A(A const& a);
    void f(int const& x);
};
```

Before:
```cpp
class [[deprecated("")]] // ...
A:  public B, public C
{
public:
    A(A const & a);
    void f(int const & x);
};
```

<details><summary>Debug info before</summary>

```
# -=====-
# number of loops               = 4
# -=====-
# Line                Tag         Parent_type  Type of the parent         Columns Br/Lvl/pp      Flag   Nl  Text
#   1>              CLASS|               NONE|     PARENT_NOT_SET[  1/  1/  6/  0][0/0/0][      60000][0-0] class
#   1>          ATTRIBUTE|               NONE|     PARENT_NOT_SET[  7/  7/ 25/  1][0/0/0][          0][0-0]       [[deprecated("")]]
#   1>        COMMENT_CPP|        COMMENT_END|     PARENT_NOT_SET[ 26/ 26/ 32/  1][0/0/0][    4000000][0-0]                          // ...
#   1>            NEWLINE|               NONE|     PARENT_NOT_SET[ 32/ 32/  1/  0][0/0/0][          0][1-0]
#   2>              LABEL|               NONE|     PARENT_NOT_SET[  1/  1/  2/  0][0/0/0][    1800000][0-0] A
#   2>        LABEL_COLON|               NONE|     PARENT_NOT_SET[  2/  3/  4/  1][0/0/0][  100000000][0-0]  :
#   2>          QUALIFIER|               NONE|     PARENT_NOT_SET[  5/  5/ 11/  1][0/0/0][     470000][0-0]     public
#   2>               WORD|               NONE|     PARENT_NOT_SET[ 12/ 12/ 13/  1][0/0/0][    1800000][0-0]            B
#   2>              COMMA|               NONE|     PARENT_NOT_SET[ 13/ 13/ 14/  0][0/0/0][  100000000][0-0]             ,
#   2>          QUALIFIER|               NONE|     PARENT_NOT_SET[ 15/ 15/ 21/  1][0/0/0][   10050000][0-0]               public
#   2>               WORD|               NONE|     PARENT_NOT_SET[ 22/ 22/ 23/  1][0/0/0][   10800000][0-0]                      C
#   2>            NEWLINE|               NONE|     PARENT_NOT_SET[ 23/ 23/  1/  0][0/0/0][          0][1-0]
#   3>         BRACE_OPEN|   BRACED_INIT_LIST|     PARENT_NOT_SET[  1/  1/  2/  0][0/0/0][  100000000][0-0] {
#   3>            NEWLINE|               NONE|     PARENT_NOT_SET[  2/  2/  1/  0][1/1/0][          0][1-0]
#   4>             ACCESS|               NONE|     PARENT_NOT_SET[  1/  1/  7/  0][1/1/0][      60000][0-0] public
#   4>       ACCESS_COLON|               NONE|     PARENT_NOT_SET[  7/  7/  8/  0][1/1/0][  100000000][0-0]       :
#   4>            NEWLINE|               NONE|     PARENT_NOT_SET[  8/  8/  5/  0][1/1/0][          0][1-0]
#   5>          FUNC_CALL|               NONE|     PARENT_NOT_SET[  5/  5/  6/  0][1/1/0][      60000][0-0]     A
#   5>        FPAREN_OPEN|          FUNC_CALL|     PARENT_NOT_SET[  6/  6/  7/  0][1/1/0][  100000000][0-0]      (
#   5>               WORD|               NONE|     PARENT_NOT_SET[  7/  7/  8/  0][1/2/0][      50010][0-0]       A
#   5>          QUALIFIER|               NONE|     PARENT_NOT_SET[  9/  9/ 14/  1][1/2/0][         10][0-0]         const
#   5>              ARITH|               NONE|     PARENT_NOT_SET[ 15/ 14/ 15/  0][1/2/0][  100000010][0-0]               &
#   5>               WORD|               NONE|     PARENT_NOT_SET[ 17/ 16/ 17/  1][1/2/0][         10][0-0]                 a
#   5>       FPAREN_CLOSE|          FUNC_CALL|     PARENT_NOT_SET[ 18/ 17/ 18/  0][1/1/0][  100000010][0-0]                  )
#   5>          SEMICOLON|              CLASS|     PARENT_NOT_SET[ 19/ 18/ 19/  0][1/1/0][  100000000][0-0]                   ;
#   5>            NEWLINE|               NONE|     PARENT_NOT_SET[ 20/ 19/  5/  0][1/1/0][          0][1-0]
#   6>               TYPE|               NONE|     PARENT_NOT_SET[  5/  5/  9/  0][1/1/0][      70000][0-0]     void
#   6>      FUNC_CTOR_VAR|               NONE|     PARENT_NOT_SET[ 10/ 10/ 11/  1][1/1/0][    1800000][0-0]          f
#   6>        FPAREN_OPEN|      FUNC_CTOR_VAR|     PARENT_NOT_SET[ 11/ 11/ 12/  0][1/1/0][  100000000][0-0]           (
#   6>               TYPE|               NONE|     PARENT_NOT_SET[ 12/ 12/ 15/  0][1/2/0][20000050000][0-0]            int
#   6>          QUALIFIER|               NONE|     PARENT_NOT_SET[ 16/ 16/ 21/  1][1/2/0][20000000000][0-0]                const
#   6>              ARITH|               NONE|     PARENT_NOT_SET[ 22/ 21/ 22/  0][1/2/0][20100000000][0-0]                      &
#   6>               WORD|               NONE|     PARENT_NOT_SET[ 24/ 23/ 24/  1][1/2/0][20000000000][0-0]                        x
#   6>       FPAREN_CLOSE|      FUNC_CTOR_VAR|     PARENT_NOT_SET[ 25/ 24/ 25/  0][1/1/0][20100000000][0-0]                         )
#   6>          SEMICOLON|      FUNC_CTOR_VAR|     PARENT_NOT_SET[ 26/ 25/ 26/  0][1/1/0][  100000000][0-0]                          ;
#   6>            NEWLINE|               NONE|     PARENT_NOT_SET[ 27/ 26/  1/  0][1/1/0][          0][1-0]
#   7>        BRACE_CLOSE|   BRACED_INIT_LIST|     PARENT_NOT_SET[  1/  1/  2/  0][0/0/0][  100000000][0-0] }
#   7>          SEMICOLON|               NONE|     PARENT_NOT_SET[  2/  2/  3/  0][0/0/0][  100000000][0-0]  ;
#   7>            NEWLINE|               NONE|     PARENT_NOT_SET[  3/  3/  1/  0][0/0/0][          0][1-0]
# -=====-
```
</details>

After:
```cpp
class [[deprecated("")]] // ...
    A : public B, public C
{
public:
    A(A const& a);
    void f(int const& x);
};
```

<details><summary>Debug info after</summary>

```
# -=====-
# number of loops               = 4
# -=====-
# Line                Tag         Parent_type  Type of the parent         Columns Br/Lvl/pp      Flag   Nl  Text
#   1>              CLASS|               NONE|     PARENT_NOT_SET[  1/  1/  6/  0][0/0/0][      60000][0-0] class
#   1>          ATTRIBUTE|               NONE|     PARENT_NOT_SET[  7/  7/ 25/  1][0/0/0][          0][0-0]       [[deprecated("")]]
#   1>        COMMENT_CPP|        COMMENT_END|     PARENT_NOT_SET[ 26/ 26/ 32/  1][0/0/0][    4000000][0-0]                          // ...
#   1>            NEWLINE|               NONE|     PARENT_NOT_SET[ 32/ 32/  1/  0][0/0/0][          0][1-0]
#   2>               TYPE|               NONE|     PARENT_NOT_SET[  5/  1/  2/  0][0/0/0][          0][0-0]     A
#   2>        CLASS_COLON|              CLASS|     PARENT_NOT_SET[  7/  3/  4/  1][0/0/0][  100000800][0-0]       :
#   2>          QUALIFIER|               NONE|     PARENT_NOT_SET[  9/  5/ 11/  1][0/0/0][     470800][0-0]         public
#   2>               WORD|               NONE|     PARENT_NOT_SET[ 16/ 12/ 13/  1][0/0/0][    1800800][0-0]                B
#   2>              COMMA|               NONE|     PARENT_NOT_SET[ 17/ 13/ 14/  0][0/0/0][  100000800][0-0]                 ,
#   2>          QUALIFIER|               NONE|     PARENT_NOT_SET[ 19/ 15/ 21/  1][0/0/0][   10050800][0-0]                   public
#   2>               WORD|               NONE|     PARENT_NOT_SET[ 26/ 22/ 23/  1][0/0/0][   10800800][0-0]                          C
#   2>            NEWLINE|               NONE|     PARENT_NOT_SET[ 27/ 23/  1/  0][0/0/0][          0][1-0]
#   3>         BRACE_OPEN|              CLASS|     PARENT_NOT_SET[  1/  1/  2/  0][0/0/0][  100000400][0-0] {
#   3>            NEWLINE|               NONE|     PARENT_NOT_SET[  2/  2/  1/  0][1/1/0][          0][1-0]
#   4>             ACCESS|               NONE|     PARENT_NOT_SET[  1/  1/  7/  0][1/1/0][      60400][0-0] public
#   4>       ACCESS_COLON|               NONE|     PARENT_NOT_SET[  7/  7/  8/  0][1/1/0][  100000400][0-0]       :
#   4>            NEWLINE|               NONE|     PARENT_NOT_SET[  8/  8/  5/  0][1/1/0][          0][1-0]
#   5>   FUNC_CLASS_PROTO|               NONE|     PARENT_NOT_SET[  5/  5/  6/  0][1/1/0][      60400][0-0]     A
#   5>        FPAREN_OPEN|   FUNC_CLASS_PROTO|     PARENT_NOT_SET[  6/  6/  7/  0][1/1/0][  100000500][0-0]      (
#   5>               TYPE|               NONE|     PARENT_NOT_SET[  7/  7/  8/  0][1/2/0][     450510][0-0]       A
#   5>          QUALIFIER|               NONE|     PARENT_NOT_SET[  9/  9/ 14/  1][1/2/0][        510][0-0]         const
#   5>              BYREF|               NONE|     PARENT_NOT_SET[ 14/ 14/ 15/  0][1/2/0][  100000510][0-0]              &
#   5>               WORD|               NONE|     PARENT_NOT_SET[ 16/ 16/ 17/  1][1/2/0][     800510][0-0]                a
#   5>       FPAREN_CLOSE|   FUNC_CLASS_PROTO|     PARENT_NOT_SET[ 17/ 17/ 18/  0][1/1/0][  100000510][0-0]                 )
#   5>          SEMICOLON|   FUNC_CLASS_PROTO|     PARENT_NOT_SET[ 18/ 18/ 19/  0][1/1/0][  100000400][0-0]                  ;
#   5>            NEWLINE|               NONE|     PARENT_NOT_SET[ 19/ 19/  5/  0][1/1/0][          0][1-0]
#   6>               TYPE|         FUNC_PROTO|     PARENT_NOT_SET[  5/  5/  9/  0][1/1/0][      70400][0-0]     void
#   6>         FUNC_PROTO|               NONE|     PARENT_NOT_SET[ 10/ 10/ 11/  1][1/1/0][        400][0-0]          f
#   6>        FPAREN_OPEN|         FUNC_PROTO|     PARENT_NOT_SET[ 11/ 11/ 12/  0][1/1/0][  100000400][0-0]           (
#   6>               TYPE|               NONE|     PARENT_NOT_SET[ 12/ 12/ 15/  0][1/2/0][     450408][0-0]            int
#   6>          QUALIFIER|               NONE|     PARENT_NOT_SET[ 16/ 16/ 21/  1][1/2/0][        408][0-0]                const
#   6>              BYREF|               NONE|     PARENT_NOT_SET[ 21/ 21/ 22/  0][1/2/0][  100000408][0-0]                     &
#   6>               WORD|               NONE|     PARENT_NOT_SET[ 23/ 23/ 24/  1][1/2/0][     800408][0-0]                       x
#   6>       FPAREN_CLOSE|         FUNC_PROTO|     PARENT_NOT_SET[ 24/ 24/ 25/  0][1/1/0][  100000408][0-0]                        )
#   6>          SEMICOLON|         FUNC_PROTO|     PARENT_NOT_SET[ 25/ 25/ 26/  0][1/1/0][  100000400][0-0]                         ;
#   6>            NEWLINE|               NONE|     PARENT_NOT_SET[ 26/ 26/  1/  0][1/1/0][          0][1-0]
#   7>        BRACE_CLOSE|              CLASS|     PARENT_NOT_SET[  1/  1/  2/  0][0/0/0][  100000400][0-0] }
#   7>          SEMICOLON|              CLASS|     PARENT_NOT_SET[  2/  2/  3/  0][0/0/0][  100000000][0-0]  ;
#   7>            NEWLINE|               NONE|     PARENT_NOT_SET[  3/  3/  1/  0][0/0/0][          0][1-0]
# -=====-
```
</details>

<details><summary>Config</summary>

```
sp_while_paren_open             = force
sp_arith                        = force
sp_arith_additive               = force
sp_assign                       = force
sp_cpp_lambda_assign            = remove
sp_cpp_lambda_square_paren      = remove
sp_assign_default               = force
sp_enum_assign                  = force
sp_enum_colon                   = force
sp_pp_concat                    = force
sp_bool                         = force
sp_compare                      = force
sp_inside_paren                 = remove
sp_paren_paren                  = remove
sp_cparen_oparen                = remove
sp_brace_brace                  = force
sp_before_ptr_star              = remove
sp_between_ptr_star             = remove
sp_after_ptr_star               = force
sp_after_ptr_star_qualifier     = force
sp_after_ptr_star_func          = force
sp_ptr_star_paren               = force
sp_before_ptr_star_func         = remove
sp_before_byref                 = remove
sp_before_unnamed_byref         = remove
sp_after_byref                  = force
sp_after_byref_func             = force
sp_before_byref_func            = remove
sp_after_type                   = add
sp_after_decltype               = force
sp_template_angle               = remove
sp_before_angle                 = remove
sp_inside_angle                 = remove
sp_angle_colon                  = remove
sp_after_angle                  = remove
sp_angle_paren                  = remove
sp_angle_paren_empty            = remove
sp_angle_word                   = force
sp_angle_shift                  = remove
sp_permit_cpp11_shift           = true
sp_before_sparen                = force
sp_inside_sparen                = remove
sp_after_semi                   = force
sp_after_semi_for_empty         = remove
sp_before_square                = remove
sp_before_squares               = remove
sp_inside_square                = remove
sp_after_comma                  = force
sp_before_ellipsis              = remove
sp_type_ellipsis                = remove
sp_paren_ellipsis               = remove
sp_paren_qualifier              = add
sp_paren_noexcept               = add
sp_before_class_colon           = force
sp_before_constr_colon          = force
sp_after_operator               = remove
sp_after_operator_sym           = remove
sp_after_operator_sym_empty     = remove
sp_after_cast                   = remove
sp_inside_paren_cast            = remove
sp_cpp_cast_paren               = remove
sp_sizeof_paren                 = remove
sp_sizeof_ellipsis              = remove
sp_sizeof_ellipsis_paren        = remove
sp_decltype_paren               = remove
sp_after_type_brace_init_lst_open = force
sp_before_type_brace_init_lst_close = force
sp_inside_type_brace_init_lst   = force
sp_inside_braces                = force
sp_inside_braces_empty          = remove
sp_type_func                    = force
sp_type_brace_init_lst          = remove
sp_func_proto_paren             = remove
sp_func_proto_paren_empty       = remove
sp_func_def_paren               = remove
sp_func_def_paren_empty         = remove
sp_inside_fparens               = remove
sp_inside_fparen                = remove
sp_inside_tparen                = remove
sp_after_tparen_close           = remove
sp_square_fparen                = remove
sp_fparen_brace                 = force
sp_fparen_brace_initializer     = force
sp_func_call_paren              = remove
sp_func_call_user_inside_fparen = remove
sp_func_call_user_paren_paren   = remove
sp_func_class_paren             = remove
sp_func_class_paren_empty       = remove
sp_return_paren                 = force
sp_return_brace                 = force
sp_attribute_paren              = remove
sp_defined_paren                = remove
sp_throw_paren                  = force
sp_after_throw                  = force
sp_catch_paren                  = force
sp_before_dc                    = remove
sp_after_dc                     = remove
sp_cond_colon                   = force
sp_cond_question                = force
sp_case_label                   = force
sp_after_for_colon              = force
sp_before_for_colon             = force
sp_cmt_cpp_start                = add
sp_cmt_cpp_doxygen              = true
sp_cmt_cpp_qttr                 = true
sp_endif_cmt                    = force
sp_after_new                    = force
sp_between_new_paren            = force
sp_after_newop_paren            = force
sp_inside_newop_paren           = remove
sp_inside_newop_paren_open      = remove
sp_inside_newop_paren_close     = remove
sp_before_tr_emb_cmt            = force
sp_num_before_tr_emb_cmt        = 1
sp_after_noexcept               = remove
indent_columns                  = 4
indent_with_tabs                = 0
indent_paren_open_brace         = true
indent_class                    = true
indent_func_call_param          = true
indent_func_def_param           = true
indent_func_proto_param         = true
indent_func_class_param         = true
indent_func_ctor_var_param      = true
indent_template_param           = true
indent_member                   = 4
indent_member_single            = true
indent_case_brace               = 4
indent_access_spec              = -4
indent_align_assign             = false
indent_align_paren              = false
indent_token_after_brace        = false
indent_cpp_lambda_body          = true
indent_single_after_return      = true
nl_assign_leave_one_liners      = true
nl_class_leave_one_liners       = true
nl_cpp_lambda_leave_one_liners  = true
nl_start_of_file                = remove
nl_end_of_file                  = force
nl_end_of_file_min              = 1
nl_assign_brace                 = force
nl_enum_brace                   = force
nl_struct_brace                 = force
nl_union_brace                  = force
nl_if_brace                     = force
nl_brace_else                   = force
nl_elseif_brace                 = force
nl_else_brace                   = force
nl_else_if                      = remove
nl_before_if_closing_paren      = remove
nl_try_brace                    = force
nl_for_brace                    = force
nl_catch_brace                  = force
nl_brace_catch                  = force
nl_brace_fparen                 = remove
nl_while_brace                  = force
nl_do_brace                     = force
nl_brace_while                  = force
nl_switch_brace                 = force
nl_before_case                  = true
nl_after_case                   = true
nl_namespace_brace              = force
nl_template_class               = force
nl_class_brace                  = force
nl_constr_init_args             = force
nl_func_class_scope             = remove
nl_func_scope_name              = remove
nl_func_proto_type_name         = remove
nl_func_paren                   = remove
nl_func_paren_empty             = remove
nl_func_def_paren               = remove
nl_func_def_paren_empty         = remove
nl_func_call_paren              = remove
nl_func_call_paren_empty        = remove
nl_func_decl_start_multi_line   = true
nl_func_def_start_multi_line    = true
nl_func_decl_args_multi_line    = true
nl_func_def_args_multi_line     = true
nl_func_decl_end                = remove
nl_func_def_end                 = remove
nl_func_decl_empty              = remove
nl_func_def_empty               = remove
nl_func_call_empty              = remove
nl_fdef_brace                   = force
nl_cpp_ldef_brace               = force
nl_return_expr                  = remove
nl_after_semicolon              = true
nl_after_brace_open             = true
nl_after_if                     = force
nl_after_for                    = force
nl_after_while                  = force
nl_after_switch                 = force
nl_after_synchronized           = force
nl_after_do                     = force
nl_constr_colon                 = force
nl_max                          = 2
nl_after_func_body              = 2
nl_after_func_body_class        = 2
nl_after_struct                 = 1
nl_before_class                 = 1
nl_after_class                  = 1
nl_inside_namespace             = 2
nl_after_access_spec            = 1
nl_after_try_catch_finally      = 2
eat_blanks_after_open_brace     = true
eat_blanks_before_close_brace   = true
pos_arith                       = trail
pos_assign                      = trail
pos_bool                        = trail
pos_compare                     = trail
pos_conditional                 = trail
pos_comma                       = trail
pos_enum_comma                  = trail
pos_class_comma                 = trail
pos_constr_comma                = trail
pos_class_colon                 = trail
pos_constr_colon                = trail
code_width                      = 128
ls_func_split_full              = true
align_var_def_attribute         = true
align_right_cmt_same_level      = true
mod_full_brace_do               = force
mod_full_brace_for              = force
mod_full_brace_if               = force
mod_full_brace_while            = force
mod_paren_on_return             = remove
mod_add_long_namespace_closebrace_comment = 1
pp_indent                       = remove
use_options_overriding_for_qt_macros = false
```
</details>
</details>

Any comments are welcome, including total rejection of current approach. If necessary, I'm open to reworking this in any way desired.

References:
* [Class/struct declaration](https://en.cppreference.com/w/cpp/language/class) (note `attr` placement)
* [Union declaration](https://en.cppreference.com/w/cpp/language/union) (note `attr` placement)
* [Enum [class/struct] declaration](https://en.cppreference.com/w/cpp/language/enum) (note `attr` placement, `struct` support)