### PR TITLE
special gcc case ellipsis type

### DIFF
--- a/src/combine_labels.cpp
+++ b/src/combine_labels.cpp
@@ -50,7 +50,6 @@ void combine_labels(void)
    chunk_t *cur;
    chunk_t *prev;
    chunk_t *next;
-   chunk_t *tmp;
    bool    hit_case  = false;
    bool    hit_class = false;
 
@@ -165,7 +164,7 @@ void combine_labels(void)
          {
             hit_case = false;
             set_chunk_type(next, CT_CASE_COLON);
-            tmp = chunk_get_next_ncnlnp(next);                // Issue #2150
+            chunk_t *tmp = chunk_get_next_ncnlnp(next);                // Issue #2150
 
             if (chunk_is_token(tmp, CT_BRACE_OPEN))
             {
@@ -213,7 +212,7 @@ void combine_labels(void)
                {
                   c_token_t new_type = CT_TAG;
 
-                  tmp = chunk_get_next_nc(next);
+                  chunk_t   *tmp = chunk_get_next_nc(next);
 
                   if (tmp == nullptr)
                   {
@@ -250,7 +249,7 @@ void combine_labels(void)
             }
             else if (chunk_is_token(cur, CT_WORD))
             {
-               tmp = chunk_get_next_nc(next, scope_e::PREPROC);
+               chunk_t *tmp = chunk_get_next_nc(next, scope_e::PREPROC);
 
                // Issue #1187
                if (tmp == nullptr)
@@ -308,23 +307,23 @@ void combine_labels(void)
                {
                   set_chunk_type(next, CT_BIT_COLON);
 
-                  tmp = chunk_get_next(next);
+                  chunk_t *nnext = chunk_get_next(next);
 
-                  if (tmp == nullptr)
+                  if (nnext == nullptr)
                   {
                      return;
                   }
 
-                  while ((tmp = chunk_get_next(tmp)) != nullptr)
+                  while ((nnext = chunk_get_next(nnext)) != nullptr)
                   {
-                     if (chunk_is_token(tmp, CT_SEMICOLON))
+                     if (chunk_is_token(nnext, CT_SEMICOLON))
                      {
                         break;
                      }
 
-                     if (chunk_is_token(tmp, CT_COLON))
+                     if (chunk_is_token(nnext, CT_COLON))
                      {
-                        set_chunk_type(tmp, CT_BIT_COLON);
+                        set_chunk_type(nnext, CT_BIT_COLON);
                      }
                   }
                }
@@ -388,7 +387,7 @@ void combine_labels(void)
             }
             else
             {
-               tmp = chunk_get_next_ncnl(next);
+               chunk_t *tmp = chunk_get_next_ncnl(next);
 
                //tmp = chunk_get_next_local(next);
                if (tmp != nullptr)

--- a/src/combine_labels.cpp
+++ b/src/combine_labels.cpp
@@ -177,6 +177,16 @@ void combine_labels(void)
                   set_chunk_parent(tmp, CT_CASE);
                }
             }
+
+            if (chunk_is_token(cur, CT_NUMBER) && chunk_is_token(prev, CT_ELLIPSIS))
+            {
+               chunk_t *pre_elipsis = chunk_get_prev_ncnlnp(prev);
+
+               if (chunk_is_token(pre_elipsis, CT_NUMBER))
+               {
+                  set_chunk_type(prev, CT_CASE_ELLIPSIS);
+               }
+            }
          }
          else if (cur->flags.test(PCF_IN_WHERE_SPEC))
          {

--- a/src/token_enum.h
+++ b/src/token_enum.h
@@ -21,9 +21,6 @@
  * This is an enum of all the different chunks/tokens/elements that the
  * program can work with.  The parser and scanner assigns one of these to
  * each chunk/token.
- *
- * The script 'make_token_names.sh' creates token_names.h, so be sure to run
- * that after adding or removing an entry.
  */
 enum c_token_t
 {
@@ -141,6 +138,7 @@ enum c_token_t
    CT_COLON,
    CT_ASM_COLON,
    CT_CASE_COLON,
+   CT_CASE_ELLIPSIS,       // '...' in `case 1 ... 5`:
    CT_CLASS_COLON,         // colon after a class def
    CT_CONSTR_COLON,        // colon after a constructor
    CT_D_ARRAY_COLON,       // D named array initializer colon

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -820,6 +820,7 @@
 10023  U05-Cpp.cfg                          cpp/for_auto.cpp
 10024  U06-Cpp.cfg                          cpp/ifcomment.cpp
 10025  U07-Cpp.cfg                          cpp/qtargs.cpp
+10026  sp_before_ellipsis-r.cfg             cpp/gcc_case_ellipsis.cpp
 10047  U16-Cpp.cfg                          cpp/UNI-1334.cpp
 10048  empty.cfg                            cpp/UNI-1335.cpp
 10050  U18-Cpp.cfg                          cpp/UNI-1337.cpp

--- a/tests/expected/cpp/10026-gcc_case_ellipsis.cpp
+++ b/tests/expected/cpp/10026-gcc_case_ellipsis.cpp
@@ -1,0 +1,15 @@
+void f(int i)
+{
+	switch(i)
+	{
+	case 1 ... 2:
+	{
+		break;
+	}
+	case 3 ... 5:
+		break;
+
+	default:
+		break
+	}
+}

--- a/tests/input/cpp/gcc_case_ellipsis.cpp
+++ b/tests/input/cpp/gcc_case_ellipsis.cpp
@@ -1,0 +1,15 @@
+void f(int i)
+{
+	switch(i)
+	{
+	case 1 ... 2:
+	{
+		break;
+	}
+	case 3 ... 5:
+		break;
+
+	default:
+		break
+	}
+}


### PR DESCRIPTION
this will prevent normal ellipsis spacing options like `sp_before_ellipsis` to be applied

fixes #2849