### PR TITLE
Code impr/get next nvb

### DIFF
--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -945,15 +945,15 @@ void chunk_swap_lines(Chunk *pc1, Chunk *pc2)
 } // chunk_swap_lines
 
 
-Chunk *chunk_get_next_nvb(Chunk *cur, const E_Scope scope)
+Chunk *Chunk::GetNextNvb(E_Scope scope) const
 {
-   return(__internal_chunk_search(cur, chunk_is_vbrace, scope, E_Direction::FORWARD, false));
+   return(Search(&Chunk::IsVBrace, scope, E_Direction::FORWARD, false));
 }
 
 
-Chunk *chunk_get_prev_nvb(Chunk *cur, const E_Scope scope)
+Chunk *Chunk::GetPrevNvb(E_Scope scope) const
 {
-   return(__internal_chunk_search(cur, chunk_is_vbrace, scope, E_Direction::BACKWARD, false));
+   return(Search(&Chunk::IsVBrace, scope, E_Direction::BACKWARD, false));
 }
 
 

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -158,7 +158,7 @@ const char *Chunk::ElidedText(char *for_the_copy) const
 }
 
 
-Chunk *Chunk::GetNext(E_Scope scope) const
+Chunk *Chunk::GetNext(const E_Scope scope) const
 {
    if (IsNullChunk())
    {
@@ -204,7 +204,7 @@ Chunk *Chunk::GetNext(E_Scope scope) const
 } // Chunk::GetNext
 
 
-Chunk *Chunk::GetPrev(E_Scope scope) const
+Chunk *Chunk::GetPrev(const E_Scope scope) const
 {
    if (IsNullChunk())
    {
@@ -623,73 +623,73 @@ void chunk_move_after(Chunk *pc_in, Chunk *ref)
 }
 
 
-Chunk *Chunk::GetNextNl(E_Scope scope) const
+Chunk *Chunk::GetNextNl(const E_Scope scope) const
 {
    return(Search(&Chunk::IsNewline, scope, E_Direction::FORWARD, true));
 }
 
 
-Chunk *Chunk::GetPrevNl(E_Scope scope) const
+Chunk *Chunk::GetPrevNl(const E_Scope scope) const
 {
    return(Search(&Chunk::IsNewline, scope, E_Direction::BACKWARD, true));
 }
 
 
-Chunk *Chunk::GetNextNnl(E_Scope scope) const
+Chunk *Chunk::GetNextNnl(const E_Scope scope) const
 {
    return(Search(&Chunk::IsNewline, scope, E_Direction::FORWARD, false));
 }
 
 
-Chunk *Chunk::GetPrevNnl(E_Scope scope) const
+Chunk *Chunk::GetPrevNnl(const E_Scope scope) const
 {
    return(Search(&Chunk::IsNewline, scope, E_Direction::BACKWARD, false));
 }
 
 
-Chunk *Chunk::GetNextNc(E_Scope scope) const
+Chunk *Chunk::GetNextNc(const E_Scope scope) const
 {
    return(Search(&Chunk::IsComment, scope, E_Direction::FORWARD, false));
 }
 
 
-Chunk *Chunk::GetPrevNc(E_Scope scope) const
+Chunk *Chunk::GetPrevNc(const E_Scope scope) const
 {
    return(Search(&Chunk::IsComment, scope, E_Direction::BACKWARD, false));
 }
 
 
-Chunk *Chunk::GetNextNcNnl(E_Scope scope) const
+Chunk *Chunk::GetNextNcNnl(const E_Scope scope) const
 {
    return(Search(&Chunk::IsCommentOrNewline, scope, E_Direction::FORWARD, false));
 }
 
 
-Chunk *Chunk::GetPrevNcNnl(E_Scope scope) const
+Chunk *Chunk::GetPrevNcNnl(const E_Scope scope) const
 {
    return(Search(&Chunk::IsCommentOrNewline, scope, E_Direction::BACKWARD, false));
 }
 
 
-Chunk *Chunk::GetNextNcNnlNpp(E_Scope scope) const
+Chunk *Chunk::GetNextNcNnlNpp(const E_Scope scope) const
 {
    return(Search(&Chunk::IsCommentNewlineOrPreproc, scope, E_Direction::FORWARD, false));
 }
 
 
-Chunk *Chunk::GetPrevNcNnlNpp(E_Scope scope) const
+Chunk *Chunk::GetPrevNcNnlNpp(const E_Scope scope) const
 {
    return(Search(&Chunk::IsCommentNewlineOrPreproc, scope, E_Direction::BACKWARD, false));
 }
 
 
-Chunk *Chunk::GetNextNppOrNcNnl(E_Scope scope) const
+Chunk *Chunk::GetNextNppOrNcNnl(const E_Scope scope) const
 {
    return(Search(&Chunk::IsCommentOrNewlineInPreproc, scope, E_Direction::FORWARD, false));
 }
 
 
-Chunk *Chunk::GetPrevNppOrNcNnl(E_Scope scope) const
+Chunk *Chunk::GetPrevNppOrNcNnl(const E_Scope scope) const
 {
    return(Search(&Chunk::IsCommentOrNewlineInPreproc, scope, E_Direction::BACKWARD, false));
 }
@@ -701,25 +701,25 @@ Chunk *Chunk::PpaGetNextNcNnl() const
 }
 
 
-Chunk *Chunk::GetNextNcNnlNet(E_Scope scope) const
+Chunk *Chunk::GetNextNcNnlNet(const E_Scope scope) const
 {
    return(Search(&Chunk::IsCommentNewlineOrEmptyText, scope, E_Direction::FORWARD, false));
 }
 
 
-Chunk *Chunk::GetPrevNcNnlNet(E_Scope scope) const
+Chunk *Chunk::GetPrevNcNnlNet(const E_Scope scope) const
 {
    return(Search(&Chunk::IsCommentNewlineOrEmptyText, scope, E_Direction::BACKWARD, false));
 }
 
 
-Chunk *Chunk::GetPrevNcNnlNi(E_Scope scope) const
+Chunk *Chunk::GetPrevNcNnlNi(const E_Scope scope) const
 {
    return(Search(&Chunk::IsCommentNewlineOrIgnored, scope, E_Direction::BACKWARD, false));
 }
 
 
-Chunk *Chunk::GetNextNisq(E_Scope scope) const
+Chunk *Chunk::GetNextNisq(const E_Scope scope) const
 {
    return(Search(&Chunk::IsSquareBracket, scope, E_Direction::FORWARD, false));
 }
@@ -885,13 +885,13 @@ void chunk_swap_lines(Chunk *pc1, Chunk *pc2)
 } // chunk_swap_lines
 
 
