### PR TITLE
Avoid null pointer dereference when formatting function-like macros

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3197,7 +3197,8 @@ static void newline_func_def_or_call(chunk_t *start)
                log_rule_B("nl_func_leave_one_liners");
 
                if (  options::nl_func_leave_one_liners()
-                  && brace->flags.test(PCF_ONE_LINER))                 // Issue #1511
+                  && (  brace == nullptr
+                     || brace->flags.test(PCF_ONE_LINER)))   // Issue #1511 and #3274
                {
                   a = IARF_IGNORE;
                }

--- a/tests/c.test
+++ b/tests/c.test
@@ -401,3 +401,4 @@
 10021  sp_cparen_oparen-f.cfg               c/parenthesized_indirect_call.c
 10022  Issue_3269.cfg                       c/Issue_3269.c
 10023  Issue_3272.cfg                       c/Issue_3272.h
+10024  Issue_3274.cfg                       c/Issue_3274.c

--- a/tests/config/Issue_3274.cfg
+++ b/tests/config/Issue_3274.cfg
@@ -1,0 +1,2 @@
+nl_func_decl_args_multi_line = true
+nl_func_leave_one_liners = true

--- a/tests/expected/c/10024-Issue_3274.c
+++ b/tests/expected/c/10024-Issue_3274.c
@@ -1,0 +1,5 @@
+#define FOO
+#define BAR()
+
+FOO
+BAR()

--- a/tests/input/c/Issue_3274.c
+++ b/tests/input/c/Issue_3274.c
@@ -1,0 +1,5 @@
+#define FOO
+#define BAR()
+
+FOO
+BAR()


### PR DESCRIPTION
Fixes #3274