### PR TITLE
Remove infinite loop if the one liner is too long

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -2212,24 +2212,27 @@ static void newlines_brace_pair(chunk_t *br_open)
             // make a vector to save the chunk
             vector<chunk_t> saved_chunk;
 
-            saved_chunk.reserve(16);
-            chunk_t *current       = chunk_get_prev_ncnlni(br_open);
-            chunk_t *next_br_close = chunk_get_next(br_close);
-            current = chunk_get_next(current);
-
-            while (current != nullptr)
+            if (options::code_width() > 0)
             {
-               LOG_FMT(LNL1LINE, "%s(%d): zu  kopieren: current->orig_line is %zu, orig_col is %zu, text() is '%s'\n",
-                       __func__, __LINE__, current->orig_line, current->orig_col, current->text());
-               saved_chunk.push_back(*current);
-               chunk_t *the_next = chunk_get_next(current);
+               saved_chunk.reserve(16);
+               chunk_t *current       = chunk_get_prev_ncnlni(br_open);
+               chunk_t *next_br_close = chunk_get_next(br_close);
+               current = chunk_get_next(current);
 
-               if (  the_next == nullptr
-                  || the_next == next_br_close)
+               while (current != nullptr)
                {
-                  break;
+                  LOG_FMT(LNL1LINE, "%s(%d): zu  kopieren: current->orig_line is %zu, orig_col is %zu, text() is '%s'\n",
+                          __func__, __LINE__, current->orig_line, current->orig_col, current->text());
+                  saved_chunk.push_back(*current);
+                  chunk_t *the_next = chunk_get_next(current);
+
+                  if (  the_next == nullptr
+                     || the_next == next_br_close)
+                  {
+                     break;
+                  }
+                  current = the_next;
                }
-               current = the_next;
             }
             tmp = chunk_get_prev_ncnlni(br_open);
 

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -2253,7 +2253,7 @@ static void newlines_brace_pair(chunk_t *br_open)
             if (  options::code_width() > 0
                && br_close->column > options::code_width())
             {
-               // is too long
+               // the created line is too long
                // it is not possible to make an one_liner
                // because the line would be too long
                chunk_flags_set(br_open, PCF_NOT_POSSIBLE);

--- a/src/pcf_flags.h
+++ b/src/pcf_flags.h
@@ -83,6 +83,8 @@ enum pcf_flag_e : decltype(0ULL)
    PCF_IN_TRY_BLOCK   = pcf_bit(42),   //! inside Function-try-block
    PCF_INCOMPLETE     = pcf_bit(43),   //! class/struct forward declaration
    PCF_WF_IF          = pcf_bit(44),   //! #if for a whole file ifdef
+   PCF_NOT_POSSIBLE   = pcf_bit(45),   //! it is not possible to make an one_liner
+                                       //! because the line would be too long
 };
 
 UNC_DECLARE_FLAGS(pcf_flags_t, pcf_flag_e);

--- a/tests/cli/output/25.txt
+++ b/tests/cli/output/25.txt
@@ -14,5 +14,4 @@ newline_add_between : and end->text() is '}', orig_line is 11, orig_col is 1
 newline_add_between : start->text() is '{', type is BRACE_OPEN, orig_line is 10, orig_col is 1
 newline_add_between : and end->text() is '}', orig_line is 11, orig_col is 1
    [CallStack]
-newlines_functions_remove_extra_blank_lines :
 newlines_functions_remove_extra_blank_lines : nl_max_blank_in_func is zero

--- a/tests/cli/output/25.txt
+++ b/tests/cli/output/25.txt
@@ -14,3 +14,5 @@ newline_add_between : and end->text() is '}', orig_line is 11, orig_col is 1
 newline_add_between : start->text() is '{', type is BRACE_OPEN, orig_line is 10, orig_col is 1
 newline_add_between : and end->text() is '}', orig_line is 11, orig_col is 1
    [CallStack]
+newlines_functions_remove_extra_blank_lines :
+newlines_functions_remove_extra_blank_lines : nl_max_blank_in_func is zero

--- a/tests/config/Issue_2795.cfg
+++ b/tests/config/Issue_2795.cfg
@@ -1,0 +1,1 @@
+indent_columns = 4

--- a/tests/config/Issue_2795.cfg
+++ b/tests/config/Issue_2795.cfg
@@ -1,1 +1,3 @@
-indent_columns = 4
+indent_columns               = 4
+nl_create_func_def_one_liner = true
+code_width                   = 140

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -297,6 +297,8 @@
 
 30780 lambda_in_one_liner.cfg               cpp/lambda_in_one_liner.cpp
 
+30790 Issue_2795.cfg                        cpp/Issue_2795.cpp
+
 30800  star_pos-0.cfg                       cpp/align-star-amp-pos.cpp
 30801  star_pos-1.cfg                       cpp/align-star-amp-pos.cpp
 30802  star_pos-2.cfg                       cpp/align-star-amp-pos.cpp

--- a/tests/expected/cpp/30790-Issue_2795.cpp
+++ b/tests/expected/cpp/30790-Issue_2795.cpp
@@ -1,0 +1,3 @@
+void SnRequestTracefork::onCurlTestError(QProcess::ProcessError _error) {
+    myerror(QString("Curl process failed with error %1").arg(_error));
+}

--- a/tests/input/cpp/Issue_2795.cpp
+++ b/tests/input/cpp/Issue_2795.cpp
@@ -1,0 +1,3 @@
+void SnRequestTracefork::onCurlTestError(QProcess::ProcessError _error) {
+    myerror(QString("Curl process failed with error %1").arg(_error));
+}


### PR DESCRIPTION
Ref. #2795 
Mark the br_open with PCF_NOT_POSSIBLE