### PR TITLE
Support { } in delctypes embedded within templates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,8 @@ set(uncrustify_sources
   src/cs_top_is_question.cpp
   src/detect.cpp
   src/enum_cleanup.cpp
+  src/flag_braced_init_list.cpp
+  src/flag_decltype.cpp
   src/flag_parens.cpp
   src/frame_list.cpp
 #  src/handle_oc.cpp
@@ -352,6 +354,8 @@ set(uncrustify_headers
   src/enum_cleanup.h
   src/enum_flags.h
   src/error_types.h
+  src/flag_braced_init_list.h
+  src/flag_decltype.h
   src/flag_parens.h
   src/frame_list.h
 #  src/handle_oc.h

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -16,6 +16,7 @@
 #include "combine_tools.h"
 #include "ChunkStack.h"
 #include "error_types.h"
+#include "flag_braced_init_list.h"
 #include "flag_parens.h"
 #include "lang_pawn.h"
 #include "language_tools.h"
@@ -1155,73 +1156,10 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
             set_chunk_parent(pc, pprev->type);
          }
       }
-      // Issue #2332
-      bool we_have_a_case_before = false;
 
-      if (chunk_is_token(pc, CT_COLON))
+      if (detect_cpp_braced_init_list(pc, next))
       {
-         // check if we have a case before
-         chunk_t *switch_before = chunk_get_prev_type(pc, CT_CASE, pc->level);
-
-         if (switch_before != nullptr)
-         {
-            LOG_FMT(LFCNR, "%s(%d): switch_before->orig_line is %zu, orig_col is %zu, text() is '%s', type is %s\n",
-                    __func__, __LINE__, switch_before->orig_line, switch_before->orig_col,
-                    switch_before->text(), get_token_name(switch_before->type));
-            we_have_a_case_before = true;
-         }
-      }
-
-      // Detect a braced-init-list
-      if (  chunk_is_token(pc, CT_WORD)
-         || chunk_is_token(pc, CT_TYPE)
-         || chunk_is_token(pc, CT_ASSIGN)
-         || chunk_is_token(pc, CT_RETURN)
-         || chunk_is_token(pc, CT_COMMA)
-         || chunk_is_token(pc, CT_ANGLE_CLOSE)
-         || chunk_is_token(pc, CT_SQUARE_CLOSE)
-         || chunk_is_token(pc, CT_TSQUARE)
-         || chunk_is_token(pc, CT_FPAREN_OPEN)
-         || chunk_is_token(pc, CT_QUESTION)
-         || (  chunk_is_token(pc, CT_COLON)
-            && !we_have_a_case_before)
-         || (  chunk_is_token(pc, CT_BRACE_OPEN)
-            && (  get_chunk_parent_type(pc) == CT_NONE
-               || get_chunk_parent_type(pc) == CT_BRACED_INIT_LIST)))
-      {
-         log_pcf_flags(LFCNR, pc->flags);
-         auto brace_open = chunk_get_next_ncnl(pc);
-
-         if (  chunk_is_token(brace_open, CT_BRACE_OPEN)
-            && (  get_chunk_parent_type(brace_open) == CT_NONE
-               || get_chunk_parent_type(brace_open) == CT_ASSIGN
-               || get_chunk_parent_type(brace_open) == CT_RETURN
-               || get_chunk_parent_type(brace_open) == CT_BRACED_INIT_LIST))
-         {
-            log_pcf_flags(LFCNR, brace_open->flags);
-            auto brace_close = chunk_skip_to_match(next);
-
-            if (chunk_is_token(brace_close, CT_BRACE_CLOSE))
-            {
-               set_chunk_parent(brace_open, CT_BRACED_INIT_LIST);
-               set_chunk_parent(brace_close, CT_BRACED_INIT_LIST);
-
-               tmp = chunk_get_next_ncnl(brace_close);
-
-               if (tmp)
-               {
-                  chunk_flags_clr(tmp, PCF_EXPR_START | PCF_STMT_START);
-               }
-               // TODO: Change pc->type CT_WORD -> CT_TYPE
-               // for the case CT_ASSIGN (and others).
-
-               // TODO: Move this block to the fix_fcn_call_args function.
-               if (chunk_is_token(pc, CT_WORD) && pc->flags.test(PCF_IN_FCN_CALL))
-               {
-                  set_chunk_type(pc, CT_TYPE);
-               }
-            }
-         }
+         flag_cpp_braced_init_list(pc, next);
       }
    }
 

