### PR TITLE
Refactor brace_cleanup.cpp and cpd

### DIFF
--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -194,7 +194,6 @@ void brace_cleanup(void)
 
    BraceState braceState;
 
-   cpd.unc_stage = unc_stage_e::BRACE_CLEANUP;
    cpd.frames.clear();
    cpd.in_preproc = CT_NONE;
    cpd.pp_level   = 0;

--- a/src/frame_list.cpp
+++ b/src/frame_list.cpp
@@ -1,6 +1,6 @@
 /**
  * @file frame_list.cpp
- * Functions for the cpd.frames var, mainly used to handle preprocessor stuff
+ * mainly used to handle preprocessor stuff
  *
  * @author  Ben Gardner
  * @license GPL v2+
@@ -144,12 +144,6 @@ void fl_push(std::vector<ParseFrame> &frames, ParseFrame &frm)
 }
 
 
-void fl_push(ParseFrame &frm)
-{
-   fl_push(cpd.frames, frm);
-}
-
-
 void fl_pop(std::vector<ParseFrame> &frames, ParseFrame &pf)
 {
    if (frames.empty())
@@ -158,12 +152,6 @@ void fl_pop(std::vector<ParseFrame> &frames, ParseFrame &pf)
    }
    fl_copy_tos(pf, frames);
    fl_trash_tos(frames);
-}
-
-
-void fl_pop(ParseFrame &pf)
-{
-   fl_pop(cpd.frames, pf);
 }
 
 
@@ -316,9 +304,3 @@ int fl_check(std::vector<ParseFrame> &frames, ParseFrame &frm, int &pp_level, ch
 
    return(out_pp_level);
 } // fl_check
-
-
-int fl_check(ParseFrame &frm, chunk_t *pc)
-{
-   return(fl_check(cpd.frames, frm, cpd.pp_level, pc));
-}

--- a/src/frame_list.h
+++ b/src/frame_list.h
@@ -1,6 +1,6 @@
 /**
  * @file frame_list.h
- * Functions for the cpd.frames var, mainly used to handle preprocessor stuff
+ * mainly used to handle preprocessor stuff
  *
  * @author  Ben Gardner
  * @license GPL v2+
@@ -18,7 +18,6 @@
  * This is called on #if and #ifdef.
  */
 void fl_push(std::vector<ParseFrame> &frames, ParseFrame &frm);
-void fl_push(ParseFrame &pf);
 
 
 /**
@@ -29,12 +28,13 @@ void fl_push(ParseFrame &pf);
  * This is called on #endif
  */
 void fl_pop(std::vector<ParseFrame> &frames, ParseFrame &pf);
-void fl_pop(ParseFrame &pf);
 
 
+// TODO: this name is dumb:
+// - what is it checking?
+// - why does is much more than simple checks, it allters kinds of stuff
 //! Returns the pp_indent to use for this line
 int fl_check(std::vector<ParseFrame> &frames, ParseFrame &frm, int &pp_level, chunk_t *pc);
-int fl_check(ParseFrame &frm, chunk_t *pc);
 
 
 #endif /* PARSE_FRAME_H_INCLUDED */

--- a/src/frame_list.h
+++ b/src/frame_list.h
@@ -17,6 +17,7 @@
  * Push a copy of a ParseFrame onto the frames list.
  * This is called on #if and #ifdef.
  */
+void fl_push(std::vector<ParseFrame> &frames, ParseFrame &frm);
 void fl_push(ParseFrame &pf);
 
 
@@ -27,10 +28,12 @@ void fl_push(ParseFrame &pf);
  *
  * This is called on #endif
  */
+void fl_pop(std::vector<ParseFrame> &frames, ParseFrame &pf);
 void fl_pop(ParseFrame &pf);
 
 
 //! Returns the pp_indent to use for this line
+int fl_check(std::vector<ParseFrame> &frames, ParseFrame &frm, int &pp_level, chunk_t *pc);
 int fl_check(ParseFrame &frm, chunk_t *pc);
 
 

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -618,12 +618,13 @@ void indent_text(void)
    size_t       sql_orig_col  = 0;
    bool         in_func_def   = false;
 
-   cpd.frames.clear();
 
-   ParseFrame frm{};
+   std::vector<ParseFrame> frames;
+   ParseFrame              frm{};
 
-   chunk_t    *pc        = chunk_get_head();
-   bool       classFound = false; // Issue #672
+
+   chunk_t *pc        = chunk_get_head();
+   bool    classFound = false;                               // Issue #672
 
    while (pc != nullptr)
    {
@@ -746,7 +747,7 @@ void indent_text(void)
             frm.pop(__func__, __LINE__);
          }
          ParseFrame frmbkup = frm;
-         fl_check(frm, pc);
+         fl_check(frames, frm, cpd.pp_level, pc);
 
          // Indent the body of a #region here
          log_rule_B("pp_region_indent_code");

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -2255,10 +2255,9 @@ void uncrustify_end()
    cpd.unc_off     = false;
    cpd.al_cnt      = 0;
    cpd.did_newline = true;
-   cpd.frames.clear();
-   cpd.pp_level   = 0;
-   cpd.changes    = 0;
-   cpd.in_preproc = CT_NONE;
+   cpd.pp_level    = 0;
+   cpd.changes     = 0;
+   cpd.in_preproc  = CT_NONE;
    memset(cpd.le_counts, 0, sizeof(cpd.le_counts));
    cpd.preproc_ncnl_count                     = 0;
    cpd.ifdef_over_whole_file                  = 0;

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -2259,7 +2259,6 @@ void uncrustify_end()
    cpd.pp_level   = 0;
    cpd.changes    = 0;
    cpd.in_preproc = CT_NONE;
