### PR TITLE
the AMP character was not correctly tokenized

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1431,6 +1431,11 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       {
          set_chunk_type(pc, CT_BYREF);
       }
+      else if (  chunk_is_token(prev, CT_WORD)             // Issue #3204
+              && chunk_is_token(next, CT_OPERATOR))
+      {
+         set_chunk_type(pc, CT_BYREF);
+      }
       else if (  chunk_is_token(next, CT_FPAREN_CLOSE)
               || chunk_is_token(next, CT_COMMA))
       {

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -665,6 +665,7 @@
 33106  bool-pos-eol-force.cfg               cpp/pos_bool_in_template.h
 33107  Issue_2688.cfg                       cpp/Issue_2688.cpp
 33108  Issue_2045.cfg                       cpp/Issue_2045.cpp
+33109  empty.cfg                            cpp/Issue_3205.cpp
 
 33110  enum.cfg                             cpp/enum.cpp
 33120  Issue_2149.cfg                       cpp/Issue_2149.cpp

--- a/tests/expected/cpp/33109-Issue_3205.cpp
+++ b/tests/expected/cpp/33109-Issue_3205.cpp
@@ -1,0 +1,1 @@
+vec_& operator+=(vec_&, const vec_&);

--- a/tests/input/cpp/Issue_3205.cpp
+++ b/tests/input/cpp/Issue_3205.cpp
@@ -1,0 +1,1 @@
+vec_& operator+=(vec_&, const vec_&);


### PR DESCRIPTION
if before the keyword operator
fixes #3205