--- a/src/flag_braced_init_list.cpp
+++ b/src/flag_braced_init_list.cpp
@@ -1,0 +1,93 @@
+/**
+ * @file flag_braced_init_list.cpp
+ *
+ * @license GPL v2+
+ */
+
+#include "chunk_list.h"
+#include "flag_braced_init_list.h"
+#include "uncrustify.h"
+
+
+bool detect_cpp_braced_init_list(chunk_t *pc, chunk_t *next)
+{
+   LOG_FUNC_ENTRY();
+   // Issue #2332
+   bool we_have_a_case_before = false;
+
+   if (chunk_is_token(pc, CT_COLON))
+   {
+      // check if we have a case before
+      chunk_t *switch_before = chunk_get_prev_type(pc, CT_CASE, pc->level);
+
+      if (switch_before != nullptr)
+      {
+         LOG_FMT(LFCNR, "%s(%d): switch_before->orig_line is %zu, orig_col is %zu, text() is '%s', type is %s\n",
+                 __func__, __LINE__, switch_before->orig_line, switch_before->orig_col,
+                 switch_before->text(), get_token_name(switch_before->type));
+         we_have_a_case_before = true;
+      }
+   }
+
+   // Detect a braced-init-list
+   if (  chunk_is_token(pc, CT_WORD)
+      || chunk_is_token(pc, CT_TYPE)
+      || chunk_is_token(pc, CT_ASSIGN)
+      || chunk_is_token(pc, CT_RETURN)
+      || chunk_is_token(pc, CT_COMMA)
+      || chunk_is_token(pc, CT_ANGLE_CLOSE)
+      || chunk_is_token(pc, CT_SQUARE_CLOSE)
+      || chunk_is_token(pc, CT_TSQUARE)
+      || chunk_is_token(pc, CT_FPAREN_OPEN)
+      || chunk_is_token(pc, CT_QUESTION)
+      || (  chunk_is_token(pc, CT_COLON)
+         && !we_have_a_case_before)
+      || (  chunk_is_token(pc, CT_BRACE_OPEN)
+         && (  get_chunk_parent_type(pc) == CT_NONE
+            || get_chunk_parent_type(pc) == CT_BRACED_INIT_LIST)))
+   {
+      log_pcf_flags(LFCNR, pc->flags);
+      auto brace_open = chunk_get_next_ncnl(pc);
+
+      if (  chunk_is_token(brace_open, CT_BRACE_OPEN)
+         && (  get_chunk_parent_type(brace_open) == CT_NONE
+            || get_chunk_parent_type(brace_open) == CT_ASSIGN
+            || get_chunk_parent_type(brace_open) == CT_RETURN
+            || get_chunk_parent_type(brace_open) == CT_BRACED_INIT_LIST))
+      {
+         log_pcf_flags(LFCNR, brace_open->flags);
+         auto brace_close = chunk_skip_to_match(next);
+
+         if (chunk_is_token(brace_close, CT_BRACE_CLOSE))
+         {
+            return(true);
+         }
+      }
+   }
+   return(false);
+} // detect_cpp_braced_init_list
+
+
+void flag_cpp_braced_init_list(chunk_t *pc, chunk_t *next)
+{
+   auto brace_open  = chunk_get_next_ncnl(pc);
+   auto brace_close = chunk_skip_to_match(next);
+
+   set_chunk_parent(brace_open, CT_BRACED_INIT_LIST);
+   set_chunk_parent(brace_close, CT_BRACED_INIT_LIST);
+
+   auto *tmp = chunk_get_next_ncnl(brace_close);
+
+   if (tmp != nullptr)
+   {
+      chunk_flags_clr(tmp, PCF_EXPR_START | PCF_STMT_START);
+   }
+   // TODO: Change pc->type CT_WORD -> CT_TYPE
+   // for the case CT_ASSIGN (and others).
+
+   // TODO: Move this block to the fix_fcn_call_args function.
+   if (chunk_is_token(pc, CT_WORD) && pc->flags.test(PCF_IN_FCN_CALL))
+   {
+      set_chunk_type(pc, CT_TYPE);
+   }
+} // flag_cpp_braced_init_list

--- a/src/flag_braced_init_list.h
+++ b/src/flag_braced_init_list.h
@@ -1,0 +1,25 @@
+/**
+ * @file flag_braced_init_list.h
+ *
+ * @license GPL v2+
+ */
+
+#ifndef FLAG_BRACED_INIT_LIST_INCLUDED
+#define FLAG_BRACED_INIT_LIST_INCLUDED
+
+
+/**
+ * Detect a cpp braced init list
+ */
+bool detect_cpp_braced_init_list(chunk_t *pc, chunk_t *next);
+
+
+/**
+ * Flags the opening and closing braces of an expression deemed to be
+ * a cpp braced initializer list; a call to detect_cpp_braced_init_list()
+ * should first be made prior to calling this function
+ */
+void flag_cpp_braced_init_list(chunk_t *pc, chunk_t *next);
+
+
+#endif

--- a/src/flag_decltype.cpp
+++ b/src/flag_decltype.cpp
@@ -1,0 +1,38 @@
+/**
+ * @file flag_decltype.cpp
+ *
+ * @license GPL v2+
+ */
+
+#include "chunk_list.h"
+#include "flag_decltype.h"
+
+
+bool flag_cpp_decltype(chunk_t *pc)
+{
+   LOG_FUNC_ENTRY();
+
+   if (chunk_is_token(pc, CT_DECLTYPE))
+   {
+      auto paren_open = chunk_get_next_ncnl(pc);
+
+      if (chunk_is_token(paren_open, CT_PAREN_OPEN))
+      {
+         auto close_paren = chunk_skip_to_match(paren_open);
+
+         if (close_paren != nullptr)
+         {
+            pc = paren_open;
+
+            do
+            {
+               chunk_flags_set(pc, PCF_IN_DECLTYPE);
+               pc = pc->next;
+            } while (pc != close_paren);
+
+            return(true);
+         }
+      }
+   }
+   return(false);
+} // mark_cpp_decltype

--- a/src/flag_decltype.h
+++ b/src/flag_decltype.h
@@ -1,0 +1,20 @@
+/**
+ * @file flag_decltype.h
+ *
+ * @license GPL v2+
+ */
+
+#ifndef FLAG_DECLTYPE_INCLUDED
+#define FLAG_DECLTYPE_INCLUDED
+
+
+/**
+ * Flags all chunks within a cpp decltype expression from the opening
+ * brace to the closing brace
+ *
+ * @return Returns true if expression is a valid decltype expression
+ */
+bool flag_cpp_decltype(chunk_t *pc);
+
+
+#endif

