### PR TITLE
Add indent_ignore_assign option

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -1428,6 +1428,9 @@ indent_square_nl                = false    # true/false
 # (ESQL/C) Whether to preserve the relative indent of 'EXEC SQL' bodies.
 indent_preserve_sql             = false    # true/false
 
+# Whether to ignore the indentation of an assignment operator.
+indent_ignore_assign            = false    # true/false
+
 # Whether to align continued statements at the '='. If false or if the '=' is
 # followed by a newline, the next line is indent one tab.
 #

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -1428,6 +1428,9 @@ indent_square_nl                = false    # true/false
 # (ESQL/C) Whether to preserve the relative indent of 'EXEC SQL' bodies.
 indent_preserve_sql             = false    # true/false
 
+# Whether to ignore the indentation of an assignment operator.
+indent_ignore_assign            = false    # true/false
+
 # Whether to align continued statements at the '='. If false or if the '=' is
 # followed by a newline, the next line is indent one tab.
 #

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1428,6 +1428,9 @@ indent_square_nl                = false    # true/false
 # (ESQL/C) Whether to preserve the relative indent of 'EXEC SQL' bodies.
 indent_preserve_sql             = false    # true/false
 
+# Whether to ignore the indentation of an assignment operator.
+indent_ignore_assign            = false    # true/false
+
 # Whether to align continued statements at the '='. If false or if the '=' is
 # followed by a newline, the next line is indent one tab.
 #

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -3146,6 +3146,14 @@ EditorType=boolean
 TrueFalse=indent_preserve_sql=true|indent_preserve_sql=false
 ValueDefault=false
 
+[Indent Ignore Assign]
+Category=2
+Description="<html>Whether to ignore the indentation of an assignment operator.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=indent_ignore_assign=true|indent_ignore_assign=false
+ValueDefault=false
+
 [Indent Align Assign]
 Category=2
 Description="<html>Whether to align continued statements at the '='. If false or if the '=' is<br/>followed by a newline, the next line is indent one tab.<br/><br/>Default: true</html>"

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -4006,6 +4006,18 @@ void indent_text(void)
                     __func__, __LINE__, pc->orig_line, indent_column, pc->Text());
             reindent_line(pc, indent_column);
          }
+         else if (chunk_is_token(pc, CT_ASSIGN))
+         {
+            log_rule_B("indent_ignore_assign");
+
+            if (options::indent_ignore_assign())
+            {
+               indent_column_set(pc->orig_col);
+            }
+            LOG_FMT(LINDENT, "%s(%d): %zu] assign => %zu [%s]\n",
+                    __func__, __LINE__, pc->orig_line, indent_column, pc->Text());
+            reindent_line(pc, indent_column);
+         }
          else if (  options::indent_ternary_operator() == 1
                  && chunk_is_token(prev, CT_COND_COLON)
                  && (  chunk_is_token(pc, CT_ADDR)

--- a/src/options.h
+++ b/src/options.h
@@ -1737,6 +1737,10 @@ indent_square_nl;
 extern Option<bool>
 indent_preserve_sql;
 
+// Whether to ignore the indentation of an assignment operator.
+extern Option<bool>
+indent_ignore_assign;
+
 // Whether to align continued statements at the '='. If false or if the '=' is
 // followed by a newline, the next line is indent one tab.
 extern Option<bool>

--- a/tests/c.test
+++ b/tests/c.test
@@ -453,3 +453,4 @@
 10058  c/sp_enum_brace-r.cfg                      c/Issue_3496.h
 10059  c/sp_enum_brace-f.cfg                      c/Issue_3496.h
 10060  c/indent_ignore_bool-true.cfg              c/Issue_3548.c
+10061  c/Issue_3556.cfg                           c/Issue_3556.c

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -3164,6 +3164,14 @@ EditorType=boolean
 TrueFalse=indent_preserve_sql=true|indent_preserve_sql=false
 ValueDefault=false
 
+[Indent Ignore Assign]
+Category=2
+Description="<html>Whether to ignore the indentation of an assignment operator.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=indent_ignore_assign=true|indent_ignore_assign=false
+ValueDefault=false
+
 [Indent Align Assign]
 Category=2
 Description="<html>Whether to align continued statements at the '='. If false or if the '=' is<br/>followed by a newline, the next line is indent one tab.<br/><br/>Default: true</html>"

--- a/tests/config/c/Issue_3556.cfg
+++ b/tests/config/c/Issue_3556.cfg
@@ -1,0 +1,3 @@
+indent_columns       = 4
+indent_with_tabs     = 0
+indent_ignore_assign = true

--- a/tests/expected/c/10061-Issue_3556.c
+++ b/tests/expected/c/10061-Issue_3556.c
@@ -1,0 +1,33 @@
+int main(void)
+{
+    int a
+   = -1;
+    int b
+     = 0;
+    int c
+      = 1;
+    a
+   = -1;
+    b
+     = 0;
+    c
+      = 1;
+    if (a
+   = -1)
+    {
+        return a
+       = -1;
+    }
+    if (b
+     = 0)
+    {
+        return b
+         = 0;
+    }
+    if (c
+      = 1)
+    {
+        return c
+          = 1;
+    }
+}

--- a/tests/input/c/Issue_3556.c
+++ b/tests/input/c/Issue_3556.c
@@ -1,0 +1,33 @@
+int main(void)
+{
+    int a
+   = -1;
+    int b
+     = 0;
+    int c
+      = 1;
+    a
+   = -1;
+    b
+     = 0;
+    c
+      = 1;
+    if (a
+   = -1)
+    {
+        return a
+       = -1;
+    }
+    if (b
+     = 0)
+    {
+        return b
+         = 0;
+    }
+    if (c
+      = 1)
+    {
+        return c
+          = 1;
+    }
+}


### PR DESCRIPTION
Fixes #3556

`indent_ignore_assign` can be used together with the existing options `indent_align_assign` and `indent_off_after_assign`.