### PR TITLE
Fix nl_type_brace_init_lst with no type

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3965,8 +3965,17 @@ void newlines_cleanup_braces(bool first)
                nl_create_list_liner(pc);
                break;
             }
-            log_rule_B("nl_type_brace_init_lst");
-            newline_iarf_pair(chunk_get_prev_nnl(pc), pc, options::nl_type_brace_init_lst(), true);
+            prev = chunk_get_prev_nnl(pc);
+
+            if (  prev
+               && (  prev->type == CT_TYPE
+                  || prev->type == CT_WORD
+                  || prev->parent_type == CT_TEMPLATE
+                  || prev->parent_type == CT_DECLTYPE))
+            {
+               log_rule_B("nl_type_brace_init_lst");
+               newline_iarf_pair(prev, pc, options::nl_type_brace_init_lst(), true);
+            }
             break;
          }
 

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -260,6 +260,9 @@
 30326  indent_off_after_return.cfg          cpp/indent_off_after_return.cpp
 30327  empty.cfg                            cpp/indent_off_after_return.cpp
 
+30328  nl_type_brace_init_lst-f.cfg         cpp/call_brace_init_lst.cpp
+30329  nl_type_brace_init_lst-r.cfg         cpp/call_brace_init_lst.cpp
+
 30400  attribute_specifier_seqs.cfg         cpp/attribute_specifier_seqs.cpp
 30401  Issue_2570.cfg                       cpp/Issue_2570.cpp
 

--- a/tests/expected/cpp/30328-call_brace_init_lst.cpp
+++ b/tests/expected/cpp/30328-call_brace_init_lst.cpp
@@ -1,0 +1,33 @@
+void bar()
+{
+	foo(42, {1, 2, 3, 4});
+	foo(42,
+	    {1, 2, 3, 4});
+
+	foo(42, vector
+	    {1, 2, 3, 4});
+	foo(42,
+	    vector
+	    {1, 2, 3, 4});
+	foo(42, vector
+	    {1, 2, 3, 4});
+
+	foo(42, vector<int>
+	    {1, 2, 3, 4});
+	foo(42,
+	    vector<int>
+	    {1, 2, 3, 4});
+	foo(42, vector<int>
+	    {1, 2, 3, 4});
+	foo(42, vector
+	    <int>
+	    {1, 2, 3, 4});
+
+	foo(42, decltype(something)
+	    {1, 2, 3, 4});
+	foo(42,
+	    decltype(something)
+	    {1, 2, 3, 4});
+	foo(42, decltype(something)
+	    {1, 2, 3, 4});
+}

--- a/tests/expected/cpp/30329-call_brace_init_lst.cpp
+++ b/tests/expected/cpp/30329-call_brace_init_lst.cpp
@@ -1,0 +1,23 @@
+void bar()
+{
+	foo(42, {1, 2, 3, 4});
+	foo(42,
+	    {1, 2, 3, 4});
+
+	foo(42, vector{1, 2, 3, 4});
+	foo(42,
+	    vector{1, 2, 3, 4});
+	foo(42, vector{1, 2, 3, 4});
+
+	foo(42, vector<int>{1, 2, 3, 4});
+	foo(42,
+	    vector<int>{1, 2, 3, 4});
+	foo(42, vector<int>{1, 2, 3, 4});
+	foo(42, vector
+	    <int>{1, 2, 3, 4});
+
+	foo(42, decltype(something) {1, 2, 3, 4});
+	foo(42,
+	    decltype(something) {1, 2, 3, 4});
+	foo(42, decltype(something) {1, 2, 3, 4});
+}

--- a/tests/input/cpp/call_brace_init_lst.cpp
+++ b/tests/input/cpp/call_brace_init_lst.cpp
@@ -1,0 +1,26 @@
+void bar()
+{
+	foo(42, {1, 2, 3, 4});
+	foo(42,
+	    {1, 2, 3, 4});
+
+	foo(42, vector{1, 2, 3, 4});
+	foo(42,
+	    vector{1, 2, 3, 4});
+	foo(42, vector
+	    {1, 2, 3, 4});
+
+	foo(42, vector<int>{1, 2, 3, 4});
+	foo(42,
+	    vector<int>{1, 2, 3, 4});
+	foo(42, vector<int>
+	    {1, 2, 3, 4});
+	foo(42, vector
+	    <int>{1, 2, 3, 4});
+
+	foo(42, decltype(something){1, 2, 3, 4});
+	foo(42,
+	    decltype(something){1, 2, 3, 4});
+	foo(42, decltype(something)
+	    {1, 2, 3, 4});
+}


### PR DESCRIPTION
Don't apply `nl_type_brace_init_lst` when there is no type preceding the initializer list. This prevents spurious addition or removal of a newline between an initializer list and something else (such as a comma or open parenthesis).

Fixes #3094.