### PR TITLE
enable the use of newline before a direct-list-initialization.

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -4048,6 +4048,7 @@ void newlines_cleanup_braces(bool first)
             if (  prev != nullptr
                && (  prev->type == CT_TYPE
                   || prev->type == CT_WORD
+                  || prev->type == CT_ASSIGN                      // Issue #2957
                   || prev->parent_type == CT_TEMPLATE
                   || prev->parent_type == CT_DECLTYPE))
             {

--- a/src/options.h
+++ b/src/options.h
@@ -2431,7 +2431,8 @@ extern Option<iarf_e>
 nl_paren_dbrace_open;
 
 // Whether to add a newline after the type in an unnamed temporary
-// direct-list-initialization.
+// direct-list-initialization, better:
+// before a direct-list-initialization.
 extern Option<iarf_e>
 nl_type_brace_init_lst;
 

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -4484,7 +4484,7 @@ ValueDefault=ignore
 
 [Nl Type Brace Init Lst]
 Category=3
-Description="<html>Whether to add a newline after the type in an unnamed temporary<br/>direct-list-initialization.</html>"
+Description="<html>Whether to add a newline after the type in an unnamed temporary<br/>direct-list-initialization, better:<br/>before a direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_type_brace_init_lst=ignore|nl_type_brace_init_lst=add|nl_type_brace_init_lst=remove|nl_type_brace_init_lst=force|nl_type_brace_init_lst=not_defined

--- a/tests/config/cpp/Issue_2957.cfg
+++ b/tests/config/cpp/Issue_2957.cfg
@@ -1,0 +1,4 @@
+# Whether to add a newline after the type in an unnamed temporary
+# direct-list-initialization, better:
+# before a direct-list-initialization.
+nl_type_brace_init_lst = force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -236,6 +236,7 @@
 30281  cpp/Issue_2478.cfg                                   cpp/Issue_2478.cpp
 30282  cpp/Issue_2703.cfg                                   cpp/Issue_2703.cpp
 30283  common/empty.cfg                                     cpp/Issue_3321.h
+30284  cpp/Issue_2957.cfg                                   cpp/Issue_2957.cpp
 
 30290  cpp/indent_shift.cfg                                 cpp/align_left_shift.cpp
 30291  cpp/indent_shift.cfg                                 cpp/indent_shift.cpp

--- a/tests/expected/cpp/30284-Issue_2957.cpp
+++ b/tests/expected/cpp/30284-Issue_2957.cpp
@@ -1,0 +1,7 @@
+bus_type i2c_bus_type =
+{
+	.name    = "i2c",
+	.match   = i2c_device_match,
+	.suspend = i2c_bus_suspend,
+	.resume  = i2c_bus_resume,
+};

--- a/tests/input/cpp/Issue_2957.cpp
+++ b/tests/input/cpp/Issue_2957.cpp
@@ -1,0 +1,6 @@
+bus_type i2c_bus_type = {
+    .name    = "i2c",
+    .match   = i2c_device_match,
+    .suspend = i2c_bus_suspend,
+    .resume  = i2c_bus_resume,
+};


### PR DESCRIPTION
fixes #2957