### PR TITLE
Add new option nl_before_ignore_after_case

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -1080,6 +1080,12 @@ static void newlines_if_for_while_switch_pre_blank_lines(chunk_t *start, iarf_e 
       }
       else
       {
+         if (  chunk_is_token(pc, CT_CASE_COLON)
+            && options::nl_before_ignore_after_case())
+         {
+            return;
+         }
+
          if (do_add) // we found something previously besides a comment or a new line
          {
             // if we have run across a newline

--- a/src/options.h
+++ b/src/options.h
@@ -2423,6 +2423,13 @@ nl_before_do;
 extern Option<iarf_e>
 nl_after_do;
 
+// Ignore nl_before_{if,for,switch,do,synchronized} if the control
+// statement is immediately after a case statement.
+// if nl_before_{if,for,switch,do} is set to remove, this option
+// does nothing.
+extern Option<bool>
+nl_before_ignore_after_case;
+
 // Whether to put a blank line before 'return' statements, unless after an open
 // brace.
 extern Option<bool>

--- a/tests/c.test
+++ b/tests/c.test
@@ -124,6 +124,7 @@
 00204  bug_1718.cfg                         c/bug_1718.c
 00205  nl_before_return_false.cfg           c/case-nl_before_return.c
 00206  nl_before_return_true.cfg            c/case-nl_before_return.c
+00207  nl_before_ignore_after_case.cfg      c/nl_before_ignore_after_case.c
 
 
 # structure initializers

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -504,6 +504,7 @@ nl_before_synchronized          = ignore
 nl_after_synchronized           = ignore
 nl_before_do                    = ignore
 nl_after_do                     = ignore
+nl_before_ignore_after_case     = false
 nl_before_return                = false
 nl_after_return                 = false
 nl_before_member                = ignore

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1956,6 +1956,12 @@ nl_before_do                    = ignore   # ignore/add/remove/force/not_defined
 # Add or remove blank line after 'do/while' statement.
 nl_after_do                     = ignore   # ignore/add/remove/force/not_defined
 
+# Ignore nl_before_{if,for,switch,do,synchronized} if the control
+# statement is immediately after a case statement.
+# if nl_before_{if,for,switch,do} is set to remove, this option
+# does nothing.
+nl_before_ignore_after_case     = false    # true/false
+
 # Whether to put a blank line before 'return' statements, unless after an open
 # brace.
 nl_before_return                = false    # true/false

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -504,6 +504,7 @@ nl_before_synchronized          = ignore
 nl_after_synchronized           = ignore
 nl_before_do                    = ignore
 nl_after_do                     = ignore
+nl_before_ignore_after_case     = false
 nl_before_return                = false
 nl_after_return                 = false
 nl_before_member                = ignore

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1956,6 +1956,12 @@ nl_before_do                    = ignore   # ignore/add/remove/force/not_defined
 # Add or remove blank line after 'do/while' statement.
 nl_after_do                     = ignore   # ignore/add/remove/force/not_defined
 
+# Ignore nl_before_{if,for,switch,do,synchronized} if the control
+# statement is immediately after a case statement.
+# if nl_before_{if,for,switch,do} is set to remove, this option
+# does nothing.
+nl_before_ignore_after_case     = false    # true/false
+
 # Whether to put a blank line before 'return' statements, unless after an open
 # brace.
 nl_before_return                = false    # true/false

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1956,6 +1956,12 @@ nl_before_do                    = ignore   # ignore/add/remove/force/not_defined
 # Add or remove blank line after 'do/while' statement.
 nl_after_do                     = ignore   # ignore/add/remove/force/not_defined
 
+# Ignore nl_before_{if,for,switch,do,synchronized} if the control
+# statement is immediately after a case statement.
+# if nl_before_{if,for,switch,do} is set to remove, this option
+# does nothing.
+nl_before_ignore_after_case     = false    # true/false
+
 # Whether to put a blank line before 'return' statements, unless after an open
 # brace.
 nl_before_return                = false    # true/false

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -4469,6 +4469,14 @@ Choices=nl_after_do=ignore|nl_after_do=add|nl_after_do=remove|nl_after_do=force|
 ChoicesReadable="Ignore Nl After Do|Add Nl After Do|Remove Nl After Do|Force Nl After Do"
 ValueDefault=ignore
 
+[Nl Before Ignore After Case]
+Category=3
+Description="<html>Ignore nl_before_{if,for,switch,do,synchronized} if the control<br/>statement is immediately after a case statement.<br/>if nl_before_{if,for,switch,do} is set to remove, this option<br/>does nothing.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=nl_before_ignore_after_case=true|nl_before_ignore_after_case=false
+ValueDefault=false
+
 [Nl Before Return]
 Category=3
 Description="<html>Whether to put a blank line before 'return' statements, unless after an open<br/>brace.</html>"

--- a/tests/config/nl_before_ignore_after_case.cfg
+++ b/tests/config/nl_before_ignore_after_case.cfg
@@ -1,0 +1,11 @@
+# We need all these on, to check that nl_before_ignore_after_case
+# overrides them after case CASE_LABEL:
+
+nl_before_if = force
+nl_before_for = force
+nl_before_switch = force
+nl_before_do = force
+nl_before_while = force
+nl_before_synchronized = force
+
+nl_before_ignore_after_case  = true

--- a/tests/expected/c/00207-nl_before_ignore_after_case.c
+++ b/tests/expected/c/00207-nl_before_ignore_after_case.c
@@ -1,0 +1,53 @@
+void func(void)
+{
+	switch (cond)
+	{
+	case CASE_A:
+		for (;;)
+			do_stuff();
+		break;
+
+	case CASE_B:
+		if (cond)
+			do_stuff();
+		break;
+
+	case CASE_C:
+		do {
+			do_stuff()
+		} while (cond);
+		break;
+
+	case CASE_D:
+		while(cond)
+			do_stuff();
+		break;
+
+	case CASE_E:
+		switch(cond)
+		{
+		case CASE_EE:
+			break;
+		}
+		break;
+	}
+
+	for (;;)
+		do_stuff();
+
+	if (cond)
+		do_stuff();
+
+	do {
+		do_stuff()
+	} while (cond);
+
+	while(cond)
+		do_stuff();
+
+	switch(cond)
+	{
+	case CASE_A:
+		do_stuff();
+	}
+}

--- a/tests/expected/java/80068-nl_before_ignore_after_case.java
+++ b/tests/expected/java/80068-nl_before_ignore_after_case.java
@@ -1,0 +1,19 @@
+void func(void)
+{
+	switch (cond)
+	{
+	case CASE_F:
+		synchronized(thingy)
+		{
+			do_a();
+			do_b();
+		}
+		break;
+	}
+
+	synchronized(thingy)
+	{
+		do_a();
+		do_b();
+	}
+}

--- a/tests/input/c/nl_before_ignore_after_case.c
+++ b/tests/input/c/nl_before_ignore_after_case.c
@@ -1,0 +1,48 @@
+void func(void)
+{
+    switch (cond)
+    {
+        case CASE_A:
+            for (;;)
+                do_stuff();
+            break;
+
+        case CASE_B:
+            if (cond)
+                do_stuff();
+            break;
+
+        case CASE_C:
+            do {
+                do_stuff()
+            } while (cond);
+            break;
+
+        case CASE_D:
+            while(cond)
+                do_stuff();
+            break;
+
+        case CASE_E:
+            switch(cond)
+            {
+                case CASE_EE:
+                    break;
+            }
+            break;
+    }
+    for (;;)
+        do_stuff();
+    if (cond)
+        do_stuff();
+    do {
+        do_stuff()
+    } while (cond);
+    while(cond)
+        do_stuff();
+    switch(cond)
+    {
+        case CASE_A:
+            do_stuff();
+    }
+}

--- a/tests/input/java/nl_before_ignore_after_case.java
+++ b/tests/input/java/nl_before_ignore_after_case.java
@@ -1,0 +1,18 @@
+void func(void)
+{
+    switch (cond)
+    {
+        case CASE_F:
+            synchronized(thingy)
+            {
+                do_a();
+                do_b();
+            }
+            break;
+    }
+    synchronized(thingy)
+    {
+        do_a();
+        do_b();
+    }
+}

--- a/tests/java.test
+++ b/tests/java.test
@@ -23,6 +23,7 @@
 80065  empty.cfg                            java/Java8DoubleColon.java
 80066  sp_after_for_colon.cfg               java/sp_after_for_colon.java
 80067  doxy-javadoc-alignment.cfg           java/doxy-javadoc-alignment.java
+80068  nl_before_ignore_after_case.cfg      java/nl_before_ignore_after_case.java
 
 80100  align_same_func_call_params-t.cfg    java/sf567.java
 


### PR DESCRIPTION
This option is useful when the following are set to add or force:
- nl_before_if
- nl_before_for
- nl_before_while
- nl_before_do
- nl_before_switch
- nl_before_synchronized

Often, the block following a case will be indented from the case. In
that circumstance, the indent provides sufficent visual separation
and forcing a newline before isn't necessary.