### PR TITLE
Fix 'nl_before_class' for templates and friends

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2352,6 +2352,14 @@ static void handle_cpp_template(chunk_t *pc)
    {
       tmp = chunk_get_next_ncnl(tmp);
 
+      if (chunk_is_token(tmp, CT_FRIEND))
+      {
+         // Account for a template friend declaration
+         set_chunk_parent(tmp, CT_TEMPLATE);
+
+         tmp = chunk_get_next_ncnl(tmp);
+      }
+
       if (chunk_is_token(tmp, CT_CLASS) || chunk_is_token(tmp, CT_STRUCT))
       {
          set_chunk_parent(tmp, CT_TEMPLATE);

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -5757,6 +5757,27 @@ void do_blank_lines(void)
          chunk_t *tmp = chunk_get_prev_type(prev, CT_CLASS, prev->level);
          tmp = chunk_get_prev_nc(tmp);
 
+         // Is this a class template?
+         if (get_chunk_parent_type(tmp) == CT_TEMPLATE)
+         {
+            tmp = chunk_get_prev_type(tmp, CT_TEMPLATE, prev->level);
+            tmp = chunk_get_prev_nc(tmp);
+         }
+         else
+         {
+            while (  chunk_is_token(tmp, CT_NEWLINE)
+                  && chunk_is_comment(tmp->prev))
+            {
+               tmp = chunk_get_prev_nc(tmp->prev);
+            }
+
+            if (chunk_is_token(tmp, CT_FRIEND))
+            {
+               // Account for a friend declaration
+               tmp = chunk_get_prev_nc(tmp);
+            }
+         }
+
          while (  chunk_is_token(tmp, CT_NEWLINE)
                && chunk_is_comment(tmp->prev))
          {

--- a/tests/config/nl_before_after.cfg
+++ b/tests/config/nl_before_after.cfg
@@ -4,3 +4,4 @@ nl_before_class                 = 2
 nl_after_class                  = 2
 nl_before_namespace             = 2
 nl_after_namespace              = 2
+nl_template_class               = force

--- a/tests/expected/cpp/34001-nl_before_after.h
+++ b/tests/expected/cpp/34001-nl_before_after.h
@@ -70,3 +70,14 @@ class I
 };
 
 void bar4();
+
+class H
+{
+
+    template<typename ...>
+    friend class I;
+
+    friend class J;
+
+    class K;
+};

--- a/tests/input/cpp/nl_before_after.h
+++ b/tests/input/cpp/nl_before_after.h
@@ -1,5 +1,7 @@
 namespace A {
+
 namespace S {
+
 class C
 {
 public:
@@ -11,16 +13,20 @@ public:
 
     virtual void removeSearch(int id) = 0;
 };
+
 } // namespace S
+
 } // namespace A
 
 namespace B {
+
 // This is a comment!
 class D
 {
 public:
     D();
 };
+
 } // namespace B
 
 // This is also a comment!
@@ -29,21 +35,28 @@ class E
 public:
     E();
 };
+
 namespace F {
 }
+
 void foo();
+
 class G
 {
 };
+
 void bar();
 
 void foo2();
+
 namespace E
 {
 }
+
 void bar2();
 
 void foo3();
+
 namespace F
 {
 }
@@ -51,8 +64,17 @@ namespace F
 void bar3();
 
 void foo4();
+
 class I
 {
 };
 
 void bar4();
+
+class H
+{
+template<typename ...>
+friend class I;
+friend class J;
+class K;
+};


### PR DESCRIPTION
- This patch fixes the 'nl_before_class' option so that it correctly
  introduces newlines before a class when preceded by 'template'
  or 'friend' keywords

- Updated test configuration associated with 'nl_before_after' to demonstrate the fix