### PR TITLE
Apply sp_cparen_oparen to parenthesized indirect function calls

### DIFF
--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1602,9 +1602,9 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_after_cast");
          return(options::sp_after_cast());
       }
-      // Must be an indirect/chained function call?
-      log_rule("REMOVE");
-      return(IARF_REMOVE);  // TODO: make this configurable?
+      // Probably a parenthesized indirect function call or similar (issue #3260)
+      log_rule("sp_cparen_oparen");
+      return(options::sp_cparen_oparen());
    }
 
    // handle the space between parens in fcn type 'void (*f)(void)'

--- a/tests/c.test
+++ b/tests/c.test
@@ -398,3 +398,4 @@
 10018  sp_sparen_paren-i.cfg                c/double-sparen.c
 10019  pp_indent_in_guard.cfg               c/include-guard.h
 10020  indent_single_line_comments_after.cfg c/single_line_comment_after.c
+10021  sp_cparen_oparen-f.cfg               c/parenthesized_indirect_call.c

--- a/tests/config/ben_014.cfg
+++ b/tests/config/ben_014.cfg
@@ -18,6 +18,7 @@ sp_after_comma                  = force
 sp_func_proto_paren             = remove
 sp_inside_fparen                = remove
 sp_func_call_paren              = remove
+sp_cparen_oparen                = remove
 sp_before_dc                    = remove
 sp_after_dc                     = remove
 indent_columns                  = 3

--- a/tests/config/template_sp-remove.cfg
+++ b/tests/config/template_sp-remove.cfg
@@ -13,6 +13,7 @@ sp_inside_braces_struct         = force
 sp_inside_braces                = force
 sp_func_proto_paren             = remove
 sp_func_call_paren              = remove
+sp_cparen_oparen                = remove
 sp_angle_word                   = remove
 indent_columns                  = 3
 indent_class                    = true

