### PR TITLE
Refactor a few chunk tests and matching tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,8 @@ set(uncrustify_sources
   src/braces.cpp
   src/calculate_closing_brace_position.cpp
   src/chunk_list.cpp
+  src/chunk_tests.cpp
+  src/chunk_tools.cpp
   src/ChunkStack.cpp
   src/combine.cpp
   src/combine_fix_mark.cpp
@@ -293,6 +295,7 @@ set(uncrustify_sources
   src/logger.cpp
   src/logmask.cpp
   src/log_rules.cpp
+  src/match_tools.cpp
   src/md5.cpp
   src/newlines.cpp
   src/option.cpp
@@ -355,6 +358,8 @@ set(uncrustify_headers
   src/calculate_closing_brace_position.h
   src/char_table.h
   src/chunk_list.h
+  src/chunk_tests.h
+  src/chunk_tools.h
   src/ChunkStack.h
   src/combine.h
   src/combine_fix_mark.h
@@ -380,6 +385,7 @@ set(uncrustify_headers
   src/log_levels.h
   src/logmask.h
   src/log_rules.h
+  src/match_tools.h
   src/md5.h
   src/newlines.h
   src/option.h
@@ -394,6 +400,7 @@ set(uncrustify_headers
   src/punctuators.h
   src/quick_align_again.h
   src/remove_extra_returns.h
+  src/scope_enum.h
   src/semicolons.h
   src/sorting.h
   src/space.h

--- a/src/EnumStructUnionParser.h
+++ b/src/EnumStructUnionParser.h
@@ -1,5 +1,5 @@
 /**
- * @file combine_fix_mark_enum_struct_union.h
+ * @file EnumStructUnionParser.h
  *
  * @author
  * @license GPL v2+
@@ -11,19 +11,17 @@
 
 #include "pcf_flags.h"
 #include "token_enum.h"
+
 #include <map>
 
 
 /**
- * Class EnumStructUnionParser : This class facilitates the parsing and interpretation
- *                               of ALL instances of the class, enum, union, and
- *                               struct keywords, including user-defined types with
- *                               a body {} and any trailing inline variable declarations
- *                               that may follow the definition (as permitted by
- *                               the coding language in question). The class also
- *                               interprets variable declarations preceded by one
- *                               of those keywords, as well as any C/C++ forward
- *                               declarations
+ * Class EnumStructUnionParser
+ *
+ * This class facilitates the parsing and interpretation of ALL instances of the class, enum, union, and
+ * struct keywords, including user-defined types with a body {} and any trailing inline variable declarations
+ * that may follow the definition (as permitted by the coding language in question). The class also interprets
+ * variable declarations preceded by one of those keywords, as well as any C/C++ forward declarations
  */
 class EnumStructUnionParser
 {
@@ -493,4 +491,4 @@ private:
 };
 
 
-#endif
+#endif /* ENUM_STRUCT_UNION_PARSER_H_INCLUDED */

--- a/src/align_assign.cpp
+++ b/src/align_assign.cpp
@@ -70,7 +70,7 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
       // Don't check inside SPAREN, PAREN or SQUARE groups
       if (  chunk_is_token(pc, CT_SPAREN_OPEN)
             // || chunk_is_token(pc, CT_FPAREN_OPEN) Issue #1340
-         || chunk_is_token(pc, CT_SQUARE_OPEN)
+         || chunk_is_square_open_token(pc)
          || chunk_is_token(pc, CT_PAREN_OPEN))
       {
          LOG_FMT(LALASS, "%s(%d): Don't check inside SPAREN, PAREN or SQUARE groups, type is %s\n",
@@ -98,7 +98,7 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
       }
 
       // Recurse if a brace set is found
-      if (  chunk_is_token(pc, CT_BRACE_OPEN)
+      if (  chunk_is_brace_open_token(pc)
          || chunk_is_token(pc, CT_VBRACE_OPEN))
       {
          size_t myspan;
@@ -144,7 +144,7 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
       }
 
       // Done with this brace set?
-      if (  chunk_is_token(pc, CT_BRACE_CLOSE)
+      if (  chunk_is_brace_close_token(pc)
          || chunk_is_token(pc, CT_VBRACE_CLOSE))
       {
          pc = chunk_get_next(pc);
@@ -188,11 +188,11 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
       }
       else if (  equ_count == 0                      // indent only if first '=' in line
               && !pc->flags.test(PCF_IN_TEMPLATE)    // and it is not inside a template #999
-              && (  chunk_is_token(pc, CT_ASSIGN)
+              && (  chunk_is_assign_token(pc)
                  || chunk_is_token(pc, CT_ASSIGN_DEFAULT_ARG)
                  || chunk_is_token(pc, CT_ASSIGN_FUNC_PROTO)))
       {
-         if (chunk_is_token(pc, CT_ASSIGN))               // Issue #2236
+         if (chunk_is_assign_token(pc))               // Issue #2236
          {
             equ_count++;
          }
@@ -242,7 +242,7 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
                        __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col);
                fcnProto.Add(pc);
             }
-            else if (chunk_is_token(pc, CT_ASSIGN)) // Issue #2197
+            else if (chunk_is_assign_token(pc)) // Issue #2197
             {
                LOG_FMT(LALASS, "%s(%d): vdas.Add on '%s' on orig_line %zu, orig_col is %zu\n",
                        __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col);
@@ -265,7 +265,7 @@ chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_c
          }
          else
          {
-            if (chunk_is_token(pc, CT_ASSIGN))
+            if (chunk_is_assign_token(pc))
             {
                LOG_FMT(LALASS, "%s(%d): as.Add on '%s' on orig_line %zu, orig_col is %zu\n",
                        __func__, __LINE__, pc->text(), pc->orig_line, pc->orig_col);

--- a/src/align_eigen_comma_init.cpp
+++ b/src/align_eigen_comma_init.cpp
@@ -73,7 +73,7 @@ void align_eigen_comma_init(void)
       }
       else if (  !pc->flags.test(PCF_IN_ENUM)
               && !pc->flags.test(PCF_IN_TYPEDEF)
-              && chunk_is_str(pc, "<<", 2))
+              && chunk_is_lshift_str(pc))
       {
          if (get_chunk_parent_type(pc) == CT_OPERATOR)
          {
@@ -109,7 +109,7 @@ void align_eigen_comma_init(void)
          auto *const prev = chunk_get_prev(pc);
 
          if (  chunk_is_newline(prev)
-            && chunk_is_token(chunk_get_prev_ncnnl(pc), CT_COMMA))
+            && chunk_is_comma_token(chunk_get_prev_ncnnl(pc)))
          {
             log_rule_B("align_eigen_comma_init");
             as.Add(pc);

--- a/src/align_func_params.cpp
+++ b/src/align_func_params.cpp
@@ -130,7 +130,7 @@ chunk_t *align_func_param(chunk_t *start)
             break;
          }
       }
-      else if (chunk_is_token(pc, CT_COMMA))
+      else if (chunk_is_comma_token(pc))
       {
          if (pc->flags.test(PCF_IN_TEMPLATE))            // Issue #2757
          {

--- a/src/align_func_proto.cpp
+++ b/src/align_func_proto.cpp
@@ -181,7 +181,7 @@ void align_func_proto(size_t span)
                     && options::align_single_line_brace();
       }
       else if (  look_bro
-              && chunk_is_token(pc, CT_BRACE_OPEN)
+              && chunk_is_brace_open_token(pc)
               && pc->flags.test(PCF_ONE_LINER))
       {
          AlignStack *stack_at_l_bl_brace = many_as_brace.at(pc->level).at(pc->brace_level);

--- a/src/align_init_brace.cpp
+++ b/src/align_init_brace.cpp
@@ -36,7 +36,7 @@ void align_init_brace(chunk_t *start)
    chunk_t *pcSingle = scan_ib_line(pc, true);
 
    if (  pcSingle == nullptr
-      || (  chunk_is_token(pcSingle, CT_BRACE_CLOSE)
+      || (  chunk_is_brace_close_token(pcSingle)
          && get_chunk_parent_type(pcSingle) == CT_ASSIGN))
    {
       // single line - nothing to do
@@ -126,7 +126,7 @@ void align_init_brace(chunk_t *start)
             }
 
             // Comma's need to 'fall back' to the previous token
-            if (chunk_is_token(pc, CT_COMMA))
+            if (chunk_is_comma_token(pc))
             {
                next = chunk_get_next(pc);
 
@@ -140,8 +140,7 @@ void align_init_brace(chunk_t *start)
 
                   if (  (idx < (cpd.al_cnt - 1))
                      && options::align_number_right()
-                     && (  chunk_is_token(next, CT_NUMBER_FP)
-                        || chunk_is_token(next, CT_NUMBER)
+                     && (  chunk_is_number_token(next)
                         || chunk_is_token(next, CT_POS)
                         || chunk_is_token(next, CT_NEG)))
                   {
@@ -174,8 +173,7 @@ void align_init_brace(chunk_t *start)
                   next = chunk_get_next(pc);
 
                   if (  !chunk_is_newline(next)
-                     && (  chunk_is_token(next, CT_NUMBER_FP)
-                        || chunk_is_token(next, CT_NUMBER)
+                     && (  chunk_is_number_token(next)
                         || chunk_is_token(next, CT_POS)
                         || chunk_is_token(next, CT_NEG)))
                   {

--- a/src/align_left_shift.cpp
+++ b/src/align_left_shift.cpp
@@ -73,7 +73,7 @@ void align_left_shift(void)
       }
       else if (  !pc->flags.test(PCF_IN_ENUM)
               && !pc->flags.test(PCF_IN_TYPEDEF)
-              && chunk_is_str(pc, "<<", 2))
+              && chunk_is_lshift_str(pc))
       {
          if (get_chunk_parent_type(pc) == CT_OPERATOR)
          {

--- a/src/align_oc_decl_colon.cpp
+++ b/src/align_oc_decl_colon.cpp
@@ -49,8 +49,8 @@ void align_oc_decl_colon(void)
             && pc->level >= level)
       {
          // The declaration ends with an open brace or semicolon
-         if (  chunk_is_token(pc, CT_BRACE_OPEN)
-            || chunk_is_semicolon(pc))
+         if (  chunk_is_brace_open_token(pc)
+            || chunk_is_semicolon_token(pc))
          {
             break;
          }

--- a/src/align_oc_msg_colons.cpp
+++ b/src/align_oc_msg_colons.cpp
@@ -173,7 +173,7 @@ void align_oc_msg_colons(void)
 
    for (chunk_t *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next(pc))
    {
-      if (  chunk_is_token(pc, CT_SQUARE_OPEN)
+      if (  chunk_is_square_open_token(pc)
          && get_chunk_parent_type(pc) == CT_OC_MSG)
       {
          align_oc_msg_colon(pc);

--- a/src/align_same_func_call_params.cpp
+++ b/src/align_same_func_call_params.cpp
@@ -96,8 +96,8 @@ void align_same_func_call_params(void)
       // Only align function calls that are right after a newline
       chunk_t *prev = chunk_get_prev(pc);
 
-      while (  chunk_is_token(prev, CT_MEMBER)
-            || chunk_is_token(prev, CT_DC_MEMBER))
+      while (  chunk_is_member_token(prev)
+            || chunk_is_double_colon_token(prev))
       {
          chunk_t *tprev = chunk_get_prev(prev);
 
@@ -219,8 +219,7 @@ void align_same_func_call_params(void)
 
                if (!options::align_number_right())
                {
-                  if (  chunk_is_token(chunks[idx], CT_NUMBER_FP)
-                     || chunk_is_token(chunks[idx], CT_NUMBER)
+                  if (  chunk_is_number_token(chunks[idx])
                      || chunk_is_token(chunks[idx], CT_POS)
                      || chunk_is_token(chunks[idx], CT_NEG))
                   {
@@ -274,7 +273,7 @@ void align_params(chunk_t *start, deque<chunk_t *> &chunks)
             chunks.push_back(pc);
             hit_comma = false;
          }
-         else if (chunk_is_token(pc, CT_COMMA))
+         else if (chunk_is_comma_token(pc))
          {
             hit_comma = true;
          }

--- a/src/align_stack.cpp
+++ b/src/align_stack.cpp
@@ -200,7 +200,7 @@ void AlignStack::Add(chunk_t *start, size_t seqnum)
       // back up to the first '*' or '^' preceding the token
       chunk_t *tmp_prev = chunk_get_prev(ali);
 
-      while (  chunk_is_star(tmp_prev)
+      while (  chunk_is_star_token(tmp_prev)
             || chunk_is_msref(tmp_prev))
       {
          ali      = tmp_prev;
@@ -288,7 +288,7 @@ void AlignStack::Add(chunk_t *start, size_t seqnum)
          tmp = chunk_get_next(tmp);
       }
 
-      if (  (  chunk_is_star(tmp)
+      if (  (  chunk_is_star_token(tmp)
             && m_star_style == SS_DANGLE)
          || (  chunk_is_addr(tmp)
             && m_amp_style == SS_DANGLE)
@@ -472,7 +472,7 @@ void AlignStack::Flush()
             {
                chunk_t *next = chunk_get_next(pc->align.start);
 
-               if (chunk_is_token(next, CT_NUMBER))
+               if (chunk_is_integral_number_token(next))
                {
                   start_len += next->len();
                }

--- a/src/align_struct_initializers.cpp
+++ b/src/align_struct_initializers.cpp
@@ -22,10 +22,10 @@ void align_struct_initializers(void)
    {
       chunk_t *prev = chunk_get_prev_ncnnl(pc);
 
-      if (  chunk_is_token(prev, CT_ASSIGN)
-         && (  chunk_is_token(pc, CT_BRACE_OPEN)
+      if (  chunk_is_assign_token(prev)
+         && (  chunk_is_brace_open_token(pc)
             || (  language_is_set(LANG_D)
-               && chunk_is_token(pc, CT_SQUARE_OPEN))))
+               && chunk_is_square_open_token(pc))))
       {
          align_init_brace(pc);
       }

--- a/src/align_tools.cpp
+++ b/src/align_tools.cpp
@@ -15,11 +15,11 @@
 
 chunk_t *skip_c99_array(chunk_t *sq_open)
 {
-   if (chunk_is_token(sq_open, CT_SQUARE_OPEN))
+   if (chunk_is_square_open_token(sq_open))
    {
       chunk_t *tmp = chunk_get_next_nc(chunk_skip_to_match(sq_open));
 
-      if (chunk_is_token(tmp, CT_ASSIGN))
+      if (chunk_is_assign_token(tmp))
       {
          return(chunk_get_next_nc(tmp));
       }
@@ -66,10 +66,10 @@ chunk_t *scan_ib_line(chunk_t *start, bool first_pass)
       {
          // do nothing
       }
-      else if (  chunk_is_token(pc, CT_ASSIGN)
-              || chunk_is_token(pc, CT_BRACE_OPEN)
-              || chunk_is_token(pc, CT_BRACE_CLOSE)
-              || chunk_is_token(pc, CT_COMMA))
+      else if (  chunk_is_assign_token(pc)
+              || chunk_is_brace_open_token(pc)
+              || chunk_is_brace_close_token(pc)
+              || chunk_is_comma_token(pc))
       {
          size_t token_width = space_col_align(pc, next);
 
@@ -164,7 +164,7 @@ chunk_t *step_back_over_member(chunk_t *pc)
 
    // Skip over any class stuff: bool CFoo::bar()
    while (  ((tmp = chunk_get_prev_ncnnl(pc)) != nullptr)
-         && chunk_is_token(tmp, CT_DC_MEMBER))
+         && chunk_is_double_colon_token(tmp))
    {
       // TODO: verify that we are pointing at something sane?
       pc = chunk_get_prev_ncnnl(tmp);

--- a/src/align_trailing_comments.cpp
+++ b/src/align_trailing_comments.cpp
@@ -159,7 +159,7 @@ comment_align_e get_comment_align_type(chunk_t *cmt)
       if (  chunk_is_token(prev, CT_PP_ENDIF)
          || chunk_is_token(prev, CT_PP_ELSE)
          || chunk_is_token(prev, CT_ELSE)
-         || chunk_is_token(prev, CT_BRACE_CLOSE))
+         || chunk_is_brace_close_token(prev))
       {
          // TODO: make the magic 3 configurable
          if ((cmt->column - (prev->column + prev->len())) < 3)

--- a/src/align_var_def_brace.cpp
+++ b/src/align_var_def_brace.cpp
@@ -61,7 +61,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
    // can't be any variable definitions in a "= {" block
    chunk_t *prev = chunk_get_prev_ncnnl(start);
 
-   if (chunk_is_token(prev, CT_ASSIGN))
+   if (chunk_is_assign_token(prev))
    {
       LOG_FMT(LAVDB, "%s(%d): start->text() '%s', type is %s, on orig_line %zu (abort due to assign)\n",
               __func__, __LINE__, start->text(), get_token_name(start->type), start->orig_line);
@@ -174,7 +174,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
                           && options::align_single_line_brace();
          }
          else if (  fp_look_bro
-                 && chunk_is_token(pc, CT_BRACE_OPEN)
+                 && chunk_is_brace_open_token(pc)
                  && pc->flags.test(PCF_ONE_LINER))
          {
             as_br.Add(pc);
@@ -183,7 +183,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
       }
 
       // process nested braces
-      if (chunk_is_token(pc, CT_BRACE_OPEN))
+      if (chunk_is_brace_open_token(pc))
       {
          size_t sub_nl_count = 0;
 
@@ -207,7 +207,7 @@ chunk_t *align_var_def_brace(chunk_t *start, size_t span, size_t *p_nl_count)
       }
 
       // Done with this brace set?
-      if (chunk_is_token(pc, CT_BRACE_CLOSE))
+      if (chunk_is_brace_close_token(pc))
       {
          pc = chunk_get_next(pc);
          break;

--- a/src/calculate_closing_brace_position.cpp
+++ b/src/calculate_closing_brace_position.cpp
@@ -28,7 +28,7 @@ chunk_t *calculate_closing_brace_position(const chunk_t *cl_colon, chunk_t *pc)
 
    size_t check_level = 0;
 
-   if (chunk_is_token(pc, CT_BRACE_CLOSE))
+   if (chunk_is_brace_close_token(pc))
    {
       check_level = pc->level + 1;
    }
@@ -56,7 +56,7 @@ chunk_t *calculate_closing_brace_position(const chunk_t *cl_colon, chunk_t *pc)
 
       if (back->level == check_level)
       {
-         if (  chunk_is_token(back, CT_BRACE_CLOSE)
+         if (  chunk_is_brace_close_token(back)
             || chunk_is_token(back, CT_VBRACE_CLOSE))
          {
             // brace_close found

--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -971,10 +971,10 @@ static chunk_t *chunk_add(const chunk_t *pc_in, chunk_t *ref, const direction_e 
 
 chunk_t *chunk_get_next_ssq(chunk_t *cur)
 {
-   while (  chunk_is_token(cur, CT_TSQUARE)
-         || chunk_is_token(cur, CT_SQUARE_OPEN))
+   while (  chunk_is_subscript_token(cur)
+         || chunk_is_square_open_token(cur))
    {
-      if (chunk_is_token(cur, CT_SQUARE_OPEN))
+      if (chunk_is_square_open_token(cur))
       {
          cur = chunk_skip_to_match(cur);
       }
@@ -986,10 +986,10 @@ chunk_t *chunk_get_next_ssq(chunk_t *cur)
 
 chunk_t *chunk_get_prev_ssq(chunk_t *cur)
 {
-   while (  chunk_is_token(cur, CT_TSQUARE)
-         || chunk_is_token(cur, CT_SQUARE_CLOSE))
+   while (  chunk_is_subscript_token(cur)
+         || chunk_is_square_close_token(cur))
    {
-      if (chunk_is_token(cur, CT_SQUARE_CLOSE))
+      if (chunk_is_square_close_token(cur))
       {
          cur = chunk_skip_to_match_rev(cur);
       }
@@ -1027,9 +1027,9 @@ static chunk_t *chunk_skip_dc_member(chunk_t *start, scope_e scope, direction_e 
                          ? chunk_get_next_ncnnl : chunk_get_prev_ncnnl;
 
    chunk_t *pc   = start;
-   chunk_t *next = chunk_is_token(pc, CT_DC_MEMBER) ? pc : step_fcn(pc, scope);
+   chunk_t *next = chunk_is_double_colon_token(pc) ? pc : step_fcn(pc, scope);
 
-   while (chunk_is_token(next, CT_DC_MEMBER))
+   while (chunk_is_double_colon_token(next))
    {
       pc = step_fcn(next, scope);
 

--- a/src/chunk_tests.cpp
+++ b/src/chunk_tests.cpp
@@ -1,0 +1,1708 @@
+/**
+ * @file chunk_tests.cpp
+ *
+ * @author
+ * @license GPL v2+
+ */
+
+#include "chunk_tests.h"
+
+#include "chunk_list.h"
+#include "chunk_tools.h"
+#include "keywords.h"
+#include "match_tools.h"
+
+
+bool chunk_is_add_assign_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "+=", 2));
+} // chunk_is_add_assign_str
+
+
+bool chunk_is_add_assign_token(chunk_t *pc)
+{
+   return(  chunk_is_add_assign_str(pc)
+         && chunk_is_assign_token(pc));
+} // chunk_is_add_assign_token
+
+
+bool chunk_is_add_assign_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_add_assign_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_add_assign_token_overload
+
+
+bool chunk_is_after(chunk_t *pc, chunk_t *after, bool test_equal)
+{
+   LOG_FUNC_ENTRY();
+
+   if (pc != nullptr)
+   {
+      if (  test_equal
+         && pc == after)
+      {
+         return(true);
+      }
+      else if (after != nullptr)
+      {
+         auto pc_column    = pc->orig_col;
+         auto pc_line      = pc->orig_line;
+         auto after_column = after->orig_col;
+         auto after_line   = after->orig_line;
+
+         return(  pc_line > after_line
+               || (  pc_line == after_line
+                  && pc_column > after_column));
+      }
+   }
+   return(false);
+} // chunk_is_after
+
+
+bool chunk_is_alignof_str(chunk_t *pc)
+{
+   return(  chunk_is_str(pc, "alignof", 7)
+         || chunk_is_str(pc, "_Alignof", 8));
+} // chunk_is_alignof_str
+
+
+bool chunk_is_alignof_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_ALIGN));
+} // chunk_is_alignof_token
+
+
+bool chunk_is_ampersand_assign_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "&=", 2));
+} // chunk_is_ampersand_assign_str
+
+
+bool chunk_is_ampersand_assign_token(chunk_t *pc)
+{
+   return(  chunk_is_ampersand_assign_str(pc)
+         && chunk_is_assign_token(pc));
+} // chunk_is_ampersand_assign_token
+
+
+bool chunk_is_ampersand_assign_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_ampersand_assign_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_ampersand_assign_token_overload
+
+
+bool chunk_is_ampersand_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '&'));
+} // chunk_is_ampersand_str
+
+
+bool chunk_is_ampersand_token(chunk_t *pc)
+{
+   return(  chunk_is_token(pc, CT_ADDR)
+         || chunk_is_token(pc, CT_AMP)
+         || chunk_is_token(pc, CT_BYREF));
+} // chunk_is_ampersand_token
+
+
+bool chunk_is_ampersand_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_ampersand_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_ampersand_token_overload
+
+
+bool chunk_is_angle_close_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '>'));
+} // chunk_is_angle_close_str
+
+
+bool chunk_is_angle_close_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_ANGLE_CLOSE));
+} // chunk_is_angle_close_token
+
+
+bool chunk_is_angle_close_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_angle_close_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_angle_close_token_overload
+
+
+bool chunk_is_angle_open_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '<'));
+} // chunk_is_angle_open_str
+
+
+bool chunk_is_angle_open_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_ANGLE_OPEN));
+} // chunk_is_angle_open_token
+
+
+bool chunk_is_angle_open_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_angle_open_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_angle_open_token_overload
+
+
+bool chunk_is_assign_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '='));
+} // chunk_is_assign_str
+
+
+bool chunk_is_assign_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_ASSIGN));
+} // chunk_is_assign_token
+
+
+bool chunk_is_assign_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_assign_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_assign_token_overload
+
+
+bool chunk_is_auto_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "auto", 4));
+} // chunk_is_auto_str
+
+
+bool chunk_is_auto_token(chunk_t *pc)
+{
+   return(  chunk_is_auto_str(pc)
+         && chunk_is_token(pc, CT_TYPE));
+} // chunk_is_auto_token
+
+
+bool chunk_is_before(chunk_t *pc, chunk_t *before, bool test_equal)
+{
+   LOG_FUNC_ENTRY();
+
+   if (pc != nullptr)
+   {
+      if (  test_equal
+         && pc == before)
+      {
+         return(true);
+      }
+      else if (before != nullptr)
+      {
+         auto pc_column     = pc->orig_col;
+         auto pc_line       = pc->orig_line;
+         auto before_column = before->orig_col;
+         auto before_line   = before->orig_line;
+
+         return(  pc_line < before_line
+               || (  pc_line == before_line
+                  && pc_column < before_column));
+      }
+   }
+   return(false);
+} // chunk_is_before
+
+
+bool chunk_is_between(chunk_t *pc, chunk_t *after, chunk_t *before, bool test_equal)
+{
+   return(  chunk_is_before(pc, before, test_equal)
+         && chunk_is_after(pc, after, test_equal));
+} // chunk_is_between
+
+
+bool chunk_is_bitwise_or_assign_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "|=", 2));
+} // chunk_is_bitwise_or_assign_str
+
+
+bool chunk_is_bitwise_or_assign_token(chunk_t *pc)
+{
+   return(  chunk_is_bitwise_or_assign_str(pc)
+         && chunk_is_assign_token(pc));
+} // chunk_is_bitwise_or_assign_token
+
+
+bool chunk_is_bitwise_or_assign_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_bitwise_or_assign_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_bitwise_or_assign_token_overload
+
+
+bool chunk_is_bitwise_or_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '|'));
+} // chunk_is_bitwise_or_str
+
+
+bool chunk_is_bitwise_or_token(chunk_t *pc)
+{
+   return(  chunk_is_bitwise_or_str(pc)
+         && chunk_is_token(pc, CT_ARITH));
+} // chunk_is_bitwise_or_token
+
+
+bool chunk_is_bitwise_or_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_bitwise_or_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_bitwise_or_token_overload
+
+
+bool chunk_is_brace_close_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '}'));
+} // chunk_is_brace_close_str
+
+
+bool chunk_is_brace_close_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_BRACE_CLOSE));
+} // chunk_is_brace_close_token
+
+
+bool chunk_is_brace_open_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '{'));
+} // chunk_is_brace_open_str
+
+
+bool chunk_is_brace_open_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_BRACE_OPEN));
+} // chunk_is_brace_open_token
+
+
+bool chunk_is_caret_assign_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "^=", 2));
+} // chunk_is_caret_assign_str
+
+
+bool chunk_is_caret_assign_token(chunk_t *pc)
+{
+   return(  chunk_is_caret_assign_str(pc)
+         && chunk_is_assign_token(pc));
+} // chunk_is_caret_assign_token
+
+
+bool chunk_is_caret_assign_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_caret_assign_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_caret_assign_token_overload
+
+
+bool chunk_is_caret_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '^'));
+} // chunk_is_caret_str
+
+
+bool chunk_is_caret_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_CARET));
+} // chunk_is_caret_token
+
+
+bool chunk_is_caret_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_caret_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_caret_token_overload
+
+
+bool chunk_is_catch_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "catch", 5));
+} // chunk_is_catch_str
+
+
+bool chunk_is_catch_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_CATCH));
+} // chunk_is_catch_token
+
+
+bool chunk_is_char_literal(chunk_t *pc)
+{
+   // TODO: Need to revisit this
+
+   return(  chunk_is_token(pc, CT_STRING)
+         && pc->len() == 1);
+} // chunk_is_char_literal
+
+
+bool chunk_is_colon_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == ':'));
+} // chunk_is_colon_str
+
+
+bool chunk_is_colon_token(chunk_t *pc)
+{
+   return(  chunk_is_token(pc, CT_ACCESS_COLON)
+         || chunk_is_token(pc, CT_ASM_COLON)
+         || chunk_is_token(pc, CT_BIT_COLON)
+         || chunk_is_token(pc, CT_CASE_COLON)
+         || chunk_is_token(pc, CT_CLASS_COLON)
+         || chunk_is_token(pc, CT_COLON)
+         || chunk_is_token(pc, CT_COND_COLON)
+         || chunk_is_token(pc, CT_CONSTR_COLON)
+         || chunk_is_token(pc, CT_CS_SQ_COLON)
+         || chunk_is_token(pc, CT_D_ARRAY_COLON)
+         || chunk_is_token(pc, CT_FOR_COLON)
+         || chunk_is_token(pc, CT_LABEL_COLON)
+         || chunk_is_token(pc, CT_OC_COLON)
+         || chunk_is_token(pc, CT_OC_DICT_COLON)
+         || chunk_is_token(pc, CT_TAG_COLON)
+         || chunk_is_token(pc, CT_WHERE_COLON));
+} // chunk_is_colon_token
+
+
+bool chunk_is_comma_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == ','));
+} // chunk_is_comma_str
+
+
+bool chunk_is_comma_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_COMMA));
+} // chunk_is_comma_token
+
+
+bool chunk_is_comma_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_comma_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_comma_token_overload
+
+
+bool chunk_is_compare_equal_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "==", 2));
+} // chunk_is_compare_equal_str
+
+
+bool chunk_is_compare_equal_token(chunk_t *pc)
+{
+   return(  chunk_is_compare_equal_str(pc)
+         && chunk_is_token(pc, CT_COMPARE));
+} // chunk_is_compare_equal_token
+
+
+bool chunk_is_compare_equal_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_compare_equal_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_compare_equal_token_overload
+
+
+bool chunk_is_compare_greater_equal_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, ">=", 2));
+} // chunk_is_compare_greater_equal_str
+
+
+bool chunk_is_compare_greater_equal_token(chunk_t *pc)
+{
+   return(  chunk_is_compare_greater_equal_str(pc)
+         && chunk_is_token(pc, CT_COMPARE));
+} // chunk_is_compare_greater_equal_token
+
+
+bool chunk_is_compare_greater_equal_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_compare_greater_equal_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_compare_greater_equal_token_overload
+
+
+bool chunk_is_compare_inequal_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "!=", 2));
+} // chunk_is_compare_inequal_str
+
+
+bool chunk_is_compare_inequal_token(chunk_t *pc)
+{
+   return(  chunk_is_compare_inequal_str(pc)
+         && chunk_is_token(pc, CT_COMPARE));
+} // chunk_is_compare_inequal_token
+
+
+bool chunk_is_compare_inequal_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_compare_inequal_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_compare_inequal_token_overload
+
+
+bool chunk_is_compare_less_equal_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "<=", 2));
+} // chunk_is_compare_less_equal_str
+
+
+bool chunk_is_compare_less_equal_token(chunk_t *pc)
+{
+   return(  chunk_is_compare_less_equal_str(pc)
+         && chunk_is_token(pc, CT_COMPARE));
+} // chunk_is_compare_less_equal_token
+
+
+bool chunk_is_compare_less_equal_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_compare_less_equal_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_compare_less_equal_token_overload
+
+
+bool chunk_is_compare_three_way_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "<=>", 3));
+} // chunk_is_compare_three_way_str
+
+
+bool chunk_is_compare_three_way_token(chunk_t *pc)
+{
+   return(  chunk_is_compare_three_way_str(pc)
+         && chunk_is_token(pc, CT_COMPARE));
+} // chunk_is_compare_three_way_token
+
+
+bool chunk_is_compare_three_way_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_compare_three_way_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_compare_three_way_token_overload
+
+
+bool chunk_is_comparison_str(chunk_t *pc)
+{
+   return(  chunk_is_angle_close_str(pc)
+         || chunk_is_angle_open_str(pc)
+         || chunk_is_compare_equal_str(pc)
+         || chunk_is_compare_greater_equal_str(pc)
+         || chunk_is_compare_inequal_str(pc)
+         || chunk_is_compare_less_equal_str(pc)
+         || chunk_is_compare_three_way_str(pc));
+} // chunk_is_comparison_str
+
+
+bool chunk_is_comparison_token(chunk_t *pc)
+{
+   return(  chunk_is_comparison_str(pc)
+         && chunk_is_token(pc, CT_COMPARE));
+} // chunk_is_comparison_token
+
+
+bool chunk_is_comparison_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_comparison_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_comparison_token_overload
+
+
+bool chunk_is_const_cast_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "const_cast", 10));
+} // chunk_is_const_cast_str
+
+
+bool chunk_is_const_cast_token(chunk_t *pc)
+{
+   return(  chunk_is_const_cast_str(pc)
+         && chunk_is_token(pc, CT_TYPE_CAST));
+} // chunk_is_const_cast_token
+
+
+bool chunk_is_const_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "const", 5));
+} // chunk_is_const_str
+
+
+bool chunk_is_const_token(chunk_t *pc)
+{
+   return(  chunk_is_const_str(pc)
+         && chunk_is_token(pc, CT_QUALIFIER));
+} // chunk_is_const_token
+
+
+bool chunk_is_constexpr_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "constexpr", 9));
+} // chunk_is_constexpr_str
+
+
+bool chunk_is_constexpr_token(chunk_t *pc)
+{
+   return(  chunk_is_constexpr_str(pc)
+         && chunk_is_token(pc, CT_QUALIFIER));
+} // chunk_is_constexpr_token
+
+
+bool chunk_is_cpp_type_cast_str(chunk_t *pc)
+{
+   return(  chunk_is_const_cast_str(pc)
+         || chunk_is_dynamic_cast_str(pc)
+         || chunk_is_reinterpret_cast_str(pc)
+         || chunk_is_static_cast_str(pc));
+} // chunk_is_cpp_type_cast_str
+
+
+bool chunk_is_cpp_type_cast_token(chunk_t *pc)
+{
+   return(  chunk_is_const_cast_token(pc)
+         || chunk_is_dynamic_cast_token(pc)
+         || chunk_is_reinterpret_cast_token(pc)
+         || chunk_is_static_cast_token(pc));
+} // chunk_is_cpp_type_cast_token
+
+
+bool chunk_is_cv_qualifier_str(chunk_t *pc)
+{
+   return(  chunk_is_const_str(pc)
+         || chunk_is_volatile_str(pc));
+} // chunk_is_cv_qualifier_str
+
+
+bool chunk_is_cv_qualifier_token(chunk_t *pc)
+{
+   return(  chunk_is_const_token(pc)
+         || chunk_is_volatile_token(pc));
+} // chunk_is_cv_qualifier_token
+
+
+bool chunk_is_decltype_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "decltype", 8));
+} // chunk_is_decltype_str
+
+
+bool chunk_is_decltype_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_DECLTYPE));
+} // chunk_is_decltype_token
+
+
+bool chunk_is_decrement_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "--", 2));
+} // chunk_is_decrement_str
+
+
+bool chunk_is_decrement_token(chunk_t *pc)
+{
+   return(  chunk_is_decrement_str(pc)
+         && (  chunk_is_token(pc, CT_INCDEC_AFTER)
+            || chunk_is_token(pc, CT_INCDEC_BEFORE)));
+} // chunk_is_decrement_token
+
+
+bool chunk_is_decrement_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_decrement_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_decrement_token_overload
+
+
+bool chunk_is_delete_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "delete", 6));
+} // chunk_is_delete_str
+
+
+bool chunk_is_delete_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_DELETE));
+} // chunk_is_delete_token
+
+
+bool chunk_is_delete_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_delete_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_delete_token_overload
+
+
+bool chunk_is_divide_assign_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "/=", 2));
+} // chunk_is_divide_assign_str
+
+
+bool chunk_is_divide_assign_token(chunk_t *pc)
+{
+   return(  chunk_is_divide_assign_str(pc)
+         && chunk_is_assign_token(pc));
+} // chunk_is_divide_assign_token
+
+
+bool chunk_is_divide_assign_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_divide_assign_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_divide_assign_token_overload
+
+
+bool chunk_is_divide_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '/'));
+} // chunk_is_divide_str
+
+
+bool chunk_is_divide_token(chunk_t *pc)
+{
+   return(  chunk_is_divide_str(pc)
+         && chunk_is_token(pc, CT_ARITH));
+} // chunk_is_divide_token
+
+
+bool chunk_is_divide_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_divide_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_divide_token_overload
+
+
+bool chunk_is_double_ampersand_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "&&", 2));
+} // chunk_is_double_ampersand_str
+
+
+bool chunk_is_double_ampersand_token(chunk_t *pc)
+{
+   return(  chunk_is_double_ampersand_str(pc)
+         && (  chunk_is_token(pc, CT_BOOL)
+            || chunk_is_token(pc, CT_BYREF)));
+} // chunk_is_double_ampersand_token
+
+
+bool chunk_is_double_ampersand_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_double_ampersand_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_double_ampersand_token_overload
+
+
+bool chunk_is_double_colon_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "::", 2));
+} // chunk_is_double_colon_str
+
+
+bool chunk_is_double_colon_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_DC_MEMBER));
+} // chunk_is_double_colon_token
+
+
+bool chunk_is_dynamic_cast_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "dynamic_cast", 12));
+} // chunk_is_dynamic_cast_str
+
+
+bool chunk_is_dynamic_cast_token(chunk_t *pc)
+{
+   return(  chunk_is_dynamic_cast_str(pc)
+         && chunk_is_token(pc, CT_TYPE_CAST));
+} // chunk_is_dynamic_cast_token
+
+
+bool chunk_is_ellipsis_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "...", 3));
+} // chunk_is_ellipsis_str
+
+
+bool chunk_is_ellipsis_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_ELLIPSIS));
+} // chunk_is_ellipsis_token
+
+
+bool chunk_is_empty_parens_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "()", 2));
+} // chunk_is_empty_parens_str
+
+
+bool chunk_is_empty_square_brackets_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "[]", 2));
+} // chunk_is_empty_square_brackets_str
+
+
+bool chunk_is_equals_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '='));
+} // chunk_is_equals_str
+
+
+bool chunk_is_equals_token(chunk_t *pc)
+{
+   return(  chunk_is_equals_str(pc)
+         && chunk_is_assign_token(pc));
+} // chunk_is_equals_token
+
+
+bool chunk_is_equals_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_equals_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_equals_token_overload
+
+
+bool chunk_is_floating_point_number_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_NUMBER_FP));
+} // chunk_is_floating_point_number_token
+
+
+bool chunk_is_function_call_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_empty_parens_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_function_call_token_overload
+
+
+bool chunk_is_identifier(chunk_t *pc, bool skip_dc)
+{
+   LOG_FUNC_ENTRY();
+
+   if (skip_dc)
+   {
+      pc = chunk_skip_dc_member(pc, scope_e::PREPROC);
+   }
+   return(  chunk_is_token(pc, CT_FUNC_CALL)
+         || chunk_is_token(pc, CT_FUNC_CALL_USER)
+         || chunk_is_token(pc, CT_FUNC_CLASS_DEF)
+         || chunk_is_token(pc, CT_FUNC_CLASS_PROTO)
+         || chunk_is_token(pc, CT_FUNC_CTOR_VAR)
+         || chunk_is_token(pc, CT_FUNC_DEF)
+         || chunk_is_token(pc, CT_FUNC_PROTO)
+         || chunk_is_token(pc, CT_FUNC_TYPE)
+         || chunk_is_token(pc, CT_FUNC_VAR)
+         || chunk_is_token(pc, CT_FUNCTION)
+         || chunk_is_token(pc, CT_FUNC_CALL_USER)
+         || chunk_is_token(pc, CT_FUNCTION)
+         || (  chunk_is_token(pc, CT_TYPE)
+            && !chunk_is_keyword(pc))
+         || chunk_is_token(pc, CT_WORD));
+} // chunk_is_identifier
+
+
+bool chunk_is_increment_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "++", 2));
+} // chunk_is_increment_str
+
+
+bool chunk_is_increment_token(chunk_t *pc)
+{
+   return(  chunk_is_increment_str(pc)
+         && (  chunk_is_token(pc, CT_INCDEC_AFTER)
+            || chunk_is_token(pc, CT_INCDEC_BEFORE)));
+} // chunk_is_increment_token
+
+
+bool chunk_is_increment_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_increment_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_increment_token_overload
+
+
+bool chunk_is_integral_number_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_NUMBER));
+} // chunk_is_integral_number_token
+
+
+bool chunk_is_intrinsic_type(chunk_t *pc)
+{
+   return(  chunk_is_token(pc, CT_TYPE)
+         && chunk_is_keyword(pc));
+} // chunk_is_intrinsic_type
+
+
+bool chunk_is_keyword(chunk_t *pc)
+{
+   return(find_keyword_type(pc->text(),
+                            pc->str.size()) != CT_WORD);
+} // chunk_is_keyword
+
+
+bool chunk_is_logical_or_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "||", 2));
+} // chunk_is_logical_or_str
+
+
+bool chunk_is_logical_or_token(chunk_t *pc)
+{
+   return(  chunk_is_logical_or_str(pc)
+         && chunk_is_token(pc, CT_BOOL));
+} // chunk_is_logical_or_token
+
+
+bool chunk_is_logical_or_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_logical_or_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_logical_or_token_overload
+
+
+bool chunk_is_lshift_assign_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "<<=", 3));
+} // chunk_is_lshift_assign_str
+
+
+bool chunk_is_lshift_assign_token(chunk_t *pc)
+{
+   return(  chunk_is_lshift_assign_str(pc)
+         && chunk_is_assign_token(pc));
+} // chunk_is_lshift_assign_token
+
+
+bool chunk_is_lshift_assign_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_lshift_assign_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_lshift_assign_token_overload
+
+
+bool chunk_is_lshift_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "<<", 2));
+} // chunk_is_lshift_str
+
+
+bool chunk_is_lshift_token(chunk_t *pc)
+{
+   return(  chunk_is_lshift_str(pc)
+         && chunk_is_token(pc, CT_SHIFT));
+} // chunk_is_lshift_token
+
+
+bool chunk_is_lshift_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_lshift_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_lshift_token_overload
+
+
+bool chunk_is_macro_reference(chunk_t *pc)
+{
+   LOG_FUNC_ENTRY();
+
+   auto *next = chunk_get_head();
+
+   if (  (  language_is_set(LANG_CPP)
+         || language_is_set(LANG_C))
+      && chunk_is_token(pc, CT_WORD)
+      && !pc->flags.test(PCF_IN_PREPROC))
+   {
+      while (next != nullptr)
+      {
+         if (  next->flags.test(PCF_IN_PREPROC)
+            && std::strcmp(pc->str.c_str(), next->str.c_str()) == 0)
+         {
+            return(true);
+         }
+         next = chunk_search_next_cat(next, CT_MACRO);
+      }
+   }
+   return(false);
+} // chunk_is_macro_reference
+
+
+bool chunk_is_member_str(chunk_t *pc)
+{
+   return(  chunk_is_str(pc, ".", 1)
+         || chunk_is_str(pc, ".*", 2)
+         || chunk_is_str(pc, "->", 2)
+         || chunk_is_str(pc, "->*", 3));
+} // chunk_is_member_str
+
+
+bool chunk_is_member_token(chunk_t *pc)
+{
+   return(  chunk_is_member_str(pc)
+         && chunk_is_token(pc, CT_MEMBER));
+} // chunk_is_member_token
+
+
+bool chunk_is_member_token_overload(chunk_t *pc)
+{
+   return(  (  chunk_is_str(pc, "->", 2)
+            || chunk_is_str(pc, "->*", 3))
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_member_token_overload
+
+
+bool chunk_is_minus_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '-'));
+} // chunk_is_minus_str
+
+
+bool chunk_is_minus_token(chunk_t *pc)
+{
+   return(  (  chunk_is_minus_str(pc)
+            && chunk_is_token(pc, CT_ARITH))
+         || chunk_is_token(pc, CT_MINUS));
+} // chunk_is_minus_token
+
+
+bool chunk_is_minus_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_minus_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_minus_token_overload
+
+
+bool chunk_is_modulo_assign_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "%=", 2));
+} // chunk_is_modulo_assign_str
+
+
+bool chunk_is_modulo_assign_token(chunk_t *pc)
+{
+   return(  chunk_is_modulo_assign_str(pc)
+         && chunk_is_assign_token(pc));
+} // chunk_is_modulo_assign_token
+
+
+bool chunk_is_modulo_assign_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_modulo_assign_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_modulo_assign_token_overload
+
+
+bool chunk_is_modulo_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '%'));
+} // chunk_is_modulo_str
+
+
+bool chunk_is_modulo_token(chunk_t *pc)
+{
+   return(  chunk_is_modulo_str(pc)
+         && chunk_is_token(pc, CT_ARITH));
+} // chunk_is_modulo_token
+
+
+bool chunk_is_modulo_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_modulo_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_modulo_token_overload
+
+
+bool chunk_is_mutable_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "mutable", 7));
+} // chunk_is_mutable_str
+
+
+bool chunk_is_mutable_token(chunk_t *pc)
+{
+   return(  chunk_is_mutable_str(pc)
+         && chunk_is_token(pc, CT_QUALIFIER));
+} // chunk_is_mutable_token
+
+
+bool chunk_is_new_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "new", 3));
+} // chunk_is_new_str
+
+
+bool chunk_is_new_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_NEW));
+} // chunk_is_new_token
+
+
+bool chunk_is_new_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_new_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_new_token_overload
+
+
+bool chunk_is_noexcept_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "noexcept", 8));
+} // chunk_is_noexcept_str
+
+
+bool chunk_is_noexcept_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_NOEXCEPT));
+} // chunk_is_noexcept_token
+
+
+bool chunk_is_number_token(chunk_t *pc)
+{
+   return(  chunk_is_floating_point_number_token(pc)
+         || chunk_is_integral_number_token(pc));
+} // chunk_is_number
+
+
+bool chunk_is_operator_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "operator", 8));
+} // chunk_is_operator_str
+
+
+bool chunk_is_operator_token(chunk_t *pc)
+{
+   return(  chunk_is_operator_str(pc)
+         && chunk_is_token(pc, CT_OPERATOR));
+} // chunk_is_operator_token
+
+
+bool chunk_is_overloaded_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_OPERATOR_VAL));
+} // chunk_is_overloaded_token
+
+
+bool chunk_is_override_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "override", 8));
+} // chunk_is_override_str
+
+
+bool chunk_is_override_token(chunk_t *pc)
+{
+   return(  chunk_is_override_str(pc)
+         && chunk_is_token(pc, CT_QUALIFIER));
+} // chunk_is_override_token
+
+
+bool chunk_is_paren_close_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == ')'));
+} // chunk_is_paren_close_str
+
+
+bool chunk_is_paren_close_token(chunk_t *pc)
+{
+   return(  chunk_is_token(pc, CT_FPAREN_CLOSE)
+         || chunk_is_token(pc, CT_LPAREN_CLOSE)
+         || chunk_is_token(pc, CT_PAREN_CLOSE)
+         || chunk_is_token(pc, CT_SPAREN_CLOSE)
+         || chunk_is_token(pc, CT_TPAREN_CLOSE));
+} // chunk_is_paren_close_token
+
+
+bool chunk_is_paren_open_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '('));
+} // chunk_is_paren_open_str
+
+
+bool chunk_is_paren_open_token(chunk_t *pc)
+{
+   return(  chunk_is_token(pc, CT_FPAREN_OPEN)
+         || chunk_is_token(pc, CT_LPAREN_OPEN)
+         || chunk_is_token(pc, CT_PAREN_OPEN)
+         || chunk_is_token(pc, CT_SPAREN_OPEN)
+         || chunk_is_token(pc, CT_TPAREN_OPEN));
+} // chunk_is_paren_open_token
+
+
+bool chunk_is_plus_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '+'));
+} // chunk_is_plus_str
+
+
+bool chunk_is_plus_token(chunk_t *pc)
+{
+   return(  (  chunk_is_plus_str(pc)
+            && chunk_is_token(pc, CT_ARITH))
+         || chunk_is_token(pc, CT_PLUS));
+} // chunk_is_plus_token
+
+
+bool chunk_is_plus_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_plus_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_plus_token_overload
+
+
+bool chunk_is_pointer_reference_or_cv_qualifier(chunk_t *pc)
+{
+   return(  chunk_is_pointer_or_reference(pc)
+         || (  chunk_is_cv_qualifier_token(pc)
+            && !chunk_is_cpp_inheritance_access_specifier(pc)));
+} // chunk_is_pointer_reference_or_qualifier
+
+
+bool chunk_is_question_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '?'));
+} // chunk_is_question_str
+
+
+bool chunk_is_question_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_QUESTION));
+} // chunk_is_question_token
+
+
+bool chunk_is_reinterpret_cast_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "reinterpret_cast", 16));
+} // chunk_is_reinterpret_cast_str
+
+
+bool chunk_is_reinterpret_cast_token(chunk_t *pc)
+{
+   return(  chunk_is_reinterpret_cast_str(pc)
+         && chunk_is_token(pc, CT_TYPE_CAST));
+} // chunk_is_reinterpret_cast_token
+
+
+bool chunk_is_rshift_assign_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, ">>=", 2));
+} // chunk_is_rshift_assign_str
+
+
+bool chunk_is_rshift_assign_token(chunk_t *pc)
+{
+   return(  chunk_is_rshift_assign_str(pc)
+         && chunk_is_assign_token(pc));
+} // chunk_is_rshift_assign_token
+
+
+bool chunk_is_rshift_assign_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_rshift_assign_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_rshift_assign_token_overload
+
+
+bool chunk_is_rshift_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, ">>", 2));
+} // chunk_is_rshift_str
+
+
+bool chunk_is_rshift_token(chunk_t *pc)
+{
+   return(  chunk_is_rshift_str(pc)
+         && chunk_is_token(pc, CT_SHIFT));
+} // chunk_is_rshift_token
+
+
+bool chunk_is_rshift_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_rshift_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_rshift_token_overload
+
+
+bool chunk_is_semicolon_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == ';'));
+} // chunk_is_semicolon_str
+
+
+bool chunk_is_semicolon_token(chunk_t *pc)
+{
+   return(  chunk_is_token(pc, CT_SEMICOLON)
+         || chunk_is_token(pc, CT_VSEMICOLON));
+} // chunk_is_semicolon_token
+
+
+bool chunk_is_shift_assign_str(chunk_t *pc)
+{
+   return(  chunk_is_lshift_assign_str(pc)
+         || chunk_is_rshift_assign_str(pc));
+} // chunk_is_shift_assign_str
+
+
+bool chunk_is_shift_assign_token(chunk_t *pc)
+{
+   return(  chunk_is_shift_assign_str(pc)
+         && chunk_is_assign_token(pc));
+} // chunk_is_shift_assign_token
+
+
+bool chunk_is_shift_assign_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_shift_assign_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_shift_assign_token_overload
+
+
+bool chunk_is_shift_str(chunk_t *pc)
+{
+   return(  chunk_is_lshift_str(pc)
+         || chunk_is_rshift_str(pc));
+} // chunk_is_shift_str
+
+
+bool chunk_is_shift_token(chunk_t *pc)
+{
+   return(  chunk_is_shift_str(pc)
+         && chunk_is_token(pc, CT_SHIFT));
+} // chunk_is_shift_token
+
+
+bool chunk_is_shift_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_shift_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_shift_token_overload
+
+
+bool chunk_is_sizeof_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "sizeof", 6));
+} // chunk_is_sizeof_str
+
+
+bool chunk_is_sizeof_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_SIZEOF));
+} // chunk_is_sizeof_token
+
+
+bool chunk_is_square_close_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == ']'));
+} // chunk_is_square_close_str
+
+
+bool chunk_is_square_close_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_SQUARE_CLOSE));
+} // chunk_is_square_close_token
+
+
+bool chunk_is_square_open_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '['));
+} // chunk_is_square_open_str
+
+
+bool chunk_is_square_open_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_SQUARE_OPEN));
+} // chunk_is_square_open_token
+
+
+bool chunk_is_star_assign_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "*=", 2));
+} // chunk_is_star_assign_str
+
+
+bool chunk_is_star_assign_token(chunk_t *pc)
+{
+   return(  chunk_is_star_assign_str(pc)
+         && chunk_is_assign_token(pc));
+} // chunk_is_star_assign_token
+
+
+bool chunk_is_star_assign_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_star_assign_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_star_assign_token_overload
+
+
+bool chunk_is_star_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '*'));
+} // chunk_is_star_str
+
+
+bool chunk_is_star_token(chunk_t *pc)
+{
+   return(  chunk_is_star_str(pc)
+         && (  chunk_is_token(pc, CT_ARITH)
+            || chunk_is_token(pc, CT_DEREF)
+            || chunk_is_token(pc, CT_PTR_TYPE)
+            || chunk_is_token(pc, CT_STAR)));
+} // chunk_is_star_token
+
+
+bool chunk_is_star_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_star_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_star_token_overload
+
+
+bool chunk_is_static_cast_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "static_cast", 11));
+} // chunk_is_static_cast_str
+
+
+bool chunk_is_static_cast_token(chunk_t *pc)
+{
+   return(  chunk_is_static_cast_str(pc)
+         && chunk_is_token(pc, CT_TYPE_CAST));
+} // chunk_is_static_cast_token
+
+
+bool chunk_is_static_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "static", 6));
+} // chunk_is_static_str
+
+
+bool chunk_is_static_token(chunk_t *pc)
+{
+   return(  chunk_is_static_str(pc)
+         && chunk_is_token(pc, CT_QUALIFIER));
+} // chunk_is_static_token
+
+
+bool chunk_is_string_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_STRING));
+} // chunk_is_string_token
+
+
+bool chunk_is_subscript_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_TSQUARE));
+} // chunk_is_subscript_token
+
+
+bool chunk_is_subscript_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_empty_square_brackets_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_subscript_token_overload
+
+
+bool chunk_is_subtract_assign_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "-=", 2));
+} // chunk_is_subtract_assign_str
+
+
+bool chunk_is_subtract_assign_token(chunk_t *pc)
+{
+   return(  chunk_is_subtract_assign_str(pc)
+         && chunk_is_assign_token(pc));
+} // chunk_is_subtract_assign_token
+
+
+bool chunk_is_subtract_assign_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_subtract_assign_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_subtract_assign_token_overload
+
+
+bool chunk_is_template_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "template", 8));
+} // chunk_is_template_str
+
+
+bool chunk_is_template_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_TEMPLATE));
+} // chunk_is_template_token
+
+
+bool chunk_is_throw_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "throw", 5));
+} // chunk_is_throw_str
+
+
+bool chunk_is_throw_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_THROW));
+} // chunk_is_throw_token
+
+
+bool chunk_is_tilde_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '~'));
+} // chunk_is_tilde_str
+
+
+bool chunk_is_tilde_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_INV));
+} // chunk_is_tilde_token
+
+
+bool chunk_is_tilde_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_tilde_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_tilde_token_overload
+
+
+bool chunk_is_typeid_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "typeid", 6));
+} // chunk_is_typeid_str
+
+
+bool chunk_is_typeid_token(chunk_t *pc)
+{
+   return(  chunk_is_typeid_str(pc)
+         && chunk_is_token(pc, CT_SIZEOF));
+} // chunk_is_typeid_token
+
+
+bool chunk_is_typename_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "typename", 8));
+} // chunk_is_typename_str
+
+
+bool chunk_is_typename_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_TYPENAME));
+} // chunk_is_typename_token
+
+
+bool chunk_is_unary_not_str(chunk_t *pc)
+{
+   return(  pc != nullptr
+         && (pc->len() == 1)
+         && (pc->str[0] == '!'));
+} // chunk_is_unary_not_str
+
+
+bool chunk_is_unary_not_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_NOT));
+} // chunk_is_unary_not_token
+
+
+bool chunk_is_unary_not_token_overload(chunk_t *pc)
+{
+   return(  chunk_is_unary_not_str(pc)
+         && chunk_is_overloaded_token(pc));
+} // chunk_is_unary_not_token_overload
+
+
+bool chunk_is_using_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "using", 5));
+} // chunk_is_using_str
+
+
+bool chunk_is_using_token(chunk_t *pc)
+{
+   return(  chunk_is_token(pc, CT_USING)
+         || chunk_is_token(pc, CT_USING_STMT)
+         || chunk_is_token(pc, CT_USING_ALIAS));
+} // chunk_is_using_token
+
+
+bool chunk_is_virtual_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "virtual", 7));
+} // chunk_is_virtual_str
+
+
+bool chunk_is_virtual_token(chunk_t *pc)
+{
+   return(  chunk_is_virtual_str(pc)
+         && chunk_is_token(pc, CT_QUALIFIER));
+} // chunk_is_virtual_token
+
+
+bool chunk_is_volatile_str(chunk_t *pc)
+{
+   return(chunk_is_str(pc, "volatile", 8));
+} // chunk_is_volatile_str
+
+
+bool chunk_is_volatile_token(chunk_t *pc)
+{
+   return(chunk_is_token(pc, CT_VOLATILE));
+} // chunk_is_volatile_token
+
+
+bool chunk_is_within_constructor_initializer_list(chunk_t *pc)
+{
+   LOG_FUNC_ENTRY();
+
+   if (pc != nullptr)
+   {
+      std::size_t level = pc->level;
+
+      /**
+       * Skip to the previous close brace-colon chain
+       */
+      chunk_t *close_paren = match_chain_prev(pc,
+// *INDENT-OFF*
+                                              { { ")", 1UL }, { ":", 1UL } },
+// *INDENT-ON*
+                                              level,
+                                              scope_e::PREPROC);
+
+      chunk_t *colon = nullptr;
+
+      if (match_function_header_at_close_paren(close_paren) == nullptr)
+      {
+         colon = chunk_get_next_ncnnl(close_paren, scope_e::PREPROC);
+      }
+      chunk_t *end = nullptr;
+
+      if (colon != nullptr)
+      {
+         /**
+          * Skip to the (potential) end of the initialization list
+          */
+         end = match_chain_next(pc,
+// *INDENT-OFF*
+                                { { { ")", 1UL }, { "{", 1UL } },
+                                  { { "}", 1UL }, { "{", 1UL } } },
+// *INDENT-ON*
+                                level,
+                                scope_e::PREPROC);
+      }
+
+      if (end != nullptr)
+      {
+         /**
+          * TODO: Should it already be assumed to be between the colon and
+          *       the end chunk by virtue of the tests performed thus far?
+          */
+         return(chunk_is_between(pc, colon, end));
+      }
+   }
+   return(false);
+} // chunk_is_within_member_initializer_list
+
+
+bool chunk_is_within_function_definition_body(chunk_t *pc)
+{
+   LOG_FUNC_ENTRY();
+
+   std::size_t level;
+
+   if (  pc != nullptr
+      && (level = pc->level) > 0)
+   {
+      /**
+       * Skip to the last open brace
+       */
+      chunk_t *brace_open = chunk_get_prev_type(pc,
+                                                CT_BRACE_OPEN,
+                                                level - 1,
+                                                scope_e::PREPROC);
+
+      if (chunk_is_brace_open_token(brace_open))
+      {
+         chunk_t *prev = chunk_get_prev_ncnnlni(brace_open, scope_e::PREPROC);
+         prev = skip_member_initialization_list_rev(prev);
+
+         if (chunk_is_colon_token(prev))
+         {
+            /**
+             * Detected a constructor member initialization list
+             */
+            prev = chunk_get_prev_ncnnlni(prev, scope_e::PREPROC);
+         }
+         else
+         {
+            /**
+             * Skip any trailing function qualifiers
+             */
+            prev = skip_trailing_function_qualifiers_rev(prev, scope_e::PREPROC);
+         }
+
+         if (match_function_header_at_close_paren(prev) != nullptr)
+         {
+            return(true);
+         }
+         else if (  prev != nullptr
+                 && prev->level > 0)
+         {
+            /**
+             * It's possible that the chunk is currently inside a braced-initializer list;
+             * call the function again with this chunk and perform the test again
+             */
+            return(chunk_is_within_function_definition_body(prev));
+         }
+      }
+   }
+   return(false);
+} // chunk_is_within_function_definition_body

