### PR TITLE
allow word to be present in between [] and () when indentifying a  c++ lambda

### DIFF
--- a/documentation/how_to_format_cpp_lambda_functions.rst
+++ b/documentation/how_to_format_cpp_lambda_functions.rst
@@ -3,64 +3,37 @@ Formatting C++ Lambda Expressions
 #################################
 
 Uncrustify supports some formatting of c++ lambda expressions, although the support is incomplete.
-A complete description of the c++ lambda expressions 
 The parts of c++ lambda expressions that are currently recognized by Uncrusitify are:
 
 .. code-block:: c++
 
   [ captures ] execution_context ( params ) specifiers -> ret { body }
   
-Explanations for all the tokens in the above lambda expression (except for execution_context) are found `here <https://en.cppreference.com/w/cpp/language/lambda>`_.
-The `execution_context` token is a non-standard addition to allow for specification of the execution space (e.g. host or device in CUDA).
-The native specifiers for the `execution_context` for lambda expression in CUDA are ``__device__`` and ``__host__ __device__``.
+Explanations for all the tokens in the above lambda expression (except for execution_context),
+as well as a complete description of c++ lambda expressions are found
+`here <https://en.cppreference.com/w/cpp/language/lambda>`_.
+The `execution_context` token is a non-standard addition to allow for specification of the 
+execution space (e.g. host or device in CUDA).
+The native specifiers for the `execution_context` for lambda expression in CUDA are 
+``__device__`` and ``__host__ __device__``.
 However, it is common for code to use a preprocessor variable in place of the native specifiers.
 
-The Uncrustify options for formatting of c++ lambda expressions are as follows:
+The Uncrustify options for formatting of c++ lambda expressions are:
 
 .. code-block::
 
-  # Add or remove space around '=' in C++11 lambda capture specifications.
-  #
-  # Overrides sp_assign.
-  sp_cpp_lambda_assign            = ignore   # ignore/add/remove/force
-  
-  # Add or remove space after the capture specification of a C++11 lambda when
-  # an argument list is present, as in '[] <here> (int x){ ... }'.
-  sp_cpp_lambda_square_paren      = ignore   # ignore/add/remove/force
-  
-  # Add or remove space after the capture specification of a C++11 lambda with
-  # no argument list is present, as in '[] <here> { ... }'.
-  sp_cpp_lambda_square_brace      = ignore   # ignore/add/remove/force
-  
-  # Add or remove space after the argument list of a C++11 lambda, as in
-  # '[](int x) <here> { ... }'.
-  sp_cpp_lambda_paren_brace       = ignore   # ignore/add/remove/force
-  
-  # Add or remove space between a lambda body and its call operator of an
-  # immediately invoked lambda, as in '[]( ... ){ ... } <here> ( ... )'.
-  sp_cpp_lambda_fparen            = ignore   # ignore/add/remove/force
-  
-  # Whether to indent the body of a C++11 lambda.
-  indent_cpp_lambda_body          = false    # true/false
-  
-  # Don't split one-line C++11 lambdas, as in '[]() { return 0; }'.
-  nl_cpp_lambda_leave_one_liners  = false    # true/false
-  
-  # Add or remove newline between C++11 lambda signature and '{'.
-  nl_cpp_ldef_brace               = ignore   # ignore/add/remove/force
-  
-  # The value might be used twice:
-  # - at the assignment
-  # - at the opening brace
-  #
-  # To prevent the double use of the indentation value, use this option with the
-  # value 'true'.
-  #
-  # true:  indentation will be used only once
-  # false: indentation will be used every time (default)
-  indent_cpp_lambda_only_once     = false    # true/false
+  sp_cpp_lambda_assign
+  sp_cpp_lambda_square_paren
+  sp_cpp_lambda_square_brace
+  sp_cpp_lambda_paren_brace
+  sp_cpp_lambda_fparen
+  nl_cpp_lambda_leave_one_liners
+  nl_cpp_ldef_brace
+  indent_cpp_lambda_body
+  indent_cpp_lambda_only_once
 
-  
+Please refer to the example configuration file at 
+`uncrustify/documentation/htdocs/default.cfg <https://github.com/uncrustify/uncrustify/blob/master/documentation/htdocs/default.cfg>`_ for an explanation of the options.
 Additionally, a multiple number of ``execution_context`` tokens may be set in the configuration file:
 
 .. code-block::

