### PR TITLE
Apply nl_func_var_def_blk only to first block

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -2160,7 +2160,7 @@ static chunk_t *newline_def_blk(chunk_t *start, bool fn_top)
                newline_min_after(prev, 1 + options::nl_func_var_def_blk(), PCF_VAR_DEF);
             }
             // reset the variables for the next block
-            first_var_blk = true;
+            first_var_blk = false;
             var_blk       = false;
          }
       }


### PR DESCRIPTION
Hello,

This is a small fix that addresses `nl_func_var_def_blk` applying to all var block in a function, not only the top one.

Consider the following example:

``` c
void foo(void)
{
    int a;
    bar();
    int b;
    baz();
}
```

Say you have `nl_func_var_def_blk=1`, this would give before this fix:
``` c
void foo(void)
{
    int a;
                 // <-- good
    bar();
    int b;
                 // <-- bad!
    baz();
}
```

After this fix, you get the correct:
``` c
void foo(void)
{
    int a;

    bar();
    int b;
    baz();
}
```

This is not the final fix though.

Ideally, if var block is preceded by any other (non-var) block,
`nl_func_var_def_blk` should not apply as well (because not func top).

For instance, you would still get
``` c
void foo(void)
{
    bat();
    int a;
                       // <-- space still inserted here, but a is no longer function top
    bar();
    int b;
    baz();
}
```