--- a/tests/expected/c/02000-i2c-core.c
+++ b/tests/expected/c/02000-i2c-core.c
@@ -751,7 +751,7 @@ int i2c_control(struct i2c_client *client,
  * ----------------------------------------------------
  */
 static int i2c_probe_address(struct i2c_adapter *adapter, int addr, int kind,
-                             int (*found_proc)(struct i2c_adapter *, int, int))
+                             int (*found_proc) (struct i2c_adapter *, int, int))
 {
    int err;
 
@@ -797,7 +797,7 @@ static int i2c_probe_address(struct i2c_adapter *adapter, int addr, int kind,
 
 int i2c_probe(struct i2c_adapter *adapter,
               struct i2c_client_address_data *address_data,
-              int (*found_proc)(struct i2c_adapter *, int, int))
+              int (*found_proc) (struct i2c_adapter *, int, int))
 {
    int i, err;
    int adap_id = i2c_adapter_id(adapter);

--- a/tests/expected/c/02002-i2c-core.c
+++ b/tests/expected/c/02002-i2c-core.c
@@ -751,7 +751,7 @@ int i2c_control(struct i2c_client *client,
  * ----------------------------------------------------
  */
 static int i2c_probe_address(struct i2c_adapter *adapter, int addr, int kind,
-                             int (*found_proc)(struct i2c_adapter *, int, int))
+                             int (*found_proc) (struct i2c_adapter *, int, int))
 {
    int err;
 
@@ -797,7 +797,7 @@ static int i2c_probe_address(struct i2c_adapter *adapter, int addr, int kind,
 
 int i2c_probe(struct i2c_adapter *adapter,
               struct i2c_client_address_data *address_data,
-              int (*found_proc)(struct i2c_adapter *, int, int))
+              int (*found_proc) (struct i2c_adapter *, int, int))
 {
    int i, err;
    int adap_id = i2c_adapter_id(adapter);

--- a/tests/expected/c/02100-i2c-core.c
+++ b/tests/expected/c/02100-i2c-core.c
@@ -724,7 +724,7 @@ int i2c_control(struct i2c_client *client,
  * ----------------------------------------------------
  */
 static int i2c_probe_address(struct i2c_adapter *adapter, int addr, int kind,
-                             int (*found_proc)(struct i2c_adapter *, int, int))
+                             int (*found_proc) (struct i2c_adapter *, int, int))
   {
   int err;
 
@@ -764,7 +764,7 @@ static int i2c_probe_address(struct i2c_adapter *adapter, int addr, int kind,
 
 int i2c_probe(struct i2c_adapter *adapter,
               struct i2c_client_address_data *address_data,
-              int (*found_proc)(struct i2c_adapter *, int, int))
+              int (*found_proc) (struct i2c_adapter *, int, int))
   {
   int i, err;
   int adap_id = i2c_adapter_id(adapter);

--- a/tests/expected/c/10021-parenthesized_indirect_call.c
+++ b/tests/expected/c/10021-parenthesized_indirect_call.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+void hello(void)
+{
+        printf("Hello world!\n");
+}
+
+void (*get_hello(void)) (void)
+{
+        return hello;
+}
+
+int main()
+{
+        (get_hello()) ();
+        return 0;
+}

--- a/tests/expected/cpp/30100-templates.cpp
+++ b/tests/expected/cpp/30100-templates.cpp
@@ -68,7 +68,7 @@ class MyClass
 
 static int max_value()
 {
-   return (std :: numeric_limits  <int >:: max )();
+   return (std :: numeric_limits  <int >:: max ) ();
 }
 
 template < class Config_    >

--- a/tests/expected/cpp/30101-templates.cpp
+++ b/tests/expected/cpp/30101-templates.cpp
@@ -64,7 +64,7 @@ template<typename A, typename B, typename C> class MyClass
 
 static int max_value()
 {
-   return (std :: numeric_limits  <int >:: max )();
+   return (std :: numeric_limits  <int >:: max ) ();
 }
 
 template < class Config_    > priority_queue < Config_ >   ::   ~priority_queue ()  {

--- a/tests/expected/cpp/30102-templates.cpp
+++ b/tests/expected/cpp/30102-templates.cpp
@@ -65,7 +65,7 @@ template< typename A, typename B, typename C > class MyClass
 
 static int max_value()
 {
-   return (std :: numeric_limits < int >:: max )();
+   return (std :: numeric_limits < int >:: max ) ();
 }
 
 template< class Config_ >

--- a/tests/expected/cpp/31600-parameter-packs.cpp
+++ b/tests/expected/cpp/31600-parameter-packs.cpp
@@ -53,25 +53,25 @@ template  <  int  ... X  > int bar2()
 }
 
 template  <  class R, typename  ... Args  >
-void call2v(  R (  *fp  )(  Args  ...  )  );
+void call2v(  R (  *fp  )  (  Args  ...  )  );
 
 template  <  class R, typename  ... Args  >
-void call2p(  R (  *fp  )(  Args  *  ...  )  );
+void call2p(  R (  *fp  )  (  Args  *  ...  )  );
 
 template  <  class R, typename  ... Args  >
-void call2r(  R (  *fp  )(  Args  &&  ...  )  );
+void call2r(  R (  *fp  )  (  Args  &&  ...  )  );
 
 template  <  class R, typename  ... Args  >
-struct invoke2v :  invoke  <  R (  *  )(  Args  ...  )  >
+struct invoke2v :  invoke  <  R (  *  )  (  Args  ...  )  >
 {
 };
 
 template  <  class R, typename  ... Args  >
-struct invoke2p :  invoke  <  R (  *  )(  Args  *  ...  )  >
+struct invoke2p :  invoke  <  R (  *  )  (  Args  *  ...  )  >
 {
 };
 
 template  <  class R, typename  ... Args  >
-struct invoke2r :  invoke  <  R (  *  )(  Args  &&  ...  )  >
+struct invoke2r :  invoke  <  R (  *  )  (  Args  &&  ...  )  >
 {
 };

--- a/tests/expected/cpp/31601-parameter-packs.cpp
+++ b/tests/expected/cpp/31601-parameter-packs.cpp
@@ -53,25 +53,25 @@ template  <  int  ... X  > int bar2()
 }
 
 template  <  class R, typename  ... Args  >
-void call2v(  R (  *fp  )(  Args  ...  )  );
+void call2v(  R (  *fp  )  (  Args  ...  )  );
 
 template  <  class R, typename  ... Args  >
-void call2p(  R (  *fp  )(  Args  *  ...  )  );
+void call2p(  R (  *fp  )  (  Args  *  ...  )  );
 
 template  <  class R, typename  ... Args  >
-void call2r(  R (  *fp  )(  Args  &&  ...  )  );
+void call2r(  R (  *fp  )  (  Args  &&  ...  )  );
 
 template  <  class R, typename  ... Args  >
-struct invoke2v :  invoke  <  R (  *  )(  Args  ...  )  >
+struct invoke2v :  invoke  <  R (  *  )  (  Args  ...  )  >
 {
 };
 
 template  <  class R, typename  ... Args  >
-struct invoke2p :  invoke  <  R (  *  )(  Args  *  ...  )  >
+struct invoke2p :  invoke  <  R (  *  )  (  Args  *  ...  )  >
 {
 };
 
 template  <  class R, typename  ... Args  >
-struct invoke2r :  invoke  <  R (  *  )(  Args  &&  ...  )  >
+struct invoke2r :  invoke  <  R (  *  )  (  Args  &&  ...  )  >
 {
 };

--- a/tests/expected/cpp/31602-parameter-packs.cpp
+++ b/tests/expected/cpp/31602-parameter-packs.cpp
@@ -53,25 +53,25 @@ template  <  int  ... X  > int bar2()
 }
 
 template  <  class R, typename  ... Args  >
-void call2v(  R (  *fp  )(  Args  ...  )  );
+void call2v(  R (  *fp  )  (  Args  ...  )  );
 
 template  <  class R, typename  ... Args  >
-void call2p(  R (  *fp  )(  Args  *  ...  )  );
+void call2p(  R (  *fp  )  (  Args  *  ...  )  );
 
 template  <  class R, typename  ... Args  >
-void call2r(  R (  *fp  )(  Args  &&  ...  )  );
+void call2r(  R (  *fp  )  (  Args  &&  ...  )  );
 
 template  <  class R, typename  ... Args  >
-struct invoke2v :  invoke  <  R (  *  )(  Args  ...  )  >
+struct invoke2v :  invoke  <  R (  *  )  (  Args  ...  )  >
 {
 };
 
 template  <  class R, typename  ... Args  >
-struct invoke2p :  invoke  <  R (  *  )(  Args  *  ...  )  >
+struct invoke2p :  invoke  <  R (  *  )  (  Args  *  ...  )  >
 {
 };
 
 template  <  class R, typename  ... Args  >
-struct invoke2r :  invoke  <  R (  *  )(  Args  &&  ...  )  >
+struct invoke2r :  invoke  <  R (  *  )  (  Args  &&  ...  )  >
 {
 };

--- a/tests/expected/cpp/31603-parameter-packs.cpp
+++ b/tests/expected/cpp/31603-parameter-packs.cpp
@@ -53,25 +53,25 @@ template  <  int  ... X  > int bar2()
 }
 
 template  <  class R, typename  ... Args  >
-void call2v(  R (  *fp  )(  Args  ...  )  );
+void call2v(  R (  *fp  )  (  Args  ...  )  );
 
 template  <  class R, typename  ... Args  >
-void call2p(  R (  *fp  )(  Args  *  ...  )  );
+void call2p(  R (  *fp  )  (  Args  *  ...  )  );
 
 template  <  class R, typename  ... Args  >
-void call2r(  R (  *fp  )(  Args  &&  ...  )  );
+void call2r(  R (  *fp  )  (  Args  &&  ...  )  );
 
 template  <  class R, typename  ... Args  >
-struct invoke2v :  invoke  <  R (  *  )(  Args  ...  )  >
+struct invoke2v :  invoke  <  R (  *  )  (  Args  ...  )  >
 {
 };
 
 template  <  class R, typename  ... Args  >
-struct invoke2p :  invoke  <  R (  *  )(  Args  *  ...  )  >
+struct invoke2p :  invoke  <  R (  *  )  (  Args  *  ...  )  >
 {
 };
 
 template  <  class R, typename  ... Args  >
-struct invoke2r :  invoke  <  R (  *  )(  Args  &&  ...  )  >
+struct invoke2r :  invoke  <  R (  *  )  (  Args  &&  ...  )  >
 {
 };

--- a/tests/expected/cpp/31604-parameter-packs.cpp
+++ b/tests/expected/cpp/31604-parameter-packs.cpp
@@ -53,25 +53,25 @@ template  <  int  ... X  > int bar2()
 }
 
 template  <  class R, typename ... Args  >
-void call2v(  R (  *fp  )(  Args  ...  )  );
+void call2v(  R (  *fp  )  (  Args  ...  )  );
 
 template  <  class R, typename ... Args  >
-void call2p(  R (  *fp  )(  Args  *  ...  )  );
+void call2p(  R (  *fp  )  (  Args  *  ...  )  );
 
 template  <  class R, typename ... Args  >
-void call2r(  R (  *fp  )(  Args  &&  ...  )  );
+void call2r(  R (  *fp  )  (  Args  &&  ...  )  );
 
 template  <  class R, typename ... Args  >
-struct invoke2v :  invoke  <  R (  *  )(  Args  ...  )  >
+struct invoke2v :  invoke  <  R (  *  )  (  Args  ...  )  >
 {
 };
 
 template  <  class R, typename ... Args  >
-struct invoke2p :  invoke  <  R (  *  )(  Args  *  ...  )  >
+struct invoke2p :  invoke  <  R (  *  )  (  Args  *  ...  )  >
 {
 };
 
 template  <  class R, typename ... Args  >
-struct invoke2r :  invoke  <  R (  *  )(  Args  &&  ...  )  >
+struct invoke2r :  invoke  <  R (  *  )  (  Args  &&  ...  )  >
 {
 };

--- a/tests/expected/cpp/31605-parameter-packs.cpp
+++ b/tests/expected/cpp/31605-parameter-packs.cpp
@@ -53,25 +53,25 @@ template  <  int  ... X  > int bar2()
 }
 
 template  <  class R, typename... Args  >
-void call2v(  R (  *fp  )(  Args  ...  )  );
+void call2v(  R (  *fp  )  (  Args  ...  )  );
 
 template  <  class R, typename... Args  >
-void call2p(  R (  *fp  )(  Args  *  ...  )  );
+void call2p(  R (  *fp  )  (  Args  *  ...  )  );
 
 template  <  class R, typename... Args  >
-void call2r(  R (  *fp  )(  Args  &&  ...  )  );
+void call2r(  R (  *fp  )  (  Args  &&  ...  )  );
 
 template  <  class R, typename... Args  >
-struct invoke2v :  invoke  <  R (  *  )(  Args  ...  )  >
+struct invoke2v :  invoke  <  R (  *  )  (  Args  ...  )  >
 {
 };
 
 template  <  class R, typename... Args  >
-struct invoke2p :  invoke  <  R (  *  )(  Args  *  ...  )  >
+struct invoke2p :  invoke  <  R (  *  )  (  Args  *  ...  )  >
 {
 };
 
 template  <  class R, typename... Args  >
-struct invoke2r :  invoke  <  R (  *  )(  Args  &&  ...  )  >
+struct invoke2r :  invoke  <  R (  *  )  (  Args  &&  ...  )  >
 {
 };

--- a/tests/expected/cpp/31606-parameter-packs.cpp
+++ b/tests/expected/cpp/31606-parameter-packs.cpp
@@ -53,25 +53,25 @@ template  <  int ... X  > int bar2()
 }
 
 template  <  class R, typename  ... Args  >
