### PR TITLE
Nested lambda inside function fix

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1615,14 +1615,30 @@ void indent_text(void)
                }
             }
 
+            bool toplevel = true;
+
+            for (auto it = frm.rbegin(); it != frm.rend() && tail != nullptr; ++it)
+            {
+               if (!chunk_is_token(it->pc, CT_FPAREN_OPEN))
+               {
+                  continue;
+               }
+
+               if (it->pc->level < tail->level)
+               {
+                  toplevel = false;
+                  break;
+               }
+            }
+
             // A few things to check:
             // 1. The matching brace is on the same line as the ending semicolon
             // 2a. If it's an assignment, check that both sides of the assignment operator are on the same line
-            // 2b. If it's inside some closure, check that all the frames are on the same line
+            // 2b. If it's inside some closure, check that all the frames are on the same line, and it is in the top level closure
             if (  options::align_assign_span() == 0 && are_chunks_in_same_line(chunk_skip_to_match(frm.top().pc), tail)
                && (  (  !enclosure && are_chunks_in_same_line(chunk_get_prev_ncnnlnp(frm.prev().pc), frm.prev().pc)
                      && are_chunks_in_same_line(frm.prev().pc, chunk_get_next_ncnnlnp(frm.prev().pc)))
-                  || (enclosure && linematch)))
+                  || (enclosure && linematch && toplevel)))
             {
                frm.top().brace_indent -= indent_size;
             }

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -949,3 +949,4 @@
 60053  bug_2433_2.cfg                       cpp/bug_2433_2.cpp
 60054  interface-keyword-in-cpp.cfg         cpp/interface-keyword-in-cpp.cpp
 60055  issue_3116.cfg                       cpp/issue_3116.cpp
+60056  issue_3116.cfg                       cpp/issue_3116-2.cpp

--- a/tests/expected/cpp/60056-issue_3116-2.cpp
+++ b/tests/expected/cpp/60056-issue_3116-2.cpp
@@ -1,0 +1,41 @@
+obj.AddObject(Object::UniqueName(), 10, [this] {
+    holder.Access([this](const auto &info) {
+        if (IsGood(info)) {
+            Add(info);
+        }
+    });
+});
+
+obj.AddObject(
+    Object::UniqueName(),
+    10,
+    [this] {
+        holder.Access([this](const auto &info) {
+            if (IsGood(info)) {
+                Add(info);
+            }
+        });
+    }
+);
+
+{
+    obj.AddObject(Object::UniqueName(), 10, [this] {
+        holder.Access([this](const auto &info) {
+            if (IsGood(info)) {
+                Add(info);
+            }
+        });
+    });
+
+    obj.AddObject(
+        Object::UniqueName(),
+        10,
+        [this] {
+            holder.Access([this](const auto &info) {
+                if (IsGood(info)) {
+                    Add(info);
+                }
+            });
+        }
+    );
+}

--- a/tests/input/cpp/issue_3116-2.cpp
+++ b/tests/input/cpp/issue_3116-2.cpp
@@ -1,0 +1,41 @@
+obj.AddObject(Object::UniqueName(), 10, [this] {
+    holder.Access([this](const auto &info) {
+    if (IsGood(info)) {
+        Add(info);
+    }
+});
+});
+
+obj.AddObject(
+    Object::UniqueName(),
+    10,
+    [this] {
+    holder.Access([this](const auto &info) {
+    if (IsGood(info)) {
+        Add(info);
+    }
+});
+}
+);
+
+{
+    obj.AddObject(Object::UniqueName(), 10, [this] {
+        holder.Access([this](const auto &info) {
+        if (IsGood(info)) {
+            Add(info);
+        }
+    });
+    });
+
+    obj.AddObject(
+        Object::UniqueName(),
+        10,
+        [this] {
+        holder.Access([this](const auto &info) {
+        if (IsGood(info)) {
+            Add(info);
+        }
+    });
+    }
+    );
+}


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/uncrustify/uncrustify/pull/3136 which messes up the formatting for lambdas inside a function that is nested in another function/lambda, as such:

```
obj.AddObject(Object::UniqueName(), 10, [this] {
    holder.Access([this](const auto &info) {
    if (IsGood(info)) {
        Add(info);
    }
});
});
```

Expected:

```
obj.AddObject(Object::UniqueName(), 10, [this] {
    holder.Access([this](const auto &info) {
        if (IsGood(info)) {
            Add(info);
        }
    });
});
```