### PR TITLE
Feat/chunk improvements 3

### DIFF
--- a/src/ListManager.h
+++ b/src/ListManager.h
@@ -29,15 +29,15 @@ private:
    // Hide copy constructor
    ListManager(const ListManager &ref)
    {
-      first = NULL;
-      last  = NULL;
+      first = nullptr;
+      last  = nullptr;
    }
 
 public:
    ListManager()
    {
-      first = NULL;
-      last  = NULL;
+      first = nullptr;
+      last  = nullptr;
    }
 
 
@@ -46,7 +46,7 @@ public:
     *
     * @return pointer to first element or nullptr if list is empty
     */
-   T *GetHead()
+   T *GetHead() const
    {
       return(first);
    }
@@ -57,7 +57,7 @@ public:
     *
     * @return pointer to last element or nullptr if list is empty
     */
-   T *GetTail()
+   T *GetTail() const
    {
       return(last);
    }
@@ -70,9 +70,9 @@ public:
     *
     * @return pointer to next element or nullptr if no next element exists
     */
-   T *GetNext(T *ref)
+   T *GetNext(const T *ref) const
    {
-      return((ref != NULL) ? ref->next : NULL);
+      return((ref != nullptr) ? ref->next : nullptr);
    }
 
 
@@ -83,9 +83,9 @@ public:
     *
     * @return pointer to previous element or nullptr if no previous element exists
     */
-   T *GetPrev(T *ref)
+   T *GetPrev(const T *ref) const
    {
-      return((ref != NULL) ? ref->prev : NULL);
+      return((ref != nullptr) ? ref->prev : nullptr);
    }
 
 
@@ -96,7 +96,7 @@ public:
     */
    void Pop(T *obj)
    {
-      if (obj != NULL)
+      if (obj != nullptr)
       {
          if (first == obj)
          {
@@ -108,17 +108,17 @@ public:
             last = obj->prev;
          }
 
-         if (obj->next != NULL)
+         if (obj->next != nullptr)
          {
             obj->next->prev = obj->prev;
          }
 
-         if (obj->prev != NULL)
+         if (obj->prev != nullptr)
          {
             obj->prev->next = obj->next;
          }
-         obj->next = NULL;
-         obj->prev = NULL;
+         obj->next = nullptr;
+         obj->prev = nullptr;
       }
    }
 