--- a/src/chunk_tests.h
+++ b/src/chunk_tests.h
@@ -1,0 +1,1493 @@
+/**
+ * @file chunk_tests.h
+ *
+ * @author
+ * @license GPL v2+
+ */
+
+#ifndef CHUNK_TESTS_H_INCLUDED
+#define CHUNK_TESTS_H_INCLUDED
+
+
+/**
+ * Tests whether or not the input chunk matches the '+=' string
+ */
+bool chunk_is_add_assign_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '+=' token
+ */
+bool chunk_is_add_assign_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '+=' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_add_assign_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the first chunk occurs AFTER the second chunk in the argument
+ * list
+ * @param  pc         points to the first chunk
+ * @param  after      points to the second chunk
+ * @param  test_equal if true, also tests whether or not the first and second chunks
+ *                    in fact refer to the same chunk
+ * @return            true or false
+ */
+bool chunk_is_after(struct chunk_t *pc, struct chunk_t *after, bool test_equal = true);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'alignof' string
+ */
+bool chunk_is_alignof_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'alignof' token
+ */
+bool chunk_is_alignof_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '&=' string
+ */
+bool chunk_is_ampersand_assign_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '&=' token
+ */
+bool chunk_is_ampersand_assign_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '&=' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_ampersand_assign_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '&' string
+ */
+bool chunk_is_ampersand_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '&' token
+ */
+bool chunk_is_ampersand_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '&' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_ampersand_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '>' string
+ */
+bool chunk_is_angle_close_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '>' token
+ */
+bool chunk_is_angle_close_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '>' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_angle_close_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '<' string
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_angle_open_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '<' token
+ */
+bool chunk_is_angle_open_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '<' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_angle_open_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '=' string
+ */
+bool chunk_is_assign_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '=' token
+ */
+bool chunk_is_assign_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '=' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_assign_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'auto' string
+ */
+bool chunk_is_auto_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'auto' token
+ */
+bool chunk_is_auto_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the first chunk occurs BEFORE the second chunk in the argument
+ * list
+ * @param  pc         points to the first chunk
+ * @param  before     points to the second chunk
+ * @param  test_equal if true, also tests whether or not the first and second chunks
+ *                    in fact refer to the same chunk
+ * @return            true or false
+ */
+bool chunk_is_before(struct chunk_t *pc, struct chunk_t *before, bool test_equal = true);
+
+
+/**
+ * Tests whether or not the first chunk occurs both AFTER and BEFORE
+ * the second and third chunks in the argument list, respectively
+ * @param  pc         points to the first chunk
+ * @param  after      points to the second chunk
+ * @param  before     points to the third chunk
+ * @param  test_equal if true, also tests whether or not the first, second, and third
+ *                    chunks in fact refer to the same chunk
+ * @return            true or false
+ */
+bool chunk_is_between(struct chunk_t *pc, struct chunk_t *after, struct chunk_t *before, bool test_equal = true);
+
+
+/**
+ * Tests whether or not the input chunk matches the '|=' string
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_bitwise_or_assign_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '|=' token
+ */
+bool chunk_is_bitwise_or_assign_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '|=' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_bitwise_or_assign_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '|' string
+ */
+bool chunk_is_bitwise_or_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '|' token
+ */
+bool chunk_is_bitwise_or_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '|' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_bitwise_or_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '}' string
+ */
+bool chunk_is_brace_close_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '}' token
+ */
+bool chunk_is_brace_close_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '{' string
+ */
+bool chunk_is_brace_open_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '{' token
+ */
+bool chunk_is_brace_open_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '^=' string
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_caret_assign_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '^=' token
+ */
+bool chunk_is_caret_assign_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '^=' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_caret_assign_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '^' string
+ */
+bool chunk_is_caret_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '^' token
+ */
+bool chunk_is_caret_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '^' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_caret_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'catch' string
+ */
+bool chunk_is_catch_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'catch' token
+ */
+bool chunk_is_catch_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk is a character literal
+ */
+bool chunk_is_char_literal(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the ':' string
+ */
+bool chunk_is_colon_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the ':' token
+ */
+bool chunk_is_colon_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the ',' string
+ */
+bool chunk_is_comma_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the ',' token
+ */
+bool chunk_is_comma_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the ',' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_comma_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '==' string
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_compare_equal_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '==' token
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_compare_equal_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '==' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_compare_equal_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '>=' string
+ */
+bool chunk_is_compare_greater_equal_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '>=' token
+ */
+bool chunk_is_compare_greater_equal_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '>=' token overload
+ */
+bool chunk_is_compare_greater_equal_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '!=' string
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_compare_inequal_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '!=' token
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_compare_inequal_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '!=' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_compare_inequal_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '<=' string
+ */
+bool chunk_is_compare_less_equal_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '<=' token
+ */
+bool chunk_is_compare_less_equal_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '<=' token overload
+ */
+bool chunk_is_compare_less_equal_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '<=>' string
+ */
+bool chunk_is_compare_three_way_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '<=>' token
+ */
+bool chunk_is_compare_three_way_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '<=>' token overload
+ */
+bool chunk_is_compare_three_way_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following strings:
+ * '<=>', '<=', '==', '>=', '!=', '<', '>'
+ */
+bool chunk_is_comparison_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following tokens:
+ * '<=>', '<=', '==', '>=', '!=', '<', '>'
+ */
+bool chunk_is_comparison_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following token overloads:
+ * '<=>', '<=', '==', '>=', '!=', '<', '>'
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_comparison_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'const' string
+ */
+bool chunk_is_const_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'const' token
+ */
+bool chunk_is_const_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'constexpr' string
+ */
+bool chunk_is_constexpr_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'constexpr' token
+ */
+bool chunk_is_constexpr_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'const_cast' string
+ */
+bool chunk_is_const_cast_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'const_cast' token
+ */
+bool chunk_is_const_cast_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following strings:
+ * 'const_cast', 'dynamic_cast', 'reinterpret_cast', 'static_cast'
+ */
+bool chunk_is_cpp_type_cast_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following tokens:
+ * 'const_cast', 'dynamic_cast', 'reinterpret_cast', 'static_cast'
+ */
+bool chunk_is_cpp_type_cast_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following strings:
+ * 'const', 'volatile'
+ */
+bool chunk_is_cv_qualifier_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following tokens:
+ * 'const', 'volatile'
+ */
+bool chunk_is_cv_qualifier_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'decltype' string
+ */
+bool chunk_is_decltype_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'decltype' token
+ */
+bool chunk_is_decltype_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '--' string
+ */
+bool chunk_is_decrement_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '--' token
+ */
+bool chunk_is_decrement_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '--' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_decrement_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'delete' string
+ */
+bool chunk_is_delete_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'delete' token
+ */
+bool chunk_is_delete_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'delete' or 'delete []' token overloads
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_delete_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '/=' string
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_divide_assign_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '/=' token
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_divide_assign_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '/=' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_divide_assign_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '/' string
+ */
+bool chunk_is_divide_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '/' token
+ */
+bool chunk_is_divide_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '/' token overload
+ */
+bool chunk_is_divide_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '&&' string
+ */
+bool chunk_is_double_ampersand_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '&&' token
+ */
+bool chunk_is_double_ampersand_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '&&' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_double_ampersand_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '::' string
+ */
+bool chunk_is_double_colon_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '::' token
+ */
+bool chunk_is_double_colon_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'dynamic_cast' string
+ */
+bool chunk_is_dynamic_cast_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'dynamic_cast' token
+ */
+bool chunk_is_dynamic_cast_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '...' string
+ */
+bool chunk_is_ellipsis_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '...' token
+ */
+bool chunk_is_ellipsis_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '()' string
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_empty_parens_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '[]' string
+ */
+bool chunk_is_empty_square_brackets_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '=' string
+ */
+bool chunk_is_equals_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '=' token
+ */
+bool chunk_is_equals_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '=' token overload
+ */
+bool chunk_is_equals_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk is a floating point number token
+ */
+bool chunk_is_floating_point_number_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '()' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_function_call_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the chunk is an identifier
+ * @param  pc      the input chunk
+ * @param  skip_dc if true, skips any scope resolution operators and qualifiers that
+ *                 may precede the identifier
+ * @return         true or false
+ */
+bool chunk_is_identifier(struct chunk_t *pc, bool skip_dc = true);
+
+
+/**
+ * Tests whether or not the input chunk matches the '++' string
+ */
+bool chunk_is_increment_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '++' token
+ */
+bool chunk_is_increment_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '++' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_increment_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk is an integral number token
+ */
+bool chunk_is_integral_number_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk is an intrinsic type
+ */
+bool chunk_is_intrinsic_type(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk is a built-in keyword
+ */
+bool chunk_is_keyword(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '||' string
+ */
+bool chunk_is_logical_or_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '||' token
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_logical_or_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '||' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_logical_or_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '<<=' string
+ */
+bool chunk_is_lshift_assign_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '<<=' token
+ */
+bool chunk_is_lshift_assign_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '<<=' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_lshift_assign_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '<<' string
+ */
+bool chunk_is_lshift_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '<<' token
+ */
+bool chunk_is_lshift_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '<<' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_lshift_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Returns true if the chunk under test is a reference to a macro defined elsewhere in
+ * the source file currently being processed. Note that a macro may be defined in
+ * another source or header file, for which this function does not currently account
+ */
+bool chunk_is_macro_reference(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following strings:
+ * '.', '.*', '->', '->*'
+ */
+bool chunk_is_member_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following tokens:
+ * '.', '.*', '->', '->*'
+ */
+bool chunk_is_member_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following token overloads:
+ * '->', '->*'
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_member_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '-' string
+ */
+bool chunk_is_minus_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '-' token
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_minus_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '-' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_minus_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '%=' string
+ */
+bool chunk_is_modulo_assign_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '%=' token
+ */
+bool chunk_is_modulo_assign_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '%=' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_modulo_assign_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '%' string
+ */
+bool chunk_is_modulo_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '%' token
+ */
+bool chunk_is_modulo_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '%' token overload
+ */
+bool chunk_is_modulo_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'mutable' string
+ */
+bool chunk_is_mutable_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'mutable' token
+ */
+bool chunk_is_mutable_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'new' string
+ */
+bool chunk_is_new_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'new' token
+ */
+bool chunk_is_new_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'new' or 'new []' token overloads
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_new_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'noexcept' string
+ */
+bool chunk_is_noexcept_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'noexcept' token
+ */
+bool chunk_is_noexcept_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk is a number
+ */
+bool chunk_is_number_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'operator' string
+ */
+bool chunk_is_operator_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'operator' token
+ */
+bool chunk_is_operator_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk is an overloaded token
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_overloaded_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'override' string
+ */
+bool chunk_is_override_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'override' token
+ */
+bool chunk_is_override_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the ')' string
+ */
+bool chunk_is_paren_close_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the ')' token
+ */
+bool chunk_is_paren_close_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '(' string
+ */
+bool chunk_is_paren_open_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '(' token
+ */
+bool chunk_is_paren_open_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '+' string
+ */
+bool chunk_is_plus_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '+' token
+ */
+bool chunk_is_plus_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '+' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_plus_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk is a pointer/reference operator or a
+ * qualifier
+ */
+bool chunk_is_pointer_reference_or_cv_qualifier(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '?' string
+ */
+bool chunk_is_question_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '?' token
+ */
+bool chunk_is_question_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'reinterpret_cast' string
+ */
+bool chunk_is_reinterpret_cast_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'reinterpret_cast' token
+ */
+bool chunk_is_reinterpret_cast_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the ';' string
+ */
+bool chunk_is_semicolon_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the ';' token
+ */
+bool chunk_is_semicolon_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '>>=' string
+ */
+bool chunk_is_rshift_assign_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '>>=' token
+ */
+bool chunk_is_rshift_assign_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '>>=' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_rshift_assign_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '>>' string
+ */
+bool chunk_is_rshift_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '>>' token
+ */
+bool chunk_is_rshift_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '>>' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_rshift_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following strings:
+ * '<<', '>>'
+ */
+bool chunk_is_shift_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following tokens:
+ * '<<', '>>'
+ */
+bool chunk_is_shift_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following token overloads:
+ * '<<', '>>'
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_shift_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following strings:
+ * '<<=', '>>='
+ */
+bool chunk_is_shift_assign_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following tokens:
+ * '<<=', '>>='
+ */
+bool chunk_is_shift_assign_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following token overloads:
+ * '<<=', '>>='
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_shift_assign_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following string:
+ * '<<', '>>'
+ */
+bool chunk_is_shift_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following tokens:
+ * '<<', '>>'
+ */
+bool chunk_is_shift_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches one of the following token overloads:
+ * '<<', '>>'
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_shift_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'sizeof' string
+ */
+bool chunk_is_sizeof_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'sizeof' token
+ */
+bool chunk_is_sizeof_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the ']' string
+ */
+bool chunk_is_square_close_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the ']' token
+ */
+bool chunk_is_square_close_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '[' string
+ */
+bool chunk_is_square_open_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '[' token
+ */
+bool chunk_is_square_open_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '*=' string
+ */
+bool chunk_is_star_assign_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '*=' token
+ */
+bool chunk_is_star_assign_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '*=' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_star_assign_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '*' string
+ */
+bool chunk_is_star_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '*' token
+ */
+bool chunk_is_star_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '*' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_star_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'static_cast' string
+ */
+bool chunk_is_static_cast_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'static_cast' token
+ */
+bool chunk_is_static_cast_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'static' string
+ */
+bool chunk_is_static_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'static' token
+ */
+bool chunk_is_static_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches a string token
+ */
+bool chunk_is_string_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '[]' token
+ */
+bool chunk_is_subscript_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '[]' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_subscript_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '-=' string
+ */
+bool chunk_is_subtract_assign_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '-=' token
+ */
+bool chunk_is_subtract_assign_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '-=' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_subtract_assign_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'template' string
+ */
+bool chunk_is_template_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'template' token
+ */
+bool chunk_is_template_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'throw' string
+ */
+bool chunk_is_throw_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'throw' token
+ */
+bool chunk_is_throw_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '~' string
+ */
+bool chunk_is_tilde_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '~' token
+ */
+bool chunk_is_tilde_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '~' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_tilde_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'typeid' string
+ */
+bool chunk_is_typeid_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'typeid' token
+ */
+bool chunk_is_typeid_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'typename' string
+ */
+bool chunk_is_typename_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'typename' token
+ */
+bool chunk_is_typename_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '!' string
+ */
+bool chunk_is_unary_not_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '!' token
+ */
+bool chunk_is_unary_not_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the '!' token overload
+ * @param  pc   the input chunk
+ * @return      true or false
+ */
+bool chunk_is_unary_not_token_overload(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'using' string
+ */
+bool chunk_is_using_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'using' token
+ */
+bool chunk_is_using_token(struct chunk_t *pc);
+
+
+/**
+ * Test whether or not the input chunk matches the 'virtual' string
+ */
+bool chunk_is_virtual_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'virtual' token
+ */
+bool chunk_is_virtual_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'volatile' string
+ */
+bool chunk_is_volatile_str(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk matches the 'volatile' token
+ */
+bool chunk_is_volatile_token(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk is within a member initializer list
+ */
+bool chunk_is_within_constructor_initializer_list(struct chunk_t *pc);
+
+
+/**
+ * Tests whether or not the input chunk is within a function definition
+ */
+bool chunk_is_within_function_definition_body(struct chunk_t *pc);
+
+
+#endif /* CHUNK_TESTS_H_INCLUDED */

--- a/src/chunk_tools.cpp
+++ b/src/chunk_tools.cpp
@@ -1,0 +1,573 @@
+/**
+ * @file chunk_tools.cpp
+ *
+ * @author
+ * @license GPL v2+
+ */
+
+#include "chunk_tools.h"
+
+#include "chunk_list.h"
+#include "keywords.h"
+#include "match_tools.h"
+
+
+/**
+ * use this enum to define in what direction or location an
+ * operation shall be performed.
+ */
+enum class direction_e : unsigned int
+{
+   FORWARD,
+   BACKWARD
+};
+
+
+/**
+ * Typedef declarations
+ */
+typedef bool (*chunk_order_test_t)(chunk_t *, chunk_t *, bool);
+typedef chunk_t * (*chunk_str_search_function_t)(chunk_t *, const char *, std::size_t, int, scope_e);
+typedef chunk_t * (*chunk_type_search_function_t)(chunk_t *, c_token_t, int, scope_e);
+
+
+/**
+ * Forward declarations
+ */
+static chunk_t *chunk_get_str(chunk_t *pc, const std::vector<std::pair<const char *, std::size_t> > &strings, int level, scope_e scope, chunk_str_search_function_t search_function, chunk_order_test_t chunk_order_test);
+static chunk_t *chunk_get_type(chunk_t *pc, const std::vector<c_token_t> &types, int level, scope_e scope, chunk_type_search_function_t search_function, chunk_order_test_t chunk_order_test);
+
+
+chunk_t *chunk_get_next_str(chunk_t                                                  *pc,
+                            const std::vector<std::pair<const char *, std::size_t> > &strings,
+                            int                                                      level,
+                            scope_e                                                  scope)
+{
+   return(chunk_get_str(pc,
+                        strings,
+                        level,
+                        scope,
+                        (chunk_str_search_function_t)&chunk_get_next_str,
+                        chunk_is_before));
+} // chunk_get_next_str
+
+
+chunk_t *chunk_get_prev_str(chunk_t                                                  *pc,
+                            const std::vector<std::pair<const char *, std::size_t> > &strings,
+                            int                                                      level,
+                            scope_e                                                  scope)
+{
+   return(chunk_get_str(pc,
+                        strings,
+                        level,
+                        scope,
+                        (chunk_str_search_function_t)&chunk_get_prev_str,
+                        chunk_is_after));
+} // chunk_get_prev_str
+
+
+static chunk_t *chunk_get_str(chunk_t                                                  *pc,
+                              const std::vector<std::pair<const char *, std::size_t> > &strings,
+                              int                                                      level,
+                              scope_e                                                  scope,
+                              chunk_str_search_function_t                              search_function,
+                              chunk_order_test_t                                       chunk_order_test)
+{
+   if (  pc != nullptr
+      && search_function != nullptr)
+   {
+      chunk_t *start  = pc;
+      chunk_t *result = nullptr;
+
+      for (auto &&string_size_pair : strings)
+      {
+         auto &&string = string_size_pair.first;
+         auto &&size   = string_size_pair.second;
+         pc = (*search_function)(start,
+                                 string,
+                                 size,
+                                 level,
+                                 scope);
+
+         if (  pc != nullptr
+            && (  result == nullptr
+               || (*chunk_order_test)(pc, result, false)))
+         {
+            result = pc;
+         }
+      }
+
+      pc = result;
+   }
+   return(pc);
+} // chunk_get_str
+
+
+chunk_t *chunk_get_next_type(chunk_t                      *pc,
+                             const std::vector<c_token_t> &types,
+                             int                          level,
+                             scope_e                      scope)
+{
+   return(chunk_get_type(pc,
+                         types,
+                         level,
+                         scope,
+                         (chunk_type_search_function_t)&chunk_get_next_type,
+                         chunk_is_before));
+} // chunk_get_next_type
+
+
+chunk_t *chunk_get_prev_type(chunk_t                      *pc,
+                             const std::vector<c_token_t> &types,
+                             int                          level,
+                             scope_e                      scope)
+{
+   return(chunk_get_type(pc,
+                         types,
+                         level,
+                         scope,
+                         (chunk_type_search_function_t)&chunk_get_prev_type,
+                         chunk_is_after));
+} // chunk_get_prev_type
+
+
+static chunk_t *chunk_get_type(chunk_t                      *pc,
+                               const std::vector<c_token_t> &types,
+                               int                          level,
+                               scope_e                      scope,
+                               chunk_type_search_function_t search_function,
+                               chunk_order_test_t           chunk_order_test)
+{
+   if (  pc != nullptr
+      && search_function != nullptr)
+   {
+      chunk_t *start  = pc;
+      chunk_t *result = nullptr;
+
+      for (c_token_t type : types)
+      {
+         pc = (*search_function)(start,
+                                 type,
+                                 level,
+                                 scope);
+
+         if (  pc != nullptr
+            && (  result == nullptr
+               || (*chunk_order_test)(pc, result, false)))
+         {
+            result = pc;
+         }
+      }
+
+      pc = result;
+   }
+   return(pc);
+} // chunk_get_type
+
+
+chunk_t *skip_member_initialization_list(chunk_t *pc, scope_e scope)
+{
+   if (chunk_is_colon_token(pc))
+   {
+      chunk_t *next = pc;
+      chunk_t *prev = nullptr;
+
+      do
+      {
+         next = chunk_get_next_ncnnl(next, scope);
+
+         /**
+          * Skip any scope resolution and nested name specifiers
+          */
+         next = skip_scope_resolution_and_nested_name_specifiers(next);
+
+         /**
+          * Test to see if an identifier precedes the open brace/paren
+          */
+         if (!chunk_is_identifier(next))
+         {
+            return(pc);
+         }
+         next = chunk_get_next_ncnnl(next, scope);
+
+         if (  !chunk_is_brace_open_token(next)
+            && !chunk_is_paren_open_token(next))
+         {
+            return(pc);
+         }
+         /**
+          * Skip to the matching open brace/paren
+          */
+         prev = chunk_skip_to_match(next, scope);
+
+         if (prev != nullptr)
+         {
+            next = chunk_get_next_ncnnl(prev, scope);
+         }
+      } while (chunk_is_comma_token(next));
+
+      if (chunk_is_brace_open_token(next))
+      {
+         /**
+          * Return the ending chunk
+          */
+         return(prev);
+      }
+   }
+   return(pc);
+} // skip_member_initialization_list_next
+
+
+chunk_t *skip_member_initialization_list_rev(chunk_t *pc, scope_e scope)
+{
+   chunk_t *prev = pc;
+
+   while (  chunk_is_brace_close_token(prev)
+         || chunk_is_paren_close_token(prev))
+   {
+      /**
+       * Skip to the matching open brace/paren
+       */
+      prev = chunk_skip_to_match_rev(prev, scope);
+
+      if (prev != nullptr)
+      {
+         prev = chunk_get_prev_ncnnlni(prev, scope);
+      }
+
+      /**
+       * Test to see if an identifier precedes the open brace/paren
+       */
+      if (!chunk_is_identifier(prev))
+      {
+         return(pc);
+      }
+      /**
+       * Skip any scope resolution and nested name specifiers
+       */
+      prev = skip_scope_resolution_and_nested_name_specifiers_rev(prev,
+                                                                  scope);
+
+      if (chunk_is_comma_token(prev))
+      {
+         prev = chunk_get_prev_ncnnlni(prev, scope);
+      }
+   }
+
+   if (chunk_is_colon_token(prev))
+   {
+      /**
+       * Return the chunk preceding the start of the list
+       */
+      return(prev);
+   }
+   /**
+    * Return the starting chunk
+    */
+   return(pc);
+} // skip_member_initialization_list_rev
+
+
+chunk_t *skip_operator_overload(chunk_t *pc, scope_e scope)
+{
+   if (chunk_is_operator_token(pc))
+   {
+      pc = chunk_get_prev_ncnnl(pc, scope);
+   }
+   return(pc);
+} // skip_operator_overload
+
+
+chunk_t *skip_operator_overload_next(chunk_t *pc, scope_e scope)
+{
+   pc = skip_operator_overload(pc);
+
+   if (chunk_is_overloaded_token(pc))
+   {
+      pc = chunk_get_next_ncnnl(pc, scope);
+   }
+   return(pc);
+} // skip_operator_overload_next
+
+
+chunk_t *skip_operator_overload_prev(chunk_t *pc, scope_e scope)
+{
+   pc = skip_operator_overload_rev(pc);
+
+   if (chunk_is_operator_token(pc))
+   {
+      pc = chunk_get_prev_ncnnlni(pc, scope);
+   }
+   return(pc);
+} // skip_operator_overload_prev
+
+
+chunk_t *skip_operator_overload_rev(chunk_t *pc, scope_e scope)
+{
+   if (chunk_is_overloaded_token(pc))
+   {
+      pc = chunk_get_prev_ncnnl(pc, scope);
+   }
+   return(pc);
+} // skip_operator_overload_rev
+
+
+chunk_t *skip_pointers_references_and_qualifiers(chunk_t *pc, scope_e scope)
+{
+   chunk_t *next = pc;
+
+   do
+   {
+      pc   = next;
+      next = chunk_get_next_ncnnl(pc, scope);
+   } while (chunk_is_pointer_reference_or_cv_qualifier(next));
+
+   return(pc);
+} // skip_pointers_references_and_qualifiers
+
+
+chunk_t *skip_pointers_references_and_qualifiers_next(chunk_t *pc, scope_e scope)
+{
+   auto *next = skip_pointers_references_and_qualifiers(pc);
+
+   if (next != pc)
+   {
+      return(chunk_get_next_ncnnl(next, scope));
+   }
+   return(pc);
+} // skip_pointers_references_and_qualifiers_next
+
+
+chunk_t *skip_pointers_references_and_qualifiers_prev(chunk_t *pc, scope_e scope)
+{
+   auto *prev = skip_pointers_references_and_qualifiers_rev(pc);
+
+   if (prev != pc)
+   {
+      return(chunk_get_prev_ncnnlni(prev, scope));
+   }
+   return(pc);
+} // skip_pointers_references_and_qualifiers_prev
+
+
+chunk_t *skip_pointers_references_and_qualifiers_rev(chunk_t *pc, scope_e scope)
+{
+   chunk_t *prev = pc;
+
+   do
+   {
+      pc   = prev;
+      prev = chunk_get_prev_ncnnlni(pc, scope);
+   } while (chunk_is_pointer_reference_or_cv_qualifier(prev));
+
+   return(pc);
+} // skip_pointers_references_and_qualifiers_rev
+
+
+chunk_t *skip_scope_resolution_and_nested_name_specifiers(chunk_t *pc,
+                                                          scope_e scope)
+{
+   if (  (  pc != nullptr
+         && pc->flags.test(PCF_IN_TEMPLATE))
+      || chunk_is_double_colon_token(pc)
+      || chunk_is_token(pc, CT_TYPE)
+      || chunk_is_token(pc, CT_WORD))
+   {
+      std::size_t level = pc->level;
+
+      while (  pc != nullptr
+            && pc->level >= level
+            && !chunk_is_intrinsic_type(pc))
+      {
+         /**
+          * skip to any following match for angle brackets
+          */
+         if (chunk_is_angle_open_token(pc))
+         {
+            pc = chunk_skip_to_match(pc, scope);
+         }
+         auto *next = chunk_get_next_ncnnl(pc, scope);
+
+         /**
+          * call a separate function to validate adjacent tokens as potentially
+          * matching a qualified identifier
+          */
+         if (!adj_chunks_match_qualified_identifier_pattern(pc, next))
+         {
+            break;
+         }
+         pc = next;
+      }
+   }
+   return(pc);
+} // skip_scope_resolution_and_nested_name_specifiers
+
+
+chunk_t *skip_scope_resolution_and_nested_name_specifiers_next(chunk_t *pc, scope_e scope)
+{
+   auto *next = skip_scope_resolution_and_nested_name_specifiers(pc);
+
+   if (next != pc)
+   {
+      return(chunk_get_next_ncnnl(next, scope));
+   }
+   return(pc);
+} // skip_scope_resolution_and_nested_name_specifiers_next
+
+
+chunk_t *skip_scope_resolution_and_nested_name_specifiers_prev(chunk_t *pc, scope_e scope)
+{
+   auto *prev = skip_scope_resolution_and_nested_name_specifiers_rev(pc);
+
+   if (prev != pc)
+   {
+      return(chunk_get_prev_ncnnlni(prev, scope));
+   }
+   return(pc);
+} // skip_scope_resolution_and_nested_name_specifiers_prev
+
+
+chunk_t *skip_scope_resolution_and_nested_name_specifiers_rev(chunk_t *pc,
+                                                              scope_e scope)
+{
+   if (  (  pc != nullptr
+         && pc->flags.test(PCF_IN_TEMPLATE))
+      || chunk_is_double_colon_token(pc)
+      || chunk_is_token(pc, CT_TYPE)
+      || chunk_is_token(pc, CT_WORD))
+   {
+      std::size_t level = pc->level;
+
+      while (  pc != nullptr
+            && pc->level >= level
+            && !chunk_is_intrinsic_type(pc))
+      {
+         /**
+          * skip to any preceding match for angle brackets
+          */
+         if (chunk_is_angle_close_token(pc))
+         {
+            pc = chunk_skip_to_match_rev(pc, scope);
+         }
+         auto *prev = chunk_get_prev_ncnnlni(pc, scope);
+
+         /**
+          * call a separate function to validate adjacent tokens as potentially
+          * matching a qualified identifier
+          */
+         if (!adj_chunks_match_qualified_identifier_pattern(prev, pc))
+         {
+            break;
+         }
+         pc = prev;
+      }
+   }
+   return(pc);
+} // skip_scope_resolution_and_nested_name_specifiers_rev
+
+
+static chunk_t *skip_trailing_function_qualifiers(chunk_t     *pc,
+                                                  scope_e     scope,
+                                                  direction_e direction)
+{
+   typedef std::size_t (*index_t)(std::size_t);
+   typedef chunk_t * (*search_t)(chunk_t *, scope_e);
+   typedef bool (*test_t)(chunk_t *);
+
+   auto backward_index_function = [](std::size_t index)
+   {
+      return(0x03 & ~index);
+   };
+
+   auto forward_index_function = [](std::size_t index)
+   {
+      return(index);
+   };
+
+   index_t  index_function  = nullptr;
+   search_t search_function = nullptr;
+
+   if (direction == direction_e::FORWARD)
+   {
+      index_function  = forward_index_function;
+      search_function = chunk_get_next_ncnnl;
+   }
+   else
+   {
+      index_function  = backward_index_function;
+      search_function = chunk_get_prev_ncnnlni;
+   }
+   auto chunk_is_ref_qualifier_token = [](chunk_t *pc_ref)
+   {
+      return(  chunk_is_ampersand_token(pc_ref)
+            || chunk_is_double_ampersand_token(pc_ref));
+   };
+
+   test_t tests[] =
+   {
+      chunk_is_const_token,         // skips the 'const' keyword
+      chunk_is_volatile_token,      // skip the 'volatile' keyword
+      chunk_is_ref_qualifier_token, // skips ref-qaulifiers
+      chunk_is_noexcept_token       // skips the 'noexcept' keyword
+   };
+
+   chunk_t *next = pc;
+
+   for (std::size_t i = 0; i < 4; ++i)
+   {
+      auto index = (*index_function)(i);
+
+      if ((*tests[index])(next))
+      {
+         /**
+          * Skip macro references...
+          */
+         do
+         {
+            pc   = next;
+            next = (*search_function)(pc,
+                                      scope);
+         } while (chunk_is_macro_reference(next));
+      }
+   }
+
+   return(pc);
+} // skip_trailing_function_qualifiers
+
+
+chunk_t *skip_trailing_function_qualifiers(chunk_t *pc,
+                                           scope_e scope)
+{
+   return(skip_trailing_function_qualifiers(pc, scope, direction_e::FORWARD));
+} // skip_trailing_function_qualifiers_next
+
+
+chunk_t *skip_trailing_function_qualifiers_next(chunk_t *pc, scope_e scope)
+{
+   auto *next = skip_trailing_function_qualifiers(pc);
+
+   if (next != pc)
+   {
+      return(chunk_get_next_ncnnl(next, scope));
+   }
+   return(pc);
+} // skip_trailing_function_qualifiers_next
+
+
+chunk_t *skip_trailing_function_qualifiers_prev(chunk_t *pc, scope_e scope)
+{
+   auto *prev = skip_trailing_function_qualifiers_rev(pc);
+
+   if (prev != pc)
+   {
+      return(chunk_get_prev_ncnnlni(prev, scope));
+   }
+   return(pc);
+} // skip_trailing_function_qualifiers_prev
+
+
+chunk_t *skip_trailing_function_qualifiers_rev(chunk_t *pc,
+                                               scope_e scope)
+{
+   return(skip_trailing_function_qualifiers(pc, scope, direction_e::BACKWARD));
+} // skip_trailing_function_qualifiers_rev

--- a/src/chunk_tools.h
+++ b/src/chunk_tools.h
@@ -1,0 +1,254 @@
+/**
+ * @file chunk_tools.h
+ *
+ * @author
+ * @license GPL v2+
+ */
+
+#ifndef CHUNK_TOOLS_H_INCLUDED
+#define CHUNK_TOOLS_H_INCLUDED
+
+#include "scope_enum.h"
+#include "token_enum.h"
+
+#include <vector>
+
+
+/**
+ * Return the next chunk that matches one of the specified strings at the given level
+ * @param  pc      the starting chunk
+ * @param  strings a vector of strings and size pairs for which the search will be performed
+ * @param  level   the level of the match
+ * @param  scope   code region to search
+ * @return         the next chunk that matches one of the specified strings, or nullptr if no
+ *                 match is found
+ */
+struct chunk_t *chunk_get_next_str(struct chunk_t *pc, const std::vector<std::pair<const char *, std::size_t> > &strings, int level, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Return the previous chunk that matches one of the specified strings at the given level
+ * @param  pc      the starting chunk
+ * @param  strings a vector of strings and size pairs for which the search will be performed
+ * @param  level   the level of the match
+ * @param  scope   code region to search
+ * @return         the previous chunk that matches one of the specified strings, or nullptr if no
+ *                 match is found
+ */
+struct chunk_t *chunk_get_prev_str(struct chunk_t *pc, const std::vector<std::pair<const char *, std::size_t> > &strings, int level, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Return the next chunk that matches one of the specified types at the given level
+ * @param  pc    the starting chunk
+ * @param  types a vector of token types for which the search will be performed
+ * @param  level the level of the match
+ * @param  scope code region to search
+ * @return       the next chunk that matches one of the specified types, or nullptr if no
+ *               match is found
+ */
+struct chunk_t *chunk_get_next_type(struct chunk_t *pc, const std::vector<c_token_t> &types, int level, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Return the previous chunk that matches one of the specified types at the given level
+ * @param  pc    the starting chunk
+ * @param  types a vector of token types for which the search will be performed
+ * @param  level the level of the match
+ * @param  scope code region to search
+ * @return       the previous chunk that matches one of the specified types, or nullptr if no
+ *               match is found
+ */
+struct chunk_t *chunk_get_prev_type(struct chunk_t *pc, const std::vector<c_token_t> &types, int level, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip forward to the ending chunk in a member initialization list
+ * @param  pc    the starting chunk, which should point to a colon
+ * @param  scope code region to search
+ * @return       the ending chunk of the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_member_initialization_list(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip forward to that which follows the ending chunk in a member initialization list
+ * @param  pc    the starting chunk, which should point to a colon
+ * @param  scope code region to search
+ * @return       the chunk following the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_member_initialization_list_next(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip in reverse to that which precedes the beginning chunk in a member initialization list
+ * @param  pc    the starting chunk, which should point to a closing paren or closing brace
+ * @param  scope code region to search
+ * @return       the chunk preceding the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_member_initialization_list_prev(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip in reverse to the beginning chunk in a member initialization list
+ * @param  pc    the starting chunk, which should point to a closing paren or closing brace
+ * @param  scope code region to search
+ * @return       the beginning chunk of the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_member_initialization_list_rev(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip forward to the ending chunk of an operator overload sequence
+ * @param  pc    the starting chunk, which should point to the operator keyword
+ * @param  scope code region to search
+ * @return       the ending chunk of the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_operator_overload(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip forward to the chunk following an operator overload sequence
+ * @param  pc    the starting chunk, which should point to the operator keyword
+ * @param  scope code region to search
+ * @return       the chunk following the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_operator_overload_next(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip in reverse to the chunk preceding an operator overload sequence
+ * @param  pc    the starting chunk, which should point to an overloaded symbol
+ * @param  scope code region to search
+ * @return       the chunk preceding the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_operator_overload_prev(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip in reverse to the beginning chunk of an operator overload sequence
+ * @param  pc    the starting chunk, which should point to an overloaded symbol
+ * @param  scope code region to search
+ * @return       the beginning chunk of the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_operator_overload_rev(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip forward to the ending chunk in a sequence of pointers, references, and/or qualifiers
+ * @param  pc    the starting chunk, which should point to the operator keyword
+ * @param  scope code region to search
+ * @return       the ending chunk of the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_pointers_references_and_qualifiers(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip forward to the chunk following a sequence of pointers, references, and/or qualifiers
+ * @param  pc    the starting chunk, which should point to the operator keyword
+ * @param  scope code region to search
+ * @return       the chunk following the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_pointers_references_and_qualifiers_next(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip in reverse to the chunk preceding a sequence of pointers, references, and/or qualifiers
+ * @param  pc    the starting chunk, which should point to an overloaded symbol
+ * @param  scope code region to search
+ * @return       the chunk preceding the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_pointers_references_and_qualifiers_prev(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip in reverse to the beginning chunk in a sequence of pointers, references, and/or qualifiers
+ * @param  pc    the starting chunk, which should point to an overloaded symbol
+ * @param  scope code region to search
+ * @return       the beginning chunk of the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_pointers_references_and_qualifiers_rev(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip forward past any scope resolution operators and nested name specifiers and return
+ * just the qualified identifier name; while similar to the existing skip_dc_member()
+ * function, this function also takes into account templates that may comprise any
+ * nested name specifiers
+ * @param  pc    the starting chunk
+ * @param  scope code region to search
+ * @return       the ending chunk of the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_scope_resolution_and_nested_name_specifiers(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip forward to the chunk following the ending chunk of a qualified identifier
+ * @param  pc    the starting chunk
+ * @param  scope code region to search
+ * @return       the chunk following the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_scope_resolution_and_nested_name_specifiers_next(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip in reverse to the chunk preceding the beginning chunk of a qualified identifier
+ * @param  pc    the starting chunk
+ * @param  scope code region to search
+ * @return       the chunk preceding the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_scope_resolution_and_nested_name_specifiers_prev(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip in reverse to the beginning chunk of a qualified identifier; while similar to
+ * the existing skip_dc_member_rev() function, this function also takes into account
+ * templates that may comprise any nested name specifiers
+ * @param  pc    the starting chunk
+ * @param  scope code region to search
+ * @return       the beginning chunk of the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_scope_resolution_and_nested_name_specifiers_rev(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip forward to the ending chunk in a sequence of trailing function qualifiers
+ * parameter signature list
+ * @param  pc    the starting chunk, which is assumed to point to a qualifier
+ *               following the closing paren of a function parameter list
+ * @param  scope code region to search
+ * @return       the ending chunk of the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_trailing_function_qualifiers(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip forward to the chunk following a sequence of trailing function qualifiers
+ * @param  pc    the starting chunk, which is assumed to point to a qualifier
+ *               following the closing paren of a function parameter list
+ * @param  scope code region to search
+ * @return       the chunk following the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_trailing_function_qualifiers_next(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip in reverse to the chunk preceding a sequence of trailing function qualifiers
+ * @param  pc    the starting chunk, which is assumed to point to a qualifier
+ *               following the closing paren of a function parameter list
+ * @param  scope code region to search
+ * @return       the chunk preceding the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_trailing_function_qualifiers_prev(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Skip in reverse to the beginning chunk in a sequence of trailing function qualifiers
+ * @param  pc    the starting chunk, which is assumed to point to a qualifier
+ *               following the closing paren of a function parameter list
+ * @param  scope code region to search
+ * @return       the beginning chunk of the sequence or the input chunk if no skipping occurred
+ */
+struct chunk_t *skip_trailing_function_qualifiers_rev(struct chunk_t *pc, scope_e scope = scope_e::ALL);
+
+#endif /* CHUNK_TOOLS_H_INCLUDED */

--- a/src/combine_labels.cpp
+++ b/src/combine_labels.cpp
@@ -22,7 +22,7 @@ chunk_t *chunk_get_next_local(chunk_t *pc, scope_e scope = scope_e::ALL)
       tmp = chunk_get_next(tmp, scope);
    } while (  tmp != nullptr
            && (  chunk_is_comment(tmp)
-              || chunk_is_token(tmp, CT_NOEXCEPT)));
+              || chunk_is_noexcept_token(tmp)));
 
    return(tmp);
 }
@@ -38,7 +38,7 @@ chunk_t *chunk_get_prev_local(chunk_t *pc, scope_e scope = scope_e::ALL)
    } while (  tmp != nullptr
            && (  chunk_is_comment(tmp)
               || chunk_is_newline(tmp)
-              || chunk_is_token(tmp, CT_NOEXCEPT)));
+              || chunk_is_noexcept_token(tmp)));
 
    return(tmp);
 }
@@ -100,23 +100,23 @@ void combine_labels(void)
       if (  !next->flags.test(PCF_IN_OC_MSG) // filter OC case of [self class] msg send
          && (  chunk_is_token(next, CT_CLASS)
             || chunk_is_token(next, CT_OC_CLASS)
-            || chunk_is_token(next, CT_TEMPLATE)))
+            || chunk_is_template_token(next)))
       {
          hit_class = true;
       }
 
-      if (  chunk_is_semicolon(next)
-         || chunk_is_token(next, CT_BRACE_OPEN))
+      if (  chunk_is_semicolon_token(next)
+         || chunk_is_brace_open_token(next))
       {
          hit_class = false;
       }
 
-      if (  chunk_is_token(prev, CT_SQUARE_OPEN)
+      if (  chunk_is_square_open_token(prev)
          && get_chunk_parent_type(prev) == CT_OC_MSG)
       {
          cs.Push_Back(prev);
       }
-      else if (  chunk_is_token(next, CT_SQUARE_CLOSE)
+      else if (  chunk_is_square_close_token(next)
               && get_chunk_parent_type(next) == CT_OC_MSG)
       {
          // pop until we hit '['
@@ -125,14 +125,14 @@ void combine_labels(void)
             chunk_t *t2 = cs.Top()->m_pc;
             cs.Pop_Back();
 
-            if (chunk_is_token(t2, CT_SQUARE_OPEN))
+            if (chunk_is_square_open_token(t2))
             {
                break;
             }
          }
       }
 
-      if (  chunk_is_token(next, CT_QUESTION)
+      if (  chunk_is_question_token(next)
          && !next->flags.test(PCF_IN_TEMPLATE))
       {
          cs.Push_Back(next);
@@ -170,7 +170,7 @@ void combine_labels(void)
             set_chunk_type(next, CT_CASE_COLON);
             chunk_t *tmp = chunk_get_next_ncnnlnp(next);                // Issue #2150
 
-            if (chunk_is_token(tmp, CT_BRACE_OPEN))
+            if (chunk_is_brace_open_token(tmp))
             {
                set_chunk_parent(tmp, CT_CASE);
                tmp = chunk_get_next_type(tmp, CT_BRACE_CLOSE, tmp->level);
@@ -181,12 +181,12 @@ void combine_labels(void)
                }
             }
 
-            if (  chunk_is_token(cur, CT_NUMBER)
-               && chunk_is_token(prev, CT_ELLIPSIS))
+            if (  chunk_is_integral_number_token(cur)
+               && chunk_is_ellipsis_token(prev))
             {
                chunk_t *pre_elipsis = chunk_get_prev_ncnnlnp(prev);
 
-               if (chunk_is_token(pre_elipsis, CT_NUMBER))
+               if (chunk_is_integral_number_token(pre_elipsis))
                {
                   set_chunk_type(prev, CT_CASE_ELLIPSIS);
                }
@@ -214,7 +214,7 @@ void combine_labels(void)
             if (language_is_set(LANG_PAWN))
             {
                if (  chunk_is_token(cur, CT_WORD)
-                  || chunk_is_token(cur, CT_BRACE_CLOSE))
+                  || chunk_is_brace_close_token(cur))
                {
                   c_token_t new_type = CT_TAG;
 
@@ -377,7 +377,7 @@ void combine_labels(void)
             {
                // ignore it - bit field, align or public/private, etc
             }
-            else if (  chunk_is_token(cur, CT_ANGLE_CLOSE)
+            else if (  chunk_is_angle_close_token(cur)
                     || hit_class)
             {
                // ignore it - template thingy

--- a/src/combine_skip.cpp
+++ b/src/combine_skip.cpp
@@ -8,6 +8,7 @@
 
 #include "combine_skip.h"
 
+#include "chunk_tests.h"
 #include "combine_tools.h"
 
 
@@ -15,7 +16,7 @@ chunk_t *skip_align(chunk_t *start)
 {
    chunk_t *pc = start;
 
-   if (chunk_is_token(pc, CT_ALIGN))
+   if (chunk_is_alignof_token(pc))
    {
       pc = chunk_get_next_ncnnl(pc);
 
@@ -65,8 +66,8 @@ static chunk_t *skip_to_expression_edge(chunk_t *pc, chunk_t *(*chunk_get_next)(
           * return the current chunk
           */
          if (  next->level == level
-            && (  chunk_is_token(next, CT_COMMA)
-               || chunk_is_semicolon(next)))
+            && (  chunk_is_comma_token(next)
+               || chunk_is_semicolon_token(next)))
          {
             break;
          }
@@ -103,7 +104,7 @@ chunk_t *skip_to_expression_start(chunk_t *pc)
 chunk_t *skip_to_next_statement(chunk_t *pc)
 {
    while (  pc != nullptr
-         && !chunk_is_semicolon(pc)
+         && !chunk_is_semicolon_token(pc)
          && chunk_is_not_token(pc, CT_BRACE_OPEN)
          && chunk_is_not_token(pc, CT_BRACE_CLOSE))
    {
@@ -140,8 +141,8 @@ chunk_t *skip_parent_types(chunk_t *colon)
       // Get next token
       auto next = skip_template_next(chunk_get_next_ncnnlnp(pc));
 
-      if (  chunk_is_token(next, CT_DC_MEMBER)
-         || chunk_is_token(next, CT_COMMA))
+      if (  chunk_is_double_colon_token(next)
+         || chunk_is_comma_token(next))
       {
          pc = chunk_get_next_ncnnlnp(next);
       }
@@ -164,7 +165,7 @@ chunk_t *skip_parent_types(chunk_t *colon)
 
 chunk_t *skip_template_prev(chunk_t *ang_close)
 {
-   if (chunk_is_token(ang_close, CT_ANGLE_CLOSE))
+   if (chunk_is_angle_close_token(ang_close))
    {
       chunk_t *pc = chunk_get_prev_type(ang_close, CT_ANGLE_OPEN, ang_close->level);
       return(chunk_get_prev_ncnnlni(pc));   // Issue #2279
@@ -175,8 +176,8 @@ chunk_t *skip_template_prev(chunk_t *ang_close)
 
 chunk_t *skip_tsquare_next(chunk_t *ary_def)
 {
-   if (  chunk_is_token(ary_def, CT_SQUARE_OPEN)
-      || chunk_is_token(ary_def, CT_TSQUARE))
+   if (  chunk_is_square_open_token(ary_def)
+      || chunk_is_subscript_token(ary_def))
    {
       return(chunk_get_next_nisq(ary_def));
    }
@@ -282,9 +283,9 @@ chunk_t *skip_declspec_prev(chunk_t *pc)
 
 chunk_t *skip_matching_brace_bracket_paren_next(chunk_t *pc)
 {
-   if (  chunk_is_token(pc, CT_BRACE_OPEN)
+   if (  chunk_is_brace_open_token(pc)
       || chunk_is_token(pc, CT_PAREN_OPEN)
-      || chunk_is_token(pc, CT_SQUARE_OPEN))
+      || chunk_is_square_open_token(pc))
    {
       pc = chunk_skip_to_match(pc);
 
@@ -304,9 +305,9 @@ chunk_t *skip_matching_brace_bracket_paren_next(chunk_t *pc)
 
 chunk_t *skip_to_chunk_before_matching_brace_bracket_paren_rev(chunk_t *pc)
 {
-   if (  chunk_is_token(pc, CT_BRACE_CLOSE)
+   if (  chunk_is_brace_close_token(pc)
       || chunk_is_token(pc, CT_PAREN_CLOSE)
-      || chunk_is_token(pc, CT_SQUARE_CLOSE))
+      || chunk_is_square_close_token(pc))
    {
       pc = chunk_skip_to_match_rev(pc);
 

--- a/src/cs_top_is_question.cpp
+++ b/src/cs_top_is_question.cpp
@@ -15,6 +15,6 @@ bool cs_top_is_question(ChunkStack &cs, size_t level)
 {
    chunk_t *pc = cs.Empty() ? nullptr : cs.Top()->m_pc;
 
-   return(  chunk_is_token(pc, CT_QUESTION)
+   return(  chunk_is_question_token(pc)
          && pc->level == level);
 }

--- a/src/detect.cpp
+++ b/src/detect.cpp
@@ -162,13 +162,13 @@ static void detect_space_options(void)
       }
 
       if (  chunk_is_token(pc, CT_ARITH)
-         || chunk_is_token(pc, CT_SHIFT))
+         || chunk_is_shift_token(pc))
       {
          vote_sp_arith.vote(pc, next);
          vote_sp_arith.vote(prev, pc);
       }
 
-      if (chunk_is_token(pc, CT_ASSIGN))
+      if (chunk_is_assign_token(pc))
       {
          if (!pc->flags.test(PCF_IN_ENUM))
          {
@@ -182,18 +182,18 @@ static void detect_space_options(void)
          }
       }
 
-      if (chunk_is_token(pc, CT_SQUARE_OPEN))
+      if (chunk_is_square_open_token(pc))
       {
          vote_sp_before_square.vote(prev, pc);
          vote_sp_inside_square.vote(pc, next);
       }
 
-      if (chunk_is_token(pc, CT_SQUARE_CLOSE))
+      if (chunk_is_square_close_token(pc))
       {
          vote_sp_inside_square.vote(prev, pc);
       }
 
-      if (chunk_is_token(pc, CT_TSQUARE))
+      if (chunk_is_subscript_token(pc))
       {
          vote_sp_before_squares.vote(prev, pc);
       }
@@ -204,7 +204,7 @@ static void detect_space_options(void)
          vote_sp_bool.vote(pc, next);
       }
 
-      if (chunk_is_token(pc, CT_COMPARE))
+      if (chunk_is_comparison_token(pc))
       {
          vote_sp_compare.vote(prev, pc);
          vote_sp_compare.vote(pc, next);
@@ -220,16 +220,16 @@ static void detect_space_options(void)
          vote_sp_inside_paren.vote(pc, next);
       }
 
-      if (  (  chunk_is_paren_open(pc)
-            && chunk_is_paren_open(next))
-         || (  chunk_is_paren_close(pc)
-            && chunk_is_paren_close(next)))
+      if (  (  chunk_is_paren_open_token(pc)
+            && chunk_is_paren_open_token(next))
+         || (  chunk_is_paren_close_token(pc)
+            && chunk_is_paren_close_token(next)))
       {
          vote_sp_paren_paren.vote(pc, next);
       }
 
-      if (  chunk_is_paren_close(pc)
-         && chunk_is_token(next, CT_BRACE_OPEN))
+      if (  chunk_is_paren_close_token(pc)
+         && chunk_is_brace_open_token(next))
       {
          vote_sp_paren_brace.vote(pc, next);
       }
@@ -275,11 +275,11 @@ static void detect_space_options(void)
          vote_sp_after_type.vote(prev, pc);
       }
 
-      if (chunk_is_token(pc, CT_ANGLE_OPEN))
+      if (chunk_is_angle_open_token(pc))
       {
          vote_sp_inside_angle.vote(pc, next);
 
-         if (chunk_is_token(prev, CT_TEMPLATE))
+         if (chunk_is_template_token(prev))
          {
             vote_sp_template_angle.vote(prev, pc);
          }
@@ -289,11 +289,11 @@ static void detect_space_options(void)
          }
       }
 
-      if (chunk_is_token(pc, CT_ANGLE_CLOSE))
+      if (chunk_is_angle_close_token(pc))
       {
          vote_sp_inside_angle.vote(prev, pc);
 
-         if (chunk_is_paren_open(next))
+         if (chunk_is_paren_open_token(next))
          {
             vote_sp_angle_paren.vote(prev, pc);
          }
@@ -318,7 +318,7 @@ static void detect_space_options(void)
       {
          vote_sp_inside_sparen.vote(prev, pc);
 
-         if (chunk_is_token(next, CT_BRACE_OPEN))
+         if (chunk_is_brace_open_token(next))
          {
             vote_sp_sparen_brace.vote(pc, next);
          }
@@ -365,7 +365,7 @@ static void detect_space_options(void)
          }
       }
 
-      if (chunk_is_token(pc, CT_COMMA))
+      if (chunk_is_comma_token(pc))
       {
          vote_sp_before_comma.vote(prev, pc);
          vote_sp_after_comma.vote(pc, next);
@@ -377,13 +377,13 @@ static void detect_space_options(void)
          vote_sp_after_class_colon.vote(pc, next);
       }
 
-      if (chunk_is_token(pc, CT_BRACE_OPEN))
+      if (chunk_is_brace_open_token(pc))
       {
          if (chunk_is_token(prev, CT_ELSE))
          {
             vote_sp_else_brace.vote(prev, pc);
          }
-         else if (chunk_is_token(prev, CT_CATCH))
+         else if (chunk_is_catch_token(prev))
          {
             vote_sp_catch_brace.vote(prev, pc);
          }
@@ -400,7 +400,7 @@ static void detect_space_options(void)
             vote_sp_catch_brace.vote(prev, pc);
          }
 
-         if (chunk_is_token(next, CT_BRACE_CLOSE))
+         if (chunk_is_brace_close_token(next))
          {
             vote_sp_inside_braces_empty.vote(pc, next);
          }
@@ -410,7 +410,7 @@ static void detect_space_options(void)
          }
       }
 
-      if (chunk_is_token(pc, CT_BRACE_CLOSE))
+      if (chunk_is_brace_close_token(pc))
       {
          vote_sp_inside_braces.vote(prev, pc);
 
@@ -418,7 +418,7 @@ static void detect_space_options(void)
          {
             vote_sp_brace_else.vote(pc, next);
          }
-         else if (chunk_is_token(next, CT_CATCH))
+         else if (chunk_is_catch_token(next))
          {
             vote_sp_brace_catch.vote(pc, next);
          }

--- a/src/enum_cleanup.cpp
+++ b/src/enum_cleanup.cpp
@@ -31,14 +31,14 @@ void enum_cleanup(void)
    while (pc != nullptr)
    {
       if (  get_chunk_parent_type(pc) == CT_ENUM
-         && chunk_is_token(pc, CT_BRACE_CLOSE))
+         && chunk_is_brace_close_token(pc))
       {
          LOG_FMT(LTOK, "%s(%d): orig_line is %zu, type is %s\n",
                  __func__, __LINE__, pc->orig_line, get_token_name(pc->type));
          chunk_t *prev = chunk_get_prev_ncnnlnp(pc);
 
          // test of (prev == nullptr) is not necessary
-         if (chunk_is_token(prev, CT_COMMA))
+         if (chunk_is_comma_token(prev))
          {
             log_rule_B("mod_enum_last_comma");
 
@@ -49,7 +49,7 @@ void enum_cleanup(void)
          }
          else
          {
-            if (chunk_is_token(prev, CT_BRACE_OPEN))                // Issue #2902
+            if (chunk_is_brace_open_token(prev))                // Issue #2902
             {
                // nothing betwen CT_BRACE_OPEN and CT_BRACE_CLOSE
             }

--- a/src/flag_braced_init_list.cpp
+++ b/src/flag_braced_init_list.cpp
@@ -34,24 +34,24 @@ bool detect_cpp_braced_init_list(chunk_t *pc, chunk_t *next)
    // Detect a braced-init-list
    if (  chunk_is_token(pc, CT_WORD)
       || chunk_is_token(pc, CT_TYPE)
-      || chunk_is_token(pc, CT_ASSIGN)
+      || chunk_is_assign_token(pc)
       || chunk_is_token(pc, CT_RETURN)
-      || chunk_is_token(pc, CT_COMMA)
-      || chunk_is_token(pc, CT_ANGLE_CLOSE)
-      || chunk_is_token(pc, CT_SQUARE_CLOSE)
-      || chunk_is_token(pc, CT_TSQUARE)
+      || chunk_is_comma_token(pc)
+      || chunk_is_angle_close_token(pc)
+      || chunk_is_square_close_token(pc)
+      || chunk_is_subscript_token(pc)
       || chunk_is_token(pc, CT_FPAREN_OPEN)
-      || chunk_is_token(pc, CT_QUESTION)
+      || chunk_is_question_token(pc)
       || (  chunk_is_token(pc, CT_COLON)
          && !we_have_a_case_before)
-      || (  chunk_is_token(pc, CT_BRACE_OPEN)
+      || (  chunk_is_brace_open_token(pc)
          && (  get_chunk_parent_type(pc) == CT_NONE
             || get_chunk_parent_type(pc) == CT_BRACED_INIT_LIST)))
    {
       log_pcf_flags(LFCNR, pc->flags);
       auto brace_open = chunk_get_next_ncnnl(pc);
 
-      if (  chunk_is_token(brace_open, CT_BRACE_OPEN)
+      if (  chunk_is_brace_open_token(brace_open)
          && (  get_chunk_parent_type(brace_open) == CT_NONE
             || get_chunk_parent_type(brace_open) == CT_ASSIGN
             || get_chunk_parent_type(brace_open) == CT_RETURN
@@ -60,7 +60,7 @@ bool detect_cpp_braced_init_list(chunk_t *pc, chunk_t *next)
          log_pcf_flags(LFCNR, brace_open->flags);
          auto brace_close = chunk_skip_to_match(next);
 
-         if (chunk_is_token(brace_close, CT_BRACE_CLOSE))
+         if (chunk_is_brace_close_token(brace_close))
          {
             return(true);
          }

--- a/src/flag_decltype.cpp
+++ b/src/flag_decltype.cpp
@@ -11,7 +11,7 @@ bool flag_cpp_decltype(chunk_t *pc)
 {
    LOG_FUNC_ENTRY();
 
-   if (chunk_is_token(pc, CT_DECLTYPE))
+   if (chunk_is_decltype_token(pc))
    {
       auto paren_open = chunk_get_next_ncnnl(pc);
 

--- a/src/lang_pawn.cpp
+++ b/src/lang_pawn.cpp
@@ -107,7 +107,7 @@ void pawn_scrub_vsemi(void)
       }
       chunk_t *prev = chunk_get_prev_ncnnl(pc);
 
-      if (chunk_is_token(prev, CT_BRACE_CLOSE))
+      if (chunk_is_brace_close_token(prev))
       {
          if (  get_chunk_parent_type(prev) == CT_IF
             || get_chunk_parent_type(prev) == CT_ELSE
@@ -133,19 +133,19 @@ static bool pawn_continued(chunk_t *pc, size_t br_level)
 
    if (  pc->level > br_level
       || chunk_is_token(pc, CT_ARITH)
-      || chunk_is_token(pc, CT_SHIFT)
-      || chunk_is_token(pc, CT_CARET)
-      || chunk_is_token(pc, CT_QUESTION)
+      || chunk_is_shift_token(pc)
+      || chunk_is_caret_token(pc)
+      || chunk_is_question_token(pc)
       || chunk_is_token(pc, CT_BOOL)
-      || chunk_is_token(pc, CT_ASSIGN)
-      || chunk_is_token(pc, CT_COMMA)
-      || chunk_is_token(pc, CT_COMPARE)
+      || chunk_is_assign_token(pc)
+      || chunk_is_comma_token(pc)
+      || chunk_is_comparison_token(pc)
       || chunk_is_token(pc, CT_IF)
       || chunk_is_token(pc, CT_ELSE)
       || chunk_is_token(pc, CT_DO)
       || chunk_is_token(pc, CT_SWITCH)
       || chunk_is_token(pc, CT_WHILE)
-      || chunk_is_token(pc, CT_BRACE_OPEN)
+      || chunk_is_brace_open_token(pc)
       || chunk_is_token(pc, CT_VBRACE_OPEN)
       || chunk_is_token(pc, CT_FPAREN_OPEN)
       || get_chunk_parent_type(pc) == CT_IF
@@ -158,9 +158,9 @@ static bool pawn_continued(chunk_t *pc, size_t br_level)
       || get_chunk_parent_type(pc) == CT_FUNC_DEF
       || get_chunk_parent_type(pc) == CT_ENUM
       || pc->flags.test_any(PCF_IN_ENUM | PCF_IN_STRUCT)
-      || chunk_is_str(pc, ":", 1)
-      || chunk_is_str(pc, "+", 1)
-      || chunk_is_str(pc, "-", 1))
+      || chunk_is_colon_str(pc)
+      || chunk_is_plus_str(pc)
+      || chunk_is_minus_str(pc))
    {
       return(true);
    }
@@ -207,8 +207,8 @@ static chunk_t *pawn_process_line(chunk_t *start)
    //LOG_FMT(LSYS, "%s: %d - %s\n", __func__,
    //        start->orig_line, start->text());
 
-   if (  chunk_is_token(start, CT_NEW)
-      || chunk_is_str(start, "const", 5))
+   if (  chunk_is_new_token(start)
+      || chunk_is_const_str(start))
    {
       return(pawn_process_variable(start));
    }
@@ -222,14 +222,14 @@ static chunk_t *pawn_process_line(chunk_t *start)
    chunk_t *pc = start;
 
    while (  ((pc = chunk_get_next_nc(pc)) != nullptr)
-         && !chunk_is_str(pc, "(", 1)
+         && !chunk_is_paren_open_str(pc)
          && pc->type != CT_ASSIGN
          && pc->type != CT_NEWLINE)
    {
       if (  pc->level == 0
          && (  chunk_is_token(pc, CT_FUNCTION)
             || chunk_is_token(pc, CT_WORD)
-            || chunk_is_token(pc, CT_OPERATOR_VAL)))
+            || chunk_is_overloaded_token(pc)))
       {
          fcn = pc;
       }
@@ -237,7 +237,7 @@ static chunk_t *pawn_process_line(chunk_t *start)
 
    if (pc != nullptr)
    {
-      if (chunk_is_token(pc, CT_ASSIGN))
+      if (chunk_is_assign_token(pc))
       {
          return(pawn_process_variable(pc));
       }
@@ -389,7 +389,7 @@ static chunk_t *pawn_process_func_def(chunk_t *pc)
 
    // See if there is a state clause after the function
    if (  last != nullptr
-      && chunk_is_str(last, "<", 1))
+      && chunk_is_angle_open_str(last))
    {
       LOG_FMT(LPFUNC, "%s: %zu] '%s' has state angle open %s\n",
               __func__, pc->orig_line, pc->text(), get_token_name(last->type));
@@ -398,7 +398,7 @@ static chunk_t *pawn_process_func_def(chunk_t *pc)
       set_chunk_parent(last, CT_FUNC_DEF);
 
       while (  ((last = chunk_get_next(last)) != nullptr)
-            && !chunk_is_str(last, ">", 1))
+            && !chunk_is_angle_close_str(last))
       {
          // do nothing just search, TODO: use search_chunk
       }
@@ -418,7 +418,7 @@ static chunk_t *pawn_process_func_def(chunk_t *pc)
       return(last);
    }
 
-   if (chunk_is_token(last, CT_BRACE_OPEN))
+   if (chunk_is_brace_open_token(last))
    {
       set_chunk_parent(last, CT_FUNC_DEF);
       last = chunk_get_next_type(last, CT_BRACE_CLOSE, last->level);

--- a/src/match_tools.cpp
+++ b/src/match_tools.cpp
@@ -1,0 +1,1871 @@
+/**
+ * @file match_tools.cpp
+ *
+ * @author
+ * @license GPL v2+
+ */
+
+#include "match_tools.h"
+
+#include "chunk_list.h"
+#include "chunk_tests.h"
+#include "chunk_tools.h"
+#include "combine_skip.h"
+#include "keywords.h"
+
+#include <map>
+
+
+bool adj_chunks_match_compound_type_pattern(chunk_t *prev,
+                                            chunk_t *next)
+{
+   LOG_FUNC_ENTRY();
+
+   if (  prev != nullptr
+      && next != nullptr)
+   {
+      auto get_token_type = [](chunk_t *pc)
+      {
+         static std::map<bool (*)(chunk_t *), c_token_t> chunk_reassignment_map =
+         {
+            {
+               [](chunk_t *pc_arg)
+               {
+                  return(chunk_is_identifier(pc_arg, false));
+               }, CT_TYPE
+            },
+            { chunk_is_paren_close_token, CT_PAREN_CLOSE },
+            { chunk_is_paren_open_token, CT_PAREN_OPEN  }
+         };
+
+         for (auto &&chunk_reassignment_entry : chunk_reassignment_map)
+         {
+            auto &&test  = chunk_reassignment_entry.first;
+            auto &&token = chunk_reassignment_entry.second;
+
+            if (test(pc))
+            {
+               return(token);
+            }
+         }
+
+         return(pc != nullptr ? pc->type : CT_NONE);
+      };
+      auto next_token_type = get_token_type(next);
+      auto prev_token_type = get_token_type(prev);
+
+      switch (prev_token_type)
+      {
+      case CT_ANGLE_CLOSE:
+         /**
+          * assuming the previous token is possibly the closing angle of a
+          * templated type, the next token may be one of the following:
+          * - a pointer symbol ('*', '^')
+          * - a double colon ('::')
+          * - a reference symbol ('&')
+          * - a qualifier (const, etc.)
+          * - an open square bracket
+          * - a set of empty square brackets
+          */
+         return(  chunk_is_pointer_or_reference(next)
+               || next_token_type == CT_DC_MEMBER
+               || next_token_type == CT_QUALIFIER
+               || next_token_type == CT_SQUARE_OPEN
+               || next_token_type == CT_TSQUARE);
+
+      case CT_ANGLE_OPEN:
+         /**
+          * assuming the previous token is possibly the opening angle of a
+          * templated type, just check to see if there's a matching closing
+          * angle
+          */
+         return(chunk_skip_to_match(prev, scope_e::PREPROC) != nullptr);
+
+      case CT_CARET:
+         /**
+          * if the previous token is a managed C++/CLI pointer symbol ('^'),
+          * the next token may be one of the following:
+          * - a pointer symbol ('*', '^')
+          * - a reference symbol ('&')
+          * - a qualifier (const, etc.)
+          * - an open square bracket
+          * - a set of empty square brackets
+          */
+         return(  language_is_set(LANG_CPP)
+               && (  chunk_is_pointer_or_reference(next)
+                  || next_token_type == CT_QUALIFIER
+                  || next_token_type == CT_SQUARE_OPEN
+                  || next_token_type == CT_TSQUARE));
+
+      case CT_DC_MEMBER:
+         /**
+          * if the previous token is a double colon ('::'), it is likely part
+          * of a chain of scope-resolution qualifications preceding a word or
+          * type
+          */
+         return(  next_token_type == CT_TYPE
+               || next_token_type == CT_WORD);
+
+      case CT_DECLTYPE:
+         /**
+          * if the previous token is the decltype keyword, then the next token
+          * must be an open paren
+          */
+         return(next_token_type == CT_PAREN_OPEN);
+
+      case CT_PAREN_CLOSE:
+         /**
+          * if the previous token is a closing paren, it may be part of a function
+          * pointer signature, and so the next token may be an opening paren; on the
+          * other hand, the closing paren may conclude the end of a decltype statement,
+          * in which case the next token may be one of the following:
+          * - a pointer symbol ('*', '^')
+          * - a double colon ('::')
+          * - a reference symbol ('&')
+          * - a qualifier (const, etc.)
+          * - an open square bracket
+          * - a set of empty square brackets
+          */
+         return(  chunk_is_pointer_or_reference(next)
+               || next_token_type == CT_DC_MEMBER
+               || next_token_type == CT_PAREN_OPEN
+               || next_token_type == CT_QUALIFIER
+               || next_token_type == CT_SQUARE_OPEN
+               || next_token_type == CT_TSQUARE);
+
+      case CT_PAREN_OPEN:
+         /**
+          * if the previous token is an opening paren, it may be part of a function
+          * pointer signature, and so the next token may be a pointer symbol; it also
+          * may be associated with a decltype statement, so in that case simply skip
+          * ahead to a matching closing paren
+          */
+         return(  chunk_is_ptr_operator(next)
+               || chunk_skip_to_match(prev, scope_e::PREPROC) != nullptr);
+
+      case CT_PTR_TYPE:
+      case CT_STAR:
+
+         /**
+          * if the previous token is a pointer type, ('*'), it may be part of a function
+          * pointer signature, and so the next token may be a closing paren; otherwise,
+          * the next token may be one of the following:
+          * - another pointer symbol ('*', '^')
+          * - a reference symbol ('&')
+          * - a qualifier (const, etc.)
+          * - an open square bracket
+          * - a set of empty square brackets
+          */
+         return(  chunk_is_pointer_or_reference(next)
+               || next_token_type == CT_PAREN_CLOSE
+               || next_token_type == CT_QUALIFIER
+               || next_token_type == CT_SQUARE_OPEN
+               || next_token_type == CT_TSQUARE);
+
+      case CT_QUALIFIER:
+         /**
+          * if the previous token is a qualifier (const, etc.), the next token
+          * may be one of the following:
+          * - a pointer symbol ('*', '^')
+          * - a reference symbol ('&')
+          * - another qualifier
+          * - an open square bracket
+          * - a set of empty square brackets
+          */
+         return(  chunk_is_pointer_or_reference(next)
+               || next_token_type == CT_QUALIFIER
+               || next_token_type == CT_SQUARE_OPEN
+               || next_token_type == CT_TSQUARE);
+
+      case CT_SQUARE_CLOSE:
+         /**
+          * if the previous token is a close square bracket, the next token may be
+          * another opening square bracket
+          */
+         return(next_token_type == CT_SQUARE_OPEN);
+
+      case CT_SQUARE_OPEN:
+         /**
+          * if the previous token is an open square bracket, it may indicate an
+          * array declaration - skip ahead to find a matching close square bracket
+          */
+         return(chunk_skip_to_match(prev, scope_e::PREPROC) != nullptr);
+
+      case CT_TSQUARE:
+         /**
+          * if the previous token is a set of brackets, the next token may be
+          * an open square bracket
+          */
+         return(next_token_type == CT_SQUARE_OPEN);
+
+      case CT_TYPE:
+         /**
+          * if the previous token is marked as a type, the next token may be
+          * one of the following:
+          * - a pointer symbol ('*', '^')
+          * - a reference symbol ('&')
+          * - an opening angle, which may indicate a templated type
+          * - a double colon ('::')
+          * - an opening paren, which may indicate a function pointer
+          * - a qualifier (const, etc.)
+          * - an opening square bracket, which may indicate an array
+          * - a set of empty square brackets, which may also indicate an array
+          * - an identifier
+          */
+         return(  chunk_is_pointer_or_reference(next)
+               || next_token_type == CT_ANGLE_OPEN
+               || (  next_token_type == CT_DC_MEMBER
+                  && !chunk_is_keyword(prev))
+               || next_token_type == CT_PAREN_OPEN
+               || next_token_type == CT_QUALIFIER
+               || next_token_type == CT_SQUARE_OPEN
+               || next_token_type == CT_TSQUARE
+               || next_token_type == CT_WORD);
+
+      case CT_TYPEDEF:
+         /**
+          * if the previous token is a typedef, the next token may be one of the
+          * following:
+          * - a double colon ('::')
+          * - the decltype keyword
+          * - a qualifier (const, etc.)
+          * - an identifier
+          * - the typename keyword
+          */
+         return(  next_token_type == CT_DC_MEMBER
+               || next_token_type == CT_DECLTYPE
+               || next_token_type == CT_QUALIFIER
+               || next_token_type == CT_TYPE
+               || next_token_type == CT_TYPENAME);
+
+      case CT_TYPENAME:
+         /**
+          * if the previous token is a typename, the next token may be one of the
+          * following:
+          */
+         return(  next_token_type == CT_DC_MEMBER
+               || next_token_type == CT_DECLTYPE
+               || next_token_type == CT_QUALIFIER
+               || (  next_token_type == CT_TYPE
+                  && !chunk_is_keyword(prev)));
+
+      default:
+         // do nothing
+         break;
+      } // switch
+   }
+   return(false);
+} // adj_chunks_match_compound_type_pattern
+
+
+bool adj_chunks_match_qualified_identifier_pattern(chunk_t *prev,
+                                                   chunk_t *next)
+{
+   LOG_FUNC_ENTRY();
+
+   if (  prev != nullptr
+      && next != nullptr)
+   {
+      auto prev_token_type = prev->type;
+      auto next_token_type = next->type;
+
+      switch (prev_token_type)
+      {
+      case CT_ANGLE_CLOSE:
+         /**
+          * assuming the previous token is possibly the closing angle of a
+          * templated type, the next token may be a scope resolution operator ('::')
+          */
+         return(next_token_type == CT_DC_MEMBER);
+
+      case CT_ANGLE_OPEN:
+         /**
+          * assuming the previous token is possibly the opening angle of a
+          * templated type, just check to see if there's a matching closing
+          * angle
+          */
+         return(chunk_skip_to_match(prev, scope_e::PREPROC) != nullptr);
+
+      case CT_DC_MEMBER:
+         /**
+          * if the previous token is a double colon ('::'), it is likely part
+          * of a chain of scope-resolution qualifications preceding a word or
+          * type
+          */
+         return(  next_token_type == CT_TYPE
+               || next_token_type == CT_WORD);
+
+      case CT_TYPE:
+      case CT_WORD:
+         /**
+          * if the previous token is an identifier, the next token may be
+          * one of the following:
+          * - an opening angle, which may indicate a templated type as part of a
+          *   scope resolution preceding the actual variable identifier
+          * - a double colon ('::')
+          */
+         return(  next_token_type == CT_ANGLE_OPEN
+               || next_token_type == CT_DC_MEMBER);
+
+      default:
+         // do nothing
+         break;
+      } // switch
+   }
+   return(false);
+} // adj_chunks_match_qualified_identifier_pattern
+
+
+bool adj_chunks_match_template_end_pattern(chunk_t *prev,
+                                           chunk_t *next)
+{
+   LOG_FUNC_ENTRY();
+
+   if (  prev != nullptr
+      && next != nullptr)
+   {
+      auto prev_token_type = prev->type;
+      auto next_token_type = next->type;
+
+      switch (prev_token_type)
+      {
+      case CT_ANGLE_CLOSE:
+
+         /**
+          * assuming the previous token is possibly the closing angle of a
+          * templated type, the next token may be one of the following:
+          * - class, struct or union:                template<... > class/struct/union
+          * - a colon (':'):                                T<... > : public ... { }
+          * - a pointer symbol ('*', '^'):               vector<T > *
+          * - a reference symbol ('&'):                  vector<T > &
+          * - a closing angle ('>'):            <Class<typename T > >
+          * - an assignment symbol ('='):                         ? Not sure if this situation can arise in valid C++ syntax?
+          * - an opening brace ('{'):                    vector<T > { t, ... }
+          * - a comma (','):                    void foo(vector<T > , ...)
+          * - a double colon ('::'):                     vector<T > ::iterator
+          * - an ellipsis ('...'):                             <T > ...
+          * - a closing paren (')'):            void foo(vector<T > )
+          * - an opening paren ('('):                    vector<T > ()
+          * - a qualifier (const, etc.):                 vector<T > const
+          * - a semicolon (';'):               using A = vector<T > ;
+          * - an opening square bracket ('['):           vector<T > []
+          * - a template keyword:                       template< > template
+          * - an identifier:                             vector<T > ClassType::function
+          * - a using keyword:                       template<... > using
+          */
+         return(  chunk_is_class_struct_union(next)
+               || chunk_is_colon_token(next)
+               || chunk_is_pointer_or_reference(next)
+               || next_token_type == CT_ANGLE_CLOSE
+               || next_token_type == CT_ASSIGN // TODO: not sure about this one...
+               || next_token_type == CT_BRACE_OPEN
+               || next_token_type == CT_COMMA
+               || next_token_type == CT_DC_MEMBER
+               || next_token_type == CT_ELLIPSIS
+               || next_token_type == CT_PAREN_CLOSE
+               || next_token_type == CT_PAREN_OPEN
+               || next_token_type == CT_QUALIFIER
+               || next_token_type == CT_SEMICOLON
+               || next_token_type == CT_SQUARE_OPEN
+               || next_token_type == CT_TEMPLATE
+               || next_token_type == CT_TYPE
+               || next_token_type == CT_USING
+               || next_token_type == CT_WORD
+               || get_chunk_parent_type(next) == CT_CLASS
+               || get_chunk_parent_type(next) == CT_ENUM
+               || get_chunk_parent_type(next) == CT_ENUM_CLASS
+               || get_chunk_parent_type(next) == CT_FUNC_CLASS_DEF
+               || get_chunk_parent_type(next) == CT_FUNC_DEF
+               || get_chunk_parent_type(next) == CT_FUNCTION
+               || get_chunk_parent_type(next) == CT_STRUCT
+               || get_chunk_parent_type(next) == CT_UNION);
+
+      case CT_ANGLE_OPEN:
+      case CT_BYREF:
+      case CT_CLASS:
+      case CT_ELLIPSIS:
+      case CT_NUMBER:
+      case CT_PAREN_CLOSE:
+      case CT_PTR_TYPE:
+      case CT_QUALIFIER:
+      case CT_SQUARE_CLOSE:
+      case CT_STAR:
+      case CT_TYPE:
+      case CT_TYPENAME:
+      case CT_WORD:
+         /**
+          * assuming the next token may be a closing angle to a templated type,
+          * the previous token may be one of the following:
+          * - an opening angle ('<'):    template < >
+          * - a reference symbol ('&'):        <T & >
+          * - a class keyword:               <class >
+          * - an ellipsis ('...'):    <typename ... >
+          * - a number:                          <1 >
+          * - a closing paren:                <T () >
+          * - a pointer symbol ('*', '^'):     <T * >
+          * - a qualifier (const, etc.):   <T const >
+          * - a closing square bracket (']'): <T [] >
+          * - an identifier:                     <T >
+          * - typename keyword:           <typename >
+          */
+         return(next_token_type == CT_ANGLE_CLOSE);
+
+      // TODO: verify that this actually works...
+      case CT_STRING:
+         /**
+          * assuming the next token may be a closing angle to a templated type,
+          * the previous token may also be a single quote ('''): T <'a' >
+          */
+         return(  prev->str.size() > 0
+               && prev->str.back() == '\'');
+
+      default:
+         // do nothing
+         break;
+      } // switch
+   }
+   return(false);
+} // adj_chunks_match_template_end_pattern
+
+
+bool adj_chunks_match_template_start_pattern(chunk_t *prev,
+                                             chunk_t *next)
+{
+   LOG_FUNC_ENTRY();
+
+   if (  prev != nullptr
+      && next != nullptr)
+   {
+      auto prev_token_type = prev->type;
+      auto next_token_type = next->type;
+
+      switch (prev_token_type)
+      {
+      case CT_ANGLE_OPEN:
+
+         /**
+          * assuming the previous token is possibly the opening angle of a
+          * templated type, the next token may be one of the following:
+          * - class, enum, struct or union: template < class/enum/struct/union ...>
+          * - an closing angle ('>'):       template < >
+          * - a double colon ('::'):          vector < ::T>
+          * - a decltype statement:           vector < decltype(T::foo)>
+          * - bitwise not ('~'):                   T < ~0>
+          * - unary minus ('-'):                   T < -1>
+          * - a logical not operator ('!'):        T < !true>
+          * - a number:                              < 1>
+          * - an opening paren ('('):              T < (X > 3)>
+          * - unary plus ('+'):                    T < +1>
+          * - a qualifier (const, etc.):      vector < const T>
+          * - sizeof operator:                     T < sizeof(int)>
+          * - a single quote ('''):                T < 'a'>
+          * - a template keyword:           template < template<class> T>
+          * - an identifier:                  vector < T> ClassType::function
+          * - typename keyword:             template < typename>
+          */
+         return(  chunk_is_class_struct_union(next)
+               || next_token_type == CT_ANGLE_CLOSE
+               || next_token_type == CT_DC_MEMBER
+               || next_token_type == CT_DECLTYPE
+               || next_token_type == CT_INV
+               || next_token_type == CT_MINUS
+               || next_token_type == CT_NOT
+               || next_token_type == CT_NUMBER
+               || next_token_type == CT_PAREN_OPEN
+               || next_token_type == CT_PLUS
+               || next_token_type == CT_QUALIFIER
+               || next_token_type == CT_SIZEOF
+               || (  next_token_type == CT_STRING // TODO: verify that this actually works...
+                  && next->str.size() > 0
+                  && next->str[0] == '\'')
+               || next_token_type == CT_TEMPLATE
+               || next_token_type == CT_TYPE
+               || next_token_type == CT_TYPENAME
+               || next_token_type == CT_WORD);
+
+      case CT_TEMPLATE:
+      case CT_TYPE:
+      case CT_WORD:
+         /**
+          * assuming the next token may be an opening angle to a templated type,
+          * the previous token may be one of the following:
+          * - a template keyword: template < >
+          * - an identifier:             T < ...>
+          */
+         return(next_token_type == CT_ANGLE_OPEN);
+
+      default:
+         // do nothing
+         break;
+      } // switch
+   }
+   return(false);
+} // adj_chunks_match_template_start_pattern
+
+
+bool adj_chunks_match_var_def_pattern(chunk_t *prev,
+                                      chunk_t *next)
+{
+   LOG_FUNC_ENTRY();
+
+   if (  prev != nullptr
+      && next != nullptr)
+   {
+      auto get_token_type = [](chunk_t *pc)
+      {
+         if (chunk_is_paren_close_token(pc))
+         {
+            return(CT_PAREN_CLOSE);
+         }
+         else if (chunk_is_paren_open_token(pc))
+         {
+            return(CT_PAREN_OPEN);
+         }
+         return(pc != nullptr ? pc->type : CT_NONE);
+      };
+      auto next_token_type = get_token_type(next);
+      auto prev_token_type = get_token_type(prev);
+
+      switch (prev_token_type)
+      {
+      case CT_ANGLE_CLOSE:
+         /**
+          * assuming the previous token is possibly the closing angle of a
+          * templated type, the next token may be one of the following:
+          * - a pointer symbol ('*', '^')
+          * - a double colon ('::')
+          * - a reference symbol ('&')
+          * - a qualifier (const, etc.)
+          * - an identifier
+          */
+         return(  chunk_is_pointer_or_reference(next)
+               || next_token_type == CT_DC_MEMBER
+               || next_token_type == CT_QUALIFIER
+               || next_token_type == CT_WORD);
+
+
+      case CT_ANGLE_OPEN:
+         /**
+          * assuming the previous token is possibly the opening angle of a
+          * templated type, just check to see if there's a matching closing
+          * angle
+          */
+         return(chunk_skip_to_match(prev, scope_e::PREPROC) != nullptr);
+
+      case CT_BRACE_CLOSE:
+         /**
+          * assuming the previous token is possibly the closing brace of a
+          * class/enum/struct/union definition, one or more inline variable
+          * definitions may follow; in that case, the next token may be one of
+          * the following:
+          * - a pointer symbol ('*', '^')
+          * - a reference symbol ('&')
+          * - a qualifier (const, etc.)
+          * - an identifier
+          */
+         return(  chunk_is_pointer_or_reference(next)
+               || next_token_type == CT_QUALIFIER
+               || next_token_type == CT_WORD);
+
+      case CT_BRACE_OPEN:
+         /**
+          * if the previous token is an opening brace, it may indicate the
+          * start of a braced initializer list - skip ahead to find a matching
+          * closing brace
+          */
+         return(chunk_skip_to_match(prev, scope_e::PREPROC) != nullptr);
+
+      case CT_BYREF:
+         /**
+          * if the previous token is a reference symbol ('&'), the next token
+          * may be an identifier
+          */
+         return(next_token_type == CT_WORD);
+
+      case CT_CARET:
+         /**
+          * if the previous token is a managed C++/CLI pointer symbol ('^'),
+          * the next token may be one of the following:
+          * - a pointer symbol ('*', '^')
+          * - a reference symbol ('&')
+          * - a qualifier (const, etc.)
+          * - an identifier
+          */
+         return(  language_is_set(LANG_CPP)
+               && (  chunk_is_pointer_or_reference(next)
+                  || next_token_type == CT_QUALIFIER
+                  || next_token_type == CT_WORD));
+
+      case CT_COMMA:
+         /**
+          * if the previous token is a comma, this may indicate a variable
+          * declaration trailing a prior declaration; in that case, the next
+          * token may be one of the following:
+          * - a pointer symbol ('*', '^')
+          * - a reference symbol ('&')
+          * - an identifier
+          */
+         return(  chunk_is_pointer_or_reference(next)
+               || next_token_type == CT_WORD);
+
+      case CT_DC_MEMBER:
+         /**
+          * if the previous token is a double colon ('::'), it is likely part
+          * of a chain of scope-resolution qualifications preceding a word or
+          * type
+          */
+         return(  next_token_type == CT_TYPE
+               || next_token_type == CT_WORD);
+
+      case CT_PAREN_OPEN:
+         /**
+          * if the previous token is an opening paren, it may indicate the
+          * start of a constructor call parameter list - skip ahead to find a
+          * matching closing paren
+          */
+         return(chunk_skip_to_match(prev, scope_e::PREPROC) != nullptr);
+
+      case CT_PTR_TYPE:
+      case CT_STAR:
+
+         /**
+          * if the previous token is a pointer type, ('*', '^'), the next token
+          * may be one of the following:
+          * - another pointer symbol ('*', '^')
+          * - a reference symbol ('&')
+          * - a qualifier (const, etc.)
+          * - an identifier
+          */
+         return(  chunk_is_pointer_or_reference(next)
+               || next_token_type == CT_QUALIFIER
+               || next_token_type == CT_WORD);
+
+      case CT_QUALIFIER:
+         /**
+          * if the previous token is a qualifier (const, etc.), the next token
+          * may be one of the following:
+          * - a pointer symbol ('*', '^')
+          * - a reference symbol ('&')
+          * - another qualifier
+          * - an identifier
+          */
+         return(  chunk_is_pointer_or_reference(next)
+               || next_token_type == CT_QUALIFIER
+               || next_token_type == CT_WORD);
+
+      case CT_SQUARE_CLOSE:
+         /**
+          * if the previous token is a close square bracket, the next token may be
+          * another open square bracket or an assignment following an array variable
+          * declaration
+          */
+         return(  next_token_type == CT_ASSIGN
+               || next_token_type == CT_SQUARE_OPEN);
+
+      case CT_SQUARE_OPEN:
+         /**
+          * if the previous token is an open square bracket, it may indicate an
+          * array declaration - skip ahead to find a matching close square bracket
+          */
+         return(chunk_skip_to_match(prev, scope_e::PREPROC) != nullptr);
+
+      case CT_TSQUARE:
+         /**
+          * if the previous token is a set of brackets, the next token may be
+          * another open square bracket or an assignment following an array variable
+          * declaration
+          */
+         return(  next_token_type == CT_ASSIGN
+               || next_token_type == CT_SQUARE_OPEN);
+
+      case CT_TYPE:
+         /**
+          * if the previous token is marked as a type, the next token may be
+          * one of the following:
+          * - a pointer symbol ('*', '^')
+          * - a reference symbol ('&')
+          * - an opening angle, which may indicate a templated type as part of a
+          *   scope resolution preceding the actual variable identifier
+          * - a double colon ('::')
+          * - a qualifier (const, etc.)
+          * - an identifier
+          */
+         return(  chunk_is_pointer_or_reference(next)
+               || next_token_type == CT_ANGLE_OPEN
+               || (  next_token_type == CT_DC_MEMBER
+                  && !chunk_is_keyword(prev))
+               || next_token_type == CT_QUALIFIER
+               || next_token_type == CT_WORD);
+
+      case CT_WORD:
+         /**
+          * if the previous token is an identifier, the next token may be one
+          * of the following:
+          * - an assignment symbol ('=')
+          * - an opening angle, which may indicate a templated type as part of a
+          *   scope resolution preceding the actual variable identifier
+          * - an opening brace, which may indicate a braced-initializer list
+          * - a double colon ('::')
+          * - an opening paren, which may indicate a constructor call parameter
+          *   list
+          * - an opening square bracket, which may indicate an array variable
+          * - a set of empty square brackets, which also may indicate an array
+          *   variable
+          */
+         return(  next_token_type == CT_ANGLE_OPEN
+               || next_token_type == CT_ASSIGN
+               || next_token_type == CT_BRACE_OPEN
+               || next_token_type == CT_DC_MEMBER
+               || next_token_type == CT_PAREN_OPEN
+               || next_token_type == CT_SQUARE_OPEN
+               || next_token_type == CT_TSQUARE);
+
+      default:
+         // do nothing
+         break;
+      } // switch
+   }
+   return(false);
+} // adj_chunks_match_var_def_pattern
+
+
+chunk_t *match_assigned_type(chunk_t *pc_assign)
+{
+   if (chunk_is_assign_token(pc_assign))
+   {
+      auto *prev = chunk_get_prev_ncnnlni(pc_assign, scope_e::PREPROC);
+
+      /**
+       * skip any preceding pointers, references, or qualifiers
+       */
+      prev = skip_pointers_references_and_qualifiers(prev, scope_e::PREPROC);
+
+      if (chunk_is_identifier(prev))
+      {
+         auto *next = prev;
+         prev = chunk_get_prev_ncnnlni(prev);
+
+         if (  chunk_is_typename_token(prev)
+            || chunk_is_token(prev, CT_USING))
+         {
+            return(next);
+         }
+      }
+      else if (chunk_is_auto_token(prev))
+      {
+         return(prev);
+      }
+   }
+   return(nullptr);
+} // match_assigned_type
+
+
+chunk_t *match_chain_next(chunk_t                                                  *pc,
+                          const std::vector<std::pair<const char *, std::size_t> > &chain,
+                          int                                                      level,
+                          scope_e                                                  scope)
+{
+   chunk_t *next = nullptr;
+
+   do
+   {
+      auto &&itChain = chain.cbegin();
+
+      while (itChain != chain.cend())
+      {
+         auto &&string = itChain->first;
+         auto &&size   = itChain->second;
+
+         if (itChain == chain.cbegin())
+         {
+            if (!chunk_is_str(pc, string, size))
+            {
+               pc = chunk_get_next_str(pc,
+                                       string,
+                                       size,
+                                       level,
+                                       scope);
+            }
+            next = pc;
+         }
+         else
+         {
+            next = chunk_get_next(next, scope);
+
+            if (  next == nullptr
+               || !chunk_is_str(next, string, size))
+            {
+               break;
+            }
+         }
+         ++itChain;
+      }
+
+      if (itChain == chain.cend())
+      {
+         return(pc);
+      }
+   } while (next != nullptr);
+
+   return(nullptr);
+} // match_chain_next
+
+
+chunk_t *match_chain_next(chunk_t                      *pc,
+                          const std::vector<c_token_t> &chain,
+                          int                          level,
+                          scope_e                      scope)
+{
+   chunk_t *next = nullptr;
+
+   do
+   {
+      auto &&itChain = chain.cbegin();
+
+      while (itChain != chain.cend())
+      {
+         auto &&type = *itChain;
+
+         if (itChain == chain.cbegin())
+         {
+            if (chunk_is_not_token(pc, type))
+            {
+               pc = chunk_get_next_type(pc,
+                                        type,
+                                        level,
+                                        scope);
+            }
+            next = pc;
+         }
+         else
+         {
+            next = chunk_get_next(next, scope);
+
+            if (  next == nullptr
+               || chunk_is_not_token(next, type))
+            {
+               break;
+            }
+         }
+         ++itChain;
+      }
+
+      if (itChain == chain.cend())
+      {
+         return(pc);
+      }
+   } while (next != nullptr);
+
+   return(nullptr);
+} // match_chain_next
+
+
+chunk_t *match_chain_prev(chunk_t                                                  *pc,
+                          const std::vector<std::pair<const char *, std::size_t> > &chain,
+                          int                                                      level,
+                          scope_e                                                  scope)
+{
+   chunk_t *prev = nullptr;
+
+   do
+   {
+      auto &&itChain = chain.crbegin();
+
+      while (itChain != chain.crend())
+      {
+         auto &&string = itChain->first;
+         auto &&size   = itChain->second;
+
+         if (itChain == chain.crbegin())
+         {
+            if (!chunk_is_str(pc, string, size))
+            {
+               pc = chunk_get_prev_str(pc,
+                                       string,
+                                       size,
+                                       -1,
+                                       scope);
+            }
+            prev = pc;
+         }
+         else
+         {
+            prev = chunk_get_prev(prev, scope);
+
+            if (  prev == nullptr
+               || !chunk_is_str(prev, string, size))
+            {
+               break;
+            }
+         }
+         ++itChain;
+      }
+
+      if (  itChain == chain.crend()
+         && int(pc->level) == level)
+      {
+         return(pc);
+      }
+   } while (prev != nullptr);
+
+   return(nullptr);
+} // match_chain_prev
+
+
+chunk_t *match_chain_prev(chunk_t                      *pc,
+                          const std::vector<c_token_t> &chain,
+                          int                          level,
+                          scope_e                      scope)
+{
+   chunk_t *prev = nullptr;
+
+   do
+   {
+      auto &&itChain = chain.crbegin();
+
+      while (itChain != chain.crend())
+      {
+         auto &&type = *itChain;
+
+         if (itChain == chain.crbegin())
+         {
+            if (chunk_is_not_token(pc, type))
+            {
+               pc = chunk_get_prev_type(pc,
+                                        type,
+                                        -1,
+                                        scope);
+            }
+            prev = pc;
+         }
+         else
+         {
+            prev = chunk_get_prev(prev, scope);
+
+            if (  prev == nullptr
+               || chunk_is_not_token(prev, type))
+            {
+               break;
+            }
+         }
+         ++itChain;
+      }
+
+      if (  itChain == chain.crend()
+         && int(pc->level) == level)
+      {
+         return(pc);
+      }
+   } while (prev != nullptr);
+
+   return(nullptr);
+} // match_chain_prev
+
+
+std::pair<chunk_t *,
+          chunk_t *> match_compound_type(chunk_t *pc, std::size_t level)
+{
+   chunk_t *start = match_compound_type_start(pc, level);
+   chunk_t *end   = match_compound_type_end(pc, level);
+
+   if (  start != nullptr
+      && end != nullptr)
+   {
+      return(std::make_pair(start, end));
+   }
+   return(std::make_pair(nullptr, nullptr));
+} // match_compound_type
+
+
+chunk_t *match_compound_type_end(chunk_t *pc, std::size_t level)
+{
+   LOG_FUNC_ENTRY();
+
+   /**
+    * if the chunk under test is a closing paren, back up to the matching open paren
+    */
+   if (chunk_is_paren_close_token(pc))
+   {
+      pc = chunk_skip_to_match_rev(pc, scope_e::PREPROC);
+   }
+
+   /**
+    * if the chunk under test is an open paren, back up to the preceding chunk
+    */
+   if (chunk_is_paren_open_token(pc))
+   {
+      pc = chunk_get_prev_ncnnlni(pc, scope_e::PREPROC);
+   }
+
+   while (pc != nullptr)
+   {
+      /**
+       * skip current and subsequent chunks if at a higher level
+       */
+      while (  pc != nullptr
+            && pc->level > level)
+      {
+         pc = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
+      }
+
+      /**
+       * skip to any subsequent match for angle brackets or square brackets
+       */
+      if (  chunk_is_angle_open_token(pc)
+         || chunk_is_square_open_token(pc))
+      {
+         pc = chunk_skip_to_match(pc, scope_e::PREPROC);
+
+         if (pc == nullptr)
+         {
+            return(nullptr);
+         }
+         else if (chunk_is_angle_close_token(pc))
+         {
+            // TODO: Should we descend into sequence enclosed by the angle brackets
+            //       and perform tests to determine if a valid template is represented?
+         }
+      }
+      /**
+       * get the next chunk
+       */
+      auto *next = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
+
+      if (  chunk_is_intrinsic_type(pc)
+         && chunk_is_angle_open_token(next))
+      {
+         /**
+          * This shouldn't happen if the code is valid...
+          */
+         return(nullptr);
+      }
+
+      /**
+       * skip decltype statements
+       */
+      if (  chunk_is_decltype_token(pc)
+         && chunk_is_token(next, CT_PAREN_OPEN))
+      {
+         pc   = chunk_skip_to_match(next, scope_e::PREPROC);
+         next = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
+      }
+
+      /**
+       * test for type assignment, which may be embedded within
+       * template argument lists or type alias declarations
+       */
+      if (  chunk_is_identifier(pc)
+         && chunk_is_assign_token(next)
+         && match_assigned_type(next) == pc)
+      {
+         return(pc);
+      }
+
+      /**
+       * we're done searching under the following conditions:
+       * - next chunk is null
+       * - the level decreases relative to the starting chunk
+       * - a comma is encountered at brace level
+       * - a semicolon is encountered
+       * TODO: what are some additional constraints that should be tested?
+       */
+      if (  next == nullptr
+         || next->level < level
+         || (  chunk_is_comma_token(next)
+            && next->level == level)
+         || chunk_is_semicolon_token(next))
+      {
+         return(pc);
+      }
+
+      /**
+       * if the chunk is an opening paren, test to see if it belongs
+       * to a function pointer signature
+       */
+      if (chunk_is_paren_open_token(next))
+      {
+         /**
+          * check to see the paren is part of a function pointer signature
+          */
+         std::tuple<chunk_t *, chunk_t *, chunk_t *> match(nullptr, nullptr, nullptr);
+
+         if (match_function_pointer_at_paren(next, match))
+         {
+            /**
+             * it matches a function pointer, return the ending chunk
+             */
+            return(std::get<2>(match));
+         }
+         /**
+          * TODO: is there another case in which an opening paren is valid as part of a
+          * compound type declaration?
+          */
+         return(nullptr);
+      }
+
+      /**
+       * call a separate function to validate adjacent tokens as potentially
+       * matching a variable declaration/definition
+       */
+      if (!adj_chunks_match_compound_type_pattern(pc, next))
+      {
+         /**
+          * before abandoning, test for two adjacent identifiers -
+          * it's possible that one may be a reference to a macro
+          */
+         if (  !chunk_is_macro_reference(pc)
+            || !chunk_is_identifier(next))
+         {
+            return(nullptr);
+         }
+      }
+      pc = next;
+   }
+   return(nullptr);
+} // match_compound_type_end
+
+
+chunk_t *match_compound_type_start(chunk_t *pc, std::size_t level)
+{
+   LOG_FUNC_ENTRY();
+
+   while (pc != nullptr)
+   {
+      /**
+       * skip current and preceding chunks if at a higher level
+       */
+      while (  pc != nullptr
+            && pc->level > level)
+      {
+         pc = chunk_get_prev_ncnnlni(pc, scope_e::PREPROC);
+      }
+
+      /**
+       * skip to any preceding match for angle brackets or square brackets
+       */
+      if (  chunk_is_angle_close_token(pc)
+         || chunk_is_square_close_token(pc))
+      {
+         pc = chunk_skip_to_match_rev(pc, scope_e::PREPROC);
+
+         if (pc == nullptr)
+         {
+            return(nullptr);
+         }
+         else if (chunk_is_angle_open_token(pc))
+         {
+            // TODO: Should we descend into sequence enclosed by the angle brackets
+            //       and perform tests to determine if a valid template is represented?
+         }
+      }
+      /**
+       * get the previous chunk
+       */
+      auto *prev = chunk_get_prev_ncnnlni(pc, scope_e::PREPROC);
+
+      if (  chunk_is_intrinsic_type(prev)
+         && chunk_is_angle_open_token(pc))
+      {
+         /**
+          * This shouldn't happen if the code is valid...
+          */
+         return(nullptr);
+      }
+
+      /**
+       * test for type assignment, which may be embedded within
+       * template argument lists or type alias declarations
+       */
+      if (  chunk_is_identifier(prev)
+         && chunk_is_assign_token(pc)
+         && match_assigned_type(pc) == prev)
+      {
+         return(prev);
+      }
+
+      /**
+       * we're done searching under the following conditions:
+       * - previous chunk is null
+       * - the level decreases relative to the starting chunk
+       * - a comma is encountered at brace level
+       * - a semicolon is encountered
+       * - typedef keyword is encountered
+       * - typename keyword is encountered
+       *
+       * TODO: what are some additional constraints that should be tested?
+       */
+      if (  prev == nullptr
+         || prev->level < level
+         || (  chunk_is_comma_token(prev)
+            && prev->level == level)
+         || chunk_is_semicolon_token(prev)
+         || chunk_is_token(prev, CT_TYPEDEF)
+         || chunk_is_typename_token(prev))
+      {
+         return(pc);
+      }
+
+      /**
+       * if the chunk is a closing paren, skip back to the matching
+       * open paren
+       */
+      if (chunk_is_paren_close_token(pc))
+      {
+         pc   = chunk_skip_to_match_rev(pc, scope_e::PREPROC);
+         prev = chunk_get_prev_ncnnlni(pc, scope_e::PREPROC);
+      }
+
+      /**
+       * if the chunk is an opening paren, test to see if it belongs
+       * to a function pointer signature or decltype statement
+       */
+      if (  chunk_is_paren_open_token(pc)
+         && chunk_is_not_token(prev, CT_DECLTYPE))
+      {
+         /**
+          * check to see the paren is part of a function pointer signature
+          */
+         std::tuple<chunk_t *, chunk_t *, chunk_t *> match(nullptr, nullptr, nullptr);
+
+         if (match_function_pointer_at_paren(pc, match))
+         {
+            /**
+             * it matches a function pointer, return the starting chunk
+             */
+            return(std::get<0>(match));
+         }
+         /**
+          * TODO: is there another case in which a paren is valid as part of a
+          * compound type declaration?
+          */
+         return(nullptr);
+      }
+
+      /**
+       * call a separate function to validate adjacent tokens as potentially
+       * matching a variable declaration/definition
+       */
+      if (!adj_chunks_match_compound_type_pattern(prev, pc))
+      {
+         /**
+          * before abandoning, test for two adjacent identifiers -
+          * it's possible that one may be a reference to a macro
+          */
+         if (  !chunk_is_macro_reference(prev)
+            || !chunk_is_identifier(pc))
+         {
+            return(nullptr);
+         }
+      }
+      pc = prev;
+   }
+   return(nullptr);
+} // match_compound_type_start
+
+
+chunk_t *match_function_header_at_close_paren(chunk_t *pc)
+{
+   // TODO: Need to account for virtual and override keywords!!!!
+
+   if (chunk_is_paren_close_token(pc))
+   {
+      /**
+       * Skip to the matching open paren
+       */
+      auto *paren_close = pc;
+      auto *paren_open  = chunk_skip_to_match_rev(paren_close, scope_e::PREPROC);
+
+      if (paren_open != nullptr)
+      {
+         chunk_t *identifier = nullptr;
+
+         /**
+          * Test to see if an identifier precedes the open paren
+          */
+         pc = chunk_get_prev_ncnnlni(paren_open, scope_e::PREPROC);
+
+         if (chunk_is_identifier(pc))
+         {
+            /**
+             * Skip any scope resolution and nested name specifiers
+             */
+            identifier = skip_scope_resolution_and_nested_name_specifiers_rev(pc,
+                                                                              scope_e::PREPROC);
+         }
+         else if (chunk_is_overloaded_token(pc))
+         {
+            pc = skip_operator_overload_prev(pc, scope_e::PREPROC);
+
+            /**
+             * It's an operator overload; if a double colon precedes the operator keyword,
+             * it's a member operator overload
+             */
+            if (chunk_is_double_colon_token(pc))
+            {
+               /**
+                * Skip any scope resolution and nested name specifiers
+                */
+               identifier = skip_scope_resolution_and_nested_name_specifiers_rev(pc,
+                                                                                 scope_e::PREPROC);
+            }
+         }
+         else
+         {
+            /**
+             * If neither an identifier nor an operator overload precede the open paren,
+             * we're likely not dealing with a function header
+             */
+            return(nullptr);
+         }
+
+         if (identifier != nullptr)
+         {
+            /**
+             * If we're dealing with something other than a non-member operator overload,
+             * then get the chunk preceding the (qualified) identifier
+             */
+            pc = chunk_get_prev_ncnnlni(identifier, scope_e::PREPROC);
+         }
+         std::size_t level = pc->level;
+         pc = chunk_get_prev_ncnnlni(pc, scope_e::PREPROC);
+         auto        *return_type_start = match_compound_type_start(pc, level);
+
+         if (  return_type_start != nullptr
+            && (  chunk_is_identifier(return_type_start)
+               || chunk_is_intrinsic_type(return_type_start)))
+         {
+            /**
+             * We've matched a chain of chunks consisting of the form:
+             *
+             * - return_type function(...) [const/volatile/&/&&] { ... pc ... }
+             */
+            return(return_type_start);
+         }
+         /**
+          * If no return type, test to see if it is a constructor...
+          */
+         else if (identifier != nullptr)
+         {
+            /**
+             * We've matched a chain of chunks consisting of the form:
+             *
+             * - function(...) [const/volatile/&/&&] { ... pc ... }
+             */
+            chunk_t *next = chunk_get_next_ncnnl(paren_close);
+
+            if (  level > 0
+                  /* constructors CANNOT have trailing qualifiers... */
+               && (  chunk_is_ampersand_token(next)
+                  || chunk_is_cv_qualifier_token(next)
+                  || chunk_is_double_ampersand_token(next)
+                  || chunk_is_noexcept_token(next)))
+            {
+               chunk_t *brace_open = chunk_get_prev_type(identifier,
+                                                         CT_BRACE_OPEN,
+                                                         level - 1,
+                                                         scope_e::PREPROC);
+               chunk_t *class_type = nullptr;
+
+               if (brace_open != nullptr)
+               {
+                  class_type = chunk_get_prev_str(brace_open,
+                                                  identifier->str.c_str(),
+                                                  identifier->str.size(),
+                                                  level - 1,
+                                                  scope_e::PREPROC);
+               }
+               chunk_t *keyword = nullptr;
+
+               if (class_type != nullptr)
+               {
+                  keyword = chunk_get_prev_type(class_type,
+                                                { CT_CLASS, CT_STRUCT },
+                                                level - 1,
+                                                scope_e::PREPROC);
+               }
+
+               if (  class_type != nullptr
+                  && keyword != nullptr)
+               {
+                  /**
+                   * We've matched a class constructor definition of the form:
+                   *
+                   * - class_type(...) { ... pc ... }
+                   */
+
+                  return(identifier);
+               }
+            }
+         }
+      }
+   }
+   return(nullptr);
+} // match_function_header_at_close_paren
+
+
+std::tuple<chunk_t *,
+           chunk_t *,
+           chunk_t *> match_function_pointer_at_paren(chunk_t *pc_paren)
+{
+   LOG_FUNC_ENTRY();
+
+   std::tuple<chunk_t *, chunk_t *, chunk_t *> match(nullptr, nullptr, nullptr);
+
+   match_function_pointer_at_paren(pc_paren,
+                                   match);
+
+   return(match);
+} // match_function_pointer_at_paren
+
+
+bool match_function_pointer_at_paren(chunk_t               *pc_paren,
+                                     std::tuple<chunk_t *,
+                                                chunk_t *,
+                                                chunk_t *> &match)
+{
+   LOG_FUNC_ENTRY();
+
+   if (chunk_is_paren_close_token(pc_paren))
+   {
+      pc_paren = chunk_skip_to_match_rev(pc_paren);
+   }
+
+   if (chunk_is_paren_open_token(pc_paren))
+   {
+      /**
+       * The form of a function pointer will look similar to the following:
+       * - [return_type/void] (*ptr)(...)
+       * - [return_type/void] (Class::*ptr)(...) [const]
+       */
+
+      chunk_t *param_list_paren_close = nullptr;
+      chunk_t *param_list_paren_open  = nullptr;
+      chunk_t *pc_paren_open          = pc_paren;
+      chunk_t *pc_paren_close         = chunk_skip_to_match(pc_paren_open, scope_e::PREPROC);
+
+      chunk_t *prev = chunk_get_prev_ncnnlni(pc_paren_open, scope_e::PREPROC);
+
+      if (chunk_is_paren_close_token(prev))
+      {
+         param_list_paren_close = pc_paren_close;
+         param_list_paren_open  = pc_paren_open;
+         pc_paren_close         = prev;
+         pc_paren_open          = chunk_skip_to_match_rev(pc_paren_close, scope_e::PREPROC);
+      }
+      else
+      {
+         chunk_t *next = chunk_get_next_ncnnl(pc_paren_close, scope_e::PREPROC);
+
+         if (chunk_is_paren_open_token(next))
+         {
+            param_list_paren_open  = next;
+            param_list_paren_close = chunk_skip_to_match(param_list_paren_open, scope_e::PREPROC);
+         }
+      }
+
+      if (  param_list_paren_close != nullptr
+         && param_list_paren_open != nullptr
+         && pc_paren_close != nullptr
+         && pc_paren_open != nullptr)
+      {
+         /**
+          * test the tokens between the first set of parenthesis
+          */
+         chunk_t *next = chunk_get_next_ncnnl(pc_paren_open, scope_e::PREPROC);
+
+         /**
+          * skip any scope resolution qualifiers
+          */
+         next = chunk_skip_dc_member(next, scope_e::PREPROC);
+
+         /**
+          * check to see if the next token is a star
+          */
+         if (chunk_is_star_token(next))
+         {
+            /**
+             * get the next chunk - if it's a function pointer variable or typedef,
+             * the next chunk will be an identifier
+             */
+            next = chunk_get_next_ncnnl(next, scope_e::PREPROC);
+
+            chunk_t *identifier = nullptr;
+
+            if (chunk_is_identifier(next))
+            {
+               identifier = next;
+
+               next = chunk_get_next_ncnnl(identifier, scope_e::PREPROC);
+            }
+
+            /**
+             * the next chunk should be the closing paren identified earlier
+             */
+            if (next == param_list_paren_close)
+            {
+               std::size_t level  = prev->level;
+               auto        *start = match_compound_type_start(prev, level);
+
+               if (start != nullptr)
+               {
+                  /**
+                   * check the chunk after the parameter list closing paren - it could
+                   * be a member function qualifier such as 'const' or a ref qualifier '& or &&'
+                   */
+                  auto *end = param_list_paren_close;
+                  next = chunk_get_next_ncnnl(param_list_paren_close,
+                                              scope_e::PREPROC);
+
+                  if (chunk_is_token(next, CT_QUALIFIER))
+                  {
+                     end = next;
+                  }
+                  next = chunk_get_next_ncnnl(next, scope_e::PREPROC);
+
+                  if (  chunk_is_double_ampersand_str(next)
+                     || chunk_is_ampersand_str(next))
+                  {
+                     end = next;
+                  }
+                  std::get<0>(match) = start;
+                  std::get<1>(match) = identifier;
+                  std::get<2>(match) = end;
+
+                  return(true);
+               }
+            }
+         }
+      }
+   }
+   return(false);
+} // match_function_pointer_at_paren
+
+
+std::tuple<chunk_t *,
+           chunk_t *,
+           chunk_t *> match_function_pointer_typedef_at_identifier(chunk_t *pc_identifier)
+{
+   LOG_FUNC_ENTRY();
+
+   std::tuple<chunk_t *, chunk_t *, chunk_t *> match(nullptr, nullptr, nullptr);
+
+   match_function_pointer_at_paren(pc_identifier,
+                                   match);
+
+   return(match);
+} // match_function_pointer_typedef_at_identifier
+
+
+bool match_function_pointer_typedef_at_identifier(chunk_t *pc_identifier, std::tuple<chunk_t *,
+                                                                                     chunk_t *,
+                                                                                     chunk_t *> &match)
+{
+   LOG_FUNC_ENTRY();
+
+   if (match_function_pointer_variable_at_identifier(pc_identifier,
+                                                     match))
+   {
+      auto * &start = std::get<0>(match);
+      auto   *prev  = chunk_get_prev_ncnnlni(start, scope_e::PREPROC);
+
+      if (chunk_is_token(prev, CT_TYPEDEF))
+      {
+         start = prev;
+
+         return(true);
+      }
+      match = { nullptr, nullptr, nullptr };
+   }
+   return(false);
+} // match_function_pointer_typedef_at_identifier
+
+
+std::tuple<chunk_t *,
+           chunk_t *,
+           chunk_t *> match_function_pointer_variable_at_identifier(chunk_t *pc_identifier)
+{
+   LOG_FUNC_ENTRY();
+
+   std::tuple<chunk_t *, chunk_t *, chunk_t *> match(nullptr, nullptr, nullptr);
+
+   match_function_pointer_variable_at_identifier(pc_identifier,
+                                                 match);
+
+   return(match);
+} // match_function_pointer_variable_at_identifier
+
+
+bool match_function_pointer_variable_at_identifier(chunk_t               *pc_identifier,
+                                                   std::tuple<chunk_t *,
+                                                              chunk_t *,
+                                                              chunk_t *> &match)
+{
+   LOG_FUNC_ENTRY();
+
+   chunk_t *next = pc_identifier;
+
+   if (chunk_is_identifier(next))
+   {
+      /**
+       * skip any scope resolution qualifiers
+       */
+      next = chunk_skip_dc_member(next, scope_e::PREPROC);
+
+      /**
+       * get the next chunk - it must be a closing paren if we're hoping to match a function pointer
+       */
+      next = chunk_get_next_ncnnl(next, scope_e::PREPROC);
+
+      if (chunk_is_paren_close_token(next))
+      {
+         /**
+          * get the next chunk - it must be an opening paren if we're hoping to match a function pointer
+          */
+         next = chunk_get_next_ncnnl(next, scope_e::PREPROC);
+
+         if (chunk_is_paren_open_token(next))
+         {
+            return(match_function_pointer_at_paren(next, match));
+         }
+      }
+   }
+   return(false);
+} // match_function_pointer_variable_at_identifier
+
+
+std::pair<chunk_t *, chunk_t *> match_qualified_identifier(chunk_t *pc)
+{
+   LOG_FUNC_ENTRY();
+
+   auto *end   = skip_scope_resolution_and_nested_name_specifiers(pc);
+   auto *start = skip_scope_resolution_and_nested_name_specifiers_rev(pc);
+
+   if (  end != nullptr
+      && start != nullptr)
+   {
+      auto *double_colon = chunk_search_next_cat(start, CT_DC_MEMBER);
+
+      if (  double_colon != nullptr
+         && chunk_is_between(double_colon, start, end))
+      {
+         return(std::make_pair(start, end));
+      }
+   }
+   return(std::make_pair(nullptr, nullptr));
+} // match_qualified_identifier
+
+
+std::tuple<chunk_t *, chunk_t *, chunk_t *> match_variable(chunk_t *pc, std::size_t level)
+{
+   LOG_FUNC_ENTRY();
+
+   auto identifier_end_pair   = match_variable_end(pc, level);
+   auto start_identifier_pair = match_variable_start(pc, level);
+   auto *end                  = identifier_end_pair.second;
+   auto *identifier           = identifier_end_pair.first != nullptr ? identifier_end_pair.first : start_identifier_pair.second;
+   auto *start                = start_identifier_pair.first;
+
+   /**
+    * a forward search starting at the chunk under test will fail if two consecutive chunks marked as CT_WORD
+    * are encountered; in that case, it's likely that the preceding chunk indicates a type and the subsequent
+    * chunk indicates a variable declaration/definition
+    */
+
+   if (  identifier != nullptr
+      && start != nullptr
+      && (  end != nullptr
+         || chunk_is_token(chunk_get_prev_ncnnlni(identifier), CT_WORD)))
+   {
+      return(std::make_tuple(start, identifier, end));
+   }
+   return(std::make_tuple(nullptr, nullptr, nullptr));
+} // match_variable
+
+
+std::pair<chunk_t *, chunk_t *> match_variable_end(chunk_t *pc, std::size_t level)
+{
+   LOG_FUNC_ENTRY();
+
+   chunk_t *identifier = nullptr;
+
+   while (pc != nullptr)
+   {
+      /**
+       * skip any right-hand side assignments
+       */
+      chunk_t *rhs_exp_end = nullptr;
+
+      if (chunk_is_assign_token(pc))
+      {
+         /**
+          * store a pointer to the end chunk of the rhs expression;
+          * use it later to test against setting the identifier
+          */
+         rhs_exp_end = skip_to_expression_end(pc);
+         pc          = rhs_exp_end;
+      }
+
+      /**
+       * skip current and subsequent chunks if at a higher level
+       */
+      while (  pc != nullptr
+            && pc->level > level)
+      {
+         pc = chunk_get_next_ncnnl(pc);
+      }
+
+      /**
+       * skip to any following match for angle brackets, braces, parens,
+       * or square brackets
+       */
+      if (  chunk_is_angle_open_token(pc)
+         || chunk_is_brace_open_token(pc)
+         || chunk_is_paren_open_token(pc)
+         || chunk_is_square_open_token(pc))
+      {
+         pc = chunk_skip_to_match(pc, scope_e::PREPROC);
+      }
+      /**
+       * call a separate function to validate adjacent tokens as potentially
+       * matching a variable declaration/definition
+       */
+
+      chunk_t *next = chunk_get_next_ncnnl(pc);
+
+      if (  chunk_is_not_token(next, CT_COMMA)
+         && chunk_is_not_token(next, CT_FPAREN_CLOSE)
+         && !chunk_is_semicolon_token(next)
+         && !adj_chunks_match_var_def_pattern(pc, next))
+      {
+         /**
+          * error, pattern is not consistent with a variable declaration/definition
+          */
+
+         break;
+      }
+
+      if (  chunk_is_token(pc, CT_WORD)
+         && pc != rhs_exp_end)
+      {
+         /**
+          * we've encountered a candidate for the variable name
+          */
+
+         identifier = pc;
+      }
+
+      /**
+       * we're done searching if we've previously identified a variable name
+       * and then encounter a comma or semicolon
+       */
+      if (  chunk_is_comma_token(next)
+         || chunk_is_token(next, CT_FPAREN_CLOSE)
+         || chunk_is_semicolon_token(next))
+      {
+         return(std::make_pair(identifier, pc));
+      }
+      pc = next;
+   }
+   return(std::make_pair(nullptr, nullptr));
+} // match_variable_end
+
+
+std::pair<chunk_t *, chunk_t *> match_variable_start(chunk_t *pc, std::size_t level)
+{
+   LOG_FUNC_ENTRY();
+
+   chunk_t *identifier = nullptr;
+
+   while (pc != nullptr)
+   {
+      /**
+       * skip any right-hand side assignments
+       */
+      chunk_t *before_rhs_exp_start = skip_expression_rev(pc);
+      chunk_t *prev                 = pc;
+      chunk_t *next                 = nullptr;
+
+      while (  chunk_is_after(prev, before_rhs_exp_start)
+            && pc != prev)
+      {
+         next = prev;
+         prev = chunk_get_prev_ncnnlni(next, scope_e::PREPROC);
+
+         if (chunk_is_assign_token(next))
+         {
+            pc = prev;
+         }
+      }
+
+      /**
+       * skip current and preceding chunks if at a higher level
+       */
+      while (  pc != nullptr
+            && pc->level > level)
+      {
+         pc = chunk_get_prev_ncnnlni(pc, scope_e::PREPROC);
+      }
+
+      /**
+       * skip to any preceding match for angle brackets, braces, parens,
+       * or square brackets
+       */
+      if (  chunk_is_angle_close_token(pc)
+         || chunk_is_brace_close_token(pc)
+         || chunk_is_paren_close_token(pc)
+         || chunk_is_square_close_token(pc))
+      {
+         pc = chunk_skip_to_match_rev(pc, scope_e::PREPROC);
+      }
+      /**
+       * call a separate function to validate adjacent tokens as potentially
+       * matching a variable declaration/definition
+       */
+
+      prev = chunk_get_prev_ncnnlni(pc, scope_e::PREPROC);
+
+      if (!adj_chunks_match_var_def_pattern(prev, pc))
+      {
+         /**
+          * perhaps the previous chunk possibly indicates a type that yet to be
+          * marked? if not, then break
+          */
+         if (  chunk_is_not_token(prev, CT_WORD)
+            || (  !chunk_is_pointer_or_reference(pc)
+               && chunk_is_not_token(pc, CT_WORD)))
+         {
+            /**
+             * error, pattern is not consistent with a variable declaration/definition
+             */
+
+            break;
+         }
+      }
+
+      if (  identifier == nullptr
+         && chunk_is_token(pc, CT_WORD))
+      {
+         /**
+          * we've encountered a candidate for the variable name
+          */
+
+         identifier = pc;
+      }
+
+      /**
+       * we're done searching if we've previously identified a variable name
+       * and then encounter another identifier, or we encounter a closing
+       * brace (which would likely indicate an inline variable definition)
+       */
+      if (  chunk_is_angle_close_token(prev)
+         || chunk_is_brace_close_token(prev)
+         || chunk_is_comma_token(prev)
+         || chunk_is_token(prev, CT_TYPE)
+         || chunk_is_token(prev, CT_WORD))
+      {
+         return(std::make_pair(pc, identifier));
+      }
+      pc = prev;
+   }
+   return(std::make_pair(nullptr, nullptr));
+} // match_variable_start

--- a/src/match_tools.h
+++ b/src/match_tools.h
@@ -1,0 +1,393 @@
+/**
+ * @file match_tools.h
+ *
+ * @author
+ * @license GPL v2+
+ */
+
+#ifndef MATCH_TOOLS_H_INCLUDED
+#define MATCH_TOOLS_H_INCLUDED
+
+#include "scope_enum.h"
+#include "token_enum.h"
+
+#include <tuple>
+#include <vector>
+
+
+/**
+ * Returns true if two adjacent chunks potentially match a pattern consistent
+ * with that of a compound type
+ */
+bool adj_chunks_match_compound_type_pattern(struct chunk_t *prev, struct chunk_t *next);
+
+
+/**
+ * Returns true if two adjacent chunks potentially match a pattern consistent
+ * with that of a qualified identifier
+ */
+bool adj_chunks_match_qualified_identifier_pattern(struct chunk_t *prev, struct chunk_t *next);
+
+
+/**
+ * Returns true if two adjacent chunks potentially match a pattern consistent
+ * with the end of a template definition
+ */
+bool adj_chunks_match_template_end_pattern(struct chunk_t *prev, struct chunk_t *next);
+
+
+/**
+ * Returns true if two adjacent chunks potentially match a pattern consistent
+ * with the start of a template definition
+ */
+bool adj_chunks_match_template_start_pattern(struct chunk_t *prev, struct chunk_t *next);
+
+
+/**
+ * Returns true if two adjacent chunks potentially match a pattern consistent
+ * with that of a variable definition
+ */
+bool adj_chunks_match_var_def_pattern(struct chunk_t *prev, struct chunk_t *next);
+
+
+/**
+ * Starting from the input chunk, this function attempts to match a type on the left-hand-side
+ * of an assignment associated with a default template argument or type alias associated with
+ * a using declaration
+ * @param  pc the input chunk, which points to a chunk containing an assignment symbol '='
+ * @return    upon successful match, function returns a non-null pointer to the identifier or
+ *            auto keyword; if no match is not found, function returns null
+ */
+struct chunk_t *match_assigned_type(struct chunk_t *pc_assign);
+
+
+/**
+ * Searching in the forward direction, return the beginning chunk of a sequence that matches the specified
+ * chain of strings at the given level, where level applies strictly to the start of the chain
+ * @param  pc    the starting chunk
+ * @param  chain a vector of strings and size pairs for which the search will be performed
+ * @param  level the level of the match
+ * @param  scope code region to search
+ * @return       a pointer to the next chunk to match the chain specified by the search criteria,
+ *               or nullptr if no match is found
+ */
+struct chunk_t *match_chain_next(struct chunk_t *pc, const std::vector<std::pair<const char *, std::size_t> > &chain, int level, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Searching in the forward direction, return the beginning chunk of a sequence that matches the specified
+ * chain of token types at the given level, where level applies strictly to the start of the chain
+ * @param  pc    the starting chunk
+ * @param  chain a vector of token types for which the search will be performed
+ * @param  level the level of the match
+ * @param  scope code region to search
+ * @return       a pointer to the next chunk to match the sequence specified by the search criteria,
+ *               or nullptr if no match is found
+ */
+struct chunk_t *match_chain_next(struct chunk_t *pc, const std::vector<c_token_t> &chain, int level, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Searching in the forward direction, return the beginning chunk of the first-encountered sequence
+ * that matches one of the specified chains of strings or token types at the given level, where level
+ * applies strictly to the start of the chain
+ * @param  pc    the starting chunk
+ * @param  chain a vector of string or token type vector chains for which the search will be performed
+ * @param  level the level of the match
+ * @param  scope code region to search
+ * @return       a pointer to the beginning chunk of the nearest sequence to match one of the specified chains,
+ *               or nullptr if no match is found
+ */
+template<typename T = std::pair<const char *, std::size_t> >
+auto match_chain_next(struct chunk_t *pc, const std::initializer_list<std::initializer_list<T> > &chains, int level, scope_e scope = scope_e::ALL) -> struct chunk_t *
+{
+   struct chunk_t *next = nullptr;
+
+   for (auto &&chain : chains)
+   {
+      auto *tmp = match_chain_next(pc, chain, level, scope);
+
+      if (  tmp != nullptr
+         && (  next == nullptr
+            || chunk_is_before(tmp, next)))
+      {
+         next = tmp;
+      }
+   }
+
+   return(next);
+} // match_chain_next
+
+
+/**
+ * Searching in the reverse direction, return the beginning chunk of a sequence that matches the specified
+ * chain of strings at the given level, where level applies strictly to the start of the chain
+ * @param  pc    the starting chunk
+ * @param  chain a vector of strings and size pairs for which the search will be performed
+ * @param  level the level of the match
+ * @param  scope code region to search
+ * @return       a pointer to the next chunk to match the sequence specified by the search criteria,
+ *               or nullptr if no match is found
+ */
+struct chunk_t *match_chain_prev(struct chunk_t *pc, const std::vector<std::pair<const char *, std::size_t> > &chain, int level, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Searching in the reverse direction, return the beginning chunk of a sequence that matches the specified
+ * chain of token types at the given level, where level applies strictly to the start of the chain
+ * @param  pc    the starting chunk
+ * @param  chain a vector of token types for which the search will be performed
+ * @param  level the level of the match
+ * @param  scope code region to search
+ * @return       a pointer to the next chunk to match the sequence specified by the search criteria,
+ *               or nullptr if no match is found
+ */
+struct chunk_t *match_chain_prev(struct chunk_t *pc, const std::vector<c_token_t> &chain, int level, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Searching in the reverse direction, return the beginning chunk of the first-encountered sequence
+ * that matches one of the specified chains of strings or token types at the given level, where level
+ * applies strictly to the start of the chain
+ * @param  pc    the starting chunk
+ * @param  chain a vector of string or token type vector chains for which the search will be performed
+ * @param  level the level of the match
+ * @param  scope code region to search
+ * @return       a pointer to the beginning chunk of the nearest sequence to match one of the specified chains,
+ *               or nullptr if no match is found
+ */
+template<typename T = std::pair<const char *, std::size_t> >
+auto match_chain_prev(struct chunk_t *pc, const std::initializer_list<std::initializer_list<T> > &chains, int level, scope_e scope = scope_e::ALL) -> struct chunk_t *
+{
+   struct chunk_t *prev = nullptr;
+
+   for (auto &&chain : chains)
+   {
+      auto *tmp = match_chain_prev(pc, chain, level, scope);
+
+      if (  tmp != nullptr
+         && (  prev == nullptr
+            || chunk_is_after(tmp, prev)))
+      {
+         prev = tmp;
+      }
+   }
+
+   return(prev);
+} // match_chain_prev
+
+
+/**
+ * Attempt to match a potential compound type (including pointers, references,
+ * qualifiers, etc.) starting at the input chunk
+ * @param  pc    the input chunk
+ * @param  level the level of the match
+ * @return       upon success, function returns a pair of non-null starting and
+ *               ending chunks if a potential type has been matched
+ */
+std::pair<struct chunk_t *,
+          struct chunk_t *> match_compound_type(struct chunk_t *pc, std::size_t level);
+
+
+/**
+ * Attempt to match a potential compound type (including pointers, references,
+ * qualifiers, etc.) in the forward direction starting at the input chunk
+ * @param  pc    the input chunk
+ * @param  level the level of the match
+ * @return       upon success, function returns a non-null end chunk if
+ *               a potential type has been matched
+ */
+struct chunk_t *match_compound_type_end(struct chunk_t *pc, std::size_t level);
+
+
+/**
+ * Attempt to match a potential compound type (including pointers, references,
+ * qualifiers, etc.) in the reverse direction starting at the input chunk
+ * @param  pc    the input chunk
+ * @param  level the level of the match
+ * @return       upon success, function returns a non-null starting chunk if
+ *               a potential type has been matched
+ */
+struct chunk_t *match_compound_type_start(struct chunk_t *pc, std::size_t level);
+
+
+/**
+ * Attempt to match the beginning of a potential function header at the closing paren
+ * associated with its parameter list
+ * @param  pc the input chunk, which should point to a closing paren
+ * @return    upon success, function returns a non-null starting chunk that
+ *            points to the beginning of the function header, or nullptr if no
+ *            match is found
+ */
+struct chunk_t *match_function_header_at_close_paren(struct chunk_t *pc);
+
+
+/**
+ * Starting from the input chunk, this function attempts to match a function pointer
+ * type signature or variable declaration at an open/close paren
+ * @param  pc_paren the input chunk, which should point to an open/close paren
+ * @return          upon successful match, function returns a tuple of chunks, where the
+ *                  first chunk indicates the beginning of the declaration or type signature,
+ *                  the second chunk indicates the variable name (or null if a type signature
+ *                  is detected), and the third chunk indicates the end associated with the
+ *                  declaration/type signature; if no match is found, function returns a tuple
+ *                  of null chunks
+ */
+std::tuple<struct chunk_t *,
+           struct chunk_t *,
+           struct chunk_t *> match_function_pointer_at_paren(struct chunk_t *pc_paren);
+
+
+/**
+ * Starting from the input chunk, this function attempts to match a function pointer
+ * type signature or variable declaration at an open/close paren
+ * @param[in]  pc_paren the input chunk, which should point to an open/close paren
+ * @param[out] match    upon successful match, argument is populated with a tuple of chunks,
+ *                      where the first chunk indicates the beginning of the declaration or type
+ *                      signature, the second chunk indicates the variable name (or null if
+ *                      a type signature is detected), and the third chunk indicates the end
+ *                      associated with the declaration/type signature; if no match is found,
+ *                      argument is unmodified
+ * @return              true upon successful match
+ */
+bool match_function_pointer_at_paren(struct chunk_t *pc_paren, std::tuple<struct chunk_t *,
+                                                                          struct chunk_t *,
+                                                                          struct chunk_t *> &match);
+
+/**
+ * Starting from the input chunk, this function attempts to match a function pointer
+ * typedef at the specified identifier
+ * @param  pc_identifier the input chunk, which should point to an identifier
+ * @return               upon successful match, function returns an std::tuple, where the
+ *                       first chunk indicates the beginning of the typedef, the second
+ *                       chunk indicates the variable name, and the third chunk indicates
+ *                       the end associated with the function pointer typedef;
+ *                       if no match is found, function returns a tuple of null chunks
+ */
+std::tuple<struct chunk_t *,
+           struct chunk_t *,
+           struct chunk_t *> match_function_pointer_typedef_at_identifier(struct chunk_t *pc_identifier);
+
+
+/**
+ * Starting from the input chunk, this function attempts to match a function pointer
+ * typedef at the specified identifier
+ * @param[in]  pc_identifier the input chunk, which should point to an identifier
+ * @param[out] match         upon successful match, argument is populated with a tuple of
+ *                           chunks, where the first chunk indicates the beginning of the
+ *                           declaration, the second chunk indicates the variable name, and
+ *                           the third chunk indicates the end associated with the function
+ *                           pointer typedef; if no match is found, argument is
+ *                           unmodified
+ * @return                   true upon successful match
+ */
+bool match_function_pointer_typedef_at_identifier(struct chunk_t *pc_identifier, std::tuple<struct chunk_t *,
+                                                                                            struct chunk_t *,
+                                                                                            struct chunk_t *> &match);
+
+
+/**
+ * Starting from the input chunk, this function attempts to match a function pointer
+ * variable declaration at the specified identifier
+ * @param  pc_identifier the input chunk, which should point to an identifier
+ * @return               upon successful match, function returns an std::tuple, where the
+ *                       first chunk indicates the beginning of the declaration, the second
+ *                       chunk indicates the variable name, and the third chunk indicates
+ *                       the end associated with the function pointer variable declaration;
+ *                       if no match is found, function returns a tuple of null chunks
+ */
+std::tuple<struct chunk_t *,
+           struct chunk_t *,
+           struct chunk_t *> match_function_pointer_variable_at_identifier(struct chunk_t *pc_identifier);
+
+
+/**
+ * Starting from the input chunk, this function attempts to match a function pointer
+ * variable declaration at the specified identifier
+ * @param[in]  pc_identifier the input chunk, which should point to an identifier
+ * @param[out] match         upon successful match, argument is populated with a tuple of
+ *                           chunks, where the first chunk indicates the beginning of the
+ *                           declaration, the second chunk indicates the variable name, and
+ *                           the third chunk indicates the end associated with the function
+ *                           pointer variable declaration; if no match is found, argument is
+ *                           unmodified
+ * @return                   true upon successful match
+ */
+bool match_function_pointer_variable_at_identifier(struct chunk_t *pc_identifier, std::tuple<struct chunk_t *,
+                                                                                             struct chunk_t *,
+                                                                                             struct chunk_t *> &match);
+
+
+/**
+ * This function attempts to match the starting and ending chunks of a qualified
+ * identifier, which consists of one or more scope resolution operator(s) and
+ * zero or more nested name specifiers
+ * specifiers
+ * @param  pc the starting chunk
+ * @return    an std::pair, where the first chunk indicates the starting chunk of the
+ *            match and second indicates the ending chunk. Upon finding a successful
+ *            match, the starting chunk may consist of an identifier or a scope
+ *            resolution operator, while the ending chunk may consist of identifier
+ *            or the closing angle bracket of a template. If no match is found, a
+ *            pair of null chunks is returned
+ */
+std::pair<struct chunk_t *,
+          struct chunk_t *> match_qualified_identifier(struct chunk_t *pc);
+
+
+/**
+ * Starting from the input chunk, this function attempts to match a variable
+ * declaration/definition in both the forward and reverse directions; each pair of
+ * consecutive chunks is tested to determine if a potential match is satisfied.
+ * @param  pc    the starting chunk
+ * @param  level the level of the match
+ * @return       upon successful match, function returns an std::tuple, where the
+ *               first chunk indicates the starting chunk, the second chunk indicates
+ *               the identifier name, and the third chunk indicates the end associated
+ *               with the variable declaration/definition
+ */
+std::tuple<struct chunk_t *,
+           struct chunk_t *,
+           struct chunk_t *> match_variable(struct chunk_t *pc, std::size_t level);
+
+
+/**
+ * Starting from the input chunk, this function attempts to match a variable in the
+ * forward direction, and tests each pair of consecutive chunks to determine if a
+ * potential variable declaration/definition match is satisfied. Secondly, the
+ * function attempts to identify the end chunk associated with the candidate variable
+ * match. For scalar variables (simply declared and not defined), both the end chunk
+ * and identifier chunk should be one in the same
+ * @param  pc    the starting chunk
+ * @param  level the level of the match
+ * @return       an std::pair, where the first chunk indicates the identifier
+ *               (if non-null) and the second chunk indicates the end associated with
+ *               the variable declaration/definition; assuming a valid match, the first
+ *               chunk may be null if the function is called with a starting chunk
+ *               that occurs after the identifier
+ */
+std::pair<struct chunk_t *,
+          struct chunk_t *> match_variable_end(struct chunk_t *pc, std::size_t level);
+
+
+/**
+ * Starting from the input chunk, this function attempts to match a variable in the
+ * reverse direction, and tests each pair of consecutive chunks to determine if a
+ * potential variable declaration/definition match is satisfied. Secondly, the
+ * function attempts to identify the starting chunk associated with the candidate
+ * variable match. The start and identifier chunks may refer to each other in cases
+ * where the identifier is not preceded by pointer or reference operators or qualifiers,
+ * etc.
+ * @param  pc    the starting chunk
+ * @param  level the level of the match
+ * @return       an std::pair, where the first chunk indicates the starting chunk and
+ *               the second chunk indicates the identifier associated with the variable
+ *               match; assuming a valid match, the second chunk may be null if the
+ *               function is called with a starting chunk that occurs before the
+ *               identifier
+ */
+std::pair<struct chunk_t *,
+          struct chunk_t *> match_variable_start(struct chunk_t *pc, std::size_t level);
+
+
+#endif /* MATCH_TOOLS_H_INCLUDED */

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -360,7 +360,7 @@ static bool can_increase_nl(chunk_t *nl)
       }
    }
 
-   if (chunk_is_token(next, CT_BRACE_CLOSE))
+   if (chunk_is_brace_close_token(next))
    {
       if (  options::nl_inside_namespace() > 0
          && get_chunk_parent_type(next) == CT_NAMESPACE)
@@ -372,7 +372,7 @@ static bool can_increase_nl(chunk_t *nl)
       }
 
       if (  options::nl_inside_empty_func() > 0
-         && chunk_is_token(prev, CT_BRACE_OPEN)
+         && chunk_is_brace_open_token(prev)
          && (  get_chunk_parent_type(next) == CT_FUNC_DEF
             || get_chunk_parent_type(next) == CT_FUNC_CLASS_DEF))
       {
@@ -391,7 +391,7 @@ static bool can_increase_nl(chunk_t *nl)
       }
    }
 
-   if (chunk_is_token(prev, CT_BRACE_CLOSE))
+   if (chunk_is_brace_close_token(prev))
    {
       if (  options::nl_before_namespace()
          && get_chunk_parent_type(prev) == CT_NAMESPACE)
@@ -403,7 +403,7 @@ static bool can_increase_nl(chunk_t *nl)
       }
    }
 
-   if (chunk_is_token(prev, CT_BRACE_OPEN))
+   if (chunk_is_brace_open_token(prev))
    {
       if (  options::nl_inside_namespace() > 0
          && get_chunk_parent_type(prev) == CT_NAMESPACE)
@@ -415,7 +415,7 @@ static bool can_increase_nl(chunk_t *nl)
       }
 
       if (  options::nl_inside_empty_func() > 0
-         && chunk_is_token(next, CT_BRACE_CLOSE)
+         && chunk_is_brace_close_token(next)
          && (  get_chunk_parent_type(prev) == CT_FUNC_DEF
             || get_chunk_parent_type(prev) == CT_FUNC_CLASS_DEF))
       {
@@ -753,7 +753,7 @@ chunk_t *newline_add_between(chunk_t *start, chunk_t *end)
     * If the second one is a brace open, then check to see
     * if a comment + newline follows
     */
-   if (chunk_is_token(end, CT_BRACE_OPEN))
+   if (chunk_is_brace_open_token(end))
    {
       chunk_t *pc = chunk_get_next(end);
 
@@ -864,8 +864,8 @@ void newline_del_between(chunk_t *start, chunk_t *end)
    } while (pc != end);
 
    if (  !start_removed
-      && chunk_is_str(end, "{", 1)
-      && (  chunk_is_str(start, ")", 1)
+      && chunk_is_brace_open_str(end)
+      && (  chunk_is_paren_close_str(start)
          || chunk_is_token(start, CT_DO)
          || chunk_is_token(start, CT_ELSE)))
    {
@@ -948,7 +948,7 @@ static bool newlines_if_for_while_switch(chunk_t *start, iarf_e nl_opt)
       chunk_t *close_paren = chunk_get_next_type(pc, CT_SPAREN_CLOSE, pc->level);
       chunk_t *brace_open  = chunk_get_next_ncnnl(close_paren);
 
-      if (  (  chunk_is_token(brace_open, CT_BRACE_OPEN)
+      if (  (  chunk_is_brace_open_token(brace_open)
             || chunk_is_token(brace_open, CT_VBRACE_OPEN))
          && one_liner_nl_ok(brace_open))
       {
@@ -1327,13 +1327,13 @@ static void newlines_func_pre_blank_lines(chunk_t *start, c_token_t start_type)
       }
       else if (  chunk_is_token(pc, CT_DESTRUCTOR)
               || chunk_is_token(pc, CT_TYPE)
-              || chunk_is_token(pc, CT_TEMPLATE)
+              || chunk_is_template_token(pc)
               || chunk_is_token(pc, CT_QUALIFIER)
               || chunk_is_token(pc, CT_PTR_TYPE)
               || chunk_is_token(pc, CT_BYREF)                  // Issue #2163
-              || chunk_is_token(pc, CT_DC_MEMBER)
+              || chunk_is_double_colon_token(pc)
               || chunk_is_token(pc, CT_EXTERN)
-              || (  chunk_is_token(pc, CT_STRING)
+              || (  chunk_is_string_token(pc)
                  && get_chunk_parent_type(pc) == CT_EXTERN))
       {
          LOG_FMT(LNLFUNCT, "%s(%d): first_line set to %zu\n",
@@ -1341,7 +1341,7 @@ static void newlines_func_pre_blank_lines(chunk_t *start, c_token_t start_type)
          first_line = pc->orig_line;
          continue;
       }
-      else if (  chunk_is_token(pc, CT_ANGLE_CLOSE)
+      else if (  chunk_is_angle_close_token(pc)
               && get_chunk_parent_type(pc) == CT_TEMPLATE)
       {
          LOG_FMT(LNLFUNCT, "%s(%d):\n", __func__, __LINE__);
@@ -1376,7 +1376,7 @@ static chunk_t *get_closing_brace(chunk_t *start)
 
    for (pc = start; (pc = chunk_get_next(pc)) != nullptr;)
    {
-      if (  (  chunk_is_token(pc, CT_BRACE_CLOSE)
+      if (  (  chunk_is_brace_close_token(pc)
             || chunk_is_token(pc, CT_VBRACE_CLOSE))
          && pc->level == level)
       {
@@ -1687,9 +1687,9 @@ static void newlines_struct_union(chunk_t *start, iarf_e nl_opt, bool leave_trai
          && pc->level >= level)
    {
       if (  pc->level == level
-         && (  chunk_is_token(pc, CT_BRACE_OPEN)
-            || chunk_is_semicolon(pc)
-            || chunk_is_token(pc, CT_ASSIGN)))
+         && (  chunk_is_brace_open_token(pc)
+            || chunk_is_semicolon_token(pc)
+            || chunk_is_assign_token(pc)))
       {
          break;
       }
@@ -1697,7 +1697,7 @@ static void newlines_struct_union(chunk_t *start, iarf_e nl_opt, bool leave_trai
    }
 
    // If we hit a brace open, then we need to toy with the newlines
-   if (chunk_is_token(pc, CT_BRACE_OPEN))
+   if (chunk_is_brace_open_token(pc))
    {
       // Skip over embedded C comments
       chunk_t *next = chunk_get_next(pc);
@@ -1788,9 +1788,9 @@ static void newlines_enum(chunk_t *start)
          && pc->level >= level)
    {
       if (  pc->level == level
-         && (  chunk_is_token(pc, CT_BRACE_OPEN)
-            || chunk_is_semicolon(pc)
-            || chunk_is_token(pc, CT_ASSIGN)))
+         && (  chunk_is_brace_open_token(pc)
+            || chunk_is_semicolon_token(pc)
+            || chunk_is_assign_token(pc)))
       {
          break;
       }
@@ -1798,7 +1798,7 @@ static void newlines_enum(chunk_t *start)
    }
 
    // If we hit a brace open, then we need to toy with the newlines
-   if (chunk_is_token(pc, CT_BRACE_OPEN))
+   if (chunk_is_brace_open_token(pc))
    {
       // Skip over embedded C comments
       chunk_t *next = chunk_get_next(pc);
@@ -1878,7 +1878,7 @@ static void newlines_cuddle_uncuddle(chunk_t *start, iarf_e nl_opt)
    }
    chunk_t *br_close = chunk_get_prev_ncnnlni(start);   // Issue #2279
 
-   if (chunk_is_token(br_close, CT_BRACE_CLOSE))
+   if (chunk_is_brace_close_token(br_close))
    {
       newline_iarf_pair(br_close, start, nl_opt);
    }
@@ -1900,7 +1900,7 @@ static void newlines_do_else(chunk_t *start, iarf_e nl_opt)
    chunk_t *next = chunk_get_next_ncnnl(start);
 
    if (  next != nullptr
-      && (  chunk_is_token(next, CT_BRACE_OPEN)
+      && (  chunk_is_brace_open_token(next)
          || chunk_is_token(next, CT_VBRACE_OPEN)))
    {
       if (!one_liner_nl_ok(next))
@@ -1936,7 +1936,7 @@ static void newlines_do_else(chunk_t *start, iarf_e nl_opt)
 
 static bool is_var_def(chunk_t *pc, chunk_t *next)
 {
-   if (  chunk_is_token(pc, CT_DECLTYPE)
+   if (  chunk_is_decltype_token(pc)
       && chunk_is_token(next, CT_PAREN_OPEN))
    {
       // If current token starts a decltype expression, skip it
@@ -1948,12 +1948,12 @@ static bool is_var_def(chunk_t *pc, chunk_t *next)
       // Otherwise, if the current token is not a type --> not a declaration
       return(false);
    }
-   else if (chunk_is_token(next, CT_DC_MEMBER))
+   else if (chunk_is_double_colon_token(next))
    {
       // If next token is CT_DC_MEMBER, skip it
       next = chunk_skip_dc_member(next);
    }
-   else if (chunk_is_token(next, CT_ANGLE_OPEN))
+   else if (chunk_is_angle_open_token(next))
    {
       // If we have a template type, skip it
       next = chunk_skip_to_match(next);
@@ -1976,7 +1976,7 @@ static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
    chunk_t *prev = chunk_get_prev_ncnnlni(start);   // Issue #2279
 
    // can't be any variable definitions in a "= {" block
-   if (chunk_is_token(prev, CT_ASSIGN))
+   if (chunk_is_assign_token(prev))
    {
       chunk_t *tmp = chunk_get_next_type(start, CT_BRACE_CLOSE, start->level);
       return(chunk_get_next_ncnnl(tmp));
@@ -1995,7 +1995,7 @@ static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
 
       chunk_t *next_pc = chunk_get_next(pc);
 
-      if (chunk_is_token(next_pc, CT_DC_MEMBER))
+      if (chunk_is_double_colon_token(next_pc))
       {
          // If next_pc token is CT_DC_MEMBER, skip it
          pc = chunk_skip_dc_member(pc);
@@ -2008,14 +2008,14 @@ static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
       }
 
       // process nested braces
-      if (chunk_is_token(pc, CT_BRACE_OPEN))
+      if (chunk_is_brace_open_token(pc))
       {
          pc = newline_def_blk(pc, false);
          continue;
       }
 
       // Done with this brace set?
-      if (chunk_is_token(pc, CT_BRACE_CLOSE))
+      if (chunk_is_brace_close_token(pc))
       {
          pc = chunk_get_next(pc);
          break;
@@ -2076,7 +2076,7 @@ static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
 
          prev = chunk_get_prev_ncnnl(pc);
 
-         while (  chunk_is_token(prev, CT_DC_MEMBER)
+         while (  chunk_is_double_colon_token(prev)
                || chunk_is_token(prev, CT_TYPE))
          {
             prev = chunk_get_prev_ncnnl(prev);
@@ -2092,7 +2092,7 @@ static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
             prev = chunk_get_prev_type(pc, CT_BRACE_OPEN, pc->level - 1);      // Issue #2692
          }
 
-         if (  chunk_is_token(prev, CT_STRING)
+         if (  chunk_is_string_token(prev)
             && get_chunk_parent_type(prev) == CT_EXTERN
             && chunk_is_token(prev->prev, CT_EXTERN))
          {
@@ -2199,7 +2199,7 @@ static bool collapse_empty_body(chunk_t *br_open)
    log_rule_B("nl_collapse_empty_body");
 
    if (  !options::nl_collapse_empty_body()
-      || !chunk_is_token(chunk_get_next_nnl(br_open), CT_BRACE_CLOSE))
+      || !chunk_is_brace_close_token(chunk_get_next_nnl(br_open)))
    {
       return(false);
    }
@@ -2235,7 +2235,7 @@ static void newlines_brace_pair(chunk_t *br_open)
    }
 
    //fixes 1235 Add single line namespace support
-   if (  chunk_is_token(br_open, CT_BRACE_OPEN)
+   if (  chunk_is_brace_open_token(br_open)
       && (get_chunk_parent_type(br_open) == CT_NAMESPACE)
       && chunk_is_newline(chunk_get_prev(br_open)))
    {
@@ -2273,7 +2273,7 @@ static void newlines_brace_pair(chunk_t *br_open)
 
       if (  br_close != nullptr                            // Issue #2594
          && ((br_close->orig_line - br_open->orig_line) <= 2)
-         && chunk_is_paren_close(tmp))                     // need to check the conditions.
+         && chunk_is_paren_close_token(tmp))               // need to check the conditions.
       {
          // Issue #1825
          bool is_it_possible = true;
@@ -2482,7 +2482,7 @@ static void newlines_brace_pair(chunk_t *br_open)
    }
    //fixes #1245 will add new line between tsquare and brace open based on nl_tsquare_brace
 
-   if (chunk_is_token(br_open, CT_BRACE_OPEN))
+   if (chunk_is_brace_open_token(br_open))
    {
       chunk_t *chunk_closeing_brace = chunk_skip_to_match(br_open, scope_e::ALL);
 
@@ -2492,7 +2492,7 @@ static void newlines_brace_pair(chunk_t *br_open)
          {
             chunk_t *prev = chunk_get_prev_nc(br_open);
 
-            if (  chunk_is_token(prev, CT_TSQUARE)
+            if (  chunk_is_subscript_token(prev)
                && chunk_is_newline(next))
             {
                log_rule_B("nl_tsquare_brace");
@@ -2512,7 +2512,7 @@ static void newlines_brace_pair(chunk_t *br_open)
          log_rule_B("nl_inside_namespace");
 
          if (  options::nl_inside_empty_func() > 0
-            && chunk_is_token(chunk_get_next_nnl(br_open), CT_BRACE_CLOSE)
+            && chunk_is_brace_close_token(chunk_get_next_nnl(br_open))
             && (  get_chunk_parent_type(br_open) == CT_FUNC_CLASS_DEF
                || get_chunk_parent_type(br_open) == CT_FUNC_DEF))
          {
@@ -2642,7 +2642,7 @@ static void newline_case(chunk_t *start)
 
    // Only add an extra line after a semicolon or brace close
    if (  chunk_is_token(prev, CT_SEMICOLON)
-      || chunk_is_token(prev, CT_BRACE_CLOSE))
+      || chunk_is_brace_close_token(prev))
    {
       if (  chunk_is_newline(pc)
          && pc->nl_count < 2)
@@ -2718,7 +2718,7 @@ static void newline_before_return(chunk_t *start)
 
    // Don't add extra blanks after an opening brace or a case statement
    if (  pc == nullptr
-      || (  chunk_is_token(pc, CT_BRACE_OPEN)
+      || (  chunk_is_brace_open_token(pc)
          || chunk_is_token(pc, CT_VBRACE_OPEN)
          || chunk_is_token(pc, CT_CASE_COLON)))
    {
@@ -2743,7 +2743,7 @@ static void newline_after_return(chunk_t *start)
 
    // If we hit a brace or an 'else', then a newline isn't needed
    if (  after == nullptr
-      || chunk_is_token(after, CT_BRACE_CLOSE)
+      || chunk_is_brace_close_token(after)
       || chunk_is_token(after, CT_VBRACE_CLOSE)
       || chunk_is_token(after, CT_ELSE))
    {
@@ -2889,12 +2889,12 @@ static void newline_func_multi_line(chunk_t *start)
       chunk_t *start_next         = chunk_get_next_ncnnl(start);
       bool    has_leading_closure = (  start_next->parent_type == CT_OC_BLOCK_EXPR
                                     || start_next->parent_type == CT_CPP_LAMBDA
-                                    || chunk_is_token(start_next, CT_BRACE_OPEN));
+                                    || chunk_is_brace_open_token(start_next));
 
       chunk_t *prev_end            = chunk_get_prev_ncnnl(pc);
       bool    has_trailing_closure = (  prev_end->parent_type == CT_OC_BLOCK_EXPR
                                      || prev_end->parent_type == CT_CPP_LAMBDA
-                                     || chunk_is_token(prev_end, CT_BRACE_OPEN));
+                                     || chunk_is_brace_open_token(prev_end));
 
       if (  add_start
          && !chunk_is_newline(chunk_get_next(start)))
@@ -2942,7 +2942,7 @@ static void newline_func_multi_line(chunk_t *start)
               pc != nullptr && pc->level > start->level;
               pc = chunk_get_next_ncnnl(pc))
          {
-            if (  chunk_is_token(pc, CT_COMMA)
+            if (  chunk_is_comma_token(pc)
                && (pc->level == (start->level + 1)))
             {
                chunk_t *tmp = chunk_get_next(pc);
@@ -2963,10 +2963,10 @@ static void newline_func_multi_line(chunk_t *start)
 
                      if (!(  (  prev_comma->parent_type == CT_OC_BLOCK_EXPR
                              || prev_comma->parent_type == CT_CPP_LAMBDA
-                             || chunk_is_token(prev_comma, CT_BRACE_OPEN))
+                             || chunk_is_brace_open_token(prev_comma))
                           || (  after_comma->parent_type == CT_OC_BLOCK_EXPR
                              || after_comma->parent_type == CT_CPP_LAMBDA
-                             || chunk_is_token(after_comma, CT_BRACE_OPEN))))
+                             || chunk_is_brace_open_token(after_comma))))
                      {
                         newline_iarf(pc, IARF_ADD);
                      }
@@ -3014,7 +3014,7 @@ static void newline_template(chunk_t *start)
       pc = chunk_get_next_ncnnl(pc);
    }
 
-   if (chunk_is_token(pc, CT_ANGLE_CLOSE))
+   if (chunk_is_angle_close_token(pc))
    {
       if (add_start)
       {
@@ -3034,7 +3034,7 @@ static void newline_template(chunk_t *start)
               pc_1 != nullptr && pc_1->level > start->level;
               pc_1 = chunk_get_next_ncnnl(pc_1))
          {
-            if (  chunk_is_token(pc_1, CT_COMMA)
+            if (  chunk_is_comma_token(pc_1)
                && (pc_1->level == (start->level + 1)))
             {
                chunk_t *tmp = chunk_get_next(pc_1);
@@ -3087,7 +3087,7 @@ static void newline_func_def_or_call(chunk_t *start)
       }
       chunk_t *pc = chunk_get_next_ncnnl(start);
 
-      if (chunk_is_str(pc, ")", 1))
+      if (chunk_is_paren_close_str(pc))
       {
          log_rule_B("nl_func_call_paren_empty");
          atmp = options::nl_func_call_paren_empty();
@@ -3136,11 +3136,11 @@ static void newline_func_def_or_call(chunk_t *start)
       chunk_t *prev = chunk_get_prev_ncnnlni(start);   // Issue #2279
       prev = skip_template_prev(prev);
       // Don't split up a function variable
-      prev = chunk_is_paren_close(prev) ? nullptr : chunk_get_prev_ncnnlni(prev);   // Issue #2279
+      prev = chunk_is_paren_close_token(prev) ? nullptr : chunk_get_prev_ncnnlni(prev);   // Issue #2279
 
       log_rule_B("nl_func_class_scope");
 
-      if (  chunk_is_token(prev, CT_DC_MEMBER)
+      if (  chunk_is_double_colon_token(prev)
          && (options::nl_func_class_scope() != IARF_IGNORE))
       {
          newline_iarf(chunk_get_prev_ncnnlni(prev), options::nl_func_class_scope());   // Issue #2279
@@ -3160,7 +3160,7 @@ static void newline_func_def_or_call(chunk_t *start)
             tmp = start;
          }
 
-         if (chunk_is_token(prev, CT_DC_MEMBER))
+         if (chunk_is_double_colon_token(prev))
          {
             log_rule_B("nl_func_scope_name");
 
@@ -3226,7 +3226,7 @@ static void newline_func_def_or_call(chunk_t *start)
                 * If we are on a '::', step back two tokens
                 * TODO: do we also need to check for '.' ?
                 */
-               while (chunk_is_token(prev, CT_DC_MEMBER))
+               while (chunk_is_double_colon_token(prev))
                {
                   prev = chunk_get_prev_ncnnlni(prev);   // Issue #2279
                   prev = skip_template_prev(prev);
@@ -3251,7 +3251,7 @@ static void newline_func_def_or_call(chunk_t *start)
       }
       chunk_t *pc = chunk_get_next_ncnnl(start);
 
-      if (chunk_is_str(pc, ")", 1))
+      if (chunk_is_paren_close_str(pc))
       {
          log_rule_B("nl_func_def_empty");
          log_rule_B("nl_func_decl_empty");
@@ -3288,7 +3288,7 @@ static void newline_func_def_or_call(chunk_t *start)
         pc != nullptr && pc->level > start->level;
         pc = chunk_get_next_ncnnl(pc))
    {
-      if (  chunk_is_token(pc, CT_COMMA)
+      if (  chunk_is_comma_token(pc)
          && (pc->level == (start->level + 1)))
       {
          comma_count++;
@@ -3420,7 +3420,7 @@ static bool one_liner_nl_ok(chunk_t *pc)
    if (chunk_is_closing_brace(br_open))
    {
       br_open = chunk_get_prev_type(br_open,
-                                    chunk_is_token(br_open, CT_BRACE_CLOSE) ? CT_BRACE_OPEN : CT_VBRACE_OPEN,
+                                    chunk_is_brace_close_token(br_open) ? CT_BRACE_OPEN : CT_VBRACE_OPEN,
                                     br_open->level, scope_e::ALL);
    }
    else
@@ -3437,8 +3437,8 @@ static bool one_liner_nl_ok(chunk_t *pc)
 
    if (  pc != nullptr
       && pc->flags.test(PCF_ONE_LINER)
-      && (  chunk_is_token(pc, CT_BRACE_OPEN)
-         || chunk_is_token(pc, CT_BRACE_CLOSE)
+      && (  chunk_is_brace_open_token(pc)
+         || chunk_is_brace_close_token(pc)
          || chunk_is_token(pc, CT_VBRACE_OPEN)
          || chunk_is_token(pc, CT_VBRACE_CLOSE)))
    {
@@ -3656,7 +3656,7 @@ static void nl_create_list_liner(chunk_t *brace_open)
 
    do
    {
-      if (chunk_is_token(tmp, CT_COMMA))
+      if (chunk_is_comma_token(tmp))
       {
          return;
       }
@@ -3748,7 +3748,7 @@ void newlines_cleanup_angles()
       LOG_FMT(LBLANK, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s'\n",
               __func__, __LINE__, pc->orig_line, pc->orig_col, pc->elided_text(copy));
 
-      if (chunk_is_token(pc, CT_ANGLE_OPEN))
+      if (chunk_is_angle_open_token(pc))
       {
          newline_template(pc);
       }
@@ -3793,7 +3793,7 @@ void newlines_cleanup_braces(bool first)
          log_rule_B("nl_for_brace");
          newlines_if_for_while_switch(pc, options::nl_for_brace());
       }
-      else if (chunk_is_token(pc, CT_CATCH))
+      else if (chunk_is_catch_token(pc))
       {
          log_rule_B("nl_oc_brace_catch");
 
@@ -3810,7 +3810,7 @@ void newlines_cleanup_braces(bool first)
          }
          chunk_t *next = chunk_get_next_ncnnl(pc);
 
-         if (chunk_is_token(next, CT_BRACE_OPEN))
+         if (chunk_is_brace_open_token(next))
          {
             log_rule_B("nl_oc_catch_brace");
 
@@ -3921,7 +3921,7 @@ void newlines_cleanup_braces(bool first)
          log_rule_B("nl_brace_while");
          newlines_cuddle_uncuddle(pc, options::nl_brace_while());
       }
-      else if (chunk_is_token(pc, CT_BRACE_OPEN))
+      else if (chunk_is_brace_open_token(pc))
       {
          switch (get_chunk_parent_type(pc))
          {
@@ -3933,7 +3933,7 @@ void newlines_cleanup_braces(bool first)
             {
                chunk_t *prev = chunk_get_prev_ncnnlni(pc, scope_e::PREPROC);   // Issue #2279
 
-               if (chunk_is_paren_close(prev))
+               if (chunk_is_paren_close_token(prev))
                {
                   log_rule_B("nl_paren_dbrace_open");
                   newline_iarf_pair(prev, pc, options::nl_paren_dbrace_open());
@@ -4080,7 +4080,7 @@ void newlines_cleanup_braces(bool first)
          {
             chunk_t *next = chunk_get_next_nc(pc, scope_e::PREPROC);
 
-            if (chunk_is_token(next, CT_BRACE_OPEN))
+            if (chunk_is_brace_open_token(next))
             {
                newline_iarf_pair(pc, next, options::nl_brace_brace());
             }
@@ -4091,11 +4091,11 @@ void newlines_cleanup_braces(bool first)
          {
             // do nothing
          }
-         else if (chunk_is_token(next, CT_BRACE_CLOSE))
+         else if (chunk_is_brace_close_token(next))
          {
             // TODO: add an option to split open empty statements? { };
          }
-         else if (chunk_is_token(next, CT_BRACE_OPEN))
+         else if (chunk_is_brace_open_token(next))
          {
             // already handled
          }
@@ -4164,7 +4164,7 @@ void newlines_cleanup_braces(bool first)
             newlines_brace_pair(pc);
          }
       }
-      else if (chunk_is_token(pc, CT_BRACE_CLOSE))
+      else if (chunk_is_brace_close_token(pc))
       {
          // newline between a close brace and x
          log_rule_B("nl_brace_brace");
@@ -4173,7 +4173,7 @@ void newlines_cleanup_braces(bool first)
          {
             chunk_t *next = chunk_get_next_nc(pc, scope_e::PREPROC);
 
-            if (chunk_is_token(next, CT_BRACE_CLOSE))
+            if (chunk_is_brace_close_token(next))
             {
                log_rule_B("nl_brace_brace");
                newline_iarf_pair(pc, next, options::nl_brace_brace());
@@ -4185,7 +4185,7 @@ void newlines_cleanup_braces(bool first)
          {
             chunk_t *next = chunk_get_next_nc(pc, scope_e::PREPROC);
 
-            if (chunk_is_token(next, CT_SQUARE_CLOSE))
+            if (chunk_is_square_close_token(next))
             {
                log_rule_B("nl_brace_square");
                newline_iarf_pair(pc, next, options::nl_brace_square());
@@ -4235,7 +4235,7 @@ void newlines_cleanup_braces(bool first)
                log_rule_B("nl_inside_empty_func");
 
                if (  options::nl_inside_empty_func() > 0
-                  && chunk_is_token(chunk_get_prev_nnl(pc), CT_BRACE_OPEN)
+                  && chunk_is_brace_open_token(chunk_get_prev_nnl(pc))
                   && (  get_chunk_parent_type(pc) == CT_FUNC_CLASS_DEF
                      || get_chunk_parent_type(pc) == CT_FUNC_DEF))
                {
@@ -4352,7 +4352,7 @@ void newlines_cleanup_braces(bool first)
             chunk_t *next = chunk_get_next(pc, scope_e::PREPROC);
             bool    add_it;
 
-            if (chunk_is_semicolon(next))
+            if (chunk_is_semicolon_token(next))
             {
                log_rule_B("nl_after_vbrace_open_empty");
                add_it = options::nl_after_vbrace_open_empty();
@@ -4433,7 +4433,7 @@ void newlines_cleanup_braces(bool first)
             }
          }
       }
-      else if (  chunk_is_token(pc, CT_SQUARE_OPEN)
+      else if (  chunk_is_square_open_token(pc)
               && get_chunk_parent_type(pc) == CT_OC_MSG)
       {
          log_rule_B("nl_oc_msg_args");
@@ -4467,7 +4467,7 @@ void newlines_cleanup_braces(bool first)
             newline_case(pc);
          }
       }
-      else if (chunk_is_token(pc, CT_THROW))
+      else if (chunk_is_throw_token(pc))
       {
          chunk_t *prev = chunk_get_prev(pc);
 
@@ -4496,7 +4496,7 @@ void newlines_cleanup_braces(bool first)
 
          log_rule_B("nl_case_colon_brace");
 
-         if (  chunk_is_token(next, CT_BRACE_OPEN)
+         if (  chunk_is_brace_open_token(next)
             && options::nl_case_colon_brace() != IARF_IGNORE)
          {
             newline_iarf(pc, options::nl_case_colon_brace());
@@ -4511,7 +4511,7 @@ void newlines_cleanup_braces(bool first)
       {
          chunk_t *next = chunk_get_next_ncnnl(pc);
 
-         if (chunk_is_token(next, CT_BRACE_OPEN))
+         if (chunk_is_brace_open_token(next))
          {
             /*
              * TODO: this could be used to control newlines between the
@@ -4692,7 +4692,7 @@ void newlines_cleanup_braces(bool first)
             newline_iarf(pc->prev, options::nl_func_call_end());
          }
       }
-      else if (chunk_is_token(pc, CT_ANGLE_CLOSE))
+      else if (chunk_is_angle_close_token(pc))
       {
          if (get_chunk_parent_type(pc) == CT_TEMPLATE)
          {
@@ -4703,7 +4703,7 @@ void newlines_cleanup_braces(bool first)
             {
                chunk_t *tmp = chunk_get_prev_ncnnlni(chunk_get_prev_type(pc, CT_ANGLE_OPEN, pc->level));   // Issue #2279
 
-               if (chunk_is_token(tmp, CT_TEMPLATE))
+               if (chunk_is_template_token(tmp))
                {
                   if (chunk_is_token(next, CT_USING))
                   {
@@ -4782,7 +4782,7 @@ void newlines_cleanup_braces(bool first)
          {
             next = chunk_get_next_ncnnl(next);
 
-            if (!chunk_is_token(next, CT_ASSIGN))
+            if (!chunk_is_assign_token(next))
             {
                // Issue #1235
                // Issue #2186
@@ -4803,7 +4803,7 @@ void newlines_cleanup_braces(bool first)
             }
          }
       }
-      else if (chunk_is_token(pc, CT_SQUARE_OPEN))
+      else if (chunk_is_square_open_token(pc))
       {
          if (  get_chunk_parent_type(pc) == CT_ASSIGN
             && !pc->flags.test(PCF_ONE_LINER))
@@ -4882,7 +4882,7 @@ void newlines_cleanup_braces(bool first)
          log_rule_B("nl_remove_extra_newlines");
          newline_iarf(pc, IARF_REMOVE);
       }
-      else if (  chunk_is_token(pc, CT_MEMBER)
+      else if (  chunk_is_member_token(pc)
               && (  language_is_set(LANG_JAVA)
                  || language_is_set(LANG_CPP)))                 // Issue #2574
       {
@@ -5112,7 +5112,7 @@ void newlines_functions_remove_extra_blank_lines(void)
 
       while (pc != nullptr)
       {
-         if (  chunk_is_token(pc, CT_BRACE_CLOSE)
+         if (  chunk_is_brace_close_token(pc)
             && pc->level == startMoveLevel)
          {
             break;
@@ -5226,8 +5226,8 @@ void newlines_squeeze_paren_close(void)
 
       if (  next != nullptr
          && prev != nullptr
-         && chunk_is_paren_close(next)
-         && chunk_is_paren_close(prev))
+         && chunk_is_paren_close_token(next)
+         && chunk_is_paren_close_token(prev))
       {
          chunk_t *prev_op = chunk_skip_to_match_rev(prev);
          chunk_t *next_op = chunk_skip_to_match_rev(next);
@@ -5237,7 +5237,7 @@ void newlines_squeeze_paren_close(void)
          {
             chunk_t *tmp = prev;
 
-            while (chunk_is_paren_close(tmp))
+            while (chunk_is_paren_close_token(tmp))
             {
                tmp = chunk_get_prev(tmp);
             }
@@ -5549,7 +5549,7 @@ void newlines_chunk_pos(c_token_t chunk_type, token_pos_e mode)
 
             if (  chunk_is_token(next2, CT_PREPROC)
                || (  chunk_type == CT_ASSIGN
-                  && chunk_is_token(next2, CT_BRACE_OPEN)))
+                  && chunk_is_brace_open_token(next2)))
             {
                continue;
             }
@@ -5726,7 +5726,7 @@ void newlines_class_colon_pos(c_token_t tok)
       else
       {
          // (pc->type != tok)
-         if (  chunk_is_token(pc, CT_BRACE_OPEN)
+         if (  chunk_is_brace_open_token(pc)
             || chunk_is_token(pc, CT_SEMICOLON))
          {
             ccolon = nullptr;
@@ -5738,7 +5738,7 @@ void newlines_class_colon_pos(c_token_t tok)
             continue;
          }
 
-         if (  chunk_is_token(pc, CT_COMMA)
+         if (  chunk_is_comma_token(pc)
             && pc->level == ccolon->level)
          {
             LOG_FMT(LBLANKD, "%s(%d): orig_line is %zu, orig_col is %zu, text() '%s', type is %s\n",
@@ -5858,7 +5858,7 @@ iarf_e newline_template_option(chunk_t *pc, iarf_e special, iarf_e base, iarf_e 
 {
    chunk_t *const prev = chunk_get_prev_ncnnl(pc);
 
-   if (  chunk_is_token(prev, CT_ANGLE_OPEN)
+   if (  chunk_is_angle_open_token(prev)
       && special != IARF_IGNORE)
    {
       return(special);
@@ -5884,7 +5884,7 @@ bool is_func_proto_group(chunk_t *pc, c_token_t one_liner_type)
    {
       log_rule_B("nl_class_leave_one_liner_groups");
 
-      if (chunk_is_token(pc, CT_BRACE_CLOSE))
+      if (chunk_is_brace_close_token(pc))
       {
          return(pc->flags.test(PCF_ONE_LINER));
       }
@@ -6031,7 +6031,7 @@ void do_blank_lines(void)
 
       // Control blanks before a class/struct
       if (  (  chunk_is_token(prev, CT_SEMICOLON)
-            || chunk_is_token(prev, CT_BRACE_CLOSE))
+            || chunk_is_brace_close_token(prev))
          && (  get_chunk_parent_type(prev) == CT_CLASS
             || get_chunk_parent_type(prev) == CT_STRUCT))
       {
@@ -6084,7 +6084,7 @@ void do_blank_lines(void)
          }
       }
 
-      if (  chunk_is_token(prev, CT_BRACE_CLOSE)
+      if (  chunk_is_brace_close_token(prev)
          && get_chunk_parent_type(prev) == CT_NAMESPACE)
       {
          // Control blanks before a namespace
@@ -6113,8 +6113,8 @@ void do_blank_lines(void)
       }
 
       // Control blanks inside empty function body
-      if (  chunk_is_token(prev, CT_BRACE_OPEN)
-         && chunk_is_token(next, CT_BRACE_CLOSE)
+      if (  chunk_is_brace_open_token(prev)
+         && chunk_is_brace_close_token(next)
          && (  get_chunk_parent_type(prev) == CT_FUNC_DEF
             || get_chunk_parent_type(prev) == CT_FUNC_CLASS_DEF)
          && options::nl_inside_empty_func() > pc->nl_count
@@ -6142,7 +6142,7 @@ void do_blank_lines(void)
       }
 
       // Add blanks after function bodies
-      if (  chunk_is_token(prev, CT_BRACE_CLOSE)
+      if (  chunk_is_brace_close_token(prev)
          && (  get_chunk_parent_type(prev) == CT_FUNC_DEF
             || get_chunk_parent_type(prev) == CT_FUNC_CLASS_DEF
             || get_chunk_parent_type(prev) == CT_OC_MSG_DECL
@@ -6232,7 +6232,7 @@ void do_blank_lines(void)
 
       // Add blanks after struct/enum/union/class
       if (  (  chunk_is_token(prev, CT_SEMICOLON)
-            || chunk_is_token(prev, CT_BRACE_CLOSE))
+            || chunk_is_brace_close_token(prev))
          && (  get_chunk_parent_type(prev) == CT_STRUCT
             || get_chunk_parent_type(prev) == CT_ENUM
             || get_chunk_parent_type(prev) == CT_UNION
@@ -6311,7 +6311,7 @@ void do_blank_lines(void)
       {
          log_rule_B("nl_after_try_catch_finally");
 
-         if (  chunk_is_token(prev, CT_BRACE_CLOSE)
+         if (  chunk_is_brace_close_token(prev)
             && (  get_chunk_parent_type(prev) == CT_CATCH
                || get_chunk_parent_type(prev) == CT_FINALLY))
          {
@@ -6335,7 +6335,7 @@ void do_blank_lines(void)
 
          if (  get_chunk_parent_type(prev) == CT_GETSET
             && chunk_is_not_token(next, CT_BRACE_CLOSE)
-            && (  chunk_is_token(prev, CT_BRACE_CLOSE)
+            && (  chunk_is_brace_close_token(prev)
                || chunk_is_token(prev, CT_SEMICOLON)))
          {
             blank_line_set(pc, options::nl_between_get_set);
@@ -6351,7 +6351,7 @@ void do_blank_lines(void)
       {
          log_rule_B("nl_around_cs_property");
 
-         if (  chunk_is_token(prev, CT_BRACE_CLOSE)
+         if (  chunk_is_brace_close_token(prev)
             && get_chunk_parent_type(prev) == CT_CS_PROPERTY
             && chunk_is_not_token(next, CT_BRACE_CLOSE))
          {
@@ -6386,9 +6386,9 @@ void do_blank_lines(void)
       // Change blanks inside namespace braces
       if (  (options::nl_inside_namespace() != 0)
          && (options::nl_inside_namespace() != pc->nl_count)
-         && (  (  chunk_is_token(prev, CT_BRACE_OPEN)
+         && (  (  chunk_is_brace_open_token(prev)
                && get_chunk_parent_type(prev) == CT_NAMESPACE)
-            || (  chunk_is_token(next, CT_BRACE_CLOSE)
+            || (  chunk_is_brace_close_token(next)
                && get_chunk_parent_type(next) == CT_NAMESPACE)))
       {
          log_rule_B("nl_inside_namespace");
@@ -6496,7 +6496,7 @@ static void newlines_enum_entries(chunk_t *open_brace, iarf_e av)
    {
       if (  (pc->level != (open_brace->level + 1))
          || chunk_is_not_token(pc, CT_COMMA)
-         || (  chunk_is_token(pc, CT_COMMA)
+         || (  chunk_is_comma_token(pc)
             && pc->next != nullptr
             && (  pc->next->type == CT_COMMENT_CPP
                || pc->next->type == CT_COMMENT)))
@@ -6556,7 +6556,7 @@ void annotations_newlines(void)
          && (next = chunk_get_next_nnl(pc)) != nullptr)
    {
       // find the end of this annotation
-      if (chunk_is_paren_open(next))
+      if (chunk_is_paren_open_token(next))
       {
          // TODO: control newline between annotation and '(' ?
          ae = chunk_skip_to_match(next);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -784,7 +784,7 @@ void output_text(FILE *pfile)
                 * FIXME: it would be better to properly set column_indent in
                 * indent_text(), but this hack for '}' and '#' seems to work.
                 */
-               if (  chunk_is_token(pc, CT_BRACE_CLOSE)
+               if (  chunk_is_brace_close_token(pc)
                   || chunk_is_token(pc, CT_CASE_COLON)
                   || chunk_is_token(pc, CT_PREPROC))
                {
@@ -845,23 +845,23 @@ void output_text(FILE *pfile)
 
          if (write_in_tracking)
          {
-            if (chunk_is_token(pc, CT_ANGLE_OPEN))
+            if (chunk_is_angle_open_token(pc))
             {
                add_text("&lt;", false, false);
             }
-            else if (chunk_is_token(pc, CT_ANGLE_CLOSE))
+            else if (chunk_is_angle_close_token(pc))
             {
                add_text("&gt;", false, false);
             }
             else
             {
-               add_text(pc->str, false, chunk_is_token(pc, CT_STRING));
+               add_text(pc->str, false, chunk_is_string_token(pc));
             }
             write_in_tracking = false;
          }
          else
          {
-            add_text(pc->str, false, chunk_is_token(pc, CT_STRING));
+            add_text(pc->str, false, chunk_is_string_token(pc));
          }
 
          if (chunk_is_token(pc, CT_PP_DEFINE))  // Issue #876
@@ -2680,7 +2680,7 @@ static bool kw_fcn_message(chunk_t *cmt, unc_text &out_txt)
 
    while (tmp != nullptr)
    {
-      if (  chunk_is_token(tmp, CT_BRACE_OPEN)
+      if (  chunk_is_brace_open_token(tmp)
          || chunk_is_token(tmp, CT_SEMICOLON))
       {
          break;
@@ -2776,7 +2776,7 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text &out_txt)
 
       while (tmp != nullptr)
       {
-         if (  chunk_is_token(tmp, CT_BRACE_OPEN)
+         if (  chunk_is_brace_open_token(tmp)
             || chunk_is_token(tmp, CT_SEMICOLON))
          {
             break;
@@ -2844,7 +2844,7 @@ static bool kw_fcn_javaparam(chunk_t *cmt, unc_text &out_txt)
 
       while ((tmp = chunk_get_next(tmp)) != nullptr)
       {
-         if (  chunk_is_token(tmp, CT_COMMA)
+         if (  chunk_is_comma_token(tmp)
             || tmp == fpc)
          {
             if (need_nl)
@@ -2914,7 +2914,7 @@ static bool kw_fcn_fclass(chunk_t *cmt, unc_text &out_txt)
       tmp = chunk_get_prev_type(tmp, CT_CLASS, tmp->level);
       tmp = chunk_get_next_ncnnl(tmp);
 
-      while (chunk_is_token(chunk_get_next_ncnnl(tmp), CT_DC_MEMBER))
+      while (chunk_is_double_colon_token(chunk_get_next_ncnnl(tmp)))
       {
          tmp = chunk_get_next_ncnnl(tmp);
          tmp = chunk_get_next_ncnnl(tmp);
@@ -2937,8 +2937,8 @@ static bool kw_fcn_fclass(chunk_t *cmt, unc_text &out_txt)
       }
 
       if (  tmp != nullptr
-         && (  chunk_is_token(tmp, CT_DC_MEMBER)
-            || chunk_is_token(tmp, CT_MEMBER)))
+         && (  chunk_is_double_colon_token(tmp)
+            || chunk_is_member_token(tmp)))
       {
          tmp = chunk_get_prev_ncnnl(tmp);
          out_txt.append(tmp->str);

--- a/src/parens.cpp
+++ b/src/parens.cpp
@@ -152,9 +152,9 @@ static void check_bool_parens(chunk_t *popen, chunk_t *pclose, int nest)
       }
 
       if (  chunk_is_token(pc, CT_BOOL)
-         || chunk_is_token(pc, CT_QUESTION)
+         || chunk_is_question_token(pc)
          || chunk_is_token(pc, CT_COND_COLON)
-         || chunk_is_token(pc, CT_COMMA))
+         || chunk_is_comma_token(pc))
       {
          LOG_FMT(LPARADD2, " -- %s [%s] at line %zu col %zu, level %zu\n",
                  get_token_name(pc->type),
@@ -171,13 +171,13 @@ static void check_bool_parens(chunk_t *popen, chunk_t *pclose, int nest)
          }
          ref = pc;
       }
-      else if (chunk_is_token(pc, CT_COMPARE))
+      else if (chunk_is_comparison_token(pc))
       {
          LOG_FMT(LPARADD2, " -- compare [%s] at line %zu col %zu, level %zu\n",
                  pc->text(), pc->orig_line, pc->orig_col, pc->level);
          hit_compare = true;
       }
-      else if (chunk_is_paren_open(pc))
+      else if (chunk_is_paren_open_token(pc))
       {
          chunk_t *next = chunk_skip_to_match(pc);
 
@@ -187,9 +187,9 @@ static void check_bool_parens(chunk_t *popen, chunk_t *pclose, int nest)
             pc = next;
          }
       }
-      else if (  chunk_is_token(pc, CT_BRACE_OPEN)
-              || chunk_is_token(pc, CT_SQUARE_OPEN)
-              || chunk_is_token(pc, CT_ANGLE_OPEN))
+      else if (  chunk_is_brace_open_token(pc)
+              || chunk_is_square_open_token(pc)
+              || chunk_is_angle_open_token(pc))
       {
          // Skip [], {}, and <>
          pc = chunk_skip_to_match(pc);

--- a/src/scope_enum.h
+++ b/src/scope_enum.h
@@ -1,0 +1,27 @@
+/**
+ * @file scope_enum.h
+ *
+ * @author
+ * @license GPL v2+
+ * extract from chunk_list.h
+ */
+
+#ifndef SCOPE_ENUM_H_INCLUDED
+#define SCOPE_ENUM_H_INCLUDED
+
+/**
+ * Specifies which chunks should/should not be found.
+ * ALL (default)
+ *  - return the true next/prev
+ *
+ * PREPROC
+ *  - If not in a preprocessor, skip over any encountered preprocessor stuff
+ *  - If in a preprocessor, fail to leave (return nullptr)
+ */
+enum class scope_e : unsigned int
+{
+   ALL,      //! search in all kind of chunks
+   PREPROC,  //! search only in preprocessor chunks
+};
+
+#endif /* SCOPE_ENUM_H_INCLUDED */

--- a/src/semicolons.cpp
+++ b/src/semicolons.cpp
@@ -57,7 +57,7 @@ void remove_extra_semicolons(void)
          {
             // keep it
          }
-         else if (  chunk_is_token(prev, CT_BRACE_CLOSE)
+         else if (  chunk_is_brace_close_token(prev)
                  && (  get_chunk_parent_type(prev) == CT_IF
                     || get_chunk_parent_type(prev) == CT_ELSEIF
                     || get_chunk_parent_type(prev) == CT_ELSE
@@ -72,7 +72,7 @@ void remove_extra_semicolons(void)
          {
             remove_semicolon(pc);
          }
-         else if (  chunk_is_token(prev, CT_BRACE_CLOSE)
+         else if (  chunk_is_brace_close_token(prev)
                  && get_chunk_parent_type(prev) == CT_NONE)
          {
             check_unknown_brace_close(pc, prev);
@@ -94,7 +94,7 @@ void remove_extra_semicolons(void)
          {
             remove_semicolon(pc);
          }
-         else if (chunk_is_token(prev, CT_BRACE_OPEN))
+         else if (chunk_is_brace_open_token(prev))
          {
             remove_semicolon(pc);
          }
@@ -118,7 +118,7 @@ static void check_unknown_brace_close(chunk_t *semi, chunk_t *brace_close)
       && pc->type != CT_SQUARE_CLOSE
       && pc->type != CT_ANGLE_CLOSE
       && pc->type != CT_TSQUARE
-      && !chunk_is_paren_close(pc))
+      && !chunk_is_paren_close_token(pc))
    {
       remove_semicolon(semi);
    }

--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -295,7 +295,7 @@ static int compare_chunks(chunk_t *pc1, chunk_t *pc2, bool tcare)
       LOG_FMT(LSORT, "%s(%d): text is %s, pc1->len is %zu, line is %zu, column is %zu\n",
               __func__, __LINE__, pc1->text(), pc1->len(), pc1->orig_line, pc1->orig_col);
 
-      if (chunk_is_token(pc1, CT_MEMBER))
+      if (chunk_is_member_token(pc1))
       {
          pc1 = chunk_get_next(pc1);
          LOG_FMT(LSORT, "%s(%d): text is %s, pc1->len is %zu, line is %zu, column is %zu\n",
@@ -305,7 +305,7 @@ static int compare_chunks(chunk_t *pc1, chunk_t *pc2, bool tcare)
       LOG_FMT(LSORT, "%s(%d): text is %s, pc2->len is %zu, line is %zu, column is %zu\n",
               __func__, __LINE__, pc2->text(), pc2->len(), pc2->orig_line, pc2->orig_col);
 
-      if (chunk_is_token(pc2, CT_MEMBER))
+      if (chunk_is_member_token(pc2))
       {
          pc2 = chunk_get_next(pc2);
          LOG_FMT(LSORT, "%s(%d): text is %s, pc2->len is %zu, line is %zu, column is %zu\n",

--- a/src/unc_tools.cpp
+++ b/src/unc_tools.cpp
@@ -218,8 +218,8 @@ void examine_Data(const char *func_name, int theLine, int what)
 
       for (pc = chunk_get_head(); pc != nullptr; pc = pc->next)
       {
-         if (  chunk_is_token(pc, CT_SQUARE_CLOSE)
-            || chunk_is_token(pc, CT_TSQUARE))
+         if (  chunk_is_square_close_token(pc)
+            || chunk_is_subscript_token(pc))
          {
             LOG_FMT(LGUY, "\n");
             LOG_FMT(LGUY, "1:(%d),", theLine);

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1709,7 +1709,7 @@ static void add_func_header(c_token_t type, file_mem &fm)
          while (  ref->type != CT_NEWLINE
                && (ref = ref->next)) // TODO: is the assignment of ref wanted here?, better move it to the loop
          {
-            if (chunk_is_token(ref, CT_BRACE_CLOSE))
+            if (chunk_is_brace_close_token(ref))
             {
                found_brace = 1;
                break;
@@ -1740,7 +1740,7 @@ static void add_func_header(c_token_t type, file_mem &fm)
          }
 
          // If we hit an angle close, back up to the angle open
-         if (chunk_is_token(ref, CT_ANGLE_CLOSE))
+         if (chunk_is_angle_close_token(ref))
          {
             ref = chunk_get_prev_type(ref, CT_ANGLE_OPEN, ref->level, scope_e::PREPROC);
             continue;
@@ -1776,7 +1776,7 @@ static void add_func_header(c_token_t type, file_mem &fm)
          if (  ref->level == pc->level
             && (  ref->flags.test(PCF_IN_PREPROC)
                || chunk_is_token(ref, CT_SEMICOLON)
-               || chunk_is_token(ref, CT_BRACE_CLOSE)))
+               || chunk_is_brace_close_token(ref)))
          {
             do_insert = true;
             break;

--- a/src/width.cpp
+++ b/src/width.cpp
@@ -275,7 +275,7 @@ static void try_split_here(cw_entry &ent, chunk_t *pc)
    LOG_FMT(LSPLIT, "%s(%d):\n", __func__, __LINE__);
 
    // Only split concatenated strings
-   if (chunk_is_token(pc, CT_STRING))
+   if (chunk_is_string_token(pc))
    {
       chunk_t *next = chunk_get_next(pc);
 
@@ -474,17 +474,17 @@ static bool split_line(chunk_t *start)
       log_rule_B("pos_shift");
       log_rule_B("pos_bool");
 
-      if (  (  chunk_is_token(ent.pc, CT_SHIFT)
+      if (  (  chunk_is_shift_token(ent.pc)
             && (options::pos_shift() & TP_LEAD))
          || (  (  chunk_is_token(ent.pc, CT_ARITH)
-               || chunk_is_token(ent.pc, CT_CARET))
+               || chunk_is_caret_token(ent.pc))
             && (options::pos_arith() & TP_LEAD))
-         || (  chunk_is_token(ent.pc, CT_ASSIGN)
+         || (  chunk_is_assign_token(ent.pc)
             && (options::pos_assign() & TP_LEAD))
-         || (  chunk_is_token(ent.pc, CT_COMPARE)
+         || (  chunk_is_comparison_token(ent.pc)
             && (options::pos_compare() & TP_LEAD))
          || (  (  chunk_is_token(ent.pc, CT_COND_COLON)
-               || chunk_is_token(ent.pc, CT_QUESTION))
+               || chunk_is_question_token(ent.pc))
             && (options::pos_conditional() & TP_LEAD))
          || (  chunk_is_token(ent.pc, CT_BOOL)
             && (options::pos_bool() & TP_LEAD)))
@@ -510,9 +510,9 @@ static bool split_line(chunk_t *start)
          || chunk_is_token(start, CT_FPAREN_OPEN)
          || chunk_is_token(start, CT_SPAREN_CLOSE)
          || chunk_is_token(start, CT_SPAREN_OPEN)
-         || chunk_is_token(start, CT_ANGLE_CLOSE)
-         || chunk_is_token(start, CT_BRACE_CLOSE)
-         || chunk_is_token(start, CT_COMMA)
+         || chunk_is_angle_close_token(start)
+         || chunk_is_brace_close_token(start)
+         || chunk_is_comma_token(start)
          || chunk_is_token(start, CT_SEMICOLON)
          || chunk_is_token(start, CT_VSEMICOLON)
          || start->len() == 0)
@@ -641,7 +641,7 @@ static void split_for_stmt(chunk_t *start)
 
    while ((pc = chunk_get_next(pc)) != start)
    {
-      if (  chunk_is_token(pc, CT_COMMA)
+      if (  chunk_is_comma_token(pc)
          && (pc->level == (open_paren->level + 1)))
       {
          split_before_chunk(chunk_get_next(pc));
@@ -657,7 +657,7 @@ static void split_for_stmt(chunk_t *start)
 
    while ((pc = chunk_get_next(pc)) != start)
    {
-      if (  chunk_is_token(pc, CT_ASSIGN)
+      if (  chunk_is_assign_token(pc)
          && (pc->level == (open_paren->level + 1)))
       {
          split_before_chunk(chunk_get_next(pc));
@@ -704,7 +704,7 @@ static void split_fcn_params_full(chunk_t *start)
       }
 
       if (  (pc->level == (fpo->level + 1))
-         && chunk_is_token(pc, CT_COMMA))
+         && chunk_is_comma_token(pc))
       {
          split_before_chunk(chunk_get_next(pc));
       }
@@ -768,7 +768,7 @@ static void split_fcn_params(chunk_t *start)
          LOG_FMT(LSPLIT, "%s(%d): last_col is %d\n",
                  __func__, __LINE__, last_col);
 
-         if (  chunk_is_token(pc, CT_COMMA)
+         if (  chunk_is_comma_token(pc)
             || chunk_is_token(pc, CT_FPAREN_CLOSE))
          {
             if (cur_width == 0)
@@ -807,7 +807,7 @@ static void split_fcn_params(chunk_t *start)
               __func__, __LINE__, prev->level, prev->text(), get_token_name(prev->type));
 
       if (  chunk_is_newline(prev)
-         || chunk_is_token(prev, CT_COMMA))
+         || chunk_is_comma_token(prev))
       {
          LOG_FMT(LSPLIT, "%s(%d): found at %zu\n",
                  __func__, __LINE__, prev->orig_col);
@@ -884,7 +884,7 @@ static void split_template(chunk_t *start)
       LOG_FMT(LSPLIT, "  %s(%d): prev '%s'\n", __func__, __LINE__, prev->text());
 
       if (  chunk_is_newline(prev)
-         || chunk_is_token(prev, CT_COMMA))
+         || chunk_is_comma_token(prev))
       {
          break;
       }


### PR DESCRIPTION
- Introduced more functions to standardize tests for chunk token types
  and strings

- Also moved some chunk sequence matching subroutines out of
  EnumStructUnionParser and into a new cpp file so that these
  subroutines may be used by others