### PR TITLE
Only indent C++ class header lines if indent_continue_class_head is set

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2248,7 +2248,8 @@ void indent_text(void)
       }
       else if (  chunk_is_token(pc, CT_SQL_BEGIN)
               || chunk_is_token(pc, CT_MACRO_OPEN)
-              || chunk_is_token(pc, CT_CLASS))
+              || (  chunk_is_token(pc, CT_CLASS)
+                 && language_is_set(LANG_CS))) // Issue #3536
       {
          frm.push(pc, __func__, __LINE__);
 

--- a/tests/config/common/attribute_specifier_seqs.cfg
+++ b/tests/config/common/attribute_specifier_seqs.cfg
@@ -1,2 +1,3 @@
-sp_before_vardef_square  = ignore
-sp_type_brace_init_lst   = remove
+sp_before_vardef_square    = ignore
+sp_type_brace_init_lst     = remove
+indent_continue_class_head = 8

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -1089,3 +1089,4 @@
 60076  cpp/indent_ignore_before_class_colon-t.cfg           cpp/indent_ctor_init.cpp
 60077  cpp/indent_ignore_before_constr_colon-t.cfg          cpp/indent_ctor_init.cpp
 60078  cpp/indent_func_proto_param-t.cfg                    cpp/Issue_3505.cpp
+60079  common/empty.cfg                                     cpp/Issue_3536.cpp

--- a/tests/expected/cpp/60079-Issue_3536.cpp
+++ b/tests/expected/cpp/60079-Issue_3536.cpp
@@ -1,0 +1,32 @@
+struct S {};
+class C {};
+
+void processStruct0(
+	struct S s,
+	int i
+	);
+
+void processClass0(
+	class C c,
+	int i
+	);
+
+void processStruct1(
+	struct S s,
+	int i
+	);
+
+void processClass1(
+	class C c,
+	int i
+	);
+
+void processStruct2(
+	struct S s,
+	int i
+	);
+
+void processClass2(
+	class C c,
+	int i
+	);

--- a/tests/input/cpp/Issue_3536.cpp
+++ b/tests/input/cpp/Issue_3536.cpp
@@ -1,0 +1,32 @@
+struct S {};
+class C {};
+
+void processStruct0(
+struct S s,
+int i
+);
+
+void processClass0(
+class C c,
+int i
+);
+
+void processStruct1(
+	struct S s,
+	int i
+	);
+
+void processClass1(
+	class C c,
+	int i
+	);
+
+void processStruct2(
+		struct S s,
+		int i
+		);
+
+void processClass2(
+		class C c,
+		int i
+		);


### PR DESCRIPTION
The code path is still enabled for indenting C# 'where' clauses, for
example those in [UNI-32658.cs](https://github.com/uncrustify/uncrustify/blob/master/tests/input/cs/UNI-32658.cs). This shouldn't be a problem because C#
does not allow using the 'class' keyword on instances of a class.

Fixes #3536