### PR TITLE
Vala: properly support nullable types

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -481,9 +481,6 @@ sp_type_ellipsis                = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space between a '*' and '...'.
 sp_ptr_type_ellipsis            = ignore   # ignore/add/remove/force/not_defined
 
-# (D) Add or remove space between a type and '?'.
-sp_type_question                = ignore   # ignore/add/remove/force/not_defined
-
 # Add or remove space between ')' and '...'.
 sp_paren_ellipsis               = ignore   # ignore/add/remove/force/not_defined
 

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -481,9 +481,6 @@ sp_type_ellipsis                = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space between a '*' and '...'.
 sp_ptr_type_ellipsis            = ignore   # ignore/add/remove/force/not_defined
 
-# (D) Add or remove space between a type and '?'.
-sp_type_question                = ignore   # ignore/add/remove/force/not_defined
-
 # Add or remove space between ')' and '...'.
 sp_paren_ellipsis               = ignore   # ignore/add/remove/force/not_defined
 

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -481,9 +481,6 @@ sp_type_ellipsis                = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space between a '*' and '...'.
 sp_ptr_type_ellipsis            = ignore   # ignore/add/remove/force/not_defined
 
-# (D) Add or remove space between a type and '?'.
-sp_type_question                = ignore   # ignore/add/remove/force/not_defined
-
 # Add or remove space between ')' and '...'.
 sp_paren_ellipsis               = ignore   # ignore/add/remove/force/not_defined
 

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -1072,15 +1072,6 @@ Choices=sp_ptr_type_ellipsis=ignore|sp_ptr_type_ellipsis=add|sp_ptr_type_ellipsi
 ChoicesReadable="Ignore Sp Ptr Type Ellipsis|Add Sp Ptr Type Ellipsis|Remove Sp Ptr Type Ellipsis|Force Sp Ptr Type Ellipsis"
 ValueDefault=ignore
 
-[Sp Type Question]
-Category=1
-Description="<html>(D) Add or remove space between a type and '?'.</html>"
-Enabled=false
-EditorType=multiple
-Choices=sp_type_question=ignore|sp_type_question=add|sp_type_question=remove|sp_type_question=force|sp_type_question=not_defined
-ChoicesReadable="Ignore Sp Type Question|Add Sp Type Question|Remove Sp Type Question|Force Sp Type Question"
-ValueDefault=ignore
-
 [Sp Paren Ellipsis]
 Category=1
 Description="<html>Add or remove space between ')' and '...'.</html>"

--- a/forUncrustifySources.cfg
+++ b/forUncrustifySources.cfg
@@ -430,7 +430,6 @@ use_form_feed_no_more_as_whitespace_character = false
 # sp_trailing_ret_t
 # sp_try_brace
 # sp_type_ellipsis
