### PR TITLE
Improve interpretation of '&&' in template arg list

### DIFF
--- a/src/combine_tools.h
+++ b/src/combine_tools.h
@@ -54,7 +54,13 @@ void fix_fcn_def_params(chunk_t *pc);
 void flag_series(chunk_t *start, chunk_t *end, pcf_flags_t set_flags, pcf_flags_t clr_flags = {}, scope_e nav = scope_e::ALL);
 
 
-chunk_t *get_d_template_types(ChunkStack &cs, chunk_t *open_paren);
+/*
+ * Checks whether or not a given chunk has a parent cpp template,
+ * and if so returns the associated angle bracket nest level
+ * with respect to the root parent template; returns 0 if
+ * the chunk is not part of a template parameter list
+ */
+size_t get_cpp_template_angle_nest_level(chunk_t *pc);
 
 
 /**

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -612,6 +612,7 @@
 33104  bug_858-r.cfg                        cpp/bug_858.cpp
 
 33105  bug_1001.cfg                         cpp/bug_1001.cpp
+33106  bool-pos-eol-force.cfg               cpp/pos_bool_in_template.h
 33108  Issue_2045.cfg                       cpp/Issue_2045.cpp
 
 33110  enum.cfg                             cpp/enum.cpp

--- a/tests/expected/cpp/33106-pos_bool_in_template.h
+++ b/tests/expected/cpp/33106-pos_bool_in_template.h
@@ -1,0 +1,13 @@
+#include <type_traits>
+
+template<typename U,
+         typename V,
+         typename = std::enable_if_t<!std::is_convertible<U,
+                                                          V>::value &&
+                                     !std::is_same<U,
+                                                   V>::value> >
+void foo(U &&u,
+         V &&v)
+{
+
+}

--- a/tests/input/cpp/pos_bool_in_template.h
+++ b/tests/input/cpp/pos_bool_in_template.h
@@ -1,0 +1,7 @@
+#include <type_traits>
+
+template<typename U, typename V, typename = std::enable_if_t<!std::is_convertible<U, V>::value && !std::is_same<U, V>::value>>
+void foo(U &&u, V &&v)
+{
+
+}


### PR DESCRIPTION
Added logic to chunk_ends_type() function to more correctly interpret
'&&' in template parameter list. Specifically, nested template parameter
lists may contain a comma, and the chunk under test should take into
account the nest level associated with any commas encountered along the
way as it performs a backtrack in making its determination. Without this
logic, '&&' may erroneously be interpreted as 'BYREF' rather than 'BOOL'