### PR TITLE
Added processing of additional cases for #1402

### DIFF
--- a/tests/expected/cpp/34180-bug_1402.cpp
+++ b/tests/expected/cpp/34180-bug_1402.cpp
@@ -4,3 +4,9 @@ double PI = 3.14;
 }
 int factor = 41;
 double result = Constants::PI * factor;
+
+return Constants::PI * factor;
+
+void func(int value) {
+	return SomeClass(value, Constants::PI * value);
+}

--- a/tests/input/cpp/bug_1402.cpp
+++ b/tests/input/cpp/bug_1402.cpp
@@ -4,3 +4,9 @@ double PI = 3.14;
 }
 int factor = 41;
 double result = Constants::PI * factor;
+
+return Constants::PI * factor;
+
+void func(int value) {
+    return SomeClass(value, Constants::PI * value);
+}


### PR DESCRIPTION
Added processing of additional cases for #1402

The search was performed only by the assign, although there are other cases in which auto-formatting does not work correctly.

For example:
`return Constants::PI* factor;` instead of `return Constants::PI * factor;`
or 
`SomeClass(Constants::PI* value);` instead of `SomeClass(Constants::PI * value);`