### PR TITLE
Improve code base

### DIFF
--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -538,10 +538,11 @@ chunk_t *chunk_add_before(const chunk_t *pc_in, chunk_t *ref)
 }
 
 
-void chunk_del_2(chunk_t *pc)
+void chunk_del(chunk_t * &pc)
 {
    g_cl.Pop(pc);
    delete pc;
+   pc = nullptr;
 }
 
 

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -87,12 +87,7 @@ chunk_t *chunk_add_before(const chunk_t *pc_in, chunk_t *ref);
  *
  * @param pc  chunk to delete
  */
-#define chunk_del(pc)    do { \
-      chunk_del_2((pc));      \
-      (pc) = nullptr;         \
-} while (false)
-
-void chunk_del_2(chunk_t *pc);
+void chunk_del(chunk_t * &pc);
 
 
 /**


### PR DESCRIPTION
Get rid of 'chunk_del' macro and replace it with a proper function call, making the code easier to read.
All tests passed successfully. In addition to that, testing on a small set of 3200 files yields no difference at all.