### PR TITLE
Resolves Issue #3446

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3170,7 +3170,8 @@ static void newline_func_def_or_call(chunk_t *start)
          {
             log_rule_B("nl_func_scope_name");
 
-            if (options::nl_func_scope_name() != IARF_IGNORE)
+            if (  options::nl_func_scope_name() != IARF_IGNORE
+               && !start->flags.test(PCF_IN_DECLTYPE))
             {
                newline_iarf(prev, options::nl_func_scope_name());
             }

--- a/tests/config/cpp/Issue_3446.cfg
+++ b/tests/config/cpp/Issue_3446.cfg
@@ -1,0 +1,1 @@
+nl_func_scope_name = add

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -555,6 +555,7 @@
 31634  cpp/sp_after_decltype-r.cfg                          cpp/sp_after_decltype.cpp
 31635  common/empty.cfg                                     cpp/sp_decltype.cpp
 31636  cpp/Issue_1923.cfg                                   cpp/Issue_1923.cpp
+31637  cpp/Issue_3446.cfg                                   cpp/Issue_3446.cpp
 
 31660  cpp/nl_func_var_def_blk-1.cfg                        cpp/issue_1919.cpp
 31661  cpp/Issue_3097.cfg                                   cpp/Issue_3097.cpp

--- a/tests/expected/cpp/31637-Issue_3446.cpp
+++ b/tests/expected/cpp/31637-Issue_3446.cpp
@@ -1,0 +1,18 @@
+Foo::
+Foo() {
+}
+
+std::true_type blarg();
+template <typename T>
+decltype(std::declval<T &>().put(foo, bar), std::true_type())
+has_module_api_(T && t);
+
+void
+foo()
+{
+	using V = decltype(STD::declval<T &>().put(foo, bar), std::true_type());
+}
+
+template <typename T>
+decltype(std::declval<T &>()./* ((( */ put(foo, bar), std::true_type())
+has_module_api_(T && t);

--- a/tests/input/cpp/Issue_3446.cpp
+++ b/tests/input/cpp/Issue_3446.cpp
@@ -1,0 +1,16 @@
+Foo::Foo() { }
+
+std::true_type blarg();
+template <typename T>
+decltype(std::declval<T &>().put(foo, bar), std::true_type())
+has_module_api_(T && t);
+
+void
+foo()
+{
+    using V = decltype(STD::declval<T &>().put(foo, bar), std::true_type());
+}
+
+template <typename T>
+decltype(std::declval<T &>()./* ((( */put(foo, bar), std::true_type())
+has_module_api_(T && t);


### PR DESCRIPTION
The code for tagging chunks as being IN_DECLTYPE stopped short in
cases where all chunks had the same level.

This change does two things.

First, it modifies the code that tags chunks with the IN_DECLTYPE
flag, by manually searching for the matching closing parenthesis.

Second, it does not honor nl_func_scope_name if the chunk has
the IN_DECLTYPE flag set.