--- a/src/pcf_flags.cpp
+++ b/src/pcf_flags.cpp
@@ -25,35 +25,36 @@ static const char *pcf_names[] =
    "IN_FOR",            // 13
    "IN_OC_MSG",         // 14
    "IN_WHERE_SPEC",     // 15
-   "FORCE_SPACE",       // 16
-   "STMT_START",        // 17
-   "EXPR_START",        // 18
-   "DONT_INDENT",       // 19
-   "ALIGN_START",       // 20
-   "WAS_ALIGNED",       // 21
-   "VAR_TYPE",          // 22
-   "VAR_DEF",           // 23
-   "VAR_1ST",           // 24
-   "VAR_INLINE",        // 25
-   "RIGHT_COMMENT",     // 26
-   "OLD_FCN_PARAMS",    // 27
-   "LVALUE",            // 28
-   "ONE_LINER",         // 29
-   "EMPTY_BODY",        // 30
-   "ANCHOR",            // 31
-   "PUNCTUATOR",        // 32
-   "INSERTED",          // 33
-   "LONG_BLOCK",        // 34
-   "OC_BOXED",          // 35
-   "KEEP_BRACE",        // 36
-   "OC_RTYPE",          // 37
-   "OC_ATYPE",          // 38
-   "WF_ENDIF",          // 39
-   "IN_QT_MACRO",       // 40
-   "IN_FCN_CTOR",       // 41                    Issue #2152
-   "IN_TRY_BLOCK",      // 42                    Issue #1734
-   "INCOMPLETE",        // 43
-   "WF_IF",             // 44
+   "IN_DECLTYPE",       // 16
+   "FORCE_SPACE",       // 17
+   "STMT_START",        // 18
+   "EXPR_START",        // 19
+   "DONT_INDENT",       // 20
+   "ALIGN_START",       // 21
+   "WAS_ALIGNED",       // 22
+   "VAR_TYPE",          // 23
+   "VAR_DEF",           // 24
+   "VAR_1ST",           // 25
+   "VAR_INLINE",        // 26
+   "RIGHT_COMMENT",     // 27
+   "OLD_FCN_PARAMS",    // 28
+   "LVALUE",            // 29
+   "ONE_LINER",         // 30
+   "EMPTY_BODY",        // 31
+   "ANCHOR",            // 32
+   "PUNCTUATOR",        // 33
+   "INSERTED",          // 34
+   "LONG_BLOCK",        // 35
+   "OC_BOXED",          // 36
+   "KEEP_BRACE",        // 37
+   "OC_RTYPE",          // 38
+   "OC_ATYPE",          // 39
+   "WF_ENDIF",          // 40
+   "IN_QT_MACRO",       // 41
+   "IN_FCN_CTOR",       // 42                    Issue #2152
+   "IN_TRY_BLOCK",      // 43                    Issue #1734
+   "INCOMPLETE",        // 44
+   "WF_IF",             // 45
 };
 
 

