### PR TITLE
Let 'pp_if_indent_code' also indent all comments

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -3870,17 +3870,6 @@ static void indent_comment(chunk_t *pc, size_t col)
       LOG_FMT(LCMTIND, "%s(%d): nl->text() is '%s', orig_line %zu, orig_col %zu, level %zu\n",
               __func__, __LINE__, nl->text(), nl->orig_line, nl->orig_col, nl->level);
    }
-
-   // outside of any expression or statement?
-   if (pc->level == 0)
-   {
-      if (nl != nullptr && nl->nl_count > 1)
-      {
-         LOG_FMT(LCMTIND, "%s(%d): rule 2 - level 0, nl before\n", __func__, __LINE__);
-         reindent_line(pc, 1);
-         return;
-      }
-   }
    // TODO: Add an indent_comment_align_thresh option?
    const size_t indent_comment_align_thresh = 3;
 

--- a/tests/config/pp_if_indent-3.cfg
+++ b/tests/config/pp_if_indent-3.cfg
@@ -1,4 +1,5 @@
 # Abs column region preproc
 indent_columns                  = 4
+indent_col1_comment             = true
 pp_indent                       = add
 pp_if_indent_code               = true

--- a/tests/expected/c/02410-ifdef-indent.c
+++ b/tests/expected/c/02410-ifdef-indent.c
@@ -4,6 +4,14 @@
  #include <foo2.h>
 #endif
 
+#ifdef foo
+/* Commentary for func1() */
+void func1();
+
+/* Commentary for func2() */
+void func2();
+#endif
+
 int
 show_interrupts(struct seq_file *p, void *v)
 {

--- a/tests/expected/c/02411-ifdef-indent.c
+++ b/tests/expected/c/02411-ifdef-indent.c
@@ -4,6 +4,14 @@
  #include <foo2.h>
 #endif
 
+#ifdef foo
+/* Commentary for func1() */
+    void func1();
+
+/* Commentary for func2() */
+    void func2();
+#endif
+
 int
 show_interrupts(struct seq_file *p, void *v)
 {

--- a/tests/expected/c/02412-ifdef-indent.c
+++ b/tests/expected/c/02412-ifdef-indent.c
@@ -4,6 +4,14 @@
  #include <foo2.h>
 #endif
 
+#ifdef foo
+/* Commentary for func1() */
+void func1();
+
+/* Commentary for func2() */
+void func2();
+#endif
+
 int
 show_interrupts(struct seq_file *p, void *v)
 {

--- a/tests/expected/c/02413-ifdef-indent.c
+++ b/tests/expected/c/02413-ifdef-indent.c
@@ -4,6 +4,14 @@
  #include <foo2.h>
 #endif
 
+#ifdef foo
+    /* Commentary for func1() */
+    void func1();
+
+    /* Commentary for func2() */
+    void func2();
+#endif
+
 int
 show_interrupts(struct seq_file *p, void *v)
 {

--- a/tests/input/c/ifdef-indent.c
+++ b/tests/input/c/ifdef-indent.c
@@ -4,6 +4,14 @@
 #include <foo2.h>
 #endif
 
+#ifdef foo
+/* Commentary for func1() */
+void func1();
+
+/* Commentary for func2() */
+void func2();
+#endif
+
 int
 show_interrupts(struct seq_file *p, void *v)
 {


### PR DESCRIPTION
Remove the special handling of comments within top-level conditional
compilation constructs when preceded by blank lines.  This makes the
indentation of such comments consistent with comments within #ifdef's
not in the global scope.