### PR TITLE
Improve comment before access spec indent heuristic

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2158,12 +2158,14 @@ void indent_text(void)
              * indented at brace level
              */
             indent_column_set(frm.top().indent_tmp);
-            // Issue 1161
+            // Issues 1161 + 2704
             // comments before 'access specifier' need to be aligned with the 'access specifier'
+            // unless it is a Doxygen comment
             chunk_t *pct = pc;
 
             while (  ((pct = chunk_get_prev_nnl(pct)) != nullptr)
-                  && chunk_is_comment(pct))
+                  && chunk_is_comment(pct)
+                  && !chunk_is_Doxygen_comment(pct))
             {
                chunk_t *t2 = chunk_get_prev(pct);
 

--- a/tests/expected/cpp/34197-bug_1161.cpp
+++ b/tests/expected/cpp/34197-bug_1161.cpp
@@ -1,3 +1,4 @@
+// Use case from issue #1161
 class test
 {
 	// comment 1 (gets methods)
@@ -17,4 +18,39 @@ class test
 		// set2
 		int set2();
 
+};
+
+// Use cases from issue #2704
+class Foo
+{
+	public:
+		/// @name Constructors
+		/// @{
+
+		Foo(int value) : value_(value)
+		{
+		}
+
+		/// @}
+
+	private:
+		int value_;
+};
+
+class Bar
+{
+	public:
+		/*!
+		 * @name Constructors
+		 * @{
+		 */
+
+		Bar(int value) : value_(value)
+		{
+		}
+
+		/*! @} */
+
+	private:
+		int value_;
 };

--- a/tests/input/cpp/bug_1161.cpp
+++ b/tests/input/cpp/bug_1161.cpp
@@ -1,3 +1,4 @@
+// Use case from issue #1161
 class test
 {
    // comment 1 (gets methods)
@@ -17,4 +18,37 @@ class test
                           // set2
                           int set2();
 
+};
+
+// Use cases from issue #2704
+class Foo
+{
+public:
+    /// @name Constructors
+    /// @{
+
+        Foo(int value) : value_(value)
+        {}
+
+            /// @}
+
+private:
+    int value_;
+};
+
+class Bar
+{
+public:
+            /*!
+             * @name Constructors
+             * @{
+             */
+
+        Bar(int value) : value_(value)
+        {}
+
+    /*! @} */
+
+private:
+    int value_;
 };


### PR DESCRIPTION
Implements the heuristic outlined in #2704. Works for `///`-style, `/*!`-style, and `/*@`-style comments, but not for the `/**`-style. It is a bit unclear how to reliably detect the latter in `chunk_is_Doxygen_comment`.