### PR TITLE
Provide space option for consecutive !!

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -997,6 +997,11 @@ sp_d_array_colon;
 extern Option<iarf_e>
 sp_not; // = IARF_REMOVE
 
+// Add or remove space between two '!' (not) unary operators.
+// If set to ignore, sp_not will be used.
+extern Option<iarf_e>
+sp_not_not; // = IARF_IGNORE
+
 // Add or remove space after the '~' (invert) unary operator.
 extern Option<iarf_e>
 sp_inv; // = IARF_REMOVE

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -2951,6 +2951,12 @@ static iarf_e do_space(chunk_t *first, chunk_t *second, int &min_sp)
 
    if (chunk_is_token(first, CT_NOT))
    {
+      if (  chunk_is_token(second, CT_NOT)
+         && (options::sp_not_not() != IARF_IGNORE))
+      {
+         log_rule("sp_not_not");
+         return(options::sp_not_not());
+      }
       // Add or remove space after the '!' (not) unary operator.
       log_rule("sp_not");
       return(options::sp_not());

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -1855,6 +1855,15 @@ Choices=sp_not=ignore|sp_not=add|sp_not=remove|sp_not=force|sp_not=not_defined
 ChoicesReadable="Ignore Sp Not|Add Sp Not|Remove Sp Not|Force Sp Not"
 ValueDefault=remove
 
+[Sp Not Not]
+Category=1
+Description="<html>Add or remove space between two '!' (not) unary operators.<br/>If set to ignore, sp_not will be used.</html>"
+Enabled=false
+EditorType=multiple
+Choices=sp_not_not=ignore|sp_not_not=add|sp_not_not=remove|sp_not_not=force|sp_not_not=not_defined
+ChoicesReadable="Ignore Sp Not Not|Add Sp Not Not|Remove Sp Not Not|Force Sp Not Not"
+ValueDefault=ignore
+
 [Sp Inv]
 Category=1
 Description="<html>Add or remove space after the '~' (invert) unary operator.<br/><br/>Default: remove</html>"

--- a/tests/config/cpp/sp_not_not.cfg
+++ b/tests/config/cpp/sp_not_not.cfg
@@ -1,0 +1,2 @@
+sp_not = add
+sp_not_not = remove

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -717,6 +717,7 @@
 
 33160  common/sp_before_byref-r.cfg                         cpp/bug_1112.cpp
 33161  common/sp_before_byref-r.cfg                         cpp/byref-3.cpp
+33162  cpp/sp_not_not.cfg                                   cpp/sp_not_not.cpp
 
 33180  cpp/pp_multi_comment.cfg                             cpp/pp_multi_comment.cpp
 33181  cpp/Issue_2759.cfg                                   cpp/Issue_2759.cpp

--- a/tests/expected/cpp/33162-sp_not_not.cpp
+++ b/tests/expected/cpp/33162-sp_not_not.cpp
@@ -1,0 +1,3 @@
+if (! hello) { }
+if (!! hello) { }
+if (!!! hello) { }

--- a/tests/input/cpp/sp_not_not.cpp
+++ b/tests/input/cpp/sp_not_not.cpp
@@ -1,0 +1,3 @@
+if (!hello) { }
+if (!!hello) { }
+if (!!!hello) { }


### PR DESCRIPTION
The current sp_not option will add space after each !, even when they
are consecutive.  When it is add or force, the following code is
generated:

if (! something) { }
if (! ! something) { }

The new sp_not_not option provides management over consecutive !,
allowing space after any number of ! - without any space in between.

if (! something) { }
if (!! something) { }