### PR TITLE
Add CLI option to dump formatting steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,18 @@ tokenize(2351): orig_line is 1, orig_col is 7, text() 'Capteur', type is WORD, o
 tokenize(2351): orig_line is 1, orig_col is 15, text() '{', type is BRACE_OPEN, orig_col_end is 16
 ```
 
+You can also dump the parsing information of each formatting step using the 'dump steps' option.
+```.txt
+   uncrustify -c myExample.cfg -f myExample.cpp -ds dump
+```
+This will create a series of 'dump_nnn.log' files, each containing the parsing information at
+specific points of the formatting process ('dump_000.log' will list the formatting options in use).
+
+You can combine this option with -p and -L to get a lot of detailed debugging information.
+```.txt
+   uncrustify -c myExample.cfg -f myExample.cpp -p myExample.p -L A 2>myExample.A -ds dump
+```
+
 It might be useful to add some code lines to see where something is happening.
 Use the package `unc_tools`.
 Remove the comment at line:

--- a/documentation/dump-steps.txt
+++ b/documentation/dump-steps.txt
@@ -1,0 +1,53 @@
+
+This file describes the purpose of the 'dump steps' command line option.
+
+
+OVERVIEW
+--------
+The '-ds/--dump-steps' option instructs uncrustify to log a lot of debug information 
+throughout the formatting process, which can be very useful when trying to understand
+why something is being formatted in the way it is. This is usually the case when the
+expected results do not match with the actual ones.
+
+
+COMPARISON WITH '-p' OPTION
+---------------------------
+While the '-p' option only prints the parsing information at the end of the process,
+the '-ds' option will print the same information at many points in time, providing 
+extra depth to users and developers when troubleshooting an issue.
+
+
+GENERATED FILES
+---------------
+Add '-ds FILE' to the command line options to enable the functionality.
+This will create a number of files as follow:
+
+- FILE_000.log:   this file contains the list of the options used by uncrustify
+- FILE_001.log:   this file lists the parsing status after uncrustify has read the input file
+                  and before starting the formatting process.
+- FILE_002.log:   this file lists the parsing status before uncrustify enters its first internal
+                  while loop
+- FILE_AAA.log - FILE_BBB.log: a variable number of files, depending on the progress of the
+                  formatting process. Each file is printed at the end of one iteration of the
+								  first internal while loop.
+- FILE_BBB+1.log: this file lists the parsing status before uncrustify enters its second internal
+                  while loop
+- FILE_BBB+2.log - FILE_CCC.log: a variable number of files, depending on the progress of the
+                  formatting process. Each file is printed at the end of one iteration of the
+								  second internal while loop.
+- FILE_CCC+1.log: this file lists the parsing status at the end of the process.
+
+NOTE: by combining FILE_000.log and FILE_CCC+1.log, you will get the same content of the parsing
+      file obtained with the '-p' option.
+
+
+USAGE
+-----
+Comparing each file with the previous one will help understanding why something is being formatted
+the way it is. When debugging a formatting issue, this provides a quick way to restrict the
+section of the code that should be investigated.
+
+The first line of each file contains a brief descriptive string which can be used to quickly find the
+point in the code where the file was created. Look for 'dump_step(dump_file, <descriptive string>)' in
+src/uncrustify.cpp.
+

--- a/man/uncrustify.1.in
+++ b/man/uncrustify.1.in
@@ -121,6 +121,17 @@ Dump debug info into \fIFILE\fR, or to stdout if \fIFILE\fR is set to '-'.
 .br
 Must be used in combination with '-f \fIFILE\fR'.
 .TP
+\fB\-ds \fIFILE\fR \fB\-\-dump\-steps \fIFILE\fR
+Dump parsing info at various moments of the formatting process.
+.br
+This creates a series of files named '\fIFILE\fR_nnn.log', each
+.br
+corresponding to a formatting step in uncrustify.
+.br
+The file '\fIFILE\fR_000.log' lists the formatting options in use.
+.br
+Must be used in combination with '-f \fIFILE\fR'.
+.TP
 \fB\-L\fI SEV\fR
 Set the log severity (see log_levels.h)
 .TP

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -448,12 +448,14 @@ static void cmt_output_indent(size_t brace_col, size_t base_col, size_t column)
 } // cmt_output_indent
 
 
-void output_parsed(FILE *pfile)
+void output_parsed(FILE *pfile, bool withOptions)
 {
    const char *eol_marker = get_eol_marker();
 
-   save_option_file(pfile, false, true);
-
+   if (withOptions)
+   {
+      save_option_file(pfile, false, true);
+   }
    fprintf(pfile, "# -=====-%s", eol_marker);
    fprintf(pfile, "# number of loops               = %d\n", cpd.changes);
    fprintf(pfile, "# -=====-%s", eol_marker);
@@ -921,6 +923,46 @@ void output_text(FILE *pfile)
       add_text("</html>\n");
    }
 } // output_text
+
+
+void dump_step(const char *filename, const char *step_description)
+{
+   static int file_num = 0;
+   char       dump_filename[256];
+   FILE       *dump_file;
+
+   if (  filename == nullptr
+      || strlen(filename) == 0)
+   {
+      return;
+   }
+
+   // On the first call, also save the options in use
+   if (file_num == 0)
+   {
+      sprintf(dump_filename, "%s_%03d.log", filename, file_num);
+      ++file_num;
+
+      dump_file = fopen(dump_filename, "wb");
+
+      if (dump_file != nullptr)
+      {
+         save_option_file(dump_file, false, true);
+         fclose(dump_file);
+      }
+   }
+   sprintf(dump_filename, "%s_%03d.log", filename, file_num);
+   ++file_num;
+
+   dump_file = fopen(dump_filename, "wb");
+
+   if (dump_file != nullptr)
+   {
+      fprintf(dump_file, "STEP: %s\n--------------\n", step_description);
+      output_parsed(dump_file, false);
+      fclose(dump_file);
+   }
+} // dump_step
 
 
 static size_t cmt_parse_lead(const unc_text &line, bool is_last)

--- a/src/output.h
+++ b/src/output.h
@@ -15,7 +15,7 @@
 
 
 //! This renders the chunk list to a file.
-void output_parsed(FILE *pfile);
+void output_parsed(FILE *pfile, bool withOptions = true);
 
 
 //! This renders the chunk list to a file formatted as csv.
@@ -24,6 +24,10 @@ void output_parsed_csv(FILE *pfile);
 
 //! This renders the chunk list to a file.
 void output_text(FILE *pfile);
+
+
+//! This save the next formatting step to a file
+void dump_step(const char *filename, const char *description);
 
 
 /**

--- a/src/uncrustify.h
+++ b/src/uncrustify.h
@@ -16,7 +16,7 @@
 int load_header_files(void);
 
 
-void uncrustify_file(const file_mem &fm, FILE *pfout, const char *parsed_file, bool defer_uncrustify_end = false);
+void uncrustify_file(const file_mem &fm, FILE *pfout, const char *parsed_file, const char *dump_filename, bool defer_uncrustify_end = false);
 
 
 void uncrustify_end();

--- a/src/uncrustify_emscripten.cpp
+++ b/src/uncrustify_emscripten.cpp
@@ -25,6 +25,7 @@
  *   --replace
  *   --mtime
  *   --universalindent
+ *   --ds/--dump-steps
  *   -help, -h, --usage, -?
  *
  *
@@ -557,7 +558,7 @@ intptr_t _uncrustify(intptr_t _file, lang_flag_e langIDX, bool frag, bool defer)
    // function which passes the debug output into a dedicated output js target.
    // This therefore would introduce the dependency on the user to always have
    // the output js target available.
-   uncrustify_file(fm, stream, nullptr, defer);
+   uncrustify_file(fm, stream, nullptr, nullptr, defer);
 
    fflush(stream);
    fclose(stream);

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -53,6 +53,11 @@ Config/Help Options:
 Debug Options:
  -p FILE               : Dump debug info into FILE, or to stdout if FILE is set to '-'.
                          Must be used in combination with '-f FILE'
+ -ds FILE              : Dump parsing info at various moments of the formatting process.
+ --dump-steps FILE       This creates a series of files named 'FILE_nnn.log', each
+                         corresponding to a formatting step in uncrustify.
+                         The file 'FILE_000.log' lists the formatting options in use.
+                         Must be used in combination with '-f FILE'
  -L SEV                : Set the log severity (see log_levels.h; note 'A' = 'all')
  -s                    : Show the log severity in the logs.
  --decode              : Decode remaining args (chunk flags) and exit.
@@ -64,6 +69,7 @@ cat foo.d | uncrustify -q -c my.cfg -l d
 uncrustify -c my.cfg -f foo.d
 uncrustify -c my.cfg -f foo.d -L0-2,20-23,51
 uncrustify -c my.cfg -f foo.d -o foo.d
+uncrustify -c my.cfg -f foo.d -o foo.d -ds dump
 uncrustify -c my.cfg foo.d
 uncrustify -c my.cfg --replace foo.d
 uncrustify -c my.cfg --no-backup foo.d


### PR DESCRIPTION
Add ability to dump the parsing information at different steps of the formatting process. See documentation in the code for more details. 
Useful for debugging complicated issues.