### PR TITLE
don't remove semi after initialisation

### DIFF
--- a/tests/c.test
+++ b/tests/c.test
@@ -166,6 +166,7 @@
 00421  c/nl_ds_struct_enum_cmt-t.cfg              c/nl_ds_struct_enum.c
 00422  c/nl_ds_struct_enum-2.cfg                  c/nl_ds_struct_enum.c
 00423  c/bug_1702.cfg                             c/bug_1702.c
+00424  c/Issue_3506.cfg                           c/Issue_3506.c
 
 00430  common/empty.cfg                           c/paren-indent.c
 00431  c/indent_paren_close-1.cfg                 c/paren-indent.c

--- a/tests/config/c/Issue_3506.cfg
+++ b/tests/config/c/Issue_3506.cfg
@@ -1,0 +1,1 @@
+mod_remove_extra_semicolon = true

--- a/tests/expected/c/00424-Issue_3506.c
+++ b/tests/expected/c/00424-Issue_3506.c
@@ -1,0 +1,12 @@
+#define CONCAT2x(a,b) a ## _ ## b
+#define CONCAT2(a,b) CONCAT2x(a,b)
+
+typedef struct S {
+	int a;
+	int b;
+} S;
+
+static const S CONCAT2(foo, bar) = {
+	3,
+	4
+};

--- a/tests/input/c/Issue_3506.c
+++ b/tests/input/c/Issue_3506.c
@@ -1,0 +1,12 @@
+#define CONCAT2x(a,b) a ## _ ## b
+#define CONCAT2(a,b) CONCAT2x(a,b)
+
+typedef struct S {
+int a;
+int b;
+} S;
+
+static const S CONCAT2(foo, bar) = {
+3,
+4
+};


### PR DESCRIPTION
fixes #3506
"a semicolon following a code block is extra UNLESS the open brace is preceded
by the = sign, as this clearly indicates that what we have within braces
is not a code block"