--- a/src/pcf_flags.h
+++ b/src/pcf_flags.h
@@ -31,9 +31,9 @@ constexpr auto pcf_bit(size_t b) -> decltype(0ULL)
 
 enum pcf_flag_e : decltype(0ULL)
 {
-// Copy flags are in the lower 16 bits
+// Copy flags are in the lower 17 bits
    PCF_NONE            = 0ULL,
-   PCF_COPY_FLAGS      = 0x0000ffffULL,
+   PCF_COPY_FLAGS      = 0x0001ffffULL,
    PCF_IN_PREPROC      = pcf_bit(0),  //! in a preprocessor
    PCF_IN_STRUCT       = pcf_bit(1),  //! in a struct
    PCF_IN_ENUM         = pcf_bit(2),  //! in enum
@@ -50,40 +50,41 @@ enum pcf_flag_e : decltype(0ULL)
    PCF_IN_FOR          = pcf_bit(13),
    PCF_IN_OC_MSG       = pcf_bit(14),
    PCF_IN_WHERE_SPEC   = pcf_bit(15),  /* inside C# 'where' constraint clause on class or function def */
+   PCF_IN_DECLTYPE     = pcf_bit(16),
 
-// Non-Copy flags are in the upper 48 bits
-   PCF_FORCE_SPACE    = pcf_bit(16),   //! must have a space after this token
-   PCF_STMT_START     = pcf_bit(17),   //! marks the start of a statement
-   PCF_EXPR_START     = pcf_bit(18),
-   PCF_DONT_INDENT    = pcf_bit(19),   //! already aligned!
-   PCF_ALIGN_START    = pcf_bit(20),
-   PCF_WAS_ALIGNED    = pcf_bit(21),
-   PCF_VAR_TYPE       = pcf_bit(22),   //! part of a variable def type
-   PCF_VAR_DEF        = pcf_bit(23),   //! variable name in a variable def
-   PCF_VAR_1ST        = pcf_bit(24),   //! 1st variable def in a statement
+// Non-Copy flags are in the upper 47 bits
+   PCF_FORCE_SPACE    = pcf_bit(17),   //! must have a space after this token
+   PCF_STMT_START     = pcf_bit(18),   //! marks the start of a statement
+   PCF_EXPR_START     = pcf_bit(19),
+   PCF_DONT_INDENT    = pcf_bit(20),   //! already aligned!
+   PCF_ALIGN_START    = pcf_bit(21),
+   PCF_WAS_ALIGNED    = pcf_bit(22),
+   PCF_VAR_TYPE       = pcf_bit(23),   //! part of a variable def type
+   PCF_VAR_DEF        = pcf_bit(24),   //! variable name in a variable def
+   PCF_VAR_1ST        = pcf_bit(25),   //! 1st variable def in a statement
    PCF_VAR_1ST_DEF    = (PCF_VAR_DEF | PCF_VAR_1ST),
-   PCF_VAR_INLINE     = pcf_bit(25),   //! type was an inline struct/enum/union
-   PCF_RIGHT_COMMENT  = pcf_bit(26),
-   PCF_OLD_FCN_PARAMS = pcf_bit(27),
-   PCF_LVALUE         = pcf_bit(28),   //! left of assignment
-   PCF_ONE_LINER      = pcf_bit(29),
+   PCF_VAR_INLINE     = pcf_bit(26),   //! type was an inline struct/enum/union
+   PCF_RIGHT_COMMENT  = pcf_bit(27),
+   PCF_OLD_FCN_PARAMS = pcf_bit(28),
+   PCF_LVALUE         = pcf_bit(29),   //! left of assignment
+   PCF_ONE_LINER      = pcf_bit(30),
    PCF_ONE_CLASS      = (PCF_ONE_LINER | PCF_IN_CLASS),
-   PCF_EMPTY_BODY     = pcf_bit(30),
-   PCF_ANCHOR         = pcf_bit(31),   //! aligning anchor
-   PCF_PUNCTUATOR     = pcf_bit(32),
-   PCF_INSERTED       = pcf_bit(33),   //! chunk was inserted from another file
-   PCF_LONG_BLOCK     = pcf_bit(34),   //! the block is 'long' by some measure
-   PCF_OC_BOXED       = pcf_bit(35),   //! inside OC boxed expression
-   PCF_KEEP_BRACE     = pcf_bit(36),   //! do not remove brace
-   PCF_OC_RTYPE       = pcf_bit(37),   //! inside OC return type
-   PCF_OC_ATYPE       = pcf_bit(38),   //! inside OC arg type
-   PCF_WF_ENDIF       = pcf_bit(39),   //! #endif for whole file ifdef
-   PCF_IN_QT_MACRO    = pcf_bit(40),   //! in a QT-macro, i.e. SIGNAL, SLOT
-   PCF_IN_FCN_CTOR    = pcf_bit(41),   //! inside function constructor
-   PCF_IN_TRY_BLOCK   = pcf_bit(42),   //! inside Function-try-block
-   PCF_INCOMPLETE     = pcf_bit(43),   //! class/struct forward declaration
-   PCF_WF_IF          = pcf_bit(44),   //! #if for a whole file ifdef
-   PCF_NOT_POSSIBLE   = pcf_bit(45),   //! it is not possible to make an one_liner
+   PCF_EMPTY_BODY     = pcf_bit(31),
+   PCF_ANCHOR         = pcf_bit(32),   //! aligning anchor
+   PCF_PUNCTUATOR     = pcf_bit(33),
+   PCF_INSERTED       = pcf_bit(34),   //! chunk was inserted from another file
+   PCF_LONG_BLOCK     = pcf_bit(35),   //! the block is 'long' by some measure
+   PCF_OC_BOXED       = pcf_bit(36),   //! inside OC boxed expression
+   PCF_KEEP_BRACE     = pcf_bit(37),   //! do not remove brace
+   PCF_OC_RTYPE       = pcf_bit(38),   //! inside OC return type
+   PCF_OC_ATYPE       = pcf_bit(39),   //! inside OC arg type
+   PCF_WF_ENDIF       = pcf_bit(40),   //! #endif for whole file ifdef
+   PCF_IN_QT_MACRO    = pcf_bit(41),   //! in a QT-macro, i.e. SIGNAL, SLOT
+   PCF_IN_FCN_CTOR    = pcf_bit(42),   //! inside function constructor
+   PCF_IN_TRY_BLOCK   = pcf_bit(43),   //! inside Function-try-block
+   PCF_INCOMPLETE     = pcf_bit(44),   //! class/struct forward declaration
+   PCF_WF_IF          = pcf_bit(45),   //! #if for a whole file ifdef
+   PCF_NOT_POSSIBLE   = pcf_bit(46),   //! it is not possible to make an one_liner
                                        //! because the line would be too long
 };
 

--- a/tests/cli/output/p.txt
+++ b/tests/cli/output/p.txt
@@ -8,72 +8,72 @@ newlines                        = crlf
 # language                      = CPP
 # -=====-
 # Line                Tag         Parent_type  Type of the parent         Columns Br/Lvl/pp      Flag   Nl  Text
