### PR TITLE
Fix eat_blanks_after_open_brace for line-wrapping

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -2463,7 +2463,7 @@ static void newlines_brace_pair(chunk_t *br_open)
          log_rule_B("nl_inside_namespace");
 
          if (  options::nl_inside_empty_func() > 0
-            && chunk_is_token(chunk_get_next_ncnl(br_open), CT_BRACE_CLOSE)
+            && chunk_is_token(chunk_get_next_nnl(br_open), CT_BRACE_CLOSE)
             && (  get_chunk_parent_type(br_open) == CT_FUNC_CLASS_DEF
                || get_chunk_parent_type(br_open) == CT_FUNC_DEF))
          {
@@ -3630,6 +3630,32 @@ void newlines_remove_newlines(void)
 }
 
 
+void newlines_remove_disallowed()
+{
+   LOG_FUNC_ENTRY();
+
+   auto *pc = chunk_get_head();
+
+   while ((pc = chunk_get_next_nl(pc)) != nullptr)
+   {
+      LOG_FMT(LBLANKD, "%s(%d): orig_line is %zu, orig_col is %zu, <Newline>, nl is %zu\n",
+              __func__, __LINE__, pc->orig_line, pc->orig_col, pc->nl_count);
+
+      if (!can_increase_nl(pc))
+      {
+         LOG_FMT(LBLANKD, "%s(%d): force to 1 orig_line is %zu, orig_col is %zu\n",
+                 __func__, __LINE__, pc->orig_line, pc->orig_col);
+
+         if (pc->nl_count != 1)
+         {
+            pc->nl_count = 1;
+            MARK_CHANGE();
+         }
+      }
+   }
+}
+
+
 void newlines_cleanup_angles()
 {
    // Issue #1167
@@ -4117,7 +4143,7 @@ void newlines_cleanup_braces(bool first)
                log_rule_B("nl_inside_empty_func");
 
                if (  options::nl_inside_empty_func() > 0
-                  && chunk_is_token(chunk_get_prev_ncnlni(pc), CT_BRACE_OPEN)
+                  && chunk_is_token(chunk_get_prev_nnl(pc), CT_BRACE_OPEN)
                   && (  get_chunk_parent_type(pc) == CT_FUNC_CLASS_DEF
                      || get_chunk_parent_type(pc) == CT_FUNC_DEF))
                {

--- a/src/newlines.h
+++ b/src/newlines.h
@@ -23,6 +23,13 @@ void double_newline(chunk_t *nl);
  */
 void newlines_remove_newlines(void);
 
+
+/**
+ * Remove all newlines that fail the checks performed by the can_increase_nl() function
+ */
+void newlines_remove_disallowed();
+
+
 /** Step through all chunks, altering newlines inside parens of if/for/while/do as needed.
  * Handles the style options: nl_multi_line_sparen_open, nl_multi_line_sparen_close, nl_before_if_closing_paren
  */

--- a/src/options.h
+++ b/src/options.h
@@ -2517,7 +2517,8 @@ nl_inside_empty_func;
 extern BoundedOption<unsigned, 0, 16>
 nl_before_func_body_proto;
 
-// The number of newlines before a multi-line function definition.
+// The number of newlines before a multi-line function definition. Where
+// applicable, this option is overridden with eat_blanks_after_open_brace=true
 extern BoundedOption<unsigned, 0, 16>
 nl_before_func_body_def;
 

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -2217,7 +2217,7 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
             {
                if (cpd.changes > options::debug_max_number_of_loops())                 // Issue #2432
                {
-                  LOG_FMT(LNEWLINE, "%s(%d): too many loop. Make a report, please.\n",
+                  LOG_FMT(LNEWLINE, "%s(%d): too many loops. Make a report, please.\n",
                           __func__, __LINE__);
                   log_flush(true);
                   exit(EX_SOFTWARE);
@@ -2231,6 +2231,7 @@ void uncrustify_file(const file_mem &fm, FILE *pfout,
                newlines_cleanup_braces(false);
                newlines_insert_blank_lines();
                newlines_functions_remove_extra_blank_lines();
+               newlines_remove_disallowed();
                first = false;
             }
          }

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -2030,7 +2030,8 @@ nl_inside_empty_func            = 0        # unsigned number
 # The number of newlines before a function prototype.
 nl_before_func_body_proto       = 0        # unsigned number
 
-# The number of newlines before a multi-line function definition.
+# The number of newlines before a multi-line function definition. Where
+# applicable, this option is overridden with eat_blanks_after_open_brace=true
 nl_before_func_body_def         = 0        # unsigned number
 
 # The number of newlines before a class constructor/destructor prototype.

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -2030,7 +2030,8 @@ nl_inside_empty_func            = 0        # unsigned number
 # The number of newlines before a function prototype.
 nl_before_func_body_proto       = 0        # unsigned number
 
-# The number of newlines before a multi-line function definition.
+# The number of newlines before a multi-line function definition. Where
+# applicable, this option is overridden with eat_blanks_after_open_brace=true
 nl_before_func_body_def         = 0        # unsigned number
 
 # The number of newlines before a class constructor/destructor prototype.

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -2030,7 +2030,8 @@ nl_inside_empty_func            = 0        # unsigned number
 # The number of newlines before a function prototype.
 nl_before_func_body_proto       = 0        # unsigned number
 
-# The number of newlines before a multi-line function definition.
+# The number of newlines before a multi-line function definition. Where
+# applicable, this option is overridden with eat_blanks_after_open_brace=true
 nl_before_func_body_def         = 0        # unsigned number
 
 # The number of newlines before a class constructor/destructor prototype.

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -4626,7 +4626,7 @@ ValueDefault=0
 
 [Nl Before Func Body Def]
 Category=4
-Description="<html>The number of newlines before a multi-line function definition.</html>"
+Description="<html>The number of newlines before a multi-line function definition. Where<br/>applicable, this option is overridden with eat_blanks_after_open_brace=true</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_before_func_body_def="

--- a/tests/config/eat_blanks_after_codewidth.cfg
+++ b/tests/config/eat_blanks_after_codewidth.cfg
@@ -1,0 +1,11 @@
+cmt_width=30
+code_width=30
+eat_blanks_after_open_brace=true
+nl_inside_empty_func=2
+nl_fdef_brace=force
+indent_columns=4
+indent_class=true
+indent_with_tabs=0
+input_tab_size=4
+nl_func_type_name=force
+nl_before_func_body_def=2

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -789,6 +789,7 @@
 34252  nl_after_func_proto_group-3.cfg      cpp/issue_2001.cpp
 34253  nl_after_func_proto_group-3.cfg      cpp/friends.cpp
 34254  issue_1985.cfg                       cpp/issue_1985.cpp
+34255  eat_blanks_after_codewidth.cfg       cpp/eat_blanks_after_codewidth.cpp
 
 34280  UNI-29935.cfg                        cpp/UNI-29935.cpp
 

--- a/tests/expected/cpp/34255-eat_blanks_after_codewidth.cpp
+++ b/tests/expected/cpp/34255-eat_blanks_after_codewidth.cpp
@@ -1,0 +1,15 @@
+class A
+{
+    void
+    func1()
+    {
+        // comment
+    }
+
+    void
+    func2()
+    {
+        auto result = 1 + 2 +
+                      3 + 4;
+    }
+};

--- a/tests/input/cpp/eat_blanks_after_codewidth.cpp
+++ b/tests/input/cpp/eat_blanks_after_codewidth.cpp
@@ -1,0 +1,7 @@
+class A
+{
+   void func1(){
+      // comment
+      }
+   void func2(){auto result = 1 + 2 + 3 + 4;}
+};


### PR DESCRIPTION
This commit fixes issues where the eat_blanks_after_open_brace
option, if true, would ordinarily remove blanks following an
open brace - if not for line-wrapping imposed by code-width
constraints (non-zero code_width is specified). After this
commit, blanks are removed (if eat_blanks_after_open_brace=true)
regardless of whether or not any line-wrapping actually occurs.