### PR TITLE
Fix issue with modernized raw string literals in OC++

### DIFF
--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -2274,6 +2274,10 @@ static bool parse_next(tok_ctx &ctx, chunk_t &pc, const chunk_t *prev_pc)
       {
          if (ctx.peek(2) == '"')
          {
+            if (parse_cr_string(ctx, pc, 2)) // Issue #3027
+            {
+               return(true);
+            }
             // parse string without escaping
             parse_string(ctx, pc, 2, false);
             return(true);

--- a/tests/expected/oc/50009-literals.mm
+++ b/tests/expected/oc/50009-literals.mm
@@ -30,7 +30,15 @@ void main(int argc, const char *argv[])
    NSNumber *noNumber  = @NO;           // equivalent to [NSNumber numberWithBool:NO]
 
    // Raw string literals
-   NSString *rawString = [NSString stringWithFormat:@R"(embedded "quotes ")"];
+   NSString *rawString          = [NSString stringWithFormat:@R"(embedded " quotes " )"];
+   NSString *delimiterRawString = [NSString stringWithFormat:@R"<<<(embedded "quotes ')<<<"];
+   NSString *groupIDString      = [NSString stringWithFormat:@R"({"group_id " : " % @",})", groupID];
+   NSString *config             = @R"({"config_v1" : [
+  {"op1" : {"type":{"unsupported1":{}}},"markers":[123]},
+  {"op2" : {"type":{"jobs":{"suspend":true,"resume":false}}},"markers":[1]},
+  {"op3" : {"type":{"Good Format":{}}},"markers":[123]}
+  ]})";
+
 
 #ifdef __cplusplus
    NSNumber *trueNumber  = @true;       // equivalent to [NSNumber numberWithBool:(BOOL)true]

--- a/tests/input/oc/literals.mm
+++ b/tests/input/oc/literals.mm
@@ -27,7 +27,15 @@ void main(int argc, const char *argv[]) {
   NSNumber *noNumber = @NO;             // equivalent to [NSNumber numberWithBool:NO]
 
   // Raw string literals
-  NSString *rawString = [NSString stringWithFormat:@R"(embedded "quotes")"];
+  NSString *rawString = [NSString stringWithFormat:@R"(embedded " quotes " )"];
+  NSString *delimiterRawString = [NSString stringWithFormat:@R"<<<(embedded "quotes ')<<<"];
+  NSString *groupIDString = [NSString stringWithFormat:@R"({"group_id " : " % @",})", groupID];
+  NSString *config = @R"({"config_v1" : [
+  {"op1" : {"type":{"unsupported1":{}}},"markers":[123]},
+  {"op2" : {"type":{"jobs":{"suspend":true,"resume":false}}},"markers":[1]},
+  {"op3" : {"type":{"Good Format":{}}},"markers":[123]}
+  ]})";
+
 
 #ifdef __cplusplus
   NSNumber *trueNumber = @true;         // equivalent to [NSNumber numberWithBool:(BOOL)true]

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -12,7 +12,7 @@
 50006  oc6.cfg                              oc/exceptions.m
 50007  oc7.cfg                              oc/misc.m
 50008  oc8.cfg                              oc/protocol.m
-50009  oc9.cfg                              oc/literals.m
+50009  oc9.cfg                              oc/literals.mm
 
 50010  sp_after_oc_return_type_add.cfg      oc/return_type.m
 50011  sp_after_oc_return_type_force.cfg    oc/return_type.m


### PR DESCRIPTION
Previous fix only applies to partial scenarios. This fixes for all "R" formatted C strings in OC++ language. The test file has to be renamed from ".m" to ".mm" to support OC++ language. Fixes issues #3027 & #223.