### PR TITLE
Fixed detection of python on distros with older cmake (< 3.12)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,15 @@ include(CheckCXXSymbolExists)
 include(CheckTypeSize)
 include(CTest)
 
-find_package(Python3 REQUIRED)
-set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+if( ${CMAKE_VERSION} VERSION_LESS "3.12" )
+    find_package( PythonInterp )
+    if( NOT PYTHON_EXECUTABLE )
+        message( FATAL_ERROR "Python is required, but was not found on your system" )
+    endif()
+ else( )
+    find_package(Python3 REQUIRED)
+    set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+endif()
 
 #
 # Check compiler flags


### PR DESCRIPTION
This was causing FTBFS on those distros.

Backported from this commit:
https://mirror.git.trinitydesktop.org/gitea/TDE/extra-dependencies/commit/766688b5179933bc1772c4572efcd884c4d8159f