### PR TITLE
Fix cmake COMPILER_PREFIX flag

### DIFF
--- a/cmake/Toolchain-mingw32.cmake
+++ b/cmake/Toolchain-mingw32.cmake
@@ -4,7 +4,7 @@
 
 set(CMAKE_SYSTEM_NAME Windows)
 
-if(NOT COMPILER_PREFIX)
+if(COMPILER_PREFIX STREQUAL "")
   if(EXISTS /usr/i686-w64-mingw32)
     # mingw-w64
     set(COMPILER_PREFIX "i686-w64-mingw32")

--- a/cmake/Toolchain-mingw64.cmake
+++ b/cmake/Toolchain-mingw64.cmake
@@ -4,7 +4,7 @@
 
 set(CMAKE_SYSTEM_NAME Windows)
 
-if(NOT COMPILER_PREFIX)
+if(COMPILER_PREFIX STREQUAL "")
   if(EXISTS /usr/x86_64-w64-mingw32)
     # mingw-w64
     set(COMPILER_PREFIX "x86_64-w64-mingw32")


### PR DESCRIPTION
`COMPILER_PREFIX` is a string instead of a boolean expression. Thus, `NOT` will not work. This PR fixes the problem to properly detect the value of this flag.