### PR TITLE
Remove Visual Studio 2015 from appveyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ environment:
   # MSVC
   - GENERATOR: Visual Studio 15 2017 Win64
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-  - GENERATOR: Visual Studio 14 2015 Win64
 configuration:
   - Debug
   - Release


### PR DESCRIPTION
As per title and discussed in PR #3528, to help reducing test built time on appveyor.