### PR TITLE
if the comma is before a member, it should be possible to remove it.

### DIFF
--- a/tests/config/Issue_2873.cfg
+++ b/tests/config/Issue_2873.cfg
@@ -1,0 +1,5 @@
+indent_columns      = 4
+indent_with_tabs    = 0
+indent_class        = true
+nl_constr_init_args = remove
+nl_class_init_args  = remove

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -143,6 +143,7 @@
 30125  sp_after_angle-2.cfg                 cpp/sp_after_angle.cpp
 30126  sp_after_angle-3.cfg                 cpp/sp_after_angle.cpp
 30127  empty.cfg                            cpp/Issue_2565.cpp
+30128  Issue_2873.cfg                       cpp/Issue_2873.cpp
 
 30200  bug_1862.cfg                         cpp/bug_1862.cpp
 30201  cmt_indent-1.cfg                     cpp/cmt_indent.cpp

--- a/tests/expected/cpp/30128-Issue_2873.cpp
+++ b/tests/expected/cpp/30128-Issue_2873.cpp
@@ -1,0 +1,16 @@
+class Capteur_CO2
+    : public Capteur, aabc, def
+{
+public:
+    Capteur_CO2()
+        : un ( 1 ), deux(2) {
+    }
+};
+class Capteur_CO3
+    : public Capteur,aabc,def
+{
+public:
+    Capteur_CO3()
+        : un ( 1 ),deux(2) {
+    }
+};

--- a/tests/input/cpp/Issue_2873.cpp
+++ b/tests/input/cpp/Issue_2873.cpp
@@ -1,0 +1,22 @@
+class Capteur_CO2
+    : public Capteur
+    , aabc
+    , def
+{
+public:
+    Capteur_CO2()
+        : un ( 1 )
+        , deux(2) {
+    }
+};
+class Capteur_CO3
+    : public Capteur,
+      aabc,
+      def
+{
+public:
+    Capteur_CO3()
+        : un ( 1 ),
+          deux(2) {
+    }
+};


### PR DESCRIPTION
Fix #2873