### PR TITLE
Add option to insert blank lines in empty function

### DIFF
--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -140,6 +140,7 @@ nl_func_type_name_class                   = remove
 nl_func_var_def_blk                       = 1
 nl_getset_leave_one_liners                = true
 nl_if_brace                               = add
+nl_inside_empty_func                      = 1
 nl_inside_namespace                       = 2
 nl_max                                    = 3
 nl_namespace_brace                        = force

--- a/src/options.h
+++ b/src/options.h
@@ -1582,7 +1582,7 @@ extern BoundedOption<unsigned, 0, 16>
 indent_min_vbrace_open;
 
 // Whether to add further spaces after regular indent to reach next tabstop
-// when identing after virtual brace open and newline.
+// when indenting after virtual brace open and newline.
 extern Option<bool>
 indent_vbrace_open_on_tabstop;
 
@@ -1643,6 +1643,7 @@ indent_ignore_asm_block;
 //BEGIN Newline adding and removing options
 
 // Whether to collapse empty blocks between '{' and '}'.
+// If true, overrides nl_inside_empty_func
 extern Option<bool>
 nl_collapse_empty_body;
 
@@ -2465,6 +2466,11 @@ nl_max;
 // The maximum number of consecutive newlines in a function.
 extern BoundedOption<unsigned, 0, 16>
 nl_max_blank_in_func;
+
+// The number of newlines inside an empty function body.
+// This option is overridden by nl_collapse_empty_body=true
+extern BoundedOption<unsigned, 0, 16>
+nl_inside_empty_func;
 
 // The number of newlines before a function prototype.
 extern BoundedOption<unsigned, 0, 16>

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -515,6 +515,7 @@ nl_split_for_one_liner          = false
 nl_split_while_one_liner        = false
 nl_max                          = 0
 nl_max_blank_in_func            = 0
+nl_inside_empty_func            = 0
 nl_before_func_body_proto       = 0
 nl_before_func_body_def         = 0
 nl_before_func_class_proto      = 0

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1289,7 +1289,7 @@ indent_oc_block_msg_from_brace  = false    # true/false
 indent_min_vbrace_open          = 0        # unsigned number
 
 # Whether to add further spaces after regular indent to reach next tabstop
-# when identing after virtual brace open and newline.
+# when indenting after virtual brace open and newline.
 indent_vbrace_open_on_tabstop   = false    # true/false
 
 # How to indent after a brace followed by another token (not a newline).
@@ -1344,6 +1344,7 @@ indent_ignore_asm_block         = false    # true/false
 #
 
 # Whether to collapse empty blocks between '{' and '}'.
+# If true, overrides nl_inside_empty_func
 nl_collapse_empty_body          = false    # true/false
 
 # Don't split one-line braced assignments, as in 'foo_t f = { 1, 2 };'.
@@ -1985,6 +1986,10 @@ nl_max                          = 0        # unsigned number
 
 # The maximum number of consecutive newlines in a function.
 nl_max_blank_in_func            = 0        # unsigned number
+
+# The number of newlines inside an empty function body.
+# This option is overridden by nl_collapse_empty_body=true
+nl_inside_empty_func            = 0        # unsigned number
 
 # The number of newlines before a function prototype.
 nl_before_func_body_proto       = 0        # unsigned number

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -515,6 +515,7 @@ nl_split_for_one_liner          = false
 nl_split_while_one_liner        = false
 nl_max                          = 0
 nl_max_blank_in_func            = 0
+nl_inside_empty_func            = 0
 nl_before_func_body_proto       = 0
 nl_before_func_body_def         = 0
 nl_before_func_class_proto      = 0

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1289,7 +1289,7 @@ indent_oc_block_msg_from_brace  = false    # true/false
 indent_min_vbrace_open          = 0        # unsigned number
 
 # Whether to add further spaces after regular indent to reach next tabstop
-# when identing after virtual brace open and newline.
+# when indenting after virtual brace open and newline.
 indent_vbrace_open_on_tabstop   = false    # true/false
 
 # How to indent after a brace followed by another token (not a newline).
@@ -1344,6 +1344,7 @@ indent_ignore_asm_block         = false    # true/false
 #
 
 # Whether to collapse empty blocks between '{' and '}'.
+# If true, overrides nl_inside_empty_func
 nl_collapse_empty_body          = false    # true/false
 
 # Don't split one-line braced assignments, as in 'foo_t f = { 1, 2 };'.
@@ -1985,6 +1986,10 @@ nl_max                          = 0        # unsigned number
 
 # The maximum number of consecutive newlines in a function.
 nl_max_blank_in_func            = 0        # unsigned number
+
+# The number of newlines inside an empty function body.
+# This option is overridden by nl_collapse_empty_body=true
+nl_inside_empty_func            = 0        # unsigned number
 
 # The number of newlines before a function prototype.
 nl_before_func_body_proto       = 0        # unsigned number

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1289,7 +1289,7 @@ indent_oc_block_msg_from_brace  = false    # true/false
 indent_min_vbrace_open          = 0        # unsigned number
 
 # Whether to add further spaces after regular indent to reach next tabstop
