### PR TITLE
Code improvements/get_next_nl-get_prev_nl

### DIFF
--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -1270,12 +1270,12 @@ static void move_case_return(void)
             {
                // This may indicate a semicolon was missing in the code to format.
                // Avoid moving the return statement to prevent potential unwanted erros.
-               pc = nullptr;
+               pc = Chunk::NullChunkPtr;
                break;
             }
             pc = pc->get_next();
          }
-         pc = chunk_get_next_nl(pc);
+         pc = pc->get_next_nl();
          pc = chunk_get_next_nc_nnl(pc);
 
          if (  pc != nullptr

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -772,9 +772,15 @@ Chunk *Chunk::get_next_nl(scope_e scope)
 }
 
 
-Chunk *chunk_get_prev_nl(Chunk *cur, scope_e scope)
+Chunk *Chunk::get_prev_nl(scope_e scope)
 {
-   return(chunk_search(cur, chunk_is_newline, scope, direction_e::BACKWARD, true));
+   Chunk *ret = chunk_search(this, chunk_is_newline, scope, direction_e::BACKWARD, true);
+
+   if (ret == nullptr)
+   {
+      return(Chunk::NullChunkPtr);
+   }
+   return(ret);
 }
 
 

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -760,9 +760,15 @@ void chunk_move_after(Chunk *pc_in, Chunk *ref)
 }
 
 
-Chunk *chunk_get_next_nl(Chunk *cur, scope_e scope)
+Chunk *Chunk::get_next_nl(scope_e scope)
 {
-   return(chunk_search(cur, chunk_is_newline, scope, direction_e::FORWARD, true));
+   Chunk *ret = chunk_search(this, chunk_is_newline, scope, direction_e::FORWARD, true);
+
+   if (ret == nullptr)
+   {
+      return(Chunk::NullChunkPtr);
+   }
+   return(ret);
 }
 
 

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -102,6 +102,17 @@ public:
    Chunk *get_next_nl(scope_e scope = scope_e::ALL);
 
 
+   /**
+    * @brief returns the prev newline chunk
+    *
+    * @param scope code region to search in
+    *
+    * @return pointer to prev newline chunk or null Chunk if no chunk was found
+    */
+   // TODO make it a const member
+   Chunk *get_prev_nl(scope_e scope = scope_e::ALL);
+
+
    Chunk        *next;          //! pointer to next chunk in list
    Chunk        *prev;          //! pointer to previous chunk in list
    Chunk        *parent;        //! pointer to parent chunk(not always set)
@@ -233,15 +244,6 @@ Chunk *chunk_first_on_line(Chunk *pc);
 
 //! check if a given chunk is the last on its line
 bool chunk_is_last_on_line(Chunk *pc);
-
-
-/**
- * Gets the prev NEWLINE chunk
- *
- * @param cur    chunk to use as start point
- * @param scope  code region to search in
- */
-Chunk *chunk_get_prev_nl(Chunk *cur, scope_e scope = scope_e::ALL);
 
 
 /**

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -74,7 +74,7 @@ public:
    /**
     * @brief returns the next chunk in a list of chunks
     *
-    * @param scope  code region to search in
+    * @param scope code region to search in
     *
     * @return pointer to next chunk or null Chunk if no chunk was found
     */
@@ -89,6 +89,17 @@ public:
     * @return pointer to previous chunk or null Chunk if no chunk was found
     */
    Chunk *get_prev(scope_e scope = scope_e::ALL) const;
+
+
+   /**
+    * @brief returns the next newline chunk
+    *
+    * @param scope code region to search in
+    *
+    * @return pointer to next newline chunk or null Chunk if no chunk was found
+    */
+   // TODO make it a const member
+   Chunk *get_next_nl(scope_e scope = scope_e::ALL);
 
 
    Chunk        *next;          //! pointer to next chunk in list
@@ -222,15 +233,6 @@ Chunk *chunk_first_on_line(Chunk *pc);
 
 //! check if a given chunk is the last on its line
 bool chunk_is_last_on_line(Chunk *pc);
-
-
-/**
- * Gets the next NEWLINE chunk
- *
- * @param cur    chunk to use as start point
- * @param scope  code region to search in
- */
-Chunk *chunk_get_next_nl(Chunk *cur, scope_e scope = scope_e::ALL);
 
 
 /**

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -818,7 +818,7 @@ void indent_text(void)
                break;
             }
             int   should_indent_preproc = true;
-            Chunk *preproc_next         = chunk_get_next_nl(pc);
+            Chunk *preproc_next         = pc->get_next_nl();
             preproc_next = chunk_get_next_nc_nnl_nb(preproc_next);
 
             /* Look ahead at what's on the line after the #if */
