### PR TITLE
doc: add --prefix option to git archive command in release-process.rst

### DIFF
--- a/release-process.rst
+++ b/release-process.rst
@@ -234,7 +234,7 @@ Create a tarball:
 .. code::
 
    $ cd /path/to/uncrustify
-   $ git archive -o uncrustify-0.1.2.tar.gz uncrustify-0.1.2
+   $ git archive -o uncrustify-0.1.2.tar.gz --prefix=uncrustify-0.1.2/ uncrustify-0.1.2
 TODO: find the best strategie...
 
 (If you don't have Ninja_, or just don't want to use it for whatever reason,


### PR DESCRIPTION
This puts the code under uncrustify-$(VERSION).
Example:
  uncrustify-0.74.0/README.md

Currently, README.md would be in the root of the tar.

Fixes #3563 