### PR TITLE
Fix issue #3366.

### DIFF
--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -1412,6 +1412,12 @@ static void mod_case_brace(void)
 
    chunk_t *pc = chunk_get_head();
 
+   // Make sure to start outside of a preprocessor line (see issue #3366)
+   while (chunk_is_preproc(pc))
+   {
+      pc = chunk_get_next(pc);
+   }
+
    while (pc != nullptr)
    {
       chunk_t *next = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
@@ -1426,6 +1432,7 @@ static void mod_case_brace(void)
          && chunk_is_token(pc, CT_BRACE_OPEN)
          && get_chunk_parent_type(pc) == CT_CASE)
       {
+         log_rule_B("mod_case_brace - add");
          pc = mod_case_brace_remove(pc);
       }
       else if (  (options::mod_case_brace() & IARF_ADD)
@@ -1434,7 +1441,7 @@ static void mod_case_brace(void)
               && chunk_is_not_token(next, CT_BRACE_CLOSE)
               && chunk_is_not_token(next, CT_CASE))
       {
-         log_rule_B("mod_case_brace");
+         log_rule_B("mod_case_brace - remove");
          pc = mod_case_brace_add(pc);
       }
       else
@@ -1442,7 +1449,7 @@ static void mod_case_brace(void)
          pc = chunk_get_next_ncnnl(pc, scope_e::PREPROC);
       }
    }
-}
+} // mod_case_brace
 
 
 static void process_if_chain(chunk_t *br_start)

--- a/tests/c.test
+++ b/tests/c.test
@@ -254,6 +254,7 @@
 01005  c/mod_case_brace_add.cfg                   c/mod_case_brace.c
 01006  common/mod_case_brace_rm.cfg               c/mod_case_brace.c
 01007  c/mod_move_case_brace.cfg                  c/mod_case_brace.c
+01008  c/mod_case_brace_add.cfg                   c/Issue_3366.c
 
 01011  common/del_semicolon.cfg                   c/semicolons.c
 01012  c/ben_086.cfg                              c/semicolons.c

--- a/tests/expected/c/01008-Issue_3366.c
+++ b/tests/expected/c/01008-Issue_3366.c
@@ -1,0 +1,14 @@
+#define __CVTENDIAN1_H
+#define __CVTENDIAN2_H
+
+static int ConvertEndian(void *ptr, int bytes)
+{
+   switch(bytes)
+   {
+   default:
+      {
+         break;
+      }
+   }
+}
+

--- a/tests/input/c/Issue_3366.c
+++ b/tests/input/c/Issue_3366.c
@@ -1,0 +1,12 @@
+#define __CVTENDIAN1_H
+#define __CVTENDIAN2_H
+
+static int ConvertEndian(void *ptr, int bytes)
+{
+	switch(bytes)
+	{
+		default:
+			break;
+	}
+}
+


### PR DESCRIPTION
When the first line of a file is a preprocessor line, the mod_case_brace() function did not iterate over the complete file but would stop at the end of the line.