-#   1>            PREPROC|          PP_DEFINE|     PARENT_NOT_SET[  1/  1/  2/  0][1/1/0][  1000e0001][0-0] #
-#   1>          PP_DEFINE|               NONE|     PARENT_NOT_SET[  2/  2/  8/  0][1/1/0][      10001][0-0]  define
-#   1>              MACRO|               NONE|     PARENT_NOT_SET[  9/  9/ 10/  1][1/1/0][      10001][0-0]         x
-#   1>               WORD|               NONE|     PARENT_NOT_SET[ 11/ 11/ 18/  1][1/1/0][      40001][0-0]           s23_foo
-#   1>             ASSIGN|               NONE|     PARENT_NOT_SET[ 19/ 19/ 21/  1][1/1/0][  100000001][0-0]                   +=
-#   1>            NL_CONT|               NONE|     PARENT_NOT_SET[ 22/ 22/  1/  1][1/1/0][      40001][1-0]                      \
-#   2>               WORD|               NONE|     PARENT_NOT_SET[  9/  1/  7/  0][1/1/0][      40001][0-0]         s8_foo
-#   2>              ARITH|               NONE|     PARENT_NOT_SET[ 16/  8/  9/  1][1/1/0][  100000001][0-0]                *
-#   2>               WORD|               NONE|     PARENT_NOT_SET[ 18/ 10/ 17/  1][1/1/0][      40001][0-0]                  s16_bar
-#   2>          SEMICOLON|               NONE|     PARENT_NOT_SET[ 25/ 17/ 18/  0][1/1/0][  100000001][0-0]                         ;
+#   1>            PREPROC|          PP_DEFINE|     PARENT_NOT_SET[  1/  1/  2/  0][1/1/0][  2001c0001][0-0] #
+#   1>          PP_DEFINE|               NONE|     PARENT_NOT_SET[  2/  2/  8/  0][1/1/0][      20001][0-0]  define
+#   1>              MACRO|               NONE|     PARENT_NOT_SET[  9/  9/ 10/  1][1/1/0][      20001][0-0]         x
+#   1>               WORD|               NONE|     PARENT_NOT_SET[ 11/ 11/ 18/  1][1/1/0][      80001][0-0]           s23_foo
+#   1>             ASSIGN|               NONE|     PARENT_NOT_SET[ 19/ 19/ 21/  1][1/1/0][  200000001][0-0]                   +=
+#   1>            NL_CONT|               NONE|     PARENT_NOT_SET[ 22/ 22/  1/  1][1/1/0][      80001][1-0]                      \
+#   2>               WORD|               NONE|     PARENT_NOT_SET[  9/  1/  7/  0][1/1/0][      80001][0-0]         s8_foo
+#   2>              ARITH|               NONE|     PARENT_NOT_SET[ 16/  8/  9/  1][1/1/0][  200000001][0-0]                *
+#   2>               WORD|               NONE|     PARENT_NOT_SET[ 18/ 10/ 17/  1][1/1/0][      80001][0-0]                  s16_bar
+#   2>          SEMICOLON|               NONE|     PARENT_NOT_SET[ 25/ 17/ 18/  0][1/1/0][  200000001][0-0]                         ;
 #   2>            NEWLINE|               NONE|     PARENT_NOT_SET[ 26/ 18/  1/  0][0/0/0][          0][2-0]
-#   4>             STRUCT|               NONE|     PARENT_NOT_SET[  1/  1/  7/  0][0/0/0][   10070000][0-0] struct
-#   4>               TYPE|             STRUCT|     PARENT_NOT_SET[  8/  8/ 21/  1][0/0/0][   10000000][0-0]        TelegramIndex
+#   4>             STRUCT|               NONE|     PARENT_NOT_SET[  1/  1/  7/  0][0/0/0][   200e0000][0-0] struct
+#   4>               TYPE|             STRUCT|     PARENT_NOT_SET[  8/  8/ 21/  1][0/0/0][   20000000][0-0]        TelegramIndex
 #   4>            NEWLINE|               NONE|     PARENT_NOT_SET[ 21/ 21/  1/  0][0/0/0][          0][1-0]
-#   5>         BRACE_OPEN|             STRUCT|     PARENT_NOT_SET[  1/  1/  2/  0][0/0/0][  100000400][0-0] {
+#   5>         BRACE_OPEN|             STRUCT|     PARENT_NOT_SET[  1/  1/  2/  0][0/0/0][  200000400][0-0] {
 #   5>            NEWLINE|               NONE|     PARENT_NOT_SET[  2/  2/  1/  0][1/1/0][          2][1-0]
-#   6>     FUNC_CLASS_DEF|               NONE|     PARENT_NOT_SET[  9/  1/ 14/  0][1/1/0][      60402][0-0]         TelegramIndex
-#   6>        FPAREN_OPEN|     FUNC_CLASS_DEF|     PARENT_NOT_SET[ 22/ 14/ 15/  0][1/1/0][  100000502][0-0]                      (
-#   6>          QUALIFIER|               NONE|     PARENT_NOT_SET[ 23/ 15/ 20/  0][1/2/0][      50512][0-0]                       const
-#   6>               TYPE|               NONE|     PARENT_NOT_SET[ 29/ 21/ 25/  1][1/2/0][     400512][0-0]                             char
-#   6>           PTR_TYPE|               NONE|     PARENT_NOT_SET[ 33/ 25/ 26/  0][1/2/0][  100000512][0-0]                                 *
-#   6>               WORD|               NONE|     PARENT_NOT_SET[ 35/ 27/ 29/  1][1/2/0][     800512][0-0]                                   pN
-#   6>              COMMA|               NONE|     PARENT_NOT_SET[ 37/ 29/ 30/  0][1/2/0][  100000512][0-0]                                     ,
-#   6>               TYPE|               NONE|     PARENT_NOT_SET[ 39/ 31/ 39/  1][1/2/0][     450512][0-0]                                       unsigned
-#   6>               TYPE|               NONE|     PARENT_NOT_SET[ 48/ 40/ 44/  1][1/2/0][     410512][0-0]                                                long
-#   6>               WORD|               NONE|     PARENT_NOT_SET[ 53/ 45/ 47/  1][1/2/0][     800512][0-0]                                                     nI
-#   6>       FPAREN_CLOSE|     FUNC_CLASS_DEF|     PARENT_NOT_SET[ 55/ 47/ 48/  0][1/1/0][  100000512][0-0]                                                       )
-#   6>       CONSTR_COLON|               NONE|     PARENT_NOT_SET[ 57/ 49/ 50/  1][1/1/0][  100000502][0-0]                                                         :
+#   6>     FUNC_CLASS_DEF|               NONE|     PARENT_NOT_SET[  9/  1/ 14/  0][1/1/0][      c0402][0-0]         TelegramIndex
+#   6>        FPAREN_OPEN|     FUNC_CLASS_DEF|     PARENT_NOT_SET[ 22/ 14/ 15/  0][1/1/0][  200000502][0-0]                      (
+#   6>          QUALIFIER|               NONE|     PARENT_NOT_SET[ 23/ 15/ 20/  0][1/2/0][      a0512][0-0]                       const
+#   6>               TYPE|               NONE|     PARENT_NOT_SET[ 29/ 21/ 25/  1][1/2/0][     800512][0-0]                             char
+#   6>           PTR_TYPE|               NONE|     PARENT_NOT_SET[ 33/ 25/ 26/  0][1/2/0][  200000512][0-0]                                 *
+#   6>               WORD|               NONE|     PARENT_NOT_SET[ 35/ 27/ 29/  1][1/2/0][    1000512][0-0]                                   pN
+#   6>              COMMA|               NONE|     PARENT_NOT_SET[ 37/ 29/ 30/  0][1/2/0][  200000512][0-0]                                     ,
+#   6>               TYPE|               NONE|     PARENT_NOT_SET[ 39/ 31/ 39/  1][1/2/0][     8a0512][0-0]                                       unsigned
+#   6>               TYPE|               NONE|     PARENT_NOT_SET[ 48/ 40/ 44/  1][1/2/0][     820512][0-0]                                                long
+#   6>               WORD|               NONE|     PARENT_NOT_SET[ 53/ 45/ 47/  1][1/2/0][    1000512][0-0]                                                     nI
+#   6>       FPAREN_CLOSE|     FUNC_CLASS_DEF|     PARENT_NOT_SET[ 55/ 47/ 48/  0][1/1/0][  200000512][0-0]                                                       )
+#   6>       CONSTR_COLON|               NONE|     PARENT_NOT_SET[ 57/ 49/ 50/  1][1/1/0][  200000502][0-0]                                                         :
 #   6>            NEWLINE|               NONE|     PARENT_NOT_SET[ 58/ 50/  1/  0][1/1/0][          2][1-0]
