### PR TITLE
Add option to modify indent before class colon

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2215,6 +2215,13 @@ void indent_text(void)
          frm.top().indent_tab = frm.top().indent;
          log_indent_tmp();
 
+         if (  options::indent_before_class_colon() != 0
+            && chunk_is_token(pc, CT_CLASS_COLON))
+         {
+            log_rule_B("indent_before_class_colon");
+            frm.top().indent_tmp = std::max<ptrdiff_t>(frm.top().indent_tmp + options::indent_before_class_colon(), 0);
+            log_indent_tmp();
+         }
          indent_column_set(frm.top().indent_tmp);
 
          log_rule_B("indent_class_colon");

--- a/src/options.h
+++ b/src/options.h
@@ -1279,6 +1279,13 @@ indent_extern;
 extern Option<bool>
 indent_class;
 
+// Additional indent before the leading base class colon.
+// Negative values decrease indent down to the first column.
+// Requires a newline break before colon (see pos_class_colon
+// and nl_class_colon)
+extern BoundedOption<signed, -16, 16>
+indent_before_class_colon;
+
 // Whether to indent the stuff after a leading base class colon.
 extern Option<bool>
 indent_class_colon;

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -263,6 +263,7 @@ indent_namespace_level          = 0
 indent_namespace_limit          = 0
 indent_extern                   = false
 indent_class                    = false
+indent_before_class_colon       = 0
 indent_class_colon              = false
 indent_class_on_colon           = false
 indent_constr_colon             = false

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1031,6 +1031,12 @@ indent_extern                   = false    # true/false
 # Whether the 'class' body is indented.
 indent_class                    = false    # true/false
 
+# Additional indent before the leading base class colon.
+# Negative values decrease indent down to the first column.
+# Requires a newline break before colon (see pos_class_colon
+# and nl_class_colon)
+indent_before_class_colon       = 0        # number
+
 # Whether to indent the stuff after a leading base class colon.
 indent_class_colon              = false    # true/false
 

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -263,6 +263,7 @@ indent_namespace_level          = 0
 indent_namespace_limit          = 0
 indent_extern                   = false
 indent_class                    = false
+indent_before_class_colon       = 0
 indent_class_colon              = false
 indent_class_on_colon           = false
 indent_constr_colon             = false

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1031,6 +1031,12 @@ indent_extern                   = false    # true/false
 # Whether the 'class' body is indented.
 indent_class                    = false    # true/false
 
+# Additional indent before the leading base class colon.
+# Negative values decrease indent down to the first column.
+# Requires a newline break before colon (see pos_class_colon
+# and nl_class_colon)
+indent_before_class_colon       = 0        # number
+
 # Whether to indent the stuff after a leading base class colon.
 indent_class_colon              = false    # true/false
 

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1031,6 +1031,12 @@ indent_extern                   = false    # true/false
 # Whether the 'class' body is indented.
 indent_class                    = false    # true/false
 
+# Additional indent before the leading base class colon.
+# Negative values decrease indent down to the first column.
+# Requires a newline break before colon (see pos_class_colon
+# and nl_class_colon)
+indent_before_class_colon       = 0        # number
+
 # Whether to indent the stuff after a leading base class colon.
 indent_class_colon              = false    # true/false
 

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2377,6 +2377,16 @@ EditorType=boolean
 TrueFalse=indent_class=true|indent_class=false
 ValueDefault=false
 
+[Indent Before Class Colon]
+Category=2
+Description="<html>Additional indent before the leading base class colon.<br/>Negative values decrease indent down to the first column.<br/>Requires a newline break before colon (see pos_class_colon<br/>and nl_class_colon)</html>"
+Enabled=false
+EditorType=numeric
+CallName="indent_before_class_colon="
+MinVal=-16
+MaxVal=16
+ValueDefault=0
+
 [Indent Class Colon]
 Category=2
 Description="<html>Whether to indent the stuff after a leading base class colon.</html>"

--- a/tests/config/indent_ctor_init.cfg
+++ b/tests/config/indent_ctor_init.cfg
@@ -1,4 +1,5 @@
 indent_columns                  = 2
+indent_before_class_colon       = 4
 indent_class_colon              = true
 indent_constr_colon             = true
 indent_ctor_init                = 2

--- a/tests/config/indent_ctor_init_leading.cfg
+++ b/tests/config/indent_ctor_init_leading.cfg
@@ -1,4 +1,5 @@
 indent_columns                  = 2
+indent_before_class_colon       = -2
 indent_class_colon              = true
 indent_constr_colon             = true
 indent_ctor_init_leading        = 5
@@ -12,3 +13,5 @@ nl_func_def_start               = add
 nl_func_def_args                = add
 nl_before_access_spec           = 2
 pos_constr_comma                = trail_force
+nl_class_colon                  = force
+pos_class_colon                 = lead_force

--- a/tests/expected/cpp/30955-indent_ctor_init.cpp
+++ b/tests/expected/cpp/30955-indent_ctor_init.cpp
@@ -13,5 +13,5 @@ struct MyClass : public Foo,
 };
 
 struct TheirClass
-  : public Foo,
-    private Bar {};
+      : public Foo,
+        private Bar {};

--- a/tests/expected/cpp/30956-indent_ctor_init.cpp
+++ b/tests/expected/cpp/30956-indent_ctor_init.cpp
@@ -1,5 +1,6 @@
-struct MyClass : public Foo,
-                 private Bar {
+struct MyClass
+: public Foo,
+  private Bar {
   MyClass(
       int a,
       int b,
@@ -13,5 +14,5 @@ struct MyClass : public Foo,
 };
 
 struct TheirClass
-  : public Foo,
-    private Bar {};
+: public Foo,
+  private Bar {};


### PR DESCRIPTION
This commit adds a new option 'indent_before_class_colon', which
allows the user the option to increase or decrease the indent
before a base class colon in instances where a break occurs before
the colon.

This option has no effect when the colon trails the class/struct
name; as such, the user should set options 'nl_class_colon' and
'pos_class_colon' accordingly.

This commit *may* close issue #2948