### PR TITLE
Add indent_ignore_label option

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -1261,7 +1261,10 @@ indent_col1_multi_string_literal = false    # true/false
 # Default: 3
 indent_comment_align_thresh     = 3        # unsigned number
 
-# How to indent goto labels.
+# Whether to ignore indent for goto labels.
+indent_ignore_label             = false    # true/false
+
+# How to indent goto labels. Requires indent_ignore_label=false.
 #
 #  >0: Absolute column where 1 is the leftmost column
 # <=0: Subtract from brace indent

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -1261,7 +1261,10 @@ indent_col1_multi_string_literal = false    # true/false
 # Default: 3
 indent_comment_align_thresh     = 3        # unsigned number
 
-# How to indent goto labels.
+# Whether to ignore indent for goto labels.
+indent_ignore_label             = false    # true/false
+
+# How to indent goto labels. Requires indent_ignore_label=false.
 #
 #  >0: Absolute column where 1 is the leftmost column
 # <=0: Subtract from brace indent

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -2820,9 +2820,17 @@ EditorType=boolean
 TrueFalse=indent_col1_multi_string_literal=true|indent_col1_multi_string_literal=false
 ValueDefault=false
 
+[Indent Ignore Label]
+Category=2
+Description="<html>Whether to ignore indent for goto labels.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=indent_ignore_label=true|indent_ignore_label=false
+ValueDefault=false
+
 [Indent Label]
 Category=2
-Description="<html>How to indent goto labels.<br/><br/> &gt;0: Absolute column where 1 is the leftmost column<br/>&lt;=0: Subtract from brace indent<br/><br/>Default: 1</html>"
+Description="<html>How to indent goto labels. Requires indent_ignore_label=false.<br/><br/> &gt;0: Absolute column where 1 is the leftmost column<br/>&lt;=0: Subtract from brace indent<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_label="

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2256,29 +2256,37 @@ void indent_text(void)
       }
       else if (chunk_is_token(pc, CT_LABEL))
       {
-         log_rule_B("indent_label");
-         const auto val        = options::indent_label();
-         const auto pse_indent = frm.top().indent;
-
-         // Labels get sent to the left or backed up
-         if (val > 0)
+         if (options::indent_ignore_label())
          {
-            indent_column_set(val);
-
-            chunk_t *next = chunk_get_next(chunk_get_next(pc));  // colon + possible statement
-
-            if (  next != nullptr
-               && !chunk_is_newline(next)
-                  // label (+ 2, because there is colon and space after it) must fit into indent
-               && (val + static_cast<int>(pc->len()) + 2 <= static_cast<int>(pse_indent)))
-            {
-               reindent_line(next, pse_indent);
-            }
+            log_rule_B("indent_ignore_label");
+            indent_column_set(pc->orig_col);
          }
          else
          {
-            const auto no_underflow = cast_abs(pse_indent, val) < pse_indent;
-            indent_column_set(((no_underflow) ? (pse_indent + val) : 0));
+            log_rule_B("indent_label");
+            const auto val        = options::indent_label();
+            const auto pse_indent = frm.top().indent;
+
+            // Labels get sent to the left or backed up
+            if (val > 0)
+            {
+               indent_column_set(val);
+
+               chunk_t *next = chunk_get_next(chunk_get_next(pc));  // colon + possible statement
+
+               if (  next != nullptr
+                  && !chunk_is_newline(next)
+                     // label (+ 2, because there is colon and space after it) must fit into indent
+                  && (val + static_cast<int>(pc->len()) + 2 <= static_cast<int>(pse_indent)))
+               {
+                  reindent_line(next, pse_indent);
+               }
+            }
+            else
+            {
+               const auto no_underflow = cast_abs(pse_indent, val) < pse_indent;
+               indent_column_set(((no_underflow) ? (pse_indent + val) : 0));
+            }
          }
       }
       else if (chunk_is_token(pc, CT_ACCESS))

--- a/src/options.h
+++ b/src/options.h
@@ -1579,7 +1579,11 @@ indent_col1_multi_string_literal;
 extern BoundedOption<unsigned, 0, 16>
 indent_comment_align_thresh; // = 3
 
-// How to indent goto labels.
+// Whether to ignore indent for goto labels.
+extern Option<bool>
+indent_ignore_label;
+
+// How to indent goto labels. Requires indent_ignore_label=false.
 //
 //  >0: Absolute column where 1 is the leftmost column
 // <=0: Subtract from brace indent

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2912,9 +2912,17 @@ MinVal=0
 MaxVal=16
 ValueDefault=3
 
+[Indent Ignore Label]
+Category=2
+Description="<html>Whether to ignore indent for goto labels.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=indent_ignore_label=true|indent_ignore_label=false
+ValueDefault=false
+
 [Indent Label]
 Category=2
-Description="<html>How to indent goto labels.<br/><br/> &gt;0: Absolute column where 1 is the leftmost column<br/>&lt;=0: Subtract from brace indent<br/><br/>Default: 1</html>"
+Description="<html>How to indent goto labels. Requires indent_ignore_label=false.<br/><br/> &gt;0: Absolute column where 1 is the leftmost column<br/>&lt;=0: Subtract from brace indent<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_label="

--- a/tests/config/cpp/issue_3378.cfg
+++ b/tests/config/cpp/issue_3378.cfg
@@ -1,0 +1,2 @@
+indent_class = true
+indent_ignore_label = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -1044,3 +1044,4 @@
 60062  cpp/sp_return-i.cfg                                  cpp/returns.cpp
 60063  cpp/sp_return-r.cfg                                  cpp/returns.cpp
 60064  cpp/sp_constr_colon-i.cfg                            cpp/issue_3368.cpp
+60065  cpp/issue_3378.cfg                                   cpp/issue_3378.cpp

--- a/tests/expected/cpp/60065-issue_3378.cpp
+++ b/tests/expected/cpp/60065-issue_3378.cpp
@@ -1,0 +1,28 @@
+class Foo
+{
+public:
+	int bar()
+	{
+one:
+ two:
+  three:
+   four:
+    five:
+     six:
+      seven:
+       eight:
+	nine:
+	 ten:
+	  eleven:
+	   twelve:
+	    thirteen:
+	     fourteen:
+	      fifteen:
+	       sixteen:
+		seventeen:
+		 eighteen:
+		  nineteen:
+		   twenty:
+		return 0;
+	}
+}

--- a/tests/input/cpp/issue_3378.cpp
+++ b/tests/input/cpp/issue_3378.cpp
@@ -1,0 +1,28 @@
+class Foo
+{
+    public:
+	int bar()
+	{
+one:
+ two:
+  three:
+   four:
+    five:
+     six:
+      seven:
+       eight:
+        nine:
+         ten:
+          eleven:
+           twelve:
+            thirteen:
+             fourteen:
+              fifteen:
+               sixteen:
+                seventeen:
+                 eighteen:
+                  nineteen:
+                   twenty:
+		return 0;
+	}
+}


### PR DESCRIPTION
The new option is similar to indent_ignore_asm_block.

Fixes #3378