-   cpd.consumed   = false;
    memset(cpd.le_counts, 0, sizeof(cpd.le_counts));
    cpd.preproc_ncnl_count                     = 0;
    cpd.ifdef_over_whole_file                  = 0;

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -327,8 +327,6 @@ struct cp_data_t
    UINT32                  le_counts[uncrustify::line_end_styles];
    unc_text                newline;
 
-   bool                    consumed;
-
    int                     did_newline; //! flag indicates if a newline was added or converted
    c_token_t               in_preproc;
    int                     preproc_ncnl_count;

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -313,7 +313,7 @@ struct cp_data_t
    bool                    lang_forced; //! overwrites automatic language detection
 
    bool                    unc_off;
-   bool                    unc_off_used; //! to check if "unc_off" is used
+   bool                    unc_off_used; //! true if the `disable_processing_cmt` option was actively used in the processed file
    UINT32                  line_number;
    size_t                  column;       //! column for parsing
    UINT16                  spaces;       //! space count on output

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -292,66 +292,65 @@ enum class unc_stage_e : unsigned int
 
 struct cp_data_t
 {
-   std::deque<UINT8>       *bout;
-   FILE                    *fout;
-   int                     last_char;
-   bool                    do_check;
-   unc_stage_e             unc_stage;
-   int                     check_fail_cnt; //! total failure count
-   bool                    if_changed;
+   std::deque<UINT8> *bout;
+   FILE              *fout;
+   int               last_char;
+   bool              do_check;
+   unc_stage_e       unc_stage;
+   int               check_fail_cnt;       //! total failure count
+   bool              if_changed;
 
-   UINT32                  error_count; //! counts how many errors occurred so far
-   std::string             filename;
+   UINT32            error_count;       //! counts how many errors occurred so far
+   std::string       filename;
 
-   file_mem                file_hdr;    // for cmt_insert_file_header
-   file_mem                file_ftr;    // for cmt_insert_file_footer
-   file_mem                func_hdr;    // for cmt_insert_func_header
-   file_mem                oc_msg_hdr;  // for cmt_insert_oc_msg_header
-   file_mem                class_hdr;   // for cmt_insert_class_header
+   file_mem          file_hdr;          // for cmt_insert_file_header
+   file_mem          file_ftr;          // for cmt_insert_file_footer
+   file_mem          func_hdr;          // for cmt_insert_func_header
+   file_mem          oc_msg_hdr;        // for cmt_insert_oc_msg_header
+   file_mem          class_hdr;         // for cmt_insert_class_header
 
-   size_t                  lang_flags;  //! defines the language of the source input
-   bool                    lang_forced; //! overwrites automatic language detection
+   size_t            lang_flags;        //! defines the language of the source input
+   bool              lang_forced;       //! overwrites automatic language detection
 
-   bool                    unc_off;
-   bool                    unc_off_used; //! true if the `disable_processing_cmt` option was actively used in the processed file
-   UINT32                  line_number;
-   size_t                  column;       //! column for parsing
-   UINT16                  spaces;       //! space count on output
+   bool              unc_off;
+   bool              unc_off_used;       //! true if the `disable_processing_cmt` option was actively used in the processed file
+   UINT32            line_number;
+   size_t            column;             //! column for parsing
+   UINT16            spaces;             //! space count on output
 
-   int                     ifdef_over_whole_file;
+   int               ifdef_over_whole_file;
 
-   bool                    frag;    //! activates code fragment option
-   UINT32                  frag_cols;
+   bool              frag;          //! activates code fragment option
+   UINT32            frag_cols;
 
    // stuff to auto-detect line endings
-   UINT32                  le_counts[uncrustify::line_end_styles];
-   unc_text                newline;
+   UINT32            le_counts[uncrustify::line_end_styles];
+   unc_text          newline;
 
-   int                     did_newline; //! flag indicates if a newline was added or converted
-   c_token_t               in_preproc;
-   int                     preproc_ncnl_count;
-   bool                    output_trailspace;
-   bool                    output_tab_as_space;
+   int               did_newline;       //! flag indicates if a newline was added or converted
+   c_token_t         in_preproc;
+   int               preproc_ncnl_count;
+   bool              output_trailspace;
+   bool              output_tab_as_space;
 
-   bool                    bom;
-   char_encoding_e         enc;
+   bool              bom;
+   char_encoding_e   enc;
 
    // bumped up when a line is split or indented
-   int                     changes;
-   int                     pass_count; //! indicates how often the chunk list shall be processed
+   int               changes;
+   int               pass_count;       //! indicates how often the chunk list shall be processed
 
 #define AL_SIZE    8000
-   align_t                 al[AL_SIZE];
-   size_t                  al_cnt;
-   bool                    al_c99_array;
+   align_t           al[AL_SIZE];
+   size_t            al_cnt;
+   bool              al_c99_array;
 
-   bool                    warned_unable_string_replace_tab_chars;
+   bool              warned_unable_string_replace_tab_chars;
 
-   std::vector<ParseFrame> frames;
-   int                     pp_level; // TODO: can this ever be -1?
+   int               pp_level;       // TODO: can this ever be -1?
 
-   const char              *phase_name;
-   const char              *dumped_file;
+   const char        *phase_name;
+   const char        *dumped_file;
 };
 
 extern cp_data_t cpd;  // TODO: can we avoid this external variable?


### PR DESCRIPTION
The goal is to:
- remove almost all dependencies to `cpd` from brace_cleanup.cpp, in the end only `cpd.filename` and `cpd.error_count` will remain.
- remove variables of `cpd` that where only used in brace_cleanup.cpp