### PR TITLE
Fixed comment for option nl_create_list_one_liner.

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -2497,7 +2497,7 @@ nl_create_while_one_liner;
 extern Option<bool>
 nl_create_func_def_one_liner;
 
-// Whether to split one-line simple unbraced list definitions into three lines by
+// Whether to split one-line simple list definitions into three lines by
 // adding newlines, as in 'int a[12] = { <here> 0 <here> };'.
 extern Option<bool>
 nl_create_list_one_liner;

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -2015,7 +2015,7 @@ nl_create_while_one_liner       = false    # true/false
 # a single line.
 nl_create_func_def_one_liner    = false    # true/false
 
-# Whether to split one-line simple unbraced list definitions into three lines by
+# Whether to split one-line simple list definitions into three lines by
 # adding newlines, as in 'int a[12] = { <here> 0 <here> };'.
 nl_create_list_one_liner        = false    # true/false
 

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -2015,7 +2015,7 @@ nl_create_while_one_liner       = false    # true/false
 # a single line.
 nl_create_func_def_one_liner    = false    # true/false
 
-# Whether to split one-line simple unbraced list definitions into three lines by
+# Whether to split one-line simple list definitions into three lines by
 # adding newlines, as in 'int a[12] = { <here> 0 <here> };'.
 nl_create_list_one_liner        = false    # true/false
 

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -2015,7 +2015,7 @@ nl_create_while_one_liner       = false    # true/false
 # a single line.
 nl_create_func_def_one_liner    = false    # true/false
 
-# Whether to split one-line simple unbraced list definitions into three lines by
+# Whether to split one-line simple list definitions into three lines by
 # adding newlines, as in 'int a[12] = { <here> 0 <here> };'.
 nl_create_list_one_liner        = false    # true/false
 

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -4597,7 +4597,7 @@ ValueDefault=false
 
 [Nl Create List One Liner]
 Category=3
-Description="<html>Whether to split one-line simple unbraced list definitions into three lines by<br/>adding newlines, as in 'int a[12] = { &lt;here&gt; 0 &lt;here&gt; };'.</html>"
+Description="<html>Whether to split one-line simple list definitions into three lines by<br/>adding newlines, as in 'int a[12] = { &lt;here&gt; 0 &lt;here&gt; };'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_create_list_one_liner=true|nl_create_list_one_liner=false


### PR DESCRIPTION
The original issue https://github.com/uncrustify/uncrustify/issues/3217 suggested the good fix.
Unfortunately one word of the fix got lost in the pull request https://github.com/uncrustify/uncrustify/pull/3221.
The word `unbraced` in the comment to option `nl_create_list_one_liner` should be removed.