### PR TITLE
add nl_before_struct option

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -2664,6 +2664,10 @@ nl_after_multiline_comment;
 extern Option<bool>
 nl_after_label_colon;
 
+// The number of newlines before a struct definition.
+extern BoundedOption<unsigned, 0, 16>
+nl_before_struct;
+
 // The number of newlines after '}' or ';' of a struct/enum/union definition.
 extern BoundedOption<unsigned, 0, 16>
 nl_after_struct;

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -549,6 +549,7 @@ nl_before_c_comment             = 0
 nl_before_cpp_comment           = 0
 nl_after_multiline_comment      = false
 nl_after_label_colon            = false
+nl_before_struct                = 0
 nl_after_struct                 = 0
 nl_before_class                 = 0
 nl_after_class                  = 0

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -2151,6 +2151,9 @@ nl_after_multiline_comment      = false    # true/false
 # Whether to force a newline after a label's colon.
 nl_after_label_colon            = false    # true/false
 
+# The number of newlines before a struct definition.
+nl_before_struct                = 0        # unsigned number
+
 # The number of newlines after '}' or ';' of a struct/enum/union definition.
 nl_after_struct                 = 0        # unsigned number
 

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -549,6 +549,7 @@ nl_before_c_comment             = 0
 nl_before_cpp_comment           = 0
 nl_after_multiline_comment      = false
 nl_after_label_colon            = false
+nl_before_struct                = 0
 nl_after_struct                 = 0
 nl_before_class                 = 0
 nl_after_class                  = 0

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -2151,6 +2151,9 @@ nl_after_multiline_comment      = false    # true/false
 # Whether to force a newline after a label's colon.
 nl_after_label_colon            = false    # true/false
 
+# The number of newlines before a struct definition.
+nl_before_struct                = 0        # unsigned number
+
 # The number of newlines after '}' or ';' of a struct/enum/union definition.
 nl_after_struct                 = 0        # unsigned number
 

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -2151,6 +2151,9 @@ nl_after_multiline_comment      = false    # true/false
 # Whether to force a newline after a label's colon.
 nl_after_label_colon            = false    # true/false
 
+# The number of newlines before a struct definition.
+nl_before_struct                = 0        # unsigned number
+
 # The number of newlines after '}' or ';' of a struct/enum/union definition.
 nl_after_struct                 = 0        # unsigned number
 

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -4881,6 +4881,16 @@ EditorType=boolean
 TrueFalse=nl_after_label_colon=true|nl_after_label_colon=false
 ValueDefault=false
 
+[Nl Before Struct]
+Category=4
+Description="<html>The number of newlines before a struct definition.</html>"
+Enabled=false
+EditorType=numeric
+CallName="nl_before_struct="
+MinVal=0
+MaxVal=16
+ValueDefault=0
+
 [Nl After Struct]
 Category=4
 Description="<html>The number of newlines after '}' or ';' of a struct/enum/union definition.</html>"

--- a/tests/config/nl_before_struct.cfg
+++ b/tests/config/nl_before_struct.cfg
@@ -1,0 +1,1 @@
+nl_before_struct = 3

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -870,6 +870,9 @@
 34350  indent_comma_brace.cfg               cpp/indent_comma_brace_glob.cpp
 34351  indent_comma_brace.cfg               cpp/indent_comma_brace_func.cpp
 
+34360  nl_before_struct.cfg                 cpp/nl_before_struct_struct.cpp
+34361  nl_before_struct.cfg                 cpp/nl_before_struct_scoped_enum.cpp
+
 # test the options sp_ with the value "ignore"
 34500  sp_before_case_colon.cfg             cpp/sp_before_case_colon.cpp
 34501  sp_endif_cmt.cfg                     cpp/sp_endif_cmt.cpp

--- a/tests/expected/cpp/34360-nl_before_struct_struct.cpp
+++ b/tests/expected/cpp/34360-nl_before_struct_struct.cpp
@@ -1,0 +1,17 @@
+#include <string>
+
+
+struct Foo
+{
+	std::string name;
+	int value;
+};
+
+
+struct Bar
+{
+	Foo* parent;
+	int modifier;
+};
+
+void baz( Foo*, Bar* );

--- a/tests/expected/cpp/34361-nl_before_struct_scoped_enum.cpp
+++ b/tests/expected/cpp/34361-nl_before_struct_scoped_enum.cpp
@@ -1,0 +1,9 @@
+int main();
+
+enum struct Baz
+{
+	Abc = 4
+	, Def = 1
+};
+
+Baz decide( Baz, Baz ) noexcept;

--- a/tests/input/cpp/nl_before_struct_scoped_enum.cpp
+++ b/tests/input/cpp/nl_before_struct_scoped_enum.cpp
@@ -1,0 +1,9 @@
+int main();
+
+enum struct Baz
+{
+     Abc = 4
+   , Def = 1
+};
+
+Baz decide( Baz, Baz ) noexcept;

--- a/tests/input/cpp/nl_before_struct_struct.cpp
+++ b/tests/input/cpp/nl_before_struct_struct.cpp
@@ -1,0 +1,15 @@
+#include <string>
+
+struct Foo
+{
+   std::string name;
+   int value;
+};
+
+struct Bar
+{
+   Foo* parent;
+   int modifier;
+};
+
+void baz( Foo*, Bar* );


### PR DESCRIPTION
This works similar to nl_before_class, but the option to modify newlines
before structs is somehow missing, as far as I can see.

Currently, we can do the following:

```cpp
int foo = 1;
class Bar {};
int baz = 2;
```

and

```
nl_before_class = 2
```

and we obtain

```cpp
int foo = 1;

class Bar {};
int baz = 2;
```

Alas, when we have

```cpp
int foo = 1;
struct Bar {};
int baz = 2;
```

this is currently not possible.