### PR TITLE
Run CI test for pull requests.

### DIFF
--- a/.github/workflows/uncrustify_test.yml
+++ b/.github/workflows/uncrustify_test.yml
@@ -1,7 +1,13 @@
 ---
 
 name: uncrustify_test
-on: [push]
+on: [push, pull_request]
+
+# Cancel any in-progress CI runs for a PR if it is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   check-uncrustify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The benefit is that the all the test results will be available on the PR
page. The uncrustify developers will also no longer need to ask to the
pull requester to activate their workflow.
