### PR TITLE
Update appveyor build to Visual Studio 2019

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,9 @@ platform: x64
 environment:
   matrix:
   # MSVC
-  - GENERATOR: Visual Studio 15 2017 Win64
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-  - GENERATOR: Visual Studio 14 2015 Win64
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    GENERATOR: Visual Studio 16 2019
+    ARCH_ARG: "-A Win32"
 configuration:
   - Debug
   - Release


### PR DESCRIPTION
Update appveyor to VS 2019.
The builds with VS 2015+2017 are approaching 1h 20m, so probably wiser to keep a single version rather than 2.