### PR TITLE
add indent_comma_brace option

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -3574,9 +3574,13 @@ void indent_text(void)
          else if (chunk_is_token(pc, CT_COMMA))
          {
             log_rule_B("indent_comma_paren");
+            bool comma_paren = options::indent_comma_paren()
+                               && chunk_is_paren_open(frm.top().pc);
+            log_rule_B("indent_comma_brace");
+            bool comma_brace = options::indent_comma_brace()
+                               && chunk_is_opening_brace(frm.top().pc);
 
-            if (  options::indent_comma_paren()
-               && chunk_is_paren_open(frm.top().pc))
+            if (comma_paren || comma_brace)
             {
                indent_column_set(frm.top().pc->column);
             }

--- a/src/options.h
+++ b/src/options.h
@@ -1517,6 +1517,11 @@ indent_paren_after_func_decl;
 extern Option<bool>
 indent_paren_after_func_call;
 
+// Whether to indent a comma when inside a brace.
+// If true, aligns under the open brace.
+extern Option<bool>
+indent_comma_brace;
+
 // Whether to indent a comma when inside a parenthesis.
 // If true, aligns under the open parenthesis.
 extern Option<bool>

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -308,6 +308,7 @@ indent_paren_close              = 0
 indent_paren_after_func_def     = false
 indent_paren_after_func_decl    = false
 indent_paren_after_func_call    = false
+indent_comma_brace              = false
 indent_comma_paren              = false
 indent_bool_paren               = false
 indent_semicolon_for_paren      = false

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1234,6 +1234,10 @@ indent_paren_after_func_decl    = false    # true/false
 # if the parenthesis is on its own line.
 indent_paren_after_func_call    = false    # true/false
 
+# Whether to indent a comma when inside a brace.
+# If true, aligns under the open brace.
+indent_comma_brace              = false    # true/false
+
 # Whether to indent a comma when inside a parenthesis.
 # If true, aligns under the open parenthesis.
 indent_comma_paren              = false    # true/false

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -308,6 +308,7 @@ indent_paren_close              = 0
 indent_paren_after_func_def     = false
 indent_paren_after_func_decl    = false
 indent_paren_after_func_call    = false
+indent_comma_brace              = false
 indent_comma_paren              = false
 indent_bool_paren               = false
 indent_semicolon_for_paren      = false

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1234,6 +1234,10 @@ indent_paren_after_func_decl    = false    # true/false
 # if the parenthesis is on its own line.
 indent_paren_after_func_call    = false    # true/false
 
+# Whether to indent a comma when inside a brace.
+# If true, aligns under the open brace.
+indent_comma_brace              = false    # true/false
+
 # Whether to indent a comma when inside a parenthesis.
 # If true, aligns under the open parenthesis.
 indent_comma_paren              = false    # true/false

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1234,6 +1234,10 @@ indent_paren_after_func_decl    = false    # true/false
 # if the parenthesis is on its own line.
 indent_paren_after_func_call    = false    # true/false
 
+# Whether to indent a comma when inside a brace.
+# If true, aligns under the open brace.
+indent_comma_brace              = false    # true/false
+
 # Whether to indent a comma when inside a parenthesis.
 # If true, aligns under the open parenthesis.
 indent_comma_paren              = false    # true/false

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2771,6 +2771,14 @@ EditorType=boolean
 TrueFalse=indent_paren_after_func_call=true|indent_paren_after_func_call=false
 ValueDefault=false
 
+[Indent Comma Brace]
+Category=2
+Description="<html>Whether to indent a comma when inside a brace.<br/>If true, aligns under the open brace.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=indent_comma_brace=true|indent_comma_brace=false
+ValueDefault=false
+
 [Indent Comma Paren]
 Category=2
 Description="<html>Whether to indent a comma when inside a parenthesis.<br/>If true, aligns under the open parenthesis.</html>"

--- a/tests/config/indent_comma_brace.cfg
+++ b/tests/config/indent_comma_brace.cfg
@@ -1,0 +1,4 @@
+code_width                      = 60
+indent_columns                  = 4
+indent_comma_brace              = true
+indent_with_tabs                = 0

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -855,6 +855,9 @@
 34340  Issue_3061_3nl.cfg                   cpp/Issue_3061_1nl.cpp
 34341  Issue_3061_3nl.cfg                   cpp/Issue_3061_2nl.cpp
 
+34350  indent_comma_brace.cfg               cpp/indent_comma_brace_glob.cpp
+34351  indent_comma_brace.cfg               cpp/indent_comma_brace_func.cpp
+
 # Adopt some UT tests
 10000  empty.cfg                            cpp/621_this-spacing.cpp
 10001  empty.cfg                            cpp/622_ifdef-indentation.cpp

--- a/tests/expected/cpp/34350-indent_comma_brace_glob.cpp
+++ b/tests/expected/cpp/34350-indent_comma_brace_glob.cpp
@@ -1,0 +1,7 @@
+#include <string>
+
+extern char* externBufferWithAVeryLongName;
+extern unsigned int externBufferSizeWithLongName;
+
+std::string foo{ externBufferWithAVeryLongName
+               , externBufferSizeWithLongName };

--- a/tests/expected/cpp/34351-indent_comma_brace_func.cpp
+++ b/tests/expected/cpp/34351-indent_comma_brace_func.cpp
@@ -1,0 +1,10 @@
+#include <string>
+
+extern char* externBufferWithAVeryLongName;
+extern unsigned int externBufferSizeWithLongName;
+
+std::string foo()
+{
+    return std::string{ externBufferWithAVeryLongName
+                      , externBufferSizeWithLongName };
+}

--- a/tests/input/cpp/indent_comma_brace_func.cpp
+++ b/tests/input/cpp/indent_comma_brace_func.cpp
@@ -1,0 +1,10 @@
+#include <string>
+
+extern char* externBufferWithAVeryLongName;
+extern unsigned int externBufferSizeWithLongName;
+
+std::string foo()
+{
+    return std::string{ externBufferWithAVeryLongName
+        , externBufferSizeWithLongName };
+}

--- a/tests/input/cpp/indent_comma_brace_glob.cpp
+++ b/tests/input/cpp/indent_comma_brace_glob.cpp
@@ -1,0 +1,7 @@
+#include <string>
+
+extern char* externBufferWithAVeryLongName;
+extern unsigned int externBufferSizeWithLongName;
+
+std::string foo{ externBufferWithAVeryLongName
+    , externBufferSizeWithLongName };


### PR DESCRIPTION
This works similar to indent_comma_paren.

One example for its usage is the following snippet:

```cpp
std::string foo()
{
    return std::string{ myLongExpressionYieldingABuffer
        , myLongExpressionYieldingASize };
}
```

which uses C++11 list initialization.

In order to align the comma to the brace, you can use the new option:

indent_comma_brace = true

which results in:

```cpp
std::string foo()
{
    return std::string{ myLongExpressionYieldingABuffer
                      , myLongExpressionYieldingASize };
}
```

This duplicates #3125 with a more appropriate branch name and added tests.