### PR TITLE
Improve processing disable/enable functionality

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -82,18 +82,23 @@ disable_processing_nl_cont;
 
 // Specify the marker used in comments to disable processing of part of the
 // file.
-// The comment should be used alone in one line.
 extern Option<string>
 disable_processing_cmt; // = UNCRUSTIFY_OFF_TEXT
 
 // Specify the marker used in comments to (re)enable processing in a file.
-// The comment should be used alone in one line.
 extern Option<string>
 enable_processing_cmt; // = UNCRUSTIFY_ON_TEXT
 
 // Enable parsing of digraphs.
 extern Option<bool>
 enable_digraphs;
+
+// Option to allow both disable_processing_cmt and enable_processing_cmt strings,
+// if specified, to be interpreted as ECMAScript regular expressions. If true,
+// a regex search will be performed within comments according to the specified
+// patterns in order to disable/enable processing
+extern Option<bool>
+processing_cmt_as_regex; // = false
 
 // Add or remove the UTF-8 BOM (recommend 'remove').
 extern Option<iarf_e>

--- a/src/tokenize.h
+++ b/src/tokenize.h
@@ -13,6 +13,30 @@
 
 
 /**
+ * Test the input string to see if it satisfies the criteria
+ * specified by the disable_processing_cmt option
+ * @param  text      the string to which a match will be attempted
+ * @param  start_idx the starting index within the string from which the
+ *                   search will be performed
+ * @return           returns a non-negative position index that points to the beginning
+ *                   of the line containing the marker, if found
+ */
+int find_disable_processing_comment_marker(const unc_text &text, std::size_t start_idx = 0);
+
+
+/**
+ * Test the input string to see if it satisfies the criteria
+ * specified by the enable_processing_cmt option
+ * @param  text      the string to which a match will be attempted
+ * @param  start_idx the starting index within the string from which the
+ *                   search will be performed
+ * @return           returns a non-negative position index that points to the end
+ *                   of the line containing the marker, if found
+ */
+int find_enable_processing_comment_marker(const unc_text &text, std::size_t start_idx = 0);
+
+
+/**
  * @brief Parse the text into chunks
  *
  * This function parses or tokenizes the whole buffer into a list.

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -10,6 +10,7 @@ disable_processing_nl_cont      = false
 disable_processing_cmt          = " *INDENT-OFF*"
 enable_processing_cmt           = " *INDENT-ON*"
 enable_digraphs                 = false
+processing_cmt_as_regex         = false
 utf8_bom                        = ignore
 utf8_byte                       = false
 utf8_force                      = false

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -42,19 +42,23 @@ disable_processing_nl_cont      = false    # true/false
 
 # Specify the marker used in comments to disable processing of part of the
 # file.
-# The comment should be used alone in one line.
 #
 # Default:  *INDENT-OFF*
 disable_processing_cmt          = " *INDENT-OFF*"      # string
 
 # Specify the marker used in comments to (re)enable processing in a file.
-# The comment should be used alone in one line.
 #
 # Default:  *INDENT-ON*
 enable_processing_cmt           = " *INDENT-ON*"     # string
 
 # Enable parsing of digraphs.
 enable_digraphs                 = false    # true/false
+
+# Option to allow both disable_processing_cmt and enable_processing_cmt strings,
+# if specified, to be interpreted as ECMAScript regular expressions. If true,
+# a regex search will be performed within comments according to the specified
+# patterns in order to disable/enable processing
+processing_cmt_as_regex         = false    # true/false
 
 # Add or remove the UTF-8 BOM (recommend 'remove').
 utf8_bom                        = ignore   # ignore/add/remove/force

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -10,6 +10,7 @@ disable_processing_nl_cont      = false
 disable_processing_cmt          = " *INDENT-OFF*"
 enable_processing_cmt           = " *INDENT-ON*"
 enable_digraphs                 = false
+processing_cmt_as_regex         = false
 utf8_bom                        = ignore
 utf8_byte                       = false
 utf8_force                      = false

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -42,19 +42,23 @@ disable_processing_nl_cont      = false    # true/false
 
 # Specify the marker used in comments to disable processing of part of the
 # file.
-# The comment should be used alone in one line.
 #
 # Default:  *INDENT-OFF*
 disable_processing_cmt          = " *INDENT-OFF*"      # string
 
 # Specify the marker used in comments to (re)enable processing in a file.
-# The comment should be used alone in one line.
 #
 # Default:  *INDENT-ON*
 enable_processing_cmt           = " *INDENT-ON*"     # string
 
 # Enable parsing of digraphs.
 enable_digraphs                 = false    # true/false
+
+# Option to allow both disable_processing_cmt and enable_processing_cmt strings,
+# if specified, to be interpreted as ECMAScript regular expressions. If true,
+# a regex search will be performed within comments according to the specified
+# patterns in order to disable/enable processing
+processing_cmt_as_regex         = false    # true/false
 
 # Add or remove the UTF-8 BOM (recommend 'remove').
 utf8_bom                        = ignore   # ignore/add/remove/force

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -42,19 +42,23 @@ disable_processing_nl_cont      = false    # true/false
 
 # Specify the marker used in comments to disable processing of part of the
 # file.
-# The comment should be used alone in one line.
 #
 # Default:  *INDENT-OFF*
 disable_processing_cmt          = " *INDENT-OFF*"      # string
 
 # Specify the marker used in comments to (re)enable processing in a file.
-# The comment should be used alone in one line.
 #
 # Default:  *INDENT-ON*
 enable_processing_cmt           = " *INDENT-ON*"     # string
 
 # Enable parsing of digraphs.
 enable_digraphs                 = false    # true/false
+
+# Option to allow both disable_processing_cmt and enable_processing_cmt strings,
+# if specified, to be interpreted as ECMAScript regular expressions. If true,
+# a regex search will be performed within comments according to the specified
+# patterns in order to disable/enable processing
+processing_cmt_as_regex         = false    # true/false
 
 # Add or remove the UTF-8 BOM (recommend 'remove').
 utf8_bom                        = ignore   # ignore/add/remove/force

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -92,7 +92,7 @@ ValueDefault=false
 
 [Disable Processing Cmt]
 Category=0
-Description="<html>Specify the marker used in comments to disable processing of part of the<br/>file.<br/>The comment should be used alone in one line.<br/><br/>Default:  *INDENT-OFF*</html>"
+Description="<html>Specify the marker used in comments to disable processing of part of the<br/>file.<br/><br/>Default:  *INDENT-OFF*</html>"
 Enabled=false
 CallName=disable_processing_cmt=
 EditorType=string
@@ -100,7 +100,7 @@ ValueDefault= *INDENT-OFF*
 
 [Enable Processing Cmt]
 Category=0
-Description="<html>Specify the marker used in comments to (re)enable processing in a file.<br/>The comment should be used alone in one line.<br/><br/>Default:  *INDENT-ON*</html>"
+Description="<html>Specify the marker used in comments to (re)enable processing in a file.<br/><br/>Default:  *INDENT-ON*</html>"
 Enabled=false
 CallName=enable_processing_cmt=
 EditorType=string
@@ -112,6 +112,14 @@ Description="<html>Enable parsing of digraphs.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=enable_digraphs=true|enable_digraphs=false
+ValueDefault=false
+
+[Processing Cmt As Regex]
+Category=0
+Description="<html>Option to allow both disable_processing_cmt and enable_processing_cmt strings,<br/>if specified, to be interpreted as ECMAScript regular expressions. If true,<br/>a regex search will be performed within comments according to the specified<br/>patterns in order to disable/enable processing</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=processing_cmt_as_regex=true|processing_cmt_as_regex=false
 ValueDefault=false
 
 [Utf8 Bom]

--- a/tests/config/toggle_processing_cmt3.cfg
+++ b/tests/config/toggle_processing_cmt3.cfg
@@ -1,0 +1,8 @@
+cmt_indent_multi = true
+cmt_reflow_mode = 2
+cmt_sp_after_star_cont = 1
+cmt_star_cont=true
+cmt_width = 70
+disable_processing_cmt="\\\\verbatim|[ \t]*(?:\\*INDENT-OFF\\*|\\*\\*ABC\\*\\*)"
+enable_processing_cmt="\\\\endverbatim|[ \t]*(?:\\*INDENT-ON\\*|\\?\\?DEF\\?\\?)"
+processing_cmt_as_regex=true

--- a/tests/config/toggle_processing_cmt4.cfg
+++ b/tests/config/toggle_processing_cmt4.cfg
@@ -1,0 +1,6 @@
+cmt_sp_after_star_cont = 1
+cmt_width = 70
+disable_processing_cmt="\\\\verbatim|[ \t]*(?:\\*INDENT-OFF\\*|\\*\\*ABC\\*\\*)"
+enable_processing_cmt="\\\\endverbatim|[ \t]*(?:\\*INDENT-ON\\*|\\?\\?DEF\\?\\?)"
+processing_cmt_as_regex=true
+

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -508,6 +508,8 @@
 
 31700  toggle_processing_cmt.cfg            cpp/toggle_processing_cmt.cpp
 31701  toggle_processing_cmt2.cfg           cpp/toggle_processing_cmt2.cpp
+31702  toggle_processing_cmt3.cfg           cpp/toggle_processing_cmt.cpp
+31703  toggle_processing_cmt4.cfg           cpp/toggle_processing_cmt.cpp
 
 31710  empty.cfg                            cpp/string_replace_tab_chars.cpp
 31711  string_replace_tab_chars-t.cfg       cpp/string_replace_tab_chars.cpp

--- a/tests/expected/cpp/31702-toggle_processing_cmt.cpp
+++ b/tests/expected/cpp/31702-toggle_processing_cmt.cpp
@@ -9,7 +9,8 @@ void func() {
 }
 
 /**
- * Function to solve for roots of a generic quartic polynomial of the following form:
+ * Function to solve for roots of a generic quartic polynomial of the
+ * following form:
  * \verbatim
 
    p(x) = a * x^4 + b * x^3 + c * x^2 + d * x + e,
@@ -18,7 +19,9 @@ void func() {
 
  * \endverbatim
  *
- * This object's tolerance defines a threshold for root solutions above which iterative methods will be employed to achieve the desired accuracy
+ * This object's tolerance defines a threshold for root solutions
+ * above which iterative methods will be employed to achieve the
+ * desired accuracy
  *
  * \verbatim - this should cause the following line to not wrap due to cmt_width
  * Upon success, the roots array contains the solution to the polynomial p(x) = 0
@@ -37,13 +40,15 @@ int solve(double a,
           std::complex<double> roots[4]);
 
 /**
- * Function to solve for roots of a generic quartic polynomial of the following form:
+ * Function to solve for roots of a generic quartic polynomial of the
+ * following form:
  *
-
-   p(x) = a * x^4 + b * x^3 + c * x^2 + d * x + e,
-   where a, b, c, d, and e are real coefficients
  *
- * Upon success, root1, root2, root3, and root4 contain the solution to the polynomial p(x) = 0
+ *  p(x) = a * x^4 + b * x^3 + c * x^2 + d * x + e, where a, b, c, d,
+ * and e are real coefficients
+ *
+ * Upon success, root1, root2, root3, and root4 contain the solution
+ * to the polynomial p(x) = 0
  * + Return value on output:
  * - 0, if an error occurs (invalid coefficients)
  * - 1, if all roots are real

--- a/tests/expected/cpp/31703-toggle_processing_cmt.cpp
+++ b/tests/expected/cpp/31703-toggle_processing_cmt.cpp
@@ -9,7 +9,8 @@ void func() {
 }
 
 /**
- * Function to solve for roots of a generic quartic polynomial of the following form:
+ * Function to solve for roots of a generic quartic polynomial of the
+ * following form:
  * \verbatim
 
    p(x) = a * x^4 + b * x^3 + c * x^2 + d * x + e,
@@ -18,7 +19,9 @@ void func() {
 
  * \endverbatim
  *
- * This object's tolerance defines a threshold for root solutions above which iterative methods will be employed to achieve the desired accuracy
+ * This object's tolerance defines a threshold for root solutions
+ * above which iterative methods will be employed to achieve the
+ * desired accuracy
  *
  * \verbatim - this should cause the following line to not wrap due to cmt_width
  * Upon success, the roots array contains the solution to the polynomial p(x) = 0
@@ -37,13 +40,15 @@ int solve(double a,
           std::complex<double> roots[4]);
 
 /**
- * Function to solve for roots of a generic quartic polynomial of the following form:
+ * Function to solve for roots of a generic quartic polynomial of the
+ * following form:
  *
 
    p(x) = a * x^4 + b * x^3 + c * x^2 + d * x + e,
    where a, b, c, d, and e are real coefficients
  *
- * Upon success, root1, root2, root3, and root4 contain the solution to the polynomial p(x) = 0
+ * Upon success, root1, root2, root3, and root4 contain the solution
+ * to the polynomial p(x) = 0
  * + Return value on output:
  * - 0, if an error occurs (invalid coefficients)
  * - 1, if all roots are real

--- a/tests/input/cpp/toggle_processing_cmt.cpp
+++ b/tests/input/cpp/toggle_processing_cmt.cpp
@@ -5,3 +5,57 @@ void func() { }
 // *INDENT-ON*
 
 void func() { }
+
+/**
+ * Function to solve for roots of a generic quartic polynomial of the following form:
+ * \verbatim
+
+   p(x) = a * x^4 + b * x^3 + c * x^2 + d * x + e,
+
+   where a, b, c, d, and e are real coefficients
+
+ * \endverbatim
+ *
+ * This object's tolerance defines a threshold for root solutions above which iterative methods will be employed to achieve the desired accuracy
+ *
+ * \verbatim - this should cause the following line to not wrap due to cmt_width
+ * Upon success, the roots array contains the solution to the polynomial p(x) = 0
+ * \endverbatim
+ * + Return value on output:
+ * - 0, if an error occurs (invalid coefficients)
+ * - 1, if all roots are real
+ * - 2, if two roots are real and two roots are complex conjugates
+ * - 3, if the roots are two pairs of complex conjugates
+ */
+int solve(double a,
+                    double b,
+                 double c,
+                 double d,
+                     double e,
+              std::complex<double> roots[4]);
+
+/**
+ * Function to solve for roots of a generic quartic polynomial of the following form:
+ *
+
+   p(x) = a * x^4 + b * x^3 + c * x^2 + d * x + e,
+   where a, b, c, d, and e are real coefficients
+ *
+ * Upon success, root1, root2, root3, and root4 contain the solution to the polynomial p(x) = 0
+ * + Return value on output:
+ * - 0, if an error occurs (invalid coefficients)
+ * - 1, if all roots are real
+ * - 2, if two roots are real and two roots are complex conjugates
+ * - 3, if the roots are two pairs of complex conjugates
+ */
+/* **ABC** */
+              int solve(double a,
+    double b,
+                  double c,
+            double d,
+            double e,
+                     std::complex<double> &root1,
+                  std::complex<double> &root2,
+            std::complex<double> &root3,
+        std::complex<double> &root4);
+/* ??DEF?? */


