### PR TITLE
Upgrade cmake_minimum_required of tests/CMakeLists.txt to 2.8.12

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 find_package(Git QUIET)
 


### PR DESCRIPTION
This is done to suppress the Cmake deprecation warning each time
uncrustify is built.