### PR TITLE
Fix inconsistent chunk names.

### DIFF
--- a/src/EnumStructUnionParser.cpp
+++ b/src/EnumStructUnionParser.cpp
@@ -516,7 +516,7 @@ static std::tuple<chunk_t *, chunk_t *, chunk_t *> match_variable(chunk_t *pc, s
    if (  identifier != nullptr
       && start != nullptr
       && (  end != nullptr
-         || chunk_is_token(chunk_get_prev_ncnlni(identifier), CT_WORD)))
+         || chunk_is_token(chunk_get_prev_ncnnlni(identifier), CT_WORD)))
    {
       return(std::make_tuple(start, identifier, end));
    }
@@ -568,7 +568,7 @@ static std::pair<chunk_t *, chunk_t *> match_variable_end(chunk_t *pc, std::size
       while (  pc != nullptr
             && pc->level > level)
       {
-         pc = chunk_get_next_ncnl(pc);
+         pc = chunk_get_next_ncnnl(pc);
       }
 
       /**
@@ -587,7 +587,7 @@ static std::pair<chunk_t *, chunk_t *> match_variable_end(chunk_t *pc, std::size
        * matching a variable declaration/definition
        */
 
-      chunk_t *next = chunk_get_next_ncnl(pc);
+      chunk_t *next = chunk_get_next_ncnnl(pc);
 
       if (  chunk_is_not_token(next, CT_COMMA)
          && chunk_is_not_token(next, CT_FPAREN_CLOSE)
@@ -662,7 +662,7 @@ static std::pair<chunk_t *, chunk_t *> match_variable_start(chunk_t *pc, std::si
             && pc != prev)
       {
          next = prev;
-         prev = chunk_get_prev_ncnlni(next);
+         prev = chunk_get_prev_ncnnlni(next);
 
          if (chunk_is_token(next, CT_ASSIGN))
          {
@@ -676,7 +676,7 @@ static std::pair<chunk_t *, chunk_t *> match_variable_start(chunk_t *pc, std::si
       while (  pc != nullptr
             && pc->level > level)
       {
-         pc = chunk_get_prev_ncnlni(pc);
+         pc = chunk_get_prev_ncnnlni(pc);
       }
 
       /**
@@ -695,7 +695,7 @@ static std::pair<chunk_t *, chunk_t *> match_variable_start(chunk_t *pc, std::si
        * matching a variable declaration/definition
        */
 
-      prev = chunk_get_prev_ncnlni(pc);
+      prev = chunk_get_prev_ncnnlni(pc);
 
       if (!adj_tokens_match_var_def_pattern(prev, pc))
       {
@@ -769,7 +769,7 @@ static chunk_t *skip_scope_resolution_and_nested_name_specifiers(chunk_t *pc)
          {
             pc = chunk_skip_to_match(pc, scope_e::PREPROC);
          }
-         auto *next = chunk_get_next_ncnl(pc);
+         auto *next = chunk_get_next_ncnnl(pc);
 
          /**
           * call a separate function to validate adjacent tokens as potentially
@@ -810,7 +810,7 @@ static chunk_t *skip_scope_resolution_and_nested_name_specifiers_rev(chunk_t *pc
          {
             pc = chunk_skip_to_match_rev(pc, scope_e::PREPROC);
          }
-         auto *prev = chunk_get_prev_ncnlni(pc);
+         auto *prev = chunk_get_prev_ncnnlni(pc);
 
          /**
           * call a separate function to validate adjacent tokens as potentially
@@ -897,14 +897,14 @@ void EnumStructUnionParser::analyze_identifiers()
       }
    }
 
-   if (chunk_get_next_ncnl(pc) == m_end)
+   if (chunk_get_next_ncnnl(pc) == m_end)
    {
       /**
        * we're likely at the end of a class/enum/struct/union body which lacks
        * any trailing inline definitions
        */
 
-      pc = chunk_get_next_ncnl(m_end);
+      pc = chunk_get_next_ncnnl(m_end);
    }
 
    if (  type_identified()
@@ -916,7 +916,7 @@ void EnumStructUnionParser::analyze_identifiers()
        * by one more so that we don't perform a variable identifier search
        * below
        */
-      pc = chunk_get_next_ncnl(pc);
+      pc = chunk_get_next_ncnnl(pc);
    }
 
    if (body_end != nullptr)
@@ -973,7 +973,7 @@ void EnumStructUnionParser::analyze_identifiers()
       {
          pc = end;
       }
-      pc = chunk_get_next_ncnl(pc);
+      pc = chunk_get_next_ncnnl(pc);
 
       /**
        * skip any right-hand side assignments
@@ -991,7 +991,7 @@ void EnumStructUnionParser::analyze_identifiers()
             && !pc->flags.test_any(PCF_IN_FCN_DEF | PCF_IN_FCN_CALL | PCF_IN_TEMPLATE)
             && !chunk_is_between(pc, inheritance_start, body_start)))
       {
-         pc = chunk_get_next_ncnl(pc);
+         pc = chunk_get_next_ncnnl(pc);
       }
    }
    /**
@@ -1436,7 +1436,7 @@ void EnumStructUnionParser::mark_base_classes(chunk_t *pc)
        */
       pc->flags &= ~PCF_VAR_TYPE;
 
-      chunk_t *next = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+      chunk_t *next = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
 
       if (chunk_is_token(next, CT_DC_MEMBER))
       {
@@ -1613,7 +1613,7 @@ void EnumStructUnionParser::mark_constructors()
       {
          chunk_flags_set(prev, PCF_IN_CLASS);
 
-         next = chunk_get_next_ncnl(prev, scope_e::PREPROC);
+         next = chunk_get_next_ncnnl(prev, scope_e::PREPROC);
 
          /**
           * find a chunk within the class/struct body that
@@ -1651,7 +1651,7 @@ void EnumStructUnionParser::mark_enum_integral_type(chunk_t *colon)
    set_chunk_parent(colon, m_start->type);
 
    auto *body_start = get_body_start();
-   auto *pc         = chunk_get_next_ncnl(colon);
+   auto *pc         = chunk_get_next_ncnnl(colon);
 
    /**
     * the chunk(s) between the colon and opening
@@ -1674,7 +1674,7 @@ void EnumStructUnionParser::mark_enum_integral_type(chunk_t *colon)
       set_chunk_type(pc, CT_TYPE);
       set_chunk_parent(pc, colon->type);
 
-      pc = chunk_get_next_ncnl(pc);
+      pc = chunk_get_next_ncnnl(pc);
    }
 } // EnumStructUnionParser::mark_enum_integral_type
 
@@ -1699,7 +1699,7 @@ void EnumStructUnionParser::mark_extracorporeal_lvalues()
    {
       while (true)
       {
-         prev = chunk_get_prev_ncnlni(next);
+         prev = chunk_get_prev_ncnnlni(next);
 
          if (  prev == nullptr
             || (  !prev->flags.test(PCF_IN_TEMPLATE)
@@ -1728,7 +1728,7 @@ void EnumStructUnionParser::mark_extracorporeal_lvalues()
          chunk_flags_set(prev, PCF_LVALUE);
       }
       prev = next;
-      next = chunk_get_next_ncnl(next);
+      next = chunk_get_next_ncnnl(next);
    }
 } // EnumStructUnionParser::mark_extracorporeal_lavlues
 
@@ -1741,7 +1741,7 @@ void EnumStructUnionParser::mark_nested_name_specifiers(chunk_t *pc)
    auto start          = start_end_pair.first;
    auto end            = start_end_pair.second;
 
-   for (pc = start; chunk_is_between(pc, start, end); pc = chunk_get_next_ncnl(pc))
+   for (pc = start; chunk_is_between(pc, start, end); pc = chunk_get_next_ncnnl(pc))
    {
       if (chunk_is_token(pc, CT_WORD))
       {
@@ -1749,7 +1749,7 @@ void EnumStructUnionParser::mark_nested_name_specifiers(chunk_t *pc)
           * if the next token is an opening angle, then we can safely
           * mark the current identifier as a type
           */
-         auto *next = chunk_get_next_ncnl(pc);
+         auto *next = chunk_get_next_ncnnl(pc);
 
          if (chunk_is_token(next, CT_ANGLE_OPEN))
          {
@@ -1798,7 +1798,7 @@ void EnumStructUnionParser::mark_pointer_types(chunk_t *pc)
       do
       {
          // TODO: should there be a CT_BYREF_TYPE?
-         pc = chunk_get_prev_ncnlni(pc);
+         pc = chunk_get_prev_ncnnlni(pc);
 
          if (chunk_is_ptr_operator(pc))
          {
@@ -1863,7 +1863,7 @@ void EnumStructUnionParser::mark_template_args(chunk_t *start, chunk_t *end) con
 
       while (true)
       {
-         next = chunk_get_next_ncnl(next);
+         next = chunk_get_next_ncnnl(next);
 
          if (next == end)
          {
@@ -1894,7 +1894,7 @@ void EnumStructUnionParser::mark_type(chunk_t *pc)
       {
          make_type(pc);
          set_chunk_parent(pc, m_start->type);
-         pc = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+         pc = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
       } while (chunk_is_pointer_or_reference(pc));
    }
 } // EnumStructUnionParser::mark_type
@@ -1944,7 +1944,7 @@ void EnumStructUnionParser::mark_where_clause(chunk_t *where)
 
    pcf_flags_t flags;
 
-   for (auto *pc = where_start; pc != where_end; pc = chunk_get_next_ncnl(pc))
+   for (auto *pc = where_start; pc != where_end; pc = chunk_get_next_ncnnl(pc))
    {
       flags = mark_where_chunk(pc, m_start->type, flags);
    }
@@ -1985,7 +1985,7 @@ void EnumStructUnionParser::parse(chunk_t *pc)
       return;
    }
    chunk_t *prev = m_start;
-   chunk_t *next = chunk_get_next_ncnl(prev);
+   chunk_t *next = chunk_get_next_ncnnl(prev);
 
    /**
     * the enum-key might be enum, enum class or enum struct
@@ -1993,11 +1993,11 @@ void EnumStructUnionParser::parse(chunk_t *pc)
    if (chunk_is_enum(next))
    {
       prev = next;
-      next = chunk_get_next_ncnl(prev);
+      next = chunk_get_next_ncnnl(prev);
    }
    else if (chunk_is_enum(prev))
    {
-      auto *prev_prev = chunk_get_prev_ncnlni(prev);
+      auto *prev_prev = chunk_get_prev_ncnnlni(prev);
 
       if (  chunk_is_enum(prev_prev)
          && chunk_is_enum(prev))
@@ -2085,7 +2085,7 @@ void EnumStructUnionParser::parse(chunk_t *pc)
 
       do
       {
-         next = chunk_get_next_ncnl(next);
+         next = chunk_get_next_ncnnl(next);
       } while (  next != nullptr
               && next->level > m_start->level);
    }
@@ -2144,7 +2144,7 @@ chunk_t *EnumStructUnionParser::parse_angles(chunk_t *angle_open)
           * check to make sure that the template is the final chunk in a list
           * of scope-resolution qualifications
           */
-         auto *next = chunk_get_next_ncnl(angle_close);
+         auto *next = chunk_get_next_ncnnl(angle_close);
 
          if (chunk_is_not_token(next, CT_DC_MEMBER))
          {
@@ -2155,7 +2155,7 @@ chunk_t *EnumStructUnionParser::parse_angles(chunk_t *angle_open)
              * bracket should be preceded by a CT_WORD token and we should have
              * found a closing angle bracket
              */
-            auto *prev = chunk_get_prev_ncnlni(angle_open);
+            auto *prev = chunk_get_prev_ncnnlni(angle_open);
 
             if (chunk_is_not_token(prev, CT_WORD))
             {
@@ -2222,7 +2222,7 @@ chunk_t *EnumStructUnionParser::parse_braces(chunk_t *brace_open)
 
       auto *enum_base_start   = get_enum_base_start();
       auto *inheritance_start = get_inheritance_start();
-      auto *prev              = chunk_get_prev_ncnlni(pc);
+      auto *prev              = chunk_get_prev_ncnnlni(pc);
 
       /**
        * check to see if the open brace was preceded by a closing paren;
@@ -2395,7 +2395,7 @@ chunk_t *EnumStructUnionParser::refine_end_chunk(chunk_t *pc)
        * the terminating chunk is located. For instance, see operator.cpp and
        * enum_comma.h for examples of offenders
        */
-      auto *next = chunk_get_next_ncnl(pc);
+      auto *next = chunk_get_next_ncnnl(pc);
 
       while (true)
       {
@@ -2412,7 +2412,7 @@ chunk_t *EnumStructUnionParser::refine_end_chunk(chunk_t *pc)
              */
             if (chunk_is_token(next, CT_COMMA))
             {
-               next = chunk_get_next_ncnl(next);
+               next = chunk_get_next_ncnnl(next);
             }
             auto match       = match_variable(next, m_start->level);
             auto *start      = std::get<0>(match);
@@ -2427,7 +2427,7 @@ chunk_t *EnumStructUnionParser::refine_end_chunk(chunk_t *pc)
             }
             else
             {
-               pc = chunk_get_next_ncnl(end);
+               pc = chunk_get_next_ncnnl(end);
 
                /**
                 * skip any right-hand side assignments
@@ -2566,7 +2566,7 @@ chunk_t *EnumStructUnionParser::try_find_end_chunk(chunk_t *pc)
 
       do
       {
-         pc = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+         pc = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
       } while (  pc != nullptr
               && pc->level > m_start->level);
    } while (!is_potential_end_chunk(pc));
@@ -2623,7 +2623,7 @@ void EnumStructUnionParser::try_post_identify_macro_calls()
             }
          }
          prev = pc;
-         pc   = chunk_get_next_ncnl(prev);
+         pc   = chunk_get_next_ncnnl(prev);
       } while (chunk_is_between(pc, m_start, m_end));
    }
 } // EnumStructUnionParser::try_post_identify_macro_calls
@@ -2667,7 +2667,7 @@ void EnumStructUnionParser::try_post_identify_type()
          {
             type = skip_template_prev(pc);
          }
-         pc = chunk_get_next_ncnl(pc);
+         pc = chunk_get_next_ncnnl(pc);
       } while (chunk_is_between(pc, m_start, m_end));
 
       if (type != nullptr)
@@ -2723,7 +2723,7 @@ bool EnumStructUnionParser::try_pre_identify_type()
 
    if (pc == nullptr)
    {
-      chunk_t *next = chunk_get_next_ncnl(m_start);
+      chunk_t *next = chunk_get_next_ncnnl(m_start);
 
       /**
        * in case it's a qualified identifier, skip scope-resolution and
@@ -2731,7 +2731,7 @@ bool EnumStructUnionParser::try_pre_identify_type()
        */
       next = skip_scope_resolution_and_nested_name_specifiers(next);
 
-      chunk_t *next_next = chunk_get_next_ncnl(next);
+      chunk_t *next_next = chunk_get_next_ncnnl(next);
 
       /**
        * in case it's a qualified identifier, skip scope-resolution and
@@ -2753,7 +2753,7 @@ bool EnumStructUnionParser::try_pre_identify_type()
       else if (  next != nullptr
               && chunk_is_token(next, CT_WORD)
               && chunk_is_token(next_next, CT_WORD)
-              && chunk_get_prev_ncnlni(m_end) == next_next)
+              && chunk_get_prev_ncnnlni(m_end) == next_next)
       {
          /**
           * check to see if we've got a macro reference preceding the last word chunk;
@@ -2785,7 +2785,7 @@ bool EnumStructUnionParser::try_pre_identify_type()
                && !chunk_is_semicolon(next))
          {
             prev = next;
-            next = chunk_get_next_ncnl(next);
+            next = chunk_get_next_ncnnl(next);
 
             /**
              * in case it's a qualified identifier, skip scope-resolution and
@@ -2810,19 +2810,19 @@ bool EnumStructUnionParser::try_pre_identify_type()
        * the chunk preceding the previously selected chunk should indicate the type
        */
 
-      pc = chunk_get_prev_ncnlni(pc, scope_e::PREPROC);
+      pc = chunk_get_prev_ncnnlni(pc, scope_e::PREPROC);
 
       if (  chunk_is_token(pc, CT_QUALIFIER)
          && std::strncmp(pc->str.c_str(), "final", 5) == 0)
       {
-         pc = chunk_get_prev_ncnlni(pc, scope_e::PREPROC);
+         pc = chunk_get_prev_ncnnlni(pc, scope_e::PREPROC);
       }
 
       if (  language_is_set(LANG_D)
          && chunk_is_paren_close(pc))
       {
          pc = chunk_skip_to_match_rev(pc);
-         pc = chunk_get_prev_ncnlni(pc);
+         pc = chunk_get_prev_ncnnlni(pc);
       }
 
       if (chunk_is_token(pc, CT_WORD))

--- a/src/align_asm_colon.cpp
+++ b/src/align_asm_colon.cpp
@@ -33,7 +33,7 @@ void align_asm_colon(void)
       }
       cas.Reset();
 
-      pc = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+      pc = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
       size_t level = pc ? pc->level : 0;
       did_nl = true;
 

--- a/src/align_assign.cpp
+++ b/src/align_assign.cpp
@@ -123,7 +123,7 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
             log_rule_B("align_assign_thresh");
             mythresh = options::align_assign_thresh();
          }
-         pc = align_assign(chunk_get_next_ncnl(pc), myspan, mythresh, &sub_nl_count);
+         pc = align_assign(chunk_get_next_ncnnl(pc), myspan, mythresh, &sub_nl_count);
 
          if (sub_nl_count > 0)
          {

--- a/src/align_eigen_comma_init.cpp
+++ b/src/align_eigen_comma_init.cpp
@@ -112,7 +112,7 @@ void align_eigen_comma_init(void)
          auto *const prev = chunk_get_prev(pc);
 
          if (  chunk_is_newline(prev)
-            && chunk_is_token(chunk_get_prev_ncnl(pc), CT_COMMA))
+            && chunk_is_token(chunk_get_prev_ncnnl(pc), CT_COMMA))
          {
             log_rule_B("align_eigen_comma_init");
             as.Add(pc);

--- a/src/align_func_proto.cpp
+++ b/src/align_func_proto.cpp
@@ -127,7 +127,7 @@ void align_func_proto(size_t span)
          if (  get_chunk_parent_type(pc) == CT_OPERATOR
             && options::align_on_operator())
          {
-            toadd = chunk_get_prev_ncnl(pc);
+            toadd = chunk_get_prev_ncnnl(pc);
          }
          else
          {

--- a/src/align_init_brace.cpp
+++ b/src/align_init_brace.cpp
@@ -33,7 +33,7 @@ void align_init_brace(chunk_t *start)
    LOG_FMT(LALBR, "%s(%d): start @ orig_line is %zu, orig_col is %zu\n",
            __func__, __LINE__, start->orig_line, start->orig_col);
 
-   chunk_t *pc       = chunk_get_next_ncnl(start);
+   chunk_t *pc       = chunk_get_next_ncnnl(start);
    chunk_t *pcSingle = scan_ib_line(pc, true);
 
    if (  pcSingle == nullptr

--- a/src/align_oc_decl_colon.cpp
+++ b/src/align_oc_decl_colon.cpp
@@ -42,7 +42,7 @@ void align_oc_decl_colon(void)
       cas.Reset();
 
       size_t level = pc->level;
-      pc = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+      pc = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
 
       did_line = false;
 
@@ -68,7 +68,7 @@ void align_oc_decl_colon(void)
             cas.Add(pc);
 
             chunk_t *tmp  = chunk_get_prev(pc, scope_e::PREPROC);
-            chunk_t *tmp2 = chunk_get_prev_ncnl(tmp, scope_e::PREPROC);
+            chunk_t *tmp2 = chunk_get_prev_ncnnl(tmp, scope_e::PREPROC);
 
             // Check for an un-labeled parameter
             if (  (  chunk_is_token(tmp, CT_WORD)

--- a/src/align_oc_msg_colons.cpp
+++ b/src/align_oc_msg_colons.cpp
@@ -35,7 +35,7 @@ void align_oc_msg_colon(chunk_t *so)
    cas.Start(span);
 
    size_t  level = so->level;
-   chunk_t *pc   = chunk_get_next_ncnl(so, scope_e::PREPROC);
+   chunk_t *pc   = chunk_get_next_ncnnl(so, scope_e::PREPROC);
 
    bool    did_line   = false;
    bool    has_colon  = false;

--- a/src/align_struct_initializers.cpp
+++ b/src/align_struct_initializers.cpp
@@ -20,7 +20,7 @@ void align_struct_initializers(void)
 
    while (pc != nullptr)
    {
-      chunk_t *prev = chunk_get_prev_ncnl(pc);
+      chunk_t *prev = chunk_get_prev_ncnnl(pc);
 
       if (  chunk_is_token(prev, CT_ASSIGN)
          && (  chunk_is_token(pc, CT_BRACE_OPEN)

--- a/src/align_tools.cpp
+++ b/src/align_tools.cpp
@@ -164,11 +164,11 @@ chunk_t *step_back_over_member(chunk_t *pc)
    chunk_t *tmp;
 
    // Skip over any class stuff: bool CFoo::bar()
-   while (  ((tmp = chunk_get_prev_ncnl(pc)) != nullptr)
+   while (  ((tmp = chunk_get_prev_ncnnl(pc)) != nullptr)
          && chunk_is_token(tmp, CT_DC_MEMBER))
    {
       // TODO: verify that we are pointing at something sane?
-      pc = chunk_get_prev_ncnl(tmp);
+      pc = chunk_get_prev_ncnnl(tmp);
    }
    return(pc);
 } // step_back_over_member

--- a/src/align_var_def_brace.cpp
+++ b/src/align_var_def_brace.cpp
@@ -60,7 +60,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
       mygap = options::align_var_def_gap();
    }
    // can't be any variable definitions in a "= {" block
-   chunk_t *prev = chunk_get_prev_ncnl(start);
+   chunk_t *prev = chunk_get_prev_ncnnl(start);
 
    if (chunk_is_token(prev, CT_ASSIGN))
    {
@@ -68,7 +68,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
               __func__, __LINE__, start->text(), get_token_name(start->type), start->orig_line);
 
       chunk_t *pc = chunk_get_next_type(start, CT_BRACE_CLOSE, start->level);
-      return(chunk_get_next_ncnl(pc));
+      return(chunk_get_next_ncnnl(pc));
    }
    char copy[1000];
 
@@ -163,7 +163,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
             if (  get_chunk_parent_type(pc) == CT_OPERATOR
                && options::align_on_operator())
             {
-               toadd = chunk_get_prev_ncnl(pc);
+               toadd = chunk_get_prev_ncnnl(pc);
             }
             else
             {

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -131,7 +131,7 @@ static size_t preproc_start(BraceState &braceState, ParseFrame &frm, chunk_t *pc
    LOG_FUNC_ENTRY();
    const size_t pp_level = braceState.pp_level;
 
-   chunk_t      *next = chunk_get_next_ncnl(pc);
+   chunk_t      *next = chunk_get_next_ncnnl(pc);
 
    if (next == nullptr)
    {
@@ -263,7 +263,7 @@ static bool maybe_while_of_do(chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
 
-   chunk_t *prev = chunk_get_prev_ncnl(pc);
+   chunk_t *prev = chunk_get_prev_ncnnl(pc);
 
    if (  prev == nullptr
       || !prev->flags.test(PCF_IN_PREPROC))
@@ -275,7 +275,7 @@ static bool maybe_while_of_do(chunk_t *pc)
    while (  prev != nullptr
          && prev->flags.test(PCF_IN_PREPROC))
    {
-      prev = chunk_get_prev_ncnl(prev);
+      prev = chunk_get_prev_ncnnl(prev);
    }
 
    if (  (  chunk_is_token(prev, CT_VBRACE_CLOSE)
@@ -539,7 +539,7 @@ static void parse_cleanup(BraceState &braceState, ParseFrame &frm, chunk_t *pc)
           */
          if (language_is_set(LANG_PAWN))
          {
-            chunk_t *tmp = chunk_get_next_ncnl(pc);
+            chunk_t *tmp = chunk_get_next_ncnnl(pc);
 
             if (  chunk_is_not_token(tmp, CT_SEMICOLON)
                && chunk_is_not_token(tmp, CT_VSEMICOLON))
@@ -575,7 +575,7 @@ static void parse_cleanup(BraceState &braceState, ParseFrame &frm, chunk_t *pc)
       || chunk_is_token(pc, CT_SPAREN_OPEN)
       || chunk_is_token(pc, CT_BRACE_OPEN))
    {
-      chunk_t *prev = chunk_get_prev_ncnl(pc);
+      chunk_t *prev = chunk_get_prev_ncnnl(pc);
 
       if (prev != nullptr)
       {
@@ -833,7 +833,7 @@ static void parse_cleanup(BraceState &braceState, ParseFrame &frm, chunk_t *pc)
    // Mark expression starts
    LOG_FMT(LSTMT, "%s(%d): Mark expression starts: orig_line is %zu, orig_col is %zu, text() is '%s'\n",
            __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text());
-   chunk_t *tmp = chunk_get_next_ncnl(pc);
+   chunk_t *tmp = chunk_get_next_ncnnl(pc);
 
    if (  chunk_is_token(pc, CT_ARITH)
       || chunk_is_token(pc, CT_SHIFT)
@@ -1147,7 +1147,7 @@ static bool handle_complex_close(ParseFrame &frm, chunk_t *pc, const BraceState 
          frm.top().stage = brace_stage_e::ELSE;
 
          // If the next chunk isn't CT_ELSE, close the statement
-         chunk_t *next = chunk_get_next_ncnl(pc);
+         chunk_t *next = chunk_get_next_ncnnl(pc);
 
          if (  next == nullptr
             || chunk_is_not_token(next, CT_ELSE))
@@ -1166,7 +1166,7 @@ static bool handle_complex_close(ParseFrame &frm, chunk_t *pc, const BraceState 
          frm.top().stage = brace_stage_e::CATCH;
 
          // If the next chunk isn't CT_CATCH or CT_FINALLY, close the statement
-         chunk_t *next = chunk_get_next_ncnl(pc);
+         chunk_t *next = chunk_get_next_ncnnl(pc);
 
          if (  chunk_is_not_token(next, CT_CATCH)
             && chunk_is_not_token(next, CT_FINALLY))
@@ -1233,14 +1233,14 @@ static void mark_namespace(chunk_t *pns)
    chunk_t *br_close;
    bool    is_using = false;
 
-   chunk_t *pc = chunk_get_prev_ncnl(pns);
+   chunk_t *pc = chunk_get_prev_ncnnl(pns);
 
    if (chunk_is_token(pc, CT_USING))
    {
       is_using = true;
       set_chunk_parent(pns, CT_USING);
    }
-   pc = chunk_get_next_ncnl(pns);
+   pc = chunk_get_next_ncnnl(pns);
 
    while (pc != nullptr)
    {
@@ -1256,7 +1256,7 @@ static void mark_namespace(chunk_t *pns)
             }
             return;
          }
-         pc = chunk_get_next_ncnl(pc);
+         pc = chunk_get_next_ncnnl(pc);
          continue;
       }
       log_rule_B("indent_namespace_limit");
@@ -1399,7 +1399,7 @@ bool close_statement(ParseFrame &frm, chunk_t *pc, const BraceState &braceState)
       else
       {
          // otherwise, add before it and consume the vbrace
-         vbc = chunk_get_prev_ncnl(pc);
+         vbc = chunk_get_prev_ncnnl(pc);
 
          frm.level--;
          frm.brace_level--;

--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -172,7 +172,7 @@ void do_braces(void)
    // Issue #2232 put this at the beginning
    chunk_t *pc = chunk_get_head();
 
-   while ((pc = chunk_get_next_ncnl(pc)) != nullptr)
+   while ((pc = chunk_get_next_ncnnl(pc)) != nullptr)
    {
       if (  chunk_is_not_token(pc, CT_BRACE_OPEN)
          && chunk_is_not_token(pc, CT_VBRACE_OPEN))
@@ -182,7 +182,7 @@ void do_braces(void)
       chunk_t         *br_open = pc;
       const c_token_t brc_type = c_token_t(pc->type + 1); // corresponds to closing type
       // Detect empty bodies
-      chunk_t         *tmp = chunk_get_next_ncnl(pc);
+      chunk_t         *tmp = chunk_get_next_ncnnl(pc);
 
       if (chunk_is_token(tmp, brc_type))
       {
@@ -356,7 +356,7 @@ static bool can_remove_braces(chunk_t *bopen)
    {
       return(false);
    }
-   chunk_t *pc = chunk_get_next_ncnl(bopen, scope_e::PREPROC);
+   chunk_t *pc = chunk_get_next_ncnnl(bopen, scope_e::PREPROC);
 
    if (chunk_is_token(pc, CT_BRACE_CLOSE))
    {
@@ -488,8 +488,8 @@ static bool can_remove_braces(chunk_t *bopen)
    if (  chunk_is_token(pc, CT_BRACE_CLOSE)
       && get_chunk_parent_type(pc) == CT_IF)
    {
-      chunk_t *next     = chunk_get_next_ncnl(pc, scope_e::PREPROC);
-      chunk_t *tmp_prev = chunk_get_prev_ncnl(pc, scope_e::PREPROC);
+      chunk_t *next     = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
+      chunk_t *tmp_prev = chunk_get_prev_ncnnl(pc, scope_e::PREPROC);
 
       if (  chunk_is_token(next, CT_ELSE)
          && (  chunk_is_token(tmp_prev, CT_BRACE_CLOSE)
@@ -591,7 +591,7 @@ static void examine_brace(chunk_t *bopen)
 
             if (br_count == 0)
             {
-               chunk_t *next = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+               chunk_t *next = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
 
                if (  next == nullptr
                   || chunk_is_not_token(next, CT_BRACE_CLOSE))
@@ -683,13 +683,13 @@ static void examine_brace(chunk_t *bopen)
 
    if (chunk_is_token(pc, CT_BRACE_CLOSE))
    {
-      chunk_t *next = chunk_get_next_ncnl(pc);
+      chunk_t *next = chunk_get_next_ncnnl(pc);
 
       if (next != nullptr)
       {
          while (chunk_is_token(next, CT_VBRACE_CLOSE))
          {
-            next = chunk_get_next_ncnl(next);
+            next = chunk_get_next_ncnnl(next);
          }
 
          if (next != nullptr)
@@ -717,11 +717,11 @@ static void examine_brace(chunk_t *bopen)
 
          if (get_chunk_parent_type(bopen) == CT_ELSE)
          {
-            chunk_t *tmp_next = chunk_get_next_ncnl(bopen);
+            chunk_t *tmp_next = chunk_get_next_ncnnl(bopen);
 
             if (chunk_is_token(tmp_next, CT_IF))
             {
-               chunk_t *tmp_prev = chunk_get_prev_ncnl(bopen);
+               chunk_t *tmp_prev = chunk_get_prev_ncnnl(bopen);
                LOG_FMT(LBRDEL, "%s(%d):  else-if removing braces on line %zu and %zu\n",
                        __func__, __LINE__, bopen->orig_line, pc->orig_line);
 
@@ -915,7 +915,7 @@ static void convert_vbrace_to_brace(void)
    log_rule_B("mod_full_brace_using");
    log_rule_B("mod_full_brace_function");
 
-   for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnl(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnnl(pc))
    {
       if (chunk_is_not_token(pc, CT_VBRACE_OPEN))
       {
@@ -1020,14 +1020,14 @@ static void append_tag_name(unc_text &txt, chunk_t *pc)
            __func__, __LINE__, txt.c_str());
 
    // step backwards over all a::b stuff
-   while ((tmp = chunk_get_prev_ncnl(tmp)) != nullptr)
+   while ((tmp = chunk_get_prev_ncnnl(tmp)) != nullptr)
    {
       if (  chunk_is_not_token(tmp, CT_DC_MEMBER)
          && chunk_is_not_token(tmp, CT_MEMBER))
       {
          break;
       }
-      tmp = chunk_get_prev_ncnl(tmp);
+      tmp = chunk_get_prev_ncnnl(tmp);
       pc  = tmp;
 
       if (!chunk_is_word(tmp))
@@ -1039,7 +1039,7 @@ static void append_tag_name(unc_text &txt, chunk_t *pc)
    LOG_FMT(LMCB, "%s(%d): txt is '%s'\n",
            __func__, __LINE__, txt.c_str());
 
-   while ((pc = chunk_get_next_ncnl(pc)) != nullptr)
+   while ((pc = chunk_get_next_ncnnl(pc)) != nullptr)
    {
       if (  chunk_is_not_token(pc, CT_DC_MEMBER)
          && chunk_is_not_token(pc, CT_MEMBER))
@@ -1049,7 +1049,7 @@ static void append_tag_name(unc_text &txt, chunk_t *pc)
       txt += pc->str;
       LOG_FMT(LMCB, "%s(%d): txt is '%s'\n",
               __func__, __LINE__, txt.c_str());
-      pc = chunk_get_next_ncnl(pc);
+      pc = chunk_get_next_ncnnl(pc);
 
       if (pc != nullptr)
       {
@@ -1069,7 +1069,7 @@ void add_long_closebrace_comment(void)
    chunk_t *ns_pc  = nullptr;
    chunk_t *cl_pc  = nullptr;
 
-   for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnl(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnnl(pc))
    {
       if (  chunk_is_token(pc, CT_FUNC_DEF)
          || chunk_is_token(pc, CT_OC_MSG_DECL))
@@ -1174,7 +1174,7 @@ void add_long_closebrace_comment(void)
 
             // next chunk, normally is going to be the namespace name
             // append it with a space to generate "namespace xyz"
-            chunk_t *tmp_next = chunk_get_next_ncnl(tag_pc);
+            chunk_t *tmp_next = chunk_get_next_ncnnl(tag_pc);
 
             if (chunk_is_not_token(tmp_next, CT_BRACE_OPEN)) // anonymous namespace -> ignore
             {
@@ -1235,7 +1235,7 @@ static void move_case_break(void)
    LOG_FUNC_ENTRY();
    chunk_t *prev = nullptr;
 
-   for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnl(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnnl(pc))
    {
       if (  chunk_is_token(pc, CT_BREAK)
          && chunk_is_token(prev, CT_BRACE_CLOSE)
@@ -1257,7 +1257,7 @@ static chunk_t *mod_case_brace_remove(chunk_t *br_open)
            __func__, __LINE__, br_open->orig_line);
 
    // Find the matching brace close
-   chunk_t *next     = chunk_get_next_ncnl(br_open, scope_e::PREPROC);
+   chunk_t *next     = chunk_get_next_ncnnl(br_open, scope_e::PREPROC);
    chunk_t *br_close = chunk_get_next_type(br_open, CT_BRACE_CLOSE, br_open->level, scope_e::PREPROC);
 
    if (br_close == nullptr)
@@ -1266,7 +1266,7 @@ static chunk_t *mod_case_brace_remove(chunk_t *br_open)
       return(next);
    }
    // Make sure 'break', 'return', 'goto', 'case' or '}' is after the close brace
-   chunk_t *pc = chunk_get_next_ncnl(br_close, scope_e::PREPROC);
+   chunk_t *pc = chunk_get_next_ncnnl(br_close, scope_e::PREPROC);
 
    if (  pc == nullptr
       || (  chunk_is_not_token(pc, CT_BREAK)
@@ -1283,7 +1283,7 @@ static chunk_t *mod_case_brace_remove(chunk_t *br_open)
    // scan to make sure there are no definitions at brace level between braces
    for (chunk_t *tmp_pc = br_open;
         tmp_pc != br_close;
-        tmp_pc = chunk_get_next_ncnl(tmp_pc, scope_e::PREPROC))
+        tmp_pc = chunk_get_next_ncnnl(tmp_pc, scope_e::PREPROC))
    {
       if (  tmp_pc->level == (br_open->level + 1)
          && tmp_pc->flags.test(PCF_VAR_DEF))
@@ -1299,7 +1299,7 @@ static chunk_t *mod_case_brace_remove(chunk_t *br_open)
 
    for (chunk_t *tmp_pc = br_open;
         tmp_pc != br_close;
-        tmp_pc = chunk_get_next_ncnl(tmp_pc, scope_e::PREPROC))
+        tmp_pc = chunk_get_next_ncnnl(tmp_pc, scope_e::PREPROC))
    {
       if (tmp_pc->brace_level == 0)
       {
@@ -1347,7 +1347,7 @@ static chunk_t *mod_case_brace_add(chunk_t *cl_colon)
    chunk_t *clos = chunk_skip_to_match(open);
 
    // find the end of the case-block
-   while ((pc = chunk_get_next_ncnl(pc, scope_e::PREPROC)) != nullptr)
+   while ((pc = chunk_get_next_ncnnl(pc, scope_e::PREPROC)) != nullptr)
    {
       LOG_FMT(LMCB, "%s(%d): text() is '%s', orig_line %zu, orig_col is %zu, pp_level is %zu\n",
               __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col, pc->pp_level);
@@ -1378,7 +1378,7 @@ static chunk_t *mod_case_brace_add(chunk_t *cl_colon)
    if (last == nullptr)
    {
       LOG_FMT(LMCB, "%s(%d):  - last is nullptr\n", __func__, __LINE__);
-      chunk_t *next = chunk_get_next_ncnl(cl_colon, scope_e::PREPROC);
+      chunk_t *next = chunk_get_next_ncnnl(cl_colon, scope_e::PREPROC);
       return(next);
    }
    LOG_FMT(LMCB, "%s(%d): text() is '%s', orig_line %zu, orig_col is %zu\n",
@@ -1424,7 +1424,7 @@ static void mod_case_brace(void)
 
    while (pc != nullptr)
    {
-      chunk_t *next = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+      chunk_t *next = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
 
       if (next == nullptr)
       {
@@ -1449,7 +1449,7 @@ static void mod_case_brace(void)
       }
       else
       {
-         pc = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+         pc = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
       }
    }
 }
@@ -1507,7 +1507,7 @@ static void process_if_chain(chunk_t *br_start)
       }
       braces.push_back(br_close);
 
-      pc = chunk_get_next_ncnl(br_close, scope_e::PREPROC);
+      pc = chunk_get_next_ncnnl(br_close, scope_e::PREPROC);
 
       if (  pc == nullptr
          || chunk_is_not_token(pc, CT_ELSE))
@@ -1521,14 +1521,14 @@ static void process_if_chain(chunk_t *br_start)
          // There is an 'else' - we want full braces.
          must_have_braces = true;
       }
-      pc = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+      pc = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
 
       if (chunk_is_token(pc, CT_ELSEIF))
       {
          while (  chunk_is_not_token(pc, CT_VBRACE_OPEN)
                && chunk_is_not_token(pc, CT_BRACE_OPEN))
          {
-            pc = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+            pc = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
          }
       }
 

--- a/src/calculate_closing_brace_position.cpp
+++ b/src/calculate_closing_brace_position.cpp
@@ -16,7 +16,7 @@ chunk_t *calculate_closing_brace_position(const chunk_t *cl_colon, chunk_t *pc)
 {
    // end of block is reached
    // look back over comment, newline, preprocessor BUT NOT #endif
-   chunk_t *last = chunk_get_prev_ncnl(pc);
+   chunk_t *last = chunk_get_prev_ncnnl(pc);
 
    LOG_FMT(LMCB, "%s(%d): text() is '%s', orig_line %zu, orig_col is %zu\n",
            __func__, __LINE__, last->text(), last->orig_line, last->orig_col);
@@ -56,7 +56,7 @@ chunk_t *calculate_closing_brace_position(const chunk_t *cl_colon, chunk_t *pc)
             }
             break;
          }
-         last = chunk_get_prev_ncnl(last);
+         last = chunk_get_prev_ncnnl(last);
          LOG_FMT(LMCB, "%s(%d): text() is '%s', orig_line %zu, orig_col is %zu\n",
                  __func__, __LINE__, last->text(), last->orig_line, last->orig_col);
 

--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -591,25 +591,25 @@ chunk_t *chunk_get_prev_nnl(chunk_t *cur, scope_e scope)
 }
 
 
-chunk_t *chunk_get_next_ncnl(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next_ncnnl(chunk_t *cur, scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment_or_newline, scope, direction_e::FORWARD, false));
 }
 
 
-chunk_t *chunk_get_next_ncnlnp(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next_ncnnlnp(chunk_t *cur, scope_e scope)
 {
    return(chunk_get_ncnlnp(cur, scope, direction_e::FORWARD));
 }
 
 
-chunk_t *chunk_ppa_get_next_ncnl(chunk_t *cur)
+chunk_t *chunk_ppa_get_next_ncnnl(chunk_t *cur)
 {
    return(chunk_ppa_search(cur, chunk_is_comment_or_newline, false));
 }
 
 
-chunk_t *chunk_get_prev_ncnlnp(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_ncnnlnp(chunk_t *cur, scope_e scope)
 {
    return(chunk_get_ncnlnp(cur, scope, direction_e::BACKWARD));
 }
@@ -639,13 +639,13 @@ chunk_t *chunk_get_next_nisq(chunk_t *cur, scope_e scope)
 }
 
 
-chunk_t *chunk_get_prev_ncnl(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_ncnnl(chunk_t *cur, scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment_or_newline, scope, direction_e::BACKWARD, false));
 }
 
 
-chunk_t *chunk_get_prev_ncnlni(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_ncnnlni(chunk_t *cur, scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment_or_newline_or_ignored, scope, direction_e::BACKWARD, false));
 }
@@ -975,7 +975,7 @@ chunk_t *chunk_get_next_ssq(chunk_t *cur)
       {
          cur = chunk_skip_to_match(cur);
       }
-      cur = chunk_get_next_ncnl(cur);
+      cur = chunk_get_next_ncnnl(cur);
    }
    return(cur);
 }
@@ -990,7 +990,7 @@ chunk_t *chunk_get_prev_ssq(chunk_t *cur)
       {
          cur = chunk_skip_to_match_rev(cur);
       }
-      cur = chunk_get_prev_ncnl(cur);
+      cur = chunk_get_prev_ncnnl(cur);
    }
    return(cur);
 }
@@ -1021,7 +1021,7 @@ static chunk_t *chunk_skip_dc_member(chunk_t *start, scope_e scope, direction_e 
       return(nullptr);
    }
    const auto step_fcn = (dir == direction_e::FORWARD)
-                         ? chunk_get_next_ncnl : chunk_get_prev_ncnl;
+                         ? chunk_get_next_ncnnl : chunk_get_prev_ncnnl;
 
    chunk_t *pc   = start;
    chunk_t *next = chunk_is_token(pc, CT_DC_MEMBER) ? pc : step_fcn(pc, scope);

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -201,7 +201,7 @@ chunk_t *chunk_get_next_nnl(chunk_t *cur, scope_e scope = scope_e::ALL);
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_next_ncnl(chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_next_ncnnl(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -210,19 +210,19 @@ chunk_t *chunk_get_next_ncnl(chunk_t *cur, scope_e scope = scope_e::ALL);
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_next_ncnlnp(chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_next_ncnnlnp(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
  * Gets the next non-NEWLINE and non-comment chunk (preprocessor aware).
- * Unlike chunk_get_next_ncnl, this will also ignore a line continuation if
+ * Unlike chunk_get_next_ncnnl, this will also ignore a line continuation if
  * the starting chunk is in a preprocessor directive, and may return a newline
  * if the search reaches the end of a preprocessor directive.
  *
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_ppa_get_next_ncnl(chunk_t *cur);
+chunk_t *chunk_ppa_get_next_ncnnl(chunk_t *cur);
 
 
 /**
@@ -289,7 +289,7 @@ chunk_t *chunk_get_prev_nnl(chunk_t *cur, scope_e scope = scope_e::ALL);
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_prev_ncnl(chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_prev_ncnnl(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -298,7 +298,7 @@ chunk_t *chunk_get_prev_ncnl(chunk_t *cur, scope_e scope = scope_e::ALL);
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_prev_ncnlni(chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_prev_ncnnlni(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -307,7 +307,7 @@ chunk_t *chunk_get_prev_ncnlni(chunk_t *cur, scope_e scope = scope_e::ALL);
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_prev_ncnlnp(chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_prev_ncnnlnp(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -903,7 +903,7 @@ static inline bool chunk_is_forin(chunk_t *pc)
    if (  language_is_set(LANG_OC)
       && chunk_is_token(pc, CT_SPAREN_OPEN))
    {
-      chunk_t *prev = chunk_get_prev_ncnl(pc);
+      chunk_t *prev = chunk_get_prev_ncnnl(pc);
 
       if (chunk_is_token(prev, CT_FOR))
       {
@@ -913,7 +913,7 @@ static inline bool chunk_is_forin(chunk_t *pc)
                && next->type != CT_SPAREN_CLOSE
                && next->type != CT_IN)
          {
-            next = chunk_get_next_ncnl(next);
+            next = chunk_get_next_ncnnl(next);
          }
 
          if (chunk_is_token(next, CT_IN))

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -267,13 +267,13 @@ static void flag_asm(chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
 
-   chunk_t *tmp = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+   chunk_t *tmp = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
 
    if (chunk_is_not_token(tmp, CT_QUALIFIER))
    {
       return;
    }
-   chunk_t *po = chunk_get_next_ncnl(tmp, scope_e::PREPROC);
+   chunk_t *po = chunk_get_next_ncnnl(tmp, scope_e::PREPROC);
 
    if (!chunk_is_paren_open(po))
    {
@@ -288,10 +288,10 @@ static void flag_asm(chunk_t *pc)
    set_chunk_parent(po, CT_ASM);
    set_chunk_parent(end, CT_ASM);
 
-   for (  tmp = chunk_get_next_ncnl(po, scope_e::PREPROC);
+   for (  tmp = chunk_get_next_ncnnl(po, scope_e::PREPROC);
           tmp != nullptr
        && tmp != end;
-          tmp = chunk_get_next_ncnl(tmp, scope_e::PREPROC))
+          tmp = chunk_get_next_ncnnl(tmp, scope_e::PREPROC))
    {
       if (chunk_is_token(tmp, CT_COLON))
       {
@@ -300,8 +300,8 @@ static void flag_asm(chunk_t *pc)
       else if (chunk_is_token(tmp, CT_DC_MEMBER))
       {
          // if there is a string on both sides, then this is two ASM_COLONs
-         if (  chunk_is_token(chunk_get_next_ncnl(tmp, scope_e::PREPROC), CT_STRING)
-            && chunk_is_token(chunk_get_prev_ncnlni(tmp, scope_e::PREPROC), CT_STRING)) // Issue #2279
+         if (  chunk_is_token(chunk_get_next_ncnnl(tmp, scope_e::PREPROC), CT_STRING)
+            && chunk_is_token(chunk_get_prev_ncnnlni(tmp, scope_e::PREPROC), CT_STRING)) // Issue #2279
          {
             chunk_t nc;
 
@@ -320,7 +320,7 @@ static void flag_asm(chunk_t *pc)
       }
    }
 
-   tmp = chunk_get_next_ncnl(end, scope_e::PREPROC);
+   tmp = chunk_get_next_ncnnl(end, scope_e::PREPROC);
 
    if (tmp == nullptr)
    {
@@ -433,7 +433,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
             }
          }
 
-         for (tmp = chunk_get_prev_ncnlni(pc); tmp != nullptr; tmp = chunk_get_prev_ncnlni(tmp)) // Issue #2279
+         for (tmp = chunk_get_prev_ncnnlni(pc); tmp != nullptr; tmp = chunk_get_prev_ncnnlni(tmp)) // Issue #2279
          {
             if (  chunk_is_semicolon(tmp)
                || chunk_is_token(tmp, CT_BRACE_OPEN)
@@ -598,7 +598,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       if (chunk_is_token(tmp, CT_TSQUARE))
       {
          ts  = tmp;
-         tmp = chunk_get_next_ncnl(tmp);
+         tmp = chunk_get_next_ncnnl(tmp);
       }
 
       if (  chunk_is_token(tmp, CT_BRACE_OPEN)
@@ -658,7 +658,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
 
    if (chunk_is_token(pc, CT_ANNOTATION))
    {
-      chunk_t *tmp = chunk_get_next_ncnl(pc);
+      chunk_t *tmp = chunk_get_next_ncnnl(pc);
 
       if (chunk_is_paren_open(tmp))
       {
@@ -669,7 +669,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
    if (  chunk_is_token(pc, CT_SIZEOF)
       && language_is_set(LANG_ALLC))
    {
-      chunk_t *tmp = chunk_get_next_ncnl(pc);
+      chunk_t *tmp = chunk_get_next_ncnnl(pc);
 
       if (chunk_is_token(tmp, CT_ELLIPSIS))
       {
@@ -680,7 +680,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
    if (  chunk_is_token(pc, CT_DECLTYPE)
       && pc->parent_type != CT_FUNC_DEF)
    {
-      chunk_t *tmp = chunk_get_next_ncnl(pc);
+      chunk_t *tmp = chunk_get_next_ncnnl(pc);
 
       if (chunk_is_paren_open(tmp))
       {
@@ -761,7 +761,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       {
          // next likely is a string (see tokenize_cleanup.cpp)
          set_chunk_parent(next, CT_EXTERN);
-         chunk_t *tmp = chunk_get_next_ncnl(next);
+         chunk_t *tmp = chunk_get_next_ncnnl(next);
 
          if (chunk_is_token(tmp, CT_BRACE_OPEN))
          {
@@ -819,7 +819,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
     */
    if (chunk_is_token(next, CT_PAREN_OPEN))
    {
-      chunk_t *tmp = chunk_get_next_ncnl(next);
+      chunk_t *tmp = chunk_get_next_ncnnl(next);
 
       if (  language_is_set(LANG_C | LANG_CPP | LANG_OC)
          && chunk_is_token(tmp, CT_CARET))
@@ -869,20 +869,20 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
             // If the open paren is followed by an ampersand, an optional word,
             // a close parenthesis, and an open square bracket, then it is an
             // array being passed by reference, not a cast
-            tmp = chunk_get_next_ncnl(next);
+            tmp = chunk_get_next_ncnnl(next);
 
             if (chunk_is_token(tmp, CT_AMP))
             {
-               auto tmp2 = chunk_get_next_ncnl(tmp);
+               auto tmp2 = chunk_get_next_ncnnl(tmp);
 
                if (chunk_is_token(tmp2, CT_WORD))
                {
-                  tmp2 = chunk_get_next_ncnl(tmp2);
+                  tmp2 = chunk_get_next_ncnnl(tmp2);
                }
 
                if (chunk_is_token(tmp2, CT_PAREN_CLOSE))
                {
-                  tmp2 = chunk_get_next_ncnl(tmp2);
+                  tmp2 = chunk_get_next_ncnnl(tmp2);
 
                   if (chunk_is_token(tmp2, CT_SQUARE_OPEN))
                   {
@@ -910,7 +910,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
                   if (  get_chunk_parent_type(pc) == CT_NONE
                      && !pc->flags.test(PCF_IN_TYPEDEF))
                   {
-                     tmp = chunk_get_next_ncnl(next);
+                     tmp = chunk_get_next_ncnnl(next);
 
                      if (chunk_is_token(tmp, CT_PAREN_CLOSE))
                      {
@@ -981,7 +981,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       else if (  chunk_is_token(tmp, CT_TSQUARE)
               || get_chunk_parent_type(tmp) == CT_OPERATOR)
       {
-         tmp = chunk_get_next_ncnl(tmp);
+         tmp = chunk_get_next_ncnnl(tmp);
       }
 
       if (tmp != nullptr)
@@ -1103,7 +1103,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
 
    if (language_is_set(LANG_CPP))
    {
-      chunk_t *nnext = chunk_get_next_ncnl(next);
+      chunk_t *nnext = chunk_get_next_ncnnl(next);
 
       // handle parent_type of assigns in special functions (ro5 + pure virtual)
       if (  pc->flags.test_any(PCF_IN_STRUCT | PCF_IN_CLASS)
@@ -1340,7 +1340,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
                   is_multiplication = true;
                   break;
                }
-               tmp = chunk_get_prev_ncnlni(tmp); // Issue #2279
+               tmp = chunk_get_prev_ncnnlni(tmp); // Issue #2279
             }
 
             if (is_multiplication)
@@ -1427,7 +1427,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
                {
                   set_chunk_type(pc, CT_PTR_TYPE);
                }
-               tmp = chunk_get_prev_ncnlni(tmp); // Issue #2279
+               tmp = chunk_get_prev_ncnnlni(tmp); // Issue #2279
             }
          }
       }
@@ -1477,7 +1477,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
 
             if (chunk_is_token(prev, CT_WORD))
             {
-               chunk_t *tmp = chunk_get_prev_ncnlni(prev); // Issue #2279
+               chunk_t *tmp = chunk_get_prev_ncnnlni(prev); // Issue #2279
 
                if (tmp != nullptr)
                {
@@ -1642,7 +1642,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
 
       auto const search_assign = [&pc, &is_preproc]()
       {
-         for (chunk_t *temp = pc; temp != nullptr; temp = chunk_get_next_ncnl(temp))
+         for (chunk_t *temp = pc; temp != nullptr; temp = chunk_get_next_ncnnl(temp))
          {
             LOG_FMT(LFCNR, "%s(%d): orig_line is %zu, orig_col is %zu, text() '%s', type is %s\n",
                     __func__, __LINE__, temp->orig_line, temp->orig_col,
@@ -1670,7 +1670,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       if (assign_found)
       {
          // it is a Type alias, alias template
-         for (chunk_t *temp = pc; temp != nullptr; temp = chunk_get_next_ncnl(temp))
+         for (chunk_t *temp = pc; temp != nullptr; temp = chunk_get_next_ncnnl(temp))
          {
             if (get_chunk_parent_type(temp) == CT_NONE)
             {
@@ -1751,7 +1751,7 @@ static void check_double_brace_init(chunk_t *bo1)
 {
    LOG_FUNC_ENTRY();
    LOG_FMT(LJDBI, "%s(%d): orig_line is %zu, orig_col is %zu", __func__, __LINE__, bo1->orig_line, bo1->orig_col);
-   chunk_t *pc = chunk_get_prev_ncnlni(bo1);   // Issue #2279
+   chunk_t *pc = chunk_get_prev_ncnnlni(bo1);   // Issue #2279
 
    if (pc == nullptr)
    {
@@ -1817,7 +1817,7 @@ void fix_symbols(void)
    bool is_cpp  = language_is_set(LANG_CPP);
    bool is_java = language_is_set(LANG_JAVA);
 
-   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnl(pc))
+   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnnl(pc))
    {
       if (  chunk_is_token(pc, CT_FUNC_WRAP)
          || chunk_is_token(pc, CT_TYPE_WRAP))
@@ -1832,7 +1832,7 @@ void fix_symbols(void)
       // a brace immediately preceded by word in C++11 is an initializer list though it may also
       // by a type casting initializer list if the word is really a type; sadly uncrustify knows
       // only built-in types and knows nothing of user-defined types
-      chunk_t *prev = chunk_get_prev_ncnlni(pc);   // Issue #2279
+      chunk_t *prev = chunk_get_prev_ncnnlni(pc);   // Issue #2279
 
       if (  is_cpp
          && chunk_is_token(pc, CT_BRACE_OPEN)
@@ -1850,7 +1850,7 @@ void fix_symbols(void)
 
       if (chunk_is_token(pc, CT_ATTRIBUTE))
       {
-         chunk_t *next = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+         chunk_t *next = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
 
          if (  next != nullptr
             && chunk_is_token(next, CT_PAREN_OPEN))
@@ -1870,19 +1870,19 @@ void fix_symbols(void)
    if (  chunk_is_newline(pc)
       || chunk_is_comment(pc))
    {
-      pc = chunk_get_next_ncnl(pc);
+      pc = chunk_get_next_ncnnl(pc);
    }
 
    while (pc != nullptr)
    {
       if (chunk_is_token(pc, CT_IGNORED))
       {
-         pc = chunk_get_next_ncnl(pc);
+         pc = chunk_get_next_ncnnl(pc);
          continue;
       }
       LOG_FMT(LFCNR, "%s(%d): pc->orig_line       is %zu, orig_col is %zu, text() is '%s', type is %s\n",
               __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(), get_token_name(pc->type));
-      chunk_t *prev = chunk_get_prev_ncnlni(pc, scope_e::PREPROC);   // Issue #2279
+      chunk_t *prev = chunk_get_prev_ncnnlni(pc, scope_e::PREPROC);   // Issue #2279
 
       if (prev == nullptr)
       {
@@ -1894,7 +1894,7 @@ void fix_symbols(void)
          LOG_FMT(LFCNR, "%s(%d): prev(ni)->orig_line is %zu, orig_col is %zu, text() is '%s', type is %s\n",
                  __func__, __LINE__, prev->orig_line, prev->orig_col, prev->text(), get_token_name(prev->type));
       }
-      chunk_t *next = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+      chunk_t *next = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
 
       if (next == nullptr)
       {
@@ -1909,7 +1909,7 @@ void fix_symbols(void)
       LOG_FMT(LFCNR, "%s(%d): do_symbol_check(%s, %s, %s)\n",
               __func__, __LINE__, prev->text(), pc->text(), next->text());
       do_symbol_check(prev, pc, next);
-      pc = chunk_get_next_ncnl(pc);
+      pc = chunk_get_next_ncnnl(pc);
    }
    pawn_add_virtual_semicolons();
    process_returns();
@@ -1946,11 +1946,11 @@ void fix_symbols(void)
       if (  chunk_is_token(pc, CT_EXTERN)
          && language_is_set(LANG_ALLC))
       {
-         chunk_t *next = chunk_get_next_ncnl(pc);
+         chunk_t *next = chunk_get_next_ncnnl(pc);
 
          if (chunk_is_token(next, CT_STRING))
          {
-            chunk_t *tmp = chunk_get_next_ncnl(next);
+            chunk_t *tmp = chunk_get_next_ncnnl(next);
 
             while (tmp != nullptr)
             {
@@ -1966,7 +1966,7 @@ void fix_symbols(void)
                   chunk_flags_set(tmp, PCF_STMT_START | PCF_EXPR_START);
                   break;
                }
-               tmp = chunk_get_next_ncnl(tmp);
+               tmp = chunk_get_next_ncnnl(tmp);
             }
          }
       }
@@ -2015,7 +2015,7 @@ void fix_symbols(void)
       }
       else
       {
-         pc = chunk_get_next_ncnl(pc);
+         pc = chunk_get_next_ncnnl(pc);
       }
    }
 } // fix_symbols
@@ -2050,7 +2050,7 @@ static chunk_t *process_return(chunk_t *pc)
    chunk_t chunk;
 
    // grab next and bail if it is a semicolon
-   next = chunk_ppa_get_next_ncnl(pc);
+   next = chunk_ppa_get_next_ncnnl(pc);
 
    if (  next == nullptr
       || chunk_is_semicolon(next)
@@ -2075,7 +2075,7 @@ static chunk_t *process_return(chunk_t *pc)
       {
          return(nullptr);
       }
-      semi = chunk_ppa_get_next_ncnl(cpar);
+      semi = chunk_ppa_get_next_ncnnl(cpar);
 
       if (semi == nullptr)
       {
@@ -2285,7 +2285,7 @@ static void handle_cpp_template(chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
 
-   chunk_t *tmp = chunk_get_next_ncnl(pc);
+   chunk_t *tmp = chunk_get_next_ncnnl(pc);
 
    if (chunk_is_not_token(tmp, CT_ANGLE_OPEN))
    {
@@ -2312,14 +2312,14 @@ static void handle_cpp_template(chunk_t *pc)
 
    if (tmp != nullptr)
    {
-      tmp = chunk_get_next_ncnl(tmp);
+      tmp = chunk_get_next_ncnnl(tmp);
 
       if (chunk_is_token(tmp, CT_FRIEND))
       {
          // Account for a template friend declaration
          set_chunk_parent(tmp, CT_TEMPLATE);
 
-         tmp = chunk_get_next_ncnl(tmp);
+         tmp = chunk_get_next_ncnnl(tmp);
       }
 
       if (  chunk_is_token(tmp, CT_CLASS)
@@ -2346,7 +2346,7 @@ static void handle_cpp_lambda(chunk_t *sq_o)
    chunk_t *ret = nullptr;
 
    // abort if type of the previous token is not contained in this whitelist
-   chunk_t *prev = chunk_get_prev_ncnlni(sq_o);   // Issue #2279
+   chunk_t *prev = chunk_get_prev_ncnnlni(sq_o);   // Issue #2279
 
    if (  prev == nullptr
       || (  chunk_is_not_token(prev, CT_ASSIGN)
@@ -2372,14 +2372,14 @@ static void handle_cpp_lambda(chunk_t *sq_o)
          return;
       }
    }
-   chunk_t *pa_o = chunk_get_next_ncnl(sq_c);
+   chunk_t *pa_o = chunk_get_next_ncnnl(sq_c);
 
    // check to see if there is a lambda-specifier in the pa_o chunk;
    // assuming chunk is CT_EXECUTION_CONTEXT, ignore lambda-specifier
    while (chunk_is_token(pa_o, CT_EXECUTION_CONTEXT))
    {
       // set pa_o to next chunk after this specifier
-      pa_o = chunk_get_next_ncnl(pa_o);
+      pa_o = chunk_get_next_ncnnl(pa_o);
    }
 
    if (pa_o == nullptr)
@@ -2400,11 +2400,11 @@ static void handle_cpp_lambda(chunk_t *sq_o)
       }
    }
    // Check for 'mutable' keyword: '[]() mutable {}' or []() mutable -> ret {}
-   chunk_t *br_o = pa_c ? chunk_get_next_ncnl(pa_c) : pa_o;
+   chunk_t *br_o = pa_c ? chunk_get_next_ncnnl(pa_c) : pa_o;
 
    if (chunk_is_str(br_o, "mutable", 7))
    {
-      br_o = chunk_get_next_ncnl(br_o);
+      br_o = chunk_get_next_ncnnl(br_o);
    }
    //TODO: also check for exception and attribute between [] ... {}
 
@@ -2474,12 +2474,12 @@ static void handle_cpp_lambda(chunk_t *sq_o)
    if (ret != nullptr)
    {
       set_chunk_type(ret, CT_CPP_LAMBDA_RET);
-      ret = chunk_get_next_ncnl(ret);
+      ret = chunk_get_next_ncnnl(ret);
 
       while (ret != br_o)
       {
          make_type(ret);
-         ret = chunk_get_next_ncnl(ret);
+         ret = chunk_get_next_ncnnl(ret);
       }
    }
 
@@ -2488,7 +2488,7 @@ static void handle_cpp_lambda(chunk_t *sq_o)
       fix_fcn_def_params(pa_o);
    }
    //handle self calling lambda paren
-   chunk_t *call_pa_o = chunk_get_next_ncnl(br_c);
+   chunk_t *call_pa_o = chunk_get_next_ncnnl(br_c);
 
    if (chunk_is_token(call_pa_o, CT_PAREN_OPEN))
    {
@@ -2510,8 +2510,8 @@ static void handle_d_template(chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
 
-   chunk_t *name = chunk_get_next_ncnl(pc);
-   chunk_t *po   = chunk_get_next_ncnl(name);
+   chunk_t *name = chunk_get_next_ncnnl(pc);
+   chunk_t *po   = chunk_get_next_ncnnl(name);
 
    //if (!name || (name->type != CT_WORD && name->type != CT_WORD))  Coverity CID 76000 Same on both sides, 2016-03-16
    if (  name == nullptr
@@ -2542,7 +2542,7 @@ static void handle_d_template(chunk_t *pc)
    }
    set_chunk_parent(tmp, CT_TEMPLATE);
 
-   tmp = chunk_get_next_ncnl(tmp);
+   tmp = chunk_get_next_ncnnl(tmp);
 
    if (chunk_is_not_token(tmp, CT_BRACE_OPEN))
    {
@@ -2554,7 +2554,7 @@ static void handle_d_template(chunk_t *pc)
 
    tmp = po;
 
-   while (  ((tmp = chunk_get_next_ncnl(tmp)) != nullptr)
+   while (  ((tmp = chunk_get_next_ncnnl(tmp)) != nullptr)
          && tmp->level > po->level)
    {
       if (  chunk_is_token(tmp, CT_WORD)
@@ -2576,7 +2576,7 @@ chunk_t *skip_template_next(chunk_t *ang_open)
    if (chunk_is_token(ang_open, CT_ANGLE_OPEN))
    {
       chunk_t *pc = chunk_get_next_type(ang_open, CT_ANGLE_CLOSE, ang_open->level);
-      return(chunk_get_next_ncnl(pc));
+      return(chunk_get_next_ncnnl(pc));
    }
    return(ang_open);
 }
@@ -2603,7 +2603,7 @@ static void handle_oc_class(chunk_t *pc)
 
    if (get_chunk_parent_type(pc) == CT_OC_PROTOCOL)
    {
-      tmp = chunk_get_next_ncnl(pc);
+      tmp = chunk_get_next_ncnnl(pc);
 
       if (chunk_is_semicolon(tmp))
       {
@@ -2754,8 +2754,8 @@ static void handle_oc_class(chunk_t *pc)
 static void handle_oc_block_literal(chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *prev = chunk_get_prev_ncnlni(pc);   // Issue #2279
-   chunk_t *next = chunk_get_next_ncnl(pc);
+   chunk_t *prev = chunk_get_prev_ncnnlni(pc);   // Issue #2279
+   chunk_t *next = chunk_get_next_ncnnl(pc);
 
    if (  pc == nullptr
       || prev == nullptr
@@ -2777,7 +2777,7 @@ static void handle_oc_block_literal(chunk_t *pc)
    LOG_FMT(LOCBLK, "%s(%d):  + scan", __func__, __LINE__);
    chunk_t *tmp;
 
-   for (tmp = next; tmp; tmp = chunk_get_next_ncnl(tmp))
+   for (tmp = next; tmp; tmp = chunk_get_next_ncnnl(tmp))
    {
       /* handle '< protocol >' */
       if (chunk_is_str(tmp, "<", 1))
@@ -2798,7 +2798,7 @@ static void handle_oc_block_literal(chunk_t *pc)
                set_chunk_parent(tmp, CT_OC_PROTO_LIST);
             }
          }
-         tmp = chunk_get_next_ncnl(ac);
+         tmp = chunk_get_next_ncnnl(ac);
       }
       LOG_FMT(LOCBLK, " '%s'", tmp->text());
 
@@ -2855,11 +2855,11 @@ static void handle_oc_block_literal(chunk_t *pc)
          flag_parens(apo, PCF_OC_ATYPE, CT_FPAREN_OPEN, CT_OC_BLOCK_EXPR, true);
          fix_fcn_def_params(apo);
       }
-      lbp = chunk_get_prev_ncnlni(apo);   // Issue #2279
+      lbp = chunk_get_prev_ncnnlni(apo);   // Issue #2279
    }
    else
    {
-      lbp = chunk_get_prev_ncnlni(bbo);   // Issue #2279
+      lbp = chunk_get_prev_ncnnlni(bbo);   // Issue #2279
    }
 
    // mark the return type, if any
@@ -2869,7 +2869,7 @@ static void handle_oc_block_literal(chunk_t *pc)
       make_type(lbp);
       chunk_flags_set(lbp, PCF_OC_RTYPE);
       set_chunk_parent(lbp, CT_OC_BLOCK_EXPR);
-      lbp = chunk_get_prev_ncnlni(lbp);   // Issue #2279
+      lbp = chunk_get_prev_ncnnlni(lbp);   // Issue #2279
    }
    // mark the braces
    set_chunk_parent(bbo, CT_OC_BLOCK_EXPR);
@@ -2893,7 +2893,7 @@ static void handle_oc_block_type(chunk_t *pc)
       return;
    }
    // make sure we have '( ^'
-   chunk_t *tpo = chunk_get_prev_ncnlni(pc); // type paren open   Issue #2279
+   chunk_t *tpo = chunk_get_prev_ncnnlni(pc); // type paren open   Issue #2279
 
    if (chunk_is_paren_open(tpo))
    {
@@ -2901,10 +2901,10 @@ static void handle_oc_block_type(chunk_t *pc)
        * block type: 'RTYPE (^LABEL)(ARGS)'
        * LABEL is optional.
        */
-      chunk_t *tpc = chunk_skip_to_match(tpo);   // type close paren (after '^')
-      chunk_t *nam = chunk_get_prev_ncnlni(tpc); // name (if any) or '^'   Issue #2279
-      chunk_t *apo = chunk_get_next_ncnl(tpc);   // arg open paren
-      chunk_t *apc = chunk_skip_to_match(apo);   // arg close paren
+      chunk_t *tpc = chunk_skip_to_match(tpo);    // type close paren (after '^')
+      chunk_t *nam = chunk_get_prev_ncnnlni(tpc); // name (if any) or '^'   Issue #2279
+      chunk_t *apo = chunk_get_next_ncnnl(tpc);   // arg open paren
+      chunk_t *apc = chunk_skip_to_match(apo);    // arg close paren
 
       /*
        * If this is a block literal instead of a block type, 'nam'
@@ -2924,7 +2924,7 @@ static void handle_oc_block_type(chunk_t *pc)
 
       if (chunk_is_paren_close(apc))
       {
-         chunk_t   *aft = chunk_get_next_ncnl(apc);
+         chunk_t   *aft = chunk_get_next_ncnnl(apc);
          c_token_t pt;
 
          if (chunk_is_str(nam, "^", 1))
@@ -2956,7 +2956,7 @@ static void handle_oc_block_type(chunk_t *pc)
          set_chunk_type(apc, CT_FPAREN_CLOSE);
          set_chunk_parent(apc, CT_FUNC_PROTO);
          fix_fcn_def_params(apo);
-         mark_function_return_type(nam, chunk_get_prev_ncnlni(tpo), pt);   // Issue #2279
+         mark_function_return_type(nam, chunk_get_prev_ncnnlni(tpo), pt);   // Issue #2279
       }
    }
 } // handle_oc_block_type
@@ -2979,9 +2979,9 @@ static chunk_t *handle_oc_md_type(chunk_t *paren_open, c_token_t ptype, pcf_flag
    set_chunk_parent(paren_close, ptype);
    chunk_flags_set(paren_close, flags);
 
-   for (chunk_t *cur = chunk_get_next_ncnl(paren_open);
+   for (chunk_t *cur = chunk_get_next_ncnnl(paren_open);
         cur != paren_close;
-        cur = chunk_get_next_ncnl(cur))
+        cur = chunk_get_next_ncnnl(cur))
    {
       LOG_FMT(LOCMSGD, " <%s|%s>", cur->text(), get_token_name(cur->type));
       chunk_flags_set(cur, flags);
@@ -2989,7 +2989,7 @@ static chunk_t *handle_oc_md_type(chunk_t *paren_open, c_token_t ptype, pcf_flag
    }
 
    // returning the chunk after the paren close
-   return(chunk_get_next_ncnl(paren_close));
+   return(chunk_get_next_ncnnl(paren_close));
 }
 
 
@@ -3035,7 +3035,7 @@ static void handle_oc_message_decl(chunk_t *pc)
    // format: -(TYPE) NAME [: (TYPE)NAME
 
    // handle the return type
-   tmp = handle_oc_md_type(chunk_get_next_ncnl(pc), pt, PCF_OC_RTYPE, did_it);
+   tmp = handle_oc_md_type(chunk_get_next_ncnnl(pc), pt, PCF_OC_RTYPE, did_it);
 
    if (!did_it)
    {
@@ -3054,7 +3054,7 @@ static void handle_oc_message_decl(chunk_t *pc)
 
    set_chunk_type(tmp, pt);
    set_chunk_parent(tmp, pt);
-   pc = chunk_get_next_ncnl(tmp);
+   pc = chunk_get_next_ncnnl(tmp);
 
    LOG_FMT(LOCMSGD, " [%s]%s", pc->text(), get_token_name(pc->type));
 
@@ -3071,7 +3071,7 @@ static void handle_oc_message_decl(chunk_t *pc)
             || chunk_is_token(pc, pt))
          {
             set_chunk_parent(pc, pt);
-            pc = chunk_get_next_ncnl(pc);
+            pc = chunk_get_next_ncnnl(pc);
          }
 
          // a colon must be next
@@ -3081,7 +3081,7 @@ static void handle_oc_message_decl(chunk_t *pc)
          }
          set_chunk_type(pc, CT_OC_COLON);
          set_chunk_parent(pc, pt);
-         pc = chunk_get_next_ncnl(pc);
+         pc = chunk_get_next_ncnnl(pc);
 
          // next is the type in parens
          LOG_FMT(LOCMSGD, "  (%s)", pc->text());
@@ -3098,7 +3098,7 @@ static void handle_oc_message_decl(chunk_t *pc)
          // we should now be on the arg name
          chunk_flags_set(pc, PCF_VAR_DEF);
          LOG_FMT(LOCMSGD, " arg[%s]", pc->text());
-         pc = chunk_get_next_ncnl(pc);
+         pc = chunk_get_next_ncnnl(pc);
       }
    }
    LOG_FMT(LOCMSGD, " end[%s]", pc->text());
@@ -3141,20 +3141,20 @@ static void handle_oc_message_send(chunk_t *os)
    LOG_FMT(LOCMSG, "%s(%d): orig_line is %zu, orig_col is %zu\n",
            __func__, __LINE__, os->orig_line, os->orig_col);
 
-   chunk_t *tmp = chunk_get_next_ncnl(cs);
+   chunk_t *tmp = chunk_get_next_ncnnl(cs);
 
    if (chunk_is_semicolon(tmp))
    {
       set_chunk_parent(tmp, CT_OC_MSG);
    }
    // expect a word first thing or [...]
-   tmp = chunk_get_next_ncnl(os);
+   tmp = chunk_get_next_ncnnl(os);
 
    if (  chunk_is_token(tmp, CT_SQUARE_OPEN)
       || chunk_is_token(tmp, CT_PAREN_OPEN)
       || chunk_is_token(tmp, CT_OC_AT))
    {
-      chunk_t *tt = chunk_get_next_ncnl(tmp);
+      chunk_t *tt = chunk_get_next_ncnnl(tmp);
 
       if (  chunk_is_token(tmp, CT_OC_AT)
          && tt != nullptr)
@@ -3191,16 +3191,16 @@ static void handle_oc_message_send(chunk_t *os)
       if (chunk_is_star(tmp)) // Issue #2722
       {
          set_chunk_type(tmp, CT_PTR_TYPE);
-         tmp = chunk_get_next_ncnl(tmp);
+         tmp = chunk_get_next_ncnnl(tmp);
       }
-      chunk_t *tt = chunk_get_next_ncnl(tmp);
+      chunk_t *tt = chunk_get_next_ncnnl(tmp);
 
       if (chunk_is_paren_open(tt))
       {
          LOG_FMT(LFCN, "%s(%d): (18) SET TO CT_FUNC_CALL: orig_line is %zu, orig_col is %zu, text() '%s'\n",
                  __func__, __LINE__, tmp->orig_line, tmp->orig_col, tmp->text());
          set_chunk_type(tmp, CT_FUNC_CALL);
-         tmp = chunk_get_prev_ncnlni(set_paren_parent(tt, CT_FUNC_CALL));   // Issue #2279
+         tmp = chunk_get_prev_ncnnlni(set_paren_parent(tt, CT_FUNC_CALL));   // Issue #2279
       }
       else
       {
@@ -3213,7 +3213,7 @@ static void handle_oc_message_send(chunk_t *os)
    chunk_flags_set(cs, PCF_IN_OC_MSG);
 
    // handle '< protocol >'
-   tmp = chunk_get_next_ncnl(tmp);
+   tmp = chunk_get_next_ncnnl(tmp);
 
    if (chunk_is_str(tmp, "<", 1))
    {
@@ -3233,7 +3233,7 @@ static void handle_oc_message_send(chunk_t *os)
             set_chunk_parent(tmp, CT_OC_PROTO_LIST);
          }
       }
-      tmp = chunk_get_next_ncnl(ac);
+      tmp = chunk_get_next_ncnnl(ac);
    }
    // handle 'object.property' and 'collection[index]'
    else
@@ -3242,12 +3242,12 @@ static void handle_oc_message_send(chunk_t *os)
       {
          if (chunk_is_token(tmp, CT_MEMBER))  // move past [object.prop1.prop2
          {
-            chunk_t *typ = chunk_get_next_ncnl(tmp);
+            chunk_t *typ = chunk_get_next_ncnnl(tmp);
 
             if (  chunk_is_token(typ, CT_WORD)
                || chunk_is_token(typ, CT_TYPE))
             {
-               tmp = chunk_get_next_ncnl(typ);
+               tmp = chunk_get_next_ncnnl(typ);
             }
             else
             {
@@ -3256,17 +3256,17 @@ static void handle_oc_message_send(chunk_t *os)
          }
          else if (chunk_is_token(tmp, CT_SQUARE_OPEN))  // move past [collection[index]
          {
-            chunk_t *tcs = chunk_get_next_ncnl(tmp);
+            chunk_t *tcs = chunk_get_next_ncnnl(tmp);
 
             while (  tcs != nullptr
                   && tcs->level > tmp->level)
             {
-               tcs = chunk_get_next_ncnl(tcs);
+               tcs = chunk_get_next_ncnnl(tcs);
             }
 
             if (chunk_is_token(tcs, CT_SQUARE_CLOSE))
             {
-               tmp = chunk_get_next_ncnl(tcs);
+               tmp = chunk_get_next_ncnnl(tcs);
             }
             else
             {
@@ -3283,7 +3283,7 @@ static void handle_oc_message_send(chunk_t *os)
    // [(self.foo.bar) method]
    if (chunk_is_paren_open(tmp))
    {
-      tmp = chunk_get_next_ncnl(chunk_skip_to_match(tmp));
+      tmp = chunk_get_next_ncnnl(chunk_skip_to_match(tmp));
    }
 
    if (  chunk_is_token(tmp, CT_WORD)
@@ -3561,11 +3561,11 @@ static void handle_oc_property_decl(chunk_t *os)
          }
       }
    }
-   chunk_t *tmp = chunk_get_next_ncnl(os);
+   chunk_t *tmp = chunk_get_next_ncnnl(os);
 
    if (chunk_is_paren_open(tmp))
    {
-      tmp = chunk_get_next_ncnl(chunk_skip_to_match(tmp));
+      tmp = chunk_get_next_ncnnl(chunk_skip_to_match(tmp));
    }
    fix_variable_definition(tmp);
 } // handle_oc_property_decl
@@ -3603,7 +3603,7 @@ static void handle_cs_square_stmt(chunk_t *os)
       }
    }
 
-   tmp = chunk_get_next_ncnl(cs);
+   tmp = chunk_get_next_ncnnl(cs);
 
    if (tmp != nullptr)
    {
@@ -3621,7 +3621,7 @@ static void handle_cs_property(chunk_t *bro)
    bool    did_prop = false;
    chunk_t *pc      = bro;
 
-   while ((pc = chunk_get_prev_ncnlni(pc)) != nullptr)   // Issue #2279
+   while ((pc = chunk_get_prev_ncnnlni(pc)) != nullptr)   // Issue #2279
    {
       if (pc->level == bro->level)
       {
@@ -3725,11 +3725,11 @@ static void handle_wrap(chunk_t *pc)
 static void handle_proto_wrap(chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
-   chunk_t *opp  = chunk_get_next_ncnl(pc);
-   chunk_t *name = chunk_get_next_ncnl(opp);
-   chunk_t *tmp  = chunk_get_next_ncnl(chunk_get_next_ncnl(name));
+   chunk_t *opp  = chunk_get_next_ncnnl(pc);
+   chunk_t *name = chunk_get_next_ncnnl(opp);
+   chunk_t *tmp  = chunk_get_next_ncnnl(chunk_get_next_ncnnl(name));
    chunk_t *clp  = chunk_skip_to_match(opp);
-   chunk_t *cma  = chunk_get_next_ncnl(clp);
+   chunk_t *cma  = chunk_get_next_ncnnl(clp);
 
    if (  opp == nullptr
       || name == nullptr
@@ -3780,7 +3780,7 @@ static void handle_proto_wrap(chunk_t *pc)
    // Mark return type (TODO: move to own function)
    tmp = pc;
 
-   while ((tmp = chunk_get_prev_ncnlni(tmp)) != nullptr)   // Issue #2279
+   while ((tmp = chunk_get_prev_ncnnlni(tmp)) != nullptr)   // Issue #2279
    {
       if (  !chunk_is_type(tmp)
          && chunk_is_not_token(tmp, CT_OPERATOR)

--- a/src/combine_fix_mark.cpp
+++ b/src/combine_fix_mark.cpp
@@ -37,7 +37,7 @@ void fix_casts(chunk_t *start)
    LOG_FMT(LCASTS, "%s(%d): start->text() is '%s', orig_line is %zu, orig_col is %zu\n",
            __func__, __LINE__, start->text(), start->orig_line, start->orig_col);
 
-   prev = chunk_get_prev_ncnlni(start);   // Issue #2279
+   prev = chunk_get_prev_ncnnlni(start);   // Issue #2279
 
    if (prev == nullptr)
    {
@@ -58,7 +58,7 @@ void fix_casts(chunk_t *start)
       return;
    }
    // Make sure there is only WORD, TYPE, and '*' or '^' before the close paren
-   pc    = chunk_get_next_ncnl(start);
+   pc    = chunk_get_next_ncnnl(start);
    first = pc;
 
    while (  pc != nullptr
@@ -98,7 +98,7 @@ void fix_casts(chunk_t *start)
          word_count--;
       }
       last = pc;
-      pc   = chunk_get_next_ncnl(pc);
+      pc   = chunk_get_next_ncnnl(pc);
       count++;
    }
 
@@ -177,12 +177,12 @@ void fix_casts(chunk_t *start)
        *
        * Find the next non-open paren item.
        */
-      pc    = chunk_get_next_ncnl(paren_close);
+      pc    = chunk_get_next_ncnnl(paren_close);
       after = pc;
 
       do
       {
-         after = chunk_get_next_ncnl(after);
+         after = chunk_get_next_ncnnl(after);
       } while (chunk_is_token(after, CT_PAREN_OPEN));
 
       if (after == nullptr)
@@ -253,7 +253,7 @@ void fix_casts(chunk_t *start)
       }
    }
    // if the 'cast' is followed by a semicolon, comma, bool or close parenthesis, it isn't
-   pc = chunk_get_next_ncnl(paren_close);
+   pc = chunk_get_next_ncnnl(paren_close);
 
    if (pc == nullptr)
    {
@@ -277,7 +277,7 @@ void fix_casts(chunk_t *start)
 
    for (pc = first;
         pc != nullptr && pc != paren_close;
-        pc = chunk_get_next_ncnl(pc))
+        pc = chunk_get_next_ncnnl(pc))
    {
       set_chunk_parent(pc, CT_C_CAST);
       make_type(pc);
@@ -287,7 +287,7 @@ void fix_casts(chunk_t *start)
    LOG_FMT(LCASTS, " )%s\n", detail);
 
    // Mark the next item as an expression start
-   pc = chunk_get_next_ncnl(paren_close);
+   pc = chunk_get_next_ncnnl(paren_close);
 
    if (pc != nullptr)
    {
@@ -315,7 +315,7 @@ void fix_fcn_def_params(chunk_t *start)
    while (  start != nullptr
          && !chunk_is_paren_open(start))
    {
-      start = chunk_get_next_ncnl(start);
+      start = chunk_get_next_ncnnl(start);
    }
 
    if (start == nullptr)// Coverity CID 76003, 1100782
@@ -330,7 +330,7 @@ void fix_fcn_def_params(chunk_t *start)
    size_t     level = start->level + 1;
    chunk_t    *pc   = start;
 
-   while ((pc = chunk_get_next_ncnl(pc)) != nullptr)
+   while ((pc = chunk_get_next_ncnnl(pc)) != nullptr)
    {
       if (  (  (start->len() == 1)
             && (start->str[0] == ')'))
@@ -393,7 +393,7 @@ void fix_type_cast(chunk_t *start)
    LOG_FUNC_ENTRY();
    chunk_t *pc;
 
-   pc = chunk_get_next_ncnl(start);
+   pc = chunk_get_next_ncnnl(start);
 
    if (  pc == nullptr
       || chunk_is_not_token(pc, CT_ANGLE_OPEN))
@@ -401,13 +401,13 @@ void fix_type_cast(chunk_t *start)
       return;
    }
 
-   while (  ((pc = chunk_get_next_ncnl(pc)) != nullptr)
+   while (  ((pc = chunk_get_next_ncnnl(pc)) != nullptr)
          && pc->level >= start->level)
    {
       if (  pc->level == start->level
          && chunk_is_token(pc, CT_ANGLE_CLOSE))
       {
-         pc = chunk_get_next_ncnl(pc);
+         pc = chunk_get_next_ncnnl(pc);
 
          if (pc == nullptr)
          {
@@ -443,9 +443,9 @@ void fix_typedef(chunk_t *start)
     * Mark everything in the typedef and scan for ")(", which makes it a
     * function type
     */
-   for (chunk_t *next = chunk_get_next_ncnl(start, scope_e::PREPROC)
+   for (chunk_t *next = chunk_get_next_ncnnl(start, scope_e::PREPROC)
         ; next != nullptr && next->level >= start->level
-        ; next = chunk_get_next_ncnl(next, scope_e::PREPROC))
+        ; next = chunk_get_next_ncnnl(next, scope_e::PREPROC))
    {
       chunk_flags_set(next, PCF_IN_TYPEDEF);
 
@@ -491,7 +491,7 @@ void fix_typedef(chunk_t *start)
       flag_parens(last_op, PCF_NONE, CT_FPAREN_OPEN, CT_TYPEDEF, false);
       fix_fcn_def_params(last_op);
 
-      the_type = chunk_get_prev_ncnlni(last_op, scope_e::PREPROC);   // Issue #2279
+      the_type = chunk_get_prev_ncnnlni(last_op, scope_e::PREPROC);   // Issue #2279
 
       if (the_type == nullptr)
       {
@@ -503,7 +503,7 @@ void fix_typedef(chunk_t *start)
       {
          open_paren = chunk_skip_to_match_rev(the_type);
          mark_function_type(the_type);
-         the_type = chunk_get_prev_ncnlni(the_type, scope_e::PREPROC);   // Issue #2279
+         the_type = chunk_get_prev_ncnnlni(the_type, scope_e::PREPROC);   // Issue #2279
 
          if (the_type == nullptr)
          {
@@ -543,7 +543,7 @@ void fix_typedef(chunk_t *start)
     * Skip over enum/struct/union stuff, as we know it isn't a return type
     * for a function type
     */
-   chunk_t *after = chunk_get_next_ncnl(start, scope_e::PREPROC);
+   chunk_t *after = chunk_get_next_ncnnl(start, scope_e::PREPROC);
 
    if (after == nullptr)
    {
@@ -564,7 +564,7 @@ void fix_typedef(chunk_t *start)
       return;
    }
    // We have a struct/union/enum, next should be either a type or {
-   chunk_t *next = chunk_get_next_ncnl(after, scope_e::PREPROC);
+   chunk_t *next = chunk_get_next_ncnnl(after, scope_e::PREPROC);
 
    if (next == nullptr)
    {
@@ -573,7 +573,7 @@ void fix_typedef(chunk_t *start)
 
    if (chunk_is_token(next, CT_TYPE))
    {
-      next = chunk_get_next_ncnl(next, scope_e::PREPROC);
+      next = chunk_get_next_ncnnl(next, scope_e::PREPROC);
 
       if (next == nullptr)
       {
@@ -638,7 +638,7 @@ chunk_t *fix_variable_definition(chunk_t *start)
       LOG_FMT(LFVD, "%s(%d):   1:pc->text() '%s', type is %s\n",
               __func__, __LINE__, pc->text(), get_token_name(pc->type));
       cs.Push_Back(pc);
-      pc = chunk_get_next_ncnl(pc);
+      pc = chunk_get_next_ncnnl(pc);
 
       if (pc == nullptr)
       {
@@ -768,7 +768,7 @@ chunk_t *fix_variable_definition(chunk_t *start)
 
    if (chunk_is_token(end, CT_COMMA))
    {
-      return(chunk_get_next_ncnl(end));
+      return(chunk_get_next_ncnnl(end));
    }
    return(skip_to_next_statement(end));
 } // fix_variable_definition
@@ -783,7 +783,7 @@ void mark_cpp_constructor(chunk_t *pc)
    chunk_t *var;
    bool    is_destr = false;
 
-   tmp = chunk_get_prev_ncnlni(pc);   // Issue #2279
+   tmp = chunk_get_prev_ncnnlni(pc);   // Issue #2279
 
    if (  chunk_is_token(tmp, CT_INV)
       || chunk_is_token(tmp, CT_DESTRUCTOR))
@@ -798,7 +798,7 @@ void mark_cpp_constructor(chunk_t *pc)
            pc->text(), get_token_name(pc->type),
            tmp->text(), get_token_name(tmp->type));
 
-   paren_open = skip_template_next(chunk_get_next_ncnl(pc));
+   paren_open = skip_template_next(chunk_get_next_ncnnl(pc));
 
    if (!chunk_is_str(paren_open, "(", 1))
    {
@@ -825,7 +825,7 @@ void mark_cpp_constructor(chunk_t *pc)
       LOG_FMT(LFTOR, "%s(%d): tmp is '%s', orig_line is %zu, orig_col is %zu\n",
               __func__, __LINE__, tmp->text(), tmp->orig_line, tmp->orig_col);
       chunk_flags_set(tmp, PCF_IN_CONST_ARGS);
-      tmp = chunk_get_next_ncnl(tmp);
+      tmp = chunk_get_next_ncnnl(tmp);
 
       if (  chunk_is_str(tmp, ":", 1)
          && tmp->level == paren_open->level)
@@ -839,7 +839,7 @@ void mark_cpp_constructor(chunk_t *pc)
             || chunk_is_opening_brace(tmp))
          && tmp->level == paren_open->level)
       {
-         var = skip_template_prev(chunk_get_prev_ncnlni(tmp));   // Issue #2279
+         var = skip_template_prev(chunk_get_prev_ncnnlni(tmp));   // Issue #2279
 
          if (  chunk_is_token(var, CT_TYPE)
             || chunk_is_token(var, CT_WORD))
@@ -864,18 +864,18 @@ void mark_cpp_constructor(chunk_t *pc)
       LOG_FMT(LFCN, "%s(%d):  Marked '%s' as FUNC_CLASS_PROTO on orig_line %zu, orig_col %zu\n",
               __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col);
    }
-   tmp = chunk_get_prev_ncnlni(pc); // Issue #2907
+   tmp = chunk_get_prev_ncnnlni(pc); // Issue #2907
 
    if (chunk_is_token(tmp, CT_DESTRUCTOR))
    {
       set_chunk_parent(tmp, pc->type);
-      tmp = chunk_get_prev_ncnlni(tmp);
+      tmp = chunk_get_prev_ncnnlni(tmp);
    }
 
    while (chunk_is_token(tmp, CT_QUALIFIER))
    {
       set_chunk_parent(tmp, pc->type);
-      tmp = chunk_get_prev_ncnlni(tmp);
+      tmp = chunk_get_prev_ncnnlni(tmp);
    }
 } // mark_cpp_constructor
 
@@ -889,7 +889,7 @@ void mark_cpp_lambda(chunk_t *square_open)
 
       if (get_chunk_parent_type(brace_close) == CT_CPP_LAMBDA)
       {
-         for (auto *pc = square_open; pc != brace_close; pc = chunk_get_next_ncnl(pc))
+         for (auto *pc = square_open; pc != brace_close; pc = chunk_get_next_ncnnl(pc))
          {
             chunk_flags_set(pc, PCF_IN_LAMBDA);
          }
@@ -1044,7 +1044,7 @@ void mark_function_return_type(chunk_t *fname, chunk_t *start, c_token_t parent_
          {
             first = pc;
          }
-         pc = chunk_get_prev_ncnlni(pc);   // Issue #2279
+         pc = chunk_get_prev_ncnnlni(pc);   // Issue #2279
       }
       LOG_FMT(LFCNR, "%s(%d): marking returns...", __func__, __LINE__);
 
@@ -1067,7 +1067,7 @@ void mark_function_return_type(chunk_t *fname, chunk_t *start, c_token_t parent_
          {
             set_chunk_parent(pc, parent_type);
          }
-         chunk_t *prev = chunk_get_prev_ncnlni(pc);   // Issue #2279
+         chunk_t *prev = chunk_get_prev_ncnnlni(pc);   // Issue #2279
 
          if (  !is_return_tuple
             || chunk_is_not_token(pc, CT_WORD)
@@ -1081,7 +1081,7 @@ void mark_function_return_type(chunk_t *fname, chunk_t *start, c_token_t parent_
          {
             break;
          }
-         pc = chunk_get_next_ncnl(pc);
+         pc = chunk_get_next_ncnnl(pc);
 
          //template angles should keep parent type CT_TEMPLATE
          if (chunk_is_token(pc, CT_ANGLE_OPEN))
@@ -1092,7 +1092,7 @@ void mark_function_return_type(chunk_t *fname, chunk_t *start, c_token_t parent_
             {
                break;
             }
-            pc = chunk_get_next_ncnl(pc);
+            pc = chunk_get_next_ncnnl(pc);
          }
       }
       LOG_FMT(LFCNR, "\n");
@@ -1102,7 +1102,7 @@ void mark_function_return_type(chunk_t *fname, chunk_t *start, c_token_t parent_
          && first
          && first->flags.test(PCF_IN_CLASS))
       {
-         pc = chunk_get_prev_ncnlni(first);   // Issue #2279
+         pc = chunk_get_prev_ncnnlni(first);   // Issue #2279
 
          if (chunk_is_token(pc, CT_FRIEND))
          {
@@ -1111,7 +1111,7 @@ void mark_function_return_type(chunk_t *fname, chunk_t *start, c_token_t parent_
             // A friend might be preceded by a template specification, as in:
             //   template <...> friend type func(...);
             // If so, we need to mark that also
-            pc = chunk_get_prev_ncnlni(pc);   // Issue #2279
+            pc = chunk_get_prev_ncnnlni(pc);   // Issue #2279
 
             if (chunk_is_token(pc, CT_ANGLE_CLOSE))
             {
@@ -1140,8 +1140,8 @@ void mark_function(chunk_t *pc)
    }
    LOG_FMT(LFCN, "%s(%d): orig_line is %zu, orig_col is %zu, text() '%s'\n",
            __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text());
-   chunk_t *prev = chunk_get_prev_ncnlni(pc);   // Issue #2279
-   chunk_t *next = chunk_get_next_ncnlnp(pc);
+   chunk_t *prev = chunk_get_prev_ncnnlni(pc);   // Issue #2279
+   chunk_t *next = chunk_get_next_ncnnlnp(pc);
 
    if (next == nullptr)
    {
@@ -1172,7 +1172,7 @@ void mark_function(chunk_t *pc)
       {
          tmp = pc;
 
-         while ((tmp = chunk_get_prev_ncnlni(tmp)) != nullptr)   // Issue #2279
+         while ((tmp = chunk_get_prev_ncnnlni(tmp)) != nullptr)   // Issue #2279
          {
             if (  chunk_is_token(tmp, CT_BRACE_CLOSE)
                || chunk_is_token(tmp, CT_BRACE_OPEN)             // Issue 575
@@ -1232,7 +1232,7 @@ void mark_function(chunk_t *pc)
             && chunk_is_not_token(pc, CT_FUNC_CALL))
          {
             // Mark the return type
-            while (  (tmp = chunk_get_next_ncnl(tmp)) != pc
+            while (  (tmp = chunk_get_next_ncnnl(tmp)) != pc
                   && tmp != nullptr)
             {
                make_type(tmp); // Mark the return type
@@ -1243,7 +1243,7 @@ void mark_function(chunk_t *pc)
 
    if (chunk_is_ptr_operator(next))
    {
-      next = chunk_get_next_ncnlnp(next);
+      next = chunk_get_next_ncnnlnp(next);
 
       if (next == nullptr)
       {
@@ -1305,7 +1305,7 @@ void mark_function(chunk_t *pc)
     *
     * Otherwise, it must be chained function calls.
     */
-   tmp = chunk_get_next_ncnl(paren_close);
+   tmp = chunk_get_next_ncnnl(paren_close);
 
    if (  tmp != nullptr
       && chunk_is_str(tmp, "(", 1))
@@ -1315,20 +1315,20 @@ void mark_function(chunk_t *pc)
       chunk_t *tmp3;
 
       // skip over any leading class/namespace in: "T(F::*A)();"
-      tmp1 = chunk_get_next_ncnl(next);
+      tmp1 = chunk_get_next_ncnnl(next);
 
       while (tmp1 != nullptr)
       {
-         tmp2 = chunk_get_next_ncnl(tmp1);
+         tmp2 = chunk_get_next_ncnnl(tmp1);
 
          if (  !chunk_is_word(tmp1)
             || chunk_is_not_token(tmp2, CT_DC_MEMBER))
          {
             break;
          }
-         tmp1 = chunk_get_next_ncnl(tmp2);
+         tmp1 = chunk_get_next_ncnnl(tmp2);
       }
-      tmp2 = chunk_get_next_ncnl(tmp1);
+      tmp2 = chunk_get_next_ncnnl(tmp1);
 
       if (chunk_is_str(tmp2, ")", 1))
       {
@@ -1337,7 +1337,7 @@ void mark_function(chunk_t *pc)
       }
       else
       {
-         tmp3 = chunk_get_next_ncnl(tmp2);
+         tmp3 = chunk_get_next_ncnnl(tmp2);
       }
       tmp3 = chunk_get_next_ssq(tmp3);
 
@@ -1437,12 +1437,12 @@ void mark_function(chunk_t *pc)
 
          destr = prev;
          // Point to the item previous to the class name
-         prev = chunk_get_prev_ncnlnp(prev);
+         prev = chunk_get_prev_ncnnlnp(prev);
       }
 
       if (chunk_is_token(prev, CT_DC_MEMBER))
       {
-         prev = chunk_get_prev_ncnlnp(prev);
+         prev = chunk_get_prev_ncnnlnp(prev);
          LOG_FMT(LFCN, "%s(%d): prev->text() is '%s', orig_line is %zu, orig_col is %zu, type is %s\n",
                  __func__, __LINE__, prev->text(), prev->orig_line, prev->orig_col,
                  get_token_name(prev->type));
@@ -1474,7 +1474,7 @@ void mark_function(chunk_t *pc)
                return;
             }
             // Point to the item previous to the class name
-            prev = chunk_get_prev_ncnlnp(prev);
+            prev = chunk_get_prev_ncnnlnp(prev);
          }
       }
    }
@@ -1540,7 +1540,7 @@ void mark_function(chunk_t *pc)
 
          if (prev->flags.test(PCF_IN_PREPROC))
          {
-            prev = chunk_get_prev_ncnlnp(prev);
+            prev = chunk_get_prev_ncnnlnp(prev);
             continue;
          }
 
@@ -1589,7 +1589,7 @@ void mark_function(chunk_t *pc)
             while (  chunk_is_token(prev, CT_DC_MEMBER)
                   || chunk_is_token(prev, CT_MEMBER))
             {
-               prev = chunk_get_prev_ncnlnp(prev);
+               prev = chunk_get_prev_ncnnlnp(prev);
 
                if (  prev == nullptr
                   || (  chunk_is_not_token(prev, CT_WORD)
@@ -1607,7 +1607,7 @@ void mark_function(chunk_t *pc)
                // clarification: this will skip the CT_WORD, CT_TYPE or CT_THIS landing on either
                // another CT_DC_MEMBER or CT_MEMBER or a token that indicates the context of the
                // token in question; therefore, exit loop when not a CT_DC_MEMBER or CT_MEMBER
-               prev = chunk_get_prev_ncnlnp(prev);
+               prev = chunk_get_prev_ncnnlnp(prev);
 
                if (prev == nullptr)
                {
@@ -1638,7 +1638,7 @@ void mark_function(chunk_t *pc)
                isa_def = true;
                break;
             }
-            chunk_t *prev_prev = chunk_get_prev_ncnlnp(prev);
+            chunk_t *prev_prev = chunk_get_prev_ncnnlnp(prev);
 
             if (!chunk_is_token(prev_prev, CT_QUESTION))               // Issue #1753
             {
@@ -1693,7 +1693,7 @@ void mark_function(chunk_t *pc)
          }
          else
          {
-            prev = chunk_get_prev_ncnlnp(prev);
+            prev = chunk_get_prev_ncnnlnp(prev);
          }
       }
       //LOG_FMT(LFCN, " -- stopped on %s [%s]\n",
@@ -1702,25 +1702,25 @@ void mark_function(chunk_t *pc)
       // Fixes issue #1634
       if (chunk_is_paren_close(prev))
       {
-         chunk_t *preproc = chunk_get_next_ncnl(prev);
+         chunk_t *preproc = chunk_get_next_ncnnl(prev);
 
          if (chunk_is_token(preproc, CT_PREPROC))
          {
             size_t pp_level = preproc->pp_level;
 
-            if (chunk_is_token(chunk_get_next_ncnl(preproc), CT_PP_ELSE))
+            if (chunk_is_token(chunk_get_next_ncnnl(preproc), CT_PP_ELSE))
             {
                do
                {
-                  preproc = chunk_get_prev_ncnlni(preproc);      // Issue #2279
+                  preproc = chunk_get_prev_ncnnlni(preproc);      // Issue #2279
 
                   if (chunk_is_token(preproc, CT_PP_IF))
                   {
-                     preproc = chunk_get_prev_ncnlni(preproc);   // Issue #2279
+                     preproc = chunk_get_prev_ncnnlni(preproc);   // Issue #2279
 
                      if (preproc->pp_level == pp_level)
                      {
-                        prev = chunk_get_prev_ncnlnp(preproc);
+                        prev = chunk_get_prev_ncnnlnp(preproc);
                         break;
                      }
                   }
@@ -1746,7 +1746,7 @@ void mark_function(chunk_t *pc)
       // Fixes issue #1266, identification of a tuple return type in CS.
       if (  !isa_def
          && chunk_is_token(prev, CT_PAREN_CLOSE)
-         && chunk_get_next_ncnl(prev) == pc)
+         && chunk_get_next_ncnnl(prev) == pc)
       {
          tmp = chunk_skip_to_match_rev(prev);
 
@@ -1761,7 +1761,7 @@ void mark_function(chunk_t *pc)
                isa_def = true;
                break;
             }
-            tmp = chunk_get_next_ncnl(tmp);
+            tmp = chunk_get_next_ncnnl(tmp);
          }
       }
 
@@ -1779,7 +1779,7 @@ void mark_function(chunk_t *pc)
          }
 
          for (  tmp = prev; (tmp != nullptr)
-             && tmp != pc; tmp = chunk_get_next_ncnlnp(tmp))
+             && tmp != pc; tmp = chunk_get_next_ncnnlnp(tmp))
          {
             LOG_FMT(LFCN, "%s(%d): text() is '%s', type is %s\n",
                     __func__, __LINE__, tmp->text(), get_token_name(tmp->type));
@@ -1816,7 +1816,7 @@ void mark_function(chunk_t *pc)
    // Scan tokens until we hit a brace open (def) or semicolon (proto)
    tmp = paren_close;
 
-   while ((tmp = chunk_get_next_ncnl(tmp)) != nullptr)
+   while ((tmp = chunk_get_next_ncnnl(tmp)) != nullptr)
    {
       // Only care about brace or semicolon on the same level
       if (tmp->level < pc->level)
@@ -1883,7 +1883,7 @@ void mark_function(chunk_t *pc)
       while (  tmp != nullptr
             && !tmp->flags.test(PCF_STMT_START))
       {
-         tmp = chunk_get_prev_ncnlni(tmp);   // Issue #2279
+         tmp = chunk_get_prev_ncnnlni(tmp);   // Issue #2279
       }
       const bool is_extern = (  tmp != nullptr
                              && tmp->str.equals("extern"));
@@ -1895,14 +1895,14 @@ void mark_function(chunk_t *pc)
        *  - non-type fields
        *  - function calls
        */
-      chunk_t *ref = chunk_get_next_ncnl(paren_open);
+      chunk_t *ref = chunk_get_next_ncnnl(paren_open);
       chunk_t *tmp2;
       bool    is_param = true;
       tmp = ref;
 
       while (tmp != paren_close)
       {
-         tmp2 = chunk_get_next_ncnl(tmp);
+         tmp2 = chunk_get_next_ncnnl(tmp);
 
          if (  chunk_is_token(tmp, CT_COMMA)
             && (tmp->level == (paren_open->level + 1)))
@@ -1943,7 +1943,7 @@ void mark_function(chunk_t *pc)
             && get_chunk_parent_type(br_open) != CT_NAMESPACE)
          {
             // Do a check to see if the level is right
-            prev = chunk_get_prev_ncnlni(pc);   // Issue #2279
+            prev = chunk_get_prev_ncnnlni(pc);   // Issue #2279
 
             if (  !chunk_is_str(prev, "*", 1)
                && !chunk_is_str(prev, "&", 1))
@@ -1988,7 +1988,7 @@ void mark_function(chunk_t *pc)
 
    if (chunk_is_token(next, CT_TSQUARE))
    {
-      next = chunk_get_next_ncnl(next);
+      next = chunk_get_next_ncnnl(next);
 
       if (next == nullptr)
       {
@@ -1997,14 +1997,14 @@ void mark_function(chunk_t *pc)
    }
    // Mark parameters and return type
    fix_fcn_def_params(next);
-   mark_function_return_type(pc, chunk_get_prev_ncnlni(pc), pc->type);   // Issue #2279
+   mark_function_return_type(pc, chunk_get_prev_ncnnlni(pc), pc->type);   // Issue #2279
 
    /* mark C# where chunk */
    if (  language_is_set(LANG_CS)
       && (  (chunk_is_token(pc, CT_FUNC_DEF))
          || (chunk_is_token(pc, CT_FUNC_PROTO))))
    {
-      tmp = chunk_get_next_ncnl(paren_close);
+      tmp = chunk_get_next_ncnnl(paren_close);
       pcf_flags_t in_where_spec_flags = PCF_NONE;
 
       while (  tmp != nullptr
@@ -2014,14 +2014,14 @@ void mark_function(chunk_t *pc)
          mark_where_chunk(tmp, pc->type, tmp->flags | in_where_spec_flags);
          in_where_spec_flags = tmp->flags & PCF_IN_WHERE_SPEC;
 
-         tmp = chunk_get_next_ncnl(tmp);
+         tmp = chunk_get_next_ncnnl(tmp);
       }
    }
 
    // Find the brace pair and set the parent
    if (chunk_is_token(pc, CT_FUNC_DEF))
    {
-      tmp = chunk_get_next_ncnl(paren_close);
+      tmp = chunk_get_next_ncnnl(paren_close);
 
       while (  tmp != nullptr
             && chunk_is_not_token(tmp, CT_BRACE_OPEN))
@@ -2034,7 +2034,7 @@ void mark_function(chunk_t *pc)
          {
             chunk_flags_set(tmp, PCF_OLD_FCN_PARAMS);
          }
-         tmp = chunk_get_next_ncnl(tmp);
+         tmp = chunk_get_next_ncnnl(tmp);
       }
 
       if (chunk_is_token(tmp, CT_BRACE_OPEN))
@@ -2073,7 +2073,7 @@ bool mark_function_type(chunk_t *pc)
    c_token_t pt, ptp;
 
    // Scan backwards across the name, which can only be a word and single star
-   chunk_t *varcnk = chunk_get_prev_ncnlni(pc);   // Issue #2279
+   chunk_t *varcnk = chunk_get_prev_ncnnlni(pc);   // Issue #2279
 
    varcnk = chunk_get_prev_ssq(varcnk);
 
@@ -2082,7 +2082,7 @@ bool mark_function_type(chunk_t *pc)
    {
       if (  language_is_set(LANG_OC)
          && chunk_is_str(varcnk, "^", 1)
-         && chunk_is_paren_open(chunk_get_prev_ncnlni(varcnk)))   // Issue #2279
+         && chunk_is_paren_open(chunk_get_prev_ncnnlni(varcnk)))   // Issue #2279
       {
          // anonymous ObjC block type -- RTYPE (^)(ARGS)
          anon = true;
@@ -2095,7 +2095,7 @@ bool mark_function_type(chunk_t *pc)
          goto nogo_exit;
       }
    }
-   apo = chunk_get_next_ncnl(pc);
+   apo = chunk_get_next_ncnnl(pc);
 
    if (apo == nullptr)
    {
@@ -2110,7 +2110,7 @@ bool mark_function_type(chunk_t *pc)
       LOG_FMT(LFTYPE, "%s(%d): not followed by parens\n", __func__, __LINE__);
       goto nogo_exit;
    }
-   aft = chunk_get_next_ncnl(apc);
+   aft = chunk_get_next_ncnnl(apc);
 
    if (chunk_is_token(aft, CT_BRACE_OPEN))
    {
@@ -2130,7 +2130,7 @@ bool mark_function_type(chunk_t *pc)
 
    tmp = pc;
 
-   while ((tmp = chunk_get_prev_ncnlni(tmp)) != nullptr)   // Issue #2279
+   while ((tmp = chunk_get_prev_ncnnlni(tmp)) != nullptr)   // Issue #2279
    {
       tmp = chunk_get_prev_ssq(tmp);
 
@@ -2187,7 +2187,7 @@ bool mark_function_type(chunk_t *pc)
    }
 
    // make sure what appears before the first open paren can be a return type
-   if (!chunk_ends_type(chunk_get_prev_ncnlni(tmp)))   // Issue #2279
+   if (!chunk_ends_type(chunk_get_prev_ncnnlni(tmp)))   // Issue #2279
    {
       goto nogo_exit;
    }
@@ -2229,7 +2229,7 @@ bool mark_function_type(chunk_t *pc)
    // Step backwards to the previous open paren and mark everything a
    tmp = pc;
 
-   while ((tmp = chunk_get_prev_ncnlni(tmp)) != nullptr)   // Issue #2279
+   while ((tmp = chunk_get_prev_ncnnlni(tmp)) != nullptr)   // Issue #2279
    {
       LOG_FMT(LFTYPE, " ++ type is %s, text() '%s', on orig_line %zu, orig_col %zu\n",
               get_token_name(tmp->type), tmp->text(),
@@ -2244,7 +2244,7 @@ bool mark_function_type(chunk_t *pc)
          set_chunk_type(tmp, CT_TPAREN_OPEN);
          set_chunk_parent(tmp, ptp);
 
-         tmp = chunk_get_prev_ncnlni(tmp);   // Issue #2279
+         tmp = chunk_get_prev_ncnnlni(tmp);   // Issue #2279
 
          if (  chunk_is_token(tmp, CT_FUNCTION)
             || chunk_is_token(tmp, CT_FUNC_CALL)
@@ -2262,7 +2262,7 @@ bool mark_function_type(chunk_t *pc)
    return(true);
 
 nogo_exit:
-   tmp = chunk_get_next_ncnl(pc);
+   tmp = chunk_get_next_ncnnl(pc);
 
    if (chunk_is_paren_open(tmp))
    {
@@ -2284,9 +2284,9 @@ void mark_lvalue(chunk_t *pc)
       return;
    }
 
-   for (prev = chunk_get_prev_ncnlni(pc);     // Issue #2279
+   for (prev = chunk_get_prev_ncnnlni(pc);     // Issue #2279
         prev != nullptr;
-        prev = chunk_get_prev_ncnlni(prev))   // Issue #2279
+        prev = chunk_get_prev_ncnnlni(prev))   // Issue #2279
    {
       if (  prev->level < pc->level
          || chunk_is_token(prev, CT_ACCESS_COLON)
@@ -2329,7 +2329,7 @@ void mark_struct_union_body(chunk_t *start)
          || chunk_is_token(pc, CT_BRACE_CLOSE)
          || chunk_is_token(pc, CT_SEMICOLON))
       {
-         pc = chunk_get_next_ncnl(pc);
+         pc = chunk_get_next_ncnnl(pc);
 
          if (pc == nullptr)
          {
@@ -2365,7 +2365,7 @@ void mark_template_func(chunk_t *pc, chunk_t *pc_next)
 
    // We know angle_close must be there...
    chunk_t *angle_close = chunk_get_next_type(pc_next, CT_ANGLE_CLOSE, pc->level);
-   chunk_t *after       = chunk_get_next_ncnl(angle_close);
+   chunk_t *after       = chunk_get_next_ncnnl(angle_close);
 
    if (after != nullptr)
    {
@@ -2471,7 +2471,7 @@ chunk_t *mark_variable_definition(chunk_t *start)
       {
          bit_field_colon_is_present = true;                    // Issue #2689
       }
-      pc = chunk_get_next_ncnl(pc);
+      pc = chunk_get_next_ncnnl(pc);
    }
    return(pc);
 } // mark_variable_definition

--- a/src/combine_labels.cpp
+++ b/src/combine_labels.cpp
@@ -168,7 +168,7 @@ void combine_labels(void)
          {
             hit_case = false;
             set_chunk_type(next, CT_CASE_COLON);
-            chunk_t *tmp = chunk_get_next_ncnlnp(next);                // Issue #2150
+            chunk_t *tmp = chunk_get_next_ncnnlnp(next);                // Issue #2150
 
             if (chunk_is_token(tmp, CT_BRACE_OPEN))
             {
@@ -184,7 +184,7 @@ void combine_labels(void)
             if (  chunk_is_token(cur, CT_NUMBER)
                && chunk_is_token(prev, CT_ELLIPSIS))
             {
-               chunk_t *pre_elipsis = chunk_get_prev_ncnlnp(prev);
+               chunk_t *pre_elipsis = chunk_get_prev_ncnnlnp(prev);
 
                if (chunk_is_token(pre_elipsis, CT_NUMBER))
                {
@@ -295,7 +295,7 @@ void combine_labels(void)
 
                      if (chunk_is_token(labelPrev, CT_NEWLINE))
                      {
-                        labelPrev = chunk_get_prev_ncnlni(prev);   // Issue #2279
+                        labelPrev = chunk_get_prev_ncnnlni(prev);   // Issue #2279
                      }
 
                      if (  labelPrev != nullptr
@@ -396,7 +396,7 @@ void combine_labels(void)
             }
             else
             {
-               chunk_t *tmp = chunk_get_next_ncnl(next);
+               chunk_t *tmp = chunk_get_next_ncnnl(next);
 
                //tmp = chunk_get_next_local(next);
                if (tmp != nullptr)

--- a/src/combine_skip.cpp
+++ b/src/combine_skip.cpp
@@ -17,16 +17,16 @@ chunk_t *skip_align(chunk_t *start)
 
    if (chunk_is_token(pc, CT_ALIGN))
    {
-      pc = chunk_get_next_ncnl(pc);
+      pc = chunk_get_next_ncnnl(pc);
 
       if (chunk_is_token(pc, CT_PAREN_OPEN))
       {
          pc = chunk_get_next_type(pc, CT_PAREN_CLOSE, pc->level);
-         pc = chunk_get_next_ncnl(pc);
+         pc = chunk_get_next_ncnnl(pc);
 
          if (chunk_is_token(pc, CT_COLON))
          {
-            pc = chunk_get_next_ncnl(pc);
+            pc = chunk_get_next_ncnnl(pc);
          }
       }
    }
@@ -36,13 +36,13 @@ chunk_t *skip_align(chunk_t *start)
 
 chunk_t *skip_expression(chunk_t *pc)
 {
-   return(chunk_get_next_ncnl(skip_to_expression_end(pc)));
+   return(chunk_get_next_ncnnl(skip_to_expression_end(pc)));
 }
 
 
 chunk_t *skip_expression_rev(chunk_t *pc)
 {
-   return(chunk_get_prev_ncnlni(skip_to_expression_start(pc)));
+   return(chunk_get_prev_ncnnlni(skip_to_expression_start(pc)));
 }
 
 
@@ -90,13 +90,13 @@ static chunk_t *skip_to_expression_edge(chunk_t *pc, chunk_t *(*chunk_get_next)(
 
 chunk_t *skip_to_expression_end(chunk_t *pc)
 {
-   return(skip_to_expression_edge(pc, chunk_get_next_ncnl));
+   return(skip_to_expression_edge(pc, chunk_get_next_ncnnl));
 }
 
 
 chunk_t *skip_to_expression_start(chunk_t *pc)
 {
-   return(skip_to_expression_edge(pc, chunk_get_prev_ncnlni));
+   return(skip_to_expression_edge(pc, chunk_get_prev_ncnnlni));
 }
 
 
@@ -107,7 +107,7 @@ chunk_t *skip_to_next_statement(chunk_t *pc)
          && chunk_is_not_token(pc, CT_BRACE_OPEN)
          && chunk_is_not_token(pc, CT_BRACE_CLOSE))
    {
-      pc = chunk_get_next_ncnl(pc);
+      pc = chunk_get_next_ncnnl(pc);
    }
    return(pc);
 }
@@ -115,14 +115,14 @@ chunk_t *skip_to_next_statement(chunk_t *pc)
 
 chunk_t *skip_parent_types(chunk_t *colon)
 {
-   auto pc = chunk_get_next_ncnlnp(colon);
+   auto pc = chunk_get_next_ncnnlnp(colon);
 
    while (pc)
    {
       // Skip access specifier
       if (chunk_is_token(pc, CT_ACCESS))
       {
-         pc = chunk_get_next_ncnlnp(pc);
+         pc = chunk_get_next_ncnnlnp(pc);
          continue;
       }
 
@@ -138,12 +138,12 @@ chunk_t *skip_parent_types(chunk_t *colon)
          return(colon);
       }
       // Get next token
-      auto next = skip_template_next(chunk_get_next_ncnlnp(pc));
+      auto next = skip_template_next(chunk_get_next_ncnnlnp(pc));
 
       if (  chunk_is_token(next, CT_DC_MEMBER)
          || chunk_is_token(next, CT_COMMA))
       {
-         pc = chunk_get_next_ncnlnp(next);
+         pc = chunk_get_next_ncnnlnp(next);
       }
       else if (next)
       {
@@ -167,7 +167,7 @@ chunk_t *skip_template_prev(chunk_t *ang_close)
    if (chunk_is_token(ang_close, CT_ANGLE_CLOSE))
    {
       chunk_t *pc = chunk_get_prev_type(ang_close, CT_ANGLE_OPEN, ang_close->level);
-      return(chunk_get_prev_ncnlni(pc));   // Issue #2279
+      return(chunk_get_prev_ncnnlni(pc));   // Issue #2279
    }
    return(ang_close);
 }
@@ -190,7 +190,7 @@ chunk_t *skip_attribute(chunk_t *attr)
 
    while (chunk_is_token(pc, CT_ATTRIBUTE))
    {
-      pc = chunk_get_next_ncnl(pc);
+      pc = chunk_get_next_ncnnl(pc);
 
       if (chunk_is_token(pc, CT_FPAREN_OPEN))
       {
@@ -208,7 +208,7 @@ chunk_t *skip_attribute_next(chunk_t *attr)
    if (  next != attr
       && chunk_is_token(next, CT_FPAREN_CLOSE))
    {
-      attr = chunk_get_next_ncnl(next);
+      attr = chunk_get_next_ncnnl(next);
    }
    return(attr);
 }
@@ -229,7 +229,7 @@ chunk_t *skip_attribute_prev(chunk_t *fp_close)
       {
          break;
       }
-      pc = chunk_get_prev_ncnlni(pc);   // Issue #2279
+      pc = chunk_get_prev_ncnnlni(pc);   // Issue #2279
    }
    return(pc);
 }
@@ -239,7 +239,7 @@ chunk_t *skip_declspec(chunk_t *pc)
 {
    if (chunk_is_token(pc, CT_DECLSPEC))
    {
-      pc = chunk_get_next_ncnl(pc);
+      pc = chunk_get_next_ncnnl(pc);
 
       if (chunk_is_token(pc, CT_PAREN_OPEN))
       {
@@ -257,7 +257,7 @@ chunk_t *skip_declspec_next(chunk_t *pc)
    if (  next != pc
       && chunk_is_token(next, CT_PAREN_CLOSE))
    {
-      pc = chunk_get_next_ncnl(next);
+      pc = chunk_get_next_ncnnl(next);
    }
    return(pc);
 }
@@ -269,11 +269,11 @@ chunk_t *skip_declspec_prev(chunk_t *pc)
       && get_chunk_parent_type(pc) == CT_DECLSPEC)
    {
       pc = chunk_skip_to_match_rev(pc);
-      pc = chunk_get_prev_ncnlni(pc);
+      pc = chunk_get_prev_ncnnlni(pc);
 
       if (chunk_is_token(pc, CT_DECLSPEC))
       {
-         pc = chunk_get_prev_ncnlni(pc);
+         pc = chunk_get_prev_ncnnlni(pc);
       }
    }
    return(pc);
@@ -295,7 +295,7 @@ chunk_t *skip_matching_brace_bracket_paren_next(chunk_t *pc)
           * retrieve the subsequent chunk
           */
 
-         pc = chunk_get_next_ncnl(pc);
+         pc = chunk_get_next_ncnnl(pc);
       }
    }
    return(pc);
@@ -317,7 +317,7 @@ chunk_t *skip_to_chunk_before_matching_brace_bracket_paren_rev(chunk_t *pc)
           * retrieve the preceding chunk
           */
 
-         pc = chunk_get_prev_ncnlni(pc);
+         pc = chunk_get_prev_ncnnlni(pc);
       }
    }
    return(pc);

--- a/src/combine_tools.cpp
+++ b/src/combine_tools.cpp
@@ -30,7 +30,7 @@ bool can_be_full_param(chunk_t *start, chunk_t *end)
 
    for (pc = start;
         pc != nullptr && pc != end;
-        pc = chunk_get_next_ncnl(pc, scope_e::PREPROC))
+        pc = chunk_get_next_ncnnl(pc, scope_e::PREPROC))
    {
       LOG_FMT(LFPARAM, "%s(%d): pc->text() is '%s', type is %s\n",
               __func__, __LINE__, pc->text(), get_token_name(pc->type));
@@ -104,7 +104,7 @@ bool can_be_full_param(chunk_t *start, chunk_t *end)
          {
             return(false);
          }
-         chunk_t *tmp2 = chunk_get_next_ncnl(tmp1, scope_e::PREPROC);
+         chunk_t *tmp2 = chunk_get_next_ncnnl(tmp1, scope_e::PREPROC);
 
          if (tmp2 == nullptr)
          {
@@ -116,7 +116,7 @@ bool can_be_full_param(chunk_t *start, chunk_t *end)
          {
             do
             {
-               pc = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+               pc = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
 
                if (pc == nullptr)
                {
@@ -143,19 +143,19 @@ bool can_be_full_param(chunk_t *start, chunk_t *end)
       {
          // Check for func proto param 'void (*name)' or 'void (*name)(params)' or 'void (^name)(params)'
          // <name> can be optional
-         chunk_t *tmp1 = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+         chunk_t *tmp1 = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
 
          if (tmp1 == nullptr)
          {
             return(false);
          }
-         chunk_t *tmp2 = chunk_get_next_ncnl(tmp1, scope_e::PREPROC);
+         chunk_t *tmp2 = chunk_get_next_ncnnl(tmp1, scope_e::PREPROC);
 
          if (tmp2 == nullptr)
          {
             return(false);
          }
-         chunk_t *tmp3 = (chunk_is_str(tmp2, ")", 1)) ? tmp2 : chunk_get_next_ncnl(tmp2, scope_e::PREPROC);
+         chunk_t *tmp3 = (chunk_is_str(tmp2, ")", 1)) ? tmp2 : chunk_get_next_ncnnl(tmp2, scope_e::PREPROC);
 
          if (tmp3 == nullptr)
          {
@@ -174,7 +174,7 @@ bool can_be_full_param(chunk_t *start, chunk_t *end)
          }
          LOG_FMT(LFPARAM, "%s(%d): <skip fcn type>\n",
                  __func__, __LINE__);
-         tmp1 = chunk_get_next_ncnl(tmp3, scope_e::PREPROC);
+         tmp1 = chunk_get_next_ncnnl(tmp3, scope_e::PREPROC);
 
          if (tmp1 == nullptr)
          {
@@ -229,7 +229,7 @@ bool can_be_full_param(chunk_t *start, chunk_t *end)
               __func__, __LINE__, pc->text(), get_token_name(pc->type));
    }
 
-   chunk_t *last = chunk_get_prev_ncnlni(pc);   // Issue #2279
+   chunk_t *last = chunk_get_prev_ncnnlni(pc);   // Issue #2279
 
    LOG_FMT(LFPARAM, "%s(%d): last->text() is '%s', type is %s\n",
            __func__, __LINE__, last->text(), get_token_name(last->type));
@@ -294,7 +294,7 @@ bool can_be_full_param(chunk_t *start, chunk_t *end)
       {
          set_chunk_type(first_word, CT_TYPE);
       }
-      chunk_t *tmp = chunk_get_prev_ncnl(first_word);
+      chunk_t *tmp = chunk_get_prev_ncnnl(first_word);
 
       if (chunk_is_token(tmp, CT_STAR))
       {
@@ -325,7 +325,7 @@ bool chunk_ends_type(chunk_t *start)
       return(false);
    }
 
-   for ( ; pc != nullptr; pc = chunk_get_prev_ncnlni(pc)) // Issue #2279
+   for ( ; pc != nullptr; pc = chunk_get_prev_ncnnlni(pc)) // Issue #2279
    {
       LOG_FMT(LFTYPE, "%s(%d): type is %s, text() '%s', orig_line %zu, orig_col %zu\n   ",
               __func__, __LINE__, get_token_name(pc->type), pc->text(),
@@ -453,7 +453,7 @@ size_t get_cpp_template_angle_nest_level(chunk_t *pc)
       {
          ++nestLevel;
       }
-      pc = chunk_get_prev_ncnlni(pc);
+      pc = chunk_get_prev_ncnnlni(pc);
    }
    return(nestLevel <= 0 ? 0 : size_t(nestLevel));
 }
@@ -465,7 +465,7 @@ chunk_t *get_d_template_types(ChunkStack &cs, chunk_t *open_paren)
    chunk_t *tmp       = open_paren;
    bool    maybe_type = true;
 
-   while (  ((tmp = chunk_get_next_ncnl(tmp)) != nullptr)
+   while (  ((tmp = chunk_get_next_ncnnl(tmp)) != nullptr)
          && tmp->level > open_paren->level)
    {
       if (  chunk_is_token(tmp, CT_TYPE)
@@ -562,5 +562,5 @@ chunk_t *set_paren_parent(chunk_t *start, c_token_t parent)
       set_chunk_parent(end, parent);
    }
    LOG_FMT(LFLPAREN, "%s(%d):\n", __func__, __LINE__);
-   return(chunk_get_next_ncnl(end, scope_e::PREPROC));
+   return(chunk_get_next_ncnnl(end, scope_e::PREPROC));
 } // set_paren_parent

--- a/src/enum_cleanup.cpp
+++ b/src/enum_cleanup.cpp
@@ -39,7 +39,7 @@ void enum_cleanup(void)
       {
          LOG_FMT(LTOK, "%s(%d): orig_line is %zu, type is %s\n",
                  __func__, __LINE__, pc->orig_line, get_token_name(pc->type));
-         chunk_t *prev = chunk_get_prev_ncnlnp(pc);
+         chunk_t *prev = chunk_get_prev_ncnnlnp(pc);
 
          // test of (prev == nullptr) is not necessary
          if (chunk_is_token(prev, CT_COMMA))

--- a/src/flag_braced_init_list.cpp
+++ b/src/flag_braced_init_list.cpp
@@ -47,7 +47,7 @@ bool detect_cpp_braced_init_list(chunk_t *pc, chunk_t *next)
             || get_chunk_parent_type(pc) == CT_BRACED_INIT_LIST)))
    {
       log_pcf_flags(LFCNR, pc->flags);
-      auto brace_open = chunk_get_next_ncnl(pc);
+      auto brace_open = chunk_get_next_ncnnl(pc);
 
       if (  chunk_is_token(brace_open, CT_BRACE_OPEN)
          && (  get_chunk_parent_type(brace_open) == CT_NONE
@@ -70,13 +70,13 @@ bool detect_cpp_braced_init_list(chunk_t *pc, chunk_t *next)
 
 void flag_cpp_braced_init_list(chunk_t *pc, chunk_t *next)
 {
-   auto brace_open  = chunk_get_next_ncnl(pc);
+   auto brace_open  = chunk_get_next_ncnnl(pc);
    auto brace_close = chunk_skip_to_match(next);
 
    set_chunk_parent(brace_open, CT_BRACED_INIT_LIST);
    set_chunk_parent(brace_close, CT_BRACED_INIT_LIST);
 
-   auto *tmp = chunk_get_next_ncnl(brace_close);
+   auto *tmp = chunk_get_next_ncnnl(brace_close);
 
    if (tmp != nullptr)
    {

--- a/src/flag_decltype.cpp
+++ b/src/flag_decltype.cpp
@@ -14,7 +14,7 @@ bool flag_cpp_decltype(chunk_t *pc)
 
    if (chunk_is_token(pc, CT_DECLTYPE))
    {
-      auto paren_open = chunk_get_next_ncnl(pc);
+      auto paren_open = chunk_get_next_ncnnl(pc);
 
       if (chunk_is_token(paren_open, CT_PAREN_OPEN))
       {

--- a/src/flag_parens.cpp
+++ b/src/flag_parens.cpp
@@ -67,5 +67,5 @@ chunk_t *flag_parens(chunk_t *po, pcf_flags_t flags, c_token_t opentype, c_token
          set_chunk_parent(paren_close, parenttype);
       }
    }
-   return(chunk_get_next_ncnl(paren_close, scope_e::PREPROC));
+   return(chunk_get_next_ncnnl(paren_close, scope_e::PREPROC));
 } // flag_parens

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -456,7 +456,7 @@ static chunk_t *candidate_chunk_first_on_line(chunk_t *pc)
       && (  chunk_is_token(first, CT_QUESTION)
          || chunk_is_token(first, CT_COND_COLON)))
    {
-      return(chunk_get_next_ncnl(first));
+      return(chunk_get_next_ncnnl(first));
    }
    else
    {
@@ -700,7 +700,7 @@ void indent_text(void)
       {
          if (!in_func_def)
          {
-            chunk_t *next = chunk_get_next_ncnl(pc);
+            chunk_t *next = chunk_get_next_ncnnl(pc);
 
             if (  get_chunk_parent_type(pc) == CT_FUNC_DEF
                || (  chunk_is_token(pc, CT_COMMENT)
@@ -889,14 +889,14 @@ void indent_text(void)
                   && frm.top().pop_pc
                   && frm.top().pc != frmbkup.top().pc)
                {
-                  chunk_t *tmp = chunk_get_next_ncnlnp(pc);
+                  chunk_t *tmp = chunk_get_next_ncnnlnp(pc);
 
                   if (tmp != nullptr)
                   {
                      if (  chunk_is_token(tmp, CT_WORD)
                         || chunk_is_token(tmp, CT_TYPE))
                      {
-                        tmp = chunk_get_next_ncnlnp(pc);
+                        tmp = chunk_get_next_ncnnlnp(pc);
                      }
                      else if (  chunk_is_token(tmp, CT_FUNC_CALL)
                              || chunk_is_token(tmp, CT_FPAREN_OPEN))
@@ -905,7 +905,7 @@ void indent_text(void)
 
                         if (tmp != nullptr)
                         {
-                           tmp = chunk_get_next_ncnlnp(pc);
+                           tmp = chunk_get_next_ncnnlnp(pc);
                         }
                      }
 
@@ -1067,7 +1067,7 @@ void indent_text(void)
             if (  chunk_is_token(pc, CT_BRACE_CLOSE)
                && get_chunk_parent_type(pc) == CT_ENUM)
             {
-               chunk_t *prev_ncnl = chunk_get_prev_ncnl(pc);
+               chunk_t *prev_ncnl = chunk_get_prev_ncnnl(pc);
                LOG_FMT(LINDLINE, "%s(%d): prev_ncnl is '%s', prev_ncnl->orig_line is %zu, prev_ncnl->orig_col is %zu\n",
                        __func__, __LINE__, prev_ncnl->text(), prev_ncnl->orig_line, prev_ncnl->orig_col);
 
@@ -1650,7 +1650,7 @@ void indent_text(void)
             frm.top().brace_indent = frm.prev().indent;
 
             // Issue # 1620, UNI-24090.cs
-            if (are_chunks_in_same_line(frm.prev().pc, chunk_get_prev_ncnlnp(frm.top().pc)))
+            if (are_chunks_in_same_line(frm.prev().pc, chunk_get_prev_ncnnlnp(frm.top().pc)))
             {
                frm.top().brace_indent -= indent_size;
             }
@@ -1754,7 +1754,7 @@ void indent_text(void)
                   if (options::indent_oc_block_msg_xcode_style())
                   {
                      chunk_t *bbc           = chunk_skip_to_match(pc); // block brace close '}'
-                     chunk_t *bbc_next_ncnl = chunk_get_next_ncnl(bbc);
+                     chunk_t *bbc_next_ncnl = chunk_get_next_ncnnl(bbc);
 
                      if (  bbc_next_ncnl->type == CT_OC_MSG_NAME
                         || bbc_next_ncnl->type == CT_OC_MSG_FUNC)
@@ -1821,7 +1821,7 @@ void indent_text(void)
                frm.top().indent = frm.prev().indent_tmp;
                log_indent();
             }
-            else if (  are_chunks_in_same_line(frm.prev().pc, chunk_get_prev_ncnlnp(frm.top().pc))
+            else if (  are_chunks_in_same_line(frm.prev().pc, chunk_get_prev_ncnnlnp(frm.top().pc))
                     && !options::indent_align_paren()
                     && chunk_is_paren_open(frm.prev().pc)
                     && !pc->flags.test(PCF_ONE_LINER))
@@ -2024,7 +2024,7 @@ void indent_text(void)
              * { a++;
              *   b--; };
              */
-            chunk_t *next = chunk_get_next_ncnl(pc);
+            chunk_t *next = chunk_get_next_ncnnl(pc);
 
             if (next == nullptr)
             {
@@ -2141,7 +2141,7 @@ void indent_text(void)
       }
       else if (chunk_is_token(pc, CT_BREAK))
       {
-         chunk_t *prev = chunk_get_prev_ncnl(pc);
+         chunk_t *prev = chunk_get_prev_ncnnl(pc);
 
          if (  chunk_is_token(prev, CT_BRACE_CLOSE)
             && get_chunk_parent_type(prev) == CT_CASE)
@@ -2343,8 +2343,8 @@ void indent_text(void)
       }
       else if (  chunk_is_token(pc, CT_PAREN_OPEN)
               && (  get_chunk_parent_type(pc) == CT_ASM
-                 || (  chunk_get_prev_ncnl(pc) != nullptr
-                    && chunk_get_prev_ncnl(pc)->type == CT_ASM))
+                 || (  chunk_get_prev_ncnnl(pc) != nullptr
+                    && chunk_get_prev_ncnnl(pc)->type == CT_ASM))
               && options::indent_ignore_asm_block())
       {
          log_rule_B("indent_ignore_asm_block");
@@ -2740,7 +2740,7 @@ void indent_text(void)
          if (frm.top().type != CT_MEMBER)
          {
             frm.push(pc, __func__, __LINE__);
-            chunk_t *tmp = chunk_get_prev_ncnlnp(frm.top().pc);
+            chunk_t *tmp = chunk_get_prev_ncnnlnp(frm.top().pc);
 
             if (are_chunks_in_same_line(frm.prev().pc, tmp))
             {
@@ -2771,18 +2771,18 @@ void indent_text(void)
             }
          }
          //check for the series of CT_member chunks else pop it.
-         chunk_t *tmp = chunk_get_next_ncnlnp(pc);
+         chunk_t *tmp = chunk_get_next_ncnnlnp(pc);
 
          if (tmp != nullptr)
          {
             if (chunk_is_token(tmp, CT_FUNC_CALL))
             {
-               tmp = chunk_get_next_ncnlnp(chunk_get_next_type(tmp, CT_FPAREN_CLOSE, tmp->level));
+               tmp = chunk_get_next_ncnnlnp(chunk_get_next_type(tmp, CT_FPAREN_CLOSE, tmp->level));
             }
             else if (  chunk_is_token(tmp, CT_WORD)
                     || chunk_is_token(tmp, CT_TYPE))
             {
-               tmp = chunk_get_next_ncnlnp(tmp);
+               tmp = chunk_get_next_ncnnlnp(tmp);
             }
          }
 
@@ -2792,13 +2792,13 @@ void indent_text(void)
          {
             if (chunk_is_paren_close(tmp))
             {
-               tmp = chunk_get_prev_ncnlnp(tmp);
+               tmp = chunk_get_prev_ncnnlnp(tmp);
             }
 
             if (  tmp != nullptr
                && chunk_is_newline(tmp->prev))
             {
-               tmp = chunk_get_next_nl(chunk_get_prev_ncnlnp(tmp));
+               tmp = chunk_get_next_nl(chunk_get_prev_ncnnlnp(tmp));
             }
 
             if (tmp != nullptr)
@@ -3047,7 +3047,7 @@ void indent_text(void)
       }
       else if (  chunk_is_token(pc, CT_LAMBDA)
               && (language_is_set(LANG_CS | LANG_JAVA))
-              && chunk_get_next_ncnlnp(pc)->type != CT_BRACE_OPEN
+              && chunk_get_next_ncnnlnp(pc)->type != CT_BRACE_OPEN
               && options::indent_cs_delegate_body())
       {
          log_rule_B("indent_cs_delegate_body");
@@ -3056,7 +3056,7 @@ void indent_text(void)
          log_indent();
 
          if (  chunk_is_newline(chunk_get_prev_nc(pc))
-            && !are_chunks_in_same_line(frm.prev().pc, chunk_get_prev_ncnl(pc)))
+            && !are_chunks_in_same_line(frm.prev().pc, chunk_get_prev_ncnnl(pc)))
          {
             frm.top().indent = frm.prev().indent + indent_size;
             log_indent();
@@ -3075,7 +3075,7 @@ void indent_text(void)
       else if (  options::indent_oc_inside_msg_sel()
               && (  chunk_is_token(pc, CT_OC_MSG_FUNC)
                  || chunk_is_token(pc, CT_OC_MSG_NAME))
-              && chunk_is_token(chunk_get_next_ncnl(pc), CT_OC_COLON)) // Issue #2658
+              && chunk_is_token(chunk_get_next_ncnnl(pc), CT_OC_COLON)) // Issue #2658
       {
          log_rule_B("indent_oc_inside_msg_sel");
          // Pop the OC msg name that is on the top of the stack
@@ -3121,7 +3121,7 @@ void indent_text(void)
                LOG_FMT(LINDENT2, "%s(%d): in_shift set to TRUE\n",
                        __func__, __LINE__);
 
-               tmp = chunk_get_prev_ncnl(tmp);
+               tmp = chunk_get_prev_ncnnl(tmp);
 
                if (chunk_is_token(tmp, CT_OPERATOR))
                {
@@ -3129,7 +3129,7 @@ void indent_text(void)
                }
                break;
             }
-            tmp = chunk_get_prev_ncnl(tmp);
+            tmp = chunk_get_prev_ncnnl(tmp);
          } while (  !in_shift
                  && tmp != nullptr
                  && tmp->type != CT_SEMICOLON
@@ -3143,7 +3143,7 @@ void indent_text(void)
 
          do
          {
-            tmp = chunk_get_next_ncnl(tmp);
+            tmp = chunk_get_next_ncnnl(tmp);
 
             if (  tmp != nullptr
                && chunk_is_token(tmp, CT_SHIFT))
@@ -3152,7 +3152,7 @@ void indent_text(void)
                LOG_FMT(LINDENT2, "%s(%d): in_shift set to TRUE\n",
                        __func__, __LINE__);
 
-               tmp = chunk_get_prev_ncnl(tmp);
+               tmp = chunk_get_prev_ncnnl(tmp);
 
                if (chunk_is_token(tmp, CT_OPERATOR))
                {
@@ -3171,7 +3171,7 @@ void indent_text(void)
 
          LOG_FMT(LINDENT2, "%s(%d): in_shift is %s\n",
                  __func__, __LINE__, in_shift ? "TRUE" : "FALSE");
-         chunk_t *prev_nonl = chunk_get_prev_ncnl(pc);
+         chunk_t *prev_nonl = chunk_get_prev_ncnnl(pc);
          chunk_t *prev2     = chunk_get_prev_nc(pc);
 
          if ((  chunk_is_semicolon(prev_nonl)
@@ -3287,9 +3287,9 @@ void indent_text(void)
           * everything else
           */
 
-         auto prev  = chunk_get_prev_ncnl(pc);
-         auto prevv = chunk_get_prev_ncnl(prev);
-         auto next  = chunk_get_next_ncnl(pc);
+         auto prev  = chunk_get_prev_ncnnl(pc);
+         auto prevv = chunk_get_prev_ncnnl(prev);
+         auto next  = chunk_get_next_ncnnl(pc);
 
          bool do_vardefcol = false;
 
@@ -3304,7 +3304,7 @@ void indent_text(void)
 
             while (chunk_is_token(tmp, CT_PTR_TYPE))
             {
-               tmp = chunk_get_next_ncnl(tmp);
+               tmp = chunk_get_next_ncnnl(tmp);
             }
             LOG_FMT(LINDENT2, "%s(%d): orig_line is %zu, for '%s'",
                     __func__, __LINE__, tmp->orig_line, tmp->text());
@@ -3493,7 +3493,7 @@ void indent_text(void)
                            search = chunk_skip_to_match_rev(search);
 
                            if (  options::indent_oc_inside_msg_sel()
-                              && chunk_is_token(chunk_get_prev_ncnl(search), CT_OC_COLON)
+                              && chunk_is_token(chunk_get_prev_ncnnl(search), CT_OC_COLON)
                               && (  frm.top().type == CT_OC_MSG_FUNC
                                  || frm.top().type == CT_OC_MSG_NAME)) // Issue #2658
                            {
@@ -3651,7 +3651,7 @@ void indent_text(void)
 
             if (tmp != nullptr)
             {
-               tmp = chunk_get_next_ncnl(tmp);
+               tmp = chunk_get_next_ncnnl(tmp);
 
                if (tmp != nullptr)
                {
@@ -4255,7 +4255,7 @@ void indent_preproc(void)
       {
          continue;
       }
-      chunk_t *next = chunk_get_next_ncnl(pc);
+      chunk_t *next = chunk_get_next_ncnnl(pc);
 
       if (next == nullptr)
       {

--- a/src/lang_pawn.cpp
+++ b/src/lang_pawn.cpp
@@ -110,7 +110,7 @@ void pawn_scrub_vsemi(void)
       {
          continue;
       }
-      chunk_t *prev = chunk_get_prev_ncnl(pc);
+      chunk_t *prev = chunk_get_prev_ncnnl(pc);
 
       if (chunk_is_token(prev, CT_BRACE_CLOSE))
       {
@@ -384,7 +384,7 @@ static chunk_t *pawn_process_func_def(chunk_t *pc)
     * we need to add virtual braces around the function body.
     */
    chunk_t *clp  = chunk_get_next_str(pc, ")", 1, 0);
-   chunk_t *last = chunk_get_next_ncnl(clp);
+   chunk_t *last = chunk_get_next_ncnnl(clp);
 
    if (last != nullptr)
    {
@@ -415,7 +415,7 @@ static chunk_t *pawn_process_func_def(chunk_t *pc)
          set_chunk_type(last, CT_ANGLE_CLOSE);
          set_chunk_parent(last, CT_FUNC_DEF);
       }
-      last = chunk_get_next_ncnl(last);
+      last = chunk_get_next_ncnnl(last);
    }
 
    if (last == nullptr)
@@ -452,7 +452,7 @@ static chunk_t *pawn_process_func_def(chunk_t *pc)
       last = prev;
 
       // find the next newline at level 0
-      prev = chunk_get_next_ncnl(prev);
+      prev = chunk_get_next_ncnnl(prev);
 
       do
       {
@@ -462,7 +462,7 @@ static chunk_t *pawn_process_func_def(chunk_t *pc)
          if (  chunk_is_token(prev, CT_NEWLINE)
             && prev->level == 0)
          {
-            chunk_t *next = chunk_get_next_ncnl(prev);
+            chunk_t *next = chunk_get_next_ncnnl(prev);
 
             if (  next != nullptr
                && next->type != CT_ELSE
@@ -510,7 +510,7 @@ chunk_t *pawn_check_vsemicolon(chunk_t *pc)
     *  - it is something that needs a continuation
     *    + arith, assign, bool, comma, compare
     */
-   chunk_t *prev = chunk_get_prev_ncnl(pc);
+   chunk_t *prev = chunk_get_prev_ncnnl(pc);
 
    if (  prev == nullptr
       || prev == vb_open

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -763,7 +763,7 @@ chunk_t *newline_add_between(chunk_t *start, chunk_t *end)
          if (chunk_is_newline(pc))
          {
             // are there some more (comment + newline)s ?
-            chunk_t *pc1 = chunk_get_next_ncnl(end);
+            chunk_t *pc1 = chunk_get_next_ncnnl(end);
 
             if (!chunk_is_newline(pc1))
             {
@@ -914,7 +914,7 @@ void newlines_sparens()
       else
       {
          // add/remove trailing newline in an if condition
-         chunk_t *ctrl_structure = chunk_get_prev_ncnl(sparen_open);
+         chunk_t *ctrl_structure = chunk_get_prev_ncnnl(sparen_open);
 
          if (  chunk_is_token(ctrl_structure, CT_IF)
             || chunk_is_token(ctrl_structure, CT_ELSEIF))
@@ -940,12 +940,12 @@ static bool newlines_if_for_while_switch(chunk_t *start, iarf_e nl_opt)
       return(false);
    }
    bool    retval = false;
-   chunk_t *pc    = chunk_get_next_ncnl(start);
+   chunk_t *pc    = chunk_get_next_ncnnl(start);
 
    if (chunk_is_token(pc, CT_SPAREN_OPEN))
    {
       chunk_t *close_paren = chunk_get_next_type(pc, CT_SPAREN_CLOSE, pc->level);
-      chunk_t *brace_open  = chunk_get_next_ncnl(close_paren);
+      chunk_t *brace_open  = chunk_get_next_ncnnl(close_paren);
 
       if (  (  chunk_is_token(brace_open, CT_BRACE_OPEN)
             || chunk_is_token(brace_open, CT_VBRACE_OPEN))
@@ -970,7 +970,7 @@ static bool newlines_if_for_while_switch(chunk_t *start, iarf_e nl_opt)
             // Can only add - we don't want to create a one-line here
             if (nl_opt & IARF_ADD)
             {
-               newline_iarf_pair(close_paren, chunk_get_next_ncnl(brace_open), nl_opt);
+               newline_iarf_pair(close_paren, chunk_get_next_ncnnl(brace_open), nl_opt);
                pc = chunk_get_next_type(brace_open, CT_VBRACE_CLOSE, brace_open->level);
 
                if (  !chunk_is_newline(chunk_get_prev_nc(pc))
@@ -984,11 +984,11 @@ static bool newlines_if_for_while_switch(chunk_t *start, iarf_e nl_opt)
          else
          {
             newline_iarf_pair(close_paren, brace_open, nl_opt);
-            chunk_t *next = chunk_get_next_ncnl(brace_open);
+            chunk_t *next = chunk_get_next_ncnnl(brace_open);
 
             if (brace_open->type != next->type)                       // Issue #2836
             {
-               newline_add_between(brace_open, chunk_get_next_ncnl(brace_open));
+               newline_add_between(brace_open, chunk_get_next_ncnnl(brace_open));
             }
             // Make sure nothing is cuddled with the closing brace
             pc = chunk_get_next_type(brace_open, CT_BRACE_CLOSE, brace_open->level);
@@ -1451,7 +1451,7 @@ static void newlines_if_for_while_switch_post_blank_lines(chunk_t *start, iarf_e
    {
       while (true)
       {
-         next = chunk_get_next_ncnl(pc);
+         next = chunk_get_next_ncnnl(pc);
 
          if (  next != nullptr
             && (  chunk_is_token(next, CT_ELSE)
@@ -1675,7 +1675,7 @@ static void newlines_struct_union(chunk_t *start, iarf_e nl_opt, bool leave_trai
 
    pc = start;
 
-   while (  ((pc = chunk_get_next_ncnl(pc)) != nullptr)
+   while (  ((pc = chunk_get_next_ncnnl(pc)) != nullptr)
          && pc->level >= level)
    {
       if (  pc->level == level
@@ -1737,35 +1737,35 @@ static void newlines_enum(chunk_t *start)
       return;
    }
    // look for 'enum class'
-   pcClass = chunk_get_next_ncnl(start);
+   pcClass = chunk_get_next_ncnnl(start);
 
    if (chunk_is_token(pcClass, CT_ENUM_CLASS))
    {
       log_rule_B("nl_enum_class");
       newline_iarf_pair(start, pcClass, options::nl_enum_class());
       // look for 'identifier'/ 'type'
-      pcType = chunk_get_next_ncnl(pcClass);
+      pcType = chunk_get_next_ncnnl(pcClass);
 
       if (chunk_is_token(pcType, CT_TYPE))
       {
          log_rule_B("nl_enum_class_identifier");
          newline_iarf_pair(pcClass, pcType, options::nl_enum_class_identifier());
          // look for ':'
-         pcColon = chunk_get_next_ncnl(pcType);
+         pcColon = chunk_get_next_ncnnl(pcType);
 
          if (chunk_is_token(pcColon, CT_BIT_COLON))
          {
             log_rule_B("nl_enum_identifier_colon");
             newline_iarf_pair(pcType, pcColon, options::nl_enum_identifier_colon());
             // look for 'type' i.e. unsigned
-            pcType1 = chunk_get_next_ncnl(pcColon);
+            pcType1 = chunk_get_next_ncnnl(pcColon);
 
             if (chunk_is_token(pcType1, CT_TYPE))
             {
                log_rule_B("nl_enum_colon_type");
                newline_iarf_pair(pcColon, pcType1, options::nl_enum_colon_type());
                // look for 'type' i.e. int
-               pcType2 = chunk_get_next_ncnl(pcType1);
+               pcType2 = chunk_get_next_ncnnl(pcType1);
 
                if (chunk_is_token(pcType2, CT_TYPE))
                {
@@ -1784,7 +1784,7 @@ static void newlines_enum(chunk_t *start)
 
    pc = start;
 
-   while (  ((pc = chunk_get_next_ncnl(pc)) != nullptr)
+   while (  ((pc = chunk_get_next_ncnnl(pc)) != nullptr)
          && pc->level >= level)
    {
       if (  pc->level == level
@@ -1876,7 +1876,7 @@ static void newlines_cuddle_uncuddle(chunk_t *start, iarf_e nl_opt)
    {
       return;
    }
-   br_close = chunk_get_prev_ncnlni(start);   // Issue #2279
+   br_close = chunk_get_prev_ncnnlni(start);   // Issue #2279
 
    if (chunk_is_token(br_close, CT_BRACE_CLOSE))
    {
@@ -1898,7 +1898,7 @@ static void newlines_do_else(chunk_t *start, iarf_e nl_opt)
    {
       return;
    }
-   next = chunk_get_next_ncnl(start);
+   next = chunk_get_next_ncnnl(start);
 
    if (  next != nullptr
       && (  chunk_is_token(next, CT_BRACE_OPEN)
@@ -1916,7 +1916,7 @@ static void newlines_do_else(chunk_t *start, iarf_e nl_opt)
          // Can only add - we don't want to create a one-line here
          if (nl_opt & IARF_ADD)
          {
-            newline_iarf_pair(start, chunk_get_next_ncnl(next), nl_opt);
+            newline_iarf_pair(start, chunk_get_next_ncnnl(next), nl_opt);
             chunk_t *tmp = chunk_get_next_type(next, CT_VBRACE_CLOSE, next->level);
 
             if (  !chunk_is_newline(chunk_get_next_nc(tmp))
@@ -1930,7 +1930,7 @@ static void newlines_do_else(chunk_t *start, iarf_e nl_opt)
       {
          newline_iarf_pair(start, next, nl_opt);
 
-         newline_add_between(next, chunk_get_next_ncnl(next));
+         newline_add_between(next, chunk_get_next_ncnnl(next));
       }
    }
 } // newlines_do_else
@@ -1943,7 +1943,7 @@ static bool is_var_def(chunk_t *pc, chunk_t *next)
    {
       // If current token starts a decltype expression, skip it
       next = chunk_skip_to_match(next);
-      next = chunk_get_next_ncnl(next);
+      next = chunk_get_next_ncnnl(next);
    }
    else if (!chunk_is_type(pc))
    {
@@ -1959,7 +1959,7 @@ static bool is_var_def(chunk_t *pc, chunk_t *next)
    {
       // If we have a template type, skip it
       next = chunk_skip_to_match(next);
-      next = chunk_get_next_ncnl(next);
+      next = chunk_get_next_ncnnl(next);
    }
    bool is = (  (  chunk_is_type(next)
                 && get_chunk_parent_type(next) != CT_FUNC_DEF)           // Issue #2639
@@ -1978,13 +1978,13 @@ static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
    bool    first_var_blk = true;
    bool    var_blk       = false;
 
-   chunk_t *prev = chunk_get_prev_ncnlni(start);   // Issue #2279
+   chunk_t *prev = chunk_get_prev_ncnnlni(start);   // Issue #2279
 
    // can't be any variable definitions in a "= {" block
    if (chunk_is_token(prev, CT_ASSIGN))
    {
       chunk_t *tmp = chunk_get_next_type(start, CT_BRACE_CLOSE, start->level);
-      return(chunk_get_next_ncnl(tmp));
+      return(chunk_get_next_ncnnl(tmp));
    }
    chunk_t *pc = chunk_get_next(start);
 
@@ -2061,12 +2061,12 @@ static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
          && (  (pc->level == (start->level + 1))
             || pc->level == 0))
       {
-         chunk_t *next = chunk_get_next_ncnl(pc);
+         chunk_t *next = chunk_get_next_ncnnl(pc);
 
          if (  chunk_is_token(next, CT_PTR_TYPE) // Issue #2692
             || chunk_is_token(next, CT_BYREF))   // Issue #3018
          {
-            next = chunk_get_next_ncnl(next);
+            next = chunk_get_next_ncnnl(next);
          }
 
          if (next == nullptr)
@@ -2086,7 +2086,7 @@ static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
             && get_chunk_parent_type(prev) == CT_EXTERN
             && chunk_is_token(prev->prev, CT_EXTERN))
          {
-            prev = chunk_get_prev_ncnlni(prev->prev);   // Issue #2279
+            prev = chunk_get_prev_ncnnlni(prev->prev);   // Issue #2279
          }
 
          if (is_var_def(pc, next))
@@ -2251,11 +2251,11 @@ static void newlines_brace_pair(chunk_t *br_open)
       && !br_open->flags.test(PCF_NOT_POSSIBLE))          // Issue #2795
    {
       chunk_t *br_close = chunk_skip_to_match(br_open, scope_e::ALL);
-      chunk_t *tmp      = chunk_get_prev_ncnlni(br_open); // Issue #2279
+      chunk_t *tmp      = chunk_get_prev_ncnnlni(br_open); // Issue #2279
 
-      if (  br_close != nullptr                           // Issue #2594
+      if (  br_close != nullptr                            // Issue #2594
          && ((br_close->orig_line - br_open->orig_line) <= 2)
-         && chunk_is_paren_close(tmp))                    // need to check the conditions.
+         && chunk_is_paren_close(tmp))                     // need to check the conditions.
       {
          // Issue #1825
          bool is_it_possible = true;
@@ -2286,7 +2286,7 @@ static void newlines_brace_pair(chunk_t *br_open)
             if (options::code_width() > 0)
             {
                saved_chunk.reserve(16);
-               chunk_t *current       = chunk_get_prev_ncnlni(br_open);
+               chunk_t *current       = chunk_get_prev_ncnnlni(br_open);
                chunk_t *next_br_close = chunk_get_next(br_close);
                current = chunk_get_next(current);
 
@@ -2305,7 +2305,7 @@ static void newlines_brace_pair(chunk_t *br_open)
                   current = the_next;
                }
             }
-            tmp = chunk_get_prev_ncnlni(br_open);
+            tmp = chunk_get_prev_ncnnlni(br_open);
 
             while (  tmp != nullptr
                   && (tmp = chunk_get_next(tmp)) != nullptr
@@ -2318,7 +2318,7 @@ static void newlines_brace_pair(chunk_t *br_open)
                if (chunk_is_newline(tmp))
                {
                   tmp = chunk_get_prev(tmp);                 // Issue #1825
-                  newline_iarf_pair(tmp, chunk_get_next_ncnl(tmp), IARF_REMOVE);
+                  newline_iarf_pair(tmp, chunk_get_next_ncnnl(tmp), IARF_REMOVE);
                }
             }
             chunk_flags_set(br_open, PCF_ONE_LINER);         // set the one liner flag if needed
@@ -2384,7 +2384,7 @@ static void newlines_brace_pair(chunk_t *br_open)
       // Only mess with it if the open brace is followed by a newline
       if (chunk_is_newline(next))
       {
-         chunk_t *prev = chunk_get_prev_ncnlni(br_open);   // Issue #2279
+         chunk_t *prev = chunk_get_prev_ncnnlni(br_open);   // Issue #2279
          log_rule_B("nl_assign_brace");
          newline_iarf_pair(prev, br_open, options::nl_assign_brace());
       }
@@ -2419,7 +2419,7 @@ static void newlines_brace_pair(chunk_t *br_open)
 
             if (nl_fdef_brace_cond_v != IARF_IGNORE)
             {
-               prev = chunk_get_prev_ncnlni(br_open);   // Issue #2279
+               prev = chunk_get_prev_ncnnlni(br_open);   // Issue #2279
 
                if (chunk_is_token(prev, CT_FPAREN_CLOSE))
                {
@@ -2451,7 +2451,7 @@ static void newlines_brace_pair(chunk_t *br_open)
          if (prev == nullptr)
          {
             // Grab the chunk before the open brace
-            prev = chunk_get_prev_ncnlni(br_open);   // Issue #2279
+            prev = chunk_get_prev_ncnnlni(br_open);   // Issue #2279
          }
          newline_iarf_pair(prev, br_open, val);
       }
@@ -2531,7 +2531,7 @@ static void newlines_brace_pair(chunk_t *br_open)
          nl_close_brace = true;
       }
       // handle newlines after the open brace
-      chunk_t *pc = chunk_get_next_ncnl(br_open);
+      chunk_t *pc = chunk_get_next_ncnnl(br_open);
       newline_add_between(br_open, pc);
 
       newline_def_blk(br_open, true);
@@ -2857,23 +2857,23 @@ static void newline_func_multi_line(chunk_t *start)
    {
       return;
    }
-   chunk_t *pc = chunk_get_next_ncnl(start);
+   chunk_t *pc = chunk_get_next_ncnnl(start);
 
    while (  pc != nullptr
          && pc->level > start->level)
    {
-      pc = chunk_get_next_ncnl(pc);
+      pc = chunk_get_next_ncnnl(pc);
    }
 
    if (  chunk_is_token(pc, CT_FPAREN_CLOSE)
       && chunk_is_newline_between(start, pc))
    {
-      chunk_t *start_next         = chunk_get_next_ncnl(start);
+      chunk_t *start_next         = chunk_get_next_ncnnl(start);
       bool    has_leading_closure = (  start_next->parent_type == CT_OC_BLOCK_EXPR
                                     || start_next->parent_type == CT_CPP_LAMBDA
                                     || chunk_is_token(start_next, CT_BRACE_OPEN));
 
-      chunk_t *prev_end            = chunk_get_prev_ncnl(pc);
+      chunk_t *prev_end            = chunk_get_prev_ncnnl(pc);
       bool    has_trailing_closure = (  prev_end->parent_type == CT_OC_BLOCK_EXPR
                                      || prev_end->parent_type == CT_CPP_LAMBDA
                                      || chunk_is_token(prev_end, CT_BRACE_OPEN));
@@ -2920,9 +2920,9 @@ static void newline_func_multi_line(chunk_t *start)
       {
          // process the function in reverse and leave the first comma if the option to leave trailing closure
          // is on. nl_func_call_args_multi_line_ignore_trailing_closure
-         for (pc = chunk_get_next_ncnl(start);
+         for (pc = chunk_get_next_ncnnl(start);
               pc != nullptr && pc->level > start->level;
-              pc = chunk_get_next_ncnl(pc))
+              pc = chunk_get_next_ncnnl(pc))
          {
             if (  chunk_is_token(pc, CT_COMMA)
                && (pc->level == (start->level + 1)))
@@ -2940,8 +2940,8 @@ static void newline_func_multi_line(chunk_t *start)
 
                   if (options::nl_func_call_args_multi_line_ignore_closures())
                   {
-                     chunk_t *prev_comma  = chunk_get_prev_ncnl(pc);
-                     chunk_t *after_comma = chunk_get_next_ncnl(pc);
+                     chunk_t *prev_comma  = chunk_get_prev_ncnnl(pc);
+                     chunk_t *after_comma = chunk_get_next_ncnnl(pc);
 
                      if (!(  (  prev_comma->parent_type == CT_OC_BLOCK_EXPR
                              || prev_comma->parent_type == CT_CPP_LAMBDA
@@ -2988,12 +2988,12 @@ static void newline_template(chunk_t *start)
    {
       return;
    }
-   chunk_t *pc = chunk_get_next_ncnl(start);
+   chunk_t *pc = chunk_get_next_ncnnl(start);
 
    while (  pc != nullptr
          && pc->level > start->level)
    {
-      pc = chunk_get_next_ncnl(pc);
+      pc = chunk_get_next_ncnnl(pc);
    }
 
    if (chunk_is_token(pc, CT_ANGLE_CLOSE))
@@ -3010,9 +3010,9 @@ static void newline_template(chunk_t *start)
 
       if (add_args)
       {
-         for (pc = chunk_get_next_ncnl(start);
+         for (pc = chunk_get_next_ncnnl(start);
               pc != nullptr && pc->level > start->level;
-              pc = chunk_get_next_ncnl(pc))
+              pc = chunk_get_next_ncnnl(pc))
          {
             if (  chunk_is_token(pc, CT_COMMA)
                && (pc->level == (start->level + 1)))
@@ -3059,14 +3059,14 @@ static void newline_func_def_or_call(chunk_t *start)
 
       if (atmp != IARF_IGNORE)
       {
-         prev = chunk_get_prev_ncnlni(start);   // Issue #2279
+         prev = chunk_get_prev_ncnnlni(start);   // Issue #2279
 
          if (prev != nullptr)
          {
             newline_iarf(prev, atmp);
          }
       }
-      chunk_t *pc = chunk_get_next_ncnl(start);
+      chunk_t *pc = chunk_get_next_ncnnl(start);
 
       if (chunk_is_str(pc, ")", 1))
       {
@@ -3075,7 +3075,7 @@ static void newline_func_def_or_call(chunk_t *start)
 
          if (atmp != IARF_IGNORE)
          {
-            prev = chunk_get_prev_ncnlni(start);   // Issue #2279
+            prev = chunk_get_prev_ncnnlni(start);   // Issue #2279
 
             if (prev != nullptr)
             {
@@ -3106,7 +3106,7 @@ static void newline_func_def_or_call(chunk_t *start)
 
       if (atmp != IARF_IGNORE)
       {
-         prev = chunk_get_prev_ncnlni(start);   // Issue #2279
+         prev = chunk_get_prev_ncnnlni(start);   // Issue #2279
 
          if (prev != nullptr)
          {
@@ -3114,17 +3114,17 @@ static void newline_func_def_or_call(chunk_t *start)
          }
       }
       // Handle break newlines type and function
-      prev = chunk_get_prev_ncnlni(start);   // Issue #2279
+      prev = chunk_get_prev_ncnnlni(start);   // Issue #2279
       prev = skip_template_prev(prev);
       // Don't split up a function variable
-      prev = chunk_is_paren_close(prev) ? nullptr : chunk_get_prev_ncnlni(prev);   // Issue #2279
+      prev = chunk_is_paren_close(prev) ? nullptr : chunk_get_prev_ncnnlni(prev);   // Issue #2279
 
       log_rule_B("nl_func_class_scope");
 
       if (  chunk_is_token(prev, CT_DC_MEMBER)
          && (options::nl_func_class_scope() != IARF_IGNORE))
       {
-         newline_iarf(chunk_get_prev_ncnlni(prev), options::nl_func_class_scope());   // Issue #2279
+         newline_iarf(chunk_get_prev_ncnnlni(prev), options::nl_func_class_scope());   // Issue #2279
       }
 
       if (chunk_is_not_token(prev, CT_ACCESS_COLON))
@@ -3134,7 +3134,7 @@ static void newline_func_def_or_call(chunk_t *start)
          if (chunk_is_token(prev, CT_OPERATOR))
          {
             tmp  = prev;
-            prev = chunk_get_prev_ncnlni(prev);   // Issue #2279
+            prev = chunk_get_prev_ncnnlni(prev);   // Issue #2279
          }
          else
          {
@@ -3150,12 +3150,12 @@ static void newline_func_def_or_call(chunk_t *start)
                newline_iarf(prev, options::nl_func_scope_name());
             }
          }
-         const chunk_t *tmp_next = chunk_get_next_ncnl(prev);
+         const chunk_t *tmp_next = chunk_get_next_ncnnl(prev);
 
          if (chunk_is_not_token(tmp_next, CT_FUNC_CLASS_DEF))
          {
             chunk_t *closing = chunk_skip_to_match(tmp);
-            chunk_t *brace   = chunk_get_next_ncnl(closing);
+            chunk_t *brace   = chunk_get_next_ncnnl(closing);
             iarf_e  a;                                           // Issue #2561
 
             if (  get_chunk_parent_type(tmp) == CT_FUNC_PROTO
@@ -3200,7 +3200,7 @@ static void newline_func_def_or_call(chunk_t *start)
 
                if (chunk_is_token(prev, CT_DESTRUCTOR))
                {
-                  prev = chunk_get_prev_ncnlni(prev);   // Issue #2279
+                  prev = chunk_get_prev_ncnnlni(prev);   // Issue #2279
                }
 
                /*
@@ -3209,9 +3209,9 @@ static void newline_func_def_or_call(chunk_t *start)
                 */
                while (chunk_is_token(prev, CT_DC_MEMBER))
                {
-                  prev = chunk_get_prev_ncnlni(prev);   // Issue #2279
+                  prev = chunk_get_prev_ncnnlni(prev);   // Issue #2279
                   prev = skip_template_prev(prev);
-                  prev = chunk_get_prev_ncnlni(prev);   // Issue #2279
+                  prev = chunk_get_prev_ncnnlni(prev);   // Issue #2279
                }
 
                if (  chunk_is_not_token(prev, CT_BRACE_CLOSE)
@@ -3230,7 +3230,7 @@ static void newline_func_def_or_call(chunk_t *start)
             }
          }
       }
-      chunk_t *pc = chunk_get_next_ncnl(start);
+      chunk_t *pc = chunk_get_next_ncnnl(start);
 
       if (chunk_is_str(pc, ")", 1))
       {
@@ -3250,7 +3250,7 @@ static void newline_func_def_or_call(chunk_t *start)
 
          if (atmp != IARF_IGNORE)
          {
-            prev = chunk_get_prev_ncnlni(start);   // Issue #2279
+            prev = chunk_get_prev_ncnnlni(start);   // Issue #2279
 
             if (prev != nullptr)
             {
@@ -3265,9 +3265,9 @@ static void newline_func_def_or_call(chunk_t *start)
    chunk_t *tmp;
    chunk_t *pc;
 
-   for (pc = chunk_get_next_ncnl(start);
+   for (pc = chunk_get_next_ncnnl(start);
         pc != nullptr && pc->level > start->level;
-        pc = chunk_get_next_ncnl(pc))
+        pc = chunk_get_next_ncnnl(pc))
    {
       if (  chunk_is_token(pc, CT_COMMA)
          && (pc->level == (start->level + 1)))
@@ -3367,7 +3367,7 @@ static void newline_oc_msg(chunk_t *start)
       return;
    }
 
-   for (chunk_t *pc = chunk_get_next_ncnl(start); pc; pc = chunk_get_next_ncnl(pc))
+   for (chunk_t *pc = chunk_get_next_ncnnl(start); pc; pc = chunk_get_next_ncnnl(pc))
    {
       if (pc->level <= start->level)
       {
@@ -3590,7 +3590,7 @@ static void nl_create_one_liner(chunk_t *vbrace_open)
    LOG_FUNC_ENTRY();
 
    // See if we get a newline between the next text and the vbrace_close
-   chunk_t *tmp   = chunk_get_next_ncnl(vbrace_open);
+   chunk_t *tmp   = chunk_get_next_ncnnl(vbrace_open);
    chunk_t *first = tmp;
 
    if (  first == nullptr
@@ -3723,7 +3723,7 @@ void newlines_cleanup_angles()
    // Issue #1167
    LOG_FUNC_ENTRY();
 
-   for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnl(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnnl(pc))
    {
       char copy[1000];
       LOG_FMT(LBLANK, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s'\n",
@@ -3746,13 +3746,13 @@ void newlines_cleanup_braces(bool first)
 
    if (chunk_is_newline(pc = chunk_get_head()))
    {
-      pc = chunk_get_next_ncnl(pc);
+      pc = chunk_get_next_ncnnl(pc);
    }
    chunk_t *next;
    chunk_t *prev;
    chunk_t *tmp;
 
-   for ( ; pc != nullptr; pc = chunk_get_next_ncnl(pc))
+   for ( ; pc != nullptr; pc = chunk_get_next_ncnnl(pc))
    {
       char copy[1000];
       LOG_FMT(LBLANK, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s'\n",
@@ -3792,7 +3792,7 @@ void newlines_cleanup_braces(bool first)
             log_rule_B("nl_brace_catch");
             newlines_cuddle_uncuddle(pc, options::nl_brace_catch());
          }
-         next = chunk_get_next_ncnl(pc);
+         next = chunk_get_next_ncnnl(pc);
 
          if (chunk_is_token(next, CT_BRACE_OPEN))
          {
@@ -3870,7 +3870,7 @@ void newlines_cleanup_braces(bool first)
       {
          log_rule_B("nl_brace_else");
          newlines_cuddle_uncuddle(pc, options::nl_brace_else());
-         next = chunk_get_next_ncnl(pc);
+         next = chunk_get_next_ncnnl(pc);
 
          if (chunk_is_token(next, CT_ELSEIF))
          {
@@ -3885,7 +3885,7 @@ void newlines_cleanup_braces(bool first)
          log_rule_B("nl_try_brace");
          newlines_do_else(pc, options::nl_try_brace());
          // Issue #1734
-         chunk_t *po = chunk_get_next_ncnl(pc);
+         chunk_t *po = chunk_get_next_ncnnl(pc);
          flag_parens(po, PCF_IN_TRY_BLOCK, po->type, CT_NONE, false);
       }
       else if (chunk_is_token(pc, CT_GETSET))
@@ -3915,7 +3915,7 @@ void newlines_cleanup_braces(bool first)
 
             if (options::nl_paren_dbrace_open() != IARF_IGNORE)
             {
-               prev = chunk_get_prev_ncnlni(pc, scope_e::PREPROC);   // Issue #2279
+               prev = chunk_get_prev_ncnnlni(pc, scope_e::PREPROC);   // Issue #2279
 
                if (chunk_is_paren_close(prev))
                {
@@ -4083,7 +4083,7 @@ void newlines_cleanup_braces(bool first)
          }
          else
          {
-            next = chunk_get_next_ncnl(pc);
+            next = chunk_get_next_ncnnl(pc);
 
             // Handle unnamed temporary direct-list-initialization
             if (get_chunk_parent_type(pc) == CT_BRACED_INIT_LIST)
@@ -4268,7 +4268,7 @@ void newlines_cleanup_braces(bool first)
                || get_chunk_parent_type(pc) == CT_ENUM
                || get_chunk_parent_type(pc) == CT_UNION))
          {
-            next = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+            next = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
 
             if (  chunk_is_not_token(next, CT_SEMICOLON)
                && chunk_is_not_token(next, CT_COMMA))
@@ -4313,7 +4313,7 @@ void newlines_cleanup_braces(bool first)
 
             if (options::nl_after_namespace() > 0)
             {
-               next = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+               next = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
 
                if (next)
                {
@@ -4457,7 +4457,7 @@ void newlines_cleanup_braces(bool first)
             || chunk_is_token(prev, CT_FPAREN_CLOSE))         // Issue #1122
          {
             log_rule_B("nl_before_throw");
-            newline_iarf(chunk_get_prev_ncnlni(pc), options::nl_before_throw());   // Issue #2279
+            newline_iarf(chunk_get_prev_ncnnlni(pc), options::nl_before_throw());   // Issue #2279
          }
       }
       else if (  chunk_is_token(pc, CT_QUALIFIER)
@@ -4469,7 +4469,7 @@ void newlines_cleanup_braces(bool first)
             || chunk_is_token(prev, CT_FPAREN_CLOSE))         // Issue #1122
          {
             log_rule_B("nl_before_throw");
-            newline_iarf(chunk_get_prev_ncnlni(pc), options::nl_before_throw());   // Issue #2279
+            newline_iarf(chunk_get_prev_ncnnlni(pc), options::nl_before_throw());   // Issue #2279
          }
       }
       else if (chunk_is_token(pc, CT_CASE_COLON))
@@ -4491,7 +4491,7 @@ void newlines_cleanup_braces(bool first)
       }
       else if (chunk_is_token(pc, CT_SPAREN_CLOSE))
       {
-         next = chunk_get_next_ncnl(pc);
+         next = chunk_get_next_ncnnl(pc);
 
          if (chunk_is_token(next, CT_BRACE_OPEN))
          {
@@ -4678,12 +4678,12 @@ void newlines_cleanup_braces(bool first)
       {
          if (get_chunk_parent_type(pc) == CT_TEMPLATE)
          {
-            next = chunk_get_next_ncnl(pc);
+            next = chunk_get_next_ncnnl(pc);
 
             if (  next != nullptr
                && next->level == next->brace_level)
             {
-               tmp = chunk_get_prev_ncnlni(chunk_get_prev_type(pc, CT_ANGLE_OPEN, pc->level));   // Issue #2279
+               tmp = chunk_get_prev_ncnnlni(chunk_get_prev_type(pc, CT_ANGLE_OPEN, pc->level));   // Issue #2279
 
                if (chunk_is_token(tmp, CT_TEMPLATE))
                {
@@ -4758,11 +4758,11 @@ void newlines_cleanup_braces(bool first)
               && get_chunk_parent_type(pc) != CT_USING)
       {
          // Issue #2387
-         next = chunk_get_next_ncnl(pc);
+         next = chunk_get_next_ncnnl(pc);
 
          if (next != nullptr)
          {
-            next = chunk_get_next_ncnl(next);
+            next = chunk_get_next_ncnnl(next);
 
             if (!chunk_is_token(next, CT_ASSIGN))
             {
@@ -4790,7 +4790,7 @@ void newlines_cleanup_braces(bool first)
          if (  get_chunk_parent_type(pc) == CT_ASSIGN
             && !pc->flags.test(PCF_ONE_LINER))
          {
-            tmp = chunk_get_prev_ncnlni(pc);   // Issue #2279
+            tmp = chunk_get_prev_ncnnlni(pc);   // Issue #2279
             newline_iarf(tmp, options::nl_assign_square());
             log_rule_B("nl_assign_square");
 
@@ -4978,7 +4978,7 @@ void newlines_insert_blank_lines(void)
 {
    LOG_FUNC_ENTRY();
 
-   for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnl(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnnl(pc))
    {
       //LOG_FMT(LNEWLINE, "%s(%d): orig_line is %zu, orig_col is %zu, text() '%s', type is %s\n",
       //        __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(), get_token_name(pc->type));
@@ -5124,7 +5124,7 @@ void newlines_squeeze_ifdef(void)
 
    chunk_t *pc;
 
-   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnl(pc))
+   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnnl(pc))
    {
       if (  chunk_is_token(pc, CT_PREPROC)
          && (  pc->level > 0
@@ -5379,7 +5379,7 @@ void newlines_chunk_pos(c_token_t chunk_type, token_pos_e mode)
       return;
    }
 
-   for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnl(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnnl(pc))
    {
       char copy[1000];
       LOG_FMT(LNEWLINE, "%s(%d): pc->orig_line is %zu, orig_col is %zu, text() is '%s'\n",
@@ -5515,7 +5515,7 @@ void newlines_chunk_pos(c_token_t chunk_type, token_pos_e mode)
             }
             else
             {
-               remove_next_newlines(chunk_get_prev_ncnlni(pc));   // Issue #2279
+               remove_next_newlines(chunk_get_prev_ncnnlni(pc));   // Issue #2279
             }
             continue;
          }
@@ -5614,7 +5614,7 @@ void newlines_class_colon_pos(c_token_t tok)
       log_rule_B("align_on_tabstop");
    }
 
-   for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnl(pc))
+   for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnnl(pc))
    {
       if (  ccolon == nullptr
          && chunk_is_not_token(pc, tok))
@@ -5830,7 +5830,7 @@ static void blank_line_max(chunk_t *pc, Option<unsigned> &opt)
 
 iarf_e newline_template_option(chunk_t *pc, iarf_e special, iarf_e base, iarf_e fallback)
 {
-   auto *const prev = chunk_get_prev_ncnl(pc);
+   auto *const prev = chunk_get_prev_ncnnl(pc);
 
    if (  chunk_is_token(prev, CT_ANGLE_OPEN)
       && special != IARF_IGNORE)

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -2678,7 +2678,7 @@ static bool kw_fcn_message(chunk_t *cmt, unc_text &out_txt)
    }
    out_txt.append(fcn->str);
 
-   chunk_t *tmp  = chunk_get_next_ncnl(fcn);
+   chunk_t *tmp  = chunk_get_next_ncnnl(fcn);
    chunk_t *word = nullptr;
 
    while (tmp != nullptr)
@@ -2703,7 +2703,7 @@ static bool kw_fcn_message(chunk_t *cmt, unc_text &out_txt)
       {
          word = tmp;
       }
-      tmp = chunk_get_next_ncnl(tmp);
+      tmp = chunk_get_next_ncnnl(tmp);
    }
    return(true);
 } // kw_fcn_message
@@ -2774,7 +2774,7 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text &out_txt)
 
    if (chunk_is_token(fcn, CT_OC_MSG_DECL))
    {
-      chunk_t *tmp = chunk_get_next_ncnl(fcn);
+      chunk_t *tmp = chunk_get_next_ncnnl(fcn);
       has_param = false;
 
       while (tmp != nullptr)
@@ -2803,7 +2803,7 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text &out_txt)
          {
             has_param = true;
          }
-         tmp = chunk_get_next_ncnl(tmp);
+         tmp = chunk_get_next_ncnnl(tmp);
       }
       fpo = fpc = nullptr;
    }
@@ -2825,15 +2825,15 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text &out_txt)
    chunk_t *tmp;
 
    // Check for 'foo()' and 'foo(void)'
-   if (chunk_get_next_ncnl(fpo) == fpc)
+   if (chunk_get_next_ncnnl(fpo) == fpc)
    {
       has_param = false;
    }
    else
    {
-      tmp = chunk_get_next_ncnl(fpo);
+      tmp = chunk_get_next_ncnnl(fpo);
 
-      if (  (tmp == chunk_get_prev_ncnl(fpc))
+      if (  (tmp == chunk_get_prev_ncnnl(fpc))
          && chunk_is_str(tmp, "void", 4))
       {
          has_param = false;
@@ -2878,14 +2878,14 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text &out_txt)
       }
    }
    // Do the return stuff
-   tmp = chunk_get_prev_ncnl(fcn);
+   tmp = chunk_get_prev_ncnnl(fcn);
 
    // For Objective-C we need to go to the previous chunk
    if (  tmp != nullptr
       && get_chunk_parent_type(tmp) == CT_OC_MSG_DECL
       && chunk_is_token(tmp, CT_PAREN_CLOSE))
    {
-      tmp = chunk_get_prev_ncnl(tmp);
+      tmp = chunk_get_prev_ncnnl(tmp);
    }
 
    if (  tmp != nullptr
@@ -2915,12 +2915,12 @@ static bool kw_fcn_fclass(chunk_t *cmt, unc_text &out_txt)
       // if inside a class, we need to find to the class name
       chunk_t *tmp = chunk_get_prev_type(fcn, CT_BRACE_OPEN, fcn->level - 1);
       tmp = chunk_get_prev_type(tmp, CT_CLASS, tmp->level);
-      tmp = chunk_get_next_ncnl(tmp);
+      tmp = chunk_get_next_ncnnl(tmp);
 
-      while (chunk_is_token(chunk_get_next_ncnl(tmp), CT_DC_MEMBER))
+      while (chunk_is_token(chunk_get_next_ncnnl(tmp), CT_DC_MEMBER))
       {
-         tmp = chunk_get_next_ncnl(tmp);
-         tmp = chunk_get_next_ncnl(tmp);
+         tmp = chunk_get_next_ncnnl(tmp);
+         tmp = chunk_get_next_ncnnl(tmp);
       }
 
       if (tmp != nullptr)
@@ -2932,18 +2932,18 @@ static bool kw_fcn_fclass(chunk_t *cmt, unc_text &out_txt)
    else
    {
       // if outside a class, we expect "CLASS::METHOD(...)"
-      chunk_t *tmp = chunk_get_prev_ncnl(fcn);
+      chunk_t *tmp = chunk_get_prev_ncnnl(fcn);
 
       if (chunk_is_token(tmp, CT_OPERATOR))
       {
-         tmp = chunk_get_prev_ncnl(tmp);
+         tmp = chunk_get_prev_ncnnl(tmp);
       }
 
       if (  tmp != nullptr
          && (  chunk_is_token(tmp, CT_DC_MEMBER)
             || chunk_is_token(tmp, CT_MEMBER)))
       {
-         tmp = chunk_get_prev_ncnl(tmp);
+         tmp = chunk_get_prev_ncnnl(tmp);
          out_txt.append(tmp->str);
          return(true);
       }
@@ -3216,7 +3216,7 @@ void add_long_preprocessor_conditional_block_comment(void)
    chunk_t *pp_start = nullptr;
    chunk_t *pp_end   = nullptr;
 
-   for (chunk_t *pc = chunk_get_head(); pc; pc = chunk_get_next_ncnl(pc))
+   for (chunk_t *pc = chunk_get_head(); pc; pc = chunk_get_next_ncnnl(pc))
    {
       // just track the preproc level:
       if (chunk_is_token(pc, CT_PREPROC))

--- a/src/parens.cpp
+++ b/src/parens.cpp
@@ -58,7 +58,7 @@ void do_parens(void)
    {
       chunk_t *pc = chunk_get_head();
 
-      while ((pc = chunk_get_next_ncnl(pc)) != nullptr)
+      while ((pc = chunk_get_next_ncnnl(pc)) != nullptr)
       {
          if (  pc->type != CT_SPAREN_OPEN
             || (  get_chunk_parent_type(pc) != CT_IF
@@ -90,7 +90,7 @@ static void add_parens_between(chunk_t *first, chunk_t *last)
            last->text(), last->level);
 
    // Don't do anything if we have a bad sequence, ie "&& )"
-   chunk_t *first_n = chunk_get_next_ncnl(first);
+   chunk_t *first_n = chunk_get_next_ncnnl(first);
 
    if (first_n == last)
    {
@@ -109,7 +109,7 @@ static void add_parens_between(chunk_t *first, chunk_t *last)
 
    chunk_add_before(&pc, first_n);
 
-   chunk_t *last_p = chunk_get_prev_ncnl(last, scope_e::PREPROC);
+   chunk_t *last_p = chunk_get_prev_ncnnl(last, scope_e::PREPROC);
 
    set_chunk_type(&pc, CT_PAREN_CLOSE);
    pc.orig_line   = last_p->orig_line;
@@ -124,7 +124,7 @@ static void add_parens_between(chunk_t *first, chunk_t *last)
 
    for (chunk_t *tmp = first_n;
         tmp != last_p;
-        tmp = chunk_get_next_ncnl(tmp))
+        tmp = chunk_get_next_ncnnl(tmp))
    {
       tmp->level++;
    }
@@ -148,7 +148,7 @@ static void check_bool_parens(chunk_t *popen, chunk_t *pclose, int nest)
 
    chunk_t *pc = popen;
 
-   while (  (pc = chunk_get_next_ncnl(pc)) != nullptr
+   while (  (pc = chunk_get_next_ncnnl(pc)) != nullptr
          && pc != pclose)
    {
       if (pc->flags.test(PCF_IN_PREPROC))

--- a/src/parent_for_pp.cpp
+++ b/src/parent_for_pp.cpp
@@ -27,7 +27,7 @@ void do_parent_for_pp(void)
 
    chunk_t           *pc = chunk_get_head();
 
-   while ((pc = chunk_get_next_ncnl(pc)) != nullptr)
+   while ((pc = chunk_get_next_ncnnl(pc)) != nullptr)
    {
       // CT_PP_IF,            // #if, #ifdef, or #ifndef
       // CT_PP_ELSE,          // #else or #elif

--- a/src/remove_extra_returns.cpp
+++ b/src/remove_extra_returns.cpp
@@ -65,7 +65,7 @@ void remove_extra_returns(void)
 
          if (remove_it)
          {
-            chunk_t *semicolon = chunk_get_next_ncnl(pc);
+            chunk_t *semicolon = chunk_get_next_ncnnl(pc);
 
             if (  semicolon != nullptr
                && chunk_is_token(semicolon, CT_SEMICOLON))

--- a/src/semicolons.cpp
+++ b/src/semicolons.cpp
@@ -51,12 +51,12 @@ void remove_extra_semicolons(void)
 
    while (pc != nullptr)
    {
-      chunk_t *next = chunk_get_next_ncnl(pc);
+      chunk_t *next = chunk_get_next_ncnnl(pc);
       chunk_t *prev;
 
       if (  chunk_is_token(pc, CT_SEMICOLON)
          && !pc->flags.test(PCF_IN_PREPROC)
-         && (prev = chunk_get_prev_ncnl(pc)) != nullptr)
+         && (prev = chunk_get_prev_ncnnl(pc)) != nullptr)
       {
          LOG_FMT(LSCANSEMI, "%s(%d): Semi orig_line is %zu, orig_col is %zu, parent is %s, prev = '%s' [%s/%s]\n",
                  __func__, __LINE__, pc->orig_line, pc->orig_col, get_token_name(get_chunk_parent_type(pc)),
@@ -119,7 +119,7 @@ static void check_unknown_brace_close(chunk_t *semi, chunk_t *brace_close)
    LOG_FUNC_ENTRY();
    chunk_t *pc = chunk_get_prev_type(brace_close, CT_BRACE_OPEN, brace_close->level);
 
-   pc = chunk_get_prev_ncnl(pc);
+   pc = chunk_get_prev_ncnnl(pc);
 
    if (  pc != nullptr
       && pc->type != CT_RETURN

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -733,7 +733,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (  chunk_is_token(tmp, CT_PTR_TYPE)
          || chunk_is_token(tmp, CT_BYREF))
       {
-         tmp = chunk_get_prev_ncnl(tmp);
+         tmp = chunk_get_prev_ncnnl(tmp);
       }
 
       if (  chunk_is_token(tmp, CT_TYPE)
@@ -1293,7 +1293,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (  chunk_is_token(second, CT_FPAREN_OPEN)
          || chunk_is_token(second, CT_PAREN_OPEN))
       {
-         chunk_t *next = chunk_get_next_ncnl(second);
+         chunk_t *next = chunk_get_next_ncnnl(second);
 
          if (chunk_is_token(next, CT_FPAREN_CLOSE))
          {
@@ -1458,7 +1458,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (  (options::sp_after_operator_sym_empty() != IARF_IGNORE)
          && chunk_is_token(second, CT_FPAREN_OPEN))
       {
-         chunk_t *next = chunk_get_next_ncnl(second);
+         chunk_t *next = chunk_get_next_ncnnl(second);
 
          if (chunk_is_token(next, CT_FPAREN_CLOSE))
          {
@@ -1501,7 +1501,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (  (options::sp_func_call_paren_empty() != IARF_IGNORE)
          && chunk_is_token(second, CT_FPAREN_OPEN))
       {
-         chunk_t *next = chunk_get_next_ncnl(second);
+         chunk_t *next = chunk_get_next_ncnnl(second);
 
          if (chunk_is_token(next, CT_FPAREN_CLOSE))
          {
@@ -1539,7 +1539,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (  (options::sp_func_def_paren_empty() != IARF_IGNORE)
          && chunk_is_token(second, CT_FPAREN_OPEN))
       {
-         chunk_t *next = chunk_get_next_ncnl(second);
+         chunk_t *next = chunk_get_next_ncnnl(second);
 
          if (chunk_is_token(next, CT_FPAREN_CLOSE))
          {
@@ -1615,7 +1615,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (  (options::sp_func_proto_paren_empty() != IARF_IGNORE)
          && chunk_is_token(second, CT_FPAREN_OPEN))
       {
-         chunk_t *next = chunk_get_next_ncnl(second);
+         chunk_t *next = chunk_get_next_ncnnl(second);
 
          if (chunk_is_token(next, CT_FPAREN_CLOSE))
          {
@@ -1645,7 +1645,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (  (options::sp_func_class_paren_empty() != IARF_IGNORE)
          && chunk_is_token(second, CT_FPAREN_OPEN))
       {
-         chunk_t *next = chunk_get_next_ncnl(second);
+         chunk_t *next = chunk_get_next_ncnnl(second);
 
          if (chunk_is_token(next, CT_FPAREN_CLOSE))
          {
@@ -1726,7 +1726,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          || get_chunk_parent_type(second) == CT_UNION)
       {
          // Fix for issue #1240  adding space in struct initializers
-         chunk_t *tmp = chunk_get_prev_ncnl(chunk_skip_to_match_rev(second));
+         chunk_t *tmp = chunk_get_prev_ncnnl(chunk_skip_to_match_rev(second));
 
          if (chunk_is_token(tmp, CT_ASSIGN))
          {
@@ -1866,7 +1866,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
       if (get_chunk_parent_type(first) == CT_FUNC_CALL)
       {
          chunk_t *tmp = chunk_get_prev_type(first, get_chunk_parent_type(first), first->level);
-         tmp = chunk_get_prev_ncnl(tmp);
+         tmp = chunk_get_prev_ncnnl(tmp);
 
          if (chunk_is_token(tmp, CT_NEW))
          {
@@ -2622,7 +2622,7 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          || get_chunk_parent_type(first) == CT_UNION)
       {
          // Fix for issue #1240  adding space in struct initializers
-         chunk_t *tmp = chunk_get_prev_ncnl(first);
+         chunk_t *tmp = chunk_get_prev_ncnnl(first);
 
          if (chunk_is_token(tmp, CT_ASSIGN))
          {

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -109,7 +109,7 @@ static chunk_t *handle_double_angle_close(chunk_t *pc)
          set_chunk_type(pc, CT_SHIFT);
          pc->orig_col_end = next->orig_col_end;
 
-         chunk_t *tmp = chunk_get_next_ncnl(next);
+         chunk_t *tmp = chunk_get_next_ncnnl(next);
          chunk_del(next);
          next = tmp;
       }
@@ -170,7 +170,7 @@ void tokenize_trailing_return_types(void)
    // auto f24() const throw() -> bool = delete;
    chunk_t *pc;
 
-   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnl(pc))
+   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnnl(pc))
    {
       char copy[1000];
       LOG_FMT(LNOTE, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s'\n",
@@ -179,7 +179,7 @@ void tokenize_trailing_return_types(void)
       if (  chunk_is_token(pc, CT_MEMBER)
          && (strcmp(pc->text(), "->") == 0))
       {
-         chunk_t *tmp = chunk_get_prev_ncnl(pc);
+         chunk_t *tmp = chunk_get_prev_ncnnl(pc);
          chunk_t *tmp_2;
          chunk_t *open_paren;
 
@@ -187,18 +187,18 @@ void tokenize_trailing_return_types(void)
          {
             // auto max(int a, int b) const -> int;
             // auto f11() const -> bool;
-            tmp = chunk_get_prev_ncnl(tmp);
+            tmp = chunk_get_prev_ncnnl(tmp);
          }
          else if (chunk_is_token(tmp, CT_NOEXCEPT))
          {
             // noexcept is present
-            tmp_2 = chunk_get_prev_ncnl(tmp);
+            tmp_2 = chunk_get_prev_ncnnl(tmp);
 
             if (chunk_is_token(tmp_2, CT_QUALIFIER))
             {
                // auto f12() const noexcept -> bool;
                // auto f15() const noexcept -> bool = delete;
-               tmp = chunk_get_prev_ncnl(tmp_2);
+               tmp = chunk_get_prev_ncnnl(tmp_2);
             }
             else
             {
@@ -210,12 +210,12 @@ void tokenize_trailing_return_types(void)
          else if (chunk_is_token(tmp, CT_PAREN_CLOSE))
          {
             open_paren = chunk_get_prev_type(tmp, CT_PAREN_OPEN, tmp->level);
-            tmp        = chunk_get_prev_ncnl(open_paren);
+            tmp        = chunk_get_prev_ncnnl(open_paren);
 
             if (chunk_is_token(tmp, CT_NOEXCEPT))
             {
                // noexcept is present
-               tmp_2 = chunk_get_prev_ncnl(tmp);
+               tmp_2 = chunk_get_prev_ncnnl(tmp);
 
                if (chunk_is_token(tmp_2, CT_QUALIFIER))
                {
@@ -223,7 +223,7 @@ void tokenize_trailing_return_types(void)
                   // auto f14() const noexcept(false) -> bool;
                   // auto f16() const noexcept(true) -> bool = delete;
                   // auto f17() const noexcept(false) -> bool = delete;
-                  tmp = chunk_get_prev_ncnl(tmp_2);
+                  tmp = chunk_get_prev_ncnnl(tmp_2);
                }
                else
                {
@@ -237,13 +237,13 @@ void tokenize_trailing_return_types(void)
             else if (chunk_is_token(tmp, CT_THROW))
             {
                // throw is present
-               tmp_2 = chunk_get_prev_ncnl(tmp);
+               tmp_2 = chunk_get_prev_ncnnl(tmp);
 
                if (chunk_is_token(tmp_2, CT_QUALIFIER))
                {
                   // auto f23() const throw() -> bool;
                   // auto f24() const throw() -> bool = delete;
-                  tmp = chunk_get_prev_ncnl(tmp_2);
+                  tmp = chunk_get_prev_ncnnl(tmp_2);
                }
                else
                {
@@ -291,11 +291,11 @@ void tokenize_cleanup(void)
     */
    chunk_t *pc;
 
-   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnl(pc))
+   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnnl(pc))
    {
       if (chunk_is_token(pc, CT_SQUARE_OPEN))
       {
-         next = chunk_get_next_ncnl(pc);
+         next = chunk_get_next_ncnnl(pc);
 
          if (chunk_is_token(next, CT_SQUARE_CLOSE))
          {
@@ -314,7 +314,7 @@ void tokenize_cleanup(void)
 
       if (  chunk_is_token(pc, CT_SEMICOLON)
          && pc->flags.test(PCF_IN_PREPROC)
-         && !chunk_get_next_ncnl(pc, scope_e::PREPROC))
+         && !chunk_get_next_ncnnl(pc, scope_e::PREPROC))
       {
          LOG_FMT(LNOTE, "%s(%d): %s:%zu Detected a macro that ends with a semicolon. Possible failures if used.\n",
                  __func__, __LINE__, cpd.filename.c_str(), pc->orig_line);
@@ -322,11 +322,11 @@ void tokenize_cleanup(void)
    }
 
    // change := to CT_SQL_ASSIGN Issue #527
-   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnl(pc))
+   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnnl(pc))
    {
       if (chunk_is_token(pc, CT_COLON))
       {
-         next = chunk_get_next_ncnl(pc);
+         next = chunk_get_next_ncnnl(pc);
 
          if (chunk_is_token(next, CT_ASSIGN))
          {
@@ -341,7 +341,7 @@ void tokenize_cleanup(void)
 
    // We can handle everything else in the second pass
    pc   = chunk_get_head();
-   next = chunk_get_next_ncnl(pc);
+   next = chunk_get_next_ncnnl(pc);
 
    while (  pc != nullptr
          && next != nullptr)
@@ -449,7 +449,7 @@ void tokenize_cleanup(void)
          else
          {
             // Something else followed by a open brace
-            chunk_t *tmp = chunk_get_next_ncnl(next);
+            chunk_t *tmp = chunk_get_next_ncnnl(next);
 
             if (  tmp == nullptr
                || tmp->type != CT_BRACE_OPEN)
@@ -568,7 +568,7 @@ void tokenize_cleanup(void)
             pc->orig_col  = prev->orig_col;
             pc->orig_line = prev->orig_line;
             chunk_t *to_be_deleted = prev;
-            prev = chunk_get_prev_ncnl(prev);
+            prev = chunk_get_prev_ncnnl(prev);
 
             if (prev != nullptr)
             {
@@ -759,7 +759,7 @@ void tokenize_cleanup(void)
             set_chunk_type(next, CT_ACCESS_COLON);
             chunk_t *tmp;
 
-            if ((tmp = chunk_get_next_ncnl(next)) != nullptr)
+            if ((tmp = chunk_get_next_ncnnl(next)) != nullptr)
             {
                chunk_flags_set(tmp, PCF_STMT_START | PCF_EXPR_START);
             }
@@ -838,7 +838,7 @@ void tokenize_cleanup(void)
                {
                   set_chunk_type(tmp, CT_SQL_WORD);
                }
-               tmp = chunk_get_next_ncnl(tmp);
+               tmp = chunk_get_next_ncnnl(tmp);
             }
          }
       }
@@ -853,12 +853,12 @@ void tokenize_cleanup(void)
          pc->str         += next->str;
          pc->orig_col_end = next->orig_col_end;
          chunk_del(next);
-         next = chunk_get_next_ncnl(pc);
+         next = chunk_get_next_ncnnl(pc);
 
          // label the 'in'
          if (chunk_is_token(next, CT_PAREN_OPEN))
          {
-            chunk_t *tmp = chunk_get_next_ncnl(next);
+            chunk_t *tmp = chunk_get_next_ncnnl(next);
 
             while (  tmp != nullptr
                   && tmp->type != CT_PAREN_CLOSE)
@@ -868,7 +868,7 @@ void tokenize_cleanup(void)
                   set_chunk_type(tmp, CT_IN);
                   break;
                }
-               tmp = chunk_get_next_ncnl(tmp);
+               tmp = chunk_get_next_ncnnl(tmp);
             }
          }
       }
@@ -934,7 +934,7 @@ void tokenize_cleanup(void)
          }
          set_chunk_parent(next, pc->type);
 
-         chunk_t *tmp = chunk_get_next_ncnl(next);
+         chunk_t *tmp = chunk_get_next_ncnnl(next);
 
          if (tmp != nullptr)
          {
@@ -950,7 +950,7 @@ void tokenize_cleanup(void)
 
       if (chunk_is_token(pc, CT_OC_INTF))
       {
-         chunk_t *tmp = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+         chunk_t *tmp = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
 
          while (  tmp != nullptr
                && tmp->type != CT_OC_END)
@@ -962,7 +962,7 @@ void tokenize_cleanup(void)
                        get_token_name(tmp->type));
                set_chunk_type(tmp, CT_WORD);
             }
-            tmp = chunk_get_next_ncnl(tmp, scope_e::PREPROC);
+            tmp = chunk_get_next_ncnnl(tmp, scope_e::PREPROC);
          }
       }
 
@@ -1039,7 +1039,7 @@ void tokenize_cleanup(void)
             set_chunk_type(tmp, CT_OC_SEL_NAME);
             set_chunk_parent(tmp, pc->type);
 
-            while ((tmp = chunk_get_next_ncnl(tmp)) != nullptr)
+            while ((tmp = chunk_get_next_ncnnl(tmp)) != nullptr)
             {
                if (chunk_is_token(tmp, CT_PAREN_CLOSE))
                {
@@ -1141,7 +1141,7 @@ void tokenize_cleanup(void)
 
       prev = pc;
       pc   = next;
-      next = chunk_get_next_ncnl(pc);
+      next = chunk_get_next_ncnnl(pc);
    }
 } // tokenize_cleanup
 
@@ -1151,7 +1151,7 @@ static void check_template(chunk_t *start, bool in_type_cast)
    LOG_FMT(LTEMPL, "%s(%d): orig_line %zu, orig_col %zu:\n",
            __func__, __LINE__, start->orig_line, start->orig_col);
 
-   chunk_t *prev = chunk_get_prev_ncnl(start, scope_e::PREPROC);
+   chunk_t *prev = chunk_get_prev_ncnnl(start, scope_e::PREPROC);
 
    if (prev == nullptr)
    {
@@ -1168,9 +1168,9 @@ static void check_template(chunk_t *start, bool in_type_cast)
       size_t level  = 1;
       size_t parens = 0;
 
-      for (pc = chunk_get_next_ncnl(start, scope_e::PREPROC);
+      for (pc = chunk_get_next_ncnnl(start, scope_e::PREPROC);
            pc != nullptr;
-           pc = chunk_get_next_ncnl(pc, scope_e::PREPROC))
+           pc = chunk_get_next_ncnnl(pc, scope_e::PREPROC))
       {
          LOG_FMT(LTEMPL, "%s(%d): type is %s, level is %zu\n",
                  __func__, __LINE__, get_token_name(pc->type), level);
@@ -1275,7 +1275,7 @@ static void check_template(chunk_t *start, bool in_type_cast)
       bool hit_semicolon = false;
       pc = start;
 
-      while ((pc = chunk_get_prev_ncnl(pc, scope_e::PREPROC)) != nullptr)
+      while ((pc = chunk_get_prev_ncnnl(pc, scope_e::PREPROC)) != nullptr)
       {
          if (  (  chunk_is_token(pc, CT_SEMICOLON)
                && hit_semicolon)
@@ -1334,9 +1334,9 @@ static void check_template(chunk_t *start, bool in_type_cast)
 
       tokens[0] = CT_ANGLE_OPEN;
 
-      for (pc = chunk_get_next_ncnl(start, scope_e::PREPROC);
+      for (pc = chunk_get_next_ncnnl(start, scope_e::PREPROC);
            pc != nullptr;
-           pc = chunk_get_next_ncnl(pc, scope_e::PREPROC))
+           pc = chunk_get_next_ncnnl(pc, scope_e::PREPROC))
       {
          constexpr static auto LCURRENT = LTEMPL;
 
@@ -1404,7 +1404,7 @@ static void check_template(chunk_t *start, bool in_type_cast)
             {
                break;
             }
-            auto brace_open  = chunk_get_next_ncnl(pc);
+            auto brace_open  = chunk_get_next_ncnnl(pc);
             auto brace_close = chunk_skip_to_match(brace_open);
 
             set_chunk_parent(brace_open, CT_BRACED_INIT_LIST);
@@ -1457,7 +1457,7 @@ static void check_template(chunk_t *start, bool in_type_cast)
 
    if (chunk_is_token(end, CT_ANGLE_CLOSE))
    {
-      pc = chunk_get_next_ncnl(end, scope_e::PREPROC);
+      pc = chunk_get_next_ncnnl(end, scope_e::PREPROC);
 
       if (  pc == nullptr
          || pc->type != CT_NUMBER)
@@ -1505,7 +1505,7 @@ static void check_template_arg(chunk_t *start, chunk_t *end)
 
    while (pc != end)
    {
-      chunk_t *next = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+      chunk_t *next = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
       // a test "if (next == nullptr)" is not necessary
       chunk_flags_set(pc, PCF_IN_TEMPLATE);
 
@@ -1538,7 +1538,7 @@ static void check_template_arg(chunk_t *start, chunk_t *end)
 
       while (pc != end)
       {
-         chunk_t *next = chunk_get_next_ncnl(pc, scope_e::PREPROC);
+         chunk_t *next = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
          // a test "if (next == nullptr)" is not necessary
          chunk_flags_set(pc, PCF_IN_TEMPLATE);
 
@@ -1559,9 +1559,9 @@ static void check_template_args(chunk_t *start, chunk_t *end)
    // Scan for commas
    chunk_t *pc;
 
-   for (pc = chunk_get_next_ncnl(start, scope_e::PREPROC);
+   for (pc = chunk_get_next_ncnnl(start, scope_e::PREPROC);
         pc != nullptr && pc != end;
-        pc = chunk_get_next_ncnl(pc, scope_e::PREPROC))
+        pc = chunk_get_next_ncnnl(pc, scope_e::PREPROC))
    {
       switch (pc->type)
       {
@@ -1626,7 +1626,7 @@ static void cleanup_objc_property(chunk_t *start)
    if (tmp != nullptr)
    {
       set_chunk_parent(tmp, start->type);
-      tmp = chunk_get_next_ncnl(tmp);
+      tmp = chunk_get_next_ncnnl(tmp);
 
       if (tmp != nullptr)
       {

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1678,7 +1678,7 @@ static void add_func_header(c_token_t type, file_mem &fm)
    chunk_t *tmp;
    bool    do_insert;
 
-   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnlnp(pc))
+   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnnlnp(pc))
    {
       if (pc->type != type)
       {
@@ -1813,7 +1813,7 @@ static void add_func_header(c_token_t type, file_mem &fm)
       else if (do_insert)
       {
          // Insert between after and ref
-         chunk_t *after = chunk_get_next_ncnl(ref);
+         chunk_t *after = chunk_get_next_ncnnl(ref);
          tokenize(fm.data, after);
 
          for (tmp = chunk_get_next(ref); tmp != after; tmp = chunk_get_next(tmp))
@@ -1832,7 +1832,7 @@ static void add_msg_header(c_token_t type, file_mem &fm)
    chunk_t *tmp;
    bool    do_insert;
 
-   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnlnp(pc))
+   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnnlnp(pc))
    {
       if (pc->type != type)
       {
@@ -1906,7 +1906,7 @@ static void add_msg_header(c_token_t type, file_mem &fm)
       if (do_insert)
       {
          // Insert between after and ref
-         chunk_t *after = chunk_get_next_ncnl(ref);
+         chunk_t *after = chunk_get_next_ncnnl(ref);
          tokenize(fm.data, after);
 
          for (tmp = chunk_get_next(ref); tmp != after; tmp = chunk_get_next(tmp))

--- a/src/width.cpp
+++ b/src/width.cpp
@@ -702,7 +702,7 @@ static void split_fcn_params_full(chunk_t *start)
    // Now break after every comma
    chunk_t *pc = fpo;
 
-   while ((pc = chunk_get_next_ncnl(pc)) != nullptr)
+   while ((pc = chunk_get_next_ncnnl(pc)) != nullptr)
    {
       if (pc->level <= fpo->level)
       {
@@ -738,7 +738,7 @@ static void split_fcn_params(chunk_t *start)
                  __func__, __LINE__, fpo->text(), fpo->orig_col, fpo->level);
       }
    }
-   chunk_t *pc     = chunk_get_next_ncnl(fpo);
+   chunk_t *pc     = chunk_get_next_ncnnl(fpo);
    size_t  min_col = pc->column;
 
    log_rule_B("code_width");

--- a/tests/expected/cpp/02102-indent-c.cpp
+++ b/tests/expected/cpp/02102-indent-c.cpp
@@ -518,7 +518,7 @@ void indent_text(void)
          * { a++;
          *   b--; };
          */
-        next = chunk_get_next_ncnl(pc);
+        next = chunk_get_next_ncnnl(pc);
 
         if (!chunk_is_newline_between(pc, next))
           frm.pse[frm.pse_tos].indent = next->column;
@@ -663,7 +663,7 @@ void indent_text(void)
        * everything else
        */
 
-      prev = chunk_get_prev_ncnl(pc);
+      prev = chunk_get_prev_ncnnl(pc);
 
       if ((pc->type == CT_MEMBER) ||
           (pc->type == CT_DC_MEMBER) ||

--- a/tests/input/cpp/indent-c.cpp
+++ b/tests/input/cpp/indent-c.cpp
@@ -546,7 +546,7 @@ void indent_text(void)
              * { a++;
              *   b--; };
              */
-            next = chunk_get_next_ncnl(pc);
+            next = chunk_get_next_ncnnl(pc);
             if (!chunk_is_newline_between(pc, next))
             {
                frm.pse[frm.pse_tos].indent = next->column;
@@ -698,7 +698,7 @@ void indent_text(void)
           * everything else
           */
 
-         prev = chunk_get_prev_ncnl(pc);
+         prev = chunk_get_prev_ncnnl(pc);
          if ((pc->type == CT_MEMBER) ||
              (pc->type == CT_DC_MEMBER) ||
              ((prev != NULL) &&


### PR DESCRIPTION
The names of some of the chuck functions is not consistent, specifically those related to non-new lines (except chunk_get_next_nnl() which is fine).

chunk_get_next_nl() is for new lines.
chunk_get_next_nnl() is for non-new lines.
chunk_get_next_nc() is for non-comments.
chunk_get_next_ncnl() is for non-comments, non-new lines. It's name is inconsistent and should be chunk_get_next_ncnnl().

Similar observation holds true for the other functions renamed in this commit.