-Chunk *Chunk::GetNextNvb(E_Scope scope) const
+Chunk *Chunk::GetNextNvb(const E_Scope scope) const
 {
    return(Search(&Chunk::IsVBrace, scope, E_Direction::FORWARD, false));
 }
 
 
-Chunk *Chunk::GetPrevNvb(E_Scope scope) const
+Chunk *Chunk::GetPrevNvb(const E_Scope scope) const
 {
    return(Search(&Chunk::IsVBrace, scope, E_Direction::BACKWARD, false));
 }

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -250,38 +250,6 @@ Chunk *Chunk::GetPrev(E_Scope scope) const
 } // Chunk::GetPrev
 
 
-/**
- *
- * This is a temporary internal function that will progressively be
- * replaced by Chunk::Search().
- *
- * @brief search for a chunk that satisfies a condition in a chunk list
- *
- * A generic function that traverses a chunks list either
- * in forward or reverse direction. The traversal continues until a
- * chunk satisfies the condition defined by the compare function.
- * Depending on the parameter cond the condition will either be
- * checked to be true or false.
- *
- * Whenever a chunk list traversal is to be performed this function
- * shall be used. This keeps the code clear and easy to understand.
- *
- * If there are performance issues this function might be worth to
- * be optimized as it is heavily used.
- *
- * @param  cur        chunk to start search at
- * @param  check_fct  compare function
- * @param  scope      code parts to consider for search
- * @param  dir        search direction
- * @param  cond       success condition
- *
- * @retval nullptr  no requested chunk was found or invalid parameters provided
- * @retval Chunk  pointer to the found chunk
- */
-// TODO remove when finished
-static Chunk *__internal_chunk_search(Chunk *cur, const check_t check_fct, const E_Scope scope = E_Scope::ALL, const E_Direction dir = E_Direction::FORWARD, const bool cond = true);
-
-
 static void chunk_log(Chunk *pc, const char *text);
 
 
