### PR TITLE
Fix some mistakes in defaults.cfg and add left-over indent_ignore_case_brace option

### DIFF
--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1298,6 +1298,9 @@ indent_switch_case              = 0        # unsigned number
 # Usually the same as indent_columns or indent_switch_case.
 indent_switch_body              = 0        # unsigned number
 
+# Whether to ignore indent for '{' following 'case'.
+indent_ignore_case_brace        = false    # true/false
+
 # Spaces to indent '{' from 'case'. By default, the brace will appear under
 # the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.
 # It might be wise to choose the same value for the option indent_switch_case.
@@ -1384,13 +1387,13 @@ indent_paren_after_func_decl    = false    # true/false
 # if the parenthesis is on its own line.
 indent_paren_after_func_call    = false    # true/false
 
-# Whether to indent a comma when inside a brace.
+# How to indent a comma when inside braces.
 #  0: Indent by one level (default)
 #  1: Align under the open brace
 # -1: Preserve original indentation
 indent_comma_brace              = 0        # signed number
 
-# Whether to indent a comma when inside a parenthesis.
+# How to indent a comma when inside parentheses.
 #  0: Indent by one level (default)
 #  1: Align under the open parenthesis
 # -1: Preserve original indentation
@@ -1402,12 +1405,12 @@ indent_comma_paren              = 0        # signed number
 # -1: Preserve original indentation
 indent_bool_paren               = 0        # signed number
 
+# Whether to ignore the indentation of an arithmetic operator.
+indent_ignore_arith             = false    # true/false
+
 # Whether to ignore the indentation of a Boolean operator when outside
 # parentheses.
 indent_ignore_bool              = false    # true/false
-
-# Whether to ignore the indentation of an arithmetic operator.
-indent_ignore_arith             = false    # true/false
 
 # Whether to indent a semicolon when inside a for parenthesis.
 # If true, aligns under the open for parenthesis.
@@ -3288,7 +3291,7 @@ pp_indent_extern                = true     # true/false
 # -1: Preserve original indentation
 #
 # Default: 1
-pp_indent_brace                 = 1        # 1
+pp_indent_brace                 = 1        # number
 
 #
 # Sort includes options


### PR DESCRIPTION
As per title, defaults.cfg was missing some updates.