### PR TITLE
Support several configuration files feature

### DIFF
--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -18,6 +18,7 @@ The '--prefix' and '--suffix' options may not be used with '--replace'.
 
 Basic Options:
  -c CFG       : Use the config file CFG, or defaults if CFG is set to '-'.
+ -C CFGS      : Read configuration files to process from CFGS, one filename per line
  -f FILE      : Process the single file FILE (output to stdout, use with -o).
  -o FILE      : Redirect stdout to FILE.
  -F FILE      : Read files to process from FILE, one filename per line (- is stdin).
@@ -66,6 +67,7 @@ uncrustify -c my.cfg foo.d
 uncrustify -c my.cfg --replace foo.d
 uncrustify -c my.cfg --no-backup foo.d
 uncrustify -c my.cfg --prefix=out -F files.txt
+uncrustify -C several_configs.txt -f foo.d
 
 Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with

--- a/tests/cli/output/xyz-err.txt
+++ b/tests/cli/output/xyz-err.txt
@@ -1,2 +1,2 @@
-Specify the config file with '-c file' or set UNCRUSTIFY_CONFIG
+Specify the config file with '-c file', multi-config with '-C file' or set UNCRUSTIFY_CONFIG
 Try running with -h for usage information

--- a/tests/config/multiple_configs-test1.cfg
+++ b/tests/config/multiple_configs-test1.cfg
@@ -1,0 +1,5 @@
+# This Setting will be setted by configuration 1 (this one) and left untouched by config 2
+nl_multi_line_sparen_open       = add   # ignore/add/remove/force
+
+# This setting will be overriden by config 2
+nl_multi_line_sparen_close      = ignore   # ignore/add/remove/force

--- a/tests/config/multiple_configs-test2.cfg
+++ b/tests/config/multiple_configs-test2.cfg
@@ -1,0 +1,5 @@
+# This setting was set by configuration 1 and will be overriden by config 2 (this one)
+nl_multi_line_sparen_close      = add   # ignore/add/remove/force
+
+# This setting is set by this configuration, and was not set on configuration 1
+sp_arith_additive               = force   # ignore/add/remove/force

--- a/tests/config/multiple_configs.cfg
+++ b/tests/config/multiple_configs.cfg
@@ -1,0 +1,2 @@
+./config/multiple_configs-test1.cfg
+./config/multiple_configs-test2.cfg

--- a/tests/expected/oc/51000-multiple_configs.mm
+++ b/tests/expected/oc/51000-multiple_configs.mm
@@ -1,0 +1,15 @@
+#import "Entropy.h"
+
+@implementation Entropy
+
+- (void)deactivateEntropy {
+	if (
+		entropy
+		&& (entropy->value() == 2)
+		|| (entropy->value() == 4)
+		) {
+		[self callHome:(entropy->value() + 6)];
+	}
+}
+
+@end

--- a/tests/input/oc/multiple_configs.mm
+++ b/tests/input/oc/multiple_configs.mm
@@ -1,0 +1,13 @@
+#import "Entropy.h"
+
+@implementation Entropy
+
+- (void)deactivateEntropy {
+    if (entropy 
+        && (entropy->value() == 2) 
+        || (entropy->value() == 4)) {
+        [self callHome:(entropy->value()+6)];
+    }
+}
+
+@end

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -170,6 +170,8 @@
 50905  double_angle_space_2.cfg             oc/double_angle_space.m
 50906  double_angle_space_3.cfg             oc/double_angle_space.m
 
+51000M multiple_configs.cfg					oc/multiple_configs.mm
+
 #
 # adopt tests from UT
 10018  empty.cfg                            oc/delete-space-oc.mm

--- a/tests/test_uncrustify/test.py
+++ b/tests/test_uncrustify/test.py
@@ -56,6 +56,7 @@ class SourceTest(object):
         self.test_config = test_config
         self.test_expected = test_expected
         self.test_xfail = False
+        self.multiple_configs = False
 
     # -------------------------------------------------------------------------
     def _check(self):
@@ -91,11 +92,15 @@ class SourceTest(object):
                 if e.errno != errno.EEXIST:
                     raise
 
+        config_param = "-c"
+        if self.multiple_configs:
+            config_param = "-C"
+
         cmd = [
             config.uncrustify_exe,
             '-q',
             '-l', self.test_lang,
-            '-c', self.test_config,
+            config_param, self.test_config,
             '-f', self.test_input,
             '-o', _result
         ]
@@ -154,7 +159,8 @@ class FormatTest(SourceTest):
     pass_input = ['test_input', 'test_expected']
     pass_expected = ['test_expected', 'test_rerun_expected']
 
-    re_test_declaration = re.compile(r'^(?P<num>\d+)(?P<mark>[~!]*)\s+'
+    re_test_declaration = re.compile(r'^(?P<num>\d+)(?P<mark>[~!]*)'
+                          r'(?P<multiple_configs>[M]*)\s+'
                           r'(?P<config>\S+)\s+(?P<input>\S+)'
                           r'(?:\s+(?P<lang>\S+))?$')
 
@@ -168,6 +174,7 @@ class FormatTest(SourceTest):
         p.test_input = getattr(self, self.pass_input[i])
         p.test_expected = getattr(self, self.pass_expected[i])
         p.test_xfail = self.test_xfail
+        p.multiple_configs = self.multiple_configs
         if i == 1 and not os.path.exists(p.test_expected):
             p.test_expected = getattr(self, self.pass_expected[0])
 
@@ -206,7 +213,7 @@ class FormatTest(SourceTest):
         is_xfail = ('~' in match.group('mark'))
 
         self.test_xfail = is_xfail
-
+        self.multiple_configs = ('M' in match.group("multiple_configs"))
         self.test_config = match.group('config')
         self.test_input = match.group('input')
 


### PR DESCRIPTION
At my office, due to historical reasons, each product team has their own code standard for Objective-C. Our techonology stack however, uses other languages, and C++ (which at the time was much less used) had the chance to have a code standard developed that was respected and adopted throughout the entire development team. 
This lead to the situation that we now have a code standard for C++, but Objective-C has several code standards.
We maintain a configuration file for uncrustify that formats the code for C++, and we wanted to share it with all teams to help them adhere. However, I also want the tool to be used for other languages.
For this reason I thought about adding support to several configuration files, which would allow us to have dedicated configurations for our C++ rules and Objective-C specific rules. This way we can share the C++ file and each team would then, if they so wish, add or modify rules for Objective-C or whatever other language they need.

This is a specific use case, but I also believe that this feature could be helpful for the quality of life of the project itself. Right now we have an amazing 735 rules and it's all set up by default into a singular file, which, of course, is huge. This would allow us to divide it into several files, either by language, by rule type or some other form of organisation.

To implement this functionality I took inspiration in the file argument, which already supports receiving multiple files at once. It's very similar: instead of passing `-c config_file.cfg"` you use a capital C and specify a file containing the paths to all the configurations you want: `-C config_files.txt`
The configurations will be loaded, one by one and by descending order. If you repeat a rule, it is overriden by the last applied configuration.
For the testing I added a new symbol ("M" for multiple) in ".test" files. When this symbol is present, it will read the configuration as a list of multiple configurations.
This was the way I found to be the less intrusive with the current system.