### PR TITLE
Improve 'nl_before_return' behavior in the presence of comments

### DIFF
--- a/tests/c.test
+++ b/tests/c.test
@@ -337,6 +337,7 @@
 
 02455  mod_paren_on_return-a.cfg            c/macro-returns.c
 02456  mod_paren_on_return-r.cfg            c/macro-returns.c
+02457  nl_before_return_true.cfg            c/nl_before_return.c
 
 02460  freebsd.cfg                          c/freebsd.c
 

--- a/tests/expected/c/00205-case-nl_before_return.c
+++ b/tests/expected/c/00205-case-nl_before_return.c
@@ -26,6 +26,50 @@ int foo(int arg)
 
 		return a;
 	}
+	case 7: /* comment */ return 8;
+	case 8:
+		/* C-style comment */
+		return 9;
+	case 9: /* trailing comment */
+		return 10;
+	case 10: /* trailing comment */
+		/* C-style comment */
+		return 11;
+	case 11:
+		// C++-style comment
+		return 12;
+	case 12:
+		// Multi-line
+		// C++-style comment
+		return 13;
+	case 13: // trailing comment
+		// Multi-line
+		// C++-style comment
+		return 14;
+	case 14:
+
+		// Multi-line
+		// C++-style comment
+		return 15;
+	case 15:
+
+		/* C-style comment */
+		return 16;
+	case 16:
+		/*
+		 * Multi-line C-style comment
+		 */
+		return 17;
+	case 17:
+		/*--------------------*/
+		/* Multi-part comment */
+		/*--------------------*/
+		return 18;
+	case 18:
+		/*---------------------*/
+		// Mixed-style comment
+		/*---------------------*/
+		return 19;
 	default:
 		return arg++;
 	}

--- a/tests/expected/c/00206-case-nl_before_return.c
+++ b/tests/expected/c/00206-case-nl_before_return.c
@@ -30,33 +30,27 @@ int foo(int arg)
 	}
 	case 7: /* comment */ return 8;
 	case 8:
-
 		/* C-style comment */
 		return 9;
 	case 9: /* trailing comment */
 		return 10;
 	case 10: /* trailing comment */
-
 		/* C-style comment */
 		return 11;
 	case 11:
-
 		// C++-style comment
 		return 12;
 	case 12:
 		// Multi-line
-
 		// C++-style comment
 		return 13;
 	case 13: // trailing comment
 		// Multi-line
-
 		// C++-style comment
 		return 14;
 	case 14:
 
 		// Multi-line
-
 		// C++-style comment
 		return 15;
 	case 15:
@@ -64,7 +58,6 @@ int foo(int arg)
 		/* C-style comment */
 		return 16;
 	case 16:
-
 		/*
 		 * Multi-line C-style comment
 		 */
@@ -72,13 +65,11 @@ int foo(int arg)
 	case 17:
 		/*--------------------*/
 		/* Multi-part comment */
-
 		/*--------------------*/
 		return 18;
 	case 18:
 		/*---------------------*/
 		// Mixed-style comment
-
 		/*---------------------*/
 		return 19;
 	default:

--- a/tests/expected/c/00206-case-nl_before_return.c
+++ b/tests/expected/c/00206-case-nl_before_return.c
@@ -28,6 +28,59 @@ int foo(int arg)
 
 		return a;
 	}
+	case 7: /* comment */ return 8;
+	case 8:
+
+		/* C-style comment */
+		return 9;
+	case 9: /* trailing comment */
+		return 10;
+	case 10: /* trailing comment */
+
+		/* C-style comment */
+		return 11;
+	case 11:
+
+		// C++-style comment
+		return 12;
+	case 12:
+		// Multi-line
+
+		// C++-style comment
+		return 13;
+	case 13: // trailing comment
+		// Multi-line
+
+		// C++-style comment
+		return 14;
+	case 14:
+
+		// Multi-line
+
+		// C++-style comment
+		return 15;
+	case 15:
+
+		/* C-style comment */
+		return 16;
+	case 16:
+
+		/*
+		 * Multi-line C-style comment
+		 */
+		return 17;
+	case 17:
+		/*--------------------*/
+		/* Multi-part comment */
+
+		/*--------------------*/
+		return 18;
+	case 18:
+		/*---------------------*/
+		// Mixed-style comment
+
+		/*---------------------*/
+		return 19;
 	default:
 		return arg++;
 	}

