### PR TITLE
Add indent_namespace_inner_only

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -1147,6 +1147,10 @@ indent_namespace_level          = 0        # unsigned number
 # indented. Requires indent_namespace=true. 0 means no limit.
 indent_namespace_limit          = 0        # unsigned number
 
+# Whether to indent only in inner namespaces (nested in other namespaces).
+# Requires indent_namespace=true.
+indent_namespace_inner_only     = false    # true/false
+
 # Whether the 'extern "C"' body is indented.
 indent_extern                   = false    # true/false
 

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -1147,6 +1147,10 @@ indent_namespace_level          = 0        # unsigned number
 # indented. Requires indent_namespace=true. 0 means no limit.
 indent_namespace_limit          = 0        # unsigned number
 
+# Whether to indent only in inner namespaces (nested in other namespaces).
+# Requires indent_namespace=true.
+indent_namespace_inner_only     = false    # true/false
+
 # Whether the 'extern "C"' body is indented.
 indent_extern                   = false    # true/false
 

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1147,6 +1147,10 @@ indent_namespace_level          = 0        # unsigned number
 # indented. Requires indent_namespace=true. 0 means no limit.
 indent_namespace_limit          = 0        # unsigned number
 
+# Whether to indent only in inner namespaces (nested in other namespaces).
+# Requires indent_namespace=true.
+indent_namespace_inner_only     = false    # true/false
+
 # Whether the 'extern "C"' body is indented.
 indent_extern                   = false    # true/false
 

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -2586,6 +2586,14 @@ MinVal=0
 MaxVal=255
 ValueDefault=0
 
+[Indent Namespace Inner Only]
+Category=2
+Description="<html>Whether to indent only in inner namespaces (nested in other namespaces).<br/>Requires indent_namespace=true.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=indent_namespace_inner_only=true|indent_namespace_inner_only=false
+ValueDefault=false
+
 [Indent Extern]
 Category=2
 Description="<html>Whether the 'extern "C"' body is indented.</html>"

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2184,6 +2184,16 @@ void indent_text(void)
                   }
                   indent_column_set(frm.prev(frm.top().ns_cnt).indent);
                }
+               else if (  options::indent_namespace()
+                       && options::indent_namespace_inner_only())
+               {
+                  if (frm.top().ns_cnt == 1)
+                  {
+                     // undo indent on first namespace only
+                     frm.top().indent -= indent_size;
+                     log_indent();
+                  }
+               }
                else if (  pc->flags.test(PCF_LONG_BLOCK)
                        || !options::indent_namespace())
                {

--- a/src/options.h
+++ b/src/options.h
@@ -1410,6 +1410,11 @@ indent_namespace_level;
 extern BoundedOption<unsigned, 0, 255>
 indent_namespace_limit;
 
+// Whether to indent only in inner namespaces (nested in other namespaces).
+// Requires indent_namespace=true.
+extern Option<bool>
+indent_namespace_inner_only;
+
 // Whether the 'extern "C"' body is indented.
 extern Option<bool>
 indent_extern;

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2604,6 +2604,14 @@ MinVal=0
 MaxVal=255
 ValueDefault=0
 
+[Indent Namespace Inner Only]
+Category=2
+Description="<html>Whether to indent only in inner namespaces (nested in other namespaces).<br/>Requires indent_namespace=true.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=indent_namespace_inner_only=true|indent_namespace_inner_only=false
+ValueDefault=false
+
 [Indent Extern]
 Category=2
 Description="<html>Whether the 'extern "C"' body is indented.</html>"

--- a/tests/config/cpp/indent_namespace_inner_only.cfg
+++ b/tests/config/cpp/indent_namespace_inner_only.cfg
@@ -1,0 +1,2 @@
+indent_namespace = true
+indent_namespace_inner_only = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -1098,3 +1098,4 @@
 60083  cpp/Issue_3570.cfg                                   cpp/Issue_3570.h
 60084  cpp/Issue_3576-a.cfg                                 cpp/Issue_3576.h
 60085  cpp/Issue_3576-b.cfg                                 cpp/Issue_3576.h
+60086  cpp/indent_namespace_inner_only.cfg                  cpp/indent_namespace_inner_only.h

--- a/tests/expected/cpp/60086-indent_namespace_inner_only.h
+++ b/tests/expected/cpp/60086-indent_namespace_inner_only.h
@@ -1,0 +1,8 @@
+namespace out
+{
+int i;
+namespace in
+{
+	int i;
+}
+}

--- a/tests/input/cpp/indent_namespace_inner_only.h
+++ b/tests/input/cpp/indent_namespace_inner_only.h
@@ -1,0 +1,8 @@
+namespace out
+{
+	int i;
+	namespace in
+	{
+		int i;
+	}
+}


### PR DESCRIPTION
Adds the ability to indent inner namespaces only (namespaces nested inside other namespaces).

The following:
```
namespace out {
int i;
namespace in {
int i;
}
}
```

with ``indent_namespace_single_indent=2``, becomes:
```
namespace out {
int i;
namespace in {
  int i;
}
}
```
AFAICT there was no option to format namespaces in this way.