### PR TITLE
a stern after a colon in a bit field is not a pointer

### DIFF
--- a/tests/config/Issue_2689.cfg
+++ b/tests/config/Issue_2689.cfg
@@ -1,0 +1,5 @@
+sp_after_ptr_star  = remove
+indent_columns     = 3
+indent_class       = true
+indent_label       = 2
+indent_access_spec = 2

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -473,6 +473,8 @@
 31711  string_replace_tab_chars-t.cfg       cpp/string_replace_tab_chars.cpp
 
 31720  ben_031.cfg                          cpp/bit-colon.cpp
+31721  Issue_2689.cfg                       cpp/Issue_2689.cpp
+
 31730  sp_arith-a.cfg                       cpp/ms-style-ref.cpp
 31740  empty.cfg                            cpp/I2102.cpp
 

--- a/tests/expected/cpp/31721-Issue_2689.cpp
+++ b/tests/expected/cpp/31721-Issue_2689.cpp
@@ -1,0 +1,5 @@
+class C
+{
+ public:
+   size_t f4 : 8 * sizeof(size_t) - 2; // <-- this star is treated a pointer token
+};

--- a/tests/input/cpp/Issue_2689.cpp
+++ b/tests/input/cpp/Issue_2689.cpp
@@ -1,0 +1,5 @@
+class C
+{
+public:
+   size_t f4 : 8 * sizeof(size_t) - 2; // <-- this star is treated a pointer token
+};


### PR DESCRIPTION
Ref. #2689 