### PR TITLE
FreeBSD style has a <TAB> after #define

### DIFF
--- a/etc/freebsd.cfg
+++ b/etc/freebsd.cfg
@@ -167,6 +167,7 @@ sp_case_label                            = remove
 sp_range                                 = ignore
 sp_cmt_cpp_start                         = ignore
 sp_endif_cmt                             = ignore
+force_tab_after_define                   = true
 align_keep_tabs                          = false
 align_with_tabs                          = true
 align_on_tabstop                         = true


### PR DESCRIPTION
$ man 9 style
...
Put a single tab character between the #define and the macro name.