### PR TITLE
Fix 'nl_squeeze_ifdef(_top_level)' again

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -349,7 +349,8 @@ static bool can_increase_nl(chunk_t *nl)
       }
 
       if (  chunk_is_token(next, CT_PREPROC)
-         && get_chunk_parent_type(next) == CT_PP_ENDIF
+         && (  get_chunk_parent_type(next) == CT_PP_ELSE
+            || get_chunk_parent_type(next) == CT_PP_ENDIF)
          && (next->level > 0 || options::nl_squeeze_ifdef_top_level()))
       {
          log_rule_B("nl_squeeze_ifdef_top_level");

--- a/tests/config/squeeze_ifdef_top.cfg
+++ b/tests/config/squeeze_ifdef_top.cfg
@@ -1,3 +1,5 @@
 nl_before_cpp_comment           = 2
+nl_after_func_proto             = 2
+nl_after_func_proto_group       = 2
 nl_squeeze_ifdef                = true
 nl_squeeze_ifdef_top_level      = true

--- a/tests/expected/cpp/33091-squeeze_ifdef.cpp
+++ b/tests/expected/cpp/33091-squeeze_ifdef.cpp
@@ -3,14 +3,17 @@
 
 // Comment
 extern int ax;
+void fa();
 
 #elif defined(B)
 
 extern int bx;
+void fb();
 
 #else
 
 extern int cx;
+void fc();
 
 #endif
 

--- a/tests/expected/cpp/33092-squeeze_ifdef.cpp
+++ b/tests/expected/cpp/33092-squeeze_ifdef.cpp
@@ -3,14 +3,17 @@
 
 // Comment
 extern int ax;
+void fa();
 
 #elif defined(B)
 
 extern int bx;
+void fb();
 
 #else
 
 extern int cx;
+void fc();
 
 #endif
 

--- a/tests/expected/cpp/33096-squeeze_ifdef.cpp
+++ b/tests/expected/cpp/33096-squeeze_ifdef.cpp
@@ -2,10 +2,13 @@
 #if defined(A)
 // Comment
 extern int ax;
+void fa();
 #elif defined(B)
 extern int bx;
+void fb();
 #else
 extern int cx;
+void fc();
 #endif
 
 int foo()

--- a/tests/input/cpp/squeeze_ifdef.cpp
+++ b/tests/input/cpp/squeeze_ifdef.cpp
@@ -3,14 +3,17 @@
 
 // Comment
 extern int ax;
+void fa();
 
 #elif defined(B)
 
 extern int bx;
+void fb();
 
 #else
 
 extern int cx;
+void fc();
 
 #endif
 


### PR DESCRIPTION
Cover another case where blank lines were inserted before an '#else/#elif' conditional.