### PR TITLE
Fix functions treated as variables

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -2036,7 +2036,8 @@ static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
       {
          chunk_t *next = chunk_get_next_ncnl(pc);
 
-         if (chunk_is_token(next, CT_PTR_TYPE))               // Issue #2692
+         if (  chunk_is_token(next, CT_PTR_TYPE) // Issue #2692
+            || chunk_is_token(next, CT_BYREF))   // Issue #3018
          {
             next = chunk_get_next_ncnl(next);
          }

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -210,6 +210,7 @@
 30265  long_br_cmt.cfg                      cpp/long_br_cmt.cpp
 30266  Issue_2921.cfg                       cpp/Issue_2921.cpp
 30267  Issue_2930.cfg                       cpp/Issue_2930.cpp
+30268  Issue_2692.cfg                       cpp/Issue_3018.cpp
 
 30270  const_throw.cfg                      cpp/const_throw.cpp
 30271  sp_throw_paren-r.cfg                 cpp/sp_throw_paren.cpp

--- a/tests/expected/cpp/30268-Issue_3018.cpp
+++ b/tests/expected/cpp/30268-Issue_3018.cpp
@@ -1,0 +1,7 @@
+class Class
+{
+int fa();
+int* fpa();
+int fb();
+int& frb();
+};

--- a/tests/input/cpp/Issue_3018.cpp
+++ b/tests/input/cpp/Issue_3018.cpp
@@ -1,0 +1,7 @@
+class Class
+{
+int fa();
+int* fpa();
+int fb();
+int& frb();
+};


### PR DESCRIPTION
Tweak code that detects variable definitions to skip over reference types when looking for the identifier associated with a type (similar to how the code was previously adjusted to do this in the face of pointer types). This fixes a bug where a member function prototype in a class definition which returns a reference type was incorrectly identified as the start of a block of variable definitions, which resulted in erroneous application of `nl_var_def_blk_start`.

Fixes #3018