### PR TITLE
Fixed FTBFS when using RelWithDebInfo config in debian-like distros.

### DIFF
--- a/tests/cli/test_cli_options.py
+++ b/tests/cli/test_cli_options.py
@@ -705,8 +705,8 @@ def main(args):
     #
     # Test --tracking_space FILE
     #
-    if parsed_args.config == 'Release':
-        eprint("Release")
+    if parsed_args.config == 'Release' or parsed_args.config == 'RelWithDebInfo':
+        eprint(parsed_args.config)
         if not check_uncrustify_output(
                 uncr_bin,
                 parsed_args,


### PR DESCRIPTION
When building with RelWithDebInfo, I have a FTBFS caused by failing 'tracking_space' test in test_cli_options.py due to wrong config used during the test ('Debug').

```
The following tests FAILED:
        1436 - cli_options (Failed)
Errors while running CTest
```