-void call2v(  R (  *fp  )(  Args ...  )  );
+void call2v(  R (  *fp  )  (  Args ...  )  );
 
 template  <  class R, typename  ... Args  >
-void call2p(  R (  *fp  )(  Args  * ...  )  );
+void call2p(  R (  *fp  )  (  Args  * ...  )  );
 
 template  <  class R, typename  ... Args  >
-void call2r(  R (  *fp  )(  Args  && ...  )  );
+void call2r(  R (  *fp  )  (  Args  && ...  )  );
 
 template  <  class R, typename  ... Args  >
-struct invoke2v :  invoke  <  R (  *  )(  Args ...  )  >
+struct invoke2v :  invoke  <  R (  *  )  (  Args ...  )  >
 {
 };
 
 template  <  class R, typename  ... Args  >
-struct invoke2p :  invoke  <  R (  *  )(  Args  * ...  )  >
+struct invoke2p :  invoke  <  R (  *  )  (  Args  * ...  )  >
 {
 };
 
 template  <  class R, typename  ... Args  >
-struct invoke2r :  invoke  <  R (  *  )(  Args  && ...  )  >
+struct invoke2r :  invoke  <  R (  *  )  (  Args  && ...  )  >
 {
 };

--- a/tests/expected/cpp/31607-parameter-packs.cpp
+++ b/tests/expected/cpp/31607-parameter-packs.cpp
@@ -53,25 +53,25 @@ template  <  int... X  > int bar2()
 }
 
 template  <  class R, typename  ... Args  >
