### PR TITLE
Add mod_move_case_return option and functionality

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -3094,6 +3094,10 @@ mod_sort_incl_import_grouping_enabled = false    # true/false
 # the close brace, as in 'case X: { ... } break;' => 'case X: { ... break; }'.
 mod_move_case_break             = false    # true/false
 
+# Whether to move a 'return' that appears after a fully braced 'case' before
+# the close brace, as in 'case X: { ... } return;' => 'case X: { ... return; }'.
+mod_move_case_return            = false    # true/false
+
 # Add or remove braces around a fully braced case statement. Will only remove
 # braces if there are no variable declarations in the block.
 mod_case_brace                  = ignore   # ignore/add/remove/force/not_defined

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -3094,6 +3094,10 @@ mod_sort_incl_import_grouping_enabled = false    # true/false
 # the close brace, as in 'case X: { ... } break;' => 'case X: { ... break; }'.
 mod_move_case_break             = false    # true/false
 
+# Whether to move a 'return' that appears after a fully braced 'case' before
+# the close brace, as in 'case X: { ... } return;' => 'case X: { ... return; }'.
+mod_move_case_return            = false    # true/false
+
 # Add or remove braces around a fully braced case statement. Will only remove
 # braces if there are no variable declarations in the block.
 mod_case_brace                  = ignore   # ignore/add/remove/force/not_defined

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -3094,6 +3094,10 @@ mod_sort_incl_import_grouping_enabled = false    # true/false
 # the close brace, as in 'case X: { ... } break;' => 'case X: { ... break; }'.
 mod_move_case_break             = false    # true/false
 
+# Whether to move a 'return' that appears after a fully braced 'case' before
+# the close brace, as in 'case X: { ... } return;' => 'case X: { ... return; }'.
+mod_move_case_return            = false    # true/false
+
 # Add or remove braces around a fully braced case statement. Will only remove
 # braces if there are no variable declarations in the block.
 mod_case_brace                  = ignore   # ignore/add/remove/force/not_defined

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -6645,6 +6645,14 @@ EditorType=boolean
 TrueFalse=mod_move_case_break=true|mod_move_case_break=false
 ValueDefault=false
 
+[Mod Move Case Return]
+Category=9
+Description="<html>Whether to move a 'return' that appears after a fully braced 'case' before<br/>the close brace, as in 'case X: { ... } return;' =&gt; 'case X: { ... return; }'.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=mod_move_case_return=true|mod_move_case_return=false
+ValueDefault=false
+
 [Mod Case Brace]
 Category=9
 Description="<html>Add or remove braces around a fully braced case statement. Will only remove<br/>braces if there are no variable declarations in the block.</html>"

--- a/src/options.h
+++ b/src/options.h
@@ -3781,6 +3781,11 @@ mod_sort_incl_import_grouping_enabled;
 extern Option<bool>
 mod_move_case_break;
 
+// Whether to move a 'return' that appears after a fully braced 'case' before
+// the close brace, as in 'case X: { ... } return;' => 'case X: { ... return; }'.
+extern Option<bool>
+mod_move_case_return;
+
 // Add or remove braces around a fully braced case statement. Will only remove
 // braces if there are no variable declarations in the block.
 extern Option<iarf_e>

--- a/tests/c.test
+++ b/tests/c.test
@@ -255,6 +255,7 @@
 01006  common/mod_case_brace_rm.cfg               c/mod_case_brace.c
 01007  c/mod_move_case_brace.cfg                  c/mod_case_brace.c
 01008  c/mod_case_brace_add.cfg                   c/Issue_3366.c
+01009  c/mod_move_case_return.cfg                 c/mod_move_case_return.c
 
 01011  common/del_semicolon.cfg                   c/semicolons.c
 01012  c/ben_086.cfg                              c/semicolons.c

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -6645,6 +6645,14 @@ EditorType=boolean
 TrueFalse=mod_move_case_break=true|mod_move_case_break=false
 ValueDefault=false
 
+[Mod Move Case Return]
+Category=9
+Description="<html>Whether to move a 'return' that appears after a fully braced 'case' before<br/>the close brace, as in 'case X: { ... } return;' =&gt; 'case X: { ... return; }'.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=mod_move_case_return=true|mod_move_case_return=false
+ValueDefault=false
+
 [Mod Case Brace]
 Category=9
 Description="<html>Add or remove braces around a fully braced case statement. Will only remove<br/>braces if there are no variable declarations in the block.</html>"

--- a/tests/config/c/mod_move_case_return.cfg
+++ b/tests/config/c/mod_move_case_return.cfg
@@ -1,0 +1,1 @@
+mod_move_case_return = true

--- a/tests/expected/c/01009-mod_move_case_return.c
+++ b/tests/expected/c/01009-mod_move_case_return.c
@@ -1,0 +1,41 @@
+static int ConvertEndian(void *ptr, int bytes)
+{
+	switch(bytes)
+	{
+	case 2:
+	{
+		uint16_t *value = (uint16_t *) ptr;
+
+		*value = bswap_16(*value);
+		return 1;
+	}
+	case 4:
+	{
+		uint32_t *value = (uint32_t *) ptr;
+
+		*value = bswap_32(*value);
+		return 1+
+		       2+3;
+	}
+
+	case 8:
+	{
+		uint64_t *value = (uint64_t *) ptr;
+
+		*value = bswap_64(*value);
+		return 1+
+
+		       2
+
+		       +fn(
+
+			x
+
+			);
+	}
+	// comment
+	default:
+		break;
+	}
+	return 0;
+}

--- a/tests/input/c/mod_move_case_return.c
+++ b/tests/input/c/mod_move_case_return.c
@@ -1,0 +1,41 @@
+static int ConvertEndian(void *ptr, int bytes)
+{
+	switch(bytes)
+	{
+		case 2:
+		{
+			uint16_t *value = (uint16_t *) ptr;
+			
+			*value = bswap_16(*value);
+		}
+		return 1;
+		case 4:
+		{
+			uint32_t *value = (uint32_t *) ptr;
+			
+			*value = bswap_32(*value);
+		}
+		return 1+
+			2+3;
+
+		case 8:
+		{
+			uint64_t *value = (uint64_t *) ptr;
+			
+			*value = bswap_64(*value);
+		}
+
+		return 1+
+
+			2
+
+			+fn(
+
+				x
+			);
+		// comment
+		default:
+			break;
+	}
+	return 0;
+}


### PR DESCRIPTION
Similar to mod_move_case_break, but moving a return statement inside the case { } block.
To identify the end of the return statement (which could be on a different line), the code looks for the next semicolon in the code. If a semicolon is not there, the results could be weird, but as long as the code is correct, the results are good. If someone has a better idea on how to identify the end of the return statement, please let me know.