### PR TITLE
Fix tracking_space tests for non-debug builds

### DIFF
--- a/tests/cli/test_cli_options.py
+++ b/tests/cli/test_cli_options.py
@@ -706,19 +706,7 @@ def main(args):
     #
     # Test --tracking_space FILE
     #
-    if parsed_args.config == 'Release' or parsed_args.config == 'RelWithDebInfo':
-        eprint(parsed_args.config)
-        if not check_uncrustify_output(
-                uncr_bin,
-                parsed_args,
-                args_arr=['-c', s_path_join(script_dir, 'config/tracking_space.cfg'),
-                          '-f', s_path_join(script_dir, 'input/tracking_space.cpp'),
-                          '--tracking_space', s_path_join(script_dir, 'results/tracking_space.html')],
-                gen_expected_path=s_path_join(script_dir, 'output/tracking_space.html'),
-                gen_result_path=s_path_join(script_dir, 'results/tracking_space.html'),
-                ):
-            return_flag = False
-    else:
+    if parsed_args.config == 'Debug':
         eprint("Debug")
         if not check_uncrustify_output(
                 uncr_bin,
@@ -727,6 +715,18 @@ def main(args):
                           '-f', s_path_join(script_dir, 'input/tracking_space.cpp'),
                           '--tracking_space', s_path_join(script_dir, 'results/tracking_space.html')],
                 gen_expected_path=s_path_join(script_dir, 'output/Debug_tracking_space.html'),
+                gen_result_path=s_path_join(script_dir, 'results/tracking_space.html'),
+                ):
+            return_flag = False
+    else:
+        eprint(parsed_args.config)
+        if not check_uncrustify_output(
+                uncr_bin,
+                parsed_args,
+                args_arr=['-c', s_path_join(script_dir, 'config/tracking_space.cfg'),
+                          '-f', s_path_join(script_dir, 'input/tracking_space.cpp'),
+                          '--tracking_space', s_path_join(script_dir, 'results/tracking_space.html')],
+                gen_expected_path=s_path_join(script_dir, 'output/tracking_space.html'),
                 gen_result_path=s_path_join(script_dir, 'results/tracking_space.html'),
                 ):
             return_flag = False


### PR DESCRIPTION
This should fix https://github.com/uncrustify/uncrustify/issues/3196.

Of course, packagers should use `Release` or `RelWithDebInfo` build types anyway, but with this PR other types (e.g. `MinSizeRel` or `undefined`) won't fail as well.