### PR TITLE
Fix behavior of "chunk_get_next_ncnnlnp" and "chunk_get_prev_ncnnlnp" 

### DIFF
--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -1413,9 +1413,9 @@ static void mod_case_brace(void)
    chunk_t *pc = chunk_get_head();
 
    // Make sure to start outside of a preprocessor line (see issue #3366)
-   while (chunk_is_preproc(pc))
+   if (chunk_is_preproc(pc))
    {
-      pc = chunk_get_next(pc);
+      pc = chunk_get_next_ncnnlnp(pc);
    }
 
    while (pc != nullptr)

--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -142,22 +142,6 @@ static chunk_t *chunk_search_typelevel(chunk_t *cur, c_token_t type, scope_e sco
 
 
 /**
- * @brief searches a chunk that is non-NEWLINE, non-comment and non-preprocessor
- *
- * Traverses a chunk list either in forward or backward direction.
- * The traversal continues until a chunk of a given category is found.
- *
- * @param cur    chunk to start search at
- * @param scope  code parts to consider for search
- * @param dir    search direction
- *
- * @retval nullptr  no chunk found or invalid parameters provided
- * @retval chunk_t  pointer to the found chunk
- */
-static chunk_t *chunk_get_ncnlnp(chunk_t *cur, const scope_e scope = scope_e::ALL, const direction_e dir = direction_e::FORWARD);
-
-
-/**
  * @brief searches a chunk that holds a specific string
  *
  * Traverses a chunk list either in forward or backward direction until a chunk
@@ -599,13 +583,25 @@ chunk_t *chunk_get_prev_ncnnl(chunk_t *cur, scope_e scope)
 
 chunk_t *chunk_get_next_ncnnlnp(chunk_t *cur, scope_e scope)
 {
-   return(chunk_get_ncnlnp(cur, scope, direction_e::FORWARD));
+   return(chunk_search(cur, chunk_is_comment_newline_or_preproc, scope, direction_e::FORWARD, false));
 }
 
 
 chunk_t *chunk_get_prev_ncnnlnp(chunk_t *cur, scope_e scope)
 {
-   return(chunk_get_ncnlnp(cur, scope, direction_e::BACKWARD));
+   return(chunk_search(cur, chunk_is_comment_newline_or_preproc, scope, direction_e::BACKWARD, false));
+}
+
+
+chunk_t *chunk_get_next_ncnnl_in_pp(chunk_t *cur, scope_e scope)
+{
+   return(chunk_search(cur, chunk_is_comment_or_newline_in_preproc, scope, direction_e::FORWARD, false));
+}
+
+
+chunk_t *chunk_get_prev_ncnnl_in_pp(chunk_t *cur, scope_e scope)
+{
+   return(chunk_search(cur, chunk_is_comment_or_newline_in_preproc, scope, direction_e::BACKWARD, false));
 }
 
 
@@ -909,17 +905,6 @@ c_token_t get_chunk_parent_type(chunk_t *pc)
    }
    return(pc->parent_type);
 } // get_chunk_parent_type
-
-
-static chunk_t *chunk_get_ncnlnp(chunk_t *cur, const scope_e scope, const direction_e dir)
-{
-   chunk_t *pc = cur;
-
-   pc = chunk_is_preproc(pc) ?
-        chunk_search(pc, chunk_is_comment_or_newline_in_preproc, scope, dir, false) :
-        chunk_search(pc, chunk_is_comment_newline_or_preproc, scope, dir, false);
-   return(pc);
-}
 
 
 static chunk_t *chunk_add(const chunk_t *pc_in, chunk_t *ref, const direction_e pos)

--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -591,21 +591,27 @@ chunk_t *chunk_get_next_ncnnl(chunk_t *cur, scope_e scope)
 }
 
 
+chunk_t *chunk_get_prev_ncnnl(chunk_t *cur, scope_e scope)
+{
+   return(chunk_search(cur, chunk_is_comment_or_newline, scope, direction_e::BACKWARD, false));
+}
+
+
 chunk_t *chunk_get_next_ncnnlnp(chunk_t *cur, scope_e scope)
 {
    return(chunk_get_ncnlnp(cur, scope, direction_e::FORWARD));
 }
 
 
-chunk_t *chunk_ppa_get_next_ncnnl(chunk_t *cur)
-{
-   return(chunk_ppa_search(cur, chunk_is_comment_or_newline, false));
-}
-
-
 chunk_t *chunk_get_prev_ncnnlnp(chunk_t *cur, scope_e scope)
 {
    return(chunk_get_ncnlnp(cur, scope, direction_e::BACKWARD));
+}
+
+
+chunk_t *chunk_ppa_get_next_ncnnl(chunk_t *cur)
+{
+   return(chunk_ppa_search(cur, chunk_is_comment_or_newline, false));
 }
 
 
@@ -627,15 +633,15 @@ chunk_t *chunk_get_next_nc(chunk_t *cur, scope_e scope)
 }
 
 
-chunk_t *chunk_get_next_nisq(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_nc(chunk_t *cur, scope_e scope)
 {
-   return(chunk_search(cur, chunk_is_balanced_square, scope, direction_e::FORWARD, false));
+   return(chunk_search(cur, chunk_is_comment, scope, direction_e::BACKWARD, false));
 }
 
 
-chunk_t *chunk_get_prev_ncnnl(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next_nisq(chunk_t *cur, scope_e scope)
 {
-   return(chunk_search(cur, chunk_is_comment_or_newline, scope, direction_e::BACKWARD, false));
+   return(chunk_search(cur, chunk_is_balanced_square, scope, direction_e::FORWARD, false));
 }
 
 
@@ -645,27 +651,21 @@ chunk_t *chunk_get_prev_ncnnlni(chunk_t *cur, scope_e scope)
 }
 
 
-chunk_t *chunk_get_prev_nc(chunk_t *cur, scope_e scope)
-{
-   return(chunk_search(cur, chunk_is_comment, scope, direction_e::BACKWARD, false));
-}
-
-
 chunk_t *chunk_get_next_type(chunk_t *cur, c_token_t type, int level, scope_e scope)
 {
    return(chunk_search_typelevel(cur, type, scope, direction_e::FORWARD, level));
 }
 
 
-chunk_t *chunk_get_next_str(chunk_t *cur, const char *str, size_t len, int level, scope_e scope)
-{
-   return(chunk_search_str(cur, str, len, scope, direction_e::FORWARD, level));
-}
-
-
 chunk_t *chunk_get_prev_type(chunk_t *cur, c_token_t type, int level, scope_e scope)
 {
    return(chunk_search_typelevel(cur, type, scope, direction_e::BACKWARD, level));
+}
+
+
+chunk_t *chunk_get_next_str(chunk_t *cur, const char *str, size_t len, int level, scope_e scope)
+{
+   return(chunk_search_str(cur, str, len, scope, direction_e::FORWARD, level));
 }
 
 

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -214,6 +214,15 @@ chunk_t *chunk_get_next_ncnnlnp(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
+ * Gets the next non-NEWLINE and non-comment chunk inside a preprocessor block
+ *
+ * @param cur    chunk to use as start point
+ * @param scope  code region to search in
+ */
+chunk_t *chunk_get_next_ncnnl_in_pp(chunk_t *cur, scope_e scope = scope_e::ALL);
+
+
+/**
  * Gets the next non-NEWLINE and non-comment chunk (preprocessor aware).
  * Unlike chunk_get_next_ncnnl, this will also ignore a line continuation if
  * the starting chunk is in a preprocessor directive, and may return a newline
@@ -290,6 +299,15 @@ chunk_t *chunk_get_prev_nnl(chunk_t *cur, scope_e scope = scope_e::ALL);
  * @param scope  code region to search in
  */
 chunk_t *chunk_get_prev_ncnnl(chunk_t *cur, scope_e scope = scope_e::ALL);
+
+
+/**
+ * Gets the prev non-NEWLINE and non-comment chunk inside a preprocessor block
+ *
+ * @param cur    chunk to use as start point
+ * @param scope  code region to search in
+ */
+chunk_t *chunk_get_prev_ncnnl_in_pp(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**

--- a/src/combine_fix_mark.cpp
+++ b/src/combine_fix_mark.cpp
@@ -1448,17 +1448,20 @@ void mark_function(chunk_t *pc)
       if (chunk_is_token(prev, CT_DC_MEMBER))
       {
          prev = chunk_get_prev_ncnnlnp(prev);
-         LOG_FMT(LFCN, "%s(%d): prev->text() is '%s', orig_line is %zu, orig_col is %zu, type is %s\n",
-                 __func__, __LINE__, prev->text(), prev->orig_line, prev->orig_col,
-                 get_token_name(prev->type));
-         prev = skip_template_prev(prev);
-         LOG_FMT(LFCN, "%s(%d): prev->text() is '%s', orig_line is %zu, orig_col is %zu, type is %s\n",
-                 __func__, __LINE__, prev->text(), prev->orig_line, prev->orig_col,
-                 get_token_name(prev->type));
-         prev = skip_attribute_prev(prev);
-         LOG_FMT(LFCN, "%s(%d): prev->text() is '%s', orig_line is %zu, orig_col is %zu, type is %s\n",
-                 __func__, __LINE__, prev->text(), prev->orig_line, prev->orig_col,
-                 get_token_name(prev->type));
+				 if (prev)
+				 {
+					 LOG_FMT(LFCN, "%s(%d): prev->text() is '%s', orig_line is %zu, orig_col is %zu, type is %s\n",
+									 __func__, __LINE__, prev->text(), prev->orig_line, prev->orig_col,
+									 get_token_name(prev->type));
+					 prev = skip_template_prev(prev);
+					 LOG_FMT(LFCN, "%s(%d): prev->text() is '%s', orig_line is %zu, orig_col is %zu, type is %s\n",
+									 __func__, __LINE__, prev->text(), prev->orig_line, prev->orig_col,
+									 get_token_name(prev->type));
+					 prev = skip_attribute_prev(prev);
+					 LOG_FMT(LFCN, "%s(%d): prev->text() is '%s', orig_line is %zu, orig_col is %zu, type is %s\n",
+									 __func__, __LINE__, prev->text(), prev->orig_line, prev->orig_col,
+									 get_token_name(prev->type));
+				 }
 
          if (  chunk_is_token(prev, CT_WORD)
             || chunk_is_token(prev, CT_TYPE))

--- a/src/combine_fix_mark.cpp
+++ b/src/combine_fix_mark.cpp
@@ -1146,7 +1146,7 @@ void mark_function(chunk_t *pc)
    LOG_FMT(LFCN, "%s(%d): orig_line is %zu, orig_col is %zu, text() '%s'\n",
            __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text());
    chunk_t *prev = chunk_get_prev_ncnnlni(pc);   // Issue #2279
-   chunk_t *next = chunk_get_next_ncnnlnp(pc);
+   chunk_t *next = chunk_get_next_ncnnl_in_pp(pc);
 
    if (next == nullptr)
    {
@@ -1246,9 +1246,10 @@ void mark_function(chunk_t *pc)
       }
    }
 
-   if (chunk_is_ptr_operator(next))
+   if (  chunk_is_ptr_operator(next)
+      || chunk_is_newline(next))
    {
-      next = chunk_get_next_ncnnlnp(next);
+      next = chunk_get_next_ncnnl_in_pp(next);
 
       if (next == nullptr)
       {
@@ -1448,20 +1449,21 @@ void mark_function(chunk_t *pc)
       if (chunk_is_token(prev, CT_DC_MEMBER))
       {
          prev = chunk_get_prev_ncnnlnp(prev);
-				 if (prev)
-				 {
-					 LOG_FMT(LFCN, "%s(%d): prev->text() is '%s', orig_line is %zu, orig_col is %zu, type is %s\n",
-									 __func__, __LINE__, prev->text(), prev->orig_line, prev->orig_col,
-									 get_token_name(prev->type));
-					 prev = skip_template_prev(prev);
-					 LOG_FMT(LFCN, "%s(%d): prev->text() is '%s', orig_line is %zu, orig_col is %zu, type is %s\n",
-									 __func__, __LINE__, prev->text(), prev->orig_line, prev->orig_col,
-									 get_token_name(prev->type));
-					 prev = skip_attribute_prev(prev);
-					 LOG_FMT(LFCN, "%s(%d): prev->text() is '%s', orig_line is %zu, orig_col is %zu, type is %s\n",
-									 __func__, __LINE__, prev->text(), prev->orig_line, prev->orig_col,
-									 get_token_name(prev->type));
-				 }
+
+         if (prev)
+         {
+            LOG_FMT(LFCN, "%s(%d): prev->text() is '%s', orig_line is %zu, orig_col is %zu, type is %s\n",
+                    __func__, __LINE__, prev->text(), prev->orig_line, prev->orig_col,
+                    get_token_name(prev->type));
+            prev = skip_template_prev(prev);
+            LOG_FMT(LFCN, "%s(%d): prev->text() is '%s', orig_line is %zu, orig_col is %zu, type is %s\n",
+                    __func__, __LINE__, prev->text(), prev->orig_line, prev->orig_col,
+                    get_token_name(prev->type));
+            prev = skip_attribute_prev(prev);
+            LOG_FMT(LFCN, "%s(%d): prev->text() is '%s', orig_line is %zu, orig_col is %zu, type is %s\n",
+                    __func__, __LINE__, prev->text(), prev->orig_line, prev->orig_col,
+                    get_token_name(prev->type));
+         }
 
          if (  chunk_is_token(prev, CT_WORD)
             || chunk_is_token(prev, CT_TYPE))


### PR DESCRIPTION
From their names, "chunk_get_next_ncnnlnp" and "chunk_get_prev_ncnnlnp" 
are expected to return the next/prev chuck which is
not a comment, not a newline and not a preprocessor.
This was true only if the start chunk "cur" was a non preprocessor one.
Instead if "cur" was a preprocessor chunk, they would return either:
- the next non-preprocessor chuck
- the next preprocessor chuck that was both not a comment nor a new line.
The new version returns the expected chunk.

2. Add "chunk_get_next_ncnnl_in_pp" and "chunk_get_prev_ncnnl_in_pp"
functions, which return the next/prev preprocessor chuck that is
both not a comment nor a new line.

3. Some other code clean up and rearrangement

4. Prevent possible SEGV caused by dereferecing null pointer (this actually came up while testing the rest of this PR).
