### PR TITLE
Fix wrong documentation for 'nl_after_brace_open' option

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -1881,8 +1881,7 @@ nl_type_brace_init_lst_open     = ignore   # ignore/add/remove/force/not_defined
 # direct-list-initialization.
 nl_type_brace_init_lst_close    = ignore   # ignore/add/remove/force/not_defined
 
-# Whether to add a newline after '{'. This also adds a newline before the
-# matching '}'.
+# Whether to add a newline after '{'.
 nl_after_brace_open             = false    # true/false
 
 # Whether to add a newline between the open brace and a trailing single-line

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -1881,8 +1881,7 @@ nl_type_brace_init_lst_open     = ignore   # ignore/add/remove/force/not_defined
 # direct-list-initialization.
 nl_type_brace_init_lst_close    = ignore   # ignore/add/remove/force/not_defined
 
-# Whether to add a newline after '{'. This also adds a newline before the
-# matching '}'.
+# Whether to add a newline after '{'.
 nl_after_brace_open             = false    # true/false
 
 # Whether to add a newline between the open brace and a trailing single-line

--- a/etc/ben.cfg
+++ b/etc/ben.cfg
@@ -794,7 +794,6 @@ nl_fdef_brace                             = add      # ignore/add/remove/force
 nl_after_semicolon                        = true     # false/true
 
 # Whether to put a newline after brace open.
-# This also adds a newline before the matching brace close.
 nl_after_brace_open                       = true     # false/true
 
 # If nl_after_brace_open and nl_after_brace_open_cmt are true, a newline is

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1878,8 +1878,7 @@ nl_type_brace_init_lst_open     = ignore   # ignore/add/remove/force/not_defined
 # direct-list-initialization.
 nl_type_brace_init_lst_close    = ignore   # ignore/add/remove/force/not_defined
 
-# Whether to add a newline after '{'. This also adds a newline before the
-# matching '}'.
+# Whether to add a newline after '{'.
 nl_after_brace_open             = false    # true/false
 
 # Whether to add a newline between the open brace and a trailing single-line

--- a/etc/sun.cfg
+++ b/etc/sun.cfg
@@ -1276,7 +1276,6 @@ nl_after_semicolon                        = true     # false/true
 nl_paren_dbrace_open                      = remove   # ignore/add/remove/force
 
 # Whether to put a newline after brace open.
-# This also adds a newline before the matching brace close.
 nl_after_brace_open                       = true     # false/true
 
 # If nl_after_brace_open and nl_after_brace_open_cmt are true, a newline is

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -4293,7 +4293,7 @@ ValueDefault=ignore
 
 [Nl After Brace Open]
 Category=3
-Description="<html>Whether to add a newline after '{'. This also adds a newline before the<br/>matching '}'.</html>"
+Description="<html>Whether to add a newline after '{'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_brace_open=true|nl_after_brace_open=false

--- a/src/options.h
+++ b/src/options.h
@@ -2344,8 +2344,7 @@ nl_type_brace_init_lst_open;
 extern Option<iarf_e>
 nl_type_brace_init_lst_close;
 
-// Whether to add a newline after '{'. This also adds a newline before the
-// matching '}'.
+// Whether to add a newline after '{'.
 extern Option<bool>
 nl_after_brace_open;
 

--- a/tests/cli/output/mini_d_ucwd.txt
+++ b/tests/cli/output/mini_d_ucwd.txt
@@ -1895,8 +1895,7 @@ nl_type_brace_init_lst_open     = ignore   # ignore/add/remove/force/not_defined
 # direct-list-initialization.
 nl_type_brace_init_lst_close    = ignore   # ignore/add/remove/force/not_defined
 
-# Whether to add a newline after '{'. This also adds a newline before the
-# matching '}'.
+# Whether to add a newline after '{'.
 nl_after_brace_open             = false    # true/false
 
 # Whether to add a newline between the open brace and a trailing single-line

--- a/tests/cli/output/mini_nd_ucwd.txt
+++ b/tests/cli/output/mini_nd_ucwd.txt
@@ -1895,8 +1895,7 @@ nl_type_brace_init_lst_open     = ignore   # ignore/add/remove/force/not_defined
 # direct-list-initialization.
 nl_type_brace_init_lst_close    = ignore   # ignore/add/remove/force/not_defined
 
-# Whether to add a newline after '{'. This also adds a newline before the
-# matching '}'.
+# Whether to add a newline after '{'.
 nl_after_brace_open             = false    # true/false
 
 # Whether to add a newline between the open brace and a trailing single-line

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1895,8 +1895,7 @@ nl_type_brace_init_lst_open     = ignore   # ignore/add/remove/force/not_defined
 # direct-list-initialization.
 nl_type_brace_init_lst_close    = ignore   # ignore/add/remove/force/not_defined
 
-# Whether to add a newline after '{'. This also adds a newline before the
-# matching '}'.
+# Whether to add a newline after '{'.
 nl_after_brace_open             = false    # true/false
 
 # Whether to add a newline between the open brace and a trailing single-line

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -4320,7 +4320,7 @@ ValueDefault=ignore
 
 [Nl After Brace Open]
 Category=3
-Description="<html>Whether to add a newline after '{'. This also adds a newline before the<br/>matching '}'.</html>"
+Description="<html>Whether to add a newline after '{'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_brace_open=true|nl_after_brace_open=false


### PR DESCRIPTION
The 'nl_after_brace_open' option only adds a new line after the brace. It does not affect the closing parenthesis.