### PR TITLE
Improve consistency of 'nl_(before|after)_access_spec'

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -5633,22 +5633,6 @@ void do_blank_lines(void)
          }
       }
 
-      // Control blanks before an access spec
-      if (  (options::nl_before_access_spec() > 0)
-         && (options::nl_before_access_spec() != pc->nl_count)
-         && chunk_is_token(next, CT_ACCESS))
-      {
-         log_rule_B("nl_before_access_spec");
-
-         // Don't add blanks after a open brace
-         if (  prev == nullptr
-            || (prev->type != CT_BRACE_OPEN && prev->type != CT_VBRACE_OPEN))
-         {
-            blank_line_set(pc, options::nl_before_access_spec);
-            log_rule_B("nl_before_access_spec");
-         }
-      }
-
       // Control blanks before a class
       if (  (chunk_is_token(prev, CT_SEMICOLON) || chunk_is_token(prev, CT_BRACE_CLOSE))
          && get_chunk_parent_type(prev) == CT_CLASS)
@@ -5925,6 +5909,22 @@ void do_blank_lines(void)
          {
             blank_line_set(pc, options::nl_around_cs_property);
             log_rule_B("nl_around_cs_property");
+         }
+      }
+
+      // Control blanks before an access spec
+      if (  (options::nl_before_access_spec() > 0)
+         && (options::nl_before_access_spec() != pc->nl_count)
+         && chunk_is_token(next, CT_ACCESS))
+      {
+         log_rule_B("nl_before_access_spec");
+
+         // Don't add blanks after a open brace
+         if (  prev == nullptr
+            || (prev->type != CT_BRACE_OPEN && prev->type != CT_VBRACE_OPEN))
+         {
+            blank_line_set(pc, options::nl_before_access_spec);
+            log_rule_B("nl_before_access_spec");
          }
       }
 

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -5919,12 +5919,13 @@ void do_blank_lines(void)
       {
          log_rule_B("nl_before_access_spec");
 
-         // Don't add blanks after a open brace
+         // Don't add blanks after an open brace
          if (  prev == nullptr
-            || (prev->type != CT_BRACE_OPEN && prev->type != CT_VBRACE_OPEN))
+            || (  chunk_is_not_token(prev, CT_BRACE_OPEN)
+               && chunk_is_not_token(prev, CT_VBRACE_OPEN)))
          {
-            blank_line_set(pc, options::nl_before_access_spec);
             log_rule_B("nl_before_access_spec");
+            blank_line_set(pc, options::nl_before_access_spec);
          }
       }
 

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -5686,7 +5686,15 @@ void do_blank_lines(void)
          && chunk_is_token(prev, CT_ACCESS_COLON))
       {
          log_rule_B("nl_after_access_spec");
-         blank_line_set(pc, options::nl_after_access_spec);
+
+         // Don't add blanks before a closing brace
+         if (  next == nullptr
+            || (  chunk_is_not_token(next, CT_BRACE_CLOSE)
+               && chunk_is_not_token(next, CT_VBRACE_CLOSE)))
+         {
+            log_rule_B("nl_after_access_spec");
+            blank_line_set(pc, options::nl_after_access_spec);
+         }
       }
 
       // Add blanks after function bodies

--- a/tests/config/nl_access_spec.cfg
+++ b/tests/config/nl_access_spec.cfg
@@ -4,3 +4,5 @@ nl_class_brace                  = force
 nl_after_semicolon              = true
 nl_before_access_spec           = 3
 nl_after_access_spec            = 2
+nl_after_func_body_class        = 2
+nl_after_struct                 = 4

--- a/tests/expected/cpp/30730-qt-1.cpp
+++ b/tests/expected/cpp/30730-qt-1.cpp
@@ -3,7 +3,8 @@ class Foo : public QObject
     Q_OBJECT
 
 private slots:
-    void mySlot( );
+    void mySlot( ) {
+    }
 
 public slots:
     void publicSlot( );
@@ -27,6 +28,9 @@ class bar : public
 
 protected:
     double d;
+    enum e {A,B};
+
+private:
 };
 
 class Foo1 : public QObject

--- a/tests/expected/cpp/30731-qt-1.cpp
+++ b/tests/expected/cpp/30731-qt-1.cpp
@@ -8,6 +8,7 @@ class Foo : public QObject
 	void mySlot() {
 	}
 
+
  public slots:
 
 	void publicSlot();
@@ -40,9 +41,7 @@ class bar : public
 	enum e {A,B};
 
 
-
  private:
-
 };
 
 class Foo1 : public QObject

--- a/tests/expected/cpp/30731-qt-1.cpp
+++ b/tests/expected/cpp/30731-qt-1.cpp
@@ -5,8 +5,8 @@ class Foo : public QObject
 
  private slots:
 
-	void mySlot();
-
+	void mySlot() {
+	}
 
  public slots:
 
@@ -37,6 +37,12 @@ class bar : public
  protected:
 
 	double d;
+	enum e {A,B};
+
+
+
+ private:
+
 };
 
 class Foo1 : public QObject

--- a/tests/input/cpp/qt-1.cpp
+++ b/tests/input/cpp/qt-1.cpp
@@ -3,7 +3,7 @@ class Foo: public QObject
 Q_OBJECT
 
 private slots:
-void mySlot();
+void mySlot() {}
 
 public slots:
 void publicSlot();
@@ -14,7 +14,7 @@ void somesignal();
 };
 
 class foo{bool b;public:int i;};class bar:public
-foo{void*p;protected:double d;};
+foo{void*p;protected:double d;enum e{A,B};private:};
 
 class Foo1: public QObject
 {


### PR DESCRIPTION
The behavior of `nl_before_access_spec` was dependent on the settings of other newline-modifying options.  By handling this option late, it now takes precedence over other options such as `nl_after_func_proto`, etc. Also, to be consistent with `nl_before_access_spec`, `nl_after_access_spec` now no longer adds extra blank lines when the access specifier is located immediately before a closing brace.