### PR TITLE
Fix name and description of "chunk_get_next_nblank" and "chunk_get_prev_nblank".

### DIFF
--- a/src/chunk_list.cpp
+++ b/src/chunk_list.cpp
@@ -611,13 +611,13 @@ chunk_t *chunk_ppa_get_next_ncnnl(chunk_t *cur)
 }
 
 
-chunk_t *chunk_get_next_nblank(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_next_ncnnlnb(chunk_t *cur, scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment_newline_or_blank, scope, direction_e::FORWARD, false));
 }
 
 
-chunk_t *chunk_get_prev_nblank(chunk_t *cur, scope_e scope)
+chunk_t *chunk_get_prev_ncnnlnb(chunk_t *cur, scope_e scope)
 {
    return(chunk_search(cur, chunk_is_comment_newline_or_blank, scope, direction_e::BACKWARD, false));
 }

--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -248,21 +248,21 @@ chunk_t *chunk_get_next_nisq(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
- * Gets the next non-blank chunk
+ * Gets the next non-comment, non-newline, non blank chunk
  *
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_next_nblank(chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_next_ncnnlnb(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
- * Gets the prev non-blank chunk
+ * Gets the prev non-comment, non-newline, non blank chunk
  *
  * @param cur    chunk to use as start point
  * @param scope  code region to search in
  */
-chunk_t *chunk_get_prev_nblank(chunk_t *cur, scope_e scope = scope_e::ALL);
+chunk_t *chunk_get_prev_ncnnlnb(chunk_t *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -710,7 +710,8 @@ static inline bool chunk_is_comment_newline_or_preproc(chunk_t *pc)
 
 static inline bool chunk_is_comment_newline_or_blank(chunk_t *pc)
 {
-   return(  chunk_is_comment_or_newline(pc)
+   return(  chunk_is_comment(pc)
+         || chunk_is_newline(pc)
          || chunk_is_blank(pc));
 }
 

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -816,7 +816,7 @@ void indent_text(void)
             }
             int     should_indent_preproc = true;
             chunk_t *preproc_next         = chunk_get_next_nl(pc);
-            preproc_next = chunk_get_next_nblank(preproc_next);
+            preproc_next = chunk_get_next_ncnnlnb(preproc_next);
 
             /* Look ahead at what's on the line after the #if */
             log_rule_B("pp_indent_brace");

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -993,7 +993,7 @@ static bool newlines_if_for_while_switch(chunk_t *start, iarf_e nl_opt)
             }
             // Make sure nothing is cuddled with the closing brace
             pc = chunk_get_next_type(brace_open, CT_BRACE_CLOSE, brace_open->level);
-            newline_add_between(pc, chunk_get_next_nblank(pc));
+            newline_add_between(pc, chunk_get_next_ncnnlnb(pc));
             retval = true;
          }
       }
@@ -2596,7 +2596,7 @@ static void newlines_brace_pair(chunk_t *br_open)
          nl_close_brace = true;
       }
    }
-   chunk_t *prev = chunk_get_prev_nblank(br_close);
+   chunk_t *prev = chunk_get_prev_ncnnlnb(br_close);
 
    if (nl_close_brace)
    {
@@ -2745,7 +2745,7 @@ static void newline_after_return(chunk_t *start)
    LOG_FUNC_ENTRY();
 
    chunk_t *semi  = chunk_get_next_type(start, CT_SEMICOLON, start->level);
-   chunk_t *after = chunk_get_next_nblank(semi);
+   chunk_t *after = chunk_get_next_ncnnlnb(semi);
 
    // If we hit a brace or an 'else', then a newline isn't needed
    if (  after == nullptr

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -662,7 +662,7 @@ void tokenize_cleanup(void)
          }
          else if (chunk_is_token(next, CT_DC_MEMBER))
          {
-            chunk_t *next2 = chunk_get_next_nblank(next);
+            chunk_t *next2 = chunk_get_next_ncnnlnb(next);
 
             if (  chunk_is_token(next2, CT_INV)      // CT_INV hasn't turned into CT_DESTRUCTOR just yet
                || (  chunk_is_token(next2, CT_CLASS) // constructor isn't turned into CT_FUNC* just yet


### PR DESCRIPTION
Those functions are actually checking for non comment, non newline and non blank, hence the new names "chunk_get_next_ncnnlnb" and "chunk_get_prev_ncnnlnb"