### PR TITLE
Fix cli options error for Ninja build on Windows

### DIFF
--- a/tests/cli/test_cli_options.py
+++ b/tests/cli/test_cli_options.py
@@ -479,6 +479,7 @@ def main(args):
     uncr_bin = ''
     bd_dir = parsed_args.build
     bin_paths = [s_path_join(bd_dir, 'uncrustify'),
+                 s_path_join(bd_dir, 'uncrustify.exe'),
                  s_path_join(bd_dir, 'Debug/uncrustify'),
                  s_path_join(bd_dir, 'Debug/uncrustify.exe'),
                  s_path_join(bd_dir, 'Release/uncrustify'),


### PR DESCRIPTION
Building with Ninja on Windows fail since it cannot find `build/uncrustify.exe`.
Here is the output:
```
is not a file: ../..\build\uncrustify
is not a file: ../..\build\Debug\uncrustify
is not a file: ../..\build\Debug\uncrustify.exe
is not a file: ../..\build\Release\uncrustify
is not a file: ../..\build\Release\uncrustify.exe
is not a file: ../..\build\RelWithDebInfo\uncrustify
is not a file: ../..\build\RelWithDebInfo\uncrustify.exe
is not a file: ../..\build\MinSizeRel\uncrustify
is not a file: ../..\build\MinSizeRel\uncrustify.exe
No Uncrustify binary found
```