--- a/documentation/how_to_format_cpp_lambda_functions.rst
+++ b/documentation/how_to_format_cpp_lambda_functions.rst
@@ -5,22 +5,20 @@ Formatting C++ Lambda Expressions
 Uncrustify supports some formatting of c++ lambda expressions, although 
 the support is incomplete.
 The parts of c++ lambda expressions that are currently recognized by Uncrusitify
- are:
+are:
 
 .. code-block:: c++
 
   [ captures ] execution_context ( params ) specifiers -> ret { body }
   
-Explanations for all the tokens in the above lambda expression (except for 
-execution_context),
-as well as a complete description of c++ lambda expressions are found
-`here <https://en.cppreference.com/w/cpp/language/lambda>`_.
-The `execution_context` token is a non-standard addition to allow for 
-specification of the 
-execution space (e.g. host or device in CUDA).
+Explanations for all the tokens in the above lambda expression
+(except for ``execution_context``),
+as well as a complete description of c++ lambda expressions,
+are found `here <https://en.cppreference.com/w/cpp/language/lambda>`_.
+The ``execution_context`` token is a non-standard addition to allow for 
+specification of the execution space (e.g. host or device in CUDA).
 The native specifiers for the `execution_context` for lambda expression in CUDA 
-are 
-``__device__`` and ``__host__ __device__``.
+are ``__device__`` and ``__host__ __device__``.
 However, it is common for code to use a preprocessor variable in place of the 
 native specifiers.
 

--- a/documentation/how_to_format_cpp_lambda_functions.rst
+++ b/documentation/how_to_format_cpp_lambda_functions.rst
@@ -4,7 +4,7 @@ Formatting C++ Lambda Expressions
 
 Uncrustify supports some formatting of c++ lambda expressions, although the support is incomplete.
 A complete description of the c++ lambda expressions 
-The parts of c++ lambda expressions that is currently recognized by Uncrusitify is:
+The parts of c++ lambda expressions that are currently recognized by Uncrusitify are:
 
 .. code-block:: c++
 
@@ -13,11 +13,11 @@ The parts of c++ lambda expressions that is currently recognized by Uncrusitify 
 Explanations for all the tokens in the above lambda expression (except for execution_context) are found `here <https://en.cppreference.com/w/cpp/language/lambda>`_.
 The `execution_context` token is a non-standard addition to allow for specification of the execution space (e.g. host or device in CUDA).
 The native specifiers for the `execution_context` for lambda expression in CUDA are ``__device__`` and ``__host__ __device__``.
-However it is common for codes to use a preprocessor variable in place of the native specifiers.
+However, it is common for code to use a preprocessor variable in place of the native specifiers.
 
 The Uncrustify options for formatting of c++ lambda expressions are as follows:
 
-.. code-block:: c++
+.. code-block::
 
   # Add or remove space around '=' in C++11 lambda capture specifications.
   #
@@ -61,16 +61,19 @@ The Uncrustify options for formatting of c++ lambda expressions are as follows:
   indent_cpp_lambda_only_once     = false    # true/false
 
   
-Additionally, a multiple number of  "execution_context" token may be set in the configuration file using the ``EXECUTION_CONTEXT`` token.
-Each specification of the ``EXECTION_CONTEXT`` populate a list of allowable keywords to be used at the "execution_context" location.
-For example, the following shows setting 4 values (2 default, and 2 custom) for the execution_context.
+Additionally, a multiple number of ``execution_context`` tokens may be set in the configuration file:
 
-.. code-block:: c++
+.. code-block::
 
-  set EXECUTION_CONTEXT __device__
   set EXECUTION_CONTEXT __host__ __device__
-  set EXECUTION_CONTEXT DEVICE_LAMBDA_CONTEXT
-  set EXECUTION_CONTEXT HOST_DEVICE_LAMBDA_CONTEXT
+  set EXECUTION_CONTEXT DEVICE_LAMBDA_CONTEXT HOST_DEVICE_LAMBDA_CONTEXT
 