-void call2v(  R (  *fp  )(  Args...  )  );
+void call2v(  R (  *fp  )  (  Args...  )  );
 
 template  <  class R, typename  ... Args  >
-void call2p(  R (  *fp  )(  Args  *...  )  );
+void call2p(  R (  *fp  )  (  Args  *...  )  );
 
 template  <  class R, typename  ... Args  >
-void call2r(  R (  *fp  )(  Args  &&...  )  );
+void call2r(  R (  *fp  )  (  Args  &&...  )  );
 
 template  <  class R, typename  ... Args  >
-struct invoke2v :  invoke  <  R (  *  )(  Args...  )  >
+struct invoke2v :  invoke  <  R (  *  )  (  Args...  )  >
 {
 };
 
 template  <  class R, typename  ... Args  >
-struct invoke2p :  invoke  <  R (  *  )(  Args  *...  )  >
+struct invoke2p :  invoke  <  R (  *  )  (  Args  *...  )  >
 {
 };
 
 template  <  class R, typename  ... Args  >
-struct invoke2r :  invoke  <  R (  *  )(  Args  &&...  )  >
+struct invoke2r :  invoke  <  R (  *  )  (  Args  &&...  )  >
 {
 };

--- a/tests/expected/cpp/31608-parameter-packs.cpp
+++ b/tests/expected/cpp/31608-parameter-packs.cpp
@@ -53,25 +53,25 @@ template  <  int  ... X  > int bar2()
 }
 
 template  <  class R, typename  ... Args  >
