### PR TITLE
Apply sp_ptr_star_func_var to function pointer types

### DIFF
--- a/src/combine_fix_mark.cpp
+++ b/src/combine_fix_mark.cpp
@@ -2211,7 +2211,7 @@ bool mark_function_type(chunk_t *pc)
    {
       if (pc->flags.test(PCF_IN_TYPEDEF))
       {
-         set_chunk_type(varcnk, CT_TYPE);
+         set_chunk_type(varcnk, CT_FUNC_TYPE);   // Issue #3402
       }
       else
       {

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -2548,7 +2548,8 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_between_ptr_star");                             // ptr_star 9
          return(options::sp_between_ptr_star());
       }
-      else if (chunk_is_token(second, CT_FUNC_VAR))
+      else if (  chunk_is_token(second, CT_FUNC_VAR)
+              || chunk_is_token(second, CT_FUNC_TYPE))
       {
          // Add or remove space between the pointer star '*' and the name of the
          // variable in a function pointer definition.

--- a/tests/c.test
+++ b/tests/c.test
@@ -436,3 +436,4 @@
 10043  c/sp_ptr_star_func_var-a.cfg               c/Issue_3376.c
 10044  c/sp_ptr_star_func_var-r.cfg               c/Issue_3376.c
 10045  c/sp_ptr_star_func_var-f.cfg               c/Issue_3376.c
+10046  c/Issue_3402.cfg                           c/Issue_3402.c

--- a/tests/config/c/Issue_3402.cfg
+++ b/tests/config/c/Issue_3402.cfg
@@ -1,0 +1,2 @@
+sp_ptr_star_func_var = remove
+sp_after_ptr_star = force

--- a/tests/config/common/aet.cfg
+++ b/tests/config/common/aet.cfg
@@ -105,6 +105,7 @@ sp_between_ptr_star                                  = remove
 sp_after_ptr_star                                    = remove
 sp_after_ptr_star_qualifier                          = remove
 sp_after_ptr_star_func                               = remove
+sp_ptr_star_func_var                                 = remove
 sp_ptr_star_paren                                    = remove
 sp_before_ptr_star_func                              = force
 sp_before_byref                                      = remove

--- a/tests/config/common/star_pos-0.cfg
+++ b/tests/config/common/star_pos-0.cfg
@@ -1,6 +1,7 @@
 # Places the byref as follows: "int &foo"
 sp_before_ptr_star              = remove
 sp_after_ptr_star               = force
+sp_ptr_star_func_var            = force
 sp_before_byref                 = remove
 indent_columns                  = 3
 align_var_def_span              = 2

--- a/tests/config/cpp/633_decl-in-func-typedef.cfg
+++ b/tests/config/cpp/633_decl-in-func-typedef.cfg
@@ -1,4 +1,5 @@
 sp_arith = add
 sp_before_ptr_star = force
 sp_after_ptr_star = remove
+sp_ptr_star_func_var = remove
 sp_ptr_star_paren = remove

--- a/tests/expected/c/10046-Issue_3402.c
+++ b/tests/expected/c/10046-Issue_3402.c
@@ -1,0 +1,2 @@
+int (*func)(void);
+typedef int (*func_t)(void);

--- a/tests/input/c/Issue_3402.c
+++ b/tests/input/c/Issue_3402.c
@@ -1,0 +1,2 @@
+int (*    func)(void);
+typedef int (*    func_t)(void);


### PR DESCRIPTION
And mark function pointer types as CT_FUNC_TYPE in mark_function_type.

I'm pretty sure that this is the right approach because token_enum.h uses a typedef in its example for CT_FUNC_TYPE:

```
   CT_FUNC_TYPE,          // function type - foo in "typedef void (*foo)(void)"
```

If anyone wants to have a different rule for function pointer typedefs than for ordinary function pointers, let me know and I will happily make a separate `sp_ptr_star_func_type` option.

Fixes #3402