### PR TITLE
Simplify code by removing hard-coded define WITH_STACKID

### DIFF
--- a/documentation/align-thresholds.txt
+++ b/documentation/align-thresholds.txt
@@ -172,22 +172,23 @@ How to do this generically in the code...
 
 Easy case - one item per line.
 
-Here's the functions and what each do:
-align_start(line_span, col_thresh)
-align_add(pc)
-align_flush()
-align_newline(count)
-align_end()
+An AlignStack is used to manage alignment.
+Here are the functions and what each of them do:
+AlignStack::Start(line_span, col_thresh)
+AlignStack::Add(pc)
+AlignStack::Flush()
+AlignStack::Newline(count)
+AlignStack::End()
 
 For each entry, a sequence number is kept.
 
-align_start(line_span, col_thresh)
+AlignStack::Start(line_span, col_thresh)
   - initializes the align and skipped lists
   - zero max_column
   - zero cur_seqnum
   - zero nl_count
 
-align_add(pc)
+AlignStack::Add(start, seqnum)
   - update cur_seqnum, assign to item
   - if item column is within threshold
     - zero nl_count
@@ -197,43 +198,22 @@ align_add(pc)
       - re-adds all items on the skipped list
   - if item column is not within threshold, add to skipped list
 
-align_newline(count)
+AlignStack::NewLines(count)
   - adds count to nl_count
-  - if nl_count > line_span, call align_flush()
+  - if nl_count > line_span, call AlignStack::Flush()
 
-align_flush()
+AlignStack::Flush()
   - step through all the items in aligned list and align the items to max_column
     - keep the seq_num of the last aligned item
   - zero max_column
   - remove all items with a seq_num < last aligned seq_num
-  - call align_add on all remaining items in the skipped list
+  - call AlignStack::Add on all remaining items in the skipped list
 
-align_end()
-  - call align_flush
+AlignStack::End()
+  - call AlignStack::Flush
   - clear the lists
   - free resources, etc
 
-Example usage:  Aligning trailing comments
+Example usage: see align_assign function in align_assign.cpp
 
-void align_trailing_comments(void)
-{
-   chunk_t *pc;
-
-   align_start(cpd.settings[UO_align_right_cmt_span],
-               cpd.settings[UO_align_right_cmt_thresh]);
-
-   for(pc = chunk_get_head(); pc != NULL; pc = chunk_get_next(pc))
-   {
-      if ((pc->flags & PCF_RIGHT_COMMENT) != 0)
-      {
-         align_add(pc);
-      }
-      else if (chunk_is_newline(pc))
-      {
-         align_newline(pc->nl_count);
-      }
-   }
-
-   align_end();
-}
-
+chunk_t *align_assign(chunk_t *first, size_t span, size_t thresh, size_t *p_nl_count);

--- a/src/align_stack.cpp
+++ b/src/align_stack.cpp
@@ -13,9 +13,7 @@
 #include "align_tab_column.h"
 #include "indent.h"
 #include "space.h"
-#if defined WITH_STACKID
 #include "unc_tools.h"                   // to get stackID and get_A_Number()
-#endif
 
 
 constexpr static auto LCURRENT = LAS;
@@ -27,9 +25,8 @@ using std::numeric_limits;
 
 void AlignStack::Start(size_t span, int thresh)
 {
-#if defined WITH_STACKID
    stackID = get_A_Number();   // for debugging purpose only
-#endif
+
    // produces much more log output. Use it only debugging purpose
    //WITH_STACKID_DEBUG;
 

--- a/src/align_stack.h
+++ b/src/align_stack.h
@@ -1,6 +1,6 @@
 /**
  * @file align_stack.h
- * Manages a align stack, which is just a pair of chunk stacks with a few
+ * Manages an align stack, which is just a pair of chunk stacks with a few
  * fancy functions.
  *
  * @author  Ben Gardner
@@ -24,7 +24,7 @@ public:
       SS_DANGLE   //! include prev * after add
    };
 
-   ChunkStack m_aligned;      //! contains the token that is aligned
+   ChunkStack m_aligned;      //! contains the tokens that are aligned
    ChunkStack m_skipped;      //! contains the tokens sent to Add()
    size_t     m_max_col;
    size_t     m_min_col;
@@ -36,12 +36,9 @@ public:
    bool       m_right_align;
    bool       m_absolute_thresh;
    StarStyle  m_star_style;
-   StarStyle  m_amp_style;  //! do not include the first item if it causes it to be indented
+   StarStyle  m_amp_style;
    bool       m_skip_first; //! do not include the first item if it causes it to be indented
-#define WITH_STACKID    1
-#if defined WITH_STACKID
-   size_t stackID;      // for debugging purpose only
-#endif
+   size_t     stackID;      //! for debugging purpose only
 
 
    AlignStack()
@@ -57,9 +54,7 @@ public:
       , m_star_style(SS_IGNORE)
       , m_amp_style(SS_IGNORE)
       , m_skip_first(false)
-#if defined WITH_STACKID
       , stackID(std::numeric_limits<std::size_t>::max()) // under linux 64 bits: 18446744073709551615
-#endif
       , m_last_added(0)
    {
    }
@@ -144,7 +139,6 @@ protected:
    void ReAddSkipped();
 };
 
-#if defined WITH_STACKID
 #define WITH_STACKID_DEBUG                                                                                  \
    if (stackID == std::numeric_limits<std::size_t>::max())                                                  \
    {                                                                                                        \
@@ -156,8 +150,5 @@ protected:
    {                                                                                                        \
       LOG_FMT(LAS, "AlignStack::%s(%d): stackID is %zu\n", __func__, __LINE__, stackID);                    \
    }
-#else
-#define WITH_STACKID_DEBUG    ;
-#endif
 
 #endif /* ALIGN_STACK_H_INCLUDED */


### PR DESCRIPTION
WITH_STACKID is hard-coded defined in the code, so removing it and where it is used results in exactly the same code. More over the stack id may be useful, so I see no need why that should be conditional.
This PR propose removing the define and simplify the code.