### PR TITLE
Fix issues with nl_inside_empty_func

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -365,7 +365,7 @@ static bool can_increase_nl(chunk_t *nl)
 
    if (chunk_is_token(next, CT_BRACE_CLOSE))
    {
-      if (  options::nl_inside_namespace()
+      if (  options::nl_inside_namespace() > 0
          && get_chunk_parent_type(next) == CT_NAMESPACE)
       {
          log_rule_B("nl_inside_namespace");
@@ -408,7 +408,7 @@ static bool can_increase_nl(chunk_t *nl)
 
    if (chunk_is_token(prev, CT_BRACE_OPEN))
    {
-      if (  options::nl_inside_namespace()
+      if (  options::nl_inside_namespace() > 0
          && get_chunk_parent_type(prev) == CT_NAMESPACE)
       {
          log_rule_B("nl_inside_namespace");
@@ -2459,9 +2459,18 @@ static void newlines_brace_pair(chunk_t *br_open)
    {
       if (chunk_is_newline(next))
       {
+         log_rule_B("nl_inside_empty_func");
          log_rule_B("nl_inside_namespace");
 
-         if (options::nl_inside_namespace() && get_chunk_parent_type(br_open) == CT_NAMESPACE)
+         if (  options::nl_inside_empty_func() > 0
+            && chunk_is_token(chunk_get_next_ncnl(br_open), CT_BRACE_CLOSE)
+            && (  get_chunk_parent_type(br_open) == CT_FUNC_CLASS_DEF
+               || get_chunk_parent_type(br_open) == CT_FUNC_DEF))
+         {
+            blank_line_set(next, options::nl_inside_empty_func);
+         }
+         else if (  options::nl_inside_namespace() > 0
+                 && get_chunk_parent_type(br_open) == CT_NAMESPACE)
          {
             blank_line_set(next, options::nl_inside_namespace);
          }
@@ -4105,8 +4114,17 @@ void newlines_cleanup_braces(bool first)
             if (chunk_is_newline(prev))
             {
                log_rule_B("nl_inside_namespace");
+               log_rule_B("nl_inside_empty_func");
 
-               if (options::nl_inside_namespace() && get_chunk_parent_type(pc) == CT_NAMESPACE)
+               if (  options::nl_inside_empty_func() > 0
+                  && chunk_is_token(chunk_get_prev_ncnlni(pc), CT_BRACE_OPEN)
+                  && (  get_chunk_parent_type(pc) == CT_FUNC_CLASS_DEF
+                     || get_chunk_parent_type(pc) == CT_FUNC_DEF))
+               {
+                  blank_line_set(prev, options::nl_inside_empty_func);
+               }
+               else if (  options::nl_inside_namespace() > 0
+                       && get_chunk_parent_type(pc) == CT_NAMESPACE)
                {
                   blank_line_set(prev, options::nl_inside_namespace);
                }

--- a/src/options.h
+++ b/src/options.h
@@ -2499,7 +2499,9 @@ extern BoundedOption<unsigned, 0, 16>
 nl_max_blank_in_func;
 
 // The number of newlines inside an empty function body.
-// This option is overridden by nl_collapse_empty_body=true
+// This option overrides eat_blanks_after_open_brace and
+// eat_blanks_before_close_brace, but is ignored when
+// nl_collapse_empty_body=true
 extern BoundedOption<unsigned, 0, 16>
 nl_inside_empty_func;
 

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -2230,6 +2230,7 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
                // retry line breaks caused by splitting 1-liners
                newlines_cleanup_braces(false);
                newlines_insert_blank_lines();
+               newlines_functions_remove_extra_blank_lines();
                first = false;
             }
          }

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -2015,7 +2015,9 @@ nl_max                          = 0        # unsigned number
 nl_max_blank_in_func            = 0        # unsigned number
 
 # The number of newlines inside an empty function body.
-# This option is overridden by nl_collapse_empty_body=true
+# This option overrides eat_blanks_after_open_brace and
+# eat_blanks_before_close_brace, but is ignored when
+# nl_collapse_empty_body=true
 nl_inside_empty_func            = 0        # unsigned number
 
 # The number of newlines before a function prototype.

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -2015,7 +2015,9 @@ nl_max                          = 0        # unsigned number
 nl_max_blank_in_func            = 0        # unsigned number
 
 # The number of newlines inside an empty function body.
-# This option is overridden by nl_collapse_empty_body=true
+# This option overrides eat_blanks_after_open_brace and
+# eat_blanks_before_close_brace, but is ignored when
+# nl_collapse_empty_body=true
 nl_inside_empty_func            = 0        # unsigned number
 
 # The number of newlines before a function prototype.

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -2015,7 +2015,9 @@ nl_max                          = 0        # unsigned number
 nl_max_blank_in_func            = 0        # unsigned number
 
 # The number of newlines inside an empty function body.
-# This option is overridden by nl_collapse_empty_body=true
+# This option overrides eat_blanks_after_open_brace and
+# eat_blanks_before_close_brace, but is ignored when
+# nl_collapse_empty_body=true
 nl_inside_empty_func            = 0        # unsigned number
 
 # The number of newlines before a function prototype.

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -4597,7 +4597,7 @@ ValueDefault=0
 
 [Nl Inside Empty Func]
 Category=4
-Description="<html>The number of newlines inside an empty function body.<br/>This option is overridden by nl_collapse_empty_body=true</html>"
+Description="<html>The number of newlines inside an empty function body.<br/>This option overrides eat_blanks_after_open_brace and<br/>eat_blanks_before_close_brace, but is ignored when<br/>nl_collapse_empty_body=true</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_inside_empty_func="

--- a/tests/config/nl_func_decl_2.cfg
+++ b/tests/config/nl_func_decl_2.cfg
@@ -15,3 +15,9 @@ nl_max_blank_in_func            = 3 # this option limits nl_inside_empty_func to
 sp_after_comma                  = force
 sp_inside_fparen                = force
 align_func_params               = true
+
+# test nl_inside_empty_func option with code width constraints and
+# 'eat_blanks_before_close_brace' and 'eat_blanks_after_open_brace' set to true
+eat_blanks_after_open_brace     = true
+eat_blanks_before_close_brace   = true
+code_width                      = 25

--- a/tests/expected/cpp/30046-nl_func_decl.cpp
+++ b/tests/expected/cpp/30046-nl_func_decl.cpp
@@ -32,7 +32,8 @@ void ble( int a, char b )
 
 }
 
-void ble2( int a, char b )
+void ble2( int  a,
+           char b )
 {
 
 


### PR DESCRIPTION
This commit addresses issues that arise when 'nl_inside_empty_func'
is used in conjunction with 'eat_blanks_before_close_brace' or
'eat_blanks_after_open_brace'. The problem occurs when a line is
split according to code width constraints imposed by the
'code_width' option. It turns out that the 'nl_max_blank_in_func'
was also ignored for similar reasons, and as such an additional
call to newlines_functions_remove_extra_blank_lines() is made
after a call to do_code_width() *if* a change results from
imposing line width constraints.