@@ -296,7 +264,7 @@ static void chunk_log(Chunk *pc, const char *text);
  * traverses a chunk list either in forward or backward direction.
  * The traversal continues until a chunk of a given category is found.
  *
- * This function is a specialization of __internal_chunk_search.
+ * This function is a specialization of Chunk::Search.
  *
  * @param cur    chunk to start search at
  * @param type   category to search for
@@ -315,7 +283,7 @@ static Chunk *chunk_search_type(Chunk *cur, const E_Token type, const E_Scope sc
  * Traverses a chunk list in the specified direction until a chunk of a given type
  * is found.
  *
- * This function is a specialization of __internal_chunk_search.
+ * This function is a specialization of Chunk::Search.
  *
  * @param cur    chunk to start search at
  * @param type   category to search for
@@ -406,34 +374,6 @@ Chunk *Chunk::Search(const T_CheckFnPtr checkFn, const E_Scope scope,
            && ((pc->*checkFn)() != cond)); // and the demanded chunk was not found either
 
    return(pc);                             // the latest chunk is the searched one
-}
-
-
-static Chunk *__internal_chunk_search(Chunk *cur, const check_t check_fct, const E_Scope scope,
-                                      const E_Direction dir, const bool cond)
-{
-   /*
-    * Depending on the parameter dir the search function searches
-    * in forward or backward direction */
-   Chunk::T_SearchFnPtr search_function = Chunk::GetSearchFn(dir);
-   Chunk                *pc             = cur;
-
-   if (pc == nullptr)
-   {
-      pc = Chunk::NullChunkPtr;
-   }
-
-   do                                     // loop over the chunk list
-   {
-      pc = (pc->*search_function)(scope); // in either direction while
-   } while (  pc->IsNotNullChunk()        // the end of the list was not reached yet
-           && (check_fct(pc) != cond));   // and the demanded chunk was not found either
-
-   if (pc->IsNullChunk())
-   {
-      pc = nullptr;
-   }
-   return(pc);                            // the latest chunk is the searched one
 }
 
 

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -249,6 +249,22 @@ public:
    Chunk *GetNextNisq(E_Scope scope = E_Scope::ALL) const;
 
 
+   /**
+    * @brief returns the next non-virtual brace chunk
+    * @param scope code region to search in
+    * @return pointer to next non-virtual brace chunk or Chunk::NullChunkPtr if no chunk was found
+    */
+   Chunk *GetNextNvb(E_Scope scope = E_Scope::ALL) const;
+
+
+   /**
+    * @brief returns the prev non-virtual brace chunk
+    * @param scope code region to search in
+    * @return pointer to prev non-virtual brace chunk or Chunk::NullChunkPtr if no chunk was found
+    */
+   Chunk *GetPrevNvb(E_Scope scope = E_Scope::ALL) const;
+
+
    // --------- Search functions
 
    /**
@@ -388,6 +404,12 @@ public:
     * @return true if the chunk is a square bracket
     */
    bool IsSquareBracket() const;
+
+   /**
+    * @brief checks whether the chunk is a virtual brace
+    * @return true if the chunk is a virtual brace
+    */
+   bool IsVBrace() const;
 
 
    // --------- Data members