-The effect of these lines in the confiuration file is that any of the strings (__device__, __host__ __device__, DEVICE_LAMBDA_CONTEXT, HOST_DEVICE_LAMBDA_CONTEXT) will be recognized by uncrusitfy and will allow the lambda to be properly identified.
-
+The effect of these lines in the configuration file is that any of the strings
+(``__host__``, ``__device__``,
+``DEVICE_LAMBDA_CONTEXT``, ``HOST_DEVICE_LAMBDA_CONTEXT``)
+will be recognized by uncrusitfy
+and will allow the lambda to be properly identified.
+Note that each word after the token name
+(``EXECUTION_CONTEXT`` in this instance) is a separate token.
+This means that uncrustify will parse ``__host__`` and ``__device__``
+as separate tokens, and there is no need to specify ``__device__`` twice.

--- a/documentation/how_to_format_cpp_lambda_functions.rst
+++ b/documentation/how_to_format_cpp_lambda_functions.rst
@@ -1,0 +1,76 @@
+#################################
+Formatting C++ Lambda Expressions
+#################################
+
+Uncrustify supports some formatting of c++ lambda expressions, although the support is incomplete.
+A complete description of the c++ lambda expressions 
+The parts of c++ lambda expressions that is currently recognized by Uncrusitify is:
+
+.. code-block:: c++
+
+  [ captures ] execution_context ( params ) specifiers -> ret { body }
+  
+Explanations for all the tokens in the above lambda expression (except for execution_context) are found `here <https://en.cppreference.com/w/cpp/language/lambda>`_.
+The `execution_context` token is a non-standard addition to allow for specification of the execution space (e.g. host or device in CUDA).
+The native specifiers for the `execution_context` for lambda expression in CUDA are ``__device__`` and ``__host__ __device__``.
+However it is common for codes to use a preprocessor variable in place of the native specifiers.
+
+The Uncrustify options for formatting of c++ lambda expressions are as follows:
+
+.. code-block:: c++
+
+  # Add or remove space around '=' in C++11 lambda capture specifications.
+  #
+  # Overrides sp_assign.
+  sp_cpp_lambda_assign            = ignore   # ignore/add/remove/force
+  
+  # Add or remove space after the capture specification of a C++11 lambda when
+  # an argument list is present, as in '[] <here> (int x){ ... }'.
+  sp_cpp_lambda_square_paren      = ignore   # ignore/add/remove/force
+  
+  # Add or remove space after the capture specification of a C++11 lambda with
+  # no argument list is present, as in '[] <here> { ... }'.
+  sp_cpp_lambda_square_brace      = ignore   # ignore/add/remove/force
+  
+  # Add or remove space after the argument list of a C++11 lambda, as in
+  # '[](int x) <here> { ... }'.
+  sp_cpp_lambda_paren_brace       = ignore   # ignore/add/remove/force
+  
+  # Add or remove space between a lambda body and its call operator of an
+  # immediately invoked lambda, as in '[]( ... ){ ... } <here> ( ... )'.
+  sp_cpp_lambda_fparen            = ignore   # ignore/add/remove/force
+  
+  # Whether to indent the body of a C++11 lambda.
+  indent_cpp_lambda_body          = false    # true/false
+  
+  # Don't split one-line C++11 lambdas, as in '[]() { return 0; }'.
+  nl_cpp_lambda_leave_one_liners  = false    # true/false
+  
+  # Add or remove newline between C++11 lambda signature and '{'.
+  nl_cpp_ldef_brace               = ignore   # ignore/add/remove/force
+  
+  # The value might be used twice:
+  # - at the assignment
+  # - at the opening brace
+  #
+  # To prevent the double use of the indentation value, use this option with the
+  # value 'true'.
+  #
+  # true:  indentation will be used only once
+  # false: indentation will be used every time (default)
+  indent_cpp_lambda_only_once     = false    # true/false
+
+  
+Additionally, a multiple number of  "execution_context" token may be set in the configuration file using the ``EXECUTION_CONTEXT`` token.
+Each specification of the ``EXECTION_CONTEXT`` populate a list of allowable keywords to be used at the "execution_context" location.
+For example, the following shows setting 4 values (2 default, and 2 custom) for the execution_context.
+
+.. code-block:: c++
+
+  set EXECUTION_CONTEXT __device__
+  set EXECUTION_CONTEXT __host__ __device__
+  set EXECUTION_CONTEXT DEVICE_LAMBDA_CONTEXT
+  set EXECUTION_CONTEXT HOST_DEVICE_LAMBDA_CONTEXT
+
+The effect of these lines in the confiuration file is that any of the strings (__device__, __host__ __device__, DEVICE_LAMBDA_CONTEXT, HOST_DEVICE_LAMBDA_CONTEXT) will be recognized by uncrusitfy and will allow the lambda to be properly identified.
+

