### PR TITLE
Fix issue on handling modernized raw string literals in OC/OC+

### DIFF
--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -2200,6 +2200,16 @@ static bool parse_next(tok_ctx &ctx, chunk_t &pc)
    {
       size_t nc = ctx.peek(1);
 
+      if (nc == 'R') // Issue #2720
+      {
+         if (ctx.peek(2) == '"')
+         {
+            // parse string without escaping
+            parse_string(ctx, pc, 2, false);
+            return(true);
+         }
+      }
+
       if ((nc == '"') || (nc == '\''))
       {
          // literal string

--- a/tests/expected/oc/50009-literals.m
+++ b/tests/expected/oc/50009-literals.m
@@ -29,6 +29,9 @@ void main(int argc, const char *argv[])
    NSNumber *yesNumber = @YES;          // equivalent to [NSNumber numberWithBool:YES]
    NSNumber *noNumber  = @NO;           // equivalent to [NSNumber numberWithBool:NO]
 
+   // Raw string literals
+   NSString *rawString = [NSString stringWithFormat:@R"(embedded "quotes ")"];
+
 #ifdef __cplusplus
    NSNumber *trueNumber  = @true;       // equivalent to [NSNumber numberWithBool:(BOOL)true]
    NSNumber *falseNumber = @false;      // equivalent to [NSNumber numberWithBool:(BOOL)false]

--- a/tests/input/oc/literals.m
+++ b/tests/input/oc/literals.m
@@ -4,7 +4,7 @@ NSDictionary *dictionary = @{@0: @"red",  @1: @"green",  @2: @"blue"};
 NSArray *array = @[@0, @1, @2, @YES, @'Z', @42U];
 
 NSArray *multilineArray = @[
-@0, @1, @2, @YES, 
+@0, @1, @2, @YES,
 @'Z', @42U
 ];
 
@@ -25,6 +25,9 @@ void main(int argc, const char *argv[]) {
   // BOOL literals.
   NSNumber *yesNumber = @YES;           // equivalent to [NSNumber numberWithBool:YES]
   NSNumber *noNumber = @NO;             // equivalent to [NSNumber numberWithBool:NO]
+
+  // Raw string literals
+  NSString *rawString = [NSString stringWithFormat:@R"(embedded "quotes")"];
 
 #ifdef __cplusplus
   NSNumber *trueNumber = @true;         // equivalent to [NSNumber numberWithBool:(BOOL)true]


### PR DESCRIPTION
Modernized raw strings are introduced in CPP 11 https://clang.llvm.org/extra/clang-tidy/checks/modernize-raw-string-literal.html. Fixed the issue to handle the raw string correctly and added required tests. Fixes issue #2720.