-void call2v(  R (  *fp  )(  Args  ...  )  );
+void call2v(  R (  *fp  )  (  Args  ...  )  );
 
 template  <  class R, typename  ... Args  >
-void call2p(  R (  *fp  )(  Args  *  ...  )  );
+void call2p(  R (  *fp  )  (  Args  *  ...  )  );
 
 template  <  class R, typename  ... Args  >
-void call2r(  R (  *fp  )(  Args  &&  ...  )  );
+void call2r(  R (  *fp  )  (  Args  &&  ...  )  );
 
 template  <  class R, typename  ... Args  >
-struct invoke2v :  invoke  <  R (  *  )(  Args  ...  )  >
+struct invoke2v :  invoke  <  R (  *  )  (  Args  ...  )  >
 {
 };
 
 template  <  class R, typename  ... Args  >
-struct invoke2p :  invoke  <  R (  *  )(  Args  *  ...  )  >
+struct invoke2p :  invoke  <  R (  *  )  (  Args  *  ...  )  >
 {
 };
 
 template  <  class R, typename  ... Args  >
-struct invoke2r :  invoke  <  R (  *  )(  Args  &&  ...  )  >
+struct invoke2r :  invoke  <  R (  *  )  (  Args  &&  ...  )  >
 {
 };

--- a/tests/expected/cpp/31609-parameter-packs.cpp
+++ b/tests/expected/cpp/31609-parameter-packs.cpp
@@ -53,25 +53,25 @@ template  <  int  ... X  > int bar2()
 }
 
 template  <  class R, typename  ... Args  >
