### PR TITLE
Fix building when SUPER_LOG is #defined.

### DIFF
--- a/src/log_rules.cpp
+++ b/src/log_rules.cpp
@@ -33,7 +33,7 @@ void log_rule2(const char *func, size_t line, const char *rule, chunk_t *first, 
 #ifdef SUPER_LOG
 
 
-void log_rule3(const char *func, size_t line, const char *rule)
+void log_rule3(log_sev_t sev, const char *func, size_t line, const char *rule)
 #else
 
 


### PR DESCRIPTION
When building current uncrustify/master with SUPER_LOG defined [here](https://github.com/uncrustify/uncrustify/blob/master/src/log_rules.h#L38), you get a FTBFS due to the wrong definition of log_rule3() [here](https://github.com/uncrustify/uncrustify/blob/master/src/log_rules.cpp#L36).

This PR fixes the function definition. To verify the fix, you need to define SUPER_LOG and build. Please note that if you do so, some tests will fail.