### PR TITLE
Add option 'mod_sort_incl_import_prioritize_filename'

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -2754,6 +2754,10 @@ mod_sort_using                  = false    # true/false
 # break your code if your includes/imports have ordering dependencies.
 mod_sort_include                = false    # true/false
 
+# Whether to prioritize '#include' and '#import' statements that contain
+# filename when sorting is enabled.
+mod_sort_incl_import_prioritize_filename = false    # true/false
+
 # Whether to move a 'break' that appears after a fully braced 'case' before
 # the close brace, as in 'case X: { ... } break;' => 'case X: { ... break; }'.
 mod_move_case_break             = false    # true/false

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -2754,6 +2754,10 @@ mod_sort_using                  = false    # true/false
 # break your code if your includes/imports have ordering dependencies.
 mod_sort_include                = false    # true/false
 
+# Whether to prioritize '#include' and '#import' statements that contains
+# filename when sorting is enabled.
+mod_sort_incl_import_prioritize_filename = false    # true/false
+
 # Whether to move a 'break' that appears after a fully braced 'case' before
 # the close brace, as in 'case X: { ... } break;' => 'case X: { ... break; }'.
 mod_move_case_break             = false    # true/false

--- a/documentation/htdocs/options_ModifyCode.html
+++ b/documentation/htdocs/options_ModifyCode.html
@@ -121,6 +121,7 @@ void a()
   <tr>
     <td><a href="#mod_sort_import">mod_sort_import</a></td>
     <td><a href="#mod_sort_include">mod_sort_include</a></td>
+    <td><a href="#mod_sort_incl_import_prioritize_filename">mod_sort_incl_import_prioritize_filename</a></td>
   </tr>
   <tr>
     <td><a href="#mod_sort_using">mod_sort_using</a></td>

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -2765,6 +2765,10 @@ mod_sort_using                  = false    # true/false
 # break your code if your includes/imports have ordering dependencies.
 mod_sort_include                = false    # true/false
 
+# Whether to prioritize '#include' and '#import' statements that contains
+# filename when sorting is enabled.
+mod_sort_incl_import_prioritize_filename = false    # true/false
+
 # Whether to move a 'break' that appears after a fully braced 'case' before
 # the close brace, as in 'case X: { ... } break;' => 'case X: { ... break; }'.
 mod_move_case_break             = false    # true/false

--- a/etc/freebsd.cfg
+++ b/etc/freebsd.cfg
@@ -342,6 +342,7 @@ mod_add_long_ifdef_else_comment          = 0
 mod_sort_import                          = false
 mod_sort_using                           = false
 mod_sort_include                         = false
+mod_sort_incl_import_prioritize_filename = false
 mod_move_case_break                      = false
 mod_case_brace                           = remove
 mod_remove_empty_return                  = true

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -6068,6 +6068,14 @@ EditorType=boolean
 TrueFalse=mod_sort_include=true|mod_sort_include=false
 ValueDefault=false
 
+[Mod Sort Include Import Prioritize Filename]
+Category=9
+Description="<html>Whether to prioritize '#include' and '#import' statements that contains<br/>filename when sorting is enabled.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=mod_sort_incl_import_prioritize_filename=true|mod_sort_incl_import_prioritize_filename=false
+ValueDefault=false
+
 [Mod Move Case Break]
 Category=9
 Description="<html>Whether to move a 'break' that appears after a fully braced 'case' before<br/>the close brace, as in 'case X: { ... } break;' =&gt; 'case X: { ... break; }'.</html>"

--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -310,6 +310,7 @@ mod_paren_on_return                       = add
 mod_remove_empty_return                   = true
 mod_remove_extra_semicolon                = true
 mod_sort_include                          = true
+mod_sort_incl_import_prioritize_filename  = false
 
 # the build of uncrustify needs the options to be set to ignore
 sp_after_assign                           = ignore

--- a/src/options.h
+++ b/src/options.h
@@ -3425,6 +3425,11 @@ mod_sort_using;
 extern Option<bool>
 mod_sort_include;
 
+// Whether to prioritize '#include' and '#import' statements that contains
+// filename when sorting is enabled.
+extern Option<bool>
+mod_sort_incl_import_prioritize_filename;
+
 // Whether to move a 'break' that appears after a fully braced 'case' before
 // the close brace, as in 'case X: { ... } break;' => 'case X: { ... break; }'.
 extern Option<bool>

--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -109,6 +109,28 @@ static int get_chunk_priority(chunk_t *pc)
 }
 
 
