### PR TITLE
Partially fix #2799

### DIFF
--- a/src/combine_labels.cpp
+++ b/src/combine_labels.cpp
@@ -392,7 +392,7 @@ void combine_labels(void)
                   {
                      // ignore it, as it is a C# base thingy
                   }
-                  else if (language_is_set(LANG_CS))
+                  else if (language_is_set(LANG_CS | LANG_D))
                   {
                      // there should be a better solution for that
                   }

--- a/tests/d.test
+++ b/tests/d.test
@@ -45,3 +45,5 @@
 40100  1438.cfg                             d/1438.d
 
 40201  invariant.cfg                        d/invariant.d
+
+40300  d.cfg                                d/extern_.d

--- a/tests/expected/d/40300-extern_.d
+++ b/tests/expected/d/40300-extern_.d
@@ -1,0 +1,6 @@
+extern(D) : void func();
+
+void x()
+{
+    int xx;
+}

--- a/tests/input/d/extern_.d
+++ b/tests/input/d/extern_.d
@@ -1,0 +1,6 @@
+extern(D): void func();
+
+void x()
+{
+    int xx;
+}


### PR DESCRIPTION
This fixes the crash in formatting `extern(D): `
Not sure if it's a good solution though.