### PR TITLE
Fix comments to say that indent_paren_close is signed

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -1346,7 +1346,7 @@ indent_paren_nl                 = false    # true/false
 #  1: Align under the open parenthesis
 #  2: Indent to the brace level
 # -1: Preserve original indentation
-indent_paren_close              = 0        # unsigned number
+indent_paren_close              = 0        # signed number
 
 # Whether to indent the open parenthesis of a function definition,
 # if the parenthesis is on its own line.

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -1346,7 +1346,7 @@ indent_paren_nl                 = false    # true/false
 #  1: Align under the open parenthesis
 #  2: Indent to the brace level
 # -1: Preserve original indentation
-indent_paren_close              = 0        # unsigned number
+indent_paren_close              = 0        # signed number
 
 # Whether to indent the open parenthesis of a function definition,
 # if the parenthesis is on its own line.


### PR DESCRIPTION
I missed this in 8b9a7611f276776689f0643d2bc1142d92eece1c.