### PR TITLE
Fix newlines before namespaces

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -394,6 +394,18 @@ static bool can_increase_nl(chunk_t *nl)
       }
    }
 
+   if (chunk_is_token(prev, CT_BRACE_CLOSE))
+   {
+      if (  options::nl_before_namespace()
+         && get_chunk_parent_type(prev) == CT_NAMESPACE)
+      {
+         log_rule_B("nl_before_namespace");
+         LOG_FMT(LBLANKD, "%s(%d): nl_before_namespace %zu\n",
+                 __func__, __LINE__, nl->orig_line);
+         return(true);
+      }
+   }
+
    if (chunk_is_token(prev, CT_BRACE_OPEN))
    {
       if (  options::nl_inside_namespace()

--- a/src/uncrustify_limits.h
+++ b/src/uncrustify_limits.h
@@ -1,4 +1,5 @@
 #pragma once
+
 namespace uncrustify
 {
 

--- a/tests/expected/cpp/34001-nl_before_after.h
+++ b/tests/expected/cpp/34001-nl_before_after.h
@@ -69,6 +69,10 @@ class I
 {
 };
 
+using namespace F;
+
+namespace M
+{
 void bar4();
 
 /* multiline test comment
@@ -95,3 +99,5 @@ class H
     };
 
 };
+
+}

--- a/tests/input/cpp/nl_before_after.h
+++ b/tests/input/cpp/nl_before_after.h
@@ -54,7 +54,9 @@ void foo4();
 class I
 {
 };
-
+using namespace F;
+namespace M
+{
 void bar4();
 /* multiline test comment
    before class */
@@ -74,3 +76,4 @@ class K
 class L { };
 };
 };
+}


### PR DESCRIPTION
This commit addresses an issue in which the can_increase_nl() function
fails to allow newlines to be added before a namespace, if say, the
preceding statment does not enforce a subsequent newline and the
closing brace of the namespace is the last token in the file. The
fixes imposed by this commit are further demonstrated by applying
the configuration specified by 'forUncrustifySources.cfg' to the
uncrustify source code itself. In 'uncrustify_limits.h', 'namespace
uncrustify' is preceded by a '#pragma once' statement, but there
should be a newline before the namespace according to the
configuration specified in 'forUncrustifySources.cfg'.