### PR TITLE
Remove dead sp_cpp_lambda_paren_brace logic

### DIFF
--- a/src/space.cpp
+++ b/src/space.cpp
@@ -928,9 +928,8 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    if (chunk_is_token(first, CT_LPAREN_OPEN))
    {
-      // Add or remove space after the opening parenthesis and before the closing
-      // parenthesis of a argument list of a C++11 lambda, as in
-      // '[]( <here> int x <here> ){ ... }'.
+      // Add or remove space after the opening parenthesis of a argument list
+      // of a C++11 lambda, as in '[]( <here> int x ){ ... }'.
       log_rule("sp_cpp_lambda_argument_list");
       return(options::sp_cpp_lambda_argument_list());
    }
@@ -946,9 +945,8 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    if (chunk_is_token(second, CT_LPAREN_CLOSE))
    {
-      // Add or remove space after the opening parenthesis and before the closing
-      // parenthesis of a argument list of a C++11 lambda, as in
-      // '[]( <here> int x <here> ){ ... }'.
+      // Add or remove space before the closing parenthesis of a argument list
+      // of a C++11 lambda, as in '[]( int x <here> ){ ... }'.
       log_rule("sp_cpp_lambda_argument_list");
       return(options::sp_cpp_lambda_argument_list());
    }
@@ -959,15 +957,6 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
    {
       log_rule("sp_cpp_lambda_fparen");
       return(options::sp_cpp_lambda_fparen());
-   }
-
-   if (  (options::sp_cpp_lambda_paren_brace() != IARF_IGNORE)
-      && chunk_is_token(first, CT_FPAREN_CLOSE)
-      && get_chunk_parent_type(first) == CT_CPP_LAMBDA
-      && chunk_is_token(second, CT_BRACE_OPEN))
-   {
-      log_rule("sp_cpp_lambda_paren_brace");
-      return(options::sp_cpp_lambda_paren_brace());
    }
 
    if (  chunk_is_token(first, CT_ENUM)


### PR DESCRIPTION
Remove old check for applying `sp_cpp_lambda_paren_brace`, which was made unnecessary by the introduction of `LPAREN` token types in 9c0799aa096b, and in fact is likely not reachable (except possibly in case of bugs), since it looks for an `FPAREN` that should now be marked as an `LPAREN`. Also, tweak some nearby comments that were verbatim copied from the option documentation to instead document more precisely what they are doing. (The option applies space on either side of lambda argument lists, inside the parentheses, but there is separate code for the open and close parentheses.)