### PR TITLE
fix preproc treated as type before func def

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -4907,7 +4907,7 @@ static void mark_function(chunk_t *pc)
          }
 
          for (  tmp = prev; (tmp != nullptr)
-             && tmp != pc; tmp = chunk_get_next_ncnl(tmp))
+             && tmp != pc; tmp = chunk_get_next_ncnlnp(tmp))
          {
             LOG_FMT(LFCN, "%s(%d): text() is '%s', type is %s\n",
                     __func__, __LINE__, tmp->text(), get_token_name(tmp->type));

--- a/tests/c.test
+++ b/tests/c.test
@@ -381,6 +381,7 @@
 09618  Issue_2360-b.cfg                     c/Issue_2360.c
 09619  Issue_2411.cfg                       c/Issue_2411.c
 09620  Issue_2640.cfg                       c/Issue_2640.c
+09621  preproc-cleanup.cfg                  c/pp-before-func-def.c
 
 10005  empty.cfg                            c/i1270.c
 

--- a/tests/expected/c/09621-pp-before-func-def.c
+++ b/tests/expected/c/09621-pp-before-func-def.c
@@ -1,0 +1,3 @@
+
+#define m_new(type, num) ((type *)(m_malloc(sizeof(type) * (num))))
+void *m_malloc(size_t num_bytes);

--- a/tests/input/c/pp-before-func-def.c
+++ b/tests/input/c/pp-before-func-def.c
@@ -1,0 +1,3 @@
+
+#define m_new(type, num) ((type *)(m_malloc(sizeof(type) * (num))))
+void *m_malloc(size_t num_bytes);


### PR DESCRIPTION
This fixes a bug where a preprocessor statement before a function definition is treated as part of the type. This causes problems with `#define` since chunks can be incorrectly modified.

This is fixed by using `chunk_get_next_ncnlnp()` to also skip over preprocessor statements in addition to comments and newlines when fixing up the type before the function definition.

The test cast catches this bug because the bug cause the `*` in `sizeof(type) * (num)` to be changed from `CT_ARITH` to `CT_PTR_TYPE` which causes the space after `*` to be deleted. When the bug is fixed, the token type of the `*` is not modified and we get the expected result.

Fixes #2690