### PR TITLE
Apply indent_paren_after_func_* if the continuation indent doesn't apply

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2853,8 +2853,10 @@ void indent_text(void)
          log_rule_B("indent_paren_after_func_def");
          log_rule_B("indent_paren_after_func_call");
 
-         if (  !options::use_indent_continue_only_once() // Issue #1160
-            && !options::indent_ignore_first_continue()  // Issue #3561
+         if (  (  (  !frm.top().indent_cont                     // Issue #3567
+                  && vardefcol == 0)
+               || (  !options::use_indent_continue_only_once()  // Issue #1160
+                  && !options::indent_ignore_first_continue())) // Issue #3561
             && (  chunk_is_token(pc, CT_FPAREN_OPEN)
                && chunk_is_newline(pc->GetPrev()))
             && (  (  (  get_chunk_parent_type(pc) == CT_FUNC_PROTO
@@ -3091,6 +3093,7 @@ void indent_text(void)
             {
                frm.top().indent = get_indent_first_continue(pc);
                log_indent();
+               frm.top().indent_cont = true; // Issue #3567
             }
             else if (options::indent_continue() != 0)
             {

--- a/tests/c.test
+++ b/tests/c.test
@@ -456,3 +456,5 @@
 10061  c/Issue_3556.cfg                           c/Issue_3556.c
 10062  c/Issue_3561.cfg                           c/Issue_3561.c
 10063  c/Issue_3565.cfg                           c/Issue_3565.c
+10064  c/Issue_3567-a.cfg                         c/Issue_3567.c
+10065  c/Issue_3567-b.cfg                         c/Issue_3567.c

--- a/tests/config/c/Issue_3567-a.cfg
+++ b/tests/config/c/Issue_3567-a.cfg
@@ -1,0 +1,4 @@
+indent_paren_after_func_def   = true
+indent_paren_after_func_decl  = true
+indent_paren_after_func_call  = true
+use_indent_continue_only_once = true

--- a/tests/config/c/Issue_3567-b.cfg
+++ b/tests/config/c/Issue_3567-b.cfg
@@ -1,0 +1,4 @@
+indent_paren_after_func_def   = true
+indent_paren_after_func_decl  = true
+indent_paren_after_func_call  = true
+use_indent_continue_only_once = false

--- a/tests/expected/c/10064-Issue_3567.c
+++ b/tests/expected/c/10064-Issue_3567.c
@@ -1,0 +1,10 @@
+int main
+        (void);
+int main
+        (void)
+{
+	int x = main
+	        ();
+	main
+	        ();
+}

--- a/tests/expected/c/10065-Issue_3567.c
+++ b/tests/expected/c/10065-Issue_3567.c
@@ -1,0 +1,10 @@
+int main
+        (void);
+int main
+        (void)
+{
+	int x = main
+	                ();
+	main
+	        ();
+}

--- a/tests/input/c/Issue_3567.c
+++ b/tests/input/c/Issue_3567.c
@@ -1,0 +1,10 @@
+int main
+(void);
+int main
+(void)
+{
+int x = main
+();
+main
+();
+}


### PR DESCRIPTION
Fixes #3567