### PR TITLE
Always include required headers for map and stack

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -17,12 +17,9 @@
 #include "unc_ctype.h"
 #include "unicode.h"
 
+#include <map>
 #include <regex>
 #include <set>
-
-#ifdef WIN32
-#include <map>                    // to get std::map
-#endif // WIN32
 
 
 constexpr static auto LCURRENT = LOUTPUT;

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -16,10 +16,7 @@
 #include "unc_ctype.h"
 
 #include <regex>
-
-#ifdef WIN32
-#include <stack>            // to get std::stack
-#endif // WIN32
+#include <stack>
 
 
 #define LE_COUNT(x)    cpd.le_counts[static_cast<size_t>(LE_ ## x)]


### PR DESCRIPTION
I have no clue why these includes were wrapped in `#ifdef WIN32`, but they are always needed.