### PR TITLE
Add sp_sparen_paren option

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -316,6 +316,9 @@ sp_inside_sparen_open           = ignore   # ignore/add/remove/force/not_defined
 # Overrides sp_inside_sparen.
 sp_inside_sparen_close          = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space between '((' or '))' of control statements.
+sp_sparen_paren                 = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space after ')' of control statements.
 sp_after_sparen                 = ignore   # ignore/add/remove/force/not_defined
 

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -316,6 +316,9 @@ sp_inside_sparen_open           = ignore   # ignore/add/remove/force/not_defined
 # Overrides sp_inside_sparen.
 sp_inside_sparen_close          = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space between '((' or '))' of control statements.
+sp_sparen_paren                 = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space after ')' of control statements.
 sp_after_sparen                 = ignore   # ignore/add/remove/force/not_defined
 

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -685,6 +685,15 @@ Choices=sp_inside_sparen_close=ignore|sp_inside_sparen_close=add|sp_inside_spare
 ChoicesReadable="Ignore Sp Inside Sparen Close|Add Sp Inside Sparen Close|Remove Sp Inside Sparen Close|Force Sp Inside Sparen Close"
 ValueDefault=ignore
 
+[Sp Sparen Paren]
+Category=1
+Description="<html>Add or remove space between '((' or '))' of control statements.</html>"
+Enabled=false
+EditorType=multiple
+Choices=sp_sparen_paren=ignore|sp_sparen_paren=add|sp_sparen_paren=remove|sp_sparen_paren=force|sp_sparen_paren=not_defined
+ChoicesReadable="Ignore Sp Sparen Paren|Add Sp Sparen Paren|Remove Sp Sparen Paren|Force Sp Sparen Paren"
+ValueDefault=ignore
+
 [Sp After Sparen]
 Category=1
 Description="<html>Add or remove space after ')' of control statements.</html>"

--- a/src/options.h
+++ b/src/options.h
@@ -423,6 +423,10 @@ sp_inside_sparen_open;
 extern Option<iarf_e>
 sp_inside_sparen_close;
 
+// Add or remove space between '((' or '))' of control statements.
+extern Option<iarf_e>
+sp_sparen_paren;
+
 // Add or remove space after ')' of control statements.
 extern Option<iarf_e>
 sp_after_sparen;

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -2024,6 +2024,16 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_func_call_user_paren_paren");
          return(options::sp_func_call_user_paren_paren());
       }
+
+      if (  options::sp_sparen_paren() != IARF_IGNORE
+         && (  chunk_is_token(first, CT_SPAREN_OPEN)
+            || chunk_is_token(second, CT_SPAREN_CLOSE)))
+      {
+         // Add or remove space between nested parentheses with control
+         // statements, i.e. 'if ((' vs. 'if ( ('. Issue #3209
+         log_rule("sp_sparen_paren");
+         return(options::sp_sparen_paren());
+      }
       // Add or remove space between nested parentheses, i.e. '((' vs. ') )'.
       log_rule("sp_paren_paren");
       return(options::sp_paren_paren());

--- a/tests/c.test
+++ b/tests/c.test
@@ -394,3 +394,5 @@
 10014  indent_continue-8.cfg                c/sparen-indent.c
 10015  empty.cfg                            c/Issue_2845.h
 10016  Issue_3233.cfg                       c/Issue_3233.c
+10017  sp_sparen_paren-a.cfg                c/double-sparen.c
+10018  sp_sparen_paren-i.cfg                c/double-sparen.c

--- a/tests/cli/output/mini_d_uc.txt
+++ b/tests/cli/output/mini_d_uc.txt
@@ -76,6 +76,7 @@ sp_before_sparen                = ignore
 sp_inside_sparen                = ignore
 sp_inside_sparen_open           = ignore
 sp_inside_sparen_close          = ignore
+sp_sparen_paren                 = ignore
 sp_after_sparen                 = ignore
 sp_sparen_brace                 = ignore
 sp_do_brace_open                = ignore

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -324,6 +324,9 @@ sp_inside_sparen_open           = ignore   # ignore/add/remove/force/not_defined
 # Overrides sp_inside_sparen.
 sp_inside_sparen_close          = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space between '((' or '))' of control statements.
