### PR TITLE
Fix bugs related to cmt_align_doxygen_javadoc_tags

### DIFF
--- a/tests/expected/java/80067-doxy-javadoc-alignment.java
+++ b/tests/expected/java/80067-doxy-javadoc-alignment.java
@@ -11,7 +11,10 @@
  * Longer description. If there were any, it would be    (2) here.
  *
  * And even more explanations to follow in consecutive paragraphs
- * separated by HTML paragraph breaks... or so we think, haha.
+ * separated by HTML paragraph breaks... or so we think, haha. After
+ * this paragraph, add a reference to an @param to verify that it is
+ * ignored since it does not occur at the beginning of the line. Let's
+ * also throw in an @return to verify that it passes the test as well.
  *
  * @param  variable Description text text text.          (3)
  * @return          Description text text text.

--- a/tests/input/java/doxy-javadoc-alignment.java
+++ b/tests/input/java/doxy-javadoc-alignment.java
@@ -12,7 +12,11 @@
  *
  * And even more explanations to follow in consecutive
  * paragraphs separated by HTML paragraph breaks...
- * or so we think, haha.
+ * or so we think, haha. After this paragraph, add a
+ * reference to an @param to verify that it is ignored
+ * since it does not occur at the beginning of the line.
+ * Let's also throw in an @return to verify that it passes
+ * the test as well.
  *
  * @param variable Description text text text.          (3)
  * @return Description text text text.


### PR DESCRIPTION
Fixed a potential crash condition and also fixed a few potential
overflow conditions due to signed/unsigned mixing in output.cpp.

Also modified the code to disallow alignment of javadoc/doxygen tags
that do not occur at the beginning of a line (or after the lead star
in a multi-line comment, if present). Updated
doxy-javadoc-alignment.java to demonstrate this behavior.