### PR TITLE
Don't mark functions as braced initializer lists

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -671,7 +671,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       }
    }
 
-   if (chunk_is_token(pc, CT_DECLTYPE))
+   if (chunk_is_token(pc, CT_DECLTYPE) && pc->parent_type != CT_FUNC_DEF)
    {
       tmp = chunk_get_next_ncnl(pc);
 

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -721,6 +721,8 @@
 
 34167 nl_func_call_args_multi_line_ignore_closures.cfg cpp/nl_func_call_args_multi_line_ignore_closures.cpp
 
+34168  nl_type_brace_init_lst-r.cfg         cpp/Issue_2910.cpp
+
 34170  empty.cfg                            cpp/i1082.cpp
 34171  empty.cfg                            cpp/i1181.cpp
 34172  space_indent_columns-4.cfg           cpp/i1165.cpp

--- a/tests/expected/cpp/34168-Issue_2910.cpp
+++ b/tests/expected/cpp/34168-Issue_2910.cpp
@@ -1,0 +1,4 @@
+auto foo() -> decltype(0)
+{
+	return 0;
+}

--- a/tests/input/cpp/Issue_2910.cpp
+++ b/tests/input/cpp/Issue_2910.cpp
@@ -1,0 +1,4 @@
+auto foo() -> decltype(0)
+{
+	return 0;
+}


### PR DESCRIPTION
Fix a bug where function bodies following a trailing return type declaration using `decltype` were erroneously marked as braced initializer lists.

Fixes #2910.