### PR TITLE
Apply various fixes given by clang-tidy

### DIFF
--- a/src/EnumStructUnionParser.cpp
+++ b/src/EnumStructUnionParser.cpp
@@ -18,7 +18,6 @@
  * Extern declarations
  */
 extern const char *get_token_name(E_Token);
-extern void log_pcf_flags(log_sev_t, pcf_flags_t);
 
 
 /**

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -38,12 +38,6 @@ static void flag_asm(Chunk *pc);
 
 
 /**
- * Skips the list of class/struct parent types.
- */
-Chunk *skip_parent_types(Chunk *colon);
-
-
-/**
  * Combines two tokens into {{ and }} if inside parens and nothing is between
  * either pair.
  */

--- a/src/frame_list.cpp
+++ b/src/frame_list.cpp
@@ -69,10 +69,10 @@ void fl_log_frms(log_sev_t                     logsev,
 {
    LOG_FMT(logsev, "%s Parse Frames(%zu):", txt, frames.size());
 
-   for (size_t idx = 0; idx < frames.size(); idx++)
+   for (const auto &frame : frames)
    {
-      LOG_FMT(logsev, " [%s-%zu]", get_token_name(frames.at(idx).in_ifdef),
-              frames.at(idx).ref_no);
+      LOG_FMT(logsev, " [%s-%zu]", get_token_name(frame.in_ifdef),
+              frame.ref_no);
    }
 
    LOG_FMT(logsev, "-[%s-%zu]\n", get_token_name(frm.in_ifdef), frm.ref_no);

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -5317,19 +5317,16 @@ void newlines_squeeze_paren_close(void)
          Chunk *next_op = chunk_skip_to_match_rev(next);
          bool  flag     = true;
 
-         if (true)
+         Chunk *tmp = prev;
+
+         while (chunk_is_paren_close(tmp))
          {
-            Chunk *tmp = prev;
+            tmp = tmp->GetPrev();
+         }
 
-            while (chunk_is_paren_close(tmp))
-            {
-               tmp = tmp->GetPrev();
-            }
-
-            if (chunk_is_not_token(tmp, CT_NEWLINE))
-            {
-               flag = false;
-            }
+         if (chunk_is_not_token(tmp, CT_NEWLINE))
+         {
+            flag = false;
          }
 
          if (flag)

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -253,7 +253,7 @@ static void add_char(UINT32 ch, bool is_literal)
    {
       write_string(cpd.newline);
       cpd.column      = 1;
-      cpd.did_newline = 1;
+      cpd.did_newline = true;
       cpd.spaces      = 0;
    }
 
@@ -263,14 +263,14 @@ static void add_char(UINT32 ch, bool is_literal)
       add_spaces();
       write_string(cpd.newline);
       cpd.column      = 1;
-      cpd.did_newline = 1;
+      cpd.did_newline = true;
       cpd.spaces      = 0;
    }
    else if (ch == '\r') // do not output the CARRIAGERETURN
    {
       // do not output '\r'
       cpd.column      = 1;
-      cpd.did_newline = 1;
+      cpd.did_newline = true;
       cpd.spaces      = 0;
    }
    else if (  (ch == '\t')
@@ -393,7 +393,7 @@ static bool next_word_exceeds_limit(const unc_text &text, size_t idx)
  */
 static void output_to_column(size_t column, bool allow_tabs)
 {
-   cpd.did_newline = 0;
+   cpd.did_newline = false;
 
    if (allow_tabs)
    {
@@ -427,7 +427,7 @@ static void cmt_output_indent(size_t brace_col, size_t base_col, size_t column)
    // LOG_FMT(LSYS, "%s(brace=%zd base=%zd col=%zd iwt=%zd) tab=%zd cur=%zd\n",
    //        __func__, brace_col, base_col, column, iwt, tab_col, cpd.column);
 
-   cpd.did_newline = 0;
+   cpd.did_newline = false;
 
    if (  iwt == 2
       || (  cpd.column == 1
@@ -587,7 +587,7 @@ void output_text(FILE *pfile)
    bool tracking = cpd.html_file != nullptr;                 // special for debugging
 
    cpd.fout        = pfile;
-   cpd.did_newline = 1;
+   cpd.did_newline = true;
    cpd.column      = 1;
 
    if (cpd.bom)
@@ -647,7 +647,7 @@ void output_text(FILE *pfile)
             add_char('\n');
          }
 
-         cpd.did_newline = 1;
+         cpd.did_newline = true;
          cpd.column      = 1;
          LOG_FMT(LOUTIND, " xx\n");
       }
@@ -729,7 +729,7 @@ void output_text(FILE *pfile)
          }
          add_char('\\');
          add_char('\n');
-         cpd.did_newline = 1;
+         cpd.did_newline = true;
          cpd.column      = 1;
          LOG_FMT(LOUTIND, " \\xx\n");
       }
@@ -1770,8 +1770,7 @@ static Chunk *output_comment_c(Chunk *first)
       tmp.set(pc->str, 2, pc->Len() - 4);
 
       if (  cpd.last_char == '*'
-         && (  tmp[0] == '/'
-            || tmp[0] != ' '))                 // Issue #1908
+         && tmp[0] != ' ')                 // Issue #1908
       {
          LOG_FMT(LCONTTEXT, "%s(%d): add_text a " "\n", __func__, __LINE__);
          add_text(" ");

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -2487,7 +2487,7 @@ static bool parse_next(tok_ctx &ctx, Chunk &pc, const Chunk *prev_pc)
 
    if (probe_lang_flags != 0)
    {
-      if ((punc = find_punctuator(punc_txt, probe_lang_flags)) != NULL)
+      if ((punc = find_punctuator(punc_txt, probe_lang_flags)) != nullptr)
       {
          cpd.lang_flags = probe_lang_flags;
          int cnt = strlen(punc->tag);

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -427,14 +427,14 @@ int main(int argc, char *argv[])
    // output.cpp, line 427: fprintf(pfile, "# Line              Tag                Parent...
    // and              430: ... fprintf(pfile, "%s# %3zu>%19.19s[%19.19s] ...
    // here                                                xx xx   xx xx
-   for (size_t token = 0; token < ARRAY_SIZE(token_names); token++)
+   for (auto &token_name : token_names)
    {
-      const size_t name_length = strlen(token_names[token]);
+      const size_t name_length = strlen(token_name);
 
       if (name_length > max_name_length)
       {
          fprintf(stderr, "%s(%d): The token name '%s' is too long (%d)\n",
-                 __func__, __LINE__, token_names[token], static_cast<int>(name_length));
+                 __func__, __LINE__, token_name, static_cast<int>(name_length));
          fprintf(stderr, "%s(%d): the max token name length is %d\n",
                  __func__, __LINE__, max_name_length);
          log_flush(true);
@@ -443,7 +443,7 @@ int main(int argc, char *argv[])
    }
 
    // make sure we have token_names.h in sync with token_enum.h
-   assert(ARRAY_SIZE(token_names) == CT_TOKEN_COUNT_);
+   static_assert(ARRAY_SIZE(token_names) == CT_TOKEN_COUNT_, "");
 #endif // DEBUG
 
    Args arg(argc, argv);
@@ -662,13 +662,13 @@ int main(int argc, char *argv[])
 
    LOG_FMT(LDATA, "%s\n", UNCRUSTIFY_VERSION);
    LOG_FMT(LDATA, "config_file = %s\n", cfg_file.c_str());
-   LOG_FMT(LDATA, "output_file = %s\n", (output_file != NULL) ? output_file : "null");
-   LOG_FMT(LDATA, "source_file = %s\n", (source_file != NULL) ? source_file : "null");
-   LOG_FMT(LDATA, "source_list = %s\n", (source_list != NULL) ? source_list : "null");
-   LOG_FMT(LDATA, "tracking    = %s\n", (cpd.html_file != NULL) ? cpd.html_file : "null");
-   LOG_FMT(LDATA, "prefix      = %s\n", (prefix != NULL) ? prefix : "null");
-   LOG_FMT(LDATA, "suffix      = %s\n", (suffix != NULL) ? suffix : "null");
-   LOG_FMT(LDATA, "assume      = %s\n", (assume != NULL) ? assume : "null");
+   LOG_FMT(LDATA, "output_file = %s\n", (output_file != nullptr) ? output_file : "null");
+   LOG_FMT(LDATA, "source_file = %s\n", (source_file != nullptr) ? source_file : "null");
+   LOG_FMT(LDATA, "source_list = %s\n", (source_list != nullptr) ? source_list : "null");
+   LOG_FMT(LDATA, "tracking    = %s\n", (cpd.html_file != nullptr) ? cpd.html_file : "null");
+   LOG_FMT(LDATA, "prefix      = %s\n", (prefix != nullptr) ? prefix : "null");
+   LOG_FMT(LDATA, "suffix      = %s\n", (suffix != nullptr) ? suffix : "null");
+   LOG_FMT(LDATA, "assume      = %s\n", (assume != nullptr) ? assume : "null");
    LOG_FMT(LDATA, "replace     = %s\n", replace ? "true" : "false");
    LOG_FMT(LDATA, "no_backup   = %s\n", no_backup ? "true" : "false");
    LOG_FMT(LDATA, "detect      = %s\n", detect ? "true" : "false");
@@ -1583,9 +1583,9 @@ static void do_source_file(const char *filename_in,
 
    if (cpd.if_changed)
    {
-      for (deque<UINT8>::const_iterator i = cpd.bout->begin(), end = cpd.bout->end(); i != end; ++i)
+      for (unsigned char i : *cpd.bout)
       {
-         fputc(*i, pfout);
+         fputc(i, pfout);
       }
 
       uncrustify_end();

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -427,7 +427,7 @@ int main(int argc, char *argv[])
    // output.cpp, line 427: fprintf(pfile, "# Line              Tag                Parent...
    // and              430: ... fprintf(pfile, "%s# %3zu>%19.19s[%19.19s] ...
    // here                                                xx xx   xx xx
-   for (auto &token_name : token_names)
+   for (const auto &token_name : token_names)
    {
       const size_t name_length = strlen(token_name);
 
@@ -1583,7 +1583,7 @@ static void do_source_file(const char *filename_in,
 
    if (cpd.if_changed)
    {
-      for (unsigned char i : *cpd.bout)
+      for (UINT8 i : *cpd.bout)
       {
          fputc(i, pfout);
       }

--- a/src/uncrustify.h
+++ b/src/uncrustify.h
@@ -42,11 +42,6 @@ const char *language_name_from_flags(size_t lang);
  */
 E_Token find_token_name(const char *text);
 
-std::string pcf_flags_str(pcf_flags_t flags);
-
-
-void log_pcf_flags(log_sev_t sev, pcf_flags_t flags);
-
 
 /**
  * Replace the brain-dead and non-portable basename().

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -249,7 +249,7 @@ struct cp_data_t
    UINT32            le_counts[uncrustify::line_end_styles];
    unc_text          newline;
 
-   int               did_newline;       //! flag indicates if a newline was added or converted
+   bool              did_newline;       //! flag indicates if a newline was added or converted
    E_Token           in_preproc;
    int               preproc_ncnl_count;
    bool              output_trailspace;


### PR DESCRIPTION
Replace type of did_newline from int to bool.
Replace assert() with static_assert() if possible.
Use nullptr over NULL.
Remove redundant if-statement.
Remove redundant function declarations.
Convert standard for loops to range-based for loops.
