### PR TITLE
Stops crash reported in Issues #3413 and #3414

### DIFF
--- a/src/align_func_proto.cpp
+++ b/src/align_func_proto.cpp
@@ -185,6 +185,15 @@ void align_func_proto(size_t span)
               && pc->flags.test(PCF_ONE_LINER))
       {
          AlignStack *stack_at_l_bl_brace = many_as_brace.at(pc->level).at(pc->brace_level);
+
+         if (stack_at_l_bl_brace == nullptr)
+         {
+            stack_at_l_bl_brace = new AlignStack();
+            stack_at_l_bl_brace->Start(myspan, mythresh);
+            stack_at_l_bl_brace->m_gap                      = mybr_gap;
+            many_as_brace.at(pc->level).at(pc->brace_level) = stack_at_l_bl_brace;
+         }
+         stack_at_l_bl_brace->Debug();
          stack_at_l_bl_brace->Add(pc);
          look_bro = false;
       }

--- a/tests/config/cpp/Issue_3413.cfg
+++ b/tests/config/cpp/Issue_3413.cfg
@@ -1,0 +1,4 @@
+align_func_proto_span   = 1
+align_single_line_func  = true
+align_single_line_brace = true
+nl_func_leave_one_liners = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -154,6 +154,7 @@
 30133  cpp/Issue_3252.cfg                                   cpp/Issue_3252.cpp
 30134  cpp/Issue_3357.cfg                                   cpp/Issue_3357.cpp
 30135  cpp/Issue_3448.cfg                                   cpp/Issue_3448.cpp
+30136  cpp/Issue_3413.cfg                                   cpp/Issue_3413.cpp
 
 30200  cpp/bug_1862.cfg                                     cpp/bug_1862.cpp
 30201  cpp/cmt_indent-1.cfg                                 cpp/cmt_indent.cpp

--- a/tests/expected/cpp/30136-Issue_3413.cpp
+++ b/tests/expected/cpp/30136-Issue_3413.cpp
@@ -1,0 +1,10 @@
+namespace
+{
+struct S { void f() {} };
+}
+
+void FuncCrash(int a =       {}) { }
+void FuncCrash(int b = int   {}) { }
+void FuncCrash(int b = int(0)) { }
+void FuncCrash(int b = double{0}) { }
+void FuncCrash(int b = 0) { }

--- a/tests/input/cpp/Issue_3413.cpp
+++ b/tests/input/cpp/Issue_3413.cpp
@@ -1,0 +1,10 @@
+namespace
+{
+struct S { void f() {} };
+}
+
+void FuncCrash(int a = {}) { }
+void FuncCrash(int b = int{}) { }
+void FuncCrash(int b = int(0)) { }
+void FuncCrash(int b = double{0}) { }
+void FuncCrash(int b = 0) { }


### PR DESCRIPTION
A stack object was assumed to exist in a vector of stack pointers.

The fix is to create a new stack object when needed.

Note that this does prevent the crash, but I'm not 100% sure that
the generated output is what would be expected.