### PR TITLE
Add sp_cmt_cpp_region

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -1068,31 +1068,30 @@ extern Option<iarf_e>
 sp_range;
 
 // Add or remove space after ':' in a Java/C++11 range-based 'for',
-// as in 'for (Type var : expr)'.
+// as in 'for (Type var : <here> expr)'.
 extern Option<iarf_e>
 sp_after_for_colon;
 
 // Add or remove space before ':' in a Java/C++11 range-based 'for',
-// as in 'for (Type var : expr)'.
+// as in 'for (Type var <here> : expr)'.
 extern Option<iarf_e>
 sp_before_for_colon;
 
-// (D) Add or remove space between 'extern' and '(' as in 'extern (C)'.
+// (D) Add or remove space between 'extern' and '(' as in 'extern <here> (C)'.
 extern Option<iarf_e>
 sp_extern_paren;
 
-// Add or remove space after the opening of a C++ comment,
-// i.e. '// A' vs. '//A'.
+// Add or remove space after the opening of a C++ comment, as in '// <here> A'.
 extern Option<iarf_e>
 sp_cmt_cpp_start;
 
-// If true, space is added with sp_cmt_cpp_start will be added after doxygen
+// If true, space added with sp_cmt_cpp_start will be added after Doxygen
 // sequences like '///', '///<', '//!' and '//!<'.
 extern Option<bool>
 sp_cmt_cpp_doxygen;
 
-// If true, space is added with sp_cmt_cpp_start will be added after Qt
-// translator or meta-data comments like '//:', '//=', and '//~'.
+// If true, space added with sp_cmt_cpp_start will be added after Qt translator
+// or meta-data comments like '//:', '//=', and '//~'.
 extern Option<bool>
 sp_cmt_cpp_qttr;
 

--- a/src/options.h
+++ b/src/options.h
@@ -1085,6 +1085,15 @@ sp_extern_paren;
 extern Option<iarf_e>
 sp_cmt_cpp_start;
 
+// Add or remove space in a C++ region marker comment, as in '// <here> BEGIN'.
+// A region marker is defined as a comment which is not preceded by other text
+// (i.e. the comment is the first non-whitespace on the line), and which starts
+// with either 'BEGIN' or 'END'.
+//
+// Overrides sp_cmt_cpp_start.
+extern Option<iarf_e>
+sp_cmt_cpp_region;
+
 // If true, space added with sp_cmt_cpp_start will be added after Doxygen
 // sequences like '///', '///<', '//!' and '//!<'.
 extern Option<bool>

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -223,6 +223,7 @@ sp_after_for_colon              = ignore
 sp_before_for_colon             = ignore
 sp_extern_paren                 = ignore
 sp_cmt_cpp_start                = ignore
+sp_cmt_cpp_region               = ignore
 sp_cmt_cpp_doxygen              = false
 sp_cmt_cpp_qttr                 = false
 sp_endif_cmt                    = ignore

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -874,6 +874,14 @@ sp_extern_paren                 = ignore   # ignore/add/remove/force
 # Add or remove space after the opening of a C++ comment, as in '// <here> A'.
 sp_cmt_cpp_start                = ignore   # ignore/add/remove/force
 
+# Add or remove space in a C++ region marker comment, as in '// <here> BEGIN'.
+# A region marker is defined as a comment which is not preceded by other text
+# (i.e. the comment is the first non-whitespace on the line), and which starts
+# with either 'BEGIN' or 'END'.
+#
+# Overrides sp_cmt_cpp_start.
+sp_cmt_cpp_region               = ignore   # ignore/add/remove/force
+
 # If true, space added with sp_cmt_cpp_start will be added after Doxygen
 # sequences like '///', '///<', '//!' and '//!<'.
 sp_cmt_cpp_doxygen              = false    # true/false

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -861,26 +861,25 @@ sp_case_label                   = ignore   # ignore/add/remove/force
 sp_range                        = ignore   # ignore/add/remove/force
 
 # Add or remove space after ':' in a Java/C++11 range-based 'for',
-# as in 'for (Type var : expr)'.
+# as in 'for (Type var : <here> expr)'.
 sp_after_for_colon              = ignore   # ignore/add/remove/force
 
 # Add or remove space before ':' in a Java/C++11 range-based 'for',
-# as in 'for (Type var : expr)'.
+# as in 'for (Type var <here> : expr)'.
 sp_before_for_colon             = ignore   # ignore/add/remove/force
 
-# (D) Add or remove space between 'extern' and '(' as in 'extern (C)'.
+# (D) Add or remove space between 'extern' and '(' as in 'extern <here> (C)'.
 sp_extern_paren                 = ignore   # ignore/add/remove/force
 
