### PR TITLE
Fix FTBFS on linux (or non-Windows)

### DIFF
--- a/src/ParseFrame.cpp
+++ b/src/ParseFrame.cpp
@@ -11,9 +11,7 @@
 
 #include "uncrustify.h"
 
-#ifdef WIN32
 #include <stdexcept>            // to get std::logic_error
-#endif // WIN32
 
 
 using std::string;

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -16,9 +16,7 @@
 #include "lang_pawn.h"
 #include "prototypes.h"
 
-#ifdef WIN32
 #include <stdexcept>            // to get std::invalid_argument
-#endif // WIN32
 
 constexpr static auto LCURRENT = LBC;
 


### PR DESCRIPTION
std::invalid_argument is not found during build and result in FTBFS.
Most likely caused by recent include cleanup.
To note that <stdexcept> was already included in other part of the code without the #ifdef guard block removed in this PR.