@@ -828,6 +828,7 @@ void indent_text(void)
             log_rule_B("pp_indent_extern");
 
             while (  preproc_next != nullptr
+                  && preproc_next->isNotNullChunk()
                   && preproc_next->type != CT_NEWLINE)
             {
                if (  (  (  (chunk_is_token(preproc_next, CT_BRACE_OPEN))
@@ -2968,11 +2969,11 @@ void indent_text(void)
             if (  tmp != nullptr
                && chunk_is_newline(tmp->prev))
             {
-               tmp = chunk_get_prev_nc_nnl_np(tmp);
-               tmp = chunk_get_next_nl(tmp);
+               tmp = chunk_get_prev_nc_nnl_np(tmp)->get_next_nl();
             }
 
-            if (tmp != nullptr)
+            if (  tmp != nullptr
+               && tmp->isNotNullChunk())
             {
                frm.top().pop_pc = tmp;
             }

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2303,17 +2303,12 @@ void indent_text(void)
             && get_chunk_parent_type(prev) == CT_CASE)
          {
             // issue #663 + issue #1366
-            Chunk *prev_newline = chunk_get_prev_nl(pc);
+            Chunk *prev_prev_newline = pc->get_prev_nl()->get_prev_nl();
 
-            if (prev_newline != nullptr)
+            if (prev_prev_newline->isNotNullChunk())
             {
-               Chunk *prev_prev_newline = chunk_get_prev_nl(prev_newline);
-
-               if (prev_prev_newline != nullptr)
-               {
-                  // This only affects the 'break', so no need for a stack entry
-                  indent_column_set(prev_prev_newline->next->column);
-               }
+               // This only affects the 'break', so no need for a stack entry
+               indent_column_set(prev_prev_newline->get_next()->column);
             }
          }
       }
@@ -3741,13 +3736,7 @@ void indent_text(void)
                            }
                            else
                            {
-                              Chunk *_search = chunk_get_prev_nl(search);
-
-                              if (_search == nullptr)
-                              {
-                                 _search = Chunk::NullChunkPtr;
-                              }
-                              search = _search->get_next();
+                              search = search->get_prev_nl()->get_next();
 
                               if (search->isNullChunk())
                               {

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -5229,20 +5229,20 @@ void newlines_squeeze_ifdef(void)
             || chunk_is_token(ppr, CT_PP_ELSE)
             || chunk_is_token(ppr, CT_PP_ENDIF))
          {
-            Chunk *pnl = nullptr;
+            Chunk *pnl = Chunk::NullChunkPtr;
             Chunk *nnl = ppr->get_next_nl();
 
             if (  chunk_is_token(ppr, CT_PP_ELSE)
                || chunk_is_token(ppr, CT_PP_ENDIF))
             {
-               pnl = chunk_get_prev_nl(pc);
+               pnl = pc->get_prev_nl();
             }
             Chunk *tmp1;
             Chunk *tmp2;
 
             if (nnl->isNotNullChunk())
             {
-               if (pnl != nullptr)
+               if (pnl->isNotNullChunk())
                {
                   if (pnl->nl_count > 1)
                   {

--- a/src/remove_duplicate_include.cpp
+++ b/src/remove_duplicate_include.cpp
@@ -45,7 +45,7 @@ void remove_duplicate_include(void)
          {
             includes.push_back(next);
             // goto next newline
-            pc = chunk_get_next_nl(next);
+            pc = next->get_next_nl();
          }
          else
          {
@@ -67,7 +67,7 @@ void remove_duplicate_include(void)
                   // erase the statement
                   Chunk *temp    = pc;
                   Chunk *comment = next->get_next();
-                  Chunk *eol     = chunk_get_next_nl(next);
+                  Chunk *eol     = next->get_next_nl();
                   pc = preproc->get_prev();
                   chunk_del(preproc);
                   chunk_del(temp);
@@ -83,7 +83,7 @@ void remove_duplicate_include(void)
                else
                {
                   // goto next newline
-                  pc = chunk_get_next_nl(next);
+                  pc = next->get_next_nl();
                   // and still look for duplicate
                }
             } // for (auto itc = includes.begin();

--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -413,7 +413,7 @@ static void remove_blank_lines_between_imports(Chunk **chunks, size_t num_chunks
 
    for (size_t idx = 0; idx < (num_chunks - 1); idx++)
    {
-      Chunk *chunk1 = chunk_get_next_nl(chunks[idx]);
+      Chunk *chunk1 = chunks[idx]->get_next_nl();
       chunk1->nl_count = 1;
       MARK_CHANGE();
    }


### PR DESCRIPTION
Currently we need an additional check for nullptr after the search and return NullChunkPtr if necessary.
When all functions will have been converted and the search function can be modified, then we can remove this extra check.

Also note the two functions are not const yet. To do that we need to make a lot of other functions const, but again I am proceeding step by step and not trying to do too many things at once, which would result in a big mess.