### PR TITLE
Fix mishandling of some class one-liners

### DIFF
--- a/src/combine_fix_mark.cpp
+++ b/src/combine_fix_mark.cpp
@@ -1279,6 +1279,19 @@ void mark_cpp_constructor(chunk_t *pc)
       LOG_FMT(LFCN, "%s(%d):  Marked '%s' as FUNC_CLASS_PROTO on orig_line %zu, orig_col %zu\n",
               __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col);
    }
+   tmp = chunk_get_prev_ncnlni(pc); // Issue #2907
+
+   if (chunk_is_token(tmp, CT_DESTRUCTOR))
+   {
+      set_chunk_parent(tmp, pc->type);
+      tmp = chunk_get_prev_ncnlni(tmp);
+   }
+
+   while (chunk_is_token(tmp, CT_QUALIFIER))
+   {
+      set_chunk_parent(tmp, pc->type);
+      tmp = chunk_get_prev_ncnlni(tmp);
+   }
 } // mark_cpp_constructor
 
 

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3904,11 +3904,19 @@ void newlines_cleanup_braces(bool first)
 
          case CT_FUNC_CLASS_DEF:                             // Issue #2343
          {
-            log_rule_B("nl_before_opening_brace_func_class_def");
-
-            if (options::nl_before_opening_brace_func_class_def() != IARF_IGNORE)
+            if (!one_liner_nl_ok(pc))
             {
-               newline_iarf_pair(chunk_get_prev(pc), pc, options::nl_before_opening_brace_func_class_def());
+               LOG_FMT(LNL1LINE, "a new line may NOT be added\n");
+               // no change - preserve one liner body
+            }
+            else
+            {
+               log_rule_B("nl_before_opening_brace_func_class_def");
+
+               if (options::nl_before_opening_brace_func_class_def() != IARF_IGNORE)
+               {
+                  newline_iarf_pair(chunk_get_prev(pc), pc, options::nl_before_opening_brace_func_class_def());
+               }
             }
          }
 

--- a/tests/cli/output/31.txt
+++ b/tests/cli/output/31.txt
@@ -177,7 +177,7 @@ indent_text : orig_line is 9, orig_col is 1, column is 1, for '~'
    []
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
-reindent_line : orig_line is 9, orig_col is 1, on '~' [DESTRUCTOR/NONE] => 9
+reindent_line : orig_line is 9, orig_col is 1, on '~' [DESTRUCTOR/FUNC_CLASS_DEF] => 9
  [CallStack]
 indent_text : orig_line is 9, orig_col is 2, column is 10, for 'TelegramIndex'
    []
@@ -477,7 +477,7 @@ indent_text : orig_line is 9, orig_col is 1, column is 9, for '~'
    []
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
-reindent_line : orig_line is 9, orig_col is 9, on '~' [DESTRUCTOR/NONE] => 9
+reindent_line : orig_line is 9, orig_col is 9, on '~' [DESTRUCTOR/FUNC_CLASS_DEF] => 9
  [CallStack]
 indent_text : orig_line is 9, orig_col is 2, column is 10, for 'TelegramIndex'
    []

--- a/tests/cli/output/66.txt
+++ b/tests/cli/output/66.txt
@@ -513,7 +513,7 @@ space_text : orig_line is 7, orig_col is 2, <Newline>, nl is 2
 space_text : orig_line is 9, orig_col is 1, '~' type is DESTRUCTOR
 space_text : orig_line is 9, orig_col is 1, pc-text() '~', type is DESTRUCTOR
 do_space : orig_line is 9, orig_col is 1, first->text() '~', type is DESTRUCTOR
-do_space : first->orig_line is 9, first->orig_col is 1, first->text() is '~', [DESTRUCTOR/NONE] <===>
+do_space : first->orig_line is 9, first->orig_col is 1, first->text() is '~', [DESTRUCTOR/FUNC_CLASS_DEF] <===>
    second->orig_line is 9, second->orig_col is 2, second->text() 'TelegramIndex', [FUNC_CLASS_DEF/DESTRUCTOR] : rule REMOVE[ ]
  rule = REMOVE @ 0 => 2
 space_text : orig_line is 9, orig_col is 2, 'TelegramIndex' type is FUNC_CLASS_DEF
@@ -1491,10 +1491,10 @@ log_rule(indent_text): rule is 'indent_braces_no_class'
 log_rule(indent_text): rule is 'indent_braces_no_struct'
 log_rule(indent_text): rule is 'indent_shift'
 log_rule(indent_text): rule is 'pos_conditional'
-space_col_align : first->orig_line is 9, orig_col is 1, [DESTRUCTOR/NONE], text() '~' <==>
+space_col_align : first->orig_line is 9, orig_col is 1, [DESTRUCTOR/FUNC_CLASS_DEF], text() '~' <==>
 space_col_align : second->orig_line is 9, orig_col is 2 [FUNC_CLASS_DEF/DESTRUCTOR], text() 'TelegramIndex', [CallStack]
 do_space : orig_line is 9, orig_col is 1, first->text() '~', type is DESTRUCTOR