-# Add or remove space after the opening of a C++ comment,
-# i.e. '// A' vs. '//A'.
+# Add or remove space after the opening of a C++ comment, as in '// <here> A'.
 sp_cmt_cpp_start                = ignore   # ignore/add/remove/force
 
-# If true, space is added with sp_cmt_cpp_start will be added after doxygen
+# If true, space added with sp_cmt_cpp_start will be added after Doxygen
 # sequences like '///', '///<', '//!' and '//!<'.
 sp_cmt_cpp_doxygen              = false    # true/false
 
-# If true, space is added with sp_cmt_cpp_start will be added after Qt
-# translator or meta-data comments like '//:', '//=', and '//~'.
+# If true, space added with sp_cmt_cpp_start will be added after Qt translator
+# or meta-data comments like '//:', '//=', and '//~'.
 sp_cmt_cpp_qttr                 = false    # true/false
 
 # Add or remove space between #else or #endif and a trailing comment.

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -223,6 +223,7 @@ sp_after_for_colon              = ignore
 sp_before_for_colon             = ignore
 sp_extern_paren                 = ignore
 sp_cmt_cpp_start                = ignore
+sp_cmt_cpp_region               = ignore
 sp_cmt_cpp_doxygen              = false
 sp_cmt_cpp_qttr                 = false
 sp_endif_cmt                    = ignore

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -874,6 +874,14 @@ sp_extern_paren                 = ignore   # ignore/add/remove/force
 # Add or remove space after the opening of a C++ comment, as in '// <here> A'.
 sp_cmt_cpp_start                = ignore   # ignore/add/remove/force
 
+# Add or remove space in a C++ region marker comment, as in '// <here> BEGIN'.
+# A region marker is defined as a comment which is not preceded by other text
+# (i.e. the comment is the first non-whitespace on the line), and which starts
+# with either 'BEGIN' or 'END'.
+#
+# Overrides sp_cmt_cpp_start.
+sp_cmt_cpp_region               = ignore   # ignore/add/remove/force
+
 # If true, space added with sp_cmt_cpp_start will be added after Doxygen
 # sequences like '///', '///<', '//!' and '//!<'.
 sp_cmt_cpp_doxygen              = false    # true/false

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -861,26 +861,25 @@ sp_case_label                   = ignore   # ignore/add/remove/force
 sp_range                        = ignore   # ignore/add/remove/force
 
 # Add or remove space after ':' in a Java/C++11 range-based 'for',
-# as in 'for (Type var : expr)'.
+# as in 'for (Type var : <here> expr)'.
 sp_after_for_colon              = ignore   # ignore/add/remove/force
 
 # Add or remove space before ':' in a Java/C++11 range-based 'for',
-# as in 'for (Type var : expr)'.
+# as in 'for (Type var <here> : expr)'.
 sp_before_for_colon             = ignore   # ignore/add/remove/force
 
-# (D) Add or remove space between 'extern' and '(' as in 'extern (C)'.
+# (D) Add or remove space between 'extern' and '(' as in 'extern <here> (C)'.
 sp_extern_paren                 = ignore   # ignore/add/remove/force
 
-# Add or remove space after the opening of a C++ comment,
-# i.e. '// A' vs. '//A'.
+# Add or remove space after the opening of a C++ comment, as in '// <here> A'.
 sp_cmt_cpp_start                = ignore   # ignore/add/remove/force
 
-# If true, space is added with sp_cmt_cpp_start will be added after doxygen
+# If true, space added with sp_cmt_cpp_start will be added after Doxygen
 # sequences like '///', '///<', '//!' and '//!<'.
 sp_cmt_cpp_doxygen              = false    # true/false
 
-# If true, space is added with sp_cmt_cpp_start will be added after Qt
-# translator or meta-data comments like '//:', '//=', and '//~'.
+# If true, space added with sp_cmt_cpp_start will be added after Qt translator
+# or meta-data comments like '//:', '//=', and '//~'.
 sp_cmt_cpp_qttr                 = false    # true/false
 
 # Add or remove space between #else or #endif and a trailing comment.

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -874,6 +874,14 @@ sp_extern_paren                 = ignore   # ignore/add/remove/force
 # Add or remove space after the opening of a C++ comment, as in '// <here> A'.
 sp_cmt_cpp_start                = ignore   # ignore/add/remove/force
 