### PR DESCRIPTION
The purpose of this commit is two-fold:

1) Add ability to interpret 'disable_processing_cmt' and
   'enable_processing_cmt' options as regular expressions. This
   includes a new option 'processing_cmt_as_regex', where if
   true, enables this interpretation. If false (which is the
   default setting), an exact string match is performed as has
   historically been the case prior to this commit.
2) The current mechanism for disabling/enabling processing does
   not work if both markers are present within the same multi-
   line c-style comment block, let alone potentially multiple
   times. Why is this important? As an example, consider Doxygen-
   style tags such as '\verbatim' and '\endverbatim'. These
   markers tell Doxygen to generate documentation using the
   text as-is. This may be desirable to prevent comment mod-
   ifications, reflow, etc. or to preserve ascii art, etc.
   This commit addresses this issue while using the existing
   'disable_processing_cmt' and 'enable_processing_cmt' options
   to accomplish this goal.

   For the given example, the following options can be used to
   disable processing of text within multi-line c-style comments
   using the '\verbatim' and '\endverbatim' tags, while at the
   same time still allowing the *INDENT-OFF* and *INDENT-ON*
   markers to disable processing elsewhere:

   disable_processing_cmt  = "\\\\verbatim|[ \t]*\\*INDENT-OFF\\*"
   enable_processing_cmt   = "\\\\endverbatim|[ \t]*\\*INDENT-ON\\*"
   processing_cmt_as_regex = true

   Unit tests have been added along with this commit to demonstrate
   the update.