### PR TITLE
Only reopen stdin as binary on Windows

### DIFF
--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1036,17 +1036,6 @@ static bool read_stdin(file_mem &fm)
    // Re-open stdin in binary mode to preserve newline characters
 #ifdef WIN32
    _setmode(_fileno(stdin), _O_BINARY);
-#else
-   FILE *my_stdin = stdin;  // Reopen stdin
-
-   my_stdin = freopen(NULL, "rb", stdin);
-
-   if (my_stdin == nullptr)
-   {
-      cpd.error_count++;
-      usage_error();
-      return(EX_IOERR);
-   }
 #endif
 
    while (!feof(stdin))


### PR DESCRIPTION
Starting with Uncrustify 0.71.0, the VSCode extension for Uncrustify that I maintain stopped working. Using git bisect, I saw that it was because of #2700 (and thus #2686).
After stdin is reopened in binary mode, NodeJS has trouble sending data to it (on Linux at least, it didn't seem to have a problem on macOS).

The original issue was because of Windows' C library converting line endings (which I have also encountered on another project, thanks Microsoft for automatically tampering with stdin data...).
So, I thought it shouldn't pose a problem if stdin was reopened in binary mode only on Windows, and not on other platforms; the same way stdout seems to be handled. This would solve my NodeJS communication issue, while still keeping the Windows C library fix.