### PR TITLE
Dont break macro definitions

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -5552,8 +5552,12 @@ void newlines_chunk_pos(c_token_t chunk_type, token_pos_e mode)
 
             if (next->nl_count == 1)
             {
-               // move the CT_BOOL to after the newline
-               chunk_move_after(pc, next);
+               if (  prev != nullptr
+                  && !prev->flags.test(PCF_IN_PREPROC))
+               {
+                  // move the CT_BOOL to after the newline
+                  chunk_move_after(pc, next);
+               }
             }
          }
          else

--- a/tests/c.test
+++ b/tests/c.test
@@ -206,6 +206,7 @@
 
 00631  nl_assign1.cfg                       c/nl_assign.c
 00632  nl_assign2.cfg                       c/nl_assign.c
+00633  nl_assign1.cfg                       c/bug_3156.c
 
 # function def newlines
 00701  func-def-1.cfg                       c/function-def.c

--- a/tests/expected/c/00633-bug_3156.c
+++ b/tests/expected/c/00633-bug_3156.c
@@ -1,0 +1,2 @@
+#define X 1 +
+int a;

--- a/tests/input/c/bug_3156.c
+++ b/tests/input/c/bug_3156.c
@@ -1,0 +1,2 @@
+#define X 1 +
+int a;


### PR DESCRIPTION
This fixes #3156

With  pos_arith = lead, newlines_chunk_pos(CT_ARITH, ...) called chunk_move_after with "+" as pc when formatting "#define X 1 +\n int a;". chunk_move_after just moves the newline before the plus, without adding a backslash before, causing the program to become invalid.

This fix just avoids the call, like it is done a few lines further down in the same function.

A better solution would perhaps be to do something like chunk_move_after here, but also add a backslash if needed. I don't know the API enough to pull that off.