### PR TITLE
Fix cast detection in C# and Vala

### DIFF
--- a/src/combine_fix_mark.cpp
+++ b/src/combine_fix_mark.cpp
@@ -72,11 +72,11 @@ void fix_casts(Chunk *start)
             || chunk_is_token(pc, CT_TSQUARE)
             || (  (  chunk_is_token(pc, CT_ANGLE_OPEN)
                   || chunk_is_token(pc, CT_ANGLE_CLOSE))
-               && language_is_set(LANG_OC | LANG_JAVA))
+               && language_is_set(LANG_OC | LANG_JAVA | LANG_CS | LANG_VALA))
             || (  (  chunk_is_token(pc, CT_QUESTION)
                   || chunk_is_token(pc, CT_COMMA)
                   || chunk_is_token(pc, CT_MEMBER))
-               && language_is_set(LANG_JAVA))
+               && language_is_set(LANG_JAVA | LANG_CS | LANG_VALA))
             || chunk_is_token(pc, CT_AMP)))
    {
       LOG_FMT(LCASTS, "%s(%d): pc->Text() is '%s', orig_line is %zu, orig_col is %zu, type is %s\n",
@@ -124,7 +124,7 @@ void fix_casts(Chunk *start)
       || chunk_is_token(last, CT_PTR_TYPE)
       || chunk_is_token(last, CT_TYPE)
       || (  chunk_is_token(last, CT_ANGLE_CLOSE)
-         && language_is_set(LANG_OC | LANG_JAVA)))
+         && language_is_set(LANG_OC | LANG_JAVA | LANG_CS | LANG_VALA)))
    {
       verb = "for sure";
    }

--- a/tests/c-sharp.test
+++ b/tests/c-sharp.test
@@ -147,3 +147,4 @@
 60042  cs/indent-multistring-coulmn1.cfg            cs/indent-multistring-coulmn1.cs
 60044  cs/UNI-37241.cfg                             cs/UNI-37241.cs
 60045  common/nl_before_after.cfg                   cs/add-nl-before-namespace.cs
+60046  common/sp_after_cast.cfg                     cs/cast.cs

--- a/tests/expected/cs/60046-cast.cs
+++ b/tests/expected/cs/60046-cast.cs
@@ -1,0 +1,7 @@
+foo = (Type) bar;
+
+foo = (Ns.Type) bar;
+
+foo = (Type<int>) bar;
+
+foo = (Type<int, int>) bar;

--- a/tests/expected/vala/70302-cast.vala
+++ b/tests/expected/vala/70302-cast.vala
@@ -1,0 +1,7 @@
+foo = (Type) bar;
+
+foo = (Ns.Type) bar;
+
+foo = (Type<int>) bar;
+
+foo = (Type<int, int>) bar;

--- a/tests/input/cs/cast.cs
+++ b/tests/input/cs/cast.cs
@@ -1,0 +1,7 @@
+foo = ( Type ) bar;
+
+foo = ( Ns.Type ) bar;
+
+foo = ( Type<int> ) bar;
+
+foo = ( Type<int, int> ) bar;

--- a/tests/input/vala/cast.vala
+++ b/tests/input/vala/cast.vala
@@ -1,0 +1,7 @@
+foo = ( Type ) bar;
+
+foo = ( Ns.Type ) bar;
+
+foo = ( Type<int> ) bar;
+
+foo = ( Type<int, int> ) bar;

--- a/tests/vala.test
+++ b/tests/vala.test
@@ -13,3 +13,4 @@
 70287  vala/ben_105.cfg                     vala/gh287.vala
 70300  vala/Issue_2090.cfg                  vala/Issue_2090.vala
 70301  vala/Issue_2270.cfg                  vala/Issue_2270.vala
+70302  common/sp_after_cast.cfg             vala/cast.vala


### PR DESCRIPTION
Fixes cast detection in C# and Vala when non-trivial type identifiers are involved.