+# Add or remove space in a C++ region marker comment, as in '// <here> BEGIN'.
+# A region marker is defined as a comment which is not preceded by other text
+# (i.e. the comment is the first non-whitespace on the line), and which starts
+# with either 'BEGIN' or 'END'.
+#
+# Overrides sp_cmt_cpp_start.
+sp_cmt_cpp_region               = ignore   # ignore/add/remove/force
+
 # If true, space added with sp_cmt_cpp_start will be added after Doxygen
 # sequences like '///', '///<', '//!' and '//!<'.
 sp_cmt_cpp_doxygen              = false    # true/false

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -861,26 +861,25 @@ sp_case_label                   = ignore   # ignore/add/remove/force
 sp_range                        = ignore   # ignore/add/remove/force
 
 # Add or remove space after ':' in a Java/C++11 range-based 'for',
-# as in 'for (Type var : expr)'.
+# as in 'for (Type var : <here> expr)'.
 sp_after_for_colon              = ignore   # ignore/add/remove/force
 
 # Add or remove space before ':' in a Java/C++11 range-based 'for',
-# as in 'for (Type var : expr)'.
+# as in 'for (Type var <here> : expr)'.
 sp_before_for_colon             = ignore   # ignore/add/remove/force
 
-# (D) Add or remove space between 'extern' and '(' as in 'extern (C)'.
+# (D) Add or remove space between 'extern' and '(' as in 'extern <here> (C)'.
 sp_extern_paren                 = ignore   # ignore/add/remove/force
 
-# Add or remove space after the opening of a C++ comment,
-# i.e. '// A' vs. '//A'.
+# Add or remove space after the opening of a C++ comment, as in '// <here> A'.
 sp_cmt_cpp_start                = ignore   # ignore/add/remove/force
 
-# If true, space is added with sp_cmt_cpp_start will be added after doxygen
+# If true, space added with sp_cmt_cpp_start will be added after Doxygen
 # sequences like '///', '///<', '//!' and '//!<'.
 sp_cmt_cpp_doxygen              = false    # true/false
 
-# If true, space is added with sp_cmt_cpp_start will be added after Qt
-# translator or meta-data comments like '//:', '//=', and '//~'.
+# If true, space added with sp_cmt_cpp_start will be added after Qt translator
+# or meta-data comments like '//:', '//=', and '//~'.
 sp_cmt_cpp_qttr                 = false    # true/false
 
 # Add or remove space between #else or #endif and a trailing comment.

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2027,6 +2027,15 @@ Choices=sp_cmt_cpp_start=ignore|sp_cmt_cpp_start=add|sp_cmt_cpp_start=remove|sp_
 ChoicesReadable="Ignore Sp Cmt Cpp Start|Add Sp Cmt Cpp Start|Remove Sp Cmt Cpp Start|Force Sp Cmt Cpp Start"
 ValueDefault=ignore
 
+[Sp Cmt Cpp Region]
+Category=1
+Description="<html>Add or remove space in a C++ region marker comment, as in '// &lt;here&gt; BEGIN'.<br/>A region marker is defined as a comment which is not preceded by other text<br/>(i.e. the comment is the first non-whitespace on the line), and which starts<br/>with either 'BEGIN' or 'END'.<br/><br/>Overrides sp_cmt_cpp_start.</html>"
+Enabled=false
+EditorType=multiple
+Choices=sp_cmt_cpp_region=ignore|sp_cmt_cpp_region=add|sp_cmt_cpp_region=remove|sp_cmt_cpp_region=force
+ChoicesReadable="Ignore Sp Cmt Cpp Region|Add Sp Cmt Cpp Region|Remove Sp Cmt Cpp Region|Force Sp Cmt Cpp Region"
+ValueDefault=ignore
+
 [Sp Cmt Cpp Doxygen]
 Category=1
 Description="<html>If true, space added with sp_cmt_cpp_start will be added after Doxygen<br/>sequences like '///', '///&lt;', '//!' and '//!&lt;'.</html>"

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -1993,7 +1993,7 @@ ValueDefault=ignore
 
 [Sp After For Colon]
 Category=1
-Description="<html>Add or remove space after ':' in a Java/C++11 range-based 'for',<br/>as in 'for (Type var : expr)'.</html>"
+Description="<html>Add or remove space after ':' in a Java/C++11 range-based 'for',<br/>as in 'for (Type var : &lt;here&gt; expr)'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_for_colon=ignore|sp_after_for_colon=add|sp_after_for_colon=remove|sp_after_for_colon=force
@@ -2002,7 +2002,7 @@ ValueDefault=ignore
 
 [Sp Before For Colon]
 Category=1
-Description="<html>Add or remove space before ':' in a Java/C++11 range-based 'for',<br/>as in 'for (Type var : expr)'.</html>"
+Description="<html>Add or remove space before ':' in a Java/C++11 range-based 'for',<br/>as in 'for (Type var &lt;here&gt; : expr)'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_for_colon=ignore|sp_before_for_colon=add|sp_before_for_colon=remove|sp_before_for_colon=force
@@ -2011,7 +2011,7 @@ ValueDefault=ignore
 
 [Sp Extern Paren]
 Category=1
