### PR TITLE
Don't define away __attribute__ on GCC and Clang on Windows

### DIFF
--- a/src/logger.h
+++ b/src/logger.h
@@ -74,6 +74,16 @@ void log_set_mask(const log_mask_t &mask);
 void log_get_mask(log_mask_t &mask);
 
 
+#ifdef __MINGW_PRINTF_FORMAT
+// On MinGW, the printf functions can be provided by a number of different
+// implementations, with different format string support. Annontate log_fmt
+// below with the same format attribute as the currently chosen default printf
+// function.
+#define PRINTF_FORMAT    __MINGW_PRINTF_FORMAT
+#else
+#define PRINTF_FORMAT    printf
+#endif
+
 /**
  * Logs a formatted string -- similar to printf()
  *
@@ -81,7 +91,7 @@ void log_get_mask(log_mask_t &mask);
  * @param fmt  The format string
  * @param ...  Additional arguments
  */
-void log_fmt(log_sev_t sev, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+void log_fmt(log_sev_t sev, const char *fmt, ...) __attribute__((format(PRINTF_FORMAT, 2, 3)));
 
 
 /**

--- a/src/windows_compat.h
+++ b/src/windows_compat.h
@@ -38,8 +38,14 @@ typedef unsigned long long   UINT64;
 #define PRIu64    "llu"
 #endif
 
+// Make sure to keep GNU style attributes if they are supported; other
+// included headers may have chosen to rely on them. This is essential
+// if building with libc++ headers, where attributes are relied upon
+// if they are supported (see _LIBCPP_EXCLUDE_FROM_EXPLICIT_INSTANTIATION).
+#ifndef __GNUC__
 // eliminate GNU's attribute
 #define __attribute__(x)
+#endif
 
 /*
  * MSVC compilers before VC7 don't have __func__ at all; later ones call it


### PR DESCRIPTION
GCC (and Clang acting in GCC mode, with `__GNUC__` defined) can handle `__attribute__` just fine.

This fixes building with libc++ - otherwise, the define no-ops out cruicial attributes within libc++ headers.