### PR TITLE
Fix comment in etc/defaults.cfg to say that indent_paren_close is signed

### DIFF
--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1346,7 +1346,7 @@ indent_paren_nl                 = false    # true/false
 #  1: Align under the open parenthesis
 #  2: Indent to the brace level
 # -1: Preserve original indentation
-indent_paren_close              = 0        # unsigned number
+indent_paren_close              = 0        # signed number
 
 # Whether to indent the open parenthesis of a function definition,
 # if the parenthesis is on its own line.


### PR DESCRIPTION
I missed this in commit 7c23bd6b89979d5cc4c7680fffbe9ff3d30590a6.