### PR TITLE
If empty, do not introduce a comma

### DIFF
--- a/src/enum_cleanup.cpp
+++ b/src/enum_cleanup.cpp
@@ -51,20 +51,27 @@ void enum_cleanup(void)
          }
          else
          {
-            log_rule_B("mod_enum_last_comma");
-
-            if (  options::mod_enum_last_comma() == IARF_ADD
-               || options::mod_enum_last_comma() == IARF_FORCE)
+            if (chunk_is_token(prev, CT_BRACE_OPEN))                // Issue #2902
             {
-               // create a comma
-               chunk_t comma;
-               set_chunk_type(&comma, CT_COMMA);
-               comma.orig_line = prev->orig_line;
-               comma.orig_col  = prev->orig_col + 1;
-               comma.nl_count  = 0;
-               comma.flags     = PCF_NONE;
-               comma.str       = ",";
-               chunk_add_after(&comma, prev);
+               // nothing betwen CT_BRACE_OPEN and CT_BRACE_CLOSE
+            }
+            else
+            {
+               log_rule_B("mod_enum_last_comma");
+
+               if (  options::mod_enum_last_comma() == IARF_ADD
+                  || options::mod_enum_last_comma() == IARF_FORCE)
+               {
+                  // create a comma
+                  chunk_t comma;
+                  set_chunk_type(&comma, CT_COMMA);
+                  comma.orig_line = prev->orig_line;
+                  comma.orig_col  = prev->orig_col + 1;
+                  comma.nl_count  = 0;
+                  comma.flags     = PCF_NONE;
+                  comma.str       = ",";
+                  chunk_add_after(&comma, prev);
+               }
             }
          }
       }

--- a/tests/config/Issue_2902.cfg
+++ b/tests/config/Issue_2902.cfg
@@ -1,0 +1,1 @@
+mod_enum_last_comma = add

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -222,6 +222,7 @@
 30300  ben_020.cfg                          cpp/enum_shr.cpp
 30301  al.cfg                               cpp/enum_class.h
 30302  bug_1315.cfg                         cpp/bug_1315.cpp
+30303  Issue_2902.cfg                       cpp/Issue_2902.cpp
 
 # TODO: Make a tests for a braced_init_list. See also 34153-34166.
 30310  sp_word_brace_force.cfg              cpp/braced_init_list.cpp

--- a/tests/expected/cpp/30303-Issue_2902.cpp
+++ b/tests/expected/cpp/30303-Issue_2902.cpp
@@ -1,0 +1,1 @@
+enum empty {};

--- a/tests/input/cpp/Issue_2902.cpp
+++ b/tests/input/cpp/Issue_2902.cpp
@@ -1,0 +1,1 @@
+enum empty {};


### PR DESCRIPTION
Fixes #2902