-void call2v(  R (  *fp  )(  Args  ...  )  );
+void call2v(  R (  *fp  )  (  Args  ...  )  );
 
 template  <  class R, typename  ... Args  >
-void call2p(  R (  *fp  )(  Args  *  ...  )  );
+void call2p(  R (  *fp  )  (  Args  *  ...  )  );
 
 template  <  class R, typename  ... Args  >
-void call2r(  R (  *fp  )(  Args  &&  ...  )  );
+void call2r(  R (  *fp  )  (  Args  &&  ...  )  );
 
 template  <  class R, typename  ... Args  >
-struct invoke2v :  invoke  <  R (  *  )(  Args  ...  )  >
+struct invoke2v :  invoke  <  R (  *  )  (  Args  ...  )  >
 {
 };
 
 template  <  class R, typename  ... Args  >
-struct invoke2p :  invoke  <  R (  *  )(  Args  *  ...  )  >
+struct invoke2p :  invoke  <  R (  *  )  (  Args  *  ...  )  >
 {
 };
 
 template  <  class R, typename  ... Args  >
-struct invoke2r :  invoke  <  R (  *  )(  Args  &&  ...  )  >
+struct invoke2r :  invoke  <  R (  *  )  (  Args  &&  ...  )  >
 {
 };

--- a/tests/expected/cpp/34209-lambda_selfcalling.cpp
+++ b/tests/expected/cpp/34209-lambda_selfcalling.cpp
@@ -6,5 +6,5 @@ void f(){
 
 	const auto l = ([](int k){
 		return k+2;
-	})(i);
+	})                     (i);
 }

--- a/tests/expected/cpp/60006-UNI-2049.cpp
+++ b/tests/expected/cpp/60006-UNI-2049.cpp
@@ -1,5 +1,5 @@
 // Pointer mark should be formatted (WINAPI* SetXX)
-typedef DWORD (WINAPI* SetDllDirectory)(LPCSTR);
+typedef DWORD (WINAPI* SetDllDirectory) (LPCSTR);
 // Pointer mark should be formatted (EXCEPTION_POINTERS* pExt)
 static LONG WINAPI CustomUnhandledExceptionFilter(EXCEPTION_POINTERS* pExInfo)
 {

--- a/tests/expected/oc/50630-nl_func_call_args_multi_line_ignore_closures.m
+++ b/tests/expected/oc/50630-nl_func_call_args_multi_line_ignore_closures.m
@@ -20,7 +20,7 @@ mapToPtr(arg1, ^ ( NSString *) (const Props &addOnProps) {
 	FSTheme *const theme = AK::getTheme();
 });
 
-mapToPtr( ^()(const Props &addOnProps) {
+mapToPtr( ^() (const Props &addOnProps) {
 	FSTheme *const theme = AK::getTheme();
 }, arg2);
 

--- a/tests/input/c/parenthesized_indirect_call.c
+++ b/tests/input/c/parenthesized_indirect_call.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+void hello(void)
+{
+        printf("Hello world!\n");
+}
+
+void (*get_hello(void))(void)
+{
+        return hello;
+}
+
+int main()
+{
+        (get_hello())();
+        return 0;
+}


### PR DESCRIPTION
`sp_cparen_oparen` is the right option to apply to `(get_hello())()`. Furthermore, this patch provides a workaround for issue #3252 because setting `sp_cparen_oparen = ignore` will avoid unwanted space removal in cases where Uncrustify does not parse function pointers correctly.