### PR TITLE
CMake: Search for Python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,8 @@ include(CheckCXXSymbolExists)
 include(CheckTypeSize)
 include(CTest)
 
-find_package(PythonInterp REQUIRED)
+find_package(Python3 REQUIRED)
+set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
 
 #
 # Check compiler flags


### PR DESCRIPTION
The FindPythonInterp CMake script is deprecated. Use the FindPython3
script instead.