### PR TITLE
Revert "Fix cmake COMPILER_PREFIX flag".

### DIFF
--- a/cmake/Toolchain-mingw32.cmake
+++ b/cmake/Toolchain-mingw32.cmake
@@ -4,7 +4,7 @@
 
 set(CMAKE_SYSTEM_NAME Windows)
 
-if(COMPILER_PREFIX STREQUAL "")
+if(NOT COMPILER_PREFIX)
   if(EXISTS /usr/i686-w64-mingw32)
     # mingw-w64
     set(COMPILER_PREFIX "i686-w64-mingw32")

--- a/cmake/Toolchain-mingw64.cmake
+++ b/cmake/Toolchain-mingw64.cmake
@@ -4,7 +4,7 @@
 
 set(CMAKE_SYSTEM_NAME Windows)
 
-if(COMPILER_PREFIX STREQUAL "")
+if(NOT COMPILER_PREFIX)
   if(EXISTS /usr/x86_64-w64-mingw32)
     # mingw-w64
     set(COMPILER_PREFIX "x86_64-w64-mingw32")


### PR DESCRIPTION
The mentioned commit breaks cross compiling for Windows from linux.
Install g++-mingw-w64 and gcc-mingw-w64. With commit 8b35f1c3, the following commands result in error.
Revert the commit and a valid windows executable is built.
$ mkdir buildwin-64
$ cd buildwin-64
$ cmake -G Ninja \
            -DCMAKE_BUILD_TYPE=Release \
            -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-mingw64.cmake \
            -DCMAKE_EXE_LINKER_FLAGS="-static -s" \
            .. 
$ ninja
