### PR TITLE
Silence VS "performance warning"

### DIFF
--- a/src/enum_flags.h
+++ b/src/enum_flags.h
@@ -98,7 +98,7 @@ public:
    inline int_t operator~() const
    { return(~m_i); }
 
-   inline operator bool() const { return(m_i); }
+   inline operator bool() const { return(!!m_i); }
    inline bool operator!() const { return(!m_i); }
 
    inline bool test(flags f) const { return((*this & f) == f); }


### PR DESCRIPTION
Visual studio has a really obnoxious "performance warning" that it likes to spew in some instances when an integral type is implicitly converted to a Boolean, even though there is nothing actually wrong with such code. Silence an instance of this by adding a `!!` to make the conversion explicit. (This should not affect the generated assembly, but it gets rid of the stupid warning.)