-do_space : first->orig_line is 9, first->orig_col is 1, first->text() is '~', [DESTRUCTOR/NONE] <===>
+do_space : first->orig_line is 9, first->orig_col is 1, first->text() is '~', [DESTRUCTOR/FUNC_CLASS_DEF] <===>
    second->orig_line is 9, second->orig_col is 2, second->text() 'TelegramIndex', [FUNC_CLASS_DEF/DESTRUCTOR] : rule REMOVE[ ]
 space_col_align : av is remove
 space_col_align :    len is 1

--- a/tests/cli/output/p.txt
+++ b/tests/cli/output/p.txt
@@ -52,7 +52,7 @@ newlines                        = crlf
 #   9>            NEWLINE|               NONE|     PARENT_NOT_SET[ 10/  2/  1/  0][2/2/0][          2][1-0]
 #  10>        BRACE_CLOSE|     FUNC_CLASS_DEF|     PARENT_NOT_SET[  9/  1/  2/  0][1/1/0][  280000402][0-0]         }
 #  10>            NEWLINE|               NONE|     PARENT_NOT_SET[ 10/  2/  1/  0][1/1/0][          2][2-0]
-#  12>         DESTRUCTOR|               NONE|     PARENT_NOT_SET[  9/  1/  2/  0][1/1/0][  2000c0402][0-0]         ~
+#  12>         DESTRUCTOR|     FUNC_CLASS_DEF|     PARENT_NOT_SET[  9/  1/  2/  0][1/1/0][  2000c0402][0-0]         ~
 #  12>     FUNC_CLASS_DEF|         DESTRUCTOR|     PARENT_NOT_SET[ 10/  2/ 15/  0][1/1/0][      80402][0-0]          TelegramIndex
 #  12>        FPAREN_OPEN|     FUNC_CLASS_DEF|     PARENT_NOT_SET[ 23/ 15/ 16/  0][1/1/0][  200000502][0-0]                       (
 #  12>       FPAREN_CLOSE|     FUNC_CLASS_DEF|     PARENT_NOT_SET[ 24/ 16/ 17/  0][1/1/0][  200000512][0-0]                        )

--- a/tests/config/Issue_2907.cfg
+++ b/tests/config/Issue_2907.cfg
@@ -1,0 +1,6 @@
+indent_columns                  = 2
+nl_class_leave_one_liners       = true
+nl_before_opening_brace_func_class_def = force
+nl_after_func_class_proto_group = 2
+nl_class_leave_one_liner_groups = true
+eat_blanks_before_close_brace   = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -427,7 +427,8 @@
 30959  nl_for_leave_one_liners-t.cfg        cpp/nl_for_leave_one_liners.cpp
 30960  Issue_2151.cfg                       cpp/Issue_2151.cpp
 30961  Issue_2232.cfg                       cpp/Issue_2232.cpp
-30962  nl_assign_leave_one_liners.cfg     cpp/nl_assign_leave_one_liners.cpp
+30962  nl_assign_leave_one_liners.cfg       cpp/nl_assign_leave_one_liners.cpp
+30963  Issue_2907.cfg                       cpp/Issue_2907.cpp
 
 30970  Issue_2219.cfg                       cpp/Issue_2219.cpp
 30971  Issue_2224.cfg                       cpp/Issue_2224.cpp

--- a/tests/expected/cpp/30117-Issue_2343.cpp
+++ b/tests/expected/cpp/30117-Issue_2343.cpp
@@ -12,8 +12,7 @@ class Capteur_CO2
     : public Capteur {
 public:
     Capteur_CO2() :
-                  un_membre_en_plus ( 0 )
-    {}
+                  un_membre_en_plus ( 0 ) {}
 public:
     int un_membre_en_plus;
 };
@@ -44,8 +43,7 @@ struct Exterieur {  // Structure qui regroupe toutes les variables de la station
                  humidite_prec ( 0 ),
                  temp_tendance ( "up" ),
                  temp_texte ( "" ),
-                 humidite_texte ( "" )
-    {}
+                 humidite_texte ( "" ) {}
 };
 
 

--- a/tests/expected/cpp/30963-Issue_2907.cpp
+++ b/tests/expected/cpp/30963-Issue_2907.cpp
@@ -1,0 +1,7 @@
+template< typename Enum > class Flags
+{
+public:
+constexpr Flags() : value{ 0 } {}
+constexpr Flags( Enum f ) : value( static_cast< value_t >( f ) ) {}
+constexpr Flags( Flags const& ) = default;
+}

--- a/tests/input/cpp/Issue_2907.cpp
+++ b/tests/input/cpp/Issue_2907.cpp
@@ -1,0 +1,7 @@
+template< typename Enum > class Flags
+{
+  public:
+    constexpr Flags() : value{ 0 } {}
+    constexpr Flags( Enum f ) : value( static_cast< value_t >( f ) ) {}
+    constexpr Flags( Flags const& ) = default;
+}


### PR DESCRIPTION
Teach `nl_before_opening_brace_func_class_def` to respect `nl_class_leave_one_liners`.

Also, tweak `mark_cpp_constructor` to also set the parent type on any qualifiers ('`virtual`', '`constexpr`') preceding a ctor/dtor prototype or definition. This fixes `nl_class_leave_one_liner_groups` not being applied to constexpr constructors.
    
Fixes #2907.
