### PR TITLE
Calculate string length in chunk_is_str instead of manually specifying it.

### DIFF
--- a/src/align_eigen_comma_init.cpp
+++ b/src/align_eigen_comma_init.cpp
@@ -73,7 +73,7 @@ void align_eigen_comma_init(void)
       }
       else if (  !pc->flags.test(PCF_IN_ENUM)
               && !pc->flags.test(PCF_IN_TYPEDEF)
-              && chunk_is_str(pc, "<<", 2))
+              && chunk_is_str(pc, "<<"))
       {
          if (get_chunk_parent_type(pc) == CT_OPERATOR)
          {

--- a/src/align_left_shift.cpp
+++ b/src/align_left_shift.cpp
@@ -73,7 +73,7 @@ void align_left_shift(void)
       }
       else if (  !pc->flags.test(PCF_IN_ENUM)
               && !pc->flags.test(PCF_IN_TYPEDEF)
-              && chunk_is_str(pc, "<<", 2))
+              && chunk_is_str(pc, "<<"))
       {
          if (get_chunk_parent_type(pc) == CT_OPERATOR)
          {

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -422,8 +422,8 @@ static void parse_cleanup(BraceState &braceState, ParseFrame &frm, Chunk *pc)
       && !chunk_is_semicolon(pc)
       && chunk_is_not_token(pc, CT_BRACE_CLOSE)
       && chunk_is_not_token(pc, CT_VBRACE_CLOSE)
-      && !chunk_is_str(pc, ")", 1)
-      && !chunk_is_str(pc, "]", 1))
+      && !chunk_is_str(pc, ")")
+      && !chunk_is_str(pc, "]"))
    {
       chunk_flags_set(pc, PCF_EXPR_START | ((frm.stmt_count == 0) ? PCF_STMT_START : PCF_NONE));
       LOG_FMT(LSTMT, "%s(%d): orig_line is %zu, 1.marked '%s' as %s, start stmt_count is %zu, expr_count is %zu\n",

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -985,8 +985,10 @@ static inline bool chunk_is_type(Chunk *pc)
 }
 
 
-static inline bool chunk_is_str(Chunk *pc, const char *str, size_t len)
+static inline bool chunk_is_str(Chunk *pc, const char *str)
 {
+   size_t len = strlen(str);
+
    return(  pc != nullptr                         // valid pc pointer
          && (pc->Len() == len)                    // token size equals size parameter
          && (memcmp(pc->Text(), str, len) == 0)); // token name is the same as str parameter

--- a/src/combine_fix_mark.cpp
+++ b/src/combine_fix_mark.cpp
@@ -153,7 +153,7 @@ void fix_casts(Chunk *start)
          detail = " -- upper case";
       }
       else if (  language_is_set(LANG_OC)
-              && chunk_is_str(last, "id", 2))
+              && chunk_is_str(last, "id"))
       {
          detail = " -- Objective-C id";
       }
@@ -360,7 +360,7 @@ void fix_fcn_def_params(Chunk *start)
       }
       else if (  chunk_is_token(pc, CT_AMP)
               || (  language_is_set(LANG_CPP)
-                 && chunk_is_str(pc, "&&", 2)))
+                 && chunk_is_str(pc, "&&")))
       {
          set_chunk_type(pc, CT_BYREF);
          cs.Push_Back(pc);
@@ -421,7 +421,7 @@ void fix_type_cast(Chunk *start)
             return;
          }
 
-         if (chunk_is_str(pc, "(", 1))
+         if (chunk_is_str(pc, "("))
          {
             set_paren_parent(pc, CT_TYPE_CAST);
          }
@@ -816,7 +816,7 @@ void mark_cpp_constructor(Chunk *pc)
 
    paren_open = skip_template_next(pc->GetNextNcNnl());
 
