### PR TITLE
Fix regression introduced by commit eb8b6af4, which broke the update-cli-options target.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -85,6 +85,7 @@ add_custom_target(update-cli-options
     --config $<CONFIG>
     --build ${uncrustify_BINARY_DIR}
     --apply
+    --test ${CMAKE_CURRENT_BINARY_DIR}/cli
   DEPENDS uncrustify
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cli
 )


### PR DESCRIPTION
As per title. Running ninja update-cli-options was giving the following error:
```
Uncrustify binary found: /home/software/uncrustify/02-uncrustify-build/obj-x86_64-linux-gnu/uncrustify
Traceback (most recent call last):
  File "/home/software/uncrustify/02-uncrustify-build/tests/cli/test_cli_options.py", line 855, in <module>
    main(argv[1:])
  File "/home/software/uncrustify/02-uncrustify-build/tests/cli/test_cli_options.py", line 518, in main
    clear_dir(s_path_join(test_dir, 'results'))
  File "/home/software/uncrustify/02-uncrustify-build/tests/cli/test_cli_options.py", line 462, in s_path_join
    p_splits = list(path_split(path))
  File "/usr/lib/python3.9/posixpath.py", line 103, in split
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```