### PR TITLE
Fix cmt_reflow_mode under code_width constraints

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -3251,7 +3251,7 @@ cmt_width;
 //
 // 0: No reflowing (apart from the line wrapping due to cmt_width) (default)
 // 1: No touching at all
-// 2: Full reflow
+// 2: Full reflow (enable cmt_indent_multi for indent with line wrapping due to cmt_width)
 extern BoundedOption<unsigned, 0, 2>
 cmt_reflow_mode;
 

--- a/tests/c.test
+++ b/tests/c.test
@@ -80,6 +80,7 @@
 00120  sp_cmt_cpp_start-r.cfg               c/sp_cmt_cpp_start.c
 00121  sp_cmt_cpp_start-a.cfg               c/sp_cmt_cpp_start.c
 00122  sp_cmt_cpp_start_force.cfg           c/sp_cmt_cpp_start.c
+00123  cmt_reflow.cfg                       c/cmt_reflow.c
 
 00130  ben_070.cfg                          c/minus-minus.c
 00135  nepenthes.cfg                        c/br_cmt.c

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -2633,7 +2633,7 @@ cmt_width                       = 0        # unsigned number
 #
 # 0: No reflowing (apart from the line wrapping due to cmt_width) (default)
 # 1: No touching at all
-# 2: Full reflow
+# 2: Full reflow (enable cmt_indent_multi for indent with line wrapping due to cmt_width)
 cmt_reflow_mode                 = 0        # unsigned number
 
 # Whether to convert all tabs to spaces in comments. If false, tabs in

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -2633,7 +2633,7 @@ cmt_width                       = 0        # unsigned number
 #
 # 0: No reflowing (apart from the line wrapping due to cmt_width) (default)
 # 1: No touching at all
-# 2: Full reflow
+# 2: Full reflow (enable cmt_indent_multi for indent with line wrapping due to cmt_width)
 cmt_reflow_mode                 = 0        # unsigned number
 
 # Whether to convert all tabs to spaces in comments. If false, tabs in

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -2633,7 +2633,7 @@ cmt_width                       = 0        # unsigned number
 #
 # 0: No reflowing (apart from the line wrapping due to cmt_width) (default)
 # 1: No touching at all
-# 2: Full reflow
+# 2: Full reflow (enable cmt_indent_multi for indent with line wrapping due to cmt_width)
 cmt_reflow_mode                 = 0        # unsigned number
 
 # Whether to convert all tabs to spaces in comments. If false, tabs in

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -5837,7 +5837,7 @@ ValueDefault=0
 
 [Cmt Reflow Mode]
 Category=8
-Description="<html>How to reflow comments.<br/><br/>0: No reflowing (apart from the line wrapping due to cmt_width) (default)<br/>1: No touching at all<br/>2: Full reflow</html>"
+Description="<html>How to reflow comments.<br/><br/>0: No reflowing (apart from the line wrapping due to cmt_width) (default)<br/>1: No touching at all<br/>2: Full reflow (enable cmt_indent_multi for indent with line wrapping due to cmt_width)</html>"
 Enabled=false
 EditorType=numeric
 CallName="cmt_reflow_mode="

--- a/tests/config/cmt_reflow.cfg
+++ b/tests/config/cmt_reflow.cfg
@@ -1,0 +1,4 @@
+cmt_reflow_mode = 2
+cmt_width = 70
+cmt_sp_after_star_cont = 2
+cmt_indent_multi = true

--- a/tests/expected/c/00123-cmt_reflow.c
+++ b/tests/expected/c/00123-cmt_reflow.c
@@ -1,0 +1,14 @@
+/**
+ * Search the tree for a match that satisfies specific comparison
+ *  criteria, branch contains the desired data for which to search the
+ *  tree
+ * @param compareFunc is a binary function object that defines how to
+ *  compare nodes
+ * @param bRetrieve indicates whether or not the input search branch
+ *  should be modified to reflect a branch in the tree, assuming a
+ *  match satisfying the given search criteria exists
+ * @return true if a branch matching the input is found or returns
+ *  nullptr otherwise
+ *
+ * Test string
+ */

--- a/tests/input/c/cmt_reflow.c
+++ b/tests/input/c/cmt_reflow.c
@@ -1,0 +1,12 @@
+/**
+  * Search the tree for a match that satisfies specific comparison criteria,
+  *                 branch contains the desired data for which to search the tree
+  * @param compareFunc is a binary function object that defines
+  *                                                                how to compare
+  *    nodes
+  * @param bRetrieve indicates whether or not the input search branch should be modified to reflect a branch in the tree, assuming a match satisfying the given search criteria exists
+  * @return true if a branch matching the input is found
+  *                    or returns nullptr otherwise
+  *
+  * Test string
+  */


### PR DESCRIPTION
This commit fixes issues with comment reflow under code width
contraints (code_width > 0) for multi-line c-style comments,
i.e. /* ... */. With this fix, lines combined by the reflow and
then wrapped due to code width limitations will now have proper
indentation according to the sp_after_star_cont option. Note that
the indentation is applied *only* for the portion of the comment
that is wrapped to the next line. This fix applies under the
following conditions:

- cmt_indent_multi = true
- cmt_width > 0
- cmt_reflow_mode = 2

Added a unit test to demonstrate the fix.