### PR TITLE
Apply indent_paren_after_func_def to class constructors

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2862,7 +2862,8 @@ void indent_text(void)
             && (  (  (  get_chunk_parent_type(pc) == CT_FUNC_PROTO
                      || get_chunk_parent_type(pc) == CT_FUNC_CLASS_PROTO)
                   && options::indent_paren_after_func_decl())
-               || (  get_chunk_parent_type(pc) == CT_FUNC_DEF
+               || (  (  get_chunk_parent_type(pc) == CT_FUNC_DEF
+                     || get_chunk_parent_type(pc) == CT_FUNC_CLASS_DEF)
                   && options::indent_paren_after_func_def())
                || (  (  get_chunk_parent_type(pc) == CT_FUNC_CALL
                      || get_chunk_parent_type(pc) == CT_FUNC_CALL_USER)

--- a/tests/config/cpp/Issue_3570.cfg
+++ b/tests/config/cpp/Issue_3570.cfg
@@ -1,0 +1,3 @@
+indent_class                 = true
+indent_paren_after_func_def  = true
+indent_paren_after_func_decl = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -1094,3 +1094,4 @@
 60080  common/empty.cfg                                     cpp/Issue_3538.cpp
 60081  cpp/Issue_3546.cfg                                   cpp/Issue_3546.cpp
 60082  cpp/Issue_3552.cfg                                   cpp/Issue_3552.cpp
+60083  cpp/Issue_3570.cfg                                   cpp/Issue_3570.h

--- a/tests/expected/cpp/60083-Issue_3570.h
+++ b/tests/expected/cpp/60083-Issue_3570.h
@@ -1,0 +1,25 @@
+class Foo
+{
+public:
+	Foo
+	        (
+	        )
+	{
+	}
+
+	Foo
+	        (
+	        int x
+	        );
+
+	void init
+	        (
+	        )
+	{
+	}
+
+	void init
+	        (
+	        int x
+	        );
+};

--- a/tests/input/cpp/Issue_3570.h
+++ b/tests/input/cpp/Issue_3570.h
@@ -1,0 +1,25 @@
+class Foo
+{
+public:
+Foo
+(
+)
+{
+}
+
+Foo
+(
+int x
+);
+
+void init
+(
+)
+{
+}
+
+void init
+(
+int x
+);
+};


### PR DESCRIPTION
Fixes #3570