### PR TITLE
Add failing test for C++ if-init-statement with `mod_full_paren_if_bool=true`

### DIFF
--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -993,3 +993,5 @@
 60055  issue_3116.cfg                       cpp/issue_3116.cpp
 60056  issue_3116.cfg                       cpp/issue_3116-2.cpp
 60057  issue_3116-2.cfg                     cpp/issue_3116.cpp
+
+60100  mod_full_paren_if_bool.cfg           cpp/if_init_statement.cpp

--- a/tests/expected/cpp/60100-if_init_statement.cpp
+++ b/tests/expected/cpp/60100-if_init_statement.cpp
@@ -1,0 +1,19 @@
+/* multi boolean works, but removes ' ' before '||' */
+if ((val < 0) || (val > 0))
+{
+}
+
+/* single condition works */
+if (auto val = getValue(); condition(val))
+{
+}
+
+/* multi boolean expression with existing parentheses will not change */
+if (auto val = getValue(); (val < 0) || (val > 0))
+{
+}
+
+/* multi boolean expression without existing parentheses produces invalid C++ code */
+if (auto val = getValue(); (val < 0) || (val > 0))
+{
+}

--- a/tests/input/cpp/if_init_statement.cpp
+++ b/tests/input/cpp/if_init_statement.cpp
@@ -1,0 +1,19 @@
+/* multi boolean works, but removes ' ' before '||' */
+if (val < 0 || val > 0)
+{
+}
+
+/* single condition works */
+if (auto val = getValue(); condition(val))
+{
+}
+
+/* multi boolean expression with existing parentheses will not change */
+if (auto val = getValue(); (val < 0) || (val > 0))
+{
+}
+
+/* multi boolean expression without existing parentheses produces invalid C++ code */
+if (auto val = getValue(); val < 0 || val > 0)
+{
+}


### PR DESCRIPTION
`mod_full_paren_if_bool` wrongly includes the init statement, when adding
parenthese. Like in:

```c++
if ((auto val = getValue(); val < 0)|| (val > 0))
```

Instead of

```c++
if (auto val = getValue(); (val < 0) || (val > 0))
```