+/**
+ * Get source filename without extension.
+ */
+static std::string get_filename_without_ext()
+{
+   std::string filepath  = cpd.filename;
+   size_t      slash_idx = filepath.find_last_of("/\\");
+
+   if (slash_idx == std::string::npos || slash_idx >= (filepath.size() - 1))
+   {
+      return(filepath);
+   }
+   std::string filename = filepath.substr(slash_idx + 1);
+   size_t      dot_idx  = filename.find_last_of('.');
+
+   return(filename.substr(0, dot_idx));
+}
+
+
+/**
+ * Returns chunk string required for sorting.
+ */
 static unc_text chunk_sort_str(chunk_t *pc)
 {
    if (get_chunk_parent_type(pc) == CT_PP_INCLUDE)
@@ -132,9 +154,28 @@ static int compare_chunks(chunk_t *pc1, chunk_t *pc2, bool tcare)
    {
       return(0);
    }
+   const char *filename = get_filename_without_ext().c_str();
 
    while (pc1 != nullptr && pc2 != nullptr)
    {
+      auto const &s1 = chunk_sort_str(pc1);
+      auto const &s2 = chunk_sort_str(pc2);
+
+      if (options::mod_sort_incl_import_prioritize_filename())
+      {
+         log_rule_B("mod_sort_incl_import_prioritize_filename");
+         int s1_contains_filename = s1.find(filename);
+         int s2_contains_filename = s2.find(filename);
+
+         if (s1_contains_filename != -1 && s2_contains_filename == -1)
+         {
+            return(-1);
+         }
+         else if (s1_contains_filename == -1 && s2_contains_filename != -1)
+         {
+            return(1);
+         }
+      }
       int ppc1 = get_chunk_priority(pc1);
       int ppc2 = get_chunk_priority(pc2);
 
@@ -146,9 +187,8 @@ static int compare_chunks(chunk_t *pc1, chunk_t *pc2, bool tcare)
               __func__, __LINE__, pc1->text(), pc1->len(), pc1->orig_line, pc1->orig_col);
       LOG_FMT(LSORT, "%s(%d): text is %s, pc2->len is %zu, line is %zu, column is %zu\n",
               __func__, __LINE__, pc2->text(), pc2->len(), pc2->orig_line, pc2->orig_col);
-      auto const &s1     = chunk_sort_str(pc1);
-      auto const &s2     = chunk_sort_str(pc2);
-      int        ret_val = unc_text::compare(s1, s2, std::min(s1.size(), s2.size()), tcare);
+
+      int ret_val = unc_text::compare(s1, s2, std::min(s1.size(), s2.size()), tcare);
       LOG_FMT(LSORT, "%s(%d): ret_val is %d\n",
               __func__, __LINE__, ret_val);
 

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -2775,6 +2775,10 @@ mod_sort_using                  = false    # true/false
 # break your code if your includes/imports have ordering dependencies.
 mod_sort_include                = false    # true/false
 
+# Whether to prioritize '#include' and '#import' statements that contains
+# filename when sorting is enabled.
+mod_sort_incl_import_prioritize_filename = false    # true/false
+
 # Whether to move a 'break' that appears after a fully braced 'case' before
 # the close brace, as in 'case X: { ... } break;' => 'case X: { ... break; }'.
 mod_move_case_break             = false    # true/false

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -6103,6 +6103,14 @@ EditorType=boolean
 TrueFalse=mod_sort_include=true|mod_sort_include=false
 ValueDefault=false
 
+[Mod Sort Incl Import Prioritize Filename]
+Category=9
+Description="<html>Whether to prioritize '#include' and '#import' statements that contains<br/>filename when sorting is enabled.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=mod_sort_incl_import_prioritize_filename=true|mod_sort_incl_import_prioritize_filename=false
+ValueDefault=false
+
 [Mod Move Case Break]
 Category=9
 Description="<html>Whether to move a 'break' that appears after a fully braced 'case' before<br/>the close brace, as in 'case X: { ... } break;' =&gt; 'case X: { ... break; }'.</html>"

--- a/tests/config/mod_sort_incl_import_prioritize_filename.cfg
+++ b/tests/config/mod_sort_incl_import_prioritize_filename.cfg
@@ -1,0 +1,4 @@
+mod_sort_import                 = true
+mod_sort_using                  = true
+mod_sort_include                = true
+mod_sort_incl_import_prioritize_filename = true

--- a/tests/expected/oc/50031-sort_import.m
+++ b/tests/expected/oc/50031-sort_import.m
@@ -1,13 +1,13 @@
 // should be ddd, eee, fff
-#import "ddd"
-#import "fff"
 #import "sort_import.h"
+#import "ddd"
 #import "eee"
+#import "fff"
 
 // should be aaa, ccc
-#import "ccc"
 #import "sort_import+internal.h"
 #import "aaa"
+#import "ccc"
 // should be just bbb
 #import "bbb"
 

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -34,6 +34,7 @@
 50026  sp_after_throw_remove.cfg            oc/exceptions.m
 
 50030  sort_imports.cfg                     oc/sort_import.m
+50031  mod_sort_incl_import_prioritize_filename.cfg oc/sort_import.m
 
 50040  objc_complex_method.cfg              oc/complex_method.m
 


### PR DESCRIPTION
This option helps to prioritize #include and #imports statements that contains filename when sorting is enabled via flags `mod_sort_include` or `mod_sort_import`.