### PR TITLE
Avoid blank line between case and return statement

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -2515,7 +2515,7 @@ static void newline_before_return(chunk_t *start)
    if (  pc == nullptr
       || (  chunk_is_token(pc, CT_BRACE_OPEN)
          || chunk_is_token(pc, CT_VBRACE_OPEN)
-         || get_chunk_parent_type(start) == CT_CASE)) // Issue #1257
+         || chunk_is_token(pc, CT_CASE_COLON)))
    {
       return;
    }

--- a/tests/c.test
+++ b/tests/c.test
@@ -124,6 +124,8 @@
 00202  case-2.cfg                           c/case.c
 00203  case-3.cfg                           c/case.c
 00204  bug_1718.cfg                         c/bug_1718.c
+00205  nl_before_return_false.cfg           c/case-nl_before_return.c
+00206  nl_before_return_true.cfg            c/case-nl_before_return.c
 
 
 # structure initializers

--- a/tests/config/U-J.cfg
+++ b/tests/config/U-J.cfg
@@ -3,3 +3,4 @@ indent_with_tabs                = 0
 indent_switch_case              = 4
 nl_end_of_file                  = force
 nl_end_of_file_min              = 1
+nl_before_return                = true

--- a/tests/config/nl_before_return_false.cfg
+++ b/tests/config/nl_before_return_false.cfg
@@ -1,0 +1,1 @@
+nl_before_return = false

--- a/tests/config/nl_before_return_true.cfg
+++ b/tests/config/nl_before_return_true.cfg
@@ -1,0 +1,1 @@
+nl_before_return = true

--- a/tests/expected/c/00205-case-nl_before_return.c
+++ b/tests/expected/c/00205-case-nl_before_return.c
@@ -1,0 +1,33 @@
+int foo(int arg)
+{
+	switch (arg)
+	{
+	case 0: return 1;
+	case 1:
+		return 2;
+	case 2:
+		printf("Hello world!\n");
+		return 3;
+	case 3:
+	{
+		int a = 4;
+		return a;
+	}
+	case 4:
+
+		return 5;
+	case 5:
+		printf("Hello world!\n");
+
+		return 6;
+	case 6:
+	{
+		int a = 7;
+
+		return a;
+	}
+	default:
+		return arg++;
+	}
+	return 0;
+}

--- a/tests/expected/c/00206-case-nl_before_return.c
+++ b/tests/expected/c/00206-case-nl_before_return.c
@@ -1,0 +1,36 @@
+int foo(int arg)
+{
+	switch (arg)
+	{
+	case 0: return 1;
+	case 1:
+		return 2;
+	case 2:
+		printf("Hello world!\n");
+
+		return 3;
+	case 3:
+	{
+		int a = 4;
+
+		return a;
+	}
+	case 4:
+
+		return 5;
+	case 5:
+		printf("Hello world!\n");
+
+		return 6;
+	case 6:
+	{
+		int a = 7;
+
+		return a;
+	}
+	default:
+		return arg++;
+	}
+
+	return 0;
+}

--- a/tests/expected/cs/60008-UNI-17253.cs
+++ b/tests/expected/cs/60008-UNI-17253.cs
@@ -58,4 +58,6 @@ switch (sometext)
         }
 
         return 1;
+    default:
+        return 0;
 }

--- a/tests/expected/cs/60008-UNI-17253.cs
+++ b/tests/expected/cs/60008-UNI-17253.cs
@@ -5,10 +5,12 @@ switch (sometext)
         return 0;
     case "b":
         Console.WrieLine("hello world\n");
+
         return 0;
     case "c":
     {
         Console.WrieLine("hello world\n");
+
         return 0;
     }
     case "d":
@@ -26,6 +28,7 @@ switch (sometext)
         {
             int a;
             int b;
+
             return 0;
         }
 
@@ -41,6 +44,7 @@ switch (sometext)
         for (i = 0; i < 10 i++)
         {
             a += i;
+
             return 0;
         }
     case "i":
@@ -49,6 +53,7 @@ switch (sometext)
         {
             int a;
             int b;
+
             return 0;
         }
 

--- a/tests/input/c/case-nl_before_return.c
+++ b/tests/input/c/case-nl_before_return.c
@@ -1,0 +1,33 @@
+int foo(int arg)
+{
+    switch (arg)
+    {
+        case 0: return 1;
+        case 1:
+            return 2;
+        case 2:
+            printf("Hello world!\n");
+            return 3;
+        case 3:
+        {
+            int a = 4;
+            return a;
+        }
+        case 4:
+
+            return 5;
+        case 5:
+            printf("Hello world!\n");
+
+            return 6;
+        case 6:
+        {
+            int a = 7;
+
+            return a;
+        }
+        default:
+            return arg++;
+    }
+    return 0;
+}

--- a/tests/input/cs/UNI-17253.cs
+++ b/tests/input/cs/UNI-17253.cs
@@ -53,4 +53,6 @@ switch (sometext)
         }
 
         return 1;
+    default:
+        return 0;
 }


### PR DESCRIPTION
This PR proposes a fix for issue #2693. I'm not familiar enough with the `uncrustify` code base to judge whether this could have any adverse side effects, though the test suite still passes. However, this means that this particular case isn't covered by the test suite yet. Please let me know whether I should include my test case from the issue as a new test case, or whether I should modify one of the existing test cases.