### PR TITLE
Allow to add text in comments of config file with local language

### DIFF
--- a/src/option.cpp
+++ b/src/option.cpp
@@ -1117,6 +1117,12 @@ bool load_option_file(const char *filename, int compat_level)
       {
          ch = line[n];
 
+         // do not check characters in comment part of line
+         if ('#' == ch)
+         {
+            break;
+         }
+
          // ch >= 0 && ch <= 255
          if (  ch < 0
             || ch > 255)

--- a/tests/config/common/indent_columns-3.cfg
+++ b/tests/config/common/indent_columns-3.cfg
@@ -1,3 +1,7 @@
 indent_columns   = 3
-sp_cond_colon    = add
+
+# Add or remove space around the ':' in 'b ? t : f'.
+# Добавить или удалить пробел вокруг ':' в операторе 'b ? t : f'.
+sp_cond_colon    = add # 只是一组象形文字
+
 sp_cond_question = add


### PR DESCRIPTION
Problem:
Using non-english characters in config file generates error message
"Character at position xx, is not printable" due to checks of ASCII range for all characters.
This check is correct for parameters and values, but in some projects there is necessity
to add comments and remarks in local language.
Solution:
To ignore all text in comments i.e after '#'.
This is similar rule as for comments in programming languages.