### PR TITLE
Fix grammar in indent_switch_case and indent_case_brace documentation

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -1203,12 +1203,12 @@ indent_sparen_extra             = 0        # number
 indent_relative_single_line_comments = false    # true/false
 
 # Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.
-# It might wise to choose the same value for the option indent_case_brace.
+# It might be wise to choose the same value for the option indent_case_brace.
 indent_switch_case              = 0        # unsigned number
 
 # Spaces to indent '{' from 'case'. By default, the brace will appear under
 # the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.
-# It might wise to choose the same value for the option indent_switch_case.
+# It might be wise to choose the same value for the option indent_switch_case.
 indent_case_brace               = 0        # number
 
 # indent 'break' with 'case' from 'switch'.

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -1203,12 +1203,12 @@ indent_sparen_extra             = 0        # number
 indent_relative_single_line_comments = false    # true/false
 
 # Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.
-# It might wise to choose the same value for the option indent_case_brace.
+# It might be wise to choose the same value for the option indent_case_brace.
 indent_switch_case              = 0        # unsigned number
 
 # Spaces to indent '{' from 'case'. By default, the brace will appear under
 # the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.
-# It might wise to choose the same value for the option indent_switch_case.
+# It might be wise to choose the same value for the option indent_switch_case.
 indent_case_brace               = 0        # number
 
 # indent 'break' with 'case' from 'switch'.

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1195,12 +1195,12 @@ indent_sparen_extra             = 0        # number
 indent_relative_single_line_comments = false    # true/false
 
 # Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.
-# It might wise to choose the same value for the option indent_case_brace.
+# It might be wise to choose the same value for the option indent_case_brace.
 indent_switch_case              = 0        # unsigned number
 
 # Spaces to indent '{' from 'case'. By default, the brace will appear under
 # the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.
-# It might wise to choose the same value for the option indent_switch_case.
+# It might be wise to choose the same value for the option indent_switch_case.
 indent_case_brace               = 0        # number
 
 # indent 'break' with 'case' from 'switch'.

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -2707,7 +2707,7 @@ ValueDefault=false
 
 [Indent Switch Case]
 Category=2
-Description="<html>Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.<br/>It might wise to choose the same value for the option indent_case_brace.</html>"
+Description="<html>Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.<br/>It might be wise to choose the same value for the option indent_case_brace.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_switch_case="
@@ -2717,7 +2717,7 @@ ValueDefault=0
 
 [Indent Case Brace]
 Category=2
-Description="<html>Spaces to indent '{' from 'case'. By default, the brace will appear under<br/>the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.<br/>It might wise to choose the same value for the option indent_switch_case.</html>"
+Description="<html>Spaces to indent '{' from 'case'. By default, the brace will appear under<br/>the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.<br/>It might be wise to choose the same value for the option indent_switch_case.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_case_brace="

--- a/src/options.h
+++ b/src/options.h
@@ -1514,13 +1514,13 @@ extern Option<bool>
 indent_relative_single_line_comments;
 
 // Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.
-// It might wise to choose the same value for the option indent_case_brace.
+// It might be wise to choose the same value for the option indent_case_brace.
 extern BoundedOption<unsigned, 0, 16>
 indent_switch_case;
 
 // Spaces to indent '{' from 'case'. By default, the brace will appear under
 // the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.
-// It might wise to choose the same value for the option indent_switch_case.
+// It might be wise to choose the same value for the option indent_switch_case.
 extern BoundedOption<signed, -16, 16>
 indent_case_brace;
 

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2789,7 +2789,7 @@ ValueDefault=false
 
 [Indent Switch Case]
 Category=2
-Description="<html>Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.<br/>It might wise to choose the same value for the option indent_case_brace.</html>"
+Description="<html>Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.<br/>It might be wise to choose the same value for the option indent_case_brace.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_switch_case="
@@ -2799,7 +2799,7 @@ ValueDefault=0
 
 [Indent Case Brace]
 Category=2
-Description="<html>Spaces to indent '{' from 'case'. By default, the brace will appear under<br/>the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.<br/>It might wise to choose the same value for the option indent_switch_case.</html>"
+Description="<html>Spaces to indent '{' from 'case'. By default, the brace will appear under<br/>the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.<br/>It might be wise to choose the same value for the option indent_switch_case.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_case_brace="


### PR DESCRIPTION
Just a minor problem I noticed while working on indent_switch_body.