### PR TITLE
Add sp_inside_braces_empty

### DIFF
--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -272,6 +272,7 @@ sp_inside_sparen                          = remove
 sp_inside_sparen_close                    = remove
 sp_inside_sparen_open                     = remove
 sp_inside_square                          = remove
+sp_inside_square_empty                    = remove
 sp_inside_tparen                          = remove
 sp_inv                                    = remove
 sp_member                                 = remove

--- a/src/options.h
+++ b/src/options.h
@@ -475,6 +475,10 @@ sp_cpp_before_struct_binding;
 extern Option<iarf_e>
 sp_inside_square;
 
+// Add or remove space inside '[]'.
+extern Option<iarf_e>
+sp_inside_square_empty;
+
 // (OC) Add or remove space inside a non-empty Objective-C boxed array '@[' and
 // ']'. If set to ignore, sp_inside_square is used.
 extern Option<iarf_e>

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -2073,6 +2073,14 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       return(options::sp_inside_paren());
    }
 
+   if (  chunk_is_token(first, CT_SQUARE_OPEN)
+      && chunk_is_token(second, CT_SQUARE_CLOSE))
+   {
+      // Add or remove space inside '[]'.
+      log_rule("sp_inside_square_empty");
+      return(options::sp_inside_square_empty());
+   }
+
    // "[3]" vs "[ 3 ]" or for objective-c "@[@3]" vs "@[ @3 ]"
    if (chunk_is_token(first, CT_SQUARE_OPEN) || chunk_is_token(second, CT_SQUARE_CLOSE))
    {

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -92,6 +92,7 @@ sp_before_square_asm_block      = ignore
 sp_before_squares               = ignore
 sp_cpp_before_struct_binding    = ignore
 sp_inside_square                = ignore
+sp_inside_square_empty          = ignore
 sp_inside_square_oc_array       = ignore
 sp_after_comma                  = ignore
 sp_before_comma                 = remove

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -367,6 +367,9 @@ sp_cpp_before_struct_binding    = ignore   # ignore/add/remove/force
 # Add or remove space inside a non-empty '[' and ']'.
 sp_inside_square                = ignore   # ignore/add/remove/force
 
+# Add or remove space inside '[]'.
+sp_inside_square_empty          = ignore   # ignore/add/remove/force
+
 # (OC) Add or remove space inside a non-empty Objective-C boxed array '@[' and
 # ']'. If set to ignore, sp_inside_square is used.
 sp_inside_square_oc_array       = ignore   # ignore/add/remove/force

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -92,6 +92,7 @@ sp_before_square_asm_block      = ignore
 sp_before_squares               = ignore
 sp_cpp_before_struct_binding    = ignore
 sp_inside_square                = ignore
+sp_inside_square_empty          = ignore
 sp_inside_square_oc_array       = ignore
 sp_after_comma                  = ignore
 sp_before_comma                 = remove

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -367,6 +367,9 @@ sp_cpp_before_struct_binding    = ignore   # ignore/add/remove/force
 # Add or remove space inside a non-empty '[' and ']'.
 sp_inside_square                = ignore   # ignore/add/remove/force
 
+# Add or remove space inside '[]'.
+sp_inside_square_empty          = ignore   # ignore/add/remove/force
+
 # (OC) Add or remove space inside a non-empty Objective-C boxed array '@[' and
 # ']'. If set to ignore, sp_inside_square is used.
 sp_inside_square_oc_array       = ignore   # ignore/add/remove/force

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -367,6 +367,9 @@ sp_cpp_before_struct_binding    = ignore   # ignore/add/remove/force
 # Add or remove space inside a non-empty '[' and ']'.
 sp_inside_square                = ignore   # ignore/add/remove/force
 
+# Add or remove space inside '[]'.
+sp_inside_square_empty          = ignore   # ignore/add/remove/force
+
 # (OC) Add or remove space inside a non-empty Objective-C boxed array '@[' and
 # ']'. If set to ignore, sp_inside_square is used.
 sp_inside_square_oc_array       = ignore   # ignore/add/remove/force

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -848,6 +848,15 @@ Choices=sp_inside_square=ignore|sp_inside_square=add|sp_inside_square=remove|sp_
 ChoicesReadable="Ignore Sp Inside Square|Add Sp Inside Square|Remove Sp Inside Square|Force Sp Inside Square"
 ValueDefault=ignore
 
+[Sp Inside Square Empty]
+Category=1
+Description="<html>Add or remove space inside '[]'.</html>"
+Enabled=false
+EditorType=multiple
+Choices=sp_inside_square_empty=ignore|sp_inside_square_empty=add|sp_inside_square_empty=remove|sp_inside_square_empty=force
+ChoicesReadable="Ignore Sp Inside Square Empty|Add Sp Inside Square Empty|Remove Sp Inside Square Empty|Force Sp Inside Square Empty"
+ValueDefault=ignore
+
 [Sp Inside Square Oc Array]
 Category=1
 Description="<html>(OC) Add or remove space inside a non-empty Objective-C boxed array '@[' and<br/>']'. If set to ignore, sp_inside_square is used.</html>"

--- a/tests/config/bug_664.cfg
+++ b/tests/config/bug_664.cfg
@@ -1,3 +1,4 @@
 sp_inside_square                = add
+sp_inside_square_empty          = add
 indent_columns                  = 4
 nl_max                          = 2


### PR DESCRIPTION
Add a separate option for whether to insert space inside '`[]`'. The documentation implies that this option was always supposed to exist, as it claims that `sp_inside_braces` doesn't apply to '`[]`', although it was being applied prior to this change.

No (new) unit test as cpp:33027 is already exercising it. (But let me know if you're prefer a new test!) 