@@ -126,8 +126,8 @@ public:
    //! swap two elements of a list
    void Swap(T *obj1, T *obj2)
    {
-      if (  obj1 != NULL
-         && obj2 != NULL)
+      if (  obj1 != nullptr
+         && obj2 != nullptr)
       {
          if (obj1->prev == obj2)
          {
@@ -162,14 +162,14 @@ public:
     */
    void AddAfter(T *obj, T *ref)
    {
-      if (  obj != NULL
-         && ref != NULL)
+      if (  obj != nullptr
+         && ref != nullptr)
       {
          Pop(obj); // TODO: is this necessary?
          obj->next = ref->next;
          obj->prev = ref;
 
-         if (ref->next != NULL)
+         if (ref->next != nullptr)
          {
             ref->next->prev = obj;
          }
@@ -190,14 +190,14 @@ public:
     */
    void AddBefore(T *obj, T *ref)
    {
-      if (  obj != NULL
-         && ref != NULL)
+      if (  obj != nullptr
+         && ref != nullptr)
       {
          Pop(obj);
          obj->next = ref;
          obj->prev = ref->prev;
 
-         if (ref->prev != NULL)
+         if (ref->prev != nullptr)
          {
             ref->prev->next = obj;
          }
@@ -217,10 +217,10 @@ public:
     */
    void AddTail(T *obj)
    {
-      obj->next = NULL;
+      obj->next = nullptr;
       obj->prev = last;
 
-      if (last == NULL)
+      if (last == nullptr)
       {
          last  = obj;
          first = obj;
@@ -241,9 +241,9 @@ public:
    void AddHead(T *obj)
    {
       obj->next = first;
-      obj->prev = NULL;
+      obj->prev = nullptr;
 
-      if (first == NULL)
+      if (first == nullptr)
       {
          last  = obj;
          first = obj;

--- a/src/align_add.cpp
+++ b/src/align_add.cpp
@@ -16,9 +16,14 @@ void align_add(ChunkStack &cs, Chunk *pc, size_t &max_col)
    LOG_FUNC_ENTRY();
 
    size_t min_col;
-   Chunk  *prev = chunk_get_prev(pc);
+   Chunk  *prev = Chunk::NullChunkPtr;
 
-   if (  prev == nullptr
+   if (pc != nullptr)
+   {
+      prev = pc->get_prev();
+   }
+
+   if (  prev->isNullChunk()
       || chunk_is_newline(prev))
    {
       min_col = 1;

--- a/src/align_eigen_comma_init.cpp
+++ b/src/align_eigen_comma_init.cpp
@@ -30,7 +30,8 @@ void align_eigen_comma_init(void)
 
    auto *pc = chunk_get_head();
 
-   while (pc != nullptr)
+   while (  pc != nullptr
+         && pc->isNotNullChunk())
    {
       if (chunk_is_newline(pc))
       {
@@ -88,9 +89,9 @@ void align_eigen_comma_init(void)
              *      cout
              *          << "something";
              */
-            Chunk *prev = chunk_get_prev(pc);
+            Chunk *prev = pc->get_prev();
 
-            if (  prev != nullptr
+            if (  prev->isNotNullChunk()
                && chunk_is_newline(prev))
             {
                log_rule_B("indent_columns");
@@ -106,7 +107,7 @@ void align_eigen_comma_init(void)
       }
       else if (!as.m_aligned.Empty())
       {
-         auto *const prev = chunk_get_prev(pc);
+         Chunk *prev = pc->get_prev();
 
          if (  chunk_is_newline(prev)
             && chunk_is_token(chunk_get_prev_nc_nnl(pc), CT_COMMA))

--- a/src/align_init_brace.cpp
+++ b/src/align_init_brace.cpp
@@ -103,7 +103,7 @@ void align_init_brace(Chunk *start)
             if (  idx == 0
                && cpd.al_c99_array)
             {
-               Chunk *prev = chunk_get_prev(pc);
+               Chunk *prev = pc->get_prev();
 
                if (chunk_is_newline(prev))
                {

--- a/src/align_left_shift.cpp
+++ b/src/align_left_shift.cpp
@@ -88,9 +88,9 @@ void align_left_shift(void)
              *      cout
              *          << "something";
              */
-            Chunk *prev = chunk_get_prev(pc);
+            Chunk *prev = pc->get_prev();
 
-            if (  prev != nullptr
+            if (  prev->isNotNullChunk()
                && chunk_is_newline(prev))
             {
                log_rule_B("indent_columns");
@@ -102,7 +102,7 @@ void align_left_shift(void)
             as.Add(pc);
             start = pc;
          }
-         else if (chunk_is_newline(chunk_get_prev(pc)))
+         else if (chunk_is_newline(pc->get_prev()))
          {
             // subsequent ones must be after a newline
             as.Add(pc);
@@ -117,7 +117,7 @@ void align_left_shift(void)
           *      cout <<
           *          "something";
           */
-         Chunk *prev = chunk_get_prev(pc);
+         Chunk *prev = pc->get_prev();
 
          if (  prev != nullptr
             && chunk_is_newline(prev))

--- a/src/align_oc_decl_colon.cpp
+++ b/src/align_oc_decl_colon.cpp
@@ -46,6 +46,7 @@ void align_oc_decl_colon(void)
       did_line = false;
 
       while (  pc != nullptr
+            && pc->isNotNullChunk()
             && pc->level >= level)
       {
          // The declaration ends with an open brace or semicolon
@@ -66,7 +67,7 @@ void align_oc_decl_colon(void)
          {
             cas.Add(pc);
 
-            Chunk *tmp  = chunk_get_prev(pc, scope_e::PREPROC);
+            Chunk *tmp  = pc->get_prev(scope_e::PREPROC);
             Chunk *tmp2 = chunk_get_prev_nc_nnl(tmp, scope_e::PREPROC);
 
             // Check for an un-labeled parameter

--- a/src/align_oc_msg_colons.cpp
+++ b/src/align_oc_msg_colons.cpp
@@ -42,6 +42,7 @@ void align_oc_msg_colon(Chunk *so)
    bool   first_line = true;
 
    while (  pc != nullptr
+         && pc->isNotNullChunk()
          && pc->level > level)
    {
       if (pc->level > (level + 1))
@@ -73,9 +74,9 @@ void align_oc_msg_colon(Chunk *so)
       {
          has_colon = true;
          cas.Add(pc);
-         Chunk *tmp = chunk_get_prev(pc);
+         Chunk *tmp = pc->get_prev();
 
-         if (  tmp != nullptr
+         if (  tmp->isNotNullChunk()
             && (  chunk_is_token(tmp, CT_OC_MSG_FUNC)
                || chunk_is_token(tmp, CT_OC_MSG_NAME)))
          {

--- a/src/align_same_func_call_params.cpp
+++ b/src/align_same_func_call_params.cpp
@@ -49,7 +49,7 @@ void align_same_func_call_params(void)
    LOG_FMT(LAS, "%s(%d): (3): span is %zu, thresh is %zu\n",
            __func__, __LINE__, span, thresh);
 
-   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next(pc))
+   for (pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next(pc))
    {
       if (chunk_is_newline(pc))
       {
@@ -94,19 +94,19 @@ void align_same_func_call_params(void)
          continue;
       }
       // Only align function calls that are right after a newline
-      Chunk *prev = chunk_get_prev(pc);
+      Chunk *prev = pc->get_prev();
 
       while (  chunk_is_token(prev, CT_MEMBER)
             || chunk_is_token(prev, CT_DC_MEMBER))
       {
-         Chunk *tprev = chunk_get_prev(prev);
+         Chunk *tprev = prev->get_prev();
 
          if (chunk_is_not_token(tprev, CT_TYPE))
          {
             prev = tprev;
             break;
          }
-         prev = chunk_get_prev(tprev);
+         prev = tprev->get_prev();
       }
 
       if (!chunk_is_newline(prev))

--- a/src/align_stack.cpp
+++ b/src/align_stack.cpp
@@ -170,9 +170,15 @@ void AlignStack::Add(Chunk *start, size_t seqnum)
    LOG_FMT(LAS, "AlignStack::%s(%d): m_star_style is %s\n",
            __func__, __LINE__, get_StarStyle_name(m_star_style));
    // Find ref. Back up to the real item that is aligned.
-   Chunk *prev = start;
+   Chunk *prev = Chunk::NullChunkPtr;
 
-   while (  (prev = chunk_get_prev(prev)) != nullptr
+   if (start != nullptr)
+   {
+      prev = start;
+   }
+
+   while (  (prev = prev->get_prev()) != nullptr
+         && prev->isNotNullChunk()
          && (  chunk_is_ptr_operator(prev)
             || chunk_is_token(prev, CT_TPAREN_OPEN)))
    {
@@ -190,39 +196,44 @@ void AlignStack::Add(Chunk *start, size_t seqnum)
       ref = chunk_get_next(ref);
    }
    // Find the item that we are going to align.
-   Chunk *ali = start;
+   Chunk *ali = Chunk::NullChunkPtr;
+
+   if (start != nullptr)
+   {
+      ali = start;
+   }
 
    if (m_star_style != SS_IGNORE)
    {
       // back up to the first '*' or '^' preceding the token
-      Chunk *tmp_prev = chunk_get_prev(ali);
+      Chunk *tmp_prev = ali->get_prev();
 
       while (  chunk_is_star(tmp_prev)
             || chunk_is_msref(tmp_prev))
       {
          ali      = tmp_prev;
-         tmp_prev = chunk_get_prev(ali);
+         tmp_prev = ali->get_prev();
       }
 
       if (chunk_is_token(tmp_prev, CT_TPAREN_OPEN))
       {
          ali      = tmp_prev;
-         tmp_prev = chunk_get_prev(ali);
+         tmp_prev = ali->get_prev();
          // this is correct, even Coverity says:
          // CID 76021 (#1 of 1): Unused value (UNUSED_VALUE)returned_pointer: Assigning value from
-         // chunk_get_prev(ali, nav_e::ALL) to prev here, but that stored value is overwritten before it can be used.
+         // ali->get_prev(nav_e::ALL) to prev here, but that stored value is overwritten before it can be used.
       }
    }
 
    if (m_amp_style != SS_IGNORE)
    {
       // back up to the first '&' preceding the token
-      Chunk *tmp_prev = chunk_get_prev(ali);
+      Chunk *tmp_prev = ali->get_prev();
 
       while (chunk_is_addr(tmp_prev))
       {
          ali      = tmp_prev;
-         tmp_prev = chunk_get_prev(ali);
+         tmp_prev = ali->get_prev();
       }
    }
    log_rule_B("align_keep_extra_space");

--- a/src/align_trailing_comments.cpp
+++ b/src/align_trailing_comments.cpp
@@ -76,6 +76,7 @@ Chunk *align_trailing_comments(Chunk *start)
    log_rule_B("align_right_cmt_span");
 
    while (  pc != nullptr
+         && pc->isNotNullChunk()
          && (nl_count < options::align_right_cmt_span()))
    {
       if (  pc->flags.test(PCF_RIGHT_COMMENT)
@@ -84,7 +85,7 @@ Chunk *align_trailing_comments(Chunk *start)
          if (  same_level
             && pc->brace_level != lvl)
          {
-            pc = chunk_get_prev(pc);
+            pc = pc->get_prev();
             break;
          }
          cmt_type_cur = get_comment_align_type(pc);
@@ -154,7 +155,8 @@ comment_align_e get_comment_align_type(Chunk *cmt)
    log_rule_B("align_right_cmt_mix");
 
    if (  !options::align_right_cmt_mix()
-      && ((prev = chunk_get_prev(cmt)) != nullptr))
+      && cmt != nullptr
+      && ((prev = cmt->get_prev())->isNotNullChunk()))
    {
       if (  chunk_is_token(prev, CT_PP_ENDIF)
          || chunk_is_token(prev, CT_PP_ELSE)
@@ -184,7 +186,7 @@ void align_right_comments(void)
       {
          if (get_chunk_parent_type(pc) == CT_COMMENT_END)
          {
-            Chunk *prev = chunk_get_prev(pc);
+            Chunk *prev = pc->get_prev();
 
             log_rule_B("align_right_cmt_gap");
 

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -1354,9 +1354,9 @@ static Chunk *insert_vbrace(Chunk *pc, bool after, const ParseFrame &frm)
       set_chunk_type(&chunk, CT_VBRACE_CLOSE);
       return(chunk_add_after(&chunk, pc));
    }
-   Chunk *ref = chunk_get_prev(pc);
+   Chunk *ref = pc->get_prev();
 
-   if (ref == nullptr)
+   if (ref->isNullChunk())
    {
       return(nullptr);
    }
@@ -1372,10 +1372,10 @@ static Chunk *insert_vbrace(Chunk *pc, bool after, const ParseFrame &frm)
    {
       ref->level++;
       ref->brace_level++;
-      ref = chunk_get_prev(ref);
+      ref = ref->get_prev();
    }
 
-   if (ref == nullptr)
+   if (ref->isNullChunk())
    {
       return(nullptr);
    }
@@ -1386,10 +1386,10 @@ static Chunk *insert_vbrace(Chunk *pc, bool after, const ParseFrame &frm)
    {
       if (chunk_is_token(ref, CT_PREPROC_BODY))
       {
-         while (  ref != nullptr
+         while (  ref->isNotNullChunk()
                && ref->flags.test(PCF_IN_PREPROC))
          {
-            ref = chunk_get_prev(ref);
+            ref = ref->get_prev();
          }
       }
       else
@@ -1408,7 +1408,7 @@ static Chunk *insert_vbrace(Chunk *pc, bool after, const ParseFrame &frm)
       ref = chunk_get_next(ref);
    }
 
-   if (ref == nullptr)
+   if (ref->isNullChunk())
    {
       return(nullptr);
    }

--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -770,9 +770,9 @@ static void convert_brace(Chunk *br)
    {
       set_chunk_type(br, CT_VBRACE_OPEN);
       br->str.clear();
-      tmp = chunk_get_prev(br);
+      tmp = br->get_prev();
 
-      if (tmp == nullptr)
+      if (tmp->isNullChunk())
       {
          return;
       }
@@ -1229,15 +1229,15 @@ void add_long_closebrace_comment(void)
 static void move_case_break(void)
 {
    LOG_FUNC_ENTRY();
-   Chunk *prev = nullptr;
+   Chunk *prev = Chunk::NullChunkPtr;
 
    for (Chunk *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_nc_nnl(pc))
    {
       if (  chunk_is_token(pc, CT_BREAK)
          && chunk_is_token(prev, CT_BRACE_CLOSE)
          && get_chunk_parent_type(prev) == CT_CASE
-         && chunk_is_newline(chunk_get_prev(pc))
-         && chunk_is_newline(chunk_get_prev(prev)))
+         && chunk_is_newline(pc->get_prev())
+         && chunk_is_newline(prev->get_prev()))
       {
          chunk_swap_lines(prev, pc);
       }
@@ -1249,15 +1249,15 @@ static void move_case_break(void)
 static void move_case_return(void)
 {
    LOG_FUNC_ENTRY();
-   Chunk *prev = nullptr;
+   Chunk *prev = Chunk::NullChunkPtr;
 
    for (Chunk *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_nc_nnl(pc))
    {
       if (  chunk_is_token(pc, CT_RETURN)
          && chunk_is_token(prev, CT_BRACE_CLOSE)
          && get_chunk_parent_type(prev) == CT_CASE
-         && chunk_is_newline(chunk_get_prev(pc))
-         && chunk_is_newline(chunk_get_prev(prev)))
+         && chunk_is_newline(pc->get_prev())
+         && chunk_is_newline(prev->get_prev()))
       {
          // Find the end of the return statement
          while (chunk_is_not_token(pc, CT_SEMICOLON))
@@ -1364,7 +1364,7 @@ static Chunk *mod_case_brace_remove(Chunk *br_open)
       tmp_pc->level--;
    }
 
-   next = chunk_get_prev(br_open, scope_e::PREPROC);
+   next = br_open->get_prev(scope_e::PREPROC);
 
    chunk_del(br_open);
    chunk_del(br_close);

--- a/src/calculate_closing_brace_position.cpp
+++ b/src/calculate_closing_brace_position.cpp
@@ -83,7 +83,7 @@ Chunk *calculate_closing_brace_position(const Chunk *cl_colon, Chunk *pc)
                     __func__, __LINE__, back->orig_line, back->orig_col, back->level);
          }
       }
-      back = chunk_get_prev(back);
+      back = back->get_prev();
    }
    LOG_FMT(LMCB, "%s(%d): erst_found is %zu\n",
            __func__, __LINE__, erst_found);

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -19,13 +19,20 @@ typedef ListManager<Chunk> ChunkList_t;
  * Chunk class methods
  */
 
-Chunk::Chunk()
+// Null Chunk
+Chunk        Chunk::NullChunk(true);
+Chunk *const Chunk::NullChunkPtr(&Chunk::NullChunk);
+
+
+Chunk::Chunk(bool null_c)
+   : null_chunk(null_c)
 {
    reset();
 }
 
 
 Chunk::Chunk(const Chunk &o)
+   : null_chunk(o.null_chunk)
 {
    copyFrom(o);
 }

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -46,12 +46,18 @@ enum class scope_e : unsigned int
 class Chunk
 {
 public:
+   static Chunk        NullChunk;          // Null Chunk
+   static Chunk *const NullChunkPtr;       // Pointer to the Null Chunk
+
    //! constructors
-   Chunk();                          // default
+   Chunk(bool null_c = false);       // default
    Chunk(const Chunk &o);            // !!! partial copy: chunk is not linked to others
 
    Chunk &operator=(const Chunk &o); // !!! partial copy: chunk is not linked to others
 
+   //! whether this is a null Chunk or not
+   bool isNullChunk() const { return(null_chunk); }
+   bool isNotNullChunk() const { return(!null_chunk); }
 
    //! sets all elements of the struct to their default value
    void reset();
@@ -97,6 +103,8 @@ public:
 
 private:
    void copyFrom(const Chunk &o); // !!! partial copy: chunk is not linked to others
+
+   const bool null_chunk;         //! true for null chunks
 };
 
 

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -71,6 +71,16 @@ public:
    // Issue #2984, fill up, if necessary, a copy of the first chars of the text() string
    const char *elided_text(char *for_the_copy);
 
+   /**
+    * @brief returns the previous chunk in a list of chunks
+    *
+    * @param scope code region to search in
+    *
+    * @return pointer to previous chunk or null Chunk if no chunk was found
+    */
+   Chunk *get_prev(scope_e scope = scope_e::ALL);
+
+
    Chunk        *next;          //! pointer to next chunk in list
    Chunk        *prev;          //! pointer to previous chunk in list
    Chunk        *parent;        //! pointer to parent chunk(not always set)
@@ -178,17 +188,6 @@ Chunk *chunk_get_tail(void);
  * @return pointer to next chunk or nullptr if no chunk was found
  */
 Chunk *chunk_get_next(Chunk *cur, scope_e scope = scope_e::ALL);
-
-
-/**
- * @brief returns the previous chunk in a list of chunks
- *
- * @param cur    chunk to use as start point
- * @param scope  code region to search in
- *
- * @return pointer to previous chunk or nullptr if no chunk was found
- */
-Chunk *chunk_get_prev(Chunk *cur, scope_e scope = scope_e::ALL);
 
 
 /**
@@ -569,6 +568,7 @@ static inline bool is_expected_string_and_level(Chunk *pc, const char *str, int 
 static inline bool chunk_is_token(const Chunk *pc, c_token_t c_token)
 {
    return(  pc != nullptr
+         && pc->isNotNullChunk()
          && pc->type == c_token);
 }
 
@@ -576,6 +576,7 @@ static inline bool chunk_is_token(const Chunk *pc, c_token_t c_token)
 static inline bool chunk_is_not_token(const Chunk *pc, c_token_t c_token)
 {
    return(  pc != nullptr
+         && pc->isNotNullChunk()
          && pc->type != c_token);
 }
 
@@ -653,6 +654,7 @@ static inline bool chunk_is_cpp_inheritance_access_specifier(Chunk *pc)
 {
    return(  language_is_set(LANG_CPP)
          && pc != nullptr
+         && pc->isNotNullChunk()
          && (  chunk_is_token(pc, CT_ACCESS)
             || chunk_is_token(pc, CT_QUALIFIER))
          && (  std::strncmp(pc->str.c_str(), "private", 7) == 0
@@ -713,6 +715,7 @@ static inline bool chunk_is_semicolon(Chunk *pc)
 static inline bool chunk_is_blank(Chunk *pc)
 {
    return(  pc != nullptr
+         && pc->isNotNullChunk()
          && (pc->len() == 0));
 }
 
@@ -745,6 +748,7 @@ static inline bool chunk_is_balanced_square(Chunk *pc)
 static inline bool chunk_is_preproc(Chunk *pc)
 {
    return(  pc != nullptr
+         && pc->isNotNullChunk()
          && pc->flags.test(PCF_IN_PREPROC));
 }
 
@@ -752,6 +756,7 @@ static inline bool chunk_is_preproc(Chunk *pc)
 static inline bool chunk_is_comment_or_newline_in_preproc(Chunk *pc)
 {
    return(  pc != nullptr
+         && pc->isNotNullChunk()
          && chunk_is_preproc(pc)
          && (  chunk_is_comment(pc)
             || chunk_is_newline(pc)));
@@ -858,12 +863,13 @@ static inline bool chunk_is_nullable(Chunk *pc)
 static inline bool chunk_is_addr(Chunk *pc)
 {
    if (  pc != nullptr
+      && pc->isNotNullChunk()
       && (  chunk_is_token(pc, CT_BYREF)
          || (  (pc->len() == 1)
             && (pc->str[0] == '&')
             && pc->type != CT_OPERATOR_VAL)))
    {
-      Chunk *prev = chunk_get_prev(pc);
+      Chunk *prev = pc->get_prev();
 
       if (  pc->flags.test(PCF_IN_TEMPLATE)
          && (  chunk_is_token(prev, CT_COMMA)
@@ -954,7 +960,9 @@ static inline bool chunk_is_paren_close(Chunk *pc)
 static inline bool chunk_same_preproc(Chunk *pc1, Chunk *pc2)
 {
    return(  pc1 == nullptr
+         || pc1->isNullChunk()
          || pc2 == nullptr
+         || pc2->isNullChunk()
          || ((pc1->flags & PCF_IN_PREPROC) == (pc2->flags & PCF_IN_PREPROC)));
 }
 
@@ -966,13 +974,18 @@ static inline bool chunk_same_preproc(Chunk *pc1, Chunk *pc2)
  */
 static inline bool chunk_safe_to_del_nl(Chunk *nl)
 {
-   Chunk *tmp = chunk_get_prev(nl);
+   Chunk *tmp = Chunk::NullChunkPtr;
+
+   if (nl != nullptr)
+   {
+      tmp = nl->get_prev();
+   }
 
    if (chunk_is_token(tmp, CT_COMMENT_CPP))
    {
       return(false);
    }
-   return(chunk_same_preproc(chunk_get_prev(nl), chunk_get_next(nl)));
+   return(chunk_same_preproc(tmp, chunk_get_next(nl)));
 }
 
 

--- a/src/combine_fix_mark.cpp
+++ b/src/combine_fix_mark.cpp
@@ -1538,7 +1538,8 @@ void mark_function(Chunk *pc)
        * a.y = foo() * bar();              -- fcn call
        * static const char * const fizz(); -- fcn def
        */
-      while (prev != nullptr)
+      while (  prev != nullptr
+            && prev->isNotNullChunk())
       {
          LOG_FMT(LFCN, "%s(%d): next step with: prev->orig_line is %zu, orig_col is %zu, text() '%s'\n",
                  __func__, __LINE__, prev->orig_line, prev->orig_col, prev->text());
@@ -1575,11 +1576,18 @@ void mark_function(Chunk *pc)
          if (get_chunk_parent_type(prev) == CT_DECLSPEC)  // Issue 1289
          {
             prev = chunk_skip_to_match_rev(prev);
-            prev = chunk_get_prev(prev);
+
+            if (prev != nullptr)
+            {
+               prev = prev->get_prev();
+            }
 
             if (chunk_is_token(prev, CT_DECLSPEC))
             {
-               prev = chunk_get_prev(prev);
+               if (prev != nullptr)
+               {
+                  prev = prev->get_prev();
+               }
             }
          }
 

--- a/src/combine_labels.cpp
+++ b/src/combine_labels.cpp
@@ -30,12 +30,16 @@ Chunk *chunk_get_next_local(Chunk *pc, scope_e scope = scope_e::ALL)
 
 Chunk *chunk_get_prev_local(Chunk *pc, scope_e scope = scope_e::ALL)
 {
+   if (pc == nullptr)
+   {
+      return(Chunk::NullChunkPtr);
+   }
    Chunk *tmp = pc;
 
    do
    {
-      tmp = chunk_get_prev(tmp, scope);
-   } while (  tmp != nullptr
+      tmp = tmp->get_prev(scope);
+   } while (  tmp->isNotNullChunk()
            && (  chunk_is_comment(tmp)
               || chunk_is_newline(tmp)
               || chunk_is_token(tmp, CT_NOEXCEPT)));

--- a/src/detect.cpp
+++ b/src/detect.cpp
@@ -152,7 +152,8 @@ static void detect_space_options(void)
    Chunk *pc   = chunk_get_next(prev);
    Chunk *next;
 
-   while (pc != nullptr)
+   while (  pc != nullptr
+         && pc->isNotNullChunk())
    {
       next = chunk_get_next(pc);
 
@@ -357,7 +358,7 @@ static void detect_space_options(void)
          }
          else if (chunk_is_token(prev, CT_VBRACE_OPEN))
          {
-            vote_sp_special_semi.vote(chunk_get_prev(prev), pc);
+            vote_sp_special_semi.vote(prev->get_prev(), pc);
          }
          else
          {

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -593,7 +593,7 @@ static void quick_indent_again(void)
       {
          continue;
       }
-      Chunk *tmp = chunk_get_prev(pc);
+      Chunk *tmp = pc->get_prev();
 
       if (!chunk_is_newline(tmp))
       {
@@ -644,7 +644,7 @@ void indent_text(void)
          string str = pc->text();
 
          if (  (str[0] == '@')
-            && (chunk_get_prev(pc)->type == CT_NEWLINE))
+            && (pc->get_prev()->type == CT_NEWLINE))
          {
             indent_column_set(1);
             reindent_line(pc, indent_column);
@@ -707,7 +707,7 @@ void indent_text(void)
          }
          else
          {
-            Chunk *prev = chunk_get_prev(pc);
+            Chunk *prev = pc->get_prev();
 
             if (  chunk_is_token(prev, CT_BRACE_CLOSE)
                && get_chunk_parent_type(prev) == CT_FUNC_DEF)
@@ -2121,7 +2121,7 @@ void indent_text(void)
             {
                break;
             }
-            Chunk *prev = chunk_get_prev(pc);
+            Chunk *prev = pc->get_prev();
 
             if (  get_chunk_parent_type(pc) == CT_BRACED_INIT_LIST
                && chunk_is_token(prev, CT_BRACE_OPEN)
@@ -2224,7 +2224,7 @@ void indent_text(void)
             while (  ((pct = chunk_get_prev_nnl(pct)) != nullptr)
                   && chunk_is_comment(pct))
             {
-               Chunk *t2 = chunk_get_prev(pct);
+               Chunk *t2 = pct->get_prev();
 
                if (chunk_is_newline(t2))
                {
@@ -2321,7 +2321,7 @@ void indent_text(void)
                   && chunk_is_comment(pct)
                   && !chunk_is_Doxygen_comment(pct))
             {
-               Chunk *t2 = chunk_get_prev(pct);
+               Chunk *t2 = pct->get_prev();
 
                if (chunk_is_newline(t2))
                {
@@ -2399,7 +2399,7 @@ void indent_text(void)
                  && chunk_is_token(pc, CT_CONSTR_COLON))
          {
             log_rule_B("indent_constr_colon");
-            Chunk *prev = chunk_get_prev(pc);
+            Chunk *prev = pc->get_prev();
 
             if (chunk_is_newline(prev))
             {
@@ -2455,7 +2455,7 @@ void indent_text(void)
 
          int   move = 0;
 
-         if (  chunk_is_newline(chunk_get_prev(pc))
+         if (  chunk_is_newline(pc->get_prev())
             && pc->column != indent_column)
          {
             move = indent_column - pc->column;
@@ -2486,7 +2486,7 @@ void indent_text(void)
           */
          frm.push(pc, __func__, __LINE__);
 
-         if (  chunk_is_newline(chunk_get_prev(pc))
+         if (  chunk_is_newline(pc->get_prev())
             && pc->column != indent_column
             && !pc->flags.test(PCF_DONT_INDENT))
          {
@@ -2750,7 +2750,7 @@ void indent_text(void)
 
          if (  !options::use_indent_continue_only_once() // Issue #1160
             && (  chunk_is_token(pc, CT_FPAREN_OPEN)
-               && chunk_is_newline(chunk_get_prev(pc)))
+               && chunk_is_newline(pc->get_prev()))
             && (  (  (  get_chunk_parent_type(pc) == CT_FUNC_PROTO
                      || get_chunk_parent_type(pc) == CT_FUNC_CLASS_PROTO)
                   && options::indent_paren_after_func_decl())
@@ -2858,7 +2858,7 @@ void indent_text(void)
             log_indent_tmp();
          }
 
-         if (chunk_is_newline(chunk_get_prev(pc)))
+         if (chunk_is_newline(pc->get_prev()))
          {
             if (  chunk_is_token(pc, CT_MEMBER)                           // Issue #2890
                && language_is_set(LANG_CPP))
@@ -2921,7 +2921,7 @@ void indent_text(void)
           * otherwise align on the '='.
           */
          if (  chunk_is_token(pc, CT_ASSIGN)
-            && chunk_is_newline(chunk_get_prev(pc)))
+            && chunk_is_newline(pc->get_prev()))
          {
             if (frm.top().type == CT_ASSIGN_NL)
             {
@@ -2958,7 +2958,7 @@ void indent_text(void)
             frm.push(pc, __func__, __LINE__);
 
             if (  chunk_is_token(pc, CT_ASSIGN)
-               && chunk_is_newline(chunk_get_prev(pc)))
+               && chunk_is_newline(pc->get_prev()))
             {
                frm.top().type = CT_ASSIGN_NL;
             }
@@ -3342,7 +3342,7 @@ void indent_text(void)
             // should only be set if frm.top().indent is also set.
          }
          else if (  options::indent_var_def_cont()
-                 || chunk_is_newline(chunk_get_prev(pc)))
+                 || chunk_is_newline(pc->get_prev()))
          {
             log_rule_B("indent_var_def_cont");
             vardefcol = frm.top().indent + indent_size;
@@ -3530,7 +3530,7 @@ void indent_text(void)
                Chunk *ck1 = frm.poped().pc;
                LOG_FMT(LINDLINE, "%s(%d): ck1->orig_line is %zu, ck1->orig_col is %zu, ck1->text() is '%s', ck1->type is %s\n",
                        __func__, __LINE__, ck1->orig_line, ck1->orig_col, ck1->text(), get_token_name(ck1->type));
-               Chunk *ck2 = chunk_get_prev(ck1);
+               Chunk *ck2 = ck1->get_prev();
                LOG_FMT(LINDLINE, "%s(%d): ck2->orig_line is %zu, ck2->orig_col is %zu, ck2->text() is '%s', ck2->type is %s\n",
                        __func__, __LINE__, ck2->orig_line, ck2->orig_col, ck2->text(), get_token_name(ck2->type));
 
@@ -3596,7 +3596,7 @@ void indent_text(void)
                      LOG_FMT(LINDLINE, "%s(%d): ck2->orig_line is %zu, ck2->orig_col is %zu, ck2->text() is '%s'\n",
                              __func__, __LINE__, ck2->orig_line, ck2->orig_col, ck2->text());
 
-                     if (chunk_get_prev(pc)->type == CT_NEWLINE)
+                     if (pc->get_prev()->type == CT_NEWLINE)
                      {
                         LOG_FMT(LINDLINE, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s', type is %s\n",
                                 __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(), get_token_name(pc->type));
@@ -3660,7 +3660,7 @@ void indent_text(void)
             LOG_FMT(LINDENT, "%s(%d): [%s/%s]\n",
                     __func__, __LINE__,
                     get_token_name(pc->type), get_token_name(get_chunk_parent_type(pc)));
-            Chunk *prev2 = chunk_get_prev(pc);                  // Issue #2930
+            Chunk *prev2 = pc->get_prev();                  // Issue #2930
             LOG_FMT(LINDENT, "%s(%d): prev2 is orig_line is %zu, text is '%s'\n",
                     __func__, __LINE__, prev2->orig_line, prev2->text());
             Chunk *next2 = chunk_get_next(pc);
@@ -4126,10 +4126,15 @@ static bool single_line_comment_indent_rule_applies(Chunk *start, bool forward)
    {
       return(false);
    }
-   Chunk  *pc      = start;
+   Chunk *pc = start;
+
+   if (pc == nullptr)
+   {
+      pc = Chunk::NullChunkPtr;
+   }
    size_t nl_count = 0;
 
-   while ((pc = forward ? chunk_get_next(pc) : chunk_get_prev(pc)) != nullptr)
+   while ((pc = forward ? chunk_get_next(pc) : pc->get_prev()) != nullptr)
    {
       if (chunk_is_newline(pc))
       {
@@ -4240,7 +4245,7 @@ static void indent_comment(Chunk *pc, size_t col)
       reindent_line(pc, 1);
       return;
    }
-   Chunk *nl = chunk_get_prev(pc);
+   Chunk *nl = pc->get_prev();
 
    if (nl != nullptr)
    {
@@ -4250,9 +4255,14 @@ static void indent_comment(Chunk *pc, size_t col)
 
    if (pc->orig_col > 1)
    {
-      Chunk *prev = chunk_get_prev(nl);
+      Chunk *prev = Chunk::NullChunkPtr;
 
-      if (prev != nullptr)
+      if (nl != nullptr)
+      {
+         prev = nl->get_prev();
+      }
+
+      if (prev->isNotNullChunk())
       {
          LOG_FMT(LCMTIND, "%s(%d): prev->text() is '%s', orig_line %zu, orig_col %zu, level %zu\n",
                  __func__, __LINE__, prev->text(), prev->orig_line, prev->orig_col, prev->level);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -667,7 +667,7 @@ void output_text(FILE *pfile)
             else
             {
                // Try to keep the same relative spacing
-               Chunk *prev = chunk_get_prev(pc);
+               Chunk *prev = pc->get_prev();
 
                if (chunk_is_token(prev, CT_PP_IGNORE))
                {
@@ -682,13 +682,15 @@ void output_text(FILE *pfile)
                {
                   // Try to keep the same relative spacing
                   while (  prev != nullptr
+                        && prev->isNotNullChunk()
                         && prev->orig_col == 0
                         && prev->nl_count == 0)
                   {
-                     prev = chunk_get_prev(prev);
+                     prev = prev->get_prev();
                   }
 
                   if (  prev != nullptr
+                     && prev->isNotNullChunk()
                      && prev->nl_count == 0)
                   {
                      int orig_sp = (pc->orig_col - prev->orig_col_end);
@@ -834,7 +836,7 @@ void output_text(FILE *pfile)
                reindent_line(pc, cpd.column);
             }
             // not the first item on a line
-            Chunk *prev = chunk_get_prev(pc);
+            Chunk *prev = pc->get_prev();
             log_rule_B("align_with_tabs");
             allow_tabs = (  options::align_with_tabs()
                          && pc->flags.test(PCF_WAS_ALIGNED)
@@ -3093,7 +3095,8 @@ static void do_kw_subst(Chunk *pc)
 
 static void output_comment_multi_simple(Chunk *pc)
 {
-   if (pc == nullptr)
+   if (  pc == nullptr
+      && pc->isNotNullChunk())
    {
       return;
    }
@@ -3112,7 +3115,7 @@ static void output_comment_multi_simple(Chunk *pc)
    {
       int diff = 0;
 
-      if (chunk_is_newline(chunk_get_prev(pc)))
+      if (chunk_is_newline(pc->get_prev()))
       {
          // The comment should be indented correctly
          diff = pc->column - pc->orig_col;

--- a/src/remove_duplicate_include.cpp
+++ b/src/remove_duplicate_include.cpp
@@ -20,10 +20,11 @@ void remove_duplicate_include(void)
 
    vector<Chunk *> includes;
 
-   Chunk           *preproc = nullptr;
+   Chunk           *preproc = Chunk::NullChunkPtr;
    Chunk           *pc      = chunk_get_head();
 
-   while (pc != nullptr)
+   while (  pc != nullptr
+         && pc->isNotNullChunk())
    {
       //LOG_FMT(LRMRETURN, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s', type is %s, parent_type is %s\n",
       //        __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(),
@@ -67,7 +68,7 @@ void remove_duplicate_include(void)
                   Chunk *temp    = pc;
                   Chunk *comment = chunk_get_next(next);
                   Chunk *eol     = chunk_get_next_nl(next);
-                  pc = chunk_get_prev(preproc);
+                  pc = preproc->get_prev();
                   chunk_del(preproc);
                   chunk_del(temp);
                   chunk_del(next);

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -127,7 +127,12 @@ bool token_is_within_trailing_return(Chunk *pc)
    //   or  CT_FPAREN_OPEN is found
    Chunk *prev = pc;
 
-   while (prev != nullptr)
+   if (prev == nullptr)
+   {
+      prev = Chunk::NullChunkPtr;
+   }
+
+   while (prev->isNotNullChunk())
    {
       if (chunk_is_token(prev, CT_TRAILING_RET))
       {
@@ -140,7 +145,7 @@ bool token_is_within_trailing_return(Chunk *pc)
       }
       else
       {
-         prev = chunk_get_prev(prev);
+         prev = prev->get_prev();
       }
    }
    return(false);
@@ -2588,7 +2593,7 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
       }
       else if (CharTable::IsKw1(second->str[0]))
       {
-         Chunk *prev = chunk_get_prev(first);
+         Chunk *prev = first->get_prev();
 
          if (chunk_is_token(prev, CT_IN))
          {
@@ -2906,7 +2911,12 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
       if (chunk_is_token(second, CT_WORD))
       {
          Chunk *open_paren = chunk_skip_to_match_rev(first);
-         Chunk *type       = chunk_get_prev(chunk_get_prev(open_paren));
+
+         if (open_paren == nullptr)
+         {
+            open_paren = Chunk::NullChunkPtr;
+         }
+         Chunk *type = open_paren->get_prev()->get_prev();
 
          if (chunk_is_token(type, CT_TYPE))
          {

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -603,9 +603,9 @@ void tokenize_cleanup(void)
          if (  chunk_is_token(pc, CT_WORD)
             && chunk_is_token(next, CT_DC_MEMBER))
          {
-            prev = chunk_get_prev(pc);
+            prev = pc->get_prev();
 
-            if (prev == nullptr)                  // Issue #3010
+            if (prev->isNullChunk())                  // Issue #3010
             {
                set_chunk_type(pc, CT_TYPE);
             }
@@ -819,7 +819,7 @@ void tokenize_cleanup(void)
                   && (!pc->str.startswith("$\""))
                   && (!pc->str.startswith("$@\""))))))
       {
-         Chunk *tmp = chunk_get_prev(pc);
+         Chunk *tmp = pc->get_prev();
 
          if (chunk_is_newline(tmp))
          {

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1660,14 +1660,16 @@ static void add_file_footer()
 
    // Back up if the file ends with a newline
    if (  pc != nullptr
+      && pc->isNotNullChunk()
       && chunk_is_newline(pc))
    {
-      pc = chunk_get_prev(pc);
+      pc = pc->get_prev();
    }
 
    if (  pc != nullptr
+      && pc->isNotNullChunk()
       && (  !chunk_is_comment(pc)
-         || !chunk_is_newline(chunk_get_prev(pc))))
+         || !chunk_is_newline(pc->get_prev())))
    {
       pc = chunk_get_tail();
 
@@ -1755,7 +1757,9 @@ static void add_func_header(c_token_t type, file_mem &fm)
        */
       ref = pc;
 
-      while ((ref = chunk_get_prev(ref)) != nullptr)
+      while (  ref != nullptr
+            && (ref = ref->get_prev()) != nullptr
+            && ref->isNotNullChunk())
       {
          // Bail if we change level or find an access specifier colon
          if (  ref->level != pc->level
@@ -1794,7 +1798,7 @@ static void add_func_header(c_token_t type, file_mem &fm)
 
          // Ignore 'right' comments
          if (  chunk_is_comment(ref)
-            && chunk_is_newline(chunk_get_prev(ref)))
+            && chunk_is_newline(ref->get_prev()))
          {
             break;
          }
@@ -1809,7 +1813,8 @@ static void add_func_header(c_token_t type, file_mem &fm)
          }
       }
 
-      if (  ref == nullptr
+      if (  (  ref == nullptr
+            || ref->isNullChunk())
          && !chunk_is_comment(chunk_get_head())
          && get_chunk_parent_type(chunk_get_head()) == type)
       {
@@ -1856,7 +1861,8 @@ static void add_msg_header(c_token_t type, file_mem &fm)
        */
       ref = pc;
 
-      while ((ref = chunk_get_prev(ref)) != nullptr)
+      while (  (ref = ref->get_prev()) != nullptr
+            && ref->isNotNullChunk())
       {
          // ignore the CT_TYPE token that is the result type
          if (  ref->level != pc->level
@@ -1897,13 +1903,13 @@ static void add_msg_header(c_token_t type, file_mem &fm)
             && (  ref->flags.test(PCF_IN_PREPROC)
                || chunk_is_token(ref, CT_OC_SCOPE)))
          {
-            ref = chunk_get_prev(ref);
+            ref = ref->get_prev();
 
             if (ref != nullptr)
             {
                // Ignore 'right' comments
                if (  chunk_is_newline(ref)
-                  && chunk_is_comment(chunk_get_prev(ref)))
+                  && chunk_is_comment(ref->get_prev()))
                {
                   break;
                }

--- a/src/width.cpp
+++ b/src/width.cpp
@@ -142,7 +142,7 @@ static void split_before_chunk(Chunk *pc)
    LOG_FMT(LSPLIT, "%s(%d): text() '%s'\n", __func__, __LINE__, pc->text());
 
    if (  !chunk_is_newline(pc)
-      && !chunk_is_newline(chunk_get_prev(pc)))
+      && !chunk_is_newline(pc->get_prev()))
    {
       newline_add_before(pc);
       // reindent needs to include the indent_continue value and was off by one
@@ -246,7 +246,7 @@ static void try_split_here(cw_entry &ent, Chunk *pc)
    }
    LOG_FMT(LSPLIT, "%s(%d):\n", __func__, __LINE__);
    // Can't split after a newline
-   Chunk *prev = chunk_get_prev(pc);
+   Chunk *prev = pc->get_prev();
 
    if (  prev == nullptr
       || (  chunk_is_newline(prev)
@@ -426,7 +426,8 @@ static bool split_line(Chunk *start)
    Chunk *pc = start;
    Chunk *prev;
 
-   while (  ((pc = chunk_get_prev(pc)) != nullptr)
+   while (  ((pc = pc->get_prev()) != nullptr)
+         && pc->isNotNullChunk()
          && !chunk_is_newline(pc))
    {
       LOG_FMT(LSPLIT, "%s(%d): at %s, orig_line is %zu, orig_col is %zu\n",
@@ -524,9 +525,10 @@ static bool split_line(Chunk *start)
       }
    }
    // add a newline before pc
-   prev = chunk_get_prev(pc);
+   prev = pc->get_prev();
 
    if (  prev != nullptr
+      && prev->isNotNullChunk()
       && !chunk_is_newline(pc)
       && !chunk_is_newline(prev))
    {
@@ -568,7 +570,8 @@ static void split_for_stmt(Chunk *start)
    // Find the open paren so we know the level and count newlines
    Chunk *pc = start;
 
-   while ((pc = chunk_get_prev(pc)) != nullptr)
+   while (  ((pc = pc->get_prev()) != nullptr)
+         && pc->isNotNullChunk())
    {
       if (chunk_is_token(pc, CT_SPAREN_OPEN))
       {
@@ -601,7 +604,8 @@ static void split_for_stmt(Chunk *start)
 
    // first scan backwards for the semicolons
    while (  (count < static_cast<int>(max_cnt))
-         && ((pc = chunk_get_prev(pc)) != nullptr)
+         && ((pc = pc->get_prev()) != nullptr)
+         && pc->isNotNullChunk()
          && pc->flags.test(PCF_IN_SPAREN))
    {
       if (  chunk_is_token(pc, CT_SEMICOLON)
@@ -682,7 +686,8 @@ static void split_fcn_params_full(Chunk *start)
 
    LOG_FMT(LSPLIT, "  %s(%d): Find the opening function parenthesis\n", __func__, __LINE__);
 
-   while ((fpo = chunk_get_prev(fpo)) != nullptr)
+   while (  (fpo = fpo->get_prev()) != nullptr
+         && fpo->isNotNullChunk())
    {
       LOG_FMT(LSPLIT, "%s(%d): %s, orig_col is %zu, level is %zu\n",
               __func__, __LINE__, fpo->text(), fpo->orig_col, fpo->level);
@@ -724,7 +729,8 @@ static void split_fcn_params(Chunk *start)
       // Find the opening function parenthesis
       LOG_FMT(LSPLIT, "%s(%d): Find the opening function parenthesis\n", __func__, __LINE__);
 
-      while (  ((fpo = chunk_get_prev(fpo)) != nullptr)
+      while (  ((fpo = fpo->get_prev()) != nullptr)
+            && fpo->isNotNullChunk()
             && chunk_is_not_token(fpo, CT_FPAREN_OPEN))
       {
          // do nothing
@@ -799,7 +805,8 @@ static void split_fcn_params(Chunk *start)
    LOG_FMT(LSPLIT, "%s(%d): back up until the prev is a comma, begin is '%s', level is %zu\n",
            __func__, __LINE__, prev->text(), prev->level);
 
-   while ((prev = chunk_get_prev(prev)) != nullptr)
+   while (  (prev = prev->get_prev()) != nullptr
+         && prev->isNotNullChunk())
    {
       LOG_FMT(LSPLIT, "%s(%d): prev->text() is '%s', prev->orig_line is %zu, prev->orig_col is %zu\n",
               __func__, __LINE__, prev->text(), prev->orig_line, prev->orig_col);
@@ -879,7 +886,8 @@ static void split_template(Chunk *start)
    // back up until the prev is a comma
    Chunk *prev = start;
 
-   while ((prev = chunk_get_prev(prev)) != nullptr)
+   while (  (prev = prev->get_prev()) != nullptr
+         && prev->isNotNullChunk())
    {
       LOG_FMT(LSPLIT, "  %s(%d): prev '%s'\n", __func__, __LINE__, prev->text());
 

--- a/tests/expected/cpp/02102-indent-c.cpp
+++ b/tests/expected/cpp/02102-indent-c.cpp
@@ -565,7 +565,7 @@ void indent_text(void)
 
       if (cpd.settings[UO_indent_class_colon].b)
         {
-        prev = chunk_get_prev(pc);
+        prev = pc->get_prev();
 
         if (chunk_is_newline(prev))
           {
@@ -862,7 +862,7 @@ static void indent_comment(Chunk *pc, int col)
     return;
     }
 
-  nl = chunk_get_prev(pc);
+  nl = pc->get_prev();
 
     /* outside of any expression or statement? */
   if (pc->level == 0)
@@ -875,7 +875,7 @@ static void indent_comment(Chunk *pc, int col)
       }
     }
 
-  prev = chunk_get_prev(nl);
+  prev = nl->get_prev();
 
   if (chunk_is_comment(prev) && (nl->nl_count == 1))
     {

--- a/tests/expected/cpp/02103-output.cpp
+++ b/tests/expected/cpp/02103-output.cpp
@@ -230,7 +230,7 @@ void output_text(FILE *pfile)
           allow_tabs = pc->after_tab;
         else
           {
-          prev       = chunk_get_prev(pc);
+          prev       = pc->get_prev();
           allow_tabs = (cpd.settings[UO_align_with_tabs].b &&
                         ((pc->flags & PCF_WAS_ALIGNED) != 0) &&
                         (((pc->column - 1) % cpd.settings[UO_output_tab_size].n) == 0) &&
@@ -363,7 +363,7 @@ Chunk *output_comment_cpp(Chunk *first)
     /* Make sure we have at least one space past the last token */
   if (first->parent_type == CT_COMMENT_END)
     {
-    Chunk *prev = chunk_get_prev(first);
+    Chunk *prev = first->get_prev();
 
     if (prev != NULL)
       {
@@ -490,7 +490,7 @@ void output_comment_multi(Chunk *pc)
   int col_diff = 0;
   int xtra     = 1;
 
-  prev = chunk_get_prev(pc);
+  prev = pc->get_prev();
 
   if ((prev != NULL) && (prev->type != CT_NEWLINE))
     cmt_col = pc->orig_col;

--- a/tests/input/cpp/indent-c.cpp
+++ b/tests/input/cpp/indent-c.cpp
@@ -599,7 +599,7 @@ void indent_text(void)
 
          if (cpd.settings[UO_indent_class_colon].b)
          {
-            prev = chunk_get_prev(pc);
+            prev = pc->get_prev();
             if (chunk_is_newline(prev))
             {
                frm.pse[frm.pse_tos].indent += 2;
@@ -908,7 +908,7 @@ static void indent_comment(Chunk *pc, int col)
       return;
    }
 
-   nl = chunk_get_prev(pc);
+   nl = pc->get_prev();
 
    /* outside of any expression or statement? */
    if (pc->level == 0)
@@ -921,7 +921,7 @@ static void indent_comment(Chunk *pc, int col)
       }
    }
 
-   prev = chunk_get_prev(nl);
+   prev = nl->get_prev();
    if (chunk_is_comment(prev) && (nl->nl_count == 1))
    {
       int coldiff = prev->orig_col - pc->orig_col;

--- a/tests/input/cpp/output.cpp
+++ b/tests/input/cpp/output.cpp
@@ -251,7 +251,7 @@ void output_text(FILE *pfile)
             }
             else
             {
-               prev       = chunk_get_prev(pc);
+               prev       = pc->get_prev();
                allow_tabs = (cpd.settings[UO_align_with_tabs].b &&
                              ((pc->flags & PCF_WAS_ALIGNED) != 0) &&
                              (((pc->column - 1) % cpd.settings[UO_output_tab_size].n) == 0) &&
@@ -393,7 +393,7 @@ Chunk *output_comment_cpp(Chunk *first)
    /* Make sure we have at least one space past the last token */
    if (first->parent_type == CT_COMMENT_END)
    {
-      Chunk *prev = chunk_get_prev(first);
+      Chunk *prev = first->get_prev();
       if (prev != NULL)
       {
          int col_min = prev->column + prev->len + 1;
@@ -521,7 +521,7 @@ void output_comment_multi(Chunk *pc)
    int        col_diff = 0;
    int        xtra     = 1;
 
-   prev = chunk_get_prev(pc);
+   prev = pc->get_prev();
    if ((prev != NULL) && (prev->type != CT_NEWLINE))
    {
       cmt_col = pc->orig_col;


### PR DESCRIPTION
1. Some improvement on the list manager
2. Added NullChunk and NullChunkPtr, together with supporting calls.
3. Replaced chunk_get_prev() with Chunk::get_prev()

NOTES:
1. while the code improvement process is on going, there will be a mix of nullptr and Chunk::NullChunkPtr in the code as well as a mix of checking for nullptr and whether a chunk is null or not. As we progress, there should be more and more checks for null chunk and less for nullptr. Ultimately when the effort is completed there should not be any nullptr chunk pointers, only NullChunkPtr.
2. chunk_get_prev() has been fully replaced by Chunk::get_prev() except for the call in select_search_fct(), where for the time being it is used a modified version called __chunk_get_prev(). This this now an internal function (removed from chunk.h) and will be ultimately removed in full when we reach the stage where select_search_fct() definition can be changed too.