-   if (!chunk_is_str(paren_open, "(", 1))
+   if (!chunk_is_str(paren_open, "("))
    {
       LOG_FMT(LWARN, "%s:%zu Expected '(', got: [%s]\n",
               cpd.filename.c_str(), paren_open->orig_line,
@@ -843,7 +843,7 @@ void mark_cpp_constructor(Chunk *pc)
       chunk_flags_set(tmp, PCF_IN_CONST_ARGS);
       tmp = tmp->GetNextNcNnl();
 
-      if (  chunk_is_str(tmp, ":", 1)
+      if (  chunk_is_str(tmp, ":")
          && tmp->level == paren_open->level)
       {
          set_chunk_type(tmp, CT_CONSTR_COLON);
@@ -1328,7 +1328,7 @@ void mark_function(Chunk *pc)
    tmp = paren_close->GetNextNcNnl();
 
    if (  tmp->IsNotNullChunk()
-      && chunk_is_str(tmp, "(", 1))
+      && chunk_is_str(tmp, "("))
    {
       Chunk *tmp1;
       Chunk *tmp2;
@@ -1350,7 +1350,7 @@ void mark_function(Chunk *pc)
       }
       tmp2 = tmp1->GetNextNcNnl();
 
-      if (chunk_is_str(tmp2, ")", 1))
+      if (chunk_is_str(tmp2, ")"))
       {
          tmp3 = tmp2;
          tmp2 = Chunk::NullChunkPtr;
@@ -1361,7 +1361,7 @@ void mark_function(Chunk *pc)
       }
       tmp3 = chunk_get_next_ssq(tmp3);
 
-      if (  chunk_is_str(tmp3, ")", 1)
+      if (  chunk_is_str(tmp3, ")")
          && (  tmp1->IsStar()
             || chunk_is_msref(tmp1)
             || (  language_is_set(LANG_OC)
@@ -1988,8 +1988,8 @@ void mark_function(Chunk *pc)
             // Do a check to see if the level is right
             prev = pc->GetPrevNcNnlNi();   // Issue #2279
 
-            if (  !chunk_is_str(prev, "*", 1)
-               && !chunk_is_str(prev, "&", 1))
+            if (  !chunk_is_str(prev, "*")
+               && !chunk_is_str(prev, "&"))
             {
                Chunk *p_op = pc->GetPrevType(CT_BRACE_OPEN, pc->brace_level - 1);
 
@@ -2124,7 +2124,7 @@ bool mark_function_type(Chunk *pc)
       && !chunk_is_word(varcnk))
    {
       if (  language_is_set(LANG_OC)
-         && chunk_is_str(varcnk, "^", 1)
+         && chunk_is_str(varcnk, "^")
          && chunk_is_paren_open(varcnk->GetPrevNcNnlNi()))   // Issue #2279
       {
          // anonymous ObjC block type -- RTYPE (^)(ARGS)
@@ -2201,7 +2201,7 @@ bool mark_function_type(Chunk *pc)
          word_count = 0;
          LOG_FMT(LFTYPE, " -- :: reset word_count\n");
       }
-      else if (chunk_is_str(tmp, "(", 1))
+      else if (chunk_is_str(tmp, "("))
       {
          LOG_FMT(LFTYPE, " -- open paren (break)\n");
          break;
@@ -2338,9 +2338,9 @@ void mark_lvalue(Chunk *pc)
          || chunk_is_token(prev, CT_COMMA)
          || chunk_is_cpp_inheritance_access_specifier(prev)
          || chunk_is_semicolon(prev)
-         || chunk_is_str(prev, "(", 1)
-         || chunk_is_str(prev, "{", 1)
-         || chunk_is_str(prev, "[", 1)
+         || chunk_is_str(prev, "(")
+         || chunk_is_str(prev, "{")
+         || chunk_is_str(prev, "[")
          || prev->flags.test(PCF_IN_PREPROC)
          || get_chunk_parent_type(prev) == CT_NAMESPACE
          || get_chunk_parent_type(prev) == CT_TEMPLATE)
@@ -2350,7 +2350,7 @@ void mark_lvalue(Chunk *pc)
       chunk_flags_set(prev, PCF_LVALUE);
 
       if (  prev->level == pc->level
-         && chunk_is_str(prev, "&", 1))
+         && chunk_is_str(prev, "&"))
       {
          make_type(prev);
       }
@@ -2416,7 +2416,7 @@ void mark_template_func(Chunk *pc, Chunk *pc_next)
 
    if (after->IsNotNullChunk())
    {
-      if (chunk_is_str(after, "(", 1))
+      if (chunk_is_str(after, "("))
       {
          if (angle_close->flags.test(PCF_IN_FCN_CALL))
          {
@@ -2595,7 +2595,7 @@ pcf_flags_t mark_where_chunk(Chunk *pc, E_Token parent_type, pcf_flags_t flags)
    }
    else if (flags.test(PCF_IN_WHERE_SPEC))
    {
-      if (chunk_is_str(pc, ":", 1))
+      if (chunk_is_str(pc, ":"))
       {
          set_chunk_type(pc, CT_WHERE_COLON);
          LOG_FMT(LFTOR, "%s: where-spec colon on line %zu\n",

--- a/src/combine_tools.cpp
+++ b/src/combine_tools.cpp
@@ -154,18 +154,18 @@ bool can_be_full_param(Chunk *start, Chunk *end)
          {
             return(false);
          }
-         Chunk *tmp3 = (chunk_is_str(tmp2, ")", 1)) ? tmp2 : tmp2->GetNextNcNnl(E_Scope::PREPROC);
+         Chunk *tmp3 = (chunk_is_str(tmp2, ")")) ? tmp2 : tmp2->GetNextNcNnl(E_Scope::PREPROC);
 
          if (tmp3->IsNullChunk())
          {
             return(false);
          }
 
-         if (  !chunk_is_str(tmp3, ")", 1)
-            || !(  chunk_is_str(tmp1, "*", 1)
-                || chunk_is_str(tmp1, "^", 1)) // Issue #2656
+         if (  !chunk_is_str(tmp3, ")")
+            || !(  chunk_is_str(tmp1, "*")
+                || chunk_is_str(tmp1, "^")) // Issue #2656
             || !(  tmp2->type == CT_WORD
-                || chunk_is_str(tmp2, ")", 1)))
+                || chunk_is_str(tmp2, ")")))
          {
             LOG_FMT(LFPARAM, "%s(%d): <== '%s' not fcn type!\n",
                     __func__, __LINE__, get_token_name(pc->type));
@@ -181,7 +181,7 @@ bool can_be_full_param(Chunk *start, Chunk *end)
             return(false);
          }
 
-         if (chunk_is_str(tmp1, "(", 1))
+         if (chunk_is_str(tmp1, "("))
          {
             tmp3 = chunk_skip_to_match(tmp1, E_Scope::PREPROC);
          }
@@ -215,7 +215,7 @@ bool can_be_full_param(Chunk *start, Chunk *end)
       }
       else if (  word_count == 1
               && language_is_set(LANG_CPP)
-              && chunk_is_str(pc, "&&", 2))
+              && chunk_is_str(pc, "&&"))
       {
          // ignore possible 'move' operator
       }

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2782,11 +2782,11 @@ void indent_text(void)
             frm.top().indent_tab = frm.top().indent;
             skipped = true;
          }
-         else if (  (  chunk_is_str(pc, "(", 1)
+         else if (  (  chunk_is_str(pc, "(")
                     && !options::indent_paren_nl())
-                 || (  chunk_is_str(pc, "<", 1)
+                 || (  chunk_is_str(pc, "<")
                     && !options::indent_paren_nl())    // TODO: add indent_angle_nl?
-                 || (  chunk_is_str(pc, "[", 1)
+                 || (  chunk_is_str(pc, "[")
                     && !options::indent_square_nl()))
          {
             log_rule_B("indent_paren_nl");

--- a/src/lang_pawn.cpp
+++ b/src/lang_pawn.cpp
@@ -163,9 +163,9 @@ static bool pawn_continued(Chunk *pc, size_t br_level)
       || get_chunk_parent_type(pc) == CT_FUNC_DEF
       || get_chunk_parent_type(pc) == CT_ENUM
       || pc->flags.test_any(PCF_IN_ENUM | PCF_IN_STRUCT)
-      || chunk_is_str(pc, ":", 1)
-      || chunk_is_str(pc, "+", 1)
-      || chunk_is_str(pc, "-", 1))
+      || chunk_is_str(pc, ":")
+      || chunk_is_str(pc, "+")
+      || chunk_is_str(pc, "-"))
    {
       return(true);
    }
@@ -215,7 +215,7 @@ static Chunk *pawn_process_line(Chunk *start)
    //        start->orig_line, start->Text());
 
    if (  chunk_is_token(start, CT_NEW)
-      || chunk_is_str(start, "const", 5))
+      || chunk_is_str(start, "const"))
    {
       return(pawn_process_variable(start));
    }
@@ -234,7 +234,7 @@ static Chunk *pawn_process_line(Chunk *start)
    }
 
    while (  ((pc = pc->GetNextNc())->IsNotNullChunk())
-         && !chunk_is_str(pc, "(", 1)
+         && !chunk_is_str(pc, "(")
          && pc->type != CT_ASSIGN
          && pc->type != CT_NEWLINE)
    {
@@ -405,7 +405,7 @@ static Chunk *pawn_process_func_def(Chunk *pc)
 
    // See if there is a state clause after the function
    if (  last->IsNotNullChunk()
-      && chunk_is_str(last, "<", 1))
+      && chunk_is_str(last, "<"))
    {
       LOG_FMT(LPFUNC, "%s: %zu] '%s' has state angle open %s\n",
               __func__, pc->orig_line, pc->Text(), get_token_name(last->type));
@@ -414,7 +414,7 @@ static Chunk *pawn_process_func_def(Chunk *pc)
       set_chunk_parent(last, CT_FUNC_DEF);
 
       while (  ((last = last->GetNext())->IsNotNullChunk())
-            && !chunk_is_str(last, ">", 1))
+            && !chunk_is_str(last, ">"))
       {
          // do nothing just search, TODO: use search_chunk
       }

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -870,8 +870,8 @@ void newline_del_between(Chunk *start, Chunk *end)
    } while (pc != end);
 
    if (  !start_removed
-      && chunk_is_str(end, "{", 1)
-      && (  chunk_is_str(start, ")", 1)
+      && chunk_is_str(end, "{")
+      && (  chunk_is_str(start, ")")
          || chunk_is_token(start, CT_DO)
          || chunk_is_token(start, CT_ELSE)))
    {
@@ -3134,7 +3134,7 @@ static void newline_func_def_or_call(Chunk *start)
       }
       Chunk *pc = start->GetNextNcNnl();
 
-      if (chunk_is_str(pc, ")", 1))
+      if (chunk_is_str(pc, ")"))
       {
          log_rule_B("nl_func_call_paren_empty");
          atmp = options::nl_func_call_paren_empty();
@@ -3300,7 +3300,7 @@ static void newline_func_def_or_call(Chunk *start)
       }
       Chunk *pc = start->GetNextNcNnl();
 
-      if (chunk_is_str(pc, ")", 1))
+      if (chunk_is_str(pc, ")"))
       {
          log_rule_B("nl_func_def_empty");
          log_rule_B("nl_func_decl_empty");

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -2915,7 +2915,7 @@ static bool kw_fcn_javaparam(Chunk *cmt, unc_text &out_txt)
          tmp = fpo->GetNextNcNnl();
 
          if (  (tmp == fpc->GetPrevNcNnl())
-            && chunk_is_str(tmp, "void", 4))
+            && chunk_is_str(tmp, "void"))
          {
             has_param = false;
          }
@@ -2971,7 +2971,7 @@ static bool kw_fcn_javaparam(Chunk *cmt, unc_text &out_txt)
    }
 
    if (  tmp->IsNotNullChunk()
-      && !chunk_is_str(tmp, "void", 4))
+      && !chunk_is_str(tmp, "void"))
    {
       if (need_nl)
       {

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1552,7 +1552,7 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
    if (  language_is_set(LANG_VALA)
       && chunk_is_token(first, CT_FUNC_CALL))
    {
-      if (  chunk_is_str(first, "_", 1)
+      if (  chunk_is_str(first, "_")
          && chunk_is_token(second, CT_FPAREN_OPEN)
          && (options::sp_vala_after_translation() != IARF_IGNORE))
       {
@@ -1688,8 +1688,8 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
    }
 
    // ")(" vs. ") ("
-   if (  (  chunk_is_str(first, ")", 1)
-         && chunk_is_str(second, "(", 1))
+   if (  (  chunk_is_str(first, ")")
+         && chunk_is_str(second, "("))
       || (  chunk_is_paren_close(first)
          && chunk_is_paren_open(second)))
    {
@@ -2092,10 +2092,10 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
 
    /* "((" vs. "( (" or "))" vs. ") )" */
    // Issue #1342
-   if (  (  chunk_is_str(first, "(", 1)
-         && chunk_is_str(second, "(", 1))
-      || (  chunk_is_str(first, ")", 1)
-         && chunk_is_str(second, ")", 1)))
+   if (  (  chunk_is_str(first, "(")
+         && chunk_is_str(second, "("))
+      || (  chunk_is_str(first, ")")
+         && chunk_is_str(second, ")")))
    {
       if (get_chunk_parent_type(second) == CT_FUNC_CALL_USER)
       {
@@ -3468,10 +3468,10 @@ void space_text(void)
          chunk_flags_clr(pc, PCF_FORCE_SPACE);
 
          if (  (pc->Len() > 0)
-            && !chunk_is_str(pc, "[]", 2)
-            && !chunk_is_str(pc, "{{", 2)
-            && !chunk_is_str(pc, "}}", 2)
-            && !chunk_is_str(pc, "()", 2)
+            && !chunk_is_str(pc, "[]")
+            && !chunk_is_str(pc, "{{")
+            && !chunk_is_str(pc, "}}")
+            && !chunk_is_str(pc, "()")
             && !pc->str.startswith("@\""))
          {
             // Find the next non-empty chunk on this line
@@ -3686,8 +3686,8 @@ void space_text_balance_nested_parens(void)
       }
 
       // if there are two successive opening parenthesis
-      if (  chunk_is_str(first, "(", 1)
-         && chunk_is_str(next, "(", 1))
+      if (  chunk_is_str(first, "(")
+         && chunk_is_str(next, "("))
       {
          // insert a space between them
          space_add_after(first, 1);
@@ -3700,8 +3700,8 @@ void space_text_balance_nested_parens(void)
             space_add_after(closing->prev, 1);
          }
       }
-      else if (  chunk_is_str(first, ")", 1)
-              && chunk_is_str(next, ")", 1))
+      else if (  chunk_is_str(first, ")")
+              && chunk_is_str(next, ")"))
       {
          // insert a space between the two closing parens
          space_add_after(first, 1);

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -583,7 +583,7 @@ void tokenize_cleanup(void)
 
          // handle 'static if' and merge the tokens
          if (  chunk_is_token(pc, CT_IF)
-            && chunk_is_str(prev, "static", 6))
+            && chunk_is_str(prev, "static"))
          {
             // delete PREV and merge with IF
             pc->str.insert(0, ' ');
@@ -628,7 +628,7 @@ void tokenize_cleanup(void)
          // Set parent type for 'if constexpr'
          if (  chunk_is_token(prev, CT_IF)
             && chunk_is_token(pc, CT_QUALIFIER)
-            && chunk_is_str(pc, "constexpr", 9))
+            && chunk_is_str(pc, "constexpr"))
          {
             set_chunk_type(pc, CT_CONSTEXPR);
          }
@@ -782,8 +782,8 @@ void tokenize_cleanup(void)
       if (chunk_is_token(pc, CT_ACCESS))
       {
          // Handle Qt slots - maybe should just check for a CT_WORD?
-         if (  chunk_is_str(next, "slots", 5)
-            || chunk_is_str(next, "Q_SLOTS", 7))
+         if (  chunk_is_str(next, "slots")
+            || chunk_is_str(next, "Q_SLOTS"))
          {
             Chunk *tmp = next->GetNext();
 
@@ -805,8 +805,8 @@ void tokenize_cleanup(void)
          }
          else
          {
-            set_chunk_type(pc, (  chunk_is_str(pc, "signals", 7)
-                               || chunk_is_str(pc, "Q_SIGNALS", 9))
+            set_chunk_type(pc, (  chunk_is_str(pc, "signals")
+                               || chunk_is_str(pc, "Q_SIGNALS"))
                            ? CT_WORD : CT_QUALIFIER);
          }
       }
@@ -884,7 +884,7 @@ void tokenize_cleanup(void)
 
       // handle MS abomination 'for each'
       if (  chunk_is_token(pc, CT_FOR)
-         && chunk_is_str(next, "each", 4)
+         && chunk_is_str(next, "each")
          && (next == pc->GetNext()))
       {
          // merge the two with a space between
@@ -902,7 +902,7 @@ void tokenize_cleanup(void)
             while (  tmp->IsNotNullChunk()
                   && tmp->type != CT_PAREN_CLOSE)
             {
-               if (chunk_is_str(tmp, "in", 2))
+               if (chunk_is_str(tmp, "in"))
                {
                   set_chunk_type(tmp, CT_IN);
                   break;
@@ -1136,7 +1136,7 @@ void tokenize_cleanup(void)
       // Add minimal support for C++0x rvalue references
       if (  chunk_is_token(pc, CT_BOOL)
          && language_is_set(LANG_CPP)
-         && chunk_is_str(pc, "&&", 2))
+         && chunk_is_str(pc, "&&"))
       {
          if (chunk_is_token(prev, CT_TYPE))
          {
@@ -1153,7 +1153,7 @@ void tokenize_cleanup(void)
        *   A::A(int) try : B() { } catch (...) { }
        */
       if (  chunk_is_token(pc, CT_TRY)
-         && chunk_is_str(pc, "try", 3)
+         && chunk_is_str(pc, "try")
          && chunk_is_token(next, CT_COLON))
       {
          set_chunk_type(pc, CT_QUALIFIER);
@@ -1261,11 +1261,11 @@ static void check_template(Chunk *start, bool in_type_cast)
 
          if (parens == 0)
          {
-            if (chunk_is_str(pc, "<", 1))
+            if (chunk_is_str(pc, "<"))
             {
                level++;
             }
-            else if (chunk_is_str(pc, ">", 1))
+            else if (chunk_is_str(pc, ">"))
             {
                if (level == 0)
                {
@@ -1408,8 +1408,8 @@ static void check_template(Chunk *start, bool in_type_cast)
             && (pc->str[0] == '>')
             && (pc->Len() > 1)
             && (  options::tok_split_gte()
-               || (  (  chunk_is_str(pc, ">>", 2)
-                     || chunk_is_str(pc, ">>>", 3))
+               || (  (  chunk_is_str(pc, ">>")
+                     || chunk_is_str(pc, ">>>"))
                   && (  num_tokens >= 2
                      || (  num_tokens >= 1
                         && in_type_cast)))))
@@ -1420,7 +1420,7 @@ static void check_template(Chunk *start, bool in_type_cast)
             split_off_angle_close(pc);
          }
 
-         if (chunk_is_str(pc, "<", 1))
+         if (chunk_is_str(pc, "<"))
          {
             if (  num_tokens > 0 && (tokens[num_tokens - 1] == CT_PAREN_OPEN)
                && invalid_open_angle_template(pc->prev))
@@ -1433,7 +1433,7 @@ static void check_template(Chunk *start, bool in_type_cast)
                num_tokens++;
             }
          }
-         else if (chunk_is_str(pc, ">", 1))
+         else if (chunk_is_str(pc, ">"))
          {
             if (num_tokens > 0 && (tokens[num_tokens - 1] == CT_PAREN_OPEN))
             {
@@ -1720,8 +1720,8 @@ static void mark_selectors_in_property_with_open_paren(Chunk *open_paren)
          && tmp->type != CT_PAREN_CLOSE)
    {
       if (  chunk_is_token(tmp, CT_WORD)
-         && (  chunk_is_str(tmp, "setter", 6)
-            || chunk_is_str(tmp, "getter", 6)))
+         && (  chunk_is_str(tmp, "setter")
+            || chunk_is_str(tmp, "getter")))
       {
          tmp = tmp->next;
 
@@ -1730,7 +1730,7 @@ static void mark_selectors_in_property_with_open_paren(Chunk *open_paren)
                && tmp->type != CT_PAREN_CLOSE)
          {
             if (  chunk_is_token(tmp, CT_WORD)
-               || chunk_is_str(tmp, ":", 1))
+               || chunk_is_str(tmp, ":"))
             {
                set_chunk_type(tmp, CT_OC_SEL_NAME);
             }


### PR DESCRIPTION
This will prevent any length-counting errors since it won't be done
manually anymore.