--- a/documentation/how_to_format_cpp_lambda_functions.rst
+++ b/documentation/how_to_format_cpp_lambda_functions.rst
@@ -2,21 +2,27 @@
 Formatting C++ Lambda Expressions
 #################################
 
-Uncrustify supports some formatting of c++ lambda expressions, although the support is incomplete.
-The parts of c++ lambda expressions that are currently recognized by Uncrusitify are:
+Uncrustify supports some formatting of c++ lambda expressions, although 
+the support is incomplete.
+The parts of c++ lambda expressions that are currently recognized by Uncrusitify
+ are:
 
 .. code-block:: c++
 
   [ captures ] execution_context ( params ) specifiers -> ret { body }
   
-Explanations for all the tokens in the above lambda expression (except for execution_context),
+Explanations for all the tokens in the above lambda expression (except for 
+execution_context),
 as well as a complete description of c++ lambda expressions are found
 `here <https://en.cppreference.com/w/cpp/language/lambda>`_.
-The `execution_context` token is a non-standard addition to allow for specification of the 
+The `execution_context` token is a non-standard addition to allow for 
+specification of the 
 execution space (e.g. host or device in CUDA).
-The native specifiers for the `execution_context` for lambda expression in CUDA are 
+The native specifiers for the `execution_context` for lambda expression in CUDA 
+are 
 ``__device__`` and ``__host__ __device__``.
-However, it is common for code to use a preprocessor variable in place of the native specifiers.
+However, it is common for code to use a preprocessor variable in place of the 
+native specifiers.
 
 The Uncrustify options for formatting of c++ lambda expressions are:
 
@@ -33,8 +39,10 @@ The Uncrustify options for formatting of c++ lambda expressions are:
   indent_cpp_lambda_only_once
 
 Please refer to the example configuration file at 
-`uncrustify/documentation/htdocs/default.cfg <https://github.com/uncrustify/uncrustify/blob/master/documentation/htdocs/default.cfg>`_ for an explanation of the options.
-Additionally, a multiple number of ``execution_context`` tokens may be set in the configuration file:
+`uncrustify/documentation/htdocs/default.cfg <https://github.com/uncrustify/uncrustify/blob/master/documentation/htdocs/default.cfg>`_ 
+for an explanation of the options.
+Additionally, a multiple number of ``execution_context`` tokens may be set in 
+the configuration file:
 
 .. code-block::
 

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -5862,8 +5862,15 @@ static void handle_cpp_lambda(chunk_t *sq_o)
          return;
       }
    }
-   // lambda-declarator '( params )' is optional
    chunk_t *pa_o = chunk_get_next_ncnl(sq_c);
+
+   // check to see if there is a lambda-specifier in the pa_o chunk
+   // assuming chunk is CT_EXECUTION_CONTEXT, ignore lambda-specifier
+   while (pa_o->type == CT_EXECUTION_CONTEXT)
+   {
+      // set pa_o to next chunk after this specifier
+      pa_o = chunk_get_next_ncnl(pa_o);
+   }
 
    if (pa_o == nullptr)
    {
@@ -5871,6 +5878,7 @@ static void handle_cpp_lambda(chunk_t *sq_o)
    }
    chunk_t *pa_c = nullptr;
 
+   // lambda-declarator '( params )' is optional
    if (chunk_is_token(pa_o, CT_PAREN_OPEN))
    {
       // and now find the ')'

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -5864,7 +5864,7 @@ static void handle_cpp_lambda(chunk_t *sq_o)
    }
    chunk_t *pa_o = chunk_get_next_ncnl(sq_c);
 
