### PR TITLE
Improve detection of the end of a return statement in case a semicolon is missing. 

### DIFF
--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -1262,6 +1262,14 @@ static void move_case_return(void)
          // Find the end of the return statement
          while (chunk_is_not_token(pc, CT_SEMICOLON))
          {
+            if (  chunk_is_token(pc, CT_CASE)
+               || chunk_is_token(pc, CT_BRACE_CLOSE))
+            {
+               // This may indicate a semicolon was missing in the code to format.
+               // Avoid moving the return statement to prevent potential unwanted erros.
+               pc = nullptr;
+               break;
+            }
             pc = chunk_get_next(pc);
          }
          pc = chunk_get_next_nl(pc);
@@ -1283,7 +1291,7 @@ static void move_case_return(void)
       }
       prev = pc;
    }
-}
+} // move_case_return
 
 
 static chunk_t *mod_case_brace_remove(chunk_t *br_open)

--- a/tests/c.test
+++ b/tests/c.test
@@ -256,6 +256,7 @@
 01007  c/mod_move_case_brace.cfg                  c/mod_case_brace.c
 01008  c/mod_case_brace_add.cfg                   c/Issue_3366.c
 01009  c/mod_move_case_return.cfg                 c/mod_move_case_return.c
+01010  c/mod_move_case_return.cfg                 c/mod_move_case_return_bad.c
 
 01011  common/del_semicolon.cfg                   c/semicolons.c
 01012  c/ben_086.cfg                              c/semicolons.c

--- a/tests/expected/c/01010-mod_move_case_return_bad.c
+++ b/tests/expected/c/01010-mod_move_case_return_bad.c
@@ -1,0 +1,52 @@
+static int ConvertEndian(void *ptr, int bytes)
+{
+	switch(bytes)
+	{
+	case 2:
+	{
+		uint16_t *value = (uint16_t *) ptr;
+
+		*value = bswap_16(*value);
+		return 1;
+	}
+	case 4:
+	{
+		uint32_t *value = (uint32_t *) ptr;
+
+		*value = bswap_32(*value);
+	}
+		return 1+
+		       2+3
+
+		       case 8:
+		       {
+			       uint64_t *value = (uint64_t *) ptr;
+
+			       *value = bswap_64(*value);
+		       }
+
+			       return 1+
+
+			              2
+
+			              +fn(
+
+				       x
+				       )
+				      // comment
+				      default:
+					      break;
+
+				      case 16:
+				      {
+					      {
+						      uint32_t *value = (uint32_t *) ptr;
+
+						      *value = bswap_32(*value);
+					      }
+					      return 1+
+					             2+3
+				      };
+	}
+	return 0;
+}

--- a/tests/input/c/mod_move_case_return_bad.c
+++ b/tests/input/c/mod_move_case_return_bad.c
@@ -1,0 +1,52 @@
+static int ConvertEndian(void *ptr, int bytes)
+{
+	switch(bytes)
+	{
+		case 2:
+		{
+			uint16_t *value = (uint16_t *) ptr;
+			
+			*value = bswap_16(*value);
+		}
+		return 1;
+		case 4:
+		{
+			uint32_t *value = (uint32_t *) ptr;
+			
+			*value = bswap_32(*value);
+		}
+		return 1+
+			2+3
+
+		case 8:
+		{
+			uint64_t *value = (uint64_t *) ptr;
+			
+			*value = bswap_64(*value);
+		}
+
+		return 1+
+
+			2
+
+			+fn(
+
+				x
+			)
+		// comment
+		default:
+			break;
+
+		case 16:
+		{
+			{
+				uint32_t *value = (uint32_t *) ptr;
+
+				*value = bswap_32(*value);
+			}
+			return 1+
+				2+3
+		};
+	}
+	return 0;
+}


### PR DESCRIPTION
This relates to the mod_move_case_return option and will reduce the number of possible errors in case the original code is not correct (semicolon missing after a return statement).