-#   7>      FUNC_CTOR_VAR|               NONE|     PARENT_NOT_SET[ 17/  1/  9/  0][1/1/0][      60502][0-0]                 pTelName
-#   7>        FPAREN_OPEN|      FUNC_CTOR_VAR|     PARENT_NOT_SET[ 25/  9/ 10/  0][1/1/0][  100000502][0-0]                         (
-#   7>               WORD|               NONE|     PARENT_NOT_SET[ 26/ 10/ 12/  0][1/2/0][      40512][0-0]                          pN
-#   7>       FPAREN_CLOSE|      FUNC_CTOR_VAR|     PARENT_NOT_SET[ 28/ 12/ 13/  0][1/1/0][  100000512][0-0]                            )
-#   7>              COMMA|               NONE|     PARENT_NOT_SET[ 29/ 13/ 14/  0][1/1/0][  100000502][0-0]                             ,
+#   7>      FUNC_CTOR_VAR|               NONE|     PARENT_NOT_SET[ 17/  1/  9/  0][1/1/0][      c0502][0-0]                 pTelName
+#   7>        FPAREN_OPEN|      FUNC_CTOR_VAR|     PARENT_NOT_SET[ 25/  9/ 10/  0][1/1/0][  200000502][0-0]                         (
+#   7>               WORD|               NONE|     PARENT_NOT_SET[ 26/ 10/ 12/  0][1/2/0][      80512][0-0]                          pN
+#   7>       FPAREN_CLOSE|      FUNC_CTOR_VAR|     PARENT_NOT_SET[ 28/ 12/ 13/  0][1/1/0][  200000512][0-0]                            )
+#   7>              COMMA|               NONE|     PARENT_NOT_SET[ 29/ 13/ 14/  0][1/1/0][  200000502][0-0]                             ,
 #   7>            NEWLINE|               NONE|     PARENT_NOT_SET[ 30/ 14/  1/  0][1/1/0][          2][1-0]
-#   8>      FUNC_CTOR_VAR|               NONE|     PARENT_NOT_SET[ 17/  1/ 10/  0][1/1/0][      40502][0-0]                 nTelIndex
-#   8>        FPAREN_OPEN|      FUNC_CTOR_VAR|     PARENT_NOT_SET[ 26/ 10/ 11/  0][1/1/0][  100000502][0-0]                          (
-#   8>               WORD|               NONE|     PARENT_NOT_SET[ 27/ 11/ 12/  0][1/2/0][      40512][0-0]                           n
-#   8>       FPAREN_CLOSE|      FUNC_CTOR_VAR|     PARENT_NOT_SET[ 28/ 12/ 13/  0][1/1/0][  100000512][0-0]                            )
+#   8>      FUNC_CTOR_VAR|               NONE|     PARENT_NOT_SET[ 17/  1/ 10/  0][1/1/0][      80502][0-0]                 nTelIndex
+#   8>        FPAREN_OPEN|      FUNC_CTOR_VAR|     PARENT_NOT_SET[ 26/ 10/ 11/  0][1/1/0][  200000502][0-0]                          (
+#   8>               WORD|               NONE|     PARENT_NOT_SET[ 27/ 11/ 12/  0][1/2/0][      80512][0-0]                           n
+#   8>       FPAREN_CLOSE|      FUNC_CTOR_VAR|     PARENT_NOT_SET[ 28/ 12/ 13/  0][1/1/0][  200000512][0-0]                            )
 #   8>            NEWLINE|               NONE|     PARENT_NOT_SET[ 29/ 13/  1/  0][1/1/0][          2][1-0]