--- a/tests/expected/c/02457-nl_before_return.c
+++ b/tests/expected/c/02457-nl_before_return.c
@@ -3,31 +3,25 @@ int foo1(int arg)
 	if (arg == 0) return 1;
 	if (arg == 1) /* comment */ return 2;
 	if (arg == 2)
-
 		/* C-style comment */
 		return 3;
 	if (arg == 3) /* trailing comment */
 		return 4;
 	if (arg == 4) /* trailing comment */
-
 		/* C-style comment */
 		return 5;
 	if (arg == 5)
-
 		// C++-style comment
 		return 6;
 	if (arg == 6)
 		// Multi-line
-
 		// C++-style comment
 		return 7;
 	if (arg == 7) // trailing comment
 		// Multi-line
-
 		// C++-style comment
 		return 8;
 	if (arg == 8)
-
 		/*
 		 * Multi-line C-style comment
 		 */
@@ -35,7 +29,6 @@ int foo1(int arg)
 	if (arg == 9)
 		/*--------------------*/
 		/* Multi-part comment */
-
 		/*--------------------*/
 		return 10;
 	if (arg == 10)
@@ -43,7 +36,6 @@ int foo1(int arg)
 		/*
 		 * Mixed-style comment
 		 */
-
 		//-----------------------
 		return 11;
 	if (arg == 11)
@@ -61,7 +53,6 @@ int foo2(int arg)
 	if (arg == 0) { return 1; }
 	if (arg == 1) { /* comment */ return 2; }
 	if (arg == 2) {
-
 		/* C-style comment */
 		return 3;
 	}
