### PR TITLE
Add ability to control spacing between type and ? in C#

### DIFF
--- a/src/space.cpp
+++ b/src/space.cpp
@@ -2659,14 +2659,6 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
          return(options::sp_before_ptr_star_trailing());
       }
 
-      if (  language_is_set(LANG_CS)
-         && chunk_is_nullable(second))
-      {
-         min_sp = 0;
-         log_rule("REMOVE");
-         return(IARF_REMOVE);
-      }
-
       // Add or remove space before a pointer star '*', if followed by a function
       // prototype or function definition.
       if (options::sp_before_ptr_star_func() != IARF_IGNORE)

--- a/tests/c-sharp.test
+++ b/tests/c-sharp.test
@@ -40,7 +40,7 @@
 
 10090  cs/ben_043.cfg                               cs/string_multi.cs
 
-10100  common/empty.cfg                             cs/bug_600.cs
+10100  cs/bug_600.cfg                               cs/bug_600.cs
 10101  cs/sf607.cfg                                 cs/sf607.cs
 
 10110  cs/mda_space_a.cfg                           cs/mdarray_space.cs

--- a/tests/config/cs/bug_600.cfg
+++ b/tests/config/cs/bug_600.cfg
@@ -1,0 +1,1 @@
+sp_before_ptr_star = remove


### PR DESCRIPTION
Adds the ability to control spacing between ``type`` and ``?`` in C# via ``sp_before_ptr_star`` and ``sp_after_ptr_star``.

Previously, spaces before ``?``, if any, were always removed.

One thing to note is that the default value for ``sp_{before,after}_ptr_star`` is set to ``ignore``, which may produce different results than before if spaces between ``type`` and ``?`` are found (see bug_600.cs).