### PR TITLE
Add log message when a dump file is created

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -928,7 +928,7 @@ void output_text(FILE *pfile)
 void dump_step(const char *filename, const char *step_description)
 {
    static int file_num = 0;
-   char       dump_filename[256];
+   char       buffer[256];
    FILE       *dump_file;
 
    if (  filename == nullptr
@@ -940,10 +940,13 @@ void dump_step(const char *filename, const char *step_description)
    // On the first call, also save the options in use
    if (file_num == 0)
    {
-      sprintf(dump_filename, "%s_%03d.log", filename, file_num);
+      snprintf(buffer, 256, "New dump file: %s_%03d.log - Options in use", filename, file_num);
+      log_rule_B(buffer);
+
+      snprintf(buffer, 256, "%s_%03d.log", filename, file_num);
       ++file_num;
 
-      dump_file = fopen(dump_filename, "wb");
+      dump_file = fopen(buffer, "wb");
 
       if (dump_file != nullptr)
       {
@@ -951,10 +954,13 @@ void dump_step(const char *filename, const char *step_description)
          fclose(dump_file);
       }
    }
-   sprintf(dump_filename, "%s_%03d.log", filename, file_num);
+   snprintf(buffer, 256, "New dump file: %s_%03d.log - %s", filename, file_num, step_description);
+   log_rule_B(buffer);
+
+   snprintf(buffer, 256, "%s_%03d.log", filename, file_num);
    ++file_num;
 
-   dump_file = fopen(dump_filename, "wb");
+   dump_file = fopen(buffer, "wb");
 
    if (dump_file != nullptr)
    {


### PR DESCRIPTION
This adds a message to the log when a dump step file is created.
This is useful to identify which part of the log file is related to each dump file when using 
```
uncrustify -c myExample.cfg -f myExample.cpp -L A 2>myExample.A -ds dump
```
since the additional messages serves as "logical divider" of a very long log file.