+sp_sparen_paren                 = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space after ')' of control statements.
 sp_after_sparen                 = ignore   # ignore/add/remove/force/not_defined
 

--- a/tests/cli/output/mini_nd_uc.txt
+++ b/tests/cli/output/mini_nd_uc.txt
@@ -76,6 +76,7 @@ sp_before_sparen                = ignore
 sp_inside_sparen                = ignore
 sp_inside_sparen_open           = ignore
 sp_inside_sparen_close          = ignore
+sp_sparen_paren                 = ignore
 sp_after_sparen                 = ignore
 sp_sparen_brace                 = ignore
 sp_do_brace_open                = ignore

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -324,6 +324,9 @@ sp_inside_sparen_open           = ignore   # ignore/add/remove/force/not_defined
 # Overrides sp_inside_sparen.
 sp_inside_sparen_close          = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space between '((' or '))' of control statements.
+sp_sparen_paren                 = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space after ')' of control statements.
 sp_after_sparen                 = ignore   # ignore/add/remove/force/not_defined
 

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -324,6 +324,9 @@ sp_inside_sparen_open           = ignore   # ignore/add/remove/force/not_defined
 # Overrides sp_inside_sparen.
 sp_inside_sparen_close          = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space between '((' or '))' of control statements.
+sp_sparen_paren                 = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space after ')' of control statements.
 sp_after_sparen                 = ignore   # ignore/add/remove/force/not_defined
 

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -703,6 +703,15 @@ Choices=sp_inside_sparen_close=ignore|sp_inside_sparen_close=add|sp_inside_spare
 ChoicesReadable="Ignore Sp Inside Sparen Close|Add Sp Inside Sparen Close|Remove Sp Inside Sparen Close|Force Sp Inside Sparen Close"
 ValueDefault=ignore
 
+[Sp Sparen Paren]
+Category=1
+Description="<html>Add or remove space between '((' or '))' of control statements.</html>"
+Enabled=false
+EditorType=multiple
+Choices=sp_sparen_paren=ignore|sp_sparen_paren=add|sp_sparen_paren=remove|sp_sparen_paren=force|sp_sparen_paren=not_defined
+ChoicesReadable="Ignore Sp Sparen Paren|Add Sp Sparen Paren|Remove Sp Sparen Paren|Force Sp Sparen Paren"
+ValueDefault=ignore
+
 [Sp After Sparen]
 Category=1
 Description="<html>Add or remove space after ')' of control statements.</html>"

--- a/tests/config/sp_sparen_paren-a.cfg
+++ b/tests/config/sp_sparen_paren-a.cfg
@@ -1,0 +1,2 @@
+# test for issue #3209
+sp_sparen_paren = add

--- a/tests/config/sp_sparen_paren-i.cfg
+++ b/tests/config/sp_sparen_paren-i.cfg
@@ -1,0 +1,3 @@
+# test for issue #3209
+sp_sparen_paren = ignore
+sp_paren_paren = add

--- a/tests/expected/c/10017-double-sparen.c
+++ b/tests/expected/c/10017-double-sparen.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int main() {
+	FILE *f;
+	if ( (f = fopen("/dev/null", "r")) )
+		puts("file is open");
+	return 0;
+}

--- a/tests/expected/c/10018-double-sparen.c
+++ b/tests/expected/c/10018-double-sparen.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int main() {
+	FILE *f;
+	if ( (f = fopen("/dev/null", "r") ) )
+		puts("file is open");
+	return 0;
+}

--- a/tests/input/c/double-sparen.c
+++ b/tests/input/c/double-sparen.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int main() {
+	FILE *f;
+	if ((f = fopen("/dev/null", "r")))
+		puts("file is open");
+	return 0;
+}


### PR DESCRIPTION
This option adds or removes spaces between double parentheses in control
statements. If set to 'ignore', the previous behavior controlled by
sp_paren_paren is preserved.

Fixes #3209