### PR TITLE
Remove dead code from CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,23 +437,9 @@ set(uncrustify_docs
 add_executable(uncrustify ${uncrustify_sources} ${uncrustify_headers})
 add_dependencies(uncrustify generate_version_header)
 
-if(CMAKE_VERSION VERSION_LESS 2.8.10)
-  if(CMAKE_CONFIGURATION_TYPES OR CMAKE_BUILD_TYPE)
-    # Multi-configuration or build type set
-    set_property(TARGET uncrustify APPEND PROPERTY
-      COMPILE_DEFINITIONS_DEBUG DEBUG
-    )
-  else()
-    # Single-configuration with no build type set
-    set_property(TARGET uncrustify APPEND PROPERTY
-      COMPILE_DEFINITIONS DEBUG
-    )
-  endif()
-else()
-  set_property(TARGET uncrustify APPEND PROPERTY
-    COMPILE_DEFINITIONS $<$<OR:$<CONFIG:Debug>,$<CONFIG:>>:DEBUG>
-  )
-endif()
+set_property(TARGET uncrustify APPEND PROPERTY
+  COMPILE_DEFINITIONS $<$<OR:$<CONFIG:Debug>,$<CONFIG:>>:DEBUG>
+)
 
 #
 # Generate uncrustify.1


### PR DESCRIPTION
The minimum required version cmake needs to be is at least 3.2, which
means the code that is run if the cmake version is less than 2.8.10 will
never be run.
