### PR TITLE
Fix handling of nl_squeeze_ifdef

### DIFF
--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -980,6 +980,21 @@ chunk_t *chunk_get_prev_ssq(chunk_t *cur)
 }
 
 
+chunk_t *chunk_get_pp_start(chunk_t *cur)
+{
+   if (!chunk_is_preproc(cur))
+   {
+      return(nullptr);
+   }
+
+   while (!chunk_is_token(cur, CT_PREPROC))
+   {
+      cur = chunk_get_prev(cur, scope_e::PREPROC);
+   }
+   return(cur);
+}
+
+
 //! skip to the final word/type in a :: chain
 static chunk_t *chunk_skip_dc_member(chunk_t *start, scope_e scope, direction_e dir)
 {

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -421,6 +421,16 @@ chunk_t *chunk_get_next_ssq(chunk_t *cur);
 chunk_t *chunk_get_prev_ssq(chunk_t *cur);
 
 /**
+ * Gets the corresponding start chunk if the given chunk is within a
+ * preprocessor directive, or nullptr otherwise.
+ *
+ * @param  cur    chunk to use as start point
+ *
+ * @return nullptr or start chunk of the preprocessor directive
+ */
+chunk_t *chunk_get_pp_start(chunk_t *cur);
+
+/**
  * @brief reverse search a chunk of a given category in a chunk list
  *
  * @param  pc   chunk list to search in

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -333,9 +333,12 @@ static bool can_increase_nl(chunk_t *nl)
    {
       log_rule_B("nl_squeeze_ifdef");
 
-      if (  chunk_is_token(prev, CT_PREPROC)
-         && get_chunk_parent_type(prev) == CT_PP_ENDIF
-         && (prev->level > 0 || options::nl_squeeze_ifdef_top_level()))
+      chunk_t *pp_start = chunk_get_pp_start(prev);
+
+      if (  pp_start != nullptr
+         && (  get_chunk_parent_type(pp_start) == CT_PP_IF
+            || get_chunk_parent_type(pp_start) == CT_PP_ELSE)
+         && (pp_start->level > 0 || options::nl_squeeze_ifdef_top_level()))
       {
          log_rule_B("nl_squeeze_ifdef_top_level");
          LOG_FMT(LBLANKD, "%s(%d): nl_squeeze_ifdef %zu (prev) pp_lvl=%zu rv=0\n",

--- a/tests/config/no_squeeze_ifdef.cfg
+++ b/tests/config/no_squeeze_ifdef.cfg
@@ -1,2 +1,3 @@
 nl_before_return                = true
 nl_after_return                 = true
+nl_before_cpp_comment           = 2

--- a/tests/config/squeeze_ifdef.cfg
+++ b/tests/config/squeeze_ifdef.cfg
@@ -1,0 +1,3 @@
+nl_before_return                = true
+nl_after_return                 = true
+nl_squeeze_ifdef                = true

--- a/tests/config/squeeze_ifdef.cfg
+++ b/tests/config/squeeze_ifdef.cfg
@@ -1,3 +1,4 @@
 nl_before_return                = true
 nl_after_return                 = true
+nl_before_cpp_comment           = 2
 nl_squeeze_ifdef                = true

--- a/tests/config/squeeze_ifdef_top.cfg
+++ b/tests/config/squeeze_ifdef_top.cfg
@@ -1,2 +1,3 @@
+nl_before_cpp_comment           = 2
 nl_squeeze_ifdef                = true
 nl_squeeze_ifdef_top_level      = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -585,7 +585,7 @@
 
 33090  empty.cfg                            cpp/gh555.cpp
 33091  no_squeeze_ifdef.cfg                 cpp/squeeze_ifdef.cpp
-33092  empty.cfg                            cpp/squeeze_ifdef.cpp
+33092  squeeze_ifdef.cfg                    cpp/squeeze_ifdef.cpp
 33093  sp_angle_paren-f.cfg                 cpp/sp_angle_paren.cpp
 33094  sp_angle_paren_empty.cfg             cpp/sp_angle_paren.cpp
 33095  bug_i_322.cfg                        cpp/bug_i_322.cpp

--- a/tests/expected/cpp/33091-squeeze_ifdef.cpp
+++ b/tests/expected/cpp/33091-squeeze_ifdef.cpp
@@ -1,20 +1,35 @@
 
 #if defined(A)
 
-extern int a;
+// Comment
+extern int ax;
 
 #elif defined(B)
 
-extern int b;
+extern int bx;
 
 #else
 
-extern int c;
+extern int cx;
 
 #endif
 
 int foo()
 {
+#if defined(A)
+
+	int a = ax;
+
+#elif defined(B)
+
+	// Comment
+	int b = bx;
+
+#else
+
+	int c = cx;
+
+#endif
 #if defined(A)
 
 	return a;
@@ -25,6 +40,7 @@ int foo()
 
 #else
 
+	// Comment
 	return c;
 
 #endif

--- a/tests/expected/cpp/33092-squeeze_ifdef.cpp
+++ b/tests/expected/cpp/33092-squeeze_ifdef.cpp
@@ -1,25 +1,37 @@
 
 #if defined(A)
 
-extern int a;
+// Comment
+extern int ax;
 
 #elif defined(B)
 
-extern int b;
+extern int bx;
 
 #else
 
-extern int c;
+extern int cx;
 
 #endif
 
 int foo()
 {
 #if defined(A)
+	int a = ax;
+#elif defined(B)
+
+	// Comment
+	int b = bx;
+#else
+	int c = cx;
+#endif
+#if defined(A)
 	return a;
 #elif defined(B)
 	return b;
 #else
+
+	// Comment
 	return c;
 #endif
 }

--- a/tests/expected/cpp/33092-squeeze_ifdef.cpp
+++ b/tests/expected/cpp/33092-squeeze_ifdef.cpp
@@ -19,7 +19,6 @@ int foo()
 #if defined(A)
 	int a = ax;
 #elif defined(B)
-
 	// Comment
 	int b = bx;
 #else
@@ -30,7 +29,6 @@ int foo()
 #elif defined(B)
 	return b;
 #else
-
 	// Comment
 	return c;
 #endif

--- a/tests/expected/cpp/33096-squeeze_ifdef.cpp
+++ b/tests/expected/cpp/33096-squeeze_ifdef.cpp
@@ -1,19 +1,32 @@
 
 #if defined(A)
-extern int a;
+
+// Comment
+extern int ax;
 #elif defined(B)
-extern int b;
+extern int bx;
 #else
-extern int c;
+extern int cx;
 #endif
 
 int foo()
 {
 #if defined(A)
+	int a = ax;
+#elif defined(B)
+
+	// Comment
+	int b = bx;
+#else
+	int c = cx;
+#endif
+#if defined(A)
 	return a;
 #elif defined(B)
 	return b;
 #else
+
+	// Comment
 	return c;
 #endif
 }

--- a/tests/expected/cpp/33096-squeeze_ifdef.cpp
+++ b/tests/expected/cpp/33096-squeeze_ifdef.cpp
@@ -1,6 +1,5 @@
 
 #if defined(A)
-
 // Comment
 extern int ax;
 #elif defined(B)
@@ -14,7 +13,6 @@ int foo()
 #if defined(A)
 	int a = ax;
 #elif defined(B)
-
 	// Comment
 	int b = bx;
 #else
@@ -25,7 +23,6 @@ int foo()
 #elif defined(B)
 	return b;
 #else
-
 	// Comment
 	return c;
 #endif

--- a/tests/input/cpp/squeeze_ifdef.cpp
+++ b/tests/input/cpp/squeeze_ifdef.cpp
@@ -1,25 +1,41 @@
 
 #if defined(A)
 
-extern int a;
+// Comment
+extern int ax;
 
 #elif defined(B)
 
-extern int b;
+extern int bx;
 
 #else
 
-extern int c;
+extern int cx;
 
 #endif
 
 int foo()
 {
 #if defined(A)
+
+    int a = ax;
+
+#elif defined(B)
+
+    // Comment
+    int b = bx;
+
+#else
+
+    int c = cx;
+
+#endif
+#if defined(A)
     return a;
 #elif defined(B)
     return b;
 #else
+    // Comment
     return c;
 #endif
 }


### PR DESCRIPTION
Prevent generation of blank lines after `#if/#elif/#else` during `do_blank_lines` if `nl_squeeze_ifdef` and/or `nl_squeeze_ifdef_top_level` are set to `true`.  This happens, for example, if an `#if` is followed by a C++-style comment and `nl_before_cpp_comment` is set to a value >1.

For a "whole-file" `#if`, squeezing is not yet disabled (like it is done for the `#endif`). Since whole-file `#if`s are most often used for include guards in conjunction with an immediately following `#define`, this may not be necessary. However, if this behavior is desired (or just for consistency), it can easily be added.