### PR TITLE
Fix test documentation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The configuration file `testConfigFileName` has to be located inside `tests/conf
 the input file `testInputFileName` inside `tests/input/<testSetName>/`,
 and expected results file inside the `tests/expected/<testSetName>/`
 directory.
-Expected results have the following naming convention: `testNr-testConfigFileName`.
+Expected results have the following naming convention: `testNr-testInputFileName`.
 
 Optionally a `!` can follow the `testNr` to enable a custom rerun
 configuration.


### PR DESCRIPTION
Expected test file names are named after the test number and the test
input file, not the config file.
For example in tests/cpp.test there is 
```
30015  ben_008.cfg                          cpp/exception.cpp
```
and the expected file is called "30015-exception.cpp", not "30015-ben_008.cfg"