### PR TITLE
Indent function open parens only once with indent_ignore_first_continue

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2854,6 +2854,7 @@ void indent_text(void)
          log_rule_B("indent_paren_after_func_call");
 
          if (  !options::use_indent_continue_only_once() // Issue #1160
+            && !options::indent_ignore_first_continue()  // Issue #3561
             && (  chunk_is_token(pc, CT_FPAREN_OPEN)
                && chunk_is_newline(pc->GetPrev()))
             && (  (  (  get_chunk_parent_type(pc) == CT_FUNC_PROTO

--- a/tests/c.test
+++ b/tests/c.test
@@ -454,3 +454,4 @@
 10059  c/sp_enum_brace-f.cfg                      c/Issue_3496.h
 10060  c/indent_ignore_bool-true.cfg              c/Issue_3548.c
 10061  c/Issue_3556.cfg                           c/Issue_3556.c
+10062  c/Issue_3561.cfg                           c/Issue_3561.c

--- a/tests/config/c/Issue_3561.cfg
+++ b/tests/config/c/Issue_3561.cfg
@@ -1,0 +1,3 @@
+indent_with_tabs = 0
+indent_columns = 4
+indent_ignore_first_continue = true

--- a/tests/expected/c/10062-Issue_3561.c
+++ b/tests/expected/c/10062-Issue_3561.c
@@ -1,0 +1,8 @@
+#include <math.h>
+
+int main(void)
+{
+    int x = abs
+               (-1);
+    return 0;
+}

--- a/tests/input/c/Issue_3561.c
+++ b/tests/input/c/Issue_3561.c
@@ -1,0 +1,8 @@
+#include <math.h>
+
+int main(void)
+{
+    int x = abs
+               (-1);
+    return 0;
+}


### PR DESCRIPTION
Fixes #3561