### PR TITLE
Don't apply nl_before_class to declarations

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -5905,7 +5905,8 @@ void do_blank_lines(void)
       if (  (chunk_is_token(prev, CT_SEMICOLON) || chunk_is_token(prev, CT_BRACE_CLOSE))
          && get_chunk_parent_type(prev) == CT_CLASS)
       {
-         chunk_t *tmp = chunk_get_prev_type(prev, CT_CLASS, prev->level);
+         chunk_t *start = chunk_get_prev_type(prev, CT_CLASS, prev->level);
+         chunk_t *tmp   = start;
 
          // Is this a class template?
          if (get_chunk_parent_type(tmp) == CT_TEMPLATE)
@@ -5936,7 +5937,8 @@ void do_blank_lines(void)
             tmp = chunk_get_prev_nc(tmp->prev);
          }
 
-         if (tmp != nullptr && options::nl_before_class() > tmp->nl_count)
+         if (  tmp != nullptr && !start->flags.test(PCF_INCOMPLETE)
+            && options::nl_before_class() > tmp->nl_count)
          {
             log_rule_B("nl_before_class");
             blank_line_set(tmp, options::nl_before_class);

--- a/tests/expected/cpp/34001-nl_before_after.h
+++ b/tests/expected/cpp/34001-nl_before_after.h
@@ -81,11 +81,9 @@ template<typename ... Args>
 // test comment between template specification and associated class
 class H
 {
-
     // nested class
     template<typename ...>
     friend class I;
-
     friend class J;
 
     // nested class K
@@ -98,6 +96,23 @@ class H
 
     };
 
+};
+
+}
+
+class AA;
+class AB;
+
+namespace BA
+{
+class BB;
+class BC;
+
+class BD
+{
+public:
+    friend class BE;
+    BD();
 };
 
 }

--- a/tests/input/cpp/nl_before_after.h
+++ b/tests/input/cpp/nl_before_after.h
@@ -77,3 +77,19 @@ class L { };
 };
 };
 }
+
+class AA;
+class AB;
+
+namespace BA
+{
+class BB;
+class BC;
+
+class BD
+{
+public:
+  friend class BE;
+  BD();
+};
+}


### PR DESCRIPTION
Fix `nl_before_class` to only apply before class definitions, as documented, and not also before class declarations.