@@ -69,29 +60,24 @@ int foo2(int arg)
 		return 4;
 	}
 	if (arg == 4) { /* trailing comment */
-
 		/* C-style comment */
 		return 5;
 	}
 	if (arg == 5) {
-
 		// C++-style comment
 		return 6;
 	}
 	if (arg == 6) {
 		// Multi-line
-
 		// C++-style comment
 		return 7;
 	}
 	if (arg == 7) { // trailing comment
 		// Multi-line
-
 		// C++-style comment
 		return 8;
 	}
 	if (arg == 8) {
-
 		/*
 		 * Multi-line C-style comment
 		 */
@@ -101,7 +87,6 @@ int foo2(int arg)
 	{
 		/*--------------------*/
 		/* Multi-part comment */
-
 		/*--------------------*/
 		return 10;
 	}
@@ -109,7 +94,6 @@ int foo2(int arg)
 	{
 		//-----------------------
 		/* Mixed-style comment */
-
 		//-----------------------
 		return 11;
 	}
@@ -138,6 +122,7 @@ int foo2(int arg)
 	}
 	if (arg == 3) {
 		int a = 4; /* trailing comment */
+
 		return a;
 	}
 	if (arg == 4) {
@@ -154,37 +139,38 @@ int foo2(int arg)
 	}
 	if (arg == 6) {
 		int a = 7;
-		// Multi-line
 
+		// Multi-line
 		// C++-style comment
 		return a;
 	}
 	if (arg == 7) {
 		int a = 8; // trailing comment
-		// Multi-line
 
+		// Multi-line
 		// C++-style comment
 		return a;
 	}
 	if (arg == 8) {
 		int a = 9;
+
 		/*--------------------*/
 		/* Multi-part comment */
-
 		/*--------------------*/
 		return a;
 	}
 	if (arg == 9) {
 		int a = 10;
+
 		/*---------------------*/
 		// Mixed-style comment
-
 		/*---------------------*/
 		return a;
 	}
 	if (arg == 11)
 	{
 		int a = 12;
+
 		/* comment */ return a;
 	}
 	if (arg == 12) {

--- a/tests/expected/c/02457-nl_before_return.c
+++ b/tests/expected/c/02457-nl_before_return.c
@@ -1,0 +1,200 @@
+int foo1(int arg)
+{
+	if (arg == 0) return 1;
+	if (arg == 1) /* comment */ return 2;
+	if (arg == 2)
+
+		/* C-style comment */
+		return 3;
+	if (arg == 3) /* trailing comment */
+		return 4;
+	if (arg == 4) /* trailing comment */
+
+		/* C-style comment */
+		return 5;
+	if (arg == 5)
+
+		// C++-style comment
+		return 6;
+	if (arg == 6)
+		// Multi-line
+
+		// C++-style comment
+		return 7;
+	if (arg == 7) // trailing comment
+		// Multi-line
+
+		// C++-style comment
+		return 8;
+	if (arg == 8)
+
+		/*
+		 * Multi-line C-style comment
+		 */
+		return 9;
+	if (arg == 9)
+		/*--------------------*/
+		/* Multi-part comment */
+
+		/*--------------------*/
+		return 10;
+	if (arg == 10)
+		//-----------------------
+		/*
+		 * Mixed-style comment
+		 */
+
+		//-----------------------
+		return 11;
+	if (arg == 11)
+		/* comment */ return 12;
+	if (arg == 12)
+
+		// C++-style comment
+		return 13;
+
+	return arg + 1;
+}
+
+int foo2(int arg)
+{
+	if (arg == 0) { return 1; }
+	if (arg == 1) { /* comment */ return 2; }
+	if (arg == 2) {
+
+		/* C-style comment */
+		return 3;
+	}
+	if (arg == 3) { /* trailing comment */
+		return 4;
+	}
+	if (arg == 4) { /* trailing comment */
+
+		/* C-style comment */
+		return 5;
+	}
+	if (arg == 5) {
+
+		// C++-style comment
+		return 6;
+	}
+	if (arg == 6) {
+		// Multi-line
+
+		// C++-style comment
+		return 7;
+	}
+	if (arg == 7) { // trailing comment
+		// Multi-line
+
+		// C++-style comment
+		return 8;
+	}
+	if (arg == 8) {
+
+		/*
+		 * Multi-line C-style comment
+		 */
+		return 9;
+	}
+	if (arg == 9)
+	{
+		/*--------------------*/
+		/* Multi-part comment */
+
+		/*--------------------*/
+		return 10;
+	}
+	if (arg == 10)
+	{
+		//-----------------------
+		/* Mixed-style comment */
+
+		//-----------------------
+		return 11;
+	}
+	if (arg == 11)
+	{
+		/* comment */ return 12;
+	}
+	if (arg == 12) {
+
+		/* C-style comment */
+		return 13;
+	}
+
+	return arg + 1;
+}
+
+int foo2(int arg)
+{
+	if (arg == 0) { int a = 1; return a; }
+	if (arg == 1) { int a = 2; /* comment */ return a; }
+	if (arg == 2) {
+		int a = 3;
+
+		/* C-style comment */
+		return a;
+	}
+	if (arg == 3) {
+		int a = 4; /* trailing comment */
+		return a;
+	}
+	if (arg == 4) {
+		int a = 5; /* trailing comment */
+
+		/* C-style comment */
+		return a;
+	}
+	if (arg == 5) {
+		int a = 6;
+
+		// C++-style comment
+		return a;
+	}
+	if (arg == 6) {
+		int a = 7;
+		// Multi-line
+
+		// C++-style comment
+		return a;
+	}
+	if (arg == 7) {
+		int a = 8; // trailing comment
+		// Multi-line
+
+		// C++-style comment
+		return a;
+	}
+	if (arg == 8) {
+		int a = 9;
+		/*--------------------*/
+		/* Multi-part comment */
+
+		/*--------------------*/
+		return a;
+	}
+	if (arg == 9) {
+		int a = 10;
+		/*---------------------*/
+		// Mixed-style comment
+
+		/*---------------------*/
+		return a;
+	}
+	if (arg == 11)
+	{
+		int a = 12;
+		/* comment */ return a;
+	}
+	if (arg == 12) {
+		int a = 13;
+
+		/*
+		 * Multi-line C-style comment
+		 */
+		return a;
+	}
+
+	return arg + 1;
+}

--- a/tests/input/c/case-nl_before_return.c
+++ b/tests/input/c/case-nl_before_return.c
@@ -26,6 +26,50 @@ int foo(int arg)
 
             return a;
         }
+        case 7: /* comment */ return 8;
+        case 8:
+            /* C-style comment */
+            return 9;
+        case 9: /* trailing comment */
+            return 10;
+        case 10: /* trailing comment */
+            /* C-style comment */
+            return 11;
+        case 11:
+            // C++-style comment
+            return 12;
+        case 12:
+            // Multi-line
+            // C++-style comment
+            return 13;
+        case 13: // trailing comment
+            // Multi-line
+            // C++-style comment
+            return 14;
+        case 14:
+
+            // Multi-line
+            // C++-style comment
+            return 15;
+        case 15:
+
+            /* C-style comment */
+            return 16;
+        case 16:
+            /*
+             * Multi-line C-style comment
+             */
+            return 17;
+        case 17:
+            /*--------------------*/
+            /* Multi-part comment */
+            /*--------------------*/
+            return 18;
+        case 18:
+            /*---------------------*/
+            // Mixed-style comment
+            /*---------------------*/
+            return 19;
         default:
             return arg++;
     }

