### PR TITLE
Include <cerrno> for errno

### DIFF
--- a/src/backup.cpp
+++ b/src/backup.cpp
@@ -29,9 +29,7 @@
 #include "md5.h"
 #include "unc_ctype.h"
 
-#ifdef __APPLE__
-#include <cerrno>                // is needed under OSX
-#endif
+#include <cerrno>
 
 using namespace std;
 

--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -13,6 +13,7 @@
 #include "args.h"
 #include "prototypes.h"
 
+#include <cerrno>
 #include <map>
 
 

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -43,6 +43,7 @@
 #include "universalindentgui.h"
 #include "width.h"
 
+#include <cerrno>
 #include <fcntl.h>
 #include <map>
 #ifdef HAVE_UNISTD_H


### PR DESCRIPTION
Similar to #3178 - include required header for `errno`