### PR TITLE
Code improvements/get_head-get_tail

### DIFF
--- a/src/EnumStructUnionParser.cpp
+++ b/src/EnumStructUnionParser.cpp
@@ -415,14 +415,15 @@ static bool chunk_is_macro_reference(Chunk *pc)
 {
    LOG_FUNC_ENTRY();
 
-   auto *next = chunk_get_head();
+   Chunk *next = Chunk::get_head();
 
    if (  (  language_is_set(LANG_CPP)
          || language_is_set(LANG_C))
       && chunk_is_token(pc, CT_WORD)
       && !pc->flags.test(PCF_IN_PREPROC))
    {
-      while (next != nullptr)
+      while (  next != nullptr
+            && next->isNotNullChunk())
       {
          if (  next->flags.test(PCF_IN_PREPROC)
             && std::strcmp(pc->str.c_str(), next->str.c_str()) == 0)

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -151,7 +151,7 @@ void align_all(void)
       || (options::align_var_struct_span() > 0)
       || (options::align_var_class_span() > 0))
    {
-      align_var_def_brace(chunk_get_head(), options::align_var_def_span(), nullptr);
+      align_var_def_brace(Chunk::get_head(), options::align_var_def_span(), nullptr);
    }
    // Align assignments
    log_rule_B("align_enum_equ_span");
@@ -161,7 +161,7 @@ void align_all(void)
    if (  (options::align_enum_equ_span() > 0)
       || (options::align_assign_span() > 0))
    {
-      align_assign(chunk_get_head(),
+      align_assign(Chunk::get_head(),
                    options::align_assign_span(),
                    options::align_assign_thresh(),
                    nullptr);
@@ -170,7 +170,7 @@ void align_all(void)
    if (  (options::align_braced_init_list_span() > 0)                   // Issue #750
       || (options::align_braced_init_list_thresh() > 0))
    {
-      align_braced_init_list(chunk_get_head(),
+      align_braced_init_list(Chunk::get_head(),
                              options::align_braced_init_list_span(),
                              options::align_braced_init_list_thresh(),
                              nullptr);

--- a/src/align_asm_colon.cpp
+++ b/src/align_asm_colon.cpp
@@ -22,7 +22,7 @@ void align_asm_colon(void)
 
    cas.Start(4);
 
-   Chunk *pc = chunk_get_head();
+   Chunk *pc = Chunk::get_head();
 
    while (  pc != nullptr
          && pc->isNotNullChunk())

--- a/src/align_assign.cpp
+++ b/src/align_assign.cpp
@@ -21,7 +21,8 @@ Chunk *align_assign(Chunk *first, size_t span, size_t thresh, size_t *p_nl_count
 {
    LOG_FUNC_ENTRY();
 
-   if (first == nullptr)
+   if (  first == nullptr
+      && first->isNotNullChunk())
    {
       // coveralls will complain here. There are no example for that.
       // see https://en.wikipedia.org/wiki/Robustness_principle

--- a/src/align_braced_init_list.cpp
+++ b/src/align_braced_init_list.cpp
@@ -19,7 +19,8 @@ Chunk *align_braced_init_list(Chunk *first, size_t span, size_t thresh, size_t *
 {
    LOG_FUNC_ENTRY();
 
-   if (first == nullptr)
+   if (  first == nullptr
+      && first->isNotNullChunk())
    {
       // coveralls will complain here. There are no example for that.
       // see https://en.wikipedia.org/wiki/Robustness_principle

--- a/src/align_eigen_comma_init.cpp
+++ b/src/align_eigen_comma_init.cpp
@@ -23,15 +23,14 @@ void align_eigen_comma_init(void)
 {
    LOG_FUNC_ENTRY();
 
-   Chunk      *start = nullptr;
+   Chunk      *start = Chunk::NullChunkPtr;
    AlignStack as;
 
    as.Start(255);
 
-   auto *pc = chunk_get_head();
+   Chunk *pc = Chunk::get_head();
 
-   while (  pc != nullptr
-         && pc->isNotNullChunk())
+   while (pc->isNotNullChunk())
    {
       if (chunk_is_newline(pc))
       {
@@ -43,25 +42,25 @@ void align_eigen_comma_init(void)
                  __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text());
       }
 
-      if (  start != nullptr
+      if (  start->isNotNullChunk()
          && ((pc->flags & PCF_IN_PREPROC) != (start->flags & PCF_IN_PREPROC)))
       {
          // a change in preproc status restarts the aligning
          as.Flush();
-         start = nullptr;
+         start = Chunk::NullChunkPtr;
       }
       else if (chunk_is_newline(pc))
       {
          as.NewLines(pc->nl_count);
       }
-      else if (  start != nullptr
+      else if (  start->isNotNullChunk()
               && pc->level < start->level)
       {
          // A drop in level restarts the aligning
          as.Flush();
-         start = nullptr;
+         start = Chunk::NullChunkPtr;
       }
-      else if (  start != nullptr
+      else if (  start->isNotNullChunk()
               && pc->level > start->level)
       {
          // Ignore any deeper levels when aligning
@@ -70,7 +69,7 @@ void align_eigen_comma_init(void)
       {
          // A semicolon at the same level flushes
          as.Flush();
-         start = nullptr;
+         start = Chunk::NullChunkPtr;
       }
       else if (  !pc->flags.test(PCF_IN_ENUM)
               && !pc->flags.test(PCF_IN_TYPEDEF)

--- a/src/align_func_params.cpp
+++ b/src/align_func_params.cpp
@@ -165,10 +165,9 @@ Chunk *align_func_param(Chunk *start)
 void align_func_params(void)
 {
    LOG_FUNC_ENTRY();
-   Chunk *pc = chunk_get_head();
+   Chunk *pc = Chunk::get_head();
 
-   while (  (pc = pc->get_next()) != nullptr
-         && pc->isNotNullChunk())
+   while ((pc = pc->get_next())->isNotNullChunk())
    {
       LOG_FMT(LFLPAREN, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s', parent_type is %s, parent_type is %s\n",
               __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(),

--- a/src/align_func_proto.cpp
+++ b/src/align_func_proto.cpp
@@ -68,7 +68,7 @@ void align_func_proto(size_t span)
    bool  look_bro = false;
    Chunk *toadd;
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (Chunk *pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       char copy[1000];
       LOG_FMT(LAS, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s', type is %s, level is %zu, brace_level is %zu\n",

--- a/src/align_left_shift.cpp
+++ b/src/align_left_shift.cpp
@@ -22,15 +22,14 @@ void align_left_shift(void)
 {
    LOG_FUNC_ENTRY();
 
-   Chunk      *start = nullptr;
+   Chunk      *start = Chunk::NullChunkPtr;
    AlignStack as;
 
    as.Start(255);
 
-   Chunk *pc = chunk_get_head();
+   Chunk *pc = Chunk::get_head();
 
-   while (  pc != nullptr
-         && pc->isNotNullChunk())
+   while (pc->isNotNullChunk())
    {
       if (chunk_is_newline(pc))
       {
@@ -43,25 +42,25 @@ void align_left_shift(void)
                  __func__, __LINE__, pc->orig_line, pc->orig_col, pc->elided_text(copy));
       }
 
-      if (  start != nullptr
+      if (  start->isNotNullChunk()
          && ((pc->flags & PCF_IN_PREPROC) != (start->flags & PCF_IN_PREPROC)))
       {
          // a change in preproc status restarts the aligning
          as.Flush();
-         start = nullptr;
+         start = Chunk::NullChunkPtr;
       }
       else if (chunk_is_newline(pc))
       {
          as.NewLines(pc->nl_count);
       }
-      else if (  start != nullptr
+      else if (  start->isNotNullChunk()
               && pc->level < start->level)
       {
          // A drop in level restarts the aligning
          as.Flush();
-         start = nullptr;
+         start = Chunk::NullChunkPtr;
       }
-      else if (  start != nullptr
+      else if (  start->isNotNullChunk()
               && pc->level > start->level)
       {
          // Ignore any deeper levels when aligning
@@ -70,7 +69,7 @@ void align_left_shift(void)
       {
          // A semicolon at the same level flushes
          as.Flush();
-         start = nullptr;
+         start = Chunk::NullChunkPtr;
       }
       else if (  !pc->flags.test(PCF_IN_ENUM)
               && !pc->flags.test(PCF_IN_TYPEDEF)
@@ -120,7 +119,7 @@ void align_left_shift(void)
           */
          Chunk *prev = pc->get_prev();
 
-         if (  prev != nullptr
+         if (  prev->isNotNullChunk()
             && chunk_is_newline(prev))
          {
             log_rule_B("indent_columns");

--- a/src/align_nl_cont.cpp
+++ b/src/align_nl_cont.cpp
@@ -50,9 +50,10 @@ Chunk *align_nl_cont(Chunk *start)
 void align_backslash_newline(void)
 {
    LOG_FUNC_ENTRY();
-   Chunk *pc = chunk_get_head();
+   Chunk *pc = Chunk::get_head();
 
-   while (pc != nullptr)
+   while (  pc != nullptr
+         && pc->isNotNullChunk())
    {
       if (chunk_is_not_token(pc, CT_NL_CONT))
       {

--- a/src/align_oc_decl_colon.cpp
+++ b/src/align_oc_decl_colon.cpp
@@ -28,7 +28,7 @@ void align_oc_decl_colon(void)
    nas.Start(4);
    nas.m_right_align = !options::align_on_tabstop();
 
-   Chunk *pc = chunk_get_head();
+   Chunk *pc = Chunk::get_head();
 
    while (  pc != nullptr
          && pc->isNotNullChunk())

--- a/src/align_oc_msg_colons.cpp
+++ b/src/align_oc_msg_colons.cpp
@@ -172,7 +172,7 @@ void align_oc_msg_colons(void)
 {
    LOG_FUNC_ENTRY();
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (Chunk *pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       if (  chunk_is_token(pc, CT_SQUARE_OPEN)
          && get_chunk_parent_type(pc) == CT_OC_MSG)

--- a/src/align_oc_msg_spec.cpp
+++ b/src/align_oc_msg_spec.cpp
@@ -21,7 +21,7 @@ void align_oc_msg_spec(size_t span)
 
    as.Start(span, 0);
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (Chunk *pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       if (chunk_is_newline(pc))
       {

--- a/src/align_preprocessor.cpp
+++ b/src/align_preprocessor.cpp
@@ -36,7 +36,7 @@ void align_preprocessor(void)
    log_rule_B("align_pp_define_gap");
    asf.m_gap = options::align_pp_define_gap();
 
-   Chunk *pc = chunk_get_head();
+   Chunk *pc = Chunk::get_head();
 
    while (  pc != nullptr
          && pc->isNotNullChunk())

--- a/src/align_same_func_call_params.cpp
+++ b/src/align_same_func_call_params.cpp
@@ -22,8 +22,8 @@ void align_same_func_call_params(void)
    LOG_FUNC_ENTRY();
 
    Chunk             *pc;
-   Chunk             *align_root = nullptr;
-   Chunk             *align_cur  = nullptr;
+   Chunk             *align_root = Chunk::NullChunkPtr;
+   Chunk             *align_cur  = Chunk::NullChunkPtr;
    size_t            align_len   = 0;
    size_t            span        = 3;
    size_t            thresh;
@@ -49,7 +49,7 @@ void align_same_func_call_params(void)
    LOG_FMT(LAS, "%s(%d): (3): span is %zu, thresh is %zu\n",
            __func__, __LINE__, span, thresh);
 
-   for (pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       if (chunk_is_newline(pc))
       {
@@ -75,7 +75,7 @@ void align_same_func_call_params(void)
          else
          {
             // if we drop below the brace level that started it, we are done
-            if (  align_root != nullptr
+            if (  align_root->isNotNullChunk()
                && align_root->brace_level > pc->brace_level)
             {
                LOG_FMT(LASFCP, "  ++ (drop) Ended with %zu fcns\n", align_len);
@@ -88,7 +88,7 @@ void align_same_func_call_params(void)
                   as_v.Flush();
                }
 
-               align_root = nullptr;
+               align_root = Chunk::NullChunkPtr;
             }
          }
          continue;
@@ -131,7 +131,7 @@ void align_same_func_call_params(void)
 
       add_str = nullptr;
 
-      if (align_root != nullptr)
+      if (align_root->isNotNullChunk())
       {
          // Issue # 1395
          // can only align functions on the same brace level
@@ -160,14 +160,14 @@ void align_same_func_call_params(void)
                as_v.Flush();
             }
 
-            align_root = nullptr;
+            align_root = Chunk::NullChunkPtr;
          }
       }
       LOG_FMT(LASFCP, "%s(%d):\n", __func__, __LINE__);
 
-      if (align_root == nullptr)
+      if (align_root->isNullChunk())
       {
-         LOG_FMT(LASFCP, "%s(%d):align_root is nullptr, Add pc '%s'\n", __func__, __LINE__, pc->text());
+         LOG_FMT(LASFCP, "%s(%d):align_root is null chunk, Add pc '%s'\n", __func__, __LINE__, pc->text());
          fcn_as.Add(pc);
          align_root      = align_fcn;
          align_root_name = align_fcn_name;

--- a/src/align_struct_initializers.cpp
+++ b/src/align_struct_initializers.cpp
@@ -16,9 +16,10 @@
 void align_struct_initializers(void)
 {
    LOG_FUNC_ENTRY();
-   Chunk *pc = chunk_get_head();
+   Chunk *pc = Chunk::get_head();
 
-   while (pc != nullptr)
+   while (  pc != nullptr
+         && pc->isNotNullChunk())
    {
       Chunk *prev = chunk_get_prev_nc_nnl(pc);
 

--- a/src/align_trailing_comments.cpp
+++ b/src/align_trailing_comments.cpp
@@ -177,7 +177,7 @@ void align_right_comments(void)
 {
    LOG_FUNC_ENTRY();
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (Chunk *pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       if (  chunk_is_token(pc, CT_COMMENT)
          || chunk_is_token(pc, CT_COMMENT_CPP)
@@ -221,10 +221,9 @@ void align_right_comments(void)
       }
    }
 
-   Chunk *pc = chunk_get_head();
+   Chunk *pc = Chunk::get_head();
 
-   while (  pc != nullptr
-         && pc->isNotNullChunk())
+   while (pc->isNotNullChunk())
    {
       if (pc->flags.test(PCF_RIGHT_COMMENT))
       {

--- a/src/align_typedefs.cpp
+++ b/src/align_typedefs.cpp
@@ -31,17 +31,17 @@ void align_typedefs(size_t span)
    log_rule_B("align_typedef_amp_style");
    as.m_amp_style = static_cast<AlignStack::StarStyle>(options::align_typedef_amp_style());
 
-   Chunk *c_typedef = nullptr;
-   Chunk *pc        = chunk_get_head();
+   Chunk *c_typedef = Chunk::NullChunkPtr;
+   Chunk *pc        = Chunk::get_head();
 
    while (pc->isNotNullChunk())
    {
       if (chunk_is_newline(pc))
       {
          as.NewLines(pc->nl_count);
-         c_typedef = nullptr;
+         c_typedef = Chunk::NullChunkPtr;
       }
-      else if (c_typedef != nullptr)
+      else if (c_typedef->isNotNullChunk())
       {
          if (pc->flags.test(PCF_ANCHOR))
          {
@@ -49,7 +49,7 @@ void align_typedefs(size_t span)
             LOG_FMT(LALTD, "%s(%d): typedef @ %zu:%zu, tag '%s' @ %zu:%zu\n",
                     __func__, __LINE__, c_typedef->orig_line, c_typedef->orig_col,
                     pc->text(), pc->orig_line, pc->orig_col);
-            c_typedef = nullptr;
+            c_typedef = Chunk::NullChunkPtr;
          }
       }
       else

--- a/src/align_var_def_brace.cpp
+++ b/src/align_var_def_brace.cpp
@@ -22,7 +22,7 @@ Chunk *align_var_def_brace(Chunk *start, size_t span, size_t *p_nl_count)
 {
    LOG_FUNC_ENTRY();
 
-   if (start == nullptr)
+   if (start->isNullChunk())
    {
       return(nullptr);
    }

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -185,10 +185,9 @@ void brace_cleanup(void)
 
    BraceState braceState;
    ParseFrame frm{};
-   Chunk      *pc = chunk_get_head();
+   Chunk      *pc = Chunk::get_head();
 
-   while (  pc != nullptr
-         && pc->isNotNullChunk())
+   while (pc->isNotNullChunk())
    {
       LOG_FMT(LTOK, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s'\n",
               __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text());
@@ -258,9 +257,9 @@ void brace_cleanup(void)
       }
       pc = pc->get_next();
    }
-//   pc = chunk_get_head();
+//   pc = Chunk::get_head();
 //
-//   while (pc != nullptr)
+//   while (pc->isNotNullChunk())
 //   {
 //      LOG_FMT(LTOK, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s'\n",
 //              __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text());

--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -160,7 +160,7 @@ void do_braces(void)
    LOG_FUNC_ENTRY();
    // Mark one-liners
    // Issue #2232 put this at the beginning
-   Chunk *pc = chunk_get_head();
+   Chunk *pc = Chunk::get_head();
 
    while ((pc = chunk_get_next_nc_nnl(pc)) != nullptr)
    {
@@ -917,7 +917,7 @@ static void convert_vbrace_to_brace(void)
    log_rule_B("mod_full_brace_using");
    log_rule_B("mod_full_brace_function");
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_nc_nnl(pc))
+   for (Chunk *pc = Chunk::get_head(); pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next_nc_nnl(pc))
    {
       if (chunk_is_not_token(pc, CT_VBRACE_OPEN))
       {
@@ -1071,7 +1071,7 @@ void add_long_closebrace_comment(void)
    Chunk *ns_pc  = nullptr;
    Chunk *cl_pc  = nullptr;
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_nc_nnl(pc))
+   for (Chunk *pc = Chunk::get_head(); pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next_nc_nnl(pc))
    {
       if (  chunk_is_token(pc, CT_FUNC_DEF)
          || chunk_is_token(pc, CT_OC_MSG_DECL))
@@ -1237,7 +1237,7 @@ static void move_case_break(void)
    LOG_FUNC_ENTRY();
    Chunk *prev = Chunk::NullChunkPtr;
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_nc_nnl(pc))
+   for (Chunk *pc = Chunk::get_head(); pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next_nc_nnl(pc))
    {
       if (  chunk_is_token(pc, CT_BREAK)
          && chunk_is_token(prev, CT_BRACE_CLOSE)
@@ -1257,7 +1257,7 @@ static void move_case_return(void)
    LOG_FUNC_ENTRY();
    Chunk *prev = Chunk::NullChunkPtr;
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next_nc_nnl(pc))
+   for (Chunk *pc = Chunk::get_head(); pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next_nc_nnl(pc))
    {
       if (  chunk_is_token(pc, CT_RETURN)
          && chunk_is_token(prev, CT_BRACE_CLOSE)
@@ -1474,7 +1474,7 @@ static void mod_case_brace(void)
 {
    LOG_FUNC_ENTRY();
 
-   Chunk *pc = chunk_get_head();
+   Chunk *pc = Chunk::get_head();
 
    // Make sure to start outside of a preprocessor line (see issue #3366)
    if (chunk_is_preproc(pc))
@@ -1482,7 +1482,8 @@ static void mod_case_brace(void)
       pc = chunk_get_next_nc_nnl_np(pc);
    }
 
-   while (pc != nullptr)
+   while (  pc != nullptr
+         && pc->isNotNullChunk())
    {
       Chunk *next = chunk_get_next_nc_nnl(pc, scope_e::PREPROC);
 
@@ -1681,7 +1682,7 @@ static void mod_full_brace_if_chain(void)
 {
    LOG_FUNC_ENTRY();
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (Chunk *pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       if (  (  chunk_is_token(pc, CT_BRACE_OPEN)
             || chunk_is_token(pc, CT_VBRACE_OPEN))

--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -270,9 +270,14 @@ static void examine_braces(void)
    log_rule_B("mod_full_brace_using");
    log_rule_B("mod_full_brace_while");
 
-   for (auto pc = chunk_get_tail(); pc != nullptr;)
+   for (Chunk *pc = Chunk::get_tail(); pc->isNotNullChunk();)
    {
-      auto prev = chunk_get_prev_type(pc, CT_BRACE_OPEN, -1);
+      Chunk *prev = chunk_get_prev_type(pc, CT_BRACE_OPEN, -1);
+
+      if (prev == nullptr)
+      {
+         prev = Chunk::NullChunkPtr;
+      }
 
       if (  chunk_is_token(pc, CT_BRACE_OPEN)
          && !pc->flags.test(PCF_IN_PREPROC)

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -450,9 +450,15 @@ static Chunk *chunk_add(const Chunk *pc_in, Chunk *ref, const direction_e pos = 
 static search_t select_search_fct(const direction_e dir = direction_e::FORWARD);
 
 
-Chunk *chunk_get_head(void)
+Chunk *Chunk::get_head(void)
 {
-   return(g_cl.GetHead());
+   Chunk *ret = g_cl.GetHead();
+
+   if (ret == nullptr)
+   {
+      return(Chunk::NullChunkPtr);
+   }
+   return(ret);
 }
 
 
@@ -1066,7 +1072,8 @@ Chunk *chunk_get_prev_nvb(Chunk *cur, const scope_e scope)
 
 void chunk_flags_set_real(Chunk *pc, pcf_flags_t clr_bits, pcf_flags_t set_bits)
 {
-   if (pc != nullptr)
+   if (  pc != nullptr
+      && pc->isNotNullChunk())
    {
       LOG_FUNC_ENTRY();
       auto const nflags = (pc->flags & ~clr_bits) | set_bits;

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -456,9 +456,15 @@ Chunk *chunk_get_head(void)
 }
 
 
-Chunk *chunk_get_tail(void)
+Chunk *Chunk::get_tail(void)
 {
-   return(g_cl.GetTail());
+   Chunk *ret = g_cl.GetTail();
+
+   if (ret == nullptr)
+   {
+      return(Chunk::NullChunkPtr);
+   }
+   return(ret);
 }
 
 
@@ -953,14 +959,14 @@ Chunk *chunk_first_on_line(Chunk *pc)
 bool chunk_is_last_on_line(Chunk *pc)  //TODO: pc should be const here
 {
    // check if pc is the very last chunk of the file
-   const auto *end = chunk_get_tail();
+   const Chunk *end = Chunk::get_tail();
 
    if (pc == end)
    {
       return(true);
    }
    // if the next chunk is a newline then pc is the last chunk on its line
-   const auto *next = pc->get_next();
+   const Chunk *next = pc->get_next();
 
    if (chunk_is_token(next, CT_NEWLINE))
    {

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -71,6 +71,15 @@ public:
    // Issue #2984, fill up, if necessary, a copy of the first chars of the text() string
    const char *elided_text(char *for_the_copy) const;
 
+
+   /**
+    * @brief returns the tail of a chunk list
+    *
+    * @return pointer to the last chunk
+    */
+   static Chunk *get_tail(void);
+
+
    /**
     * @brief returns the next chunk in a list of chunks
     *
@@ -227,10 +236,6 @@ void chunk_move_after(Chunk *pc_in, Chunk *ref);
  * @return pointer to the first chunk
  */
 Chunk *chunk_get_head(void);
-
-
-//! get the last chunk in a chunk list
-Chunk *chunk_get_tail(void);
 
 
 /**

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -73,7 +73,15 @@ public:
 
 
    /**
-    * @brief returns the tail of a chunk list
+    * @brief returns the head of the chunk list
+    *
+    * @return pointer to the first chunk
+    */
+   static Chunk *get_head(void);
+
+
+   /**
+    * @brief returns the tail of the chunk list
     *
     * @return pointer to the last chunk
     */
@@ -228,14 +236,6 @@ void chunk_del(Chunk * &pc);
  * @param ref    chunk after which to move
  */
 void chunk_move_after(Chunk *pc_in, Chunk *ref);
-
-
-/**
- * @brief returns the head of a chunk list
- *
- * @return pointer to the first chunk
- */
-Chunk *chunk_get_head(void);
 
 
 /**

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1858,7 +1858,7 @@ void fix_symbols(void)
    bool is_cpp  = language_is_set(LANG_CPP);
    bool is_java = language_is_set(LANG_JAVA);
 
-   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_nc_nnl(pc))
+   for (pc = Chunk::get_head(); pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next_nc_nnl(pc))
    {
       if (  chunk_is_token(pc, CT_FUNC_WRAP)
          || chunk_is_token(pc, CT_TYPE_WRAP))
@@ -1901,9 +1901,9 @@ void fix_symbols(void)
       }
    }
 
-   pc = chunk_get_head();
+   pc = Chunk::get_head();
 
-   if (pc == nullptr)
+   if (pc->isNullChunk())
    {
       return;
    }
@@ -1914,7 +1914,8 @@ void fix_symbols(void)
       pc = chunk_get_next_nc_nnl(pc);
    }
 
-   while (pc != nullptr)
+   while (  pc != nullptr
+         && pc->isNotNullChunk())
    {
       if (chunk_is_token(pc, CT_IGNORED))
       {
@@ -1959,10 +1960,11 @@ void fix_symbols(void)
     * 2nd pass - handle variable definitions
     * REVISIT: We need function params marked to do this (?)
     */
-   pc = chunk_get_head();
+   pc = Chunk::get_head();
    int square_level = -1;
 
-   while (pc != nullptr)
+   while (  pc != nullptr
+         && pc->isNotNullChunk())
    {
       char copy[1000];
       LOG_FMT(LFCNR, "%s(%d): pc->orig_line is %zu, orig_col is %zu, text() is '%s', type is %s, parent_type is %s\n",
@@ -2067,9 +2069,10 @@ static void process_returns(void)
    LOG_FUNC_ENTRY();
    Chunk *pc;
 
-   pc = chunk_get_head();
+   pc = Chunk::get_head();
 
-   while (pc != nullptr)
+   while (  pc != nullptr
+         && pc->isNotNullChunk())
    {
       if (chunk_is_not_token(pc, CT_RETURN))
       {
@@ -2291,9 +2294,10 @@ void mark_comments(void)
    cpd.unc_stage = unc_stage_e::MARK_COMMENTS;
 
    bool  prev_nl = true;
-   Chunk *cur    = chunk_get_head();
+   Chunk *cur    = Chunk::get_head();
 
-   while (cur != nullptr)
+   while (  cur != nullptr
+         && cur->isNotNullChunk())
    {
       Chunk *next   = chunk_get_next_nvb(cur);
       bool  next_nl = (next == nullptr) || chunk_is_newline(next);

--- a/src/combine_fix_mark.cpp
+++ b/src/combine_fix_mark.cpp
@@ -909,11 +909,10 @@ void mark_define_expressions(void)
 
    bool  in_define = false;
    bool  first     = true;
-   Chunk *pc       = chunk_get_head();
+   Chunk *pc       = Chunk::get_head();
    Chunk *prev     = pc;
 
-   while (  pc != nullptr
-         && pc->isNotNullChunk())
+   while (pc->isNotNullChunk())
    {
       if (!in_define)
       {
@@ -1794,7 +1793,7 @@ void mark_function(Chunk *pc)
 
          if (prev == nullptr)
          {
-            prev = chunk_get_head();
+            prev = Chunk::get_head();
          }
 
          for (  tmp = prev; (tmp != nullptr)

--- a/src/combine_labels.cpp
+++ b/src/combine_labels.cpp
@@ -65,9 +65,9 @@ void combine_labels(void)
    // stack to handle nesting inside of OC messages, which reset the scope
    ChunkStack cs;
 
-   Chunk      *prev = chunk_get_head();
+   Chunk      *prev = Chunk::get_head();
 
-   if (prev == nullptr)
+   if (prev->isNullChunk())
    {
       return;
    }

--- a/src/detect.cpp
+++ b/src/detect.cpp
@@ -148,7 +148,7 @@ static void detect_space_options(void)
    SP_VOTE_VAR(sp_try_brace);
    SP_VOTE_VAR(sp_getset_brace);
 
-   Chunk *prev = chunk_get_head();
+   Chunk *prev = Chunk::get_head();
    Chunk *pc   = prev->get_next();
    Chunk *next;
 

--- a/src/enum_cleanup.cpp
+++ b/src/enum_cleanup.cpp
@@ -26,7 +26,7 @@ void enum_cleanup(void)
       // nothing to do
       return;
    }
-   Chunk *pc = chunk_get_head();  // Issue #858
+   Chunk *pc = Chunk::get_head();  // Issue #858
 
    while (pc->isNotNullChunk())
    {

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -593,7 +593,7 @@ static void quick_indent_again(void)
 {
    LOG_FUNC_ENTRY();
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (Chunk *pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       if (pc->indent.ref == nullptr)
       {
@@ -635,7 +635,7 @@ void indent_text(void)
    ParseFrame              frm{};
 
 
-   Chunk *pc        = chunk_get_head();
+   Chunk *pc        = Chunk::get_head();
    bool  classFound = false;                                 // Issue #672
 
    while (  pc != nullptr
@@ -3746,7 +3746,7 @@ void indent_text(void)
 
                               if (search->isNullChunk())
                               {
-                                 search = chunk_get_head();
+                                 search = Chunk::get_head();
                               }
                               indent_column_set(search->column);
                            }
@@ -4482,11 +4482,11 @@ bool ifdef_over_whole_file(void)
    {
       return(cpd.ifdef_over_whole_file > 0);
    }
-   Chunk  *start_pp = nullptr;
-   Chunk  *end_pp   = nullptr;
+   Chunk  *start_pp = Chunk::NullChunkPtr;
+   Chunk  *end_pp   = Chunk::NullChunkPtr;
    size_t IFstage   = 0;
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (Chunk *pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       LOG_FMT(LNOTE, "%s(%d): pc->pp_level is %zu, pc->orig_line is %zu, pc->orig_col is %zu, pc->text() is '%s'\n",
               __func__, __LINE__, pc->pp_level, pc->orig_line, pc->orig_col, pc->text());
@@ -4559,7 +4559,7 @@ void indent_preproc(void)
    // Scan to see if the whole file is covered by one #ifdef
    const size_t pp_level_sub = ifdef_over_whole_file() ? 1 : 0;
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (Chunk *pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       LOG_FMT(LPPIS, "%s(%d): orig_line is %zu, orig_col is %zu, pc->text() is '%s'\n",
               __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text());

--- a/src/lang_pawn.cpp
+++ b/src/lang_pawn.cpp
@@ -104,7 +104,7 @@ void pawn_scrub_vsemi(void)
       return;
    }
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (Chunk *pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       if (pc->type != CT_VSEMICOLON)
       {
@@ -182,7 +182,7 @@ void pawn_prescan(void)
     * any questionable stuff
     */
    bool  did_nl = true;
-   Chunk *pc    = chunk_get_head();
+   Chunk *pc    = Chunk::get_head();
 
    while (  pc != nullptr
          && pc->isNotNullChunk())
@@ -310,12 +310,7 @@ void pawn_add_virtual_semicolons(void)
    if (language_is_set(LANG_PAWN))
    {
       Chunk *prev = Chunk::NullChunkPtr;
-      Chunk *pc   = chunk_get_head();
-
-      if (pc == nullptr)
-      {
-         pc = Chunk::NullChunkPtr;
-      }
+      Chunk *pc   = Chunk::get_head();
 
       while ((pc = pc->get_next())->isNotNullChunk())
       {

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -5409,9 +5409,9 @@ void newlines_eat_start_end(void)
    {
       log_rule_B("nl_end_of_file");
       log_rule_B("nl_end_of_file_min");
-      pc = chunk_get_tail();
+      pc = Chunk::get_tail();
 
-      if (pc != nullptr)
+      if (pc->isNotNullChunk())
       {
          if (chunk_is_token(pc, CT_NEWLINE))
          {

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -886,7 +886,7 @@ void newlines_sparens()
 
    //Chunk *sparen_open;
 
-   for (Chunk *sparen_open = chunk_get_next_type(chunk_get_head(), CT_SPAREN_OPEN, ANY_LEVEL);
+   for (Chunk *sparen_open = chunk_get_next_type(Chunk::get_head(), CT_SPAREN_OPEN, ANY_LEVEL);
         sparen_open != nullptr; sparen_open = chunk_get_next_type(
            sparen_open, CT_SPAREN_OPEN, ANY_LEVEL))
    {
@@ -3712,12 +3712,7 @@ void newlines_remove_newlines(void)
    LOG_FUNC_ENTRY();
 
    LOG_FMT(LBLANK, "%s(%d):\n", __func__, __LINE__);
-   Chunk *pc = chunk_get_head();
-
-   if (pc == nullptr)
-   {
-      pc = Chunk::NullChunkPtr;
-   }
+   Chunk *pc = Chunk::get_head();
 
    if (!chunk_is_newline(pc))
    {
@@ -3735,7 +3730,7 @@ void newlines_remove_newlines(void)
          prev = pc->get_prev();
          newline_iarf(pc, IARF_REMOVE);
 
-         if (next == chunk_get_head())
+         if (next == Chunk::get_head())
          {
             pc = next;
             continue;
@@ -3755,7 +3750,7 @@ void newlines_remove_disallowed()
 {
    LOG_FUNC_ENTRY();
 
-   Chunk *pc = chunk_get_head();
+   Chunk *pc = Chunk::get_head();
    Chunk *next;
 
    while ((pc = pc->get_next_nl())->isNotNullChunk())
@@ -3787,7 +3782,7 @@ void newlines_cleanup_angles()
    // Issue #1167
    LOG_FUNC_ENTRY();
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_nc_nnl(pc))
+   for (Chunk *pc = Chunk::get_head(); pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next_nc_nnl(pc))
    {
       char copy[1000];
       LOG_FMT(LBLANK, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s'\n",
@@ -3806,14 +3801,14 @@ void newlines_cleanup_braces(bool first)
    LOG_FUNC_ENTRY();
 
    // Get the first token that's not an empty line:
-   Chunk *pc;
+   Chunk *pc = Chunk::get_head();
 
-   if (chunk_is_newline(pc = chunk_get_head()))
+   if (chunk_is_newline(pc))
    {
       pc = chunk_get_next_nc_nnl(pc);
    }
 
-   for ( ; pc != nullptr; pc = chunk_get_next_nc_nnl(pc))
+   for ( ; pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next_nc_nnl(pc))
    {
       char copy[1000];
       LOG_FMT(LBLANK, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s'\n",
@@ -4975,7 +4970,7 @@ void newlines_cleanup_braces(bool first)
       }
    }
 
-   newline_def_blk(chunk_get_head(), false);
+   newline_def_blk(Chunk::get_head(), false);
 } // newlines_cleanup_braces
 
 
@@ -5016,7 +5011,7 @@ void newline_after_multiline_comment(void)
 {
    LOG_FUNC_ENTRY();
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (Chunk *pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       if (chunk_is_not_token(pc, CT_COMMENT_MULTI))
       {
@@ -5041,7 +5036,7 @@ void newline_after_label_colon(void)
 {
    LOG_FUNC_ENTRY();
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (Chunk *pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       if (chunk_is_not_token(pc, CT_LABEL_COLON))
       {
@@ -5071,7 +5066,7 @@ void newlines_insert_blank_lines(void)
 {
    LOG_FUNC_ENTRY();
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_nc_nnl(pc))
+   for (Chunk *pc = Chunk::get_head(); pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next_nc_nnl(pc))
    {
       //LOG_FMT(LNEWLINE, "%s(%d): orig_line is %zu, orig_col is %zu, text() '%s', type is %s\n",
       //        __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(), get_token_name(pc->type));
@@ -5171,7 +5166,7 @@ void newlines_functions_remove_extra_blank_lines(void)
       return;
    }
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (Chunk *pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       LOG_FMT(LNEWLINE, "%s(%d): orig_line is %zu, orig_col is %zu, text() '%s', type is %s\n",
               __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(), get_token_name(pc->type));
@@ -5217,7 +5212,7 @@ void newlines_squeeze_ifdef(void)
 
    Chunk *pc;
 
-   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_nc_nnl(pc))
+   for (pc = Chunk::get_head(); pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next_nc_nnl(pc))
    {
       if (  chunk_is_token(pc, CT_PREPROC)
          && (  pc->level > 0
@@ -5283,7 +5278,7 @@ void newlines_squeeze_paren_close(void)
 
    Chunk *pc;
 
-   for (pc = chunk_get_head(); pc->isNotNullChunk(); pc = pc->get_next())
+   for (pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       Chunk *next;
       Chunk *prev;
@@ -5356,9 +5351,9 @@ void newlines_eat_start_end(void)
    {
       log_rule_B("nl_start_of_file");
       log_rule_B("nl_start_of_file_min");
-      pc = chunk_get_head();
+      pc = Chunk::get_head();
 
-      if (pc != nullptr)
+      if (pc->isNotNullChunk())
       {
          if (chunk_is_token(pc, CT_NEWLINE))
          {
@@ -5475,7 +5470,7 @@ void newlines_chunk_pos(c_token_t chunk_type, token_pos_e mode)
       return;
    }
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_nc_nnl(pc))
+   for (Chunk *pc = Chunk::get_head(); pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next_nc_nnl(pc))
    {
       char copy[1000];
       LOG_FMT(LNEWLINE, "%s(%d): pc->orig_line is %zu, orig_col is %zu, text() is '%s'\n",
@@ -5715,7 +5710,7 @@ void newlines_class_colon_pos(c_token_t tok)
       log_rule_B("align_on_tabstop");
    }
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_nc_nnl(pc))
+   for (Chunk *pc = Chunk::get_head(); pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next_nc_nnl(pc))
    {
       if (  ccolon == nullptr
          && chunk_is_not_token(pc, tok))
@@ -5979,7 +5974,7 @@ void do_blank_lines(void)
 {
    LOG_FUNC_ENTRY();
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (Chunk *pc = Chunk::get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
    {
       if (chunk_is_token(pc, CT_NEWLINE))
       {
@@ -6022,7 +6017,7 @@ void do_blank_lines(void)
        * If this is the first or the last token, pretend that there is an extra
        * line. It will be removed at the end.
        */
-      if (  pc == chunk_get_head()
+      if (  pc == Chunk::get_head()
          || next->isNullChunk())
       {
          line_added = true;
@@ -6541,12 +6536,7 @@ void newlines_cleanup_dup(void)
 {
    LOG_FUNC_ENTRY();
 
-   Chunk *pc = chunk_get_head();
-
-   if (pc == nullptr)
-   {
-      pc = Chunk::NullChunkPtr;
-   }
+   Chunk *pc   = Chunk::get_head();
    Chunk *next = pc;
 
    while (pc->isNotNullChunk())
@@ -6640,7 +6630,7 @@ void annotations_newlines(void)
    Chunk *next;
    Chunk *prev;
    Chunk *ae;   // last token of the annotation
-   Chunk *pc = chunk_get_head();
+   Chunk *pc = Chunk::get_head();
 
    while (  (pc = chunk_get_next_type(pc, CT_ANNOTATION, -1)) != nullptr
          && (next = chunk_get_next_nnl(pc)) != nullptr)

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -471,7 +471,7 @@ void output_parsed(FILE *pfile, bool withOptions)
    fprintf(pfile, "# Line                Tag         Parent_type  Type of the parent         Columns Br/Lvl/pp         Flag   Nl  Text");
 #endif // ifdef WIN32
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (Chunk *pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
 #ifdef WIN32
       fprintf(pfile, "%s# %3d>%19.19s|%19.19s|%19.19s[%3d/%3d/%3d/%3d][%d/%d/%d][%d-%d]",
@@ -526,7 +526,7 @@ void output_parsed_csv(FILE *pfile)
    fprintf(pfile, "Line,Tag,Parent_type,Type of the parent,Column,Orig Col Strt,"
            "Orig Col End,Orig Sp Before,Br,Lvl,pp,Flags,Nl Before,Nl After,Text,");
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (Chunk *pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       fprintf(pfile, "%s%zu,%s,%s,%s,%zu,%zu,%zu,%d,%zu,%zu,%zu,",
               eol_marker, pc->orig_line, get_token_name(pc->type),
@@ -601,7 +601,7 @@ void output_text(FILE *pfile)
       size_t indent = cpd.frag_cols - 1;
 
       // loop over the whole chunk list
-      for (pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+      for (pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
       {
          pc->column        += indent;
          pc->column_indent += indent;
@@ -625,7 +625,7 @@ void output_text(FILE *pfile)
    bool write_in_tracking = false;
 
    // loop over the whole chunk list
-   for (pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       char copy[1000];
       LOG_FMT(LCONTTEXT, "%s(%d): text() is '%s', type is %s, orig_line is %zu, column is %zu, nl is %zu\n",
@@ -3307,7 +3307,7 @@ void add_long_preprocessor_conditional_block_comment(void)
    Chunk *pp_start = nullptr;
    Chunk *pp_end   = nullptr;
 
-   for (Chunk *pc = chunk_get_head(); pc; pc = chunk_get_next_nc_nnl(pc))
+   for (Chunk *pc = Chunk::get_head(); pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next_nc_nnl(pc))
    {
       // just track the preproc level:
       if (chunk_is_token(pc, CT_PREPROC))

--- a/src/parameter_pack_cleanup.cpp
+++ b/src/parameter_pack_cleanup.cpp
@@ -14,7 +14,7 @@ void parameter_pack_cleanup(void)
 {
    LOG_FUNC_ENTRY();
 
-   Chunk *pc = chunk_get_head();
+   Chunk *pc = Chunk::get_head();
 
    while (  pc != nullptr
          && pc->isNotNullChunk())

--- a/src/parens.cpp
+++ b/src/parens.cpp
@@ -48,9 +48,10 @@ void do_parens(void)
 
    if (options::mod_full_paren_if_bool())
    {
-      Chunk *pc = chunk_get_head();
+      Chunk *pc = Chunk::get_head();
 
-      while ((pc = chunk_get_next_nc_nnl(pc)) != nullptr)
+      while (  (pc = chunk_get_next_nc_nnl(pc)) != nullptr
+            && pc->isNotNullChunk())
       {
          if (  pc->type != CT_SPAREN_OPEN
             || (  get_chunk_parent_type(pc) != CT_IF
@@ -82,9 +83,10 @@ void do_parens_assign(void)                         // Issue #3316
 
    if (options::mod_full_paren_assign_bool())
    {
-      Chunk *pc = chunk_get_head();
+      Chunk *pc = Chunk::get_head();
 
-      while ((pc = chunk_get_next_nc_nnl(pc)) != nullptr)
+      while (  (pc = chunk_get_next_nc_nnl(pc)) != nullptr
+            && pc->isNotNullChunk())
       {
          if (chunk_is_token(pc, CT_ASSIGN))
          {
@@ -152,9 +154,10 @@ void do_parens_return(void)                         // Issue #3316
 
    if (options::mod_full_paren_return_bool())
    {
-      Chunk *pc = chunk_get_head();
+      Chunk *pc = Chunk::get_head();
 
-      while ((pc = chunk_get_next_nc_nnl(pc)) != nullptr)
+      while (  (pc = chunk_get_next_nc_nnl(pc)) != nullptr
+            && pc->isNotNullChunk())
       {
          if (chunk_is_token(pc, CT_RETURN))
          {

--- a/src/parent_for_pp.cpp
+++ b/src/parent_for_pp.cpp
@@ -16,9 +16,10 @@ void do_parent_for_pp(void)
 
    vector<Chunk *> viz;
 
-   Chunk           *pc = chunk_get_head();
+   Chunk           *pc = Chunk::get_head();
 
-   while ((pc = chunk_get_next_nc_nnl(pc)) != nullptr)
+   while (  (pc = chunk_get_next_nc_nnl(pc)) != nullptr
+         && pc->isNotNullChunk())
    {
       // CT_PP_IF,            // #if, #ifdef, or #ifndef
       // CT_PP_ELSE,          // #else or #elif

--- a/src/quick_align_again.cpp
+++ b/src/quick_align_again.cpp
@@ -17,7 +17,7 @@ void quick_align_again(void)
 {
    LOG_FUNC_ENTRY();
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (Chunk *pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       char copy[1000];
       LOG_FMT(LALAGAIN, "%s(%d): orig_line is %zu, orig_col is %zu, column is %zu, text() '%s'\n",

--- a/src/remove_duplicate_include.cpp
+++ b/src/remove_duplicate_include.cpp
@@ -21,10 +21,9 @@ void remove_duplicate_include(void)
    vector<Chunk *> includes;
 
    Chunk           *preproc = Chunk::NullChunkPtr;
-   Chunk           *pc      = chunk_get_head();
+   Chunk           *pc      = Chunk::get_head();
 
-   while (  pc != nullptr
-         && pc->isNotNullChunk())
+   while (pc->isNotNullChunk())
    {
       //LOG_FMT(LRMRETURN, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s', type is %s, parent_type is %s\n",
       //        __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(),

--- a/src/remove_extra_returns.cpp
+++ b/src/remove_extra_returns.cpp
@@ -17,10 +17,9 @@ void remove_extra_returns(void)
 {
    LOG_FUNC_ENTRY();
 
-   Chunk *pc = chunk_get_head();
+   Chunk *pc = Chunk::get_head();
 
-   while (  pc != nullptr
-         && pc->isNotNullChunk())
+   while (pc->isNotNullChunk())
    {
       LOG_FMT(LRMRETURN, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s', type is %s, parent_type is %s\n",
               __func__, __LINE__, pc->orig_line, pc->orig_col, pc->text(),

--- a/src/semicolons.cpp
+++ b/src/semicolons.cpp
@@ -37,9 +37,10 @@ void remove_extra_semicolons(void)
 {
    LOG_FUNC_ENTRY();
 
-   Chunk *pc = chunk_get_head();
+   Chunk *pc = Chunk::get_head();
 
-   while (pc != nullptr)
+   while (  pc != nullptr
+         && pc->isNotNullChunk())
    {
       Chunk *next = chunk_get_next_nc_nnl(pc);
       Chunk *prev;

--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -588,12 +588,11 @@ void sort_imports(void)
 
    prepare_categories();
 
-   Chunk *pc = chunk_get_head();
+   Chunk *pc = Chunk::get_head();
 
    log_rule_B("mod_sort_incl_import_grouping_enabled");
 
-   while (  pc != nullptr
-         && pc->isNotNullChunk())
+   while (pc->isNotNullChunk())
    {
       // Simple optimization to limit the sorting. Any MAX_LINES_TO_CHECK_AFTER_INCLUDE lines after last
       // import is seen are ignore from sorting.

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -3358,17 +3358,12 @@ void space_text(void)
 {
    LOG_FUNC_ENTRY();
 
-   Chunk *pc = chunk_get_head();
-
-   if (pc == nullptr)
-   {
-      return;
-   }
+   Chunk  *pc = Chunk::get_head();
    Chunk  *next;
    size_t prev_column;
    size_t column = pc->column;
 
-   while (pc != nullptr)
+   while (pc->isNotNullChunk())
    {
       if (chunk_is_token(pc, CT_NEWLINE))
       {
@@ -3427,9 +3422,9 @@ void space_text(void)
       if (  QT_SIGNAL_SLOT_found
          && options::sp_balance_nested_parens())
       {
-         Chunk *nn = next->next;                                          // Issue #2734
+         Chunk *nn = next->get_next();                                    // Issue #2734
 
-         if (  nn != nullptr
+         if (  nn->isNotNullChunk()
             && chunk_is_token(nn, CT_SPACE))
          {
             chunk_del(nn); // remove the space
@@ -3479,15 +3474,14 @@ void space_text(void)
             Chunk *tmp = next;
 
             // TODO: better use chunk_search here
-            while (  tmp != nullptr
-                  && tmp->isNotNullChunk()
+            while (  tmp->isNotNullChunk()
                   && (tmp->len() == 0)
                   && !chunk_is_newline(tmp))
             {
                tmp = tmp->get_next();
             }
 
-            if (  tmp != nullptr
+            if (  tmp->isNotNullChunk()
                && tmp->len() > 0)
             {
                bool kw1 = CharTable::IsKw2(pc->str[pc->len() - 1]);
@@ -3677,10 +3671,9 @@ void space_text_balance_nested_parens(void)
 {
    LOG_FUNC_ENTRY();
 
-   Chunk *first = chunk_get_head();
+   Chunk *first = Chunk::get_head();
 
-   while (  first != nullptr
-         && first->isNotNullChunk())
+   while (first->isNotNullChunk())
    {
       Chunk *next = first->get_next();
 

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -2367,19 +2367,20 @@ static bool parse_next(tok_ctx &ctx, Chunk &pc, const Chunk *prev_pc)
       if (  (ch == '<')
          && cpd.in_preproc == CT_PP_DEFINE)
       {
-         if (chunk_is_token(chunk_get_tail(), CT_MACRO))
+         if (chunk_is_token(Chunk::get_tail(), CT_MACRO))
          {
             // We have "#define XXX <", assume '<' starts an include string
             parse_string(ctx, pc, 0, false);
             return(true);
          }
       }
-
       /* Inside clang's __has_include() could be "path/to/file.h" or system-style <path/to/file.h> */
+      Chunk *tail = Chunk::get_tail();
+
       if (  (ch == '(')
-         && (chunk_get_tail() != nullptr)
-         && (  chunk_is_token(chunk_get_tail(), CT_CNG_HASINC)
-            || chunk_is_token(chunk_get_tail(), CT_CNG_HASINCN)))
+         && (tail->isNotNullChunk())
+         && (  chunk_is_token(tail, CT_CNG_HASINC)
+            || chunk_is_token(tail, CT_CNG_HASINCN)))
       {
          parse_string(ctx, pc, 0, false);
          return(true);

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -162,9 +162,8 @@ void tokenize_trailing_return_types(void)
    // auto f22() throw() -> bool = delete;
    // auto f23() const throw() -> bool;
    // auto f24() const throw() -> bool = delete;
-   Chunk *pc;
 
-   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_nc_nnl(pc))
+   for (Chunk *pc = Chunk::get_head(); pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next_nc_nnl(pc))
    {
       char copy[1000];
       LOG_FMT(LNOTE, "%s(%d): orig_line is %zu, orig_col is %zu, text() is '%s'\n",
@@ -315,7 +314,7 @@ void tokenize_cleanup(void)
     */
    Chunk *pc;
 
-   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_nc_nnl(pc))
+   for (pc = Chunk::get_head(); pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next_nc_nnl(pc))
    {
       if (chunk_is_token(pc, CT_SQUARE_OPEN))
       {
@@ -346,7 +345,7 @@ void tokenize_cleanup(void)
    }
 
    // change := to CT_SQL_ASSIGN Issue #527
-   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_nc_nnl(pc))
+   for (pc = Chunk::get_head(); pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next_nc_nnl(pc))
    {
       if (chunk_is_token(pc, CT_COLON))
       {
@@ -364,10 +363,11 @@ void tokenize_cleanup(void)
    }
 
    // We can handle everything else in the second pass
-   pc   = chunk_get_head();
+   pc   = Chunk::get_head();
    next = chunk_get_next_nc_nnl(pc);
 
    while (  pc != nullptr
+         && pc->isNotNullChunk()
          && next != nullptr)
    {
       if (  chunk_is_token(pc, CT_DOT)

--- a/src/unc_tools.cpp
+++ b/src/unc_tools.cpp
@@ -48,7 +48,7 @@ static size_t tokenCounter;
  */
 void prot_the_line(const char *func_name, int theLine, unsigned int actual_line, size_t partNumber)
 {
-   prot_the_line_pc(chunk_get_head(), func_name, theLine, actual_line, partNumber);
+   prot_the_line_pc(Chunk::get_head(), func_name, theLine, actual_line, partNumber);
 }
 
 
@@ -69,7 +69,7 @@ void prot_the_line_pc(Chunk *pc_sub, const char *func_name, int theLine, unsigne
    tokenCounter = 0;
    LOG_FMT(LGUY, "Prot_the_line:(%s:%d)(%zu)\n", func_name, theLine, counter);
 
-   for (Chunk *pc = pc_sub; pc != nullptr; pc = pc->next)
+   for (Chunk *pc = pc_sub; pc->isNotNullChunk(); pc = pc->get_next())
    {
       if (pc->orig_line == actual_line)
       {
@@ -154,7 +154,7 @@ void prot_all_lines(const char *func_name, int theLine)
 
    LOG_FMT(LGUY, "Prot_all_lines:(%s:%d)(%zu)\n", func_name, theLine, counter);
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr; pc = pc->next)
+   for (Chunk *pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       tokenCounter++;
 
@@ -216,7 +216,7 @@ void examine_Data(const char *func_name, int theLine, int what)
    {
    case 1:
 
-      for (pc = chunk_get_head(); pc != nullptr; pc = pc->next)
+      for (pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
       {
          if (  chunk_is_token(pc, CT_SQUARE_CLOSE)
             || chunk_is_token(pc, CT_TSQUARE))
@@ -232,7 +232,7 @@ void examine_Data(const char *func_name, int theLine, int what)
    case 2:
       LOG_FMT(LGUY, "2:(%d)\n", theLine);
 
-      for (pc = chunk_get_head(); pc != nullptr; pc = pc->next)
+      for (pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
       {
          if (pc->orig_line == 7)
          {
@@ -252,7 +252,7 @@ void examine_Data(const char *func_name, int theLine, int what)
    case 3:
       LOG_FMT(LGUY, "3:(%d)\n", theLine);
 
-      for (pc = chunk_get_head(); pc != nullptr; pc = pc->next)
+      for (pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
       {
          if (chunk_is_token(pc, CT_NEWLINE))
          {
@@ -269,7 +269,7 @@ void examine_Data(const char *func_name, int theLine, int what)
    case 4:
       LOG_FMT(LGUY, "4:(%d)\n", theLine);
 
-      for (pc = chunk_get_head(); pc != nullptr; pc = pc->next)
+      for (pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
       {
          if (pc->orig_line == 6)
          {
@@ -308,7 +308,7 @@ void dump_out(unsigned int type)
 
    if (D_file != nullptr)
    {
-      for (Chunk *pc = chunk_get_head(); pc != nullptr; pc = pc->next)
+      for (Chunk *pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
       {
          fprintf(D_file, "[%p]\n", pc);
          fprintf(D_file, "  type %s\n", get_token_name(pc->type));

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1646,10 +1646,10 @@ static void do_source_file(const char *filename_in,
 
 static void add_file_header()
 {
-   if (!chunk_is_comment(chunk_get_head()))
+   if (!chunk_is_comment(Chunk::get_head()))
    {
       // TODO: detect the typical #ifndef FOO / #define FOO sequence
-      tokenize(cpd.file_hdr.data, chunk_get_head());
+      tokenize(cpd.file_hdr.data, Chunk::get_head());
    }
 }
 
@@ -1688,7 +1688,7 @@ static void add_func_header(c_token_t type, file_mem &fm)
    Chunk *tmp;
    bool  do_insert;
 
-   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_nc_nnl_np(pc))
+   for (pc = Chunk::get_head(); pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next_nc_nnl_np(pc))
    {
       if (pc->type != type)
       {
@@ -1813,15 +1813,15 @@ static void add_func_header(c_token_t type, file_mem &fm)
 
       if (  (  ref == nullptr
             || ref->isNullChunk())
-         && !chunk_is_comment(chunk_get_head())
-         && get_chunk_parent_type(chunk_get_head()) == type)
+         && !chunk_is_comment(Chunk::get_head())
+         && get_chunk_parent_type(Chunk::get_head()) == type)
       {
          /**
           * In addition to testing for preceding semicolons, closing braces, etc.,
           * we need to also account for the possibility that the function declaration
           * or definition occurs at the very beginning of the file
           */
-         tokenize(fm.data, chunk_get_head());
+         tokenize(fm.data, Chunk::get_head());
       }
       else if (do_insert)
       {
@@ -1845,7 +1845,7 @@ static void add_msg_header(c_token_t type, file_mem &fm)
    Chunk *tmp;
    bool  do_insert;
 
-   for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_nc_nnl_np(pc))
+   for (pc = Chunk::get_head(); pc != nullptr && pc->isNotNullChunk(); pc = chunk_get_next_nc_nnl_np(pc))
    {
       if (pc->type != type)
       {
@@ -1943,9 +1943,9 @@ static void uncrustify_start(const deque<int> &data)
    // Get the column for the fragment indent
    if (cpd.frag)
    {
-      Chunk *pc = chunk_get_head();
+      Chunk *pc = Chunk::get_head();
 
-      cpd.frag_cols = (pc != nullptr) ? pc->orig_col : 0;
+      cpd.frag_cols = pc->orig_col;
    }
 
    // Add the file header
@@ -2435,7 +2435,7 @@ void uncrustify_end()
 
    cpd.unc_stage = unc_stage_e::CLEANUP;
 
-   while ((pc = chunk_get_head()) != nullptr)
+   while ((pc = Chunk::get_head())->isNotNullChunk())
    {
       chunk_del(pc);
    }

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1656,22 +1656,20 @@ static void add_file_header()
 
 static void add_file_footer()
 {
-   Chunk *pc = chunk_get_tail();
+   Chunk *pc = Chunk::get_tail();
 
    // Back up if the file ends with a newline
-   if (  pc != nullptr
-      && pc->isNotNullChunk()
+   if (  pc->isNotNullChunk()
       && chunk_is_newline(pc))
    {
       pc = pc->get_prev();
    }
 
-   if (  pc != nullptr
-      && pc->isNotNullChunk()
+   if (  pc->isNotNullChunk()
       && (  !chunk_is_comment(pc)
          || !chunk_is_newline(pc->get_prev())))
    {
-      pc = chunk_get_tail();
+      pc = Chunk::get_tail();
 
       if (!chunk_is_newline(pc))
       {

--- a/src/width.cpp
+++ b/src/width.cpp
@@ -160,7 +160,7 @@ void do_code_width(void)
    LOG_FUNC_ENTRY();
    LOG_FMT(LSPLIT, "%s(%d)\n", __func__, __LINE__);
 
-   for (Chunk *pc = chunk_get_head(); pc != nullptr && pc->isNotNullChunk(); pc = pc->get_next())
+   for (Chunk *pc = Chunk::get_head(); pc->isNotNullChunk(); pc = pc->get_next())
    {
       if (  !chunk_is_newline(pc)
          && !chunk_is_comment(pc)

--- a/tests/expected/cpp/02102-indent-c.cpp
+++ b/tests/expected/cpp/02102-indent-c.cpp
@@ -292,7 +292,7 @@ void indent_text(void)
   frm.pse[0].indent_tmp = 1;
   frm.pse[0].type       = CT_EOF;
 
-  pc = chunk_get_head();
+  pc = Chunk::get_head();
 
   while (pc != NULL)
     {
@@ -923,7 +923,7 @@ void indent_preproc(void)
     /* Scan to see if the whole file is covered by one #ifdef */
   int stage = 0;
 
-  for (pc = chunk_get_head(); pc != NULL; pc = pc->get_next())
+  for (pc = Chunk::get_head(); pc != NULL; pc = pc->get_next())
     {
     if (chunk_is_comment(pc) || chunk_is_newline(pc))
       continue;
@@ -968,7 +968,7 @@ void indent_preproc(void)
     pp_level_sub = 1;
     }
 
-  for (pc = chunk_get_head(); pc != NULL; pc = pc->get_next())
+  for (pc = Chunk::get_head(); pc != NULL; pc = pc->get_next())
     {
     if (pc->type != CT_PREPROC)
       continue;

--- a/tests/expected/cpp/02103-output.cpp
+++ b/tests/expected/cpp/02103-output.cpp
@@ -108,7 +108,7 @@ void output_parsed(FILE *pfile)
   fprintf(pfile, "-=====-\n");
   fprintf(pfile, "Line      Tag          Parent     Columns  Br/Lvl/pp Flg Nl  Text");
 
-  for (pc = chunk_get_head(); pc != NULL; pc = pc->get_next())
+  for (pc = Chunk::get_head(); pc != NULL; pc = pc->get_next())
     {
     fprintf(pfile, "\n%3d> %13.13s[%13.13s][%2d/%2d/%2d][%d/%d/%d][%6x][%d-%d]",
             pc->orig_line, get_token_name(pc->type),
@@ -186,7 +186,7 @@ void output_text(FILE *pfile)
 
   cpd.fout = pfile;
 
-  for (pc = chunk_get_head(); pc != NULL; pc = pc->get_next())
+  for (pc = Chunk::get_head(); pc != NULL; pc = pc->get_next())
     {
     if (pc->type == CT_NEWLINE)
       {

--- a/tests/expected/cpp/30012-misc2.cpp
+++ b/tests/expected/cpp/30012-misc2.cpp
@@ -30,7 +30,7 @@ void foo(void)
   List<byte> bob = new List<byte>();
 
   /* Align assignments */
-  align_assign(chunk_get_head(),
+  align_assign(Chunk::get_head(),
                cpd.settings [UO_align_assign_span].n,
                cpd.settings [UO_align_assign_thresh].n);
 }

--- a/tests/input/cpp/indent-c.cpp
+++ b/tests/input/cpp/indent-c.cpp
@@ -296,7 +296,7 @@ void indent_text(void)
    frm.pse[0].indent_tmp = 1;
    frm.pse[0].type       = CT_EOF;
 
-   pc = chunk_get_head();
+   pc = Chunk::get_head();
    while (pc != NULL)
    {
       /* Handle proprocessor transitions */
@@ -967,7 +967,7 @@ void indent_preproc(void)
    /* Scan to see if the whole file is covered by one #ifdef */
    int stage = 0;
 
-   for (pc = chunk_get_head(); pc != NULL; pc = pc->get_next())
+   for (pc = Chunk::get_head(); pc != NULL; pc = pc->get_next())
    {
       if (chunk_is_comment(pc) || chunk_is_newline(pc))
       {
@@ -1016,7 +1016,7 @@ void indent_preproc(void)
       pp_level_sub = 1;
    }
 
-   for (pc = chunk_get_head(); pc != NULL; pc = pc->get_next())
+   for (pc = Chunk::get_head(); pc != NULL; pc = pc->get_next())
    {
       if (pc->type != CT_PREPROC)
       {

--- a/tests/input/cpp/misc2.cpp
+++ b/tests/input/cpp/misc2.cpp
@@ -29,7 +29,7 @@ void foo(void)
    List<byte>bob = new List<byte> ();
 
    /* Align assignments */
-   align_assign(chunk_get_head(),
+   align_assign(Chunk::get_head(),
                 cpd.settings[UO_align_assign_span].n,
                 cpd.settings[UO_align_assign_thresh].n);
 }

--- a/tests/input/cpp/output.cpp
+++ b/tests/input/cpp/output.cpp
@@ -120,7 +120,7 @@ void output_parsed(FILE *pfile)
 
    fprintf(pfile, "-=====-\n");
    fprintf(pfile, "Line      Tag          Parent     Columns  Br/Lvl/pp Flg Nl  Text");
-   for (pc = chunk_get_head(); pc != NULL; pc = pc->get_next())
+   for (pc = Chunk::get_head(); pc != NULL; pc = pc->get_next())
    {
       fprintf(pfile, "\n%3d> %13.13s[%13.13s][%2d/%2d/%2d][%d/%d/%d][%6x][%d-%d]",
               pc->orig_line, get_token_name(pc->type),
@@ -198,7 +198,7 @@ void output_text(FILE *pfile)
 
    cpd.fout = pfile;
 
-   for (pc = chunk_get_head(); pc != NULL; pc = pc->get_next())
+   for (pc = Chunk::get_head(); pc != NULL; pc = pc->get_next())
    {
       if (pc->type == CT_NEWLINE)
       {


### PR DESCRIPTION
Use static functions to get the head or the tail of the chunk list and make sure to use the null chuck for them. I thought about leaving the two functions outside of the Chunk class, but since all the other get_next_*/get_prev_* functions are part of the chunk class, it makes sense to group this two functions together. Since they do not operate on a chunk object, they are static class method.