### PR TITLE
Add sp_ptr_star_func_type option

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -218,6 +218,10 @@ sp_after_ptr_star_trailing      = ignore   # ignore/add/remove/force/not_defined
 # in a function pointer definition.
 sp_ptr_star_func_var            = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space between the pointer star '*' and the name of the type
+# in a function pointer type definition.
+sp_ptr_star_func_type           = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space after a pointer star '*', if followed by an open
 # parenthesis, as in 'void* (*)()'.
 sp_ptr_star_paren               = ignore   # ignore/add/remove/force/not_defined

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -218,6 +218,10 @@ sp_after_ptr_star_trailing      = ignore   # ignore/add/remove/force/not_defined
 # in a function pointer definition.
 sp_ptr_star_func_var            = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space between the pointer star '*' and the name of the type
+# in a function pointer type definition.
+sp_ptr_star_func_type           = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space after a pointer star '*', if followed by an open
 # parenthesis, as in 'void* (*)()'.
 sp_ptr_star_paren               = ignore   # ignore/add/remove/force/not_defined

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -218,6 +218,10 @@ sp_after_ptr_star_trailing      = ignore   # ignore/add/remove/force/not_defined
 # in a function pointer definition.
 sp_ptr_star_func_var            = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space between the pointer star '*' and the name of the type
+# in a function pointer type definition.
+sp_ptr_star_func_type           = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space after a pointer star '*', if followed by an open
 # parenthesis, as in 'void* (*)()'.
 sp_ptr_star_paren               = ignore   # ignore/add/remove/force/not_defined

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -479,6 +479,15 @@ Choices=sp_ptr_star_func_var=ignore|sp_ptr_star_func_var=add|sp_ptr_star_func_va
 ChoicesReadable="Ignore Sp Ptr Star Func Var|Add Sp Ptr Star Func Var|Remove Sp Ptr Star Func Var|Force Sp Ptr Star Func Var"
 ValueDefault=ignore
 
+[Sp Ptr Star Func Type]
+Category=1
+Description="<html>Add or remove space between the pointer star '*' and the name of the type<br/>in a function pointer type definition.</html>"
+Enabled=false
+EditorType=multiple
+Choices=sp_ptr_star_func_type=ignore|sp_ptr_star_func_type=add|sp_ptr_star_func_type=remove|sp_ptr_star_func_type=force|sp_ptr_star_func_type=not_defined
+ChoicesReadable="Ignore Sp Ptr Star Func Type|Add Sp Ptr Star Func Type|Remove Sp Ptr Star Func Type|Force Sp Ptr Star Func Type"
+ValueDefault=ignore
+
 [Sp Ptr Star Paren]
 Category=1
 Description="<html>Add or remove space after a pointer star '*', if followed by an open<br/>parenthesis, as in 'void* (*)()'.</html>"

--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -285,6 +285,7 @@ sp_paren_qualifier                        = force
 sp_pp_concat                              = force
 sp_pp_stringify                           = force
 sp_ptr_star_func_var                      = remove
+sp_ptr_star_func_type                     = remove
 sp_ptr_star_paren                         = force
 sp_return_brace                           = remove
 sp_return_paren                           = remove

