### PR TITLE
Remove unused variable LCURRENT.

### DIFF
--- a/src/mark_question_colon.cpp
+++ b/src/mark_question_colon.cpp
@@ -12,8 +12,6 @@
 #include "log_levels.h"
 #include "unc_tools.h"
 
-constexpr static auto LCURRENT = LCOMBINE;
-
 
 /*
  * Issue #3558


### PR DESCRIPTION
This will remove the warning "unused variable 'LCURRENT'" when building
uncrustify.
