### PR TITLE
Don't format stdin if file arguments are present

### DIFF
--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -919,9 +919,11 @@ int main(int argc, char *argv[])
    {
       cpd.bout = new deque<UINT8>();
    }
+   idx = 1;
 
    if (  source_file == nullptr
-      && source_list == nullptr)
+      && source_list == nullptr
+      && arg.Unused(idx) == nullptr)
    {
       if (!arg_l_is_set)                     // Issue #3064
       {


### PR DESCRIPTION
Fix regression that cause uncrustify to try to format stdin when given a list of files to format as positional parameters.

I am... somewhat alarmed that the tests didn't catch this? Do we not have a CLI test that takes a (temporary?) file as a positional parameter?