--- a/src/combine_fix_mark.cpp
+++ b/src/combine_fix_mark.cpp
@@ -2211,7 +2211,7 @@ bool mark_function_type(chunk_t *pc)
    {
       if (pc->flags.test(PCF_IN_TYPEDEF))
       {
-         set_chunk_type(varcnk, CT_TYPE);
+         set_chunk_type(varcnk, CT_FUNC_TYPE);   // Issue #3402
       }
       else
       {

--- a/src/options.h
+++ b/src/options.h
@@ -296,6 +296,11 @@ sp_after_ptr_star_trailing;
 extern Option<iarf_e>
 sp_ptr_star_func_var;
 
+// Add or remove space between the pointer star '*' and the name of the type
+// in a function pointer type definition.
+extern Option<iarf_e>
+sp_ptr_star_func_type;
+
 // Add or remove space after a pointer star '*', if followed by an open
 // parenthesis, as in 'void* (*)()'.
 extern Option<iarf_e>

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -2555,6 +2555,13 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
          log_rule("sp_ptr_star_func_var");
          return(options::sp_ptr_star_func_var());
       }
+      else if (chunk_is_token(second, CT_FUNC_TYPE))
+      {
+         // Add or remove space between the pointer star '*' and the name of the
+         // type in a function pointer type definition.
+         log_rule("sp_ptr_star_func_type");
+         return(options::sp_ptr_star_func_type());
+      }
       else if (  get_chunk_parent_type(first) == CT_FUNC_DEF
               || get_chunk_parent_type(first) == CT_FUNC_PROTO
               || get_chunk_parent_type(first) == CT_FUNC_VAR)

--- a/tests/c.test
+++ b/tests/c.test
@@ -436,3 +436,4 @@
 10043  c/sp_ptr_star_func_var-a.cfg               c/Issue_3376.c
 10044  c/sp_ptr_star_func_var-r.cfg               c/Issue_3376.c
 10045  c/sp_ptr_star_func_var-f.cfg               c/Issue_3376.c
+10046  c/Issue_3402.cfg                           c/Issue_3402.c

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -479,6 +479,15 @@ Choices=sp_ptr_star_func_var=ignore|sp_ptr_star_func_var=add|sp_ptr_star_func_va
 ChoicesReadable="Ignore Sp Ptr Star Func Var|Add Sp Ptr Star Func Var|Remove Sp Ptr Star Func Var|Force Sp Ptr Star Func Var"
 ValueDefault=ignore
 
+[Sp Ptr Star Func Type]
+Category=1
+Description="<html>Add or remove space between the pointer star '*' and the name of the type<br/>in a function pointer type definition.</html>"
+Enabled=false
+EditorType=multiple
+Choices=sp_ptr_star_func_type=ignore|sp_ptr_star_func_type=add|sp_ptr_star_func_type=remove|sp_ptr_star_func_type=force|sp_ptr_star_func_type=not_defined
+ChoicesReadable="Ignore Sp Ptr Star Func Type|Add Sp Ptr Star Func Type|Remove Sp Ptr Star Func Type|Force Sp Ptr Star Func Type"
+ValueDefault=ignore
+
 [Sp Ptr Star Paren]
 Category=1
 Description="<html>Add or remove space after a pointer star '*', if followed by an open<br/>parenthesis, as in 'void* (*)()'.</html>"

--- a/tests/config/c/Issue_3402.cfg
+++ b/tests/config/c/Issue_3402.cfg
@@ -1,0 +1,3 @@
+sp_after_ptr_star = add
+sp_ptr_star_func_var = force
+sp_ptr_star_func_type = remove

--- a/tests/config/common/aet.cfg
+++ b/tests/config/common/aet.cfg
@@ -105,6 +105,7 @@ sp_between_ptr_star                                  = remove
 sp_after_ptr_star                                    = remove
 sp_after_ptr_star_qualifier                          = remove
 sp_after_ptr_star_func                               = remove
+sp_ptr_star_func_type                                = remove
 sp_ptr_star_paren                                    = remove
 sp_before_ptr_star_func                              = force
 sp_before_byref                                      = remove

--- a/tests/config/common/star_pos-0.cfg
+++ b/tests/config/common/star_pos-0.cfg
@@ -1,6 +1,7 @@
 # Places the byref as follows: "int &foo"
 sp_before_ptr_star              = remove
 sp_after_ptr_star               = force
+sp_ptr_star_func_type           = force
 sp_before_byref                 = remove
 indent_columns                  = 3
 align_var_def_span              = 2

--- a/tests/config/cpp/633_decl-in-func-typedef.cfg
+++ b/tests/config/cpp/633_decl-in-func-typedef.cfg
@@ -1,4 +1,5 @@
 sp_arith = add
 sp_before_ptr_star = force
 sp_after_ptr_star = remove
+sp_ptr_star_func_type = remove
 sp_ptr_star_paren = remove

--- a/tests/config/cpp/func_param.cfg
+++ b/tests/config/cpp/func_param.cfg
@@ -1,6 +1,7 @@
 sp_paren_paren                  = remove
 sp_after_ptr_star               = remove
 sp_ptr_star_func_var            = remove
+sp_ptr_star_func_type           = remove
 sp_func_proto_paren             = remove
 sp_inside_fparen                = remove
 sp_after_tparen_close           = remove

--- a/tests/expected/c/10046-Issue_3402.c
+++ b/tests/expected/c/10046-Issue_3402.c
@@ -1,0 +1,3 @@
+int *    variable;
+int (* function)(void);
+typedef int (*function_type)(void);

--- a/tests/input/c/Issue_3402.c
+++ b/tests/input/c/Issue_3402.c
@@ -1,0 +1,3 @@
+int *    variable;
+int (*    function)(void);
+typedef int (*    function_type)(void);


### PR DESCRIPTION
And mark function pointer types as CT_FUNC_TYPE in mark_function_type.

I'm pretty sure that this is the right approach because token_enum.h uses a typedef in its example for CT_FUNC_TYPE:

```
   CT_FUNC_TYPE,          // function type - foo in "typedef void (*foo)(void)"
```

Fixes #3402