-#   9>         BRACE_OPEN|     FUNC_CLASS_DEF|     PARENT_NOT_SET[  9/  1/  2/  0][1/1/0][  140000402][0-0]         {
+#   9>         BRACE_OPEN|     FUNC_CLASS_DEF|     PARENT_NOT_SET[  9/  1/  2/  0][1/1/0][  280000402][0-0]         {
 #   9>            NEWLINE|               NONE|     PARENT_NOT_SET[ 10/  2/  1/  0][2/2/0][          2][1-0]
-#  10>        BRACE_CLOSE|     FUNC_CLASS_DEF|     PARENT_NOT_SET[  9/  1/  2/  0][1/1/0][  140000402][0-0]         }
+#  10>        BRACE_CLOSE|     FUNC_CLASS_DEF|     PARENT_NOT_SET[  9/  1/  2/  0][1/1/0][  280000402][0-0]         }
 #  10>            NEWLINE|               NONE|     PARENT_NOT_SET[ 10/  2/  1/  0][1/1/0][          2][2-0]
-#  12>         DESTRUCTOR|               NONE|     PARENT_NOT_SET[  9/  1/  2/  0][1/1/0][  100060402][0-0]         ~
-#  12>     FUNC_CLASS_DEF|         DESTRUCTOR|     PARENT_NOT_SET[ 10/  2/ 15/  0][1/1/0][      40402][0-0]          TelegramIndex
-#  12>        FPAREN_OPEN|     FUNC_CLASS_DEF|     PARENT_NOT_SET[ 23/ 15/ 16/  0][1/1/0][  100000502][0-0]                       (
-#  12>       FPAREN_CLOSE|     FUNC_CLASS_DEF|     PARENT_NOT_SET[ 24/ 16/ 17/  0][1/1/0][  100000512][0-0]                        )
+#  12>         DESTRUCTOR|               NONE|     PARENT_NOT_SET[  9/  1/  2/  0][1/1/0][  2000c0402][0-0]         ~
+#  12>     FUNC_CLASS_DEF|         DESTRUCTOR|     PARENT_NOT_SET[ 10/  2/ 15/  0][1/1/0][      80402][0-0]          TelegramIndex
+#  12>        FPAREN_OPEN|     FUNC_CLASS_DEF|     PARENT_NOT_SET[ 23/ 15/ 16/  0][1/1/0][  200000502][0-0]                       (
+#  12>       FPAREN_CLOSE|     FUNC_CLASS_DEF|     PARENT_NOT_SET[ 24/ 16/ 17/  0][1/1/0][  200000512][0-0]                        )
 #  12>            NEWLINE|               NONE|     PARENT_NOT_SET[ 25/ 17/  1/  0][1/1/0][          2][1-0]
-#  13>         BRACE_OPEN|     FUNC_CLASS_DEF|     PARENT_NOT_SET[  9/  1/  2/  0][1/1/0][  140000402][0-0]         {
+#  13>         BRACE_OPEN|     FUNC_CLASS_DEF|     PARENT_NOT_SET[  9/  1/  2/  0][1/1/0][  280000402][0-0]         {
 #  13>            NEWLINE|               NONE|     PARENT_NOT_SET[ 10/  2/  1/  0][2/2/0][          2][1-0]
-#  14>        BRACE_CLOSE|     FUNC_CLASS_DEF|     PARENT_NOT_SET[  9/  1/  2/  0][1/1/0][  140000402][0-0]         }
+#  14>        BRACE_CLOSE|     FUNC_CLASS_DEF|     PARENT_NOT_SET[  9/  1/  2/  0][1/1/0][  280000402][0-0]         }
 #  14>            NEWLINE|               NONE|     PARENT_NOT_SET[ 10/  2/  1/  0][1/1/0][          2][2-0]
-#  16>          QUALIFIER|               NONE|     PARENT_NOT_SET[  9/  1/  6/  0][1/1/0][     470402][0-0]         const
-#  16>               TYPE|               NONE|     PARENT_NOT_SET[ 15/  7/ 11/  1][1/1/0][     400402][0-0]               char
-#  16>           PTR_TYPE|               NONE|     PARENT_NOT_SET[ 19/ 11/ 12/  0][1/1/0][  100400402][0-0]                   *
-#  16>          QUALIFIER|               NONE|     PARENT_NOT_SET[ 21/ 13/ 18/  1][1/1/0][     410402][0-0]                     const
-#  16>               WORD|               NONE|     PARENT_NOT_SET[ 27/ 19/ 27/  1][1/1/0][    1800402][0-0]                           pTelName
-#  16>          SEMICOLON|               NONE|     PARENT_NOT_SET[ 35/ 27/ 28/  0][1/1/0][  100000402][0-0]                                   ;
+#  16>          QUALIFIER|               NONE|     PARENT_NOT_SET[  9/  1/  6/  0][1/1/0][     8e0402][0-0]         const
+#  16>               TYPE|               NONE|     PARENT_NOT_SET[ 15/  7/ 11/  1][1/1/0][     800402][0-0]               char
+#  16>           PTR_TYPE|               NONE|     PARENT_NOT_SET[ 19/ 11/ 12/  0][1/1/0][  200800402][0-0]                   *
+#  16>          QUALIFIER|               NONE|     PARENT_NOT_SET[ 21/ 13/ 18/  1][1/1/0][     820402][0-0]                     const
+#  16>               WORD|               NONE|     PARENT_NOT_SET[ 27/ 19/ 27/  1][1/1/0][    3000402][0-0]                           pTelName
+#  16>          SEMICOLON|               NONE|     PARENT_NOT_SET[ 35/ 27/ 28/  0][1/1/0][  200000402][0-0]                                   ;
 #  16>            NEWLINE|               NONE|     PARENT_NOT_SET[ 36/ 28/  1/  0][1/1/0][          2][1-0]
