### PR TITLE
Fix 'nl_before_class' for templates and friends

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2352,6 +2352,14 @@ static void handle_cpp_template(chunk_t *pc)
    {
       tmp = chunk_get_next_ncnl(tmp);
 
+      if (chunk_is_token(tmp, CT_FRIEND))
+      {
+         // Account for a template friend declaration
+         set_chunk_parent(tmp, CT_TEMPLATE);
+
+         tmp = chunk_get_next_ncnl(tmp);
+      }
+
       if (chunk_is_token(tmp, CT_CLASS) || chunk_is_token(tmp, CT_STRUCT))
       {
          set_chunk_parent(tmp, CT_TEMPLATE);

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -5755,7 +5755,29 @@ void do_blank_lines(void)
          && get_chunk_parent_type(prev) == CT_CLASS)
       {
          chunk_t *tmp = chunk_get_prev_type(prev, CT_CLASS, prev->level);
-         tmp = chunk_get_prev_nc(tmp);
+
+         // Is this a class template?
+         if (get_chunk_parent_type(tmp) == CT_TEMPLATE)
+         {
+            tmp = chunk_get_prev_type(tmp, CT_TEMPLATE, prev->level);
+            tmp = chunk_get_prev_nc(tmp);
+         }
+         else
+         {
+            tmp = chunk_get_prev_nc(tmp);
+
+            while (  chunk_is_token(tmp, CT_NEWLINE)
+                  && chunk_is_comment(tmp->prev))
+            {
+               tmp = chunk_get_prev_nc(tmp->prev);
+            }
+
+            if (chunk_is_token(tmp, CT_FRIEND))
+            {
+               // Account for a friend declaration
+               tmp = chunk_get_prev_nc(tmp);
+            }
+         }
 
          while (  chunk_is_token(tmp, CT_NEWLINE)
                && chunk_is_comment(tmp->prev))

--- a/tests/config/nl_before_after.cfg
+++ b/tests/config/nl_before_after.cfg
@@ -4,3 +4,4 @@ nl_before_class                 = 2
 nl_after_class                  = 2
 nl_before_namespace             = 2
 nl_after_namespace              = 2
+nl_template_class               = force

--- a/tests/expected/cpp/34001-nl_before_after.h
+++ b/tests/expected/cpp/34001-nl_before_after.h
@@ -70,3 +70,28 @@ class I
 };
 
 void bar4();
+
+/* multiline test comment
+   before class */
+template<typename ... Args>
+// test comment between template specification and associated class
+class H
+{
+
+    // nested class
+    template<typename ...>
+    friend class I;
+
+    friend class J;
+
+    // nested class K
+    template<typename T>
+    class K
+    {
+
+	// double-nested class L
+	class L { };
+
+    };
+
+};

--- a/tests/input/cpp/nl_before_after.h
+++ b/tests/input/cpp/nl_before_after.h
@@ -56,3 +56,21 @@ class I
 };
 
 void bar4();
+/* multiline test comment
+   before class */
+template<typename ... Args>
+// test comment between template specification and associated class
+class H
+{
+    // nested class
+template<typename ...>
+friend class I;
+friend class J;
+    // nested class K
+template<typename T>
+class K
+{
+        // double-nested class L
+class L { };
+};
+};


### PR DESCRIPTION
- This patch fixes the 'nl_before_class' option so that it correctly
  introduces newlines before a class when preceded by 'template'
  or 'friend' keywords