-# when identing after virtual brace open and newline.
+# when indenting after virtual brace open and newline.
 indent_vbrace_open_on_tabstop   = false    # true/false
 
 # How to indent after a brace followed by another token (not a newline).
@@ -1344,6 +1344,7 @@ indent_ignore_asm_block         = false    # true/false
 #
 
 # Whether to collapse empty blocks between '{' and '}'.
+# If true, overrides nl_inside_empty_func
 nl_collapse_empty_body          = false    # true/false
 
 # Don't split one-line braced assignments, as in 'foo_t f = { 1, 2 };'.
@@ -1985,6 +1986,10 @@ nl_max                          = 0        # unsigned number
 
 # The maximum number of consecutive newlines in a function.
 nl_max_blank_in_func            = 0        # unsigned number
+
+# The number of newlines inside an empty function body.
+# This option is overridden by nl_collapse_empty_body=true
+nl_inside_empty_func            = 0        # unsigned number
 
 # The number of newlines before a function prototype.
 nl_before_func_body_proto       = 0        # unsigned number

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2902,7 +2902,7 @@ ValueDefault=0
 
 [Indent Vbrace Open On Tabstop]
 Category=2
-Description="<html>Whether to add further spaces after regular indent to reach next tabstop<br/>when identing after virtual brace open and newline.</html>"
+Description="<html>Whether to add further spaces after regular indent to reach next tabstop<br/>when indenting after virtual brace open and newline.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_vbrace_open_on_tabstop=true|indent_vbrace_open_on_tabstop=false
@@ -2992,7 +2992,7 @@ ValueDefault=false
 
 [Nl Collapse Empty Body]
 Category=3
-Description="<html>Whether to collapse empty blocks between '{' and '}'.</html>"
+Description="<html>Whether to collapse empty blocks between '{' and '}'.<br/>If true, overrides nl_inside_empty_func</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_collapse_empty_body=true|nl_collapse_empty_body=false
@@ -4556,6 +4556,16 @@ Description="<html>The maximum number of consecutive newlines in a function.</ht
 Enabled=false
 EditorType=numeric
 CallName="nl_max_blank_in_func="
+MinVal=0
+MaxVal=16
+ValueDefault=0
+
+[Nl Inside Empty Func]
+Category=4
+Description="<html>The number of newlines inside an empty function body.<br/>This option is overridden by nl_collapse_empty_body=true</html>"
+Enabled=false
+EditorType=numeric
+CallName="nl_inside_empty_func="
 MinVal=0
 MaxVal=16
 ValueDefault=0

--- a/tests/config/nl_func_decl_1.cfg
+++ b/tests/config/nl_func_decl_1.cfg
@@ -11,3 +11,5 @@ nl_func_def_args                = force
 nl_func_decl_end                = remove
 nl_func_def_end                 = force
 nl_func_def_empty               = force
+nl_inside_empty_func            = 2
+nl_collapse_empty_body          = true # this option overrides nl_inside_empty_func

--- a/tests/config/nl_func_decl_2.cfg
+++ b/tests/config/nl_func_decl_2.cfg
@@ -8,6 +8,8 @@ nl_func_decl_end                = force
 nl_func_def_end                 = remove
 nl_func_decl_empty              = force
 nl_func_def_empty               = remove
+nl_inside_empty_func            = 5
+nl_max_blank_in_func            = 3 # this option limits nl_inside_empty_func to 3
 
 # a few more options to make the output pretty
 sp_after_comma                  = force

--- a/tests/expected/cpp/30045-nl_func_decl.cpp
+++ b/tests/expected/cpp/30045-nl_func_decl.cpp
@@ -7,27 +7,23 @@ void ble2 ( int a, char b );
 void bla
 (
 )
-{
-}
+{}
 
 void bla2
 (
 )
-{
-}
+{}
 
 void ble
 (
 	int a,
 	char b
 )
-{
-}
+{}
 
 void ble2
 (
 	int a,
 	char b
 )
-{
-}
+{}

--- a/tests/expected/cpp/30046-nl_func_decl.cpp
+++ b/tests/expected/cpp/30046-nl_func_decl.cpp
@@ -16,16 +16,24 @@ void ble2
 
 void bla()
 {
+
+
 }
 
 void bla2()
 {
+
+
 }
 
 void ble( int a, char b )
 {
+
+
 }
 
 void ble2( int a, char b )
 {
+
+
 }


### PR DESCRIPTION
- This commit adds a new option 'nl_inside_empty_func', which allows
  the user the option to insert blank lines into an empty function body

  For example:

  void foo()
  {
  }

  can now be formatted as the following:

  void foo()
  {

  }

  where nl_inside_empty_func = 2 in the above example

 - The option 'nl_max_blank_in_func' limits that which is specified
    by 'nl_inside_empty_func', and 'nl_collapse_empty_body' overrides
    the new option entirely