### PR TITLE
byref ampersand (&) may follow either a type or a qualifier

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1529,7 +1529,8 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       {
          set_chunk_type(pc, CT_ADDR);
       }
-      else if (chunk_is_token(prev, CT_TYPE))
+      else if (  chunk_is_token(prev, CT_TYPE)
+              || chunk_is_token(prev, CT_QUALIFIER))
       {
          set_chunk_type(pc, CT_BYREF);
       }

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -621,6 +621,7 @@
 33152  bug_1004.cfg                         cpp/bug_1004.cpp
 
 33160  sp_before_byref-r.cfg                cpp/bug_1112.cpp
+33161  sp_before_byref-r.cfg                cpp/byref-3.cpp
 
 33180  pp_multi_comment.cfg                 cpp/pp_multi_comment.cpp
 

--- a/tests/expected/cpp/33161-byref-3.cpp
+++ b/tests/expected/cpp/33161-byref-3.cpp
@@ -1,0 +1,11 @@
+void test(void) {
+	auto const ic = 1;
+	auto iv = 1;
+	auto const& ric = ic;
+	auto& riv = iv;
+	const auto& ric2 = ic;
+	if (auto const& r(ric); r > 0) {
+	}
+	if (auto& r(riv); r > 0) {
+	}
+}

--- a/tests/input/cpp/byref-3.cpp
+++ b/tests/input/cpp/byref-3.cpp
@@ -1,0 +1,11 @@
+void test(void) {
+	auto const ic = 1;
+	auto iv = 1;
+	auto const & ric = ic;
+	auto & riv = iv;
+	const auto & ric2 = ic;
+	if (auto const & r(ric); r > 0) {
+	}
+	if (auto & r(riv); r > 0) {
+	}
+}


### PR DESCRIPTION
In C++ a reference to a const type (T) may be either `const T&` or `T const&` and uncrustify should treat the latter as a CT_BYREF not a CT_ARITH.