### PR TITLE
Never mark an ampersand in C as a byref in fix_fcn_def_params

### DIFF
--- a/src/combine_fix_mark.cpp
+++ b/src/combine_fix_mark.cpp
@@ -358,9 +358,9 @@ void fix_fcn_def_params(Chunk *start)
          set_chunk_type(pc, CT_PTR_TYPE);
          cs.Push_Back(pc);
       }
-      else if (  chunk_is_token(pc, CT_AMP)
-              || (  language_is_set(LANG_CPP)
-                 && chunk_is_str(pc, "&&")))
+      else if (  language_is_set(LANG_CPP)   // Issue #3662
+              && (  chunk_is_token(pc, CT_AMP)
+                 || chunk_is_str(pc, "&&")))
       {
          set_chunk_type(pc, CT_BYREF);
          cs.Push_Back(pc);

--- a/tests/c.test
+++ b/tests/c.test
@@ -466,3 +466,4 @@
 10066  c/Issue_3580.cfg                           c/Issue_3580.c
 10077  c/Issue_3582.cfg                           c/Issue_3582.c
 10078  c/pp_indent_brace--1.cfg                   c/Issue_3587.h
+10079  c/Issue_3662.cfg                           c/Issue_3662.c

--- a/tests/config/c/Issue_3662.cfg
+++ b/tests/config/c/Issue_3662.cfg
@@ -1,0 +1,4 @@
+sp_before_ptr_star = remove
+sp_before_byref    = remove
+sp_after_ptr_star  = add
+sp_after_byref     = add

--- a/tests/expected/c/10079-Issue_3662.c
+++ b/tests/expected/c/10079-Issue_3662.c
@@ -1,0 +1,12 @@
+#define emit /* syntactic sugar, like in Qt */
+
+void some_signal(int* x)
+{
+}
+
+int main(void)
+{
+	int x;
+	emit some_signal(&x);
+	return 0;
+}

--- a/tests/input/c/Issue_3662.c
+++ b/tests/input/c/Issue_3662.c
@@ -1,0 +1,12 @@
+#define emit /* syntactic sugar, like in Qt */
+
+void some_signal(int *x)
+{
+}
+
+int main(void)
+{
+	int x;
+	emit some_signal(&x);
+	return 0;
+}


### PR DESCRIPTION
Fixes #3662