### PR TITLE
Handle 'if constexpr' better

### DIFF
--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -576,6 +576,7 @@ static void parse_cleanup(BraceState &braceState, ParseFrame &frm, chunk_t *pc)
          {
             // Set the parent for parenthesis and change parenthesis type
             if (  chunk_is_token(prev, CT_IF)
+               || chunk_is_token(prev, CT_CONSTEXPR)
                || chunk_is_token(prev, CT_ELSEIF)
                || chunk_is_token(prev, CT_WHILE)
                || chunk_is_token(prev, CT_DO)
@@ -1065,7 +1066,7 @@ static bool check_complex_statements(ParseFrame &frm, chunk_t *pc, const BraceSt
    if (  frm.top().stage == brace_stage_e::PAREN1
       && (  frm.top().type == CT_IF
          || frm.top().type == CT_ELSEIF)
-      && pc->str.equals("constexpr")) // FIXME: Take care of the "constexpr" const string.
+      && chunk_is_token(pc, CT_CONSTEXPR))
    {
       return(false);
    }

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3638,7 +3638,7 @@ void newlines_cleanup_braces(bool first)
       LOG_FMT(LBLANK, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s'\n",
               __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text());
 
-      if (chunk_is_token(pc, CT_IF))
+      if (chunk_is_token(pc, CT_IF) || chunk_is_token(pc, CT_CONSTEXPR))
       {
          log_rule_B("nl_if_brace");
          newlines_if_for_while_switch(pc, options::nl_if_brace());

--- a/src/token_enum.h
+++ b/src/token_enum.h
@@ -55,6 +55,7 @@ enum c_token_t
    CT_IF,            // built-in keywords
    CT_ELSE,
    CT_ELSEIF,
+   CT_CONSTEXPR,     // only when preceded by 'if' (otherwise CT_QUALIFIER)
    CT_FOR,
    CT_WHILE,
    CT_WHILE_OF_DO,

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -575,6 +575,14 @@ void tokenize_cleanup(void)
          {
             set_chunk_type(pc, CT_TYPE);
          }
+
+         // Set parent type for 'if constexpr'
+         if (  chunk_is_token(prev, CT_IF)
+            && chunk_is_token(pc, CT_QUALIFIER)
+            && chunk_is_str(pc, "constexpr", 9))
+         {
+            set_chunk_type(pc, CT_CONSTEXPR);
+         }
       }
 
       // Change get/set to CT_WORD if not followed by a brace open

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -147,6 +147,8 @@
 30128  Issue_2873.cfg                       cpp/Issue_2873.cpp
 30129  Issue_2890.cfg                       cpp/Issue_2890.cpp
 
+30130  brace-allman.cfg                     cpp/if-constexpr.cpp
+
 30200  bug_1862.cfg                         cpp/bug_1862.cpp
 30201  cmt_indent-1.cfg                     cpp/cmt_indent.cpp
 30202  cmt_indent-2.cfg                     cpp/cmt_indent.cpp

--- a/tests/expected/cpp/30130-if-constexpr.cpp
+++ b/tests/expected/cpp/30130-if-constexpr.cpp
@@ -1,0 +1,8 @@
+int foo()
+{
+        if constexpr (a == 0)
+        {
+                return 1;
+        }
+        return 0;
+}

--- a/tests/input/cpp/if-constexpr.cpp
+++ b/tests/input/cpp/if-constexpr.cpp
@@ -1,0 +1,7 @@
+int foo()
+{
+        if constexpr (a == 0) {
+                return 1;
+        }
+        return 0;
+}


### PR DESCRIPTION
Mark the `constexpr` following an `if` as (new) `CT_CONSTEXPR` (in other cases, it remains `CT_QUALIFIER`) and treat this as a control statement. This improves parsing the surrounding code and fixes incorrect formatting due to following parenthesis being marked `CT_PAREN_OPEN`, as it is now correctly marked `CT_SPAREN_OPEN`.