### PR TITLE
Fix cmt_insert_func_header for head chunk

### DIFF
--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1754,7 +1754,18 @@ static void add_func_header(c_token_t type, file_mem &fm)
          }
       }
 
-      if (do_insert)
+      if (  ref == nullptr
+         && !chunk_is_comment(chunk_get_head())
+         && get_chunk_parent_type(chunk_get_head()) == type)
+      {
+         /**
+          * In addition to testing for preceding semicolons, closing braces, etc.,
+          * we need to also account for the possibility that the function declaration
+          * or definition occurs at the very beginning of the file
+          */
+         tokenize(fm.data, chunk_get_head());
+      }
+      else if (do_insert)
       {
          // Insert between after and ref
          chunk_t *after = chunk_get_next_ncnl(ref);

--- a/tests/expected/cpp/34200-i1536.cpp
+++ b/tests/expected/cpp/34200-i1536.cpp
@@ -1,3 +1,4 @@
+// FuncA
 void FuncA(void)
 {
 }


### PR DESCRIPTION
The cmt_insert_func_header option does not appear to properly
add function headers if the function or class occurs at the
very beginning of the source file. This commit attempts to
fix this, and the change to 34200-i1536.cpp demonstates the
fix made by this commit accordingly.