### PR TITLE
Fix CT_TYPE is incorrectly tokenized as CT_WORD in OC block typedef

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -662,10 +662,14 @@ static bool chunk_ends_type(chunk_t *start)
       if (  chunk_is_token(pc, CT_WORD)
          || chunk_is_token(pc, CT_TYPE)
          || chunk_is_token(pc, CT_PTR_TYPE)
+         || chunk_is_token(pc, CT_STAR)
          || chunk_is_token(pc, CT_STRUCT)
          || chunk_is_token(pc, CT_DC_MEMBER)
          || chunk_is_token(pc, CT_PP)
          || chunk_is_token(pc, CT_QUALIFIER)
+         || (  language_is_set(LANG_CPP | LANG_OC) // Issue #2727
+            && get_chunk_parent_type(pc) == CT_TEMPLATE
+            && (chunk_is_token(pc, CT_ANGLE_OPEN) || chunk_is_token(pc, CT_ANGLE_CLOSE)))
          || (language_is_set(LANG_CS) && (chunk_is_token(pc, CT_MEMBER))))
       {
          cnt++;

--- a/tests/config/633_decl-in-func-typedef.cfg
+++ b/tests/config/633_decl-in-func-typedef.cfg
@@ -1,1 +1,4 @@
 sp_arith = add
+sp_before_ptr_star = force
+sp_after_ptr_star = remove
+sp_ptr_star_paren = remove

--- a/tests/expected/cpp/10003-633_decl-in-func-typedef.cpp
+++ b/tests/expected/cpp/10003-633_decl-in-func-typedef.cpp
@@ -1,2 +1,5 @@
 typedef void (*func)();
 typedef void (__stdcall *func)();
+
+typedef std::vector<string *> *(*Finder )(std::string *);
+typedef vector<std::string *> *(*Handler )(std::map< std::string *, vector *> *);

--- a/tests/expected/oc/50206-issue_2727.m
+++ b/tests/expected/oc/50206-issue_2727.m
@@ -1,0 +1,2 @@
+typedef NSArray<NSString *> *(^Finder)(NSArray *);
+typedef NSArray<NSString *> *(^Handler)(NSDictionary<NSString *, NSArray *> *);

--- a/tests/input/cpp/633_decl-in-func-typedef.cpp
+++ b/tests/input/cpp/633_decl-in-func-typedef.cpp
@@ -1,2 +1,5 @@
 typedef void (*func)();
 typedef void (__stdcall *func)();
+
+typedef std::vector<string *> * (*   Finder )(std::string *);
+typedef vector<std::string *> * (* Handler )(std::map< std::string  * , vector *> *);

--- a/tests/input/oc/issue_2727.m
+++ b/tests/input/oc/issue_2727.m
@@ -1,0 +1,2 @@
+typedef NSArray<NSString *> * (^   Finder )(NSArray *);
+typedef NSArray<     NSString *     >    *      (^ Handler )( NSDictionary< NSString * , NSArray * >  *);

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -88,6 +88,7 @@
 50203  sp_block_as_argument3.cfg            oc/blocks_align.m
 50204  sp_block_as_argument4.cfg            oc/blocks_align.m
 50205  sp_block_as_argument5.cfg            oc/msg_align.m
+50206  aet.cfg                              oc/issue_2727.m
 
 50300  sp_after_send_oc_colon-f.cfg         oc/msg.m
 


### PR DESCRIPTION
Fixes issue #2727.