### PR TITLE
Avoid extra blank lines after 'case' if 'nl_before_comment' > 1

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -5587,11 +5587,10 @@ void do_blank_lines(void)
 
          // Don't add blanks after an open brace or a case statement
          if (  (  prev == nullptr
-               || (  prev->type != CT_BRACE_OPEN
-                  && prev->type != CT_VBRACE_OPEN
-                  && prev->type != CT_CASE_COLON))
-            && pcmt != nullptr                          // Issue #2383
-            && pcmt->type != CT_COMMENT_MULTI)
+               || (  chunk_is_not_token(prev, CT_BRACE_OPEN)
+                  && chunk_is_not_token(prev, CT_VBRACE_OPEN)
+                  && chunk_is_not_token(prev, CT_CASE_COLON)))
+            && chunk_is_not_token(pcmt, CT_COMMENT_MULTI))    // Issue #2383
          {
             blank_line_set(pc, options::nl_before_block_comment);
             log_rule_B("nl_before_block_comment");
@@ -5606,11 +5605,10 @@ void do_blank_lines(void)
 
          // Don't add blanks after an open brace, a case stamement, or a comment
          if (  (  prev == nullptr
-               || (  prev->type != CT_BRACE_OPEN
-                  && prev->type != CT_VBRACE_OPEN
-                  && prev->type != CT_CASE_COLON))
-            && pcmt != nullptr                          // Issue #2383
-            && pcmt->type != CT_COMMENT)
+               || (  chunk_is_not_token(prev, CT_BRACE_OPEN)
+                  && chunk_is_not_token(prev, CT_VBRACE_OPEN)
+                  && chunk_is_not_token(prev, CT_CASE_COLON)))
+            && chunk_is_not_token(pcmt, CT_COMMENT))    // Issue #2383
          {
             blank_line_set(pc, options::nl_before_c_comment);
             log_rule_B("nl_before_c_comment");
@@ -5625,11 +5623,10 @@ void do_blank_lines(void)
 
          // Don't add blanks after an open brace or a case statement
          if (  (  prev == nullptr
-               || (  prev->type != CT_BRACE_OPEN
-                  && prev->type != CT_VBRACE_OPEN
-                  && prev->type != CT_CASE_COLON))
-            && pcmt != nullptr                          // Issue #2383
-            && pcmt->type != CT_COMMENT_CPP)
+               || (  chunk_is_not_token(prev, CT_BRACE_OPEN)
+                  && chunk_is_not_token(prev, CT_VBRACE_OPEN)
+                  && chunk_is_not_token(prev, CT_CASE_COLON)))
+            && chunk_is_not_token(pcmt, CT_COMMENT_CPP))    // Issue #2383
          {
             blank_line_set(pc, options::nl_before_cpp_comment);
             log_rule_B("nl_before_cpp_comment");

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -5585,10 +5585,11 @@ void do_blank_lines(void)
       {
          log_rule_B("nl_before_block_comment");
 
-         // Don't add blanks after a open brace
+         // Don't add blanks after an open brace or a case statement
          if (  (  prev == nullptr
                || (  prev->type != CT_BRACE_OPEN
-                  && prev->type != CT_VBRACE_OPEN))
+                  && prev->type != CT_VBRACE_OPEN
+                  && prev->type != CT_CASE_COLON))
             && pcmt != nullptr                          // Issue #2383
             && pcmt->type != CT_COMMENT_MULTI)
          {
@@ -5603,10 +5604,11 @@ void do_blank_lines(void)
       {
          log_rule_B("nl_before_c_comment");
 
-         // Don't add blanks after a open brace or a comment
+         // Don't add blanks after an open brace, a case stamement, or a comment
          if (  (  prev == nullptr
                || (  prev->type != CT_BRACE_OPEN
-                  && prev->type != CT_VBRACE_OPEN))
+                  && prev->type != CT_VBRACE_OPEN
+                  && prev->type != CT_CASE_COLON))
             && pcmt != nullptr                          // Issue #2383
             && pcmt->type != CT_COMMENT)
          {
@@ -5621,10 +5623,11 @@ void do_blank_lines(void)
       {
          log_rule_B("nl_before_cpp_comment");
 
-         // Don't add blanks after a open brace
+         // Don't add blanks after an open brace or a case statement
          if (  (  prev == nullptr
                || (  prev->type != CT_BRACE_OPEN
-                  && prev->type != CT_VBRACE_OPEN))
+                  && prev->type != CT_VBRACE_OPEN
+                  && prev->type != CT_CASE_COLON))
             && pcmt != nullptr                          // Issue #2383
             && pcmt->type != CT_COMMENT_CPP)
          {

--- a/tests/expected/c/01001-nl-comment.c
+++ b/tests/expected/c/01001-nl-comment.c
@@ -20,6 +20,49 @@ int foo(int bar)
       /* comment in virtual braces */
       res += idx;
    }
+   switch (res)
+   {
+   case 1:
+
+
+
+      // C++-style comment
+      res++;
+      break;
+   case 2:
+
+
+      /* C-style comment */
+      res--;
+      break;
+   case 3:
+
+
+      /* Multi-line comment
+       */
+      res = 0;
+      break;
+   case 4:
+
+
+
+      // C++-style comment
+      res++;
+      break;
+   case 5:
+
+
+      /* C-style comment */
+      res--;
+      break;
+   default:
+
+
+      /* Multi-line comment
+       */
+      res = 0;
+      break;
+   }
 
    res *= idx;        // some comment
 

--- a/tests/expected/c/01001-nl-comment.c
+++ b/tests/expected/c/01001-nl-comment.c
@@ -23,40 +23,29 @@ int foo(int bar)
    switch (res)
    {
    case 1:
-
-
-
       // C++-style comment
       res++;
       break;
    case 2:
-
-
       /* C-style comment */
       res--;
       break;
    case 3:
-
-
       /* Multi-line comment
        */
       res = 0;
       break;
    case 4:
 
-
-
       // C++-style comment
       res++;
       break;
    case 5:
 
-
       /* C-style comment */
       res--;
       break;
    default:
-
 
       /* Multi-line comment
        */

--- a/tests/input/c/nl-comment.c
+++ b/tests/input/c/nl-comment.c
@@ -13,6 +13,38 @@
     for (idx = 1; idx < bar; idx++)
        /* comment in virtual braces */
        res += idx;
+    switch (res)
+    {
+        case 1:
+            // C++-style comment
+            res++;
+            break;
+        case 2:
+            /* C-style comment */
+            res--;
+            break;
+        case 3:
+            /* Multi-line comment
+            */
+            res = 0;
+            break;
+        case 4:
+
+            // C++-style comment
+            res++;
+            break;
+        case 5:
+
+            /* C-style comment */
+            res--;
+            break;
+        default:
+
+            /* Multi-line comment
+            */
+            res = 0;
+            break;
+    }
 
     res *= idx;       // some comment
 


### PR DESCRIPTION
Similar to avoiding extra blank lines before comments after braces and virtual braces, also avoid them after `case` or `default` statements of a `switch` construct.