--- a/tests/input/c/nl_before_return.c
+++ b/tests/input/c/nl_before_return.c
@@ -1,0 +1,173 @@
+int foo1(int arg)
+{
+    if (arg == 0) return 1;
+    if (arg == 1) /* comment */ return 2;
+    if (arg == 2)
+        /* C-style comment */
+        return 3;
+    if (arg == 3) /* trailing comment */
+        return 4;
+    if (arg == 4) /* trailing comment */
+        /* C-style comment */
+        return 5;
+    if (arg == 5)
+        // C++-style comment
+        return 6;
+    if (arg == 6)
+        // Multi-line
+        // C++-style comment
+        return 7;
+    if (arg == 7) // trailing comment
+        // Multi-line
+        // C++-style comment
+        return 8;
+    if (arg == 8)
+        /*
+         * Multi-line C-style comment
+         */
+        return 9;
+    if (arg == 9)
+        /*--------------------*/
+        /* Multi-part comment */
+        /*--------------------*/
+        return 10;
+    if (arg == 10)
+        //-----------------------
+        /*
+         * Mixed-style comment
+         */
+        //-----------------------
+        return 11;
+    if (arg == 11)
+        /* comment */ return 12;
+    if (arg == 12)
+
+        // C++-style comment
+        return 13;
+    return arg + 1;
+}
+
+int foo2(int arg)
+{
+    if (arg == 0) { return 1; }
+    if (arg == 1) { /* comment */ return 2; }
+    if (arg == 2) {
+        /* C-style comment */
+        return 3;
+    }
+    if (arg == 3) { /* trailing comment */
+        return 4;
+    }
+    if (arg == 4) { /* trailing comment */
+        /* C-style comment */
+        return 5;
+    }
+    if (arg == 5) {
+        // C++-style comment
+        return 6;
+    }
+    if (arg == 6) {
+        // Multi-line
+        // C++-style comment
+        return 7;
+    }
+    if (arg == 7) { // trailing comment
+        // Multi-line
+        // C++-style comment
+        return 8;
+    }
+    if (arg == 8) {
+        /*
+         * Multi-line C-style comment
+         */
+        return 9;
+    }
+    if (arg == 9)
+    {
+        /*--------------------*/
+        /* Multi-part comment */
+        /*--------------------*/
+        return 10;
+    }
+    if (arg == 10)
+    {
+        //-----------------------
+        /* Mixed-style comment */
+        //-----------------------
+        return 11;
+    }
+    if (arg == 11)
+    {
+        /* comment */ return 12;
+    }
+    if (arg == 12) {
+
+        /* C-style comment */
+        return 13;
+    }
+    return arg + 1;
+}
+
+int foo2(int arg)
+{
+    if (arg == 0) { int a = 1; return a; }
+    if (arg == 1) { int a = 2; /* comment */ return a; }
+    if (arg == 2) {
+        int a = 3;
+        /* C-style comment */
+        return a;
+    }
+    if (arg == 3) {
+        int a = 4; /* trailing comment */
+        return a;
+    }
+    if (arg == 4) {
+        int a = 5; /* trailing comment */
+        /* C-style comment */
+        return a;
+    }
+    if (arg == 5) {
+        int a = 6;
+        // C++-style comment
+        return a;
+    }
+    if (arg == 6) {
+        int a = 7;
+        // Multi-line
+        // C++-style comment
+        return a;
+    }
+    if (arg == 7) {
+        int a = 8; // trailing comment
+        // Multi-line
+        // C++-style comment
+        return a;
+    }
+    if (arg == 8) {
+        int a = 9;
+        /*--------------------*/
+        /* Multi-part comment */
+        /*--------------------*/
+        return a;
+    }
+    if (arg == 9) {
+        int a = 10;
+        /*---------------------*/
+        // Mixed-style comment
+        /*---------------------*/
+        return a;
+    }
+    if (arg == 11)
+    {
+        int a = 12;
+        /* comment */ return a;
+    }
+    if (arg == 12) {
+        int a = 13;
+        /*
+         * Multi-line C-style comment
+         */
+        return a;
+    }
+    return arg + 1;
+}


### PR DESCRIPTION
So far, the `nl_before_return` option handling only covers a very restricted set of use cases for comments in front of the `return` statement. For example, it fails to prevent adding extra blank lines after a (virtual) brace or `case` if a comment is in between the brace/`case` and the `return`. See the enhanced test cases in the first commit for more examples of broken behavior.

This PR reworks the `newline_before_return` function to handle such comments more thoroughly. (The diff looks a bit messy, though.)