### PR TITLE
Add option to indent paragraphs in c-style commments during reflow

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -3287,6 +3287,13 @@ cmt_reflow_mode;
 extern Option<string>
 cmt_reflow_fold_regex_file;
 
+// Whether to indent wrapped lines to the start of the encompassing paragraph
+// during full comment reflow (cmt_reflow_mode = 2). Overrides the value
+// specified by cmt_sp_after_star_cont. Note that cmt_align_doxygen_javadoc_tags
+// overrides this option for paragraphs associated with javadoc tags
+extern Option<bool>
+cmt_reflow_indent_to_paragraph_start;
+
 // Whether to convert all tabs to spaces in comments. If false, tabs in
 // comments are left alone, unless used for indenting.
 extern Option<bool>

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -654,6 +654,7 @@ align_oc_msg_colon_xcode_like   = false
 cmt_width                       = 0
 cmt_reflow_mode                 = 0
 cmt_reflow_fold_regex_file      = ""
+cmt_reflow_indent_to_paragraph_start = false
 cmt_convert_tab_to_spaces       = false
 cmt_indent_multi                = true
 cmt_align_doxygen_javadoc_tags  = false

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -2666,6 +2666,12 @@ cmt_reflow_mode                 = 0        # unsigned number
 # beg_of_next_line_regex[2] = "^[A-Z]"
 cmt_reflow_fold_regex_file      = ""         # string
 
+# Whether to indent wrapped lines to the start of the encompassing paragraph
+# during full comment reflow (cmt_reflow_mode = 2). Overrides the value
+# specified by cmt_sp_after_star_cont. Note that cmt_align_doxygen_javadoc_tags
+# overrides this option for paragraphs associated with javadoc tags
+cmt_reflow_indent_to_paragraph_start = false    # true/false
+
 # Whether to convert all tabs to spaces in comments. If false, tabs in
 # comments are left alone, unless used for indenting.
 cmt_convert_tab_to_spaces       = false    # true/false

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -654,6 +654,7 @@ align_oc_msg_colon_xcode_like   = false
 cmt_width                       = 0
 cmt_reflow_mode                 = 0
 cmt_reflow_fold_regex_file      = ""
+cmt_reflow_indent_to_paragraph_start = false
 cmt_convert_tab_to_spaces       = false
 cmt_indent_multi                = true
 cmt_align_doxygen_javadoc_tags  = false

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -2666,6 +2666,12 @@ cmt_reflow_mode                 = 0        # unsigned number
 # beg_of_next_line_regex[2] = "^[A-Z]"
 cmt_reflow_fold_regex_file      = ""         # string
 
+# Whether to indent wrapped lines to the start of the encompassing paragraph
+# during full comment reflow (cmt_reflow_mode = 2). Overrides the value
+# specified by cmt_sp_after_star_cont. Note that cmt_align_doxygen_javadoc_tags
+# overrides this option for paragraphs associated with javadoc tags
+cmt_reflow_indent_to_paragraph_start = false    # true/false
+
 # Whether to convert all tabs to spaces in comments. If false, tabs in
 # comments are left alone, unless used for indenting.
 cmt_convert_tab_to_spaces       = false    # true/false

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -2666,6 +2666,12 @@ cmt_reflow_mode                 = 0        # unsigned number
 # beg_of_next_line_regex[2] = "^[A-Z]"
 cmt_reflow_fold_regex_file      = ""         # string
 
+# Whether to indent wrapped lines to the start of the encompassing paragraph
+# during full comment reflow (cmt_reflow_mode = 2). Overrides the value
+# specified by cmt_sp_after_star_cont. Note that cmt_align_doxygen_javadoc_tags
+# overrides this option for paragraphs associated with javadoc tags
+cmt_reflow_indent_to_paragraph_start = false    # true/false
+
 # Whether to convert all tabs to spaces in comments. If false, tabs in
 # comments are left alone, unless used for indenting.
 cmt_convert_tab_to_spaces       = false    # true/false

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -5861,6 +5861,14 @@ CallName=cmt_reflow_fold_regex_file=
 EditorType=string
 ValueDefault=
 
+[Cmt Reflow Indent To Paragraph Start]
+Category=8
+Description="<html>Whether to indent wrapped lines to the start of the encompassing paragraph<br/>during full comment reflow (cmt_reflow_mode = 2). Overrides the value<br/>specified by cmt_sp_after_star_cont. Note that cmt_align_doxygen_javadoc_tags<br/>overrides this option for paragraphs associated with javadoc tags</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=cmt_reflow_indent_to_paragraph_start=true|cmt_reflow_indent_to_paragraph_start=false
+ValueDefault=false
+
 [Cmt Convert Tab To Spaces]
 Category=8
 Description="<html>Whether to convert all tabs to spaces in comments. If false, tabs in<br/>comments are left alone, unless used for indenting.</html>"

--- a/tests/config/cmt_reflow.cfg
+++ b/tests/config/cmt_reflow.cfg
@@ -1,4 +1,6 @@
-cmt_reflow_mode = 2
-cmt_width = 70
-cmt_sp_after_star_cont = 2
+cmt_align_doxygen_javadoc_tags = true
 cmt_indent_multi = true
+cmt_reflow_indent_to_paragraph_start = true
+cmt_reflow_mode = 2
+cmt_sp_after_star_cont = 2
+cmt_width = 70

