### PR TITLE
Implement nl_do_leave_one_liners

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3473,6 +3473,14 @@ static bool one_liner_nl_ok(chunk_t *pc)
          LOG_FMT(LNL1LINE, "%s(%d): false (while)\n", __func__, __LINE__);
          return(false);
       }
+      log_rule_B("nl_do_leave_one_liners");
+
+      if (  options::nl_do_leave_one_liners()
+         && get_chunk_parent_type(pc) == CT_DO)
+      {
+         LOG_FMT(LNL1LINE, "%s(%d): false (do)\n", __func__, __LINE__);
+         return(false);
+      }
       log_rule_B("nl_for_leave_one_liners");
 
       if (  options::nl_for_leave_one_liners()

--- a/src/options.h
+++ b/src/options.h
@@ -1729,6 +1729,10 @@ nl_if_leave_one_liners;
 extern Option<bool>
 nl_while_leave_one_liners;
 
+// Don't split one-line do statements, as in 'do { b++; } while(...);'.
+extern Option<bool>
+nl_do_leave_one_liners;
+
 // Don't split one-line for statements, as in 'for(...) b++;'.
 extern Option<bool>
 nl_for_leave_one_liners;

--- a/tests/c.test
+++ b/tests/c.test
@@ -297,6 +297,7 @@
 02320  nl_create_one_liner.cfg              c/nl_create_one_liner.c
 02325  sort_imports.cfg                     c/sort_include.c
 
+02330  leave_one_liners.cfg                 c/one_liners.c
 
 # some embedded sql stuff
 

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -351,6 +351,7 @@ nl_func_leave_one_liners        = false
 nl_cpp_lambda_leave_one_liners  = false
 nl_if_leave_one_liners          = false
 nl_while_leave_one_liners       = false
+nl_do_leave_one_liners          = false
 nl_for_leave_one_liners         = false
 nl_oc_msg_leave_one_liner       = false
 nl_oc_mdef_brace                = ignore

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1414,6 +1414,9 @@ nl_if_leave_one_liners          = false    # true/false
 # Don't split one-line while statements, as in 'while(...) b++;'.
 nl_while_leave_one_liners       = false    # true/false
 
+# Don't split one-line do statements, as in 'do { b++; } while(...);'.
+nl_do_leave_one_liners          = false    # true/false
+
 # Don't split one-line for statements, as in 'for(...) b++;'.
 nl_for_leave_one_liners         = false    # true/false
 

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -351,6 +351,7 @@ nl_func_leave_one_liners        = false
 nl_cpp_lambda_leave_one_liners  = false
 nl_if_leave_one_liners          = false
 nl_while_leave_one_liners       = false
+nl_do_leave_one_liners          = false
 nl_for_leave_one_liners         = false
 nl_oc_msg_leave_one_liner       = false
 nl_oc_mdef_brace                = ignore

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1414,6 +1414,9 @@ nl_if_leave_one_liners          = false    # true/false
 # Don't split one-line while statements, as in 'while(...) b++;'.
 nl_while_leave_one_liners       = false    # true/false
 
+# Don't split one-line do statements, as in 'do { b++; } while(...);'.
+nl_do_leave_one_liners          = false    # true/false
+
 # Don't split one-line for statements, as in 'for(...) b++;'.
 nl_for_leave_one_liners         = false    # true/false
 

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1414,6 +1414,9 @@ nl_if_leave_one_liners          = false    # true/false
 # Don't split one-line while statements, as in 'while(...) b++;'.
 nl_while_leave_one_liners       = false    # true/false
 
+# Don't split one-line do statements, as in 'do { b++; } while(...);'.
+nl_do_leave_one_liners          = false    # true/false
+
 # Don't split one-line for statements, as in 'for(...) b++;'.
 nl_for_leave_one_liners         = false    # true/false
 

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -3123,6 +3123,14 @@ EditorType=boolean
 TrueFalse=nl_while_leave_one_liners=true|nl_while_leave_one_liners=false
 ValueDefault=false
 
+[Nl Do Leave One Liners]
+Category=3
+Description="<html>Don't split one-line do statements, as in 'do { b++; } while(...);'.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=nl_do_leave_one_liners=true|nl_do_leave_one_liners=false
+ValueDefault=false
+
 [Nl For Leave One Liners]
 Category=3
 Description="<html>Don't split one-line for statements, as in 'for(...) b++;'.</html>"

--- a/tests/config/leave_one_liners.cfg
+++ b/tests/config/leave_one_liners.cfg
@@ -1,0 +1,14 @@
+nl_assign_brace                         = force
+nl_enum_brace                           = force
+nl_if_brace                             = force
+nl_while_brace                          = force
+nl_do_brace                             = force
+nl_for_brace                            = force
+
+nl_assign_leave_one_liners              = true
+nl_enum_leave_one_liners                = true
+nl_func_leave_one_liners                = true
+nl_if_leave_one_liners                  = true
+nl_while_leave_one_liners               = true
+nl_do_leave_one_liners                  = true
+nl_for_leave_one_liners                 = true

--- a/tests/expected/c/02330-one_liners.c
+++ b/tests/expected/c/02330-one_liners.c
@@ -1,0 +1,12 @@
+int baz() { return 0; }
+
+int main()
+{
+	int a, b;
+	int f[2] = { 1, 2 };
+	enum foo { BAR = 15 };
+	if (1) { a++; b++; }
+	while (0) { a++; b++; }
+	do { a++; b++; } while (0);
+	for (;;) { a++; b++; };
+}

--- a/tests/input/c/one_liners.c
+++ b/tests/input/c/one_liners.c
@@ -1,0 +1,12 @@
+int baz() { return 0; }
+
+int main()
+{
+int a, b;
+int f[2] = { 1, 2 };
+enum foo { BAR = 15 };
+if (1) { a++; b++; }
+while (0) { a++; b++; }
+do { a++; b++; } while (0);
+for (;;) { a++; b++; };
+}


### PR DESCRIPTION
Complement `nl_{if,while,for}_leave_one_liners` with a new `nl_do_leave_one_liners` option for `do { ... } while(...);` one-liner constructs.

Added a c test `02330  leave_one_liners.cfg                 c/one_liners.c`.