-   // check to see if there is a lambda-specifier in the pa_o chunk
+   // check to see if there is a lambda-specifier in the pa_o chunk;
    // assuming chunk is CT_EXECUTION_CONTEXT, ignore lambda-specifier
    while (pa_o->type == CT_EXECUTION_CONTEXT)
    {

--- a/src/token_enum.h
+++ b/src/token_enum.h
@@ -229,35 +229,36 @@ enum c_token_t
    CT_MACRO_ELSE,
 
    // aggregate types
-   CT_LABEL,            // a non-case label
-   CT_LABEL_COLON,      // the colon for a label
-   CT_FUNCTION,         // function - unspecified, call mark_function()
-   CT_FUNC_CALL,        // function call
-   CT_FUNC_CALL_USER,   // function call (special user)
-   CT_FUNC_DEF,         // function definition/implementation
-   CT_FUNC_TYPE,        // function type - foo in "typedef void (*foo)(void)"
-   CT_FUNC_VAR,         // foo and parent type of first parens in "void (*foo)(void)"
-   CT_FUNC_PROTO,       // function prototype
-   CT_FUNC_START,       // global DC member for functions(void ::func())
-   CT_FUNC_CLASS_DEF,   // ctor or dtor for a class
-   CT_FUNC_CLASS_PROTO, // ctor or dtor for a class
-   CT_FUNC_CTOR_VAR,    // variable or class initialization
-   CT_FUNC_WRAP,        // macro that wraps the function name
-   CT_PROTO_WRAP,       // macro: "RETVAL PROTO_WRAP( fcn_name, (PARAMS))". Parens for PARAMS are optional.
-   CT_MACRO_FUNC,       // function-like macro
-   CT_MACRO,            // a macro def
-   CT_QUALIFIER,        // static, const, etc
-   CT_EXTERN,           // extern
-   CT_DECLSPEC,         // __declspec
-   CT_ALIGN,            // paren'd qualifier: align(4) struct a { }
+   CT_LABEL,              // a non-case label
+   CT_LABEL_COLON,        // the colon for a label
+   CT_FUNCTION,           // function - unspecified, call mark_function()
+   CT_FUNC_CALL,          // function call
+   CT_FUNC_CALL_USER,     // function call (special user)
+   CT_FUNC_DEF,           // function definition/implementation
+   CT_FUNC_TYPE,          // function type - foo in "typedef void (*foo)(void)"
+   CT_FUNC_VAR,           // foo and parent type of first parens in "void (*foo)(void)"
+   CT_FUNC_PROTO,         // function prototype
+   CT_FUNC_START,         // global DC member for functions(void ::func())
+   CT_FUNC_CLASS_DEF,     // ctor or dtor for a class
+   CT_FUNC_CLASS_PROTO,   // ctor or dtor for a class
+   CT_FUNC_CTOR_VAR,      // variable or class initialization
+   CT_FUNC_WRAP,          // macro that wraps the function name
+   CT_PROTO_WRAP,         // macro: "RETVAL PROTO_WRAP( fcn_name, (PARAMS))". Parens for PARAMS are optional.
+   CT_MACRO_FUNC,         // function-like macro
+   CT_MACRO,              // a macro def
+   CT_QUALIFIER,          // static, const, etc
+   CT_EXTERN,             // extern
+   CT_DECLSPEC,           // __declspec
+   CT_ALIGN,              // paren'd qualifier: align(4) struct a { }
    CT_TYPE,
-   CT_PTR_TYPE,         // a '*' as part of a type
-   CT_TYPE_WRAP,        // macro that wraps a type name
-   CT_CPP_LAMBDA,       // parent for '[=](...){...}'
-   CT_CPP_LAMBDA_RET,   // '->' in '[=](...) -> type {...}'
-   CT_TRAILING_RET,     // '->' in 'auto fname(...) -> type;'
-                        // '->' in 'auto fname(...) const -> type;'
-   CT_BIT_COLON,        // a ':' in a variable declaration
+   CT_PTR_TYPE,           // a '*' as part of a type
+   CT_TYPE_WRAP,          // macro that wraps a type name
+   CT_CPP_LAMBDA,         // parent for '[=](...){...}'
+   CT_CPP_LAMBDA_RET,     // '->' in '[=](...) -> type {...}'
+   CT_EXECUTION_CONTEXT,  // Keyword for use in lambda statement: [] CT_EXECUTION_CONTEXT ()->{}
+   CT_TRAILING_RET,       // '->' in 'auto fname(...) -> type;'
+                          // '->' in 'auto fname(...) const -> type;'
+   CT_BIT_COLON,          // a ':' in a variable declaration
 
    CT_OC_DYNAMIC,
    CT_OC_END,           // ObjC: @end

--- a/tests/config/Issue_1813.cfg
+++ b/tests/config/Issue_1813.cfg
@@ -7,5 +7,4 @@ indent_cpp_lambda_only_once    = true
 sp_cpp_lambda_paren_brace      = add
 set EXECUTION_CONTEXT DEVICE_LAMBDA_CONTEXT
 set EXECUTION_CONTEXT HOST_DEVICE_LAMBDA_CONTEXT
-set EXECUTION_CONTEXT __device__
 set EXECUTION_CONTEXT __host__ __device__

--- a/tests/config/Issue_1813.cfg
+++ b/tests/config/Issue_1813.cfg
@@ -4,3 +4,8 @@ indent_namespace               = true
 indent_namespace_single_indent = true
 use_indent_continue_only_once  = true
 indent_cpp_lambda_only_once    = true
+sp_cpp_lambda_paren_brace      = add
+set EXECUTION_CONTEXT DEVICE_LAMBDA_CONTEXT
+set EXECUTION_CONTEXT HOST_DEVICE_LAMBDA_CONTEXT
+set EXECUTION_CONTEXT __device__
+set EXECUTION_CONTEXT __host__ __device__

--- a/tests/expected/cpp/30907-Issue_1813.cpp
+++ b/tests/expected/cpp/30907-Issue_1813.cpp
@@ -1,10 +1,26 @@
-namespace blah0
+namespace ns1
 {
-namespace blah
+namespace ns2
 {
    void func0()
    {
-      functionThatTakesALambda( [&]() -> void
+      functionThatTakesALambda( [&] () -> void
+      {
+         lambdaBody;
+      });
+      functionThatTakesALambda( [&] __device__ () -> void
+      {
+         lambdaBody;
+      });
+      functionThatTakesALambda( [&] __host__ __device__ () -> void
+      {
+         lambdaBody;
+      });
+      functionThatTakesALambda( [&] DEVICE_LAMBDA_CONTEXT () -> void
+      {
+         lambdaBody;
+      });
+      functionThatTakesALambda( [&] HOST_DEVICE_LAMBDA_CONTEXT () -> void
       {
          lambdaBody;
       });

--- a/tests/input/cpp/Issue_1813.cpp
+++ b/tests/input/cpp/Issue_1813.cpp
@@ -1,10 +1,26 @@
-namespace blah0
+namespace ns1
 {
-namespace blah
+namespace ns2
 {
 void func0()
 {
-functionThatTakesALambda( [&]() -> void
+functionThatTakesALambda( [&] () -> void
+{
+lambdaBody;
+});
+functionThatTakesALambda( [&] __device__ () -> void
+{
+lambdaBody;
+});
+functionThatTakesALambda( [&] __host__ __device__ () -> void
+{
+lambdaBody;
+});
+functionThatTakesALambda( [&] DEVICE_LAMBDA_CONTEXT () -> void
+{
+lambdaBody;
+});
+functionThatTakesALambda( [&] HOST_DEVICE_LAMBDA_CONTEXT () -> void
 {
 lambdaBody;
 });


### PR DESCRIPTION
This PR is related to #1813 . The code change seeks to allow for the inclusion of a lambda specifier between `[]` and `()` in a lambda function. Specifically this allows for proper identification of a lambda when a lambda specifier is included. Without this, the following example was incorrectly formatted:
```
Uncrustify_d-0.70.1-287-0625f89e

../uncrustify -c uncrustify.cfg -f test.cpp 
Parsing: test.cpp as language CPP
namespace blah0
{
namespace blah
{
void func0()
{
  functionThatTakesALambda( [&] __device__ ()->void
      {
        lambdaBody;
      });
}
}
}
```

This change results in:
```
namespace blah0
{
namespace blah
{
void func0()
{
  functionThatTakesALambda( [&] __device__ () -> void
  {
    lambdaBody;
  });
}
}
}
```

I do have concerns about how this change will conflict with the `sp_cpp_lambda_square_paren` option as it conflicts with the premise that is only whitespace possible between `[] ()`