-Description="<html>(D) Add or remove space between 'extern' and '(' as in 'extern (C)'.</html>"
+Description="<html>(D) Add or remove space between 'extern' and '(' as in 'extern &lt;here&gt; (C)'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_extern_paren=ignore|sp_extern_paren=add|sp_extern_paren=remove|sp_extern_paren=force
@@ -2020,7 +2020,7 @@ ValueDefault=ignore
 
 [Sp Cmt Cpp Start]
 Category=1
-Description="<html>Add or remove space after the opening of a C++ comment,<br/>i.e. '// A' vs. '//A'.</html>"
+Description="<html>Add or remove space after the opening of a C++ comment, as in '// &lt;here&gt; A'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cmt_cpp_start=ignore|sp_cmt_cpp_start=add|sp_cmt_cpp_start=remove|sp_cmt_cpp_start=force
@@ -2029,7 +2029,7 @@ ValueDefault=ignore
 
 [Sp Cmt Cpp Doxygen]
 Category=1
-Description="<html>If true, space is added with sp_cmt_cpp_start will be added after doxygen<br/>sequences like '///', '///&lt;', '//!' and '//!&lt;'.</html>"
+Description="<html>If true, space added with sp_cmt_cpp_start will be added after Doxygen<br/>sequences like '///', '///&lt;', '//!' and '//!&lt;'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=sp_cmt_cpp_doxygen=true|sp_cmt_cpp_doxygen=false
@@ -2037,7 +2037,7 @@ ValueDefault=false
 
 [Sp Cmt Cpp Qttr]
 Category=1
-Description="<html>If true, space is added with sp_cmt_cpp_start will be added after Qt<br/>translator or meta-data comments like '//:', '//=', and '//~'.</html>"
+Description="<html>If true, space added with sp_cmt_cpp_start will be added after Qt translator<br/>or meta-data comments like '//:', '//=', and '//~'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=sp_cmt_cpp_qttr=true|sp_cmt_cpp_qttr=false

--- a/tests/config/sp_cmt_cpp_region-f.cfg
+++ b/tests/config/sp_cmt_cpp_region-f.cfg
@@ -1,0 +1,2 @@
+sp_cmt_cpp_start                = remove
+sp_cmt_cpp_region               = force

--- a/tests/config/sp_cmt_cpp_region-r.cfg
+++ b/tests/config/sp_cmt_cpp_region-r.cfg
@@ -1,0 +1,2 @@
+sp_cmt_cpp_start                = force
+sp_cmt_cpp_region               = remove

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -366,6 +366,8 @@
 30853  sp_paren_noexcept-f.cfg              cpp/noexcept.cpp
 30854  Issue_1703.cfg                       cpp/Issue_1703.cpp
 30855  empty.cfg                            cpp/cpp_move.cpp
+30856  sp_cmt_cpp_region-f.cfg              cpp/sp_cmt_cpp_region.cpp
+30857  sp_cmt_cpp_region-r.cfg              cpp/sp_cmt_cpp_region.cpp
 
 30860  sf574.cfg                            cpp/sf574.cpp
 

--- a/tests/expected/cpp/30856-sp_cmt_cpp_region.cpp
+++ b/tests/expected/cpp/30856-sp_cmt_cpp_region.cpp
@@ -1,0 +1,9 @@
+// BEGIN real region
+
+int foo()
+{
+	int x = 0; //BEGIN not-region
+	return x; //END not-region
+}
+
+// END real region

--- a/tests/expected/cpp/30857-sp_cmt_cpp_region.cpp
+++ b/tests/expected/cpp/30857-sp_cmt_cpp_region.cpp
@@ -1,0 +1,9 @@
+//BEGIN real region
+
+int foo()
+{
+	int x = 0; // BEGIN not-region
+	return x; // END not-region
+}
+
+//END real region

--- a/tests/input/cpp/sp_cmt_cpp_region.cpp
+++ b/tests/input/cpp/sp_cmt_cpp_region.cpp
@@ -1,0 +1,9 @@
+//BEGIN real region
+
+int foo()
+{
+    int x = 0; // BEGIN not-region
+    return x;  //END not-region
+}
+
+// END real region


### PR DESCRIPTION
Add new option to control space in C++ region marker comments. See option documentation for details. The comments `//BEGIN` and `//END` (with no space, as the first non-space in a line) are treated specially by some editors and thus users may wish to preserve them while otherwise using `sp_cmt_cpp_start = add`.

Also improve some option documentation. (Let me know if it's preferred to not make those changes or make them on a separate PR.)