-# sp_type_question
 # sp_vala_after_translation
 # sp_version_paren
 # sp_word_brace

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -1018,7 +1018,7 @@ static inline bool chunk_is_word(Chunk *pc)
 
 static inline bool chunk_is_nullable(Chunk *pc)
 {
-   return(  language_is_set(LANG_CS)
+   return(  language_is_set(LANG_CS | LANG_VALA)
          && (pc != nullptr)
          && (pc->Len() == 1)
          && (pc->str[0] == '?'));

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1261,7 +1261,7 @@ void do_symbol_check(Chunk *prev, Chunk *pc, Chunk *next)
          set_chunk_type(pc, CT_PTR_TYPE);
       }
 
-      if (  language_is_set(LANG_CS)
+      if (  language_is_set(LANG_CS | LANG_VALA)
          && chunk_is_token(pc, CT_QUESTION)
          && chunk_is_token(prev, CT_ANGLE_CLOSE))
       {

--- a/src/combine_tools.cpp
+++ b/src/combine_tools.cpp
@@ -336,7 +336,7 @@ bool chunk_ends_type(Chunk *start)
             && get_chunk_parent_type(pc) == CT_TEMPLATE
             && (  chunk_is_token(pc, CT_ANGLE_OPEN)
                || chunk_is_token(pc, CT_ANGLE_CLOSE)))
-         || (  language_is_set(LANG_CS)
+         || (  language_is_set(LANG_CS | LANG_VALA)
             && (chunk_is_token(pc, CT_MEMBER))))
       {
          cnt++;

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -377,6 +377,21 @@ bool process_option_line_compat_0_73(const std::string &cmd,
    return(false);
 } // process_option_line_compat_0_73
 
+
+bool process_option_line_compat_0_74(const std::string &cmd,
+                                     const char        *filename)
+{
+   if (cmd == "sp_type_question")         // PR #3638
+   {
+      OptionWarning w{ filename, OptionWarning::MINOR };
+      w("option '%s' is deprecated; did you want to use '%s' instead?",
+        cmd.c_str(), options::sp_before_ptr_star.name());
+
+      return(true);
+   }
+   return(false);
+} // process_option_line_compat_0_74
+
 } // namespace
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1062,6 +1077,14 @@ void process_option_line(const std::string &config_line, const char *filename,
       if (compat_level < option_level(0, 74))
       {
          if (process_option_line_compat_0_73(cmd, filename))
+         {
+            return;
+         }
+      }
+
+      if (compat_level < option_level(0, 75))
+      {
+         if (process_option_line_compat_0_74(cmd, filename))
          {
             return;
          }

--- a/src/options.h
+++ b/src/options.h
@@ -611,10 +611,6 @@ sp_type_ellipsis;
 extern Option<iarf_e>
 sp_ptr_type_ellipsis;
 
-// (vala) Add or remove space between a type and '?'.
-extern Option<iarf_e>
-sp_type_question;
-
 // Add or remove space between ')' and '...'.
 extern Option<iarf_e>
 sp_paren_ellipsis;

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -327,19 +327,6 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
          log_rule("sp_cond_question_after");
          return(options::sp_cond_question_after());
       }
-
-      // Issue #2596
-      // Add or remove space around the '?' in 'b ? t : f'.
-      // replace "if (chunk_is_token(first, CT_PAREN_CLOSE) && chunk_is_token(second, CT_QUESTION))"
-      if (  language_is_set(LANG_VALA)
-         && chunk_is_token(second, CT_QUESTION))
-      {
-         // TODO: provide some test data to check this block
-         // Issue #2090
-         // (vala) Add or remove space between a type and '?'.
-         log_rule("sp_type_question");
-         return(options::sp_type_question());
-      }
       log_rule("sp_cond_question");
       return(options::sp_cond_question());
    }

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -491,7 +491,7 @@ void tokenize_cleanup(void)
       if (  (chunk_is_token(next, CT_STAR))
          || (  language_is_set(LANG_CPP)
             && (chunk_is_token(next, CT_CARET)))
-         || (  language_is_set(LANG_CS)
+         || (  language_is_set(LANG_CS | LANG_VALA)
             && (chunk_is_token(next, CT_QUESTION))
             && (strcmp(pc->Text(), "null") != 0)))
       {

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -1081,15 +1081,6 @@ Choices=sp_ptr_type_ellipsis=ignore|sp_ptr_type_ellipsis=add|sp_ptr_type_ellipsi
 ChoicesReadable="Ignore Sp Ptr Type Ellipsis|Add Sp Ptr Type Ellipsis|Remove Sp Ptr Type Ellipsis|Force Sp Ptr Type Ellipsis"
 ValueDefault=ignore
 
-[Sp Type Question]
-Category=1
-Description="<html>(vala) Add or remove space between a type and '?'.</html>"
-Enabled=false
-EditorType=multiple
-Choices=sp_type_question=ignore|sp_type_question=add|sp_type_question=remove|sp_type_question=force|sp_type_question=not_defined
-ChoicesReadable="Ignore Sp Type Question|Add Sp Type Question|Remove Sp Type Question|Force Sp Type Question"
-ValueDefault=ignore
-
 [Sp Paren Ellipsis]
 Category=1
 Description="<html>Add or remove space between ')' and '...'.</html>"

--- a/tests/config/vala/Issue_2090.cfg
+++ b/tests/config/vala/Issue_2090.cfg
@@ -1,2 +1,2 @@
-sp_type_question = force
+sp_before_ptr_star = force
 sp_cond_question = add

--- a/tests/config/vala/nullable.cfg
+++ b/tests/config/vala/nullable.cfg
@@ -1,0 +1,1 @@
+sp_before_ptr_star = remove

--- a/tests/expected/vala/70303-nullable.vala
+++ b/tests/expected/vala/70303-nullable.vala
@@ -1,0 +1,14 @@
+Vector2? a;
+Vector2 b;
+
+void G()
+{
+	int? x = true ? null : (int?)2;
+	var q = x == null ? y : z;
+	var q2 = x == q ? y : z;
+	var q3 = x == null ? (y = new Y()) : z;
+	var q4 = x == q ? (y = new Y()) : z;
+
+	var q5 = x == null ? y = new Y() : z;
+	var q6 = x == q ? y = new Y() : z;
+}

--- a/tests/input/vala/nullable.vala
+++ b/tests/input/vala/nullable.vala
@@ -1,0 +1,14 @@
+Vector2  ? a;
+Vector2 b;
+
+void G()
+{
+	int  ? x = true ? null : (int ?)2;
+	var q = x == null ? y : z;
+	var q2 = x == q ? y : z;
+	var q3 = x == null ? (y = new Y()) : z;
+	var q4 = x == q ? (y = new Y()) : z;
+
+	var q5 = x == null ? y = new Y() : z;
+	var q6 = x == q ? y = new Y() : z;
+}

--- a/tests/vala.test
+++ b/tests/vala.test
@@ -14,3 +14,4 @@
 70300  vala/Issue_2090.cfg                  vala/Issue_2090.vala
 70301  vala/Issue_2270.cfg                  vala/Issue_2270.vala
 70302  common/sp_after_cast.cfg             vala/cast.vala
+70303  vala/nullable.cfg                    vala/nullable.vala


### PR DESCRIPTION
Marks Vala nullable types as PTR_TYPE (like C# already does).

Previously, nullable types in Vala were not detected at all:
```
# -=====-
# language                      = VALA
# -=====-
# Line                Tag         Parent_type  Type of the parent         Columns Br/Lvl/pp         Flag   Nl  Text
#   1>               TYPE|               NONE|     PARENT_NOT_SET[  1/  1/  4/  0][0/0/0][     200c 0000][0-0] int
#   1>           QUESTION|               NONE|     PARENT_NOT_SET[  4/  4/  5/  0][0/0/0][   2 2000 0000][0-0]    ?
#   1>               WORD|               NONE|     PARENT_NOT_SET[  6/  6/  9/  1][0/0/0][     2008 0000][0-0]      foo
#   1>             ASSIGN|               NONE|     PARENT_NOT_SET[ 10/ 10/ 11/  1][0/0/0][   2 0000 0000][0-0]          =
#   1>               WORD|               NONE|     PARENT_NOT_SET[ 12/ 12/ 16/  1][0/0/0][        8 0000][0-0]            null
#   1>          SEMICOLON|               NONE|     PARENT_NOT_SET[ 16/ 16/ 17/  0][0/0/0][   2 0000 0000][0-0]                ;
#   1>            NEWLINE|               NONE|     PARENT_NOT_SET[ 17/ 17/  1/  0][0/0/0][             0][1-0]
# -=====-
```

This PR fixes it:
```
# -=====-
# language                      = VALA
# -=====-
# Line                Tag         Parent_type  Type of the parent         Columns Br/Lvl/pp         Flag   Nl  Text
#   1>               TYPE|               NONE|     PARENT_NOT_SET[  1/  1/  4/  0][0/0/0][     208c 0000][0-0] int
#   1>           PTR_TYPE|               NONE|     PARENT_NOT_SET[  4/  4/  5/  0][0/0/0][   2 2080 0000][0-0]    ?
#   1>               WORD|               NONE|     PARENT_NOT_SET[  6/  6/  9/  1][0/0/0][     2300 0000][0-0]      foo
#   1>             ASSIGN|               NONE|     PARENT_NOT_SET[ 10/ 10/ 11/  1][0/0/0][   2 0000 0000][0-0]          =
#   1>               WORD|               NONE|     PARENT_NOT_SET[ 12/ 12/ 16/  1][0/0/0][        8 0000][0-0]            null
#   1>          SEMICOLON|               NONE|     PARENT_NOT_SET[ 16/ 16/ 17/  0][0/0/0][   2 0000 0000][0-0]                ;
#   1>            NEWLINE|               NONE|     PARENT_NOT_SET[ 17/ 17/  1/  0][0/0/0][             0][1-0]
# -=====-
```

As a consequence, the option ``sp_type_question`` should now be removed, since ``sp_before_ptr_star`` can be used instead. 
I didn't bother to actually delete it, I will, should this PR be accepted.