-#  17>               TYPE|               NONE|     PARENT_NOT_SET[  9/  1/  9/  0][1/1/0][     470402][0-0]         unsigned
-#  17>               TYPE|               NONE|     PARENT_NOT_SET[ 18/ 10/ 14/  1][1/1/0][     410402][0-0]                  long
-#  17>               WORD|               NONE|     PARENT_NOT_SET[ 23/ 15/ 24/  1][1/1/0][    1800402][0-0]                       nTelIndex
-#  17>          SEMICOLON|               NONE|     PARENT_NOT_SET[ 32/ 24/ 25/  0][1/1/0][  100000402][0-0]                                ;
+#  17>               TYPE|               NONE|     PARENT_NOT_SET[  9/  1/  9/  0][1/1/0][     8e0402][0-0]         unsigned
+#  17>               TYPE|               NONE|     PARENT_NOT_SET[ 18/ 10/ 14/  1][1/1/0][     820402][0-0]                  long
+#  17>               WORD|               NONE|     PARENT_NOT_SET[ 23/ 15/ 24/  1][1/1/0][    3000402][0-0]                       nTelIndex
+#  17>          SEMICOLON|               NONE|     PARENT_NOT_SET[ 32/ 24/ 25/  0][1/1/0][  200000402][0-0]                                ;
 #  17>            NEWLINE|               NONE|     PARENT_NOT_SET[ 33/ 25/  1/  0][1/1/0][          2][1-0]
-#  18>        BRACE_CLOSE|             STRUCT|     PARENT_NOT_SET[  1/  1/  2/  0][0/0/0][  100000402][0-0] }
-#  18>          SEMICOLON|             STRUCT|     PARENT_NOT_SET[  2/  2/  3/  0][0/0/0][  100000000][0-0]  ;
+#  18>        BRACE_CLOSE|             STRUCT|     PARENT_NOT_SET[  1/  1/  2/  0][0/0/0][  200000402][0-0] }
+#  18>          SEMICOLON|             STRUCT|     PARENT_NOT_SET[  2/  2/  3/  0][0/0/0][  200000000][0-0]  ;
 #  18>            NEWLINE|               NONE|     PARENT_NOT_SET[  3/  3/  1/  0][0/0/0][          0][2-0]
 # -=====-

--- a/tests/cli/test_cli_options.py
+++ b/tests/cli/test_cli_options.py
@@ -702,8 +702,8 @@ def main(args):
                                   reg_replace(r'\[line [0-9]+', '[ '),
                                   reg_replace(r'   \[[_|,|1|A-Z]*\]', '   []'),
                                   reg_replace(r', \[[_|,|1|A-Z]*\]', ', []'),
-                                  reg_replace(r', \[0x[0-9]+:[_|,|1|A-Z]*\]', ', []'),
-                                  reg_replace(r'   \[0x[0-9]+:[_|,|1|A-Z]*\]', '   []'),
+                                  reg_replace(r', \[0[xX][0-9a-fA-F]+:[_|,|1|A-Z]*\]', ', []'),
+                                  reg_replace(r'   \[0[xX][0-9a-fA-F]+:[_|,|1|A-Z]*\]', '   []'),
                                   reg_replace(RE_CALLSTACK, '[CallStack]'),
                                   reg_replace(RE_DO_SPACE, '')]
             ):

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -230,6 +230,7 @@
 30314  sp_brace_brace-f.cfg                 cpp/sp_brace_brace.cpp
 30315  issue_1997.cfg                       cpp/return_braced_init.cpp
 30316  Issue_2428.cfg                       cpp/Issue_2428.cpp
+30317  pos_comma-tb.cfg                     cpp/braced_init_template_decltype.cpp
 
 30320  sp_return_paren-r.cfg                cpp/returns.cpp
 30321  sp_return_paren-f.cfg                cpp/returns.cpp

--- a/tests/expected/cpp/30317-braced_init_template_decltype.cpp
+++ b/tests/expected/cpp/30317-braced_init_template_decltype.cpp
@@ -1,0 +1,13 @@
+#include <algorithm>
+#include <type_traits>
+
+template<typename Arg,
+         typename ... Args,
+         typename std::enable_if <!std::is_same<Arg,
+                                                decltype (std::make_index_sequence<5> { })>::value,
+                                  int>::type = 0>
+void foo(Arg &&arg,
+         Args && ... args)
+{
+
+}

--- a/tests/input/cpp/braced_init_template_decltype.cpp
+++ b/tests/input/cpp/braced_init_template_decltype.cpp
@@ -1,0 +1,8 @@
+#include <algorithm>
+#include <type_traits>
+
+template<typename Arg, typename ... Args, typename std::enable_if <!std::is_same<Arg, decltype (std::make_index_sequence<5> { })>::value, int>::type = 0>
+void foo(Arg &&arg, Args && ... args)
+{
+
+}


### PR DESCRIPTION
- Modified the check_template() function to account for braces that may be
  embedded within a decltype statement that itself is within a template
  argument list. Without this modification, check_template() incorrectly
  interprets the angle brackets within a template as comparisons

- Moved existing code already used to detect braced initializer statements
  into a separate function so that check_template() may leverage this
  detection code as well

- Added new flag 'PCF_IN_DECLTYPE' to indicate chunk within cpp decltype
  statement

- Made modifications to mark chunks belonging to decltype statements

- Updated cli test scripts and expected output to reflect additions to
  pcf_flag_e bitfields.