@@ -574,28 +596,6 @@ Chunk *chunk_get_prev_str(Chunk *cur, const char *str, size_t len, int level, E_
 
 
 /**
- * @brief Gets the next non-vbrace chunk
- *
- * @param  cur    chunk to start search
- * @param  scope  chunk section to consider
- *
- * @return pointer to found chunk or nullptr if no chunk was found
- */
-Chunk *chunk_get_next_nvb(Chunk *cur, const E_Scope scope = E_Scope::ALL);
-
-
-/**
- * @brief Gets the previous non-vbrace chunk
- *
- * @param  cur    chunk to start search
- * @param  scope  chunk section to consider
- *
- * @return pointer to found chunk or nullptr if no chunk was found
- */
-Chunk *chunk_get_prev_nvb(Chunk *cur, const E_Scope scope = E_Scope::ALL);
-
-
-/**
  * Gets the next chunk not in or part of balanced square
  * brackets.This handles stacked[] instances to accommodate
  * multi - dimensional array declarations
@@ -777,6 +777,13 @@ inline bool Chunk::IsSquareBracket() const
    return(  Is(CT_SQUARE_OPEN)
          || Is(CT_TSQUARE)
          || Is(CT_SQUARE_CLOSE));
+}
+
+
+inline bool Chunk::IsVBrace() const
+{
+   return(  Is(CT_VBRACE_OPEN)
+         || Is(CT_VBRACE_CLOSE));
 }
 
 
@@ -1068,13 +1075,6 @@ static inline bool chunk_is_closing_brace(Chunk *pc)
 static inline bool chunk_is_opening_brace(Chunk *pc)
 {
    return(  chunk_is_token(pc, CT_BRACE_OPEN)
-         || chunk_is_token(pc, CT_VBRACE_OPEN));
-}
-
-
-static inline bool chunk_is_vbrace(Chunk *pc)
-{
-   return(  chunk_is_token(pc, CT_VBRACE_CLOSE)
          || chunk_is_token(pc, CT_VBRACE_OPEN));
 }
 

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -114,98 +114,98 @@ public:
     * @param scope code region to search in
     * @return pointer to next chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetNext(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetNext(const E_Scope scope = E_Scope::ALL) const;
 
    /**
     * @brief returns the previous chunk in a list of chunks
     * @param scope code region to search in
     * @return pointer to previous chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetPrev(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetPrev(const E_Scope scope = E_Scope::ALL) const;
 
    /**
     * @brief returns the next newline chunk
     * @param scope code region to search in
     * @return pointer to next newline chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetNextNl(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetNextNl(const E_Scope scope = E_Scope::ALL) const;
 
    /**
     * @brief returns the prev newline chunk
     * @param scope code region to search in
     * @return pointer to prev newline chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetPrevNl(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetPrevNl(const E_Scope scope = E_Scope::ALL) const;
 
    /**
     * @brief returns the next non-newline chunk
     * @param scope code region to search in
     * @return pointer to next non-newline chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetNextNnl(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetNextNnl(const E_Scope scope = E_Scope::ALL) const;
 
    /**
     * @brief returns the prev non-newline chunk
     * @param scope code region to search in
     * @return pointer to prev non-newline chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetPrevNnl(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetPrevNnl(const E_Scope scope = E_Scope::ALL) const;
 
    /**
     * @brief returns the next non-comment chunk
     * @param scope code region to search in
     * @return pointer to next non-comment chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetNextNc(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetNextNc(const E_Scope scope = E_Scope::ALL) const;
 
    /**
     * @brief returns the prev non-comment chunk
     * @param scope code region to search in
     * @return pointer to prev non-comment chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetPrevNc(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetPrevNc(const E_Scope scope = E_Scope::ALL) const;
 
    /**
     * @brief returns the next non-comment and non-newline chunk
     * @param scope code region to search in
     * @return pointer to next non-comment and non-newline chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetNextNcNnl(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetNextNcNnl(const E_Scope scope = E_Scope::ALL) const;
 
    /**
     * @brief returns the prev non-comment and non-newline chunk
     * @param scope code region to search in
     * @return pointer to prev non-comment and non-newline chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetPrevNcNnl(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetPrevNcNnl(const E_Scope scope = E_Scope::ALL) const;
 
    /**
     * @brief returns the next non-comment, non-newline, non-preprocessor chunk
     * @param scope code region to search in
     * @return pointer to next non-comment, non-newline, non-preprocessor chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetNextNcNnlNpp(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetNextNcNnlNpp(const E_Scope scope = E_Scope::ALL) const;
 
    /**
     * @brief returns the prev non-comment, non-newline, non-preprocessor chunk
     * @param scope code region to search in
     * @return pointer to prev non-comment, non-newline, non-preprocessor chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetPrevNcNnlNpp(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetPrevNcNnlNpp(const E_Scope scope = E_Scope::ALL) const;
 
    /**
     * @brief returns the next non-preprocessor or non-comment, non-newline chunk
     * @param scope code region to search in
     * @return pointer to next non-preprocessor or non-comment, non-newline chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetNextNppOrNcNnl(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetNextNppOrNcNnl(const E_Scope scope = E_Scope::ALL) const;
 
    /**
     * @brief returns the prev non-preprocessor or non-comment, non-newline chunk
     * @param scope code region to search in
     * @return pointer to prev non-preprocessor or non-comment, non-newline chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetPrevNppOrNcNnl(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetPrevNppOrNcNnl(const E_Scope scope = E_Scope::ALL) const;
 
    /**
     * @brief returns the next preprocessor aware non-comment and non-newline chunk
@@ -221,14 +221,14 @@ public:
     * @param scope code region to search in
     * @return pointer to next non-comment, non-newline, non-empty text chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetNextNcNnlNet(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetNextNcNnlNet(const E_Scope scope = E_Scope::ALL) const;
 
    /**
     * @brief returns the prev non-comment, non-newline, non-empty text chunk
     * @param scope code region to search in
     * @return pointer to prev non-comment, non-newline, non-empty text chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetPrevNcNnlNet(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetPrevNcNnlNet(const E_Scope scope = E_Scope::ALL) const;
 
 
    /**
@@ -236,7 +236,7 @@ public:
     * @param scope code region to search in
     * @return pointer to prev non-comment, non-newline, non-ignored chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetPrevNcNnlNi(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetPrevNcNnlNi(const E_Scope scope = E_Scope::ALL) const;
 
 
    /**
@@ -246,7 +246,7 @@ public:
     * @param scope  code region to search in
     * @return nullptr or the next chunk not in or part of square brackets
     */
-   Chunk *GetNextNisq(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetNextNisq(const E_Scope scope = E_Scope::ALL) const;
 
 
    /**
@@ -254,7 +254,7 @@ public:
     * @param scope code region to search in
     * @return pointer to next non-virtual brace chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetNextNvb(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetNextNvb(const E_Scope scope = E_Scope::ALL) const;
 
 
    /**
@@ -262,17 +262,17 @@ public:
     * @param scope code region to search in
     * @return pointer to prev non-virtual brace chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *GetPrevNvb(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetPrevNvb(const E_Scope scope = E_Scope::ALL) const;
 
 
    // --------- Search functions
 
    /**
     * @brief defines a member function pointer for a function of type
-    * Chunk *Chunk::function(E_Scope scope)
+    * Chunk *Chunk::function(const E_Scope scope)
     * that will search for a new chunk
     */
-   typedef Chunk *(Chunk::*T_SearchFnPtr)(E_Scope scope) const;
+   typedef Chunk *(Chunk::*T_SearchFnPtr)(const E_Scope scope) const;
 
    /**
     * @brief defines a member function pointer for a function of type

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2345,11 +2345,10 @@ void mark_comments(void)
    bool  prev_nl = true;
    Chunk *cur    = Chunk::GetHead();
 
-   while (  cur != nullptr
-         && cur->IsNotNullChunk())
+   while (cur->IsNotNullChunk())
    {
-      Chunk *next   = chunk_get_next_nvb(cur);
-      bool  next_nl = (next == nullptr) || chunk_is_newline(next);
+      Chunk *next   = cur->GetNextNvb();
+      bool  next_nl = next->IsNullChunk() || chunk_is_newline(next);
 
       if (chunk_is_comment(cur))
       {

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -542,7 +542,7 @@ Chunk *newline_add_before(Chunk *pc)
    LOG_FUNC_ENTRY();
 
    Chunk nl;
-   Chunk *prev = chunk_get_prev_nvb(pc);
+   Chunk *prev = pc->GetPrevNvb();
 
    if (chunk_is_newline(prev))
    {
@@ -570,7 +570,7 @@ Chunk *newline_force_before(Chunk *pc)
 
    Chunk *nl = newline_add_before(pc);
 
-   if (  nl != nullptr
+   if (  nl->IsNotNullChunk()
       && nl->nl_count > 1)
    {
       nl->nl_count = 1;
@@ -586,9 +586,9 @@ Chunk *newline_add_after(Chunk *pc)
 
    if (pc == nullptr)
    {
-      return(nullptr);
+      return(Chunk::NullChunkPtr);
    }
-   Chunk *next = chunk_get_next_nvb(pc);
+   Chunk *next = pc->GetNextNvb();
 
    if (chunk_is_newline(next))
    {
@@ -619,7 +619,7 @@ Chunk *newline_force_after(Chunk *pc)
 
    Chunk *nl = newline_add_after(pc);   // add a newline
 
-   if (  nl != nullptr
+   if (  nl->IsNotNullChunk()
       && nl->nl_count > 1) // check if there are more than 1 newline
    {
       nl->nl_count = 1;                   // if so change the newline count back to 1
@@ -1043,7 +1043,7 @@ static void newlines_if_for_while_switch_pre_blank_lines(Chunk *start, iarf_e nl
 
          // if we found 2 or more in a row
          if (  pc->nl_count > 1
-            || chunk_is_newline(chunk_get_prev_nvb(pc)))
+            || chunk_is_newline(pc->GetPrevNvb()))
          {
             // need to remove
             if (  (nl_opt & IARF_REMOVE)
@@ -1060,7 +1060,7 @@ static void newlines_if_for_while_switch_pre_blank_lines(Chunk *start, iarf_e nl
                Chunk *prev;
 
                // can keep using pc because anything other than newline stops loop, and we delete if newline
-               while (chunk_is_newline(prev = chunk_get_prev_nvb(pc)))
+               while (chunk_is_newline(prev = pc->GetPrevNvb()))
                {
                   // Make sure we don't combine a preproc and non-preproc
                   if (!chunk_safe_to_del_nl(prev))
@@ -1114,7 +1114,7 @@ static void newlines_if_for_while_switch_pre_blank_lines(Chunk *start, iarf_e nl
                   pc = next;
                }
 
-               if ((last_nl = newline_add_after(pc)) != nullptr)
+               if ((last_nl = newline_add_after(pc))->IsNotNullChunk())
                {
                   double_newline(last_nl);
                }
@@ -1422,7 +1422,7 @@ static void remove_next_newlines(Chunk *start)
          chunk_del(next);
          MARK_CHANGE();
       }
-      else if (chunk_is_vbrace(next))
+      else if (next->IsVBrace())
       {
          start = next;
       }
@@ -1517,7 +1517,7 @@ static void newlines_if_for_while_switch_post_blank_lines(Chunk *start, iarf_e n
       LOG_FMT(LNEWLINE, "%s(%d): isVBrace is FALSE\n", __func__, __LINE__);
    }
 
-   if ((prev = chunk_get_prev_nvb(pc)) == nullptr)
+   if ((prev = pc->GetPrevNvb())->IsNullChunk())
    {
       return;
    }
@@ -1546,7 +1546,7 @@ static void newlines_if_for_while_switch_post_blank_lines(Chunk *start, iarf_e n
          }
          remove_next_newlines(pc);
       }
-      else if (  (chunk_is_newline(next = chunk_get_next_nvb(pc)))
+      else if (  (chunk_is_newline(next = pc->GetNextNvb()))
               && !next->flags.test(PCF_VAR_DEF))
       {
          // otherwise just deal with newlines after brace
@@ -1589,7 +1589,7 @@ static void newlines_if_for_while_switch_post_blank_lines(Chunk *start, iarf_e n
          size_t nl_count = have_pre_vbrace_nl ? prev->nl_count : 0;
          LOG_FMT(LNEWLINE, "%s(%d): nl_count %zu\n", __func__, __LINE__, nl_count);
 
-         if (chunk_is_newline(next = chunk_get_next_nvb(pc)))
+         if (chunk_is_newline(next = pc->GetNextNvb()))
          {
             LOG_FMT(LNEWLINE, "%s(%d): next->Text() is '%s', type %s, orig_line %zu, orig_column %zu\n",
                     __func__, __LINE__, next->Text(), get_token_name(next->type), next->orig_line, next->orig_col);
@@ -1612,7 +1612,7 @@ static void newlines_if_for_while_switch_post_blank_lines(Chunk *start, iarf_e n
                        __func__, __LINE__, pc->Text(), get_token_name(pc->type), pc->orig_line, pc->orig_col);
             }
 
-            if ((next = newline_add_after(pc)) == nullptr)
+            if ((next = newline_add_after(pc))->IsNullChunk())
             {
                return;
             }


### PR DESCRIPTION
Replace chunk_is_vbrace(), chunk_get_next_nvb() and chunk_get_prev_nvb() with Chunk::IsVBrace(), Chunk::GetNextNvb() and Chunk::GetPrevNvb().
Removed no longer needed __internal_chunk_search() function.
Make E_Scope const in Chunk methods.