### PR TITLE
Correction of segmentation fault with incomplete list args

### DIFF
--- a/src/args.cpp
+++ b/src/args.cpp
@@ -99,7 +99,7 @@ const char *Args::Params(const char *token, size_t &index)
             SetUsed(idx);
             return(m_values[idx]);
          }
-         return("");
+         return(nullptr);
       }
    }
 

--- a/src/error_types.h
+++ b/src/error_types.h
@@ -45,7 +45,8 @@
 #define EX__MAX           78   //! maximum listed value
 
 #else // not WIN32 or not __QNXNTO__
-// TODO: do all non windows systems know sysexits.h, Linux probably not?
+// TODO: do all non windows systems know sysexits.h?
+//       Linux knows: /usr/include/sysexits.h
 #include "sysexits.h"      // comes from BSD
 #endif
 

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -2367,9 +2367,13 @@ void uncrustify_file(const file_mem &fm, FILE *pfout, const char *parsed_file,
          // create the tracking file
          FILE *t_file;
          t_file = fopen(cpd.html_file, "wb");
-         output_text(t_file);
-         fclose(t_file);
-         exit(EX_OK);
+         if (t_file)
+         {
+            output_text(t_file);
+            fclose(t_file);
+            exit(EX_OK);
+         }
+         exit(EX_USAGE);
       }
    }
 

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -2367,6 +2367,7 @@ void uncrustify_file(const file_mem &fm, FILE *pfout, const char *parsed_file,
          // create the tracking file
          FILE *t_file;
          t_file = fopen(cpd.html_file, "wb");
+
          if (t_file)
          {
             output_text(t_file);


### PR DESCRIPTION
./uncrustify -c uncrustifyDefault.cfg main.c --tracking_space

The --tracking_space key is exsist but there is no value as filename.
This is leads to crush of the program. The cause is Args::Params and return of ("").
The return value is not nullptr. It avoid checks for nullptr
before fopen and fopen returns invalid file descriptor.