--- a/tests/expected/c/00123-cmt_reflow.c
+++ b/tests/expected/c/00123-cmt_reflow.c
@@ -1,14 +1,50 @@
 /**
  * Search the tree for a match that satisfies specific comparison
- *  criteria, branch contains the desired data for which to search the
- *  tree
- * @param compareFunc is a binary function object that defines how to
- *  compare nodes
- * @param bRetrieve indicates whether or not the input search branch
- *  should be modified to reflect a branch in the tree, assuming a
- *  match satisfying the given search criteria exists
- * @return true if a branch matching the input is found or returns
- *  nullptr otherwise
+ * criteria, branch contains the desired data for which to search the
+ * tree
+ * @param  compareFunc is a binary function object that defines how to
+ *                     compare nodes
+ * @param  bRetrieve   indicates whether or not the input search
+ *                     branch should be modified to reflect a branch
+ *                     in the tree, assuming a match satisfying the
+ *                     given search criteria exists
+ * @return             true if a branch matching the input is found or
+ *                     returns nullptr otherwise
  *
- * Test string
+ *    It was the best of times, it was the worst of times, it was the
+ *    age of wisdom, it was the age of foolishness, it was the epoch
+ *    of belief, it was the epoch of incredulity, it was the season of
+ *    Light, it was the season of Darkness, it was the spring of hope,
+ *    it was the winter of despair, we had everything before us, we
+ *    had nothing before us, we were all going direct to Heaven, we
+ *    were all going direct the other way--in short, the period was so
+ *    far like the present period, that some of its noisiest
+ *    authorities insisted on its being received, for good or for
+ *    evil, in the superlative degree of comparison only.
+ *
+ *        There were a king with a large jaw and a queen with a plain
+ *        face on the throne of England; there were a king with a
+ *        large jaw and a queen with a fair face, on the throne of
+ *        France. In both countries it was clearer than crystal to the
+ *        lords of the State preserves of loaves and fishes, that
+ *        things in general were settled for ever.
+ *
+ *            It was the year of Our Lord one thousand seven hundred
+ *            and seventy-five. Spiritual revelations were conceded to
+ *            England at that favoured period, as at this. Mrs.
+ *            Southcott had recently attained her five-and-twentieth
+ *            blessed birthday, of whom a prophetic private in the
+ *            Life Guards had heralded the sublime appearance by
+ *            announcing that arrangements were made for the
+ *            swallowing up of London and Westminster. Even the
+ *            Cock-lane ghost had been laid only a round dozen of
+ *            years, after rapping out its messages, as the spirits of
+ *            this very year last past (supernaturally deficient in
+ *            originality) rapped out theirs. Mere messages in the
+ *            earthly order of events had lately come to the English
+ *            Crown and People, from a congress of British subjects in
+ *            America: which, strange to relate, have proved more
+ *            important to the human race than any communications yet
+ *            received through any of the chickens of the Cock-lane
+ *            brood.
  */

--- a/tests/input/c/cmt_reflow.c
+++ b/tests/input/c/cmt_reflow.c
@@ -8,5 +8,25 @@
   * @return true if a branch matching the input is found
   *                    or returns nullptr otherwise
   *
-  * Test string
+  *    It was the best of times, it was the worst of times,
+  *           it was the age of wisdom, it was the age of foolishness, it was the epoch of belief,
+  *        it was the epoch of incredulity, it was the season of Light, it was the season of Darkness, it was the spring of hope,
+  *            it was the winter of despair, we had everything before us, we had nothing before us, we were all going direct to Heaven,
+  *        we were all going direct the other way--in short, the period was so far like the present period, that some of its noisiest authorities insisted
+  *                                     on its being received, for good or for evil, in the superlative degree of comparison only.
+  *
+  *        There were a king with a large jaw and a queen with a plain face
+  *                      on the throne of England; there were a king with a large jaw and a queen with a fair
+  *                                 face,
+  *                           on the throne of France. In both countries it was clearer than crystal to the lords of the
+  *                           State preserves of loaves and fishes, that things in general were settled for ever.
+  *
+  *            It was the year of Our Lord one thousand seven hundred and seventy-five.
+  *                                                 Spiritual revelations were conceded to England at that favoured period, as at this. Mrs.
+  *                                       Southcott had recently attained her five-and-twentieth blessed birthday, of whom a prophetic private in the Life
+  *                 Guards had heralded the sublime appearance by announcing that arrangements were made for the swallowing up of London and Westminster.
+  *           Even the Cock-lane ghost had been laid only a round dozen of years, after rapping out its messages, as the spirits of this very year last past
+  *                           (supernaturally deficient in originality) rapped out theirs. Mere messages in the earthly order of events had lately come to
+  *                     the English Crown and People, from a congress of British subjects in America: which, strange to relate, have proved more important
+  *               to the human race than any communications yet received through any of the chickens of the Cock-lane brood.
   */


### PR DESCRIPTION
This commit adds an option to indent wrapped lines within c-style multi-
line comments (/* ... */) to the start of the current paragraph during
full comment reflow (cmt_reflow_mode = 2). A continuation indent is
calculated with respect to the start of the first sentence in a
paragraph, and this indent is applied to subsequent lines/sentences
that are part of the same paragraph. A separate continuation indent
is calculated for each subsequent/separate paragraph.