### PR TITLE
Don't try to pop the class header frame twice

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1452,11 +1452,6 @@ void indent_text(void)
                  __func__, __LINE__);
          LOG_FMT(LINDLINE, "%s(%d): pc->orig_line is %zu, orig_col is %zu, Text() is '%s', type is %s\n",
                  __func__, __LINE__, pc->orig_line, pc->orig_col, pc->Text(), get_token_name(pc->type));
-         frm.pop(__func__, __LINE__, pc);
-         frm.top().indent_tmp = 1;
-         frm.top().indent     = 1;
-         frm.top().indent_tab = 1;
-         log_indent();
          classFound = false;
       }
       /*
@@ -4308,7 +4303,7 @@ void indent_text(void)
          }
          else
          {
-            frm.top().indent = options::indent_continue_class_head() + 1;
+            frm.top().indent = frm.prev().indent + options::indent_continue_class_head();
          }
          log_indent();
 

--- a/tests/config/cpp/Issue_3552.cfg
+++ b/tests/config/cpp/Issue_3552.cfg
@@ -1,0 +1,6 @@
+indent_with_tabs           = 0
+indent_columns             = 4
+indent_namespace           = true
+indent_class               = true
+indent_access_spec         = -4
+indent_continue_class_head = 2

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -1093,3 +1093,4 @@
 
 60080  common/empty.cfg                                     cpp/Issue_3538.cpp
 60081  cpp/Issue_3546.cfg                                   cpp/Issue_3546.cpp
+60082  cpp/Issue_3552.cfg                                   cpp/Issue_3552.cpp

--- a/tests/expected/cpp/60082-Issue_3552.cpp
+++ b/tests/expected/cpp/60082-Issue_3552.cpp
@@ -1,0 +1,9 @@
+namespace Salads
+{
+    class
+      Waldorf
+    {
+    public:
+        int size;
+    };
+}

--- a/tests/input/cpp/Issue_3552.cpp
+++ b/tests/input/cpp/Issue_3552.cpp
@@ -1,0 +1,9 @@
+namespace Salads
+{
+class
+Waldorf
+{
+public:
+int size;
+};
+}


### PR DESCRIPTION
The frame is already popped on [line 1364](https://github.com/uncrustify/uncrustify/blob/639aed0ae591afee620688e4951815a01eb03d9e/src/indent.cpp#L1364).

Fixes #3552