### PR TITLE
Fix issue where `*` is incorrectly tokenized as `CT_ARITH` in functions decls and defs after macros

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -4872,7 +4872,10 @@ static void mark_function(chunk_t *pc)
 
       if (  isa_def
          && prev != nullptr
-         && (  (chunk_is_paren_close(prev) && get_chunk_parent_type(prev) != CT_D_CAST)
+         && (  (  chunk_is_paren_close(prev)
+               && get_chunk_parent_type(prev) != CT_D_CAST
+               && get_chunk_parent_type(prev) != CT_MACRO_OPEN  // Issue #2726
+               && get_chunk_parent_type(prev) != CT_MACRO_CLOSE)
             || prev->type == CT_ASSIGN
             || prev->type == CT_RETURN))
       {

--- a/tests/config/ptr_star-2.cfg
+++ b/tests/config/ptr_star-2.cfg
@@ -3,3 +3,7 @@ sp_between_ptr_star             = remove
 sp_after_ptr_star               = remove
 sp_before_byref                 = force
 sp_after_byref                  = remove
+
+macro-close NS_SWIFT_NAME
+macro-close VIEW_CONTROLLER_MACRO
+macro-close MACRO_FUNCTION

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -324,6 +324,7 @@
 30826  Issue_2319.cfg                       cpp/Issue_2319.cpp
 30827  Issue_1167.cfg                       cpp/Issue_1167.cpp
 30828  bug_1691.cfg                         cpp/bug_1691.cpp
+30829  ptr_star-2.cfg                       cpp/Issue_2726.cpp
 
 30830  kw_subst2.cfg                        cpp/kw_subst.cpp
 30831  kw_subst.cfg                         cpp/kw_subst2.cpp

--- a/tests/expected/cpp/30829-Issue_2726.cpp
+++ b/tests/expected/cpp/30829-Issue_2726.cpp
@@ -1,0 +1,13 @@
+VIEW_CONTROLLER_MACRO(ThreadButton)
+UIViewController *MSGCreate(MBAMailbox *mailbox, NSNumber *threadKey);
+
+
+NS_SWIFT_NAME(Create(String))
+Controller *create(NSString *str);
+
+
+MACRO_FUNCTION
+Object *create( NSString *str, NSDictionary<NSString *, NSArray *> *data, string **str)
+{
+	return nullptr;
+}

--- a/tests/input/cpp/Issue_2726.cpp
+++ b/tests/input/cpp/Issue_2726.cpp
@@ -1,0 +1,13 @@
+VIEW_CONTROLLER_MACRO(ThreadButton)
+UIViewController * MSGCreate(MBAMailbox *  mailbox, NSNumber *  threadKey);
+
+
+NS_SWIFT_NAME(Create(String))
+Controller * create(NSString *  str);
+
+
+MACRO_FUNCTION
+Object * create( NSString * str, NSDictionary<NSString *, NSArray *> *  data, string **  str)
+{
+  return nullptr;
+}


### PR DESCRIPTION
Fix issue where `*` is incorrectly tokenized as `CT_ARITH` in functions declarations and definitions after macros.

Fixes the issue #2726.