### PR TITLE
Fix issue 3061

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3647,14 +3647,19 @@ void newlines_remove_disallowed()
 {
    LOG_FUNC_ENTRY();
 
-   auto *pc = chunk_get_head();
+   chunk_t *pc = chunk_get_head();
+   chunk_t *next;
 
    while ((pc = chunk_get_next_nl(pc)) != nullptr)
    {
       LOG_FMT(LBLANKD, "%s(%d): orig_line is %zu, orig_col is %zu, <Newline>, nl is %zu\n",
               __func__, __LINE__, pc->orig_line, pc->orig_col, pc->nl_count);
 
-      if (!can_increase_nl(pc))
+      next = chunk_get_next(pc);
+
+      if (  next != nullptr
+         && !chunk_is_token(next, CT_NEWLINE)
+         && !can_increase_nl(pc))
       {
          LOG_FMT(LBLANKD, "%s(%d): force to 1 orig_line is %zu, orig_col is %zu\n",
                  __func__, __LINE__, pc->orig_line, pc->orig_col);

--- a/tests/config/Issue_3061_0nl.cfg
+++ b/tests/config/Issue_3061_0nl.cfg
@@ -1,0 +1,13 @@
+cmt_width=30
+code_width=30
+eat_blanks_after_open_brace=true
+nl_inside_empty_func=2
+nl_fdef_brace=force
+indent_columns=4
+indent_class=true
+indent_with_tabs=0
+input_tab_size=4
+nl_func_type_name=force
+nl_before_func_body_def=2
+nl_end_of_file=remove
+

--- a/tests/config/Issue_3061_1nl.cfg
+++ b/tests/config/Issue_3061_1nl.cfg
@@ -1,0 +1,14 @@
+cmt_width=30
+code_width=30
+eat_blanks_after_open_brace=true
+nl_inside_empty_func=2
+nl_fdef_brace=force
+indent_columns=4
+indent_class=true
+indent_with_tabs=0
+input_tab_size=4
+nl_func_type_name=force
+nl_before_func_body_def=2
+nl_end_of_file=force
+nl_end_of_file_min=1
+

--- a/tests/config/Issue_3061_2nl.cfg
+++ b/tests/config/Issue_3061_2nl.cfg
@@ -1,0 +1,14 @@
+cmt_width=30
+code_width=30
+eat_blanks_after_open_brace=true
+nl_inside_empty_func=2
+nl_fdef_brace=force
+indent_columns=4
+indent_class=true
+indent_with_tabs=0
+input_tab_size=4
+nl_func_type_name=force
+nl_before_func_body_def=2
+nl_end_of_file=force
+nl_end_of_file_min=2
+

--- a/tests/config/Issue_3061_3nl.cfg
+++ b/tests/config/Issue_3061_3nl.cfg
@@ -1,0 +1,14 @@
+cmt_width=30
+code_width=30
+eat_blanks_after_open_brace=true
+nl_inside_empty_func=2
+nl_fdef_brace=force
+indent_columns=4
+indent_class=true
+indent_with_tabs=0
+input_tab_size=4
+nl_func_type_name=force
+nl_before_func_body_def=2
+nl_end_of_file=force
+nl_end_of_file_min=3
+

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -838,6 +838,19 @@
 34327  Issue_3044.cfg                       cpp/Issue_3044.cpp
 34328  Issue_3048.cfg                       cpp/Issue_3048.cpp
 
+34330  Issue_3061_0nl.cfg                   cpp/Issue_3061_0nl.cpp
+34331  Issue_3061_0nl.cfg                   cpp/Issue_3061_1nl.cpp
+34332  Issue_3061_0nl.cfg                   cpp/Issue_3061_2nl.cpp
+34333  Issue_3061_1nl.cfg                   cpp/Issue_3061_0nl.cpp
+34334  Issue_3061_1nl.cfg                   cpp/Issue_3061_1nl.cpp
+34335  Issue_3061_1nl.cfg                   cpp/Issue_3061_2nl.cpp
+34336  Issue_3061_2nl.cfg                   cpp/Issue_3061_0nl.cpp
+34337  Issue_3061_2nl.cfg                   cpp/Issue_3061_1nl.cpp
+34338  Issue_3061_2nl.cfg                   cpp/Issue_3061_2nl.cpp
+34339  Issue_3061_3nl.cfg                   cpp/Issue_3061_0nl.cpp
+34340  Issue_3061_3nl.cfg                   cpp/Issue_3061_1nl.cpp
+34341  Issue_3061_3nl.cfg                   cpp/Issue_3061_2nl.cpp
+
 # Adopt some UT tests
 10000  empty.cfg                            cpp/621_this-spacing.cpp
 10001  empty.cfg                            cpp/622_ifdef-indentation.cpp

--- a/tests/expected/cpp/34330-Issue_3061_0nl.cpp
+++ b/tests/expected/cpp/34330-Issue_3061_0nl.cpp
@@ -1,0 +1,14 @@
+DCOPClient::DCOPClient()
+{
+    TQObject::connect(
+        &d->postMessageTimer, TQT_SIGNAL(
+            timeout()), this,
+        TQT_SLOT(
+            processPostedMessagesInternal()));
+    TQObject::connect(
+        &d->eventLoopTimer, TQT_SIGNAL(
+            timeout()), this, TQT_SLOT(
+            eventLoopTimeout()));
+}
+
+#include <dcopclient.moc>

--- a/tests/expected/cpp/34331-Issue_3061_1nl.cpp
+++ b/tests/expected/cpp/34331-Issue_3061_1nl.cpp
@@ -1,0 +1,14 @@
+DCOPClient::DCOPClient()
+{
+    TQObject::connect(
+        &d->postMessageTimer, TQT_SIGNAL(
+            timeout()), this,
+        TQT_SLOT(
+            processPostedMessagesInternal()));
+    TQObject::connect(
+        &d->eventLoopTimer, TQT_SIGNAL(
+            timeout()), this, TQT_SLOT(
+            eventLoopTimeout()));
+}
+
+#include <dcopclient.moc>

--- a/tests/expected/cpp/34332-Issue_3061_2nl.cpp
+++ b/tests/expected/cpp/34332-Issue_3061_2nl.cpp
@@ -1,0 +1,14 @@
+DCOPClient::DCOPClient()
+{
+    TQObject::connect(
+        &d->postMessageTimer, TQT_SIGNAL(
+            timeout()), this,
+        TQT_SLOT(
+            processPostedMessagesInternal()));
+    TQObject::connect(
+        &d->eventLoopTimer, TQT_SIGNAL(
+            timeout()), this, TQT_SLOT(
+            eventLoopTimeout()));
+}
+
+#include <dcopclient.moc>

--- a/tests/expected/cpp/34333-Issue_3061_0nl.cpp
+++ b/tests/expected/cpp/34333-Issue_3061_0nl.cpp
@@ -1,0 +1,14 @@
+DCOPClient::DCOPClient()
+{
+    TQObject::connect(
+        &d->postMessageTimer, TQT_SIGNAL(
+            timeout()), this,
+        TQT_SLOT(
+            processPostedMessagesInternal()));
+    TQObject::connect(
+        &d->eventLoopTimer, TQT_SIGNAL(
+            timeout()), this, TQT_SLOT(
+            eventLoopTimeout()));
+}
+
+#include <dcopclient.moc>

--- a/tests/expected/cpp/34334-Issue_3061_1nl.cpp
+++ b/tests/expected/cpp/34334-Issue_3061_1nl.cpp
@@ -1,0 +1,14 @@
+DCOPClient::DCOPClient()
+{
+    TQObject::connect(
+        &d->postMessageTimer, TQT_SIGNAL(
+            timeout()), this,
+        TQT_SLOT(
+            processPostedMessagesInternal()));
+    TQObject::connect(
+        &d->eventLoopTimer, TQT_SIGNAL(
+            timeout()), this, TQT_SLOT(
+            eventLoopTimeout()));
+}
+
+#include <dcopclient.moc>

--- a/tests/expected/cpp/34335-Issue_3061_2nl.cpp
+++ b/tests/expected/cpp/34335-Issue_3061_2nl.cpp
@@ -1,0 +1,14 @@
+DCOPClient::DCOPClient()
+{
+    TQObject::connect(
+        &d->postMessageTimer, TQT_SIGNAL(
+            timeout()), this,
+        TQT_SLOT(
+            processPostedMessagesInternal()));
+    TQObject::connect(
+        &d->eventLoopTimer, TQT_SIGNAL(
+            timeout()), this, TQT_SLOT(
+            eventLoopTimeout()));
+}
+
+#include <dcopclient.moc>

--- a/tests/expected/cpp/34336-Issue_3061_0nl.cpp
+++ b/tests/expected/cpp/34336-Issue_3061_0nl.cpp
@@ -1,0 +1,15 @@
+DCOPClient::DCOPClient()
+{
+    TQObject::connect(
+        &d->postMessageTimer, TQT_SIGNAL(
+            timeout()), this,
+        TQT_SLOT(
+            processPostedMessagesInternal()));
+    TQObject::connect(
+        &d->eventLoopTimer, TQT_SIGNAL(
+            timeout()), this, TQT_SLOT(
+            eventLoopTimeout()));
+}
+
+#include <dcopclient.moc>
+

--- a/tests/expected/cpp/34337-Issue_3061_1nl.cpp
+++ b/tests/expected/cpp/34337-Issue_3061_1nl.cpp
@@ -1,0 +1,15 @@
+DCOPClient::DCOPClient()
+{
+    TQObject::connect(
+        &d->postMessageTimer, TQT_SIGNAL(
+            timeout()), this,
+        TQT_SLOT(
+            processPostedMessagesInternal()));
+    TQObject::connect(
+        &d->eventLoopTimer, TQT_SIGNAL(
+            timeout()), this, TQT_SLOT(
+            eventLoopTimeout()));
+}
+
+#include <dcopclient.moc>
+

--- a/tests/expected/cpp/34338-Issue_3061_2nl.cpp
+++ b/tests/expected/cpp/34338-Issue_3061_2nl.cpp
@@ -1,0 +1,15 @@
+DCOPClient::DCOPClient()
+{
+    TQObject::connect(
+        &d->postMessageTimer, TQT_SIGNAL(
+            timeout()), this,
+        TQT_SLOT(
+            processPostedMessagesInternal()));
+    TQObject::connect(
+        &d->eventLoopTimer, TQT_SIGNAL(
+            timeout()), this, TQT_SLOT(
+            eventLoopTimeout()));
+}
+
+#include <dcopclient.moc>
+

--- a/tests/expected/cpp/34339-Issue_3061_0nl.cpp
+++ b/tests/expected/cpp/34339-Issue_3061_0nl.cpp
@@ -1,0 +1,16 @@
+DCOPClient::DCOPClient()
+{
+    TQObject::connect(
+        &d->postMessageTimer, TQT_SIGNAL(
+            timeout()), this,
+        TQT_SLOT(
+            processPostedMessagesInternal()));
+    TQObject::connect(
+        &d->eventLoopTimer, TQT_SIGNAL(
+            timeout()), this, TQT_SLOT(
+            eventLoopTimeout()));
+}
+
+#include <dcopclient.moc>
+
+

--- a/tests/expected/cpp/34340-Issue_3061_1nl.cpp
+++ b/tests/expected/cpp/34340-Issue_3061_1nl.cpp
@@ -1,0 +1,16 @@
+DCOPClient::DCOPClient()
+{
+    TQObject::connect(
+        &d->postMessageTimer, TQT_SIGNAL(
+            timeout()), this,
+        TQT_SLOT(
+            processPostedMessagesInternal()));
+    TQObject::connect(
+        &d->eventLoopTimer, TQT_SIGNAL(
+            timeout()), this, TQT_SLOT(
+            eventLoopTimeout()));
+}
+
+#include <dcopclient.moc>
+
+

--- a/tests/expected/cpp/34341-Issue_3061_2nl.cpp
+++ b/tests/expected/cpp/34341-Issue_3061_2nl.cpp
@@ -1,0 +1,16 @@
+DCOPClient::DCOPClient()
+{
+    TQObject::connect(
+        &d->postMessageTimer, TQT_SIGNAL(
+            timeout()), this,
+        TQT_SLOT(
+            processPostedMessagesInternal()));
+    TQObject::connect(
+        &d->eventLoopTimer, TQT_SIGNAL(
+            timeout()), this, TQT_SLOT(
+            eventLoopTimeout()));
+}
+
+#include <dcopclient.moc>
+
+

--- a/tests/input/cpp/Issue_3061_0nl.cpp
+++ b/tests/input/cpp/Issue_3061_0nl.cpp
@@ -1,0 +1,8 @@
+DCOPClient::DCOPClient()
+{
+	TQObject::connect(&d->postMessageTimer, TQT_SIGNAL(timeout()), this,
+	        TQT_SLOT(processPostedMessagesInternal()));
+	TQObject::connect(&d->eventLoopTimer, TQT_SIGNAL(timeout()), this, TQT_SLOT(eventLoopTimeout()));
+}
+
+#include <dcopclient.moc>

--- a/tests/input/cpp/Issue_3061_1nl.cpp
+++ b/tests/input/cpp/Issue_3061_1nl.cpp
@@ -1,0 +1,8 @@
+DCOPClient::DCOPClient()
+{
+	TQObject::connect(&d->postMessageTimer, TQT_SIGNAL(timeout()), this,
+	        TQT_SLOT(processPostedMessagesInternal()));
+	TQObject::connect(&d->eventLoopTimer, TQT_SIGNAL(timeout()), this, TQT_SLOT(eventLoopTimeout()));
+}
+
+#include <dcopclient.moc>

--- a/tests/input/cpp/Issue_3061_2nl.cpp
+++ b/tests/input/cpp/Issue_3061_2nl.cpp
@@ -1,0 +1,9 @@
+DCOPClient::DCOPClient()
+{
+	TQObject::connect(&d->postMessageTimer, TQT_SIGNAL(timeout()), this,
+	        TQT_SLOT(processPostedMessagesInternal()));
+	TQObject::connect(&d->eventLoopTimer, TQT_SIGNAL(timeout()), this, TQT_SLOT(eventLoopTimeout()));
+}
+
+#include <dcopclient.moc>
+


### PR DESCRIPTION
Issue #3061 was introduced by commit 313f6eb7 (PR #3014).

'void newlines_remove_disallowed()' should not eat new line characters
in the following cases:
1. we are at the end of the file
2. there are consecutive new line characters
because that is already dealt with in a different part of the code.

Tests with different combinations of existing and required numbers of nl are included. 4 sets, each set requiring a different number of nl on 3 different files with different original numbers of nl. This tests adding nl, removing nl, leaving nl unchanged at the end of the file.