### PR TITLE
Improve documentation of sp_after_type

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -325,11 +325,21 @@ sp_after_byref_func;
 extern Option<iarf_e>
 sp_before_byref_func;
 
-// Add or remove space between type and word.
+// Add or remove space between type and word. In cases where total removal of
+// whitespace would be a syntax error, a value of 'remove' is treated the same
+// as 'force'.
+//
+// This also affects some other instances of space following a type that are
+// not covered by other options; for example, between the return type and
+// parenthesis of a function type template argument, between the type and
+// parenthesis of an array parameter, or between 'decltype(...)' and the
+// following word.
 extern Option<iarf_e>
 sp_after_type; // = IARF_FORCE
 
 // Add or remove space between 'decltype(...)' and word.
+//
+// Overrides sp_after_type.
 extern Option<iarf_e>
 sp_after_decltype;
 

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -240,12 +240,22 @@ sp_after_byref_func             = ignore   # ignore/add/remove/force
 # prototype or function definition.
 sp_before_byref_func            = ignore   # ignore/add/remove/force
 
-# Add or remove space between type and word.
+# Add or remove space between type and word. In cases where total removal of
+# whitespace would be a syntax error, a value of 'remove' is treated the same
+# as 'force'.
+#
+# This also affects some other instances of space following a type that are
+# not covered by other options; for example, between the return type and
+# parenthesis of a function type template argument, between the type and
+# parenthesis of an array parameter, or between 'decltype(...)' and the
+# following word.
 #
 # Default: force
 sp_after_type                   = force    # ignore/add/remove/force
 
 # Add or remove space between 'decltype(...)' and word.
+#
+# Overrides sp_after_type.
 sp_after_decltype               = ignore   # ignore/add/remove/force
 
 # (D) Add or remove space before the parenthesis in the D constructs

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -240,12 +240,22 @@ sp_after_byref_func             = ignore   # ignore/add/remove/force
 # prototype or function definition.
 sp_before_byref_func            = ignore   # ignore/add/remove/force
 
-# Add or remove space between type and word.
+# Add or remove space between type and word. In cases where total removal of
+# whitespace would be a syntax error, a value of 'remove' is treated the same
+# as 'force'.
+#
+# This also affects some other instances of space following a type that are
+# not covered by other options; for example, between the return type and
+# parenthesis of a function type template argument, between the type and
+# parenthesis of an array parameter, or between 'decltype(...)' and the
+# following word.
 #
 # Default: force
 sp_after_type                   = force    # ignore/add/remove/force
 
 # Add or remove space between 'decltype(...)' and word.
+#
+# Overrides sp_after_type.
 sp_after_decltype               = ignore   # ignore/add/remove/force
 
 # (D) Add or remove space before the parenthesis in the D constructs

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -240,12 +240,22 @@ sp_after_byref_func             = ignore   # ignore/add/remove/force
 # prototype or function definition.
 sp_before_byref_func            = ignore   # ignore/add/remove/force
 
-# Add or remove space between type and word.
+# Add or remove space between type and word. In cases where total removal of
+# whitespace would be a syntax error, a value of 'remove' is treated the same
+# as 'force'.
+#
+# This also affects some other instances of space following a type that are
+# not covered by other options; for example, between the return type and
+# parenthesis of a function type template argument, between the type and
+# parenthesis of an array parameter, or between 'decltype(...)' and the
+# following word.
 #
 # Default: force
 sp_after_type                   = force    # ignore/add/remove/force
 
 # Add or remove space between 'decltype(...)' and word.
+#
+# Overrides sp_after_type.
 sp_after_decltype               = ignore   # ignore/add/remove/force
 
 # (D) Add or remove space before the parenthesis in the D constructs

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -536,7 +536,7 @@ ValueDefault=ignore
 
 [Sp After Type]
 Category=1
-Description="<html>Add or remove space between type and word.<br/><br/>Default: force</html>"
+Description="<html>Add or remove space between type and word. In cases where total removal of<br/>whitespace would be a syntax error, a value of 'remove' is treated the same<br/>as 'force'.<br/><br/>This also affects some other instances of space following a type that are<br/>not covered by other options; for example, between the return type and<br/>parenthesis of a function type template argument, between the type and<br/>parenthesis of an array parameter, or between 'decltype(...)' and the<br/>following word.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_type=ignore|sp_after_type=add|sp_after_type=remove|sp_after_type=force
@@ -545,7 +545,7 @@ ValueDefault=force
 
 [Sp After Decltype]
 Category=1
-Description="<html>Add or remove space between 'decltype(...)' and word.</html>"
+Description="<html>Add or remove space between 'decltype(...)' and word.<br/><br/>Overrides sp_after_type.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_decltype=ignore|sp_after_decltype=add|sp_after_decltype=remove|sp_after_decltype=force


### PR DESCRIPTION
Improve the documentation of `sp_after_type` to include some other instances in which the option applies and to explain the behavior of `remove` in cases where total removal of space would be a syntax error.

Fixes #2912.