### PR TITLE
Replace false type comparisons with IsNot().

### DIFF
--- a/src/align_var_def_brace.cpp
+++ b/src/align_var_def_brace.cpp
@@ -259,7 +259,7 @@ Chunk *align_var_def_brace(Chunk *start, size_t span, size_t *p_nl_count)
          && (  (pc->level == (start->level + 1))
             || pc->level == 0)
          && pc->prev != nullptr
-         && pc->prev->type != CT_MEMBER)
+         && pc->GetPrev()->IsNot(CT_MEMBER))
       {
          LOG_FMT(LAVDB, "%s(%d): a-did_this_line is %s\n",
                  __func__, __LINE__, did_this_line ? "TRUE" : "FALSE");

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -773,7 +773,7 @@ static inline bool chunk_is_not_token(const Chunk *pc, E_Token c_token)
 {
    return(  pc != nullptr
          && pc->IsNotNullChunk()
-         && pc->type != c_token);
+         && pc->IsNot(c_token));
 }
 
 
@@ -956,7 +956,7 @@ static inline bool chunk_is_addr(Chunk *pc)
       && (  chunk_is_token(pc, CT_BYREF)
          || (  (pc->Len() == 1)
             && (pc->str[0] == '&')
-            && pc->type != CT_OPERATOR_VAL)))
+            && pc->IsNot(CT_OPERATOR_VAL))))
    {
       Chunk *prev = pc->GetPrev();
 
@@ -978,7 +978,7 @@ static inline bool chunk_is_msref(Chunk *pc) // ms compilers for C++/CLI and Win
          && (  pc != nullptr
             && (pc->Len() == 1)
             && (pc->str[0] == '^')
-            && pc->type != CT_OPERATOR_VAL));
+            && pc->IsNot(CT_OPERATOR_VAL)));
 }
 
 
@@ -1089,8 +1089,8 @@ static inline bool chunk_is_forin(Chunk *pc)
          Chunk *next = pc;
 
          while (  next != nullptr
-               && next->type != CT_SPAREN_CLOSE
-               && next->type != CT_IN)
+               && next->IsNot(CT_SPAREN_CLOSE)
+               && next->IsNot(CT_IN))
          {
             next = next->GetNextNcNnl();
          }

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -611,7 +611,7 @@ void do_symbol_check(Chunk *prev, Chunk *pc, Chunk *next)
 
       if (  chunk_is_token(pc, CT_WHEN)
          && pc->GetNext()->IsNotNullChunk()
-         && pc->GetNext()->type != CT_SPAREN_OPEN)
+         && pc->GetNext()->IsNot(CT_SPAREN_OPEN))
       {
          set_chunk_type(pc, CT_WORD);
          return;
@@ -2633,7 +2633,6 @@ static void handle_d_template(Chunk *pc)
    Chunk *name = pc->GetNextNcNnl();
    Chunk *po   = name->GetNextNcNnl();
 
-   //if (!name || (name->type != CT_WORD && name->type != CT_WORD))  Coverity CID 76000 Same on both sides, 2016-03-16
    if (  name->IsNullChunk()
       || chunk_is_not_token(name, CT_WORD))
    {

--- a/src/detect.cpp
+++ b/src/detect.cpp
@@ -240,7 +240,7 @@ static void detect_space_options()
          {
             vote_sp_between_ptr_star.vote(prev, pc);
          }
-         else if (next->type != CT_WORD)
+         else if (next->IsNot(CT_WORD))
          {
             vote_sp_before_unnamed_ptr_star.vote(prev, pc);
          }
@@ -257,7 +257,7 @@ static void detect_space_options()
 
       if (chunk_is_token(pc, CT_BYREF))
       {
-         if (next->type != CT_WORD)
+         if (next->IsNot(CT_WORD))
          {
             vote_sp_before_unnamed_byref.vote(prev, pc);
          }
@@ -268,7 +268,7 @@ static void detect_space_options()
          vote_sp_after_byref.vote(pc, next);
       }
 
-      if (  pc->type != CT_PTR_TYPE
+      if (  pc->IsNot(CT_PTR_TYPE)
          && (  chunk_is_token(prev, CT_QUALIFIER)
             || chunk_is_token(prev, CT_TYPE)))
       {
@@ -346,7 +346,7 @@ static void detect_space_options()
                //                  ^ is next
                vote_sp_after_semi_for_empty.vote(pc, next);
             }
-            else if (prev->type != CT_SEMICOLON)
+            else if (prev->IsNot(CT_SEMICOLON))
             {
                // empty, ie for (; i < 8;)
                //                       ^ is pc

--- a/src/frame_list.cpp
+++ b/src/frame_list.cpp
@@ -150,7 +150,7 @@ void fl_pop(std::vector<ParseFrame> &frames, ParseFrame &pf)
 
 int fl_check(std::vector<ParseFrame> &frames, ParseFrame &frm, int &pp_level, Chunk *pc)
 {
-   if (pc->type != CT_PREPROC)
+   if (pc->IsNot(CT_PREPROC))
    {
       return(pp_level);
    }

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -537,7 +537,7 @@ static Chunk *oc_msg_block_indent(Chunk *pc, bool from_brace,
 
    // If we still cannot find caret then return first chunk on the line
    if (  tmp->IsNullChunk()
-      || tmp->type != CT_OC_BLOCK_CARET)
+      || tmp->IsNot(CT_OC_BLOCK_CARET))
    {
       return(candidate_chunk_first_on_line(pc));
    }
@@ -552,7 +552,7 @@ static Chunk *oc_msg_block_indent(Chunk *pc, bool from_brace,
    if (from_colon)
    {
       if (  tmp->IsNullChunk()
-         || tmp->type != CT_OC_COLON)
+         || tmp->IsNot(CT_OC_COLON))
       {
          return(candidate_chunk_first_on_line(pc));
       }
@@ -566,8 +566,8 @@ static Chunk *oc_msg_block_indent(Chunk *pc, bool from_brace,
    if (from_keyword)
    {
       if (  tmp->IsNullChunk()
-         || (  tmp->type != CT_OC_MSG_NAME
-            && tmp->type != CT_OC_MSG_FUNC))
+         || (  tmp->IsNot(CT_OC_MSG_NAME)
+            && tmp->IsNot(CT_OC_MSG_FUNC)))
       {
          return(candidate_chunk_first_on_line(pc));
       }
@@ -864,7 +864,7 @@ void indent_text()
             log_rule_B("pp_indent_extern");
 
             while (  preproc_next->IsNotNullChunk()
-                  && preproc_next->type != CT_NEWLINE)
+                  && preproc_next->IsNot(CT_NEWLINE))
             {
                if (  (chunk_is_token(preproc_next, CT_BRACE_OPEN))
                   || (chunk_is_token(preproc_next, CT_BRACE_CLOSE)))
@@ -1630,7 +1630,7 @@ void indent_text()
       }
       else if (  chunk_is_token(pc, CT_BRACE_OPEN)
               && (  pc->next != nullptr
-                 && pc->next->type != CT_NAMESPACE))
+                 && pc->GetNext()->IsNot(CT_NAMESPACE)))
       {
          LOG_FMT(LINDENT2, "%s(%d): orig_line is %zu, orig_col is %zu, Text() is '%s'\n",
                  __func__, __LINE__, pc->orig_line, pc->orig_col, pc->Text());
@@ -3037,7 +3037,7 @@ void indent_text()
 
          if (  tmp->IsNotNullChunk()
             && (  (strcmp(tmp->Text(), ".") != 0)
-               || tmp->type != CT_MEMBER))
+               || tmp->IsNot(CT_MEMBER)))
          {
             if (chunk_is_paren_close(tmp))
             {
@@ -3128,7 +3128,7 @@ void indent_text()
                log_indent();
 
                if (  pc->level == pc->brace_level
-                  && (  pc->type != CT_ASSIGN
+                  && (  pc->IsNot(CT_ASSIGN)
                      || (  get_chunk_parent_type(pc) != CT_FUNC_PROTO
                         && get_chunk_parent_type(pc) != CT_FUNC_DEF)))
                {
@@ -3313,7 +3313,7 @@ void indent_text()
       }
       else if (  chunk_is_token(pc, CT_LAMBDA)
               && (language_is_set(LANG_CS | LANG_JAVA))
-              && pc->GetNextNcNnlNpp()->type != CT_BRACE_OPEN
+              && pc->GetNextNcNnlNpp()->IsNot(CT_BRACE_OPEN)
               && options::indent_cs_delegate_body())
       {
          log_rule_B("indent_cs_delegate_body");
@@ -3398,7 +3398,7 @@ void indent_text()
          && !pc->flags.test(PCF_IN_ENUM)
          && get_chunk_parent_type(pc) != CT_OPERATOR
          && !pc->IsComment()
-         && pc->type != CT_BRACE_OPEN
+         && pc->IsNot(CT_BRACE_OPEN)
          && pc->level > 0
          && !pc->IsEmptyText())
       {
@@ -3427,12 +3427,12 @@ void indent_text()
             tmp = tmp->GetPrevNcNnl();
          } while (  !in_shift
                  && tmp->IsNotNullChunk()
-                 && tmp->type != CT_SEMICOLON
-                 && tmp->type != CT_BRACE_OPEN
-                 && tmp->type != CT_BRACE_CLOSE
-                 && tmp->type != CT_COMMA
-                 && tmp->type != CT_SPAREN_OPEN
-                 && tmp->type != CT_SPAREN_CLOSE);
+                 && tmp->IsNot(CT_SEMICOLON)
+                 && tmp->IsNot(CT_BRACE_OPEN)
+                 && tmp->IsNot(CT_BRACE_CLOSE)
+                 && tmp->IsNot(CT_COMMA)
+                 && tmp->IsNot(CT_SPAREN_OPEN)
+                 && tmp->IsNot(CT_SPAREN_CLOSE));
 
          tmp = pc;
 
@@ -3457,12 +3457,12 @@ void indent_text()
             }
          } while (  !in_shift
                  && tmp->IsNotNullChunk()
-                 && tmp->type != CT_SEMICOLON
-                 && tmp->type != CT_BRACE_OPEN
-                 && tmp->type != CT_BRACE_CLOSE
-                 && tmp->type != CT_COMMA
-                 && tmp->type != CT_SPAREN_OPEN
-                 && tmp->type != CT_SPAREN_CLOSE);
+                 && tmp->IsNot(CT_SEMICOLON)
+                 && tmp->IsNot(CT_BRACE_OPEN)
+                 && tmp->IsNot(CT_BRACE_CLOSE)
+                 && tmp->IsNot(CT_COMMA)
+                 && tmp->IsNot(CT_SPAREN_OPEN)
+                 && tmp->IsNot(CT_SPAREN_CLOSE));
 
          LOG_FMT(LINDENT2, "%s(%d): in_shift is %s\n",
                  __func__, __LINE__, in_shift ? "TRUE" : "FALSE");
@@ -4120,7 +4120,7 @@ void indent_text()
                     __func__, __LINE__, pc->orig_line, pc->column, pc->Text(), indent_column);
 
             if (  use_indent
-               && pc->type != CT_PP_IGNORE) // Leave indentation alone for PP_IGNORE tokens
+               && pc->IsNot(CT_PP_IGNORE)) // Leave indentation alone for PP_IGNORE tokens
             {
                log_rule_B("pos_conditional");
 
@@ -4641,14 +4641,14 @@ bool ifdef_over_whole_file()
       if (IFstage == 0)                   // 0 is BEGIN
       {
          // Check the first preprocessor, make sure it is an #if type
-         if (pc->type != CT_PREPROC)
+         if (pc->IsNot(CT_PREPROC))
          {
             break;
          }
          Chunk *next = pc->GetNext();
 
          if (  next->IsNullChunk()
-            || next->type != CT_PP_IF)
+            || next->IsNot(CT_PP_IF))
          {
             break;
          }
@@ -4705,7 +4705,7 @@ void indent_preproc()
       LOG_FMT(LPPIS, "%s(%d): orig_line is %zu, orig_col is %zu, pc->Text() is '%s'\n",
               __func__, __LINE__, pc->orig_line, pc->orig_col, pc->Text());
 
-      if (pc->type != CT_PREPROC)
+      if (pc->IsNot(CT_PREPROC))
       {
          continue;
       }

--- a/src/lang_pawn.cpp
+++ b/src/lang_pawn.cpp
@@ -104,7 +104,7 @@ void pawn_scrub_vsemi()
 
    for (Chunk *pc = Chunk::GetHead(); pc->IsNotNullChunk(); pc = pc->GetNext())
    {
-      if (pc->type != CT_VSEMICOLON)
+      if (pc->IsNot(CT_VSEMICOLON))
       {
          continue;
       }
@@ -186,7 +186,7 @@ void pawn_prescan()
          && pc->IsNotNullChunk())
    {
       if (  did_nl
-         && pc->type != CT_PREPROC
+         && pc->IsNot(CT_PREPROC)
          && !chunk_is_newline(pc)
          && pc->level == 0)
       {
@@ -233,8 +233,8 @@ static Chunk *pawn_process_line(Chunk *start)
 
    while (  ((pc = pc->GetNextNc())->IsNotNullChunk())
          && !chunk_is_str(pc, "(")
-         && pc->type != CT_ASSIGN
-         && pc->type != CT_NEWLINE)
+         && pc->IsNot(CT_ASSIGN)
+         && pc->IsNot(CT_NEWLINE))
    {
       if (  pc->level == 0
          && (  chunk_is_token(pc, CT_FUNCTION)
@@ -318,7 +318,7 @@ void pawn_add_virtual_semicolons()
          }
 
          if (  prev->IsNullChunk()
-            || (  pc->type != CT_NEWLINE
+            || (  pc->IsNot(CT_NEWLINE)
                && !chunk_is_closing_brace(pc)))
          {
             continue;
@@ -469,8 +469,8 @@ static Chunk *pawn_process_func_def(Chunk *pc)
             Chunk *next = prev->GetNextNcNnl();
 
             if (  next->IsNotNullChunk()
-               && next->type != CT_ELSE
-               && next->type != CT_WHILE_OF_DO)
+               && next->IsNot(CT_ELSE)
+               && next->IsNot(CT_WHILE_OF_DO))
             {
                break;
             }

--- a/src/log_rules.cpp
+++ b/src/log_rules.cpp
@@ -15,7 +15,7 @@ void log_rule2(const char *func, size_t line, const char *rule, Chunk *first, Ch
 {
    LOG_FUNC_ENTRY();
 
-   if (second->type != CT_NEWLINE)
+   if (second->IsNot(CT_NEWLINE))
    {
       LOG_FMT(LSPACE, "%s(%zu): first->orig_line is %zu, first->orig_col is %zu, first->Text() is '%s', [%s/%s] <===>\n",
               func, line, first->orig_line, first->orig_col, first->Text(),

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -6028,7 +6028,6 @@ void do_blank_lines()
       LOG_FMT(LBLANK, "%s(%d): nl_count is %zu\n",
               __func__, __LINE__, pc->nl_count);
 
-      //if (pc->type != CT_NEWLINE)
       if (chunk_is_not_token(pc, CT_NEWLINE))
       {
          continue;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -493,7 +493,7 @@ void output_parsed(FILE *pfile, bool withOptions)
               pc->nl_count, pc->after_tab);
 #endif // ifdef WIN32
 
-      if (  pc->type != CT_NEWLINE
+      if (  pc->IsNot(CT_NEWLINE)
          && (pc->Len() != 0))
       {
          for (size_t cnt = 0; cnt < pc->column; cnt++)
@@ -501,7 +501,7 @@ void output_parsed(FILE *pfile, bool withOptions)
             fprintf(pfile, " ");
          }
 
-         if (pc->type != CT_NL_CONT)
+         if (pc->IsNot(CT_NL_CONT))
          {
             fprintf(pfile, "%s", pc->Text());
          }
@@ -547,7 +547,7 @@ void output_parsed_csv(FILE *pfile)
       fprintf(pfile, "%zu,%d,",
               pc->nl_count, pc->after_tab);
 
-      if (  pc->type != CT_NEWLINE
+      if (  pc->IsNot(CT_NEWLINE)
          && (pc->Len() != 0))
       {
          fprintf(pfile, "\"");
@@ -557,7 +557,7 @@ void output_parsed_csv(FILE *pfile)
             fprintf(pfile, " ");
          }
 
-         if (pc->type != CT_NL_CONT)
+         if (pc->IsNot(CT_NL_CONT))
          {
             for (auto *ch = pc->Text(); *ch != '\0'; ++ch)
             {
@@ -2728,7 +2728,7 @@ static bool kw_fcn_class(Chunk *cmt, unc_text &out_txt)
 
       while ((tmp = tmp->GetNext())->IsNotNullChunk())
       {
-         if (tmp->type != CT_DC_MEMBER)
+         if (tmp->IsNot(CT_DC_MEMBER))
          {
             break;
          }
@@ -3326,7 +3326,7 @@ void add_long_preprocessor_conditional_block_comment()
          pp_end = pp_start = pc;
       }
 
-      if (  pc->type != CT_PP_IF
+      if (  pc->IsNot(CT_PP_IF)
          || !pp_start)
       {
          continue;

--- a/src/parens.cpp
+++ b/src/parens.cpp
@@ -53,7 +53,7 @@ void do_parens()
       while (  (pc = pc->GetNextNcNnl()) != nullptr
             && pc->IsNotNullChunk())
       {
-         if (  pc->type != CT_SPAREN_OPEN
+         if (  pc->IsNot(CT_SPAREN_OPEN)
             || (  get_chunk_parent_type(pc) != CT_IF
                && get_chunk_parent_type(pc) != CT_ELSEIF
                && get_chunk_parent_type(pc) != CT_SWITCH))

--- a/src/semicolons.cpp
+++ b/src/semicolons.cpp
@@ -140,12 +140,12 @@ static void check_unknown_brace_close(Chunk *semi, Chunk *brace_close)
    pc = pc->GetPrevNcNnl();
 
    if (  pc->IsNotNullChunk()
-      && pc->type != CT_RETURN
-      && pc->type != CT_WORD
-      && pc->type != CT_TYPE
-      && pc->type != CT_SQUARE_CLOSE
-      && pc->type != CT_ANGLE_CLOSE
-      && pc->type != CT_TSQUARE
+      && pc->IsNot(CT_RETURN)
+      && pc->IsNot(CT_WORD)
+      && pc->IsNot(CT_TYPE)
+      && pc->IsNot(CT_SQUARE_CLOSE)
+      && pc->IsNot(CT_ANGLE_CLOSE)
+      && pc->IsNot(CT_TSQUARE)
       && !chunk_is_paren_close(pc))
    {
       remove_semicolon(semi);

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -220,15 +220,15 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
    }
 
    if (  chunk_is_token(first, CT_VBRACE_OPEN)
-      && second->type != CT_NL_CONT
-      && second->type != CT_SEMICOLON) // # Issue 1158
+      && second->IsNot(CT_NL_CONT)
+      && second->IsNot(CT_SEMICOLON)) // # Issue 1158
    {
       log_rule("FORCE");
       return(IARF_FORCE);
    }
 
    if (  chunk_is_token(first, CT_VBRACE_CLOSE)
-      && second->type != CT_NL_CONT)
+      && second->IsNot(CT_NL_CONT))
    {
       log_rule("REMOVE");
       return(IARF_REMOVE);
@@ -502,7 +502,7 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
             return(options::sp_after_semi_for_empty());
          }
 
-         if (second->type != CT_SPAREN_CLOSE)  // Issue 1324
+         if (second->IsNot(CT_SPAREN_CLOSE))  // Issue 1324
          {
             // Add or remove space after ';' in non-empty 'for' statements.
             log_rule("sp_after_semi_for");
@@ -510,7 +510,7 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
          }
       }
       else if (  !second->IsComment()
-              && second->type != CT_BRACE_CLOSE) // issue #197
+              && second->IsNot(CT_BRACE_CLOSE)) // issue #197
       {
          // Add or remove space after ';', except when followed by a comment.
          // see the tests cpp:34517-34519
@@ -1211,9 +1211,9 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
       if (chunk_is_token(second, CT_OC_MSG_FUNC))
       {
          if (  (options::sp_after_oc_msg_receiver() == IARF_REMOVE)
-            && (  (first->type != CT_SQUARE_CLOSE)
-               && (first->type != CT_FPAREN_CLOSE)
-               && (first->type != CT_PAREN_CLOSE)))
+            && (  first->IsNot(CT_SQUARE_CLOSE)
+               && first->IsNot(CT_FPAREN_CLOSE)
+               && first->IsNot(CT_PAREN_CLOSE)))
          {
             log_rule("FORCE");
             return(IARF_FORCE);
@@ -1324,7 +1324,7 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
          return(options::sp_template_angle());
       }
 
-      if (first->type != CT_QUALIFIER)
+      if (first->IsNot(CT_QUALIFIER))
       {
          // Add or remove space before '<'.
          log_rule("sp_before_angle");
@@ -1366,10 +1366,10 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
          return(options::sp_before_dc());
       }
 
-      if (  second->type != CT_BYREF
-         && second->type != CT_PTR_TYPE
-         && second->type != CT_BRACE_OPEN
-         && second->type != CT_PAREN_CLOSE)
+      if (  second->IsNot(CT_BYREF)
+         && second->IsNot(CT_PTR_TYPE)
+         && second->IsNot(CT_BRACE_OPEN)
+         && second->IsNot(CT_PAREN_CLOSE))
       {
          if (  chunk_is_token(second, CT_CLASS_COLON)
             && options::sp_angle_colon() != IARF_IGNORE)
@@ -2158,7 +2158,7 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
       }
 
       if (  get_chunk_parent_type(first) == CT_OC_SEL
-         && second->type != CT_SQUARE_CLOSE)
+         && second->IsNot(CT_SQUARE_CLOSE))
       {
          // (OC) Add or remove space between '@selector(x)' and the following word,
          // i.e. '@selector(foo) a:' vs. '@selector(foo)a:'.
@@ -2630,7 +2630,7 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
    }
 
    if (  chunk_is_token(second, CT_PTR_TYPE)
-      && first->type != CT_IN)
+      && first->IsNot(CT_IN))
    {
       // look back for '->' type is TRAILING_RET
       if (token_is_within_trailing_return(second))
@@ -2671,7 +2671,7 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
          }
 
          if (  next->IsNotNullChunk()
-            && next->type != CT_WORD)
+            && next->IsNot(CT_WORD))
          {
             log_rule("sp_before_unnamed_ptr_star");                   // ptr_star 8
             return(options::sp_before_unnamed_ptr_star());
@@ -2696,8 +2696,8 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
    if (  chunk_is_token(second, CT_FUNC_PROTO)
       || chunk_is_token(second, CT_FUNC_DEF))
    {
-      if (  first->type != CT_PTR_TYPE
-         && first->type != CT_BYREF)
+      if (  first->IsNot(CT_PTR_TYPE)
+         && first->IsNot(CT_BYREF))
       {
          // Add or remove space between return type and function name. A
          // minimum of 1 is forced except for pointer/reference return types.
@@ -3582,8 +3582,8 @@ void space_text()
             if (  (  options::sp_before_tr_cmt() == IARF_IGNORE
                   || get_chunk_parent_type(next) != CT_COMMENT_END)
                && (  options::sp_endif_cmt() == IARF_IGNORE
-                  || (  pc->type != CT_PP_ELSE
-                     && pc->type != CT_PP_ENDIF)))
+                  || (  pc->IsNot(CT_PP_ELSE)
+                     && pc->IsNot(CT_PP_ENDIF))))
             {
                if (options::indent_relative_single_line_comments())
                {

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -390,7 +390,7 @@ void tokenize_cleanup()
          }
          else
          {
-            if (next->type != CT_ASSIGN)
+            if (next->IsNot(CT_ASSIGN))
             {
                LOG_FMT(LERR, "%s(%d): %s:%zu: version: Unexpected token %s\n",
                        __func__, __LINE__, cpd.filename.c_str(), pc->orig_line, get_token_name(next->type));
@@ -471,7 +471,7 @@ void tokenize_cleanup()
             Chunk *tmp = next->GetNextNcNnl();
 
             if (  tmp->IsNullChunk()
-               || tmp->type != CT_BRACE_OPEN)
+               || tmp->IsNot(CT_BRACE_OPEN))
             {
                set_chunk_type(pc, CT_QUALIFIER);
             }
@@ -632,7 +632,7 @@ void tokenize_cleanup()
 
       // Change get/set to CT_WORD if not followed by a brace open
       if (  chunk_is_token(pc, CT_GETSET)
-         && next->type != CT_BRACE_OPEN)
+         && next->IsNot(CT_BRACE_OPEN))
       {
          if (  chunk_is_token(next, CT_SEMICOLON)
             && (  chunk_is_token(prev, CT_BRACE_CLOSE)
@@ -738,13 +738,13 @@ void tokenize_cleanup()
 
             while ((tmp = tmp2->GetNext())->IsNotNullChunk())
             {
-               if (  tmp->type != CT_WORD
-                  && tmp->type != CT_TYPE
-                  && tmp->type != CT_QUALIFIER
-                  && tmp->type != CT_STAR
-                  && tmp->type != CT_CARET
-                  && tmp->type != CT_AMP
-                  && tmp->type != CT_TSQUARE)
+               if (  tmp->IsNot(CT_WORD)
+                  && tmp->IsNot(CT_TYPE)
+                  && tmp->IsNot(CT_QUALIFIER)
+                  && tmp->IsNot(CT_STAR)
+                  && tmp->IsNot(CT_CARET)
+                  && tmp->IsNot(CT_AMP)
+                  && tmp->IsNot(CT_TSQUARE))
                {
                   break;
                }
@@ -811,7 +811,7 @@ void tokenize_cleanup()
       if (  (  chunk_is_str_case(pc, "EXEC", 4)
             && chunk_is_str_case(next, "SQL", 3))
          || (  (*pc->str.c_str() == '$')
-            && pc->type != CT_SQL_WORD
+            && pc->IsNot(CT_SQL_WORD)
                /* but avoid breaking tokenization for C# 6 interpolated strings. */
             && (  !language_is_set(LANG_CS)
                || (  chunk_is_token(pc, CT_STRING)
@@ -896,7 +896,7 @@ void tokenize_cleanup()
             Chunk *tmp = next->GetNextNcNnl();
 
             while (  tmp->IsNotNullChunk()
-                  && tmp->type != CT_PAREN_CLOSE)
+                  && tmp->IsNot(CT_PAREN_CLOSE))
             {
                if (chunk_is_str(tmp, "in"))
                {
@@ -963,7 +963,7 @@ void tokenize_cleanup()
          || chunk_is_token(pc, CT_OC_INTF)
          || chunk_is_token(pc, CT_OC_PROTOCOL))
       {
-         if (next->type != CT_PAREN_OPEN)
+         if (next->IsNot(CT_PAREN_OPEN))
          {
             set_chunk_type(next, CT_OC_CLASS);
          }
@@ -988,7 +988,7 @@ void tokenize_cleanup()
          Chunk *tmp = pc->GetNextNcNnl(E_Scope::PREPROC);
 
          while (  tmp->IsNotNullChunk()
-               && tmp->type != CT_OC_END)
+               && tmp->IsNot(CT_OC_END))
          {
             if (get_token_pattern_class(tmp->type) != pattern_class_e::NONE)
             {
@@ -1046,7 +1046,7 @@ void tokenize_cleanup()
        */
       if (chunk_is_token(pc, CT_OC_PROPERTY))
       {
-         if (next->type != CT_PAREN_OPEN)
+         if (next->IsNot(CT_PAREN_OPEN))
          {
             chunk_flags_set(next, PCF_STMT_START | PCF_EXPR_START);
          }
@@ -1116,7 +1116,7 @@ void tokenize_cleanup()
       }
 
       if (  chunk_is_token(pc, CT_UNSAFE)
-         && next->type != CT_BRACE_OPEN)
+         && next->IsNot(CT_BRACE_OPEN))
       {
          set_chunk_type(pc, CT_QUALIFIER);
       }
@@ -1161,7 +1161,7 @@ void tokenize_cleanup()
        */
       if (  language_is_set(LANG_JAVA)
          && chunk_is_token(pc, CT_SYNCHRONIZED)
-         && next->type != CT_PAREN_OPEN)
+         && next->IsNot(CT_PAREN_OPEN))
       {
          set_chunk_type(pc, CT_QUALIFIER);
       }
@@ -1188,11 +1188,11 @@ bool invalid_open_angle_template(Chunk *prev)
       return(false);
    }
    // A template requires a word/type right before the open angle
-   return(  prev->type != CT_WORD
-         && prev->type != CT_TYPE
-         && prev->type != CT_COMMA
-         && prev->type != CT_QUALIFIER
-         && prev->type != CT_OPERATOR_VAL
+   return(  prev->IsNot(CT_WORD)
+         && prev->IsNot(CT_TYPE)
+         && prev->IsNot(CT_COMMA)
+         && prev->IsNot(CT_QUALIFIER)
+         && prev->IsNot(CT_OPERATOR_VAL)
          && get_chunk_parent_type(prev) != CT_OPERATOR);
 }
 
@@ -1513,7 +1513,7 @@ static void check_template(Chunk *start, bool in_type_cast)
       pc = end->GetNextNcNnl(E_Scope::PREPROC);
 
       if (  pc->IsNullChunk()
-         || pc->type != CT_NUMBER)
+         || pc->IsNot(CT_NUMBER))
       {
          LOG_FMT(LTEMPL, "%s(%d): Template detected\n", __func__, __LINE__);
          LOG_FMT(LTEMPL, "%s(%d):     from orig_line %zu, orig_col %zu\n",
@@ -1569,7 +1569,7 @@ static void check_template_arg(Chunk *start, Chunk *end)
          break;
       }
 
-      if (next->type != CT_PAREN_OPEN)
+      if (next->IsNot(CT_PAREN_OPEN))
       {
          if (  chunk_is_token(pc, CT_NUMBER)
             || chunk_is_token(pc, CT_ARITH)
@@ -1713,7 +1713,7 @@ static void mark_selectors_in_property_with_open_paren(Chunk *open_paren)
    Chunk *tmp = open_paren;
 
    while (  tmp != nullptr
-         && tmp->type != CT_PAREN_CLOSE)
+         && tmp->IsNot(CT_PAREN_CLOSE))
    {
       if (  chunk_is_token(tmp, CT_WORD)
          && (  chunk_is_str(tmp, "setter")
@@ -1722,8 +1722,8 @@ static void mark_selectors_in_property_with_open_paren(Chunk *open_paren)
          tmp = tmp->next;
 
          while (  tmp != nullptr
-               && tmp->type != CT_COMMA
-               && tmp->type != CT_PAREN_CLOSE)
+               && tmp->IsNot(CT_COMMA)
+               && tmp->IsNot(CT_PAREN_CLOSE))
          {
             if (  chunk_is_token(tmp, CT_WORD)
                || chunk_is_str(tmp, ":"))
@@ -1748,7 +1748,7 @@ static void mark_attributes_in_property_with_open_paren(Chunk *open_paren)
    Chunk *tmp = open_paren;
 
    while (  tmp != nullptr
-         && tmp->type != CT_PAREN_CLOSE)
+         && tmp->IsNot(CT_PAREN_CLOSE))
    {
       if (  (  chunk_is_token(tmp, CT_COMMA)
             || chunk_is_token(tmp, CT_PAREN_OPEN))

--- a/src/unc_tools.cpp
+++ b/src/unc_tools.cpp
@@ -356,7 +356,7 @@ void dump_out(unsigned int type)
             fprintf(D_file, "  after_tab %d\n", pc->after_tab);
          }
 
-         if (pc->type != CT_NEWLINE)
+         if (pc->IsNot(CT_NEWLINE))
          {
             fprintf(D_file, "  Text %s\n", pc->Text());
          }

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1736,7 +1736,7 @@ static void add_func_header(E_Token type, file_mem &fm)
       {
          int found_brace = 0;                                 // Set if a close brace is found before a newline
 
-         while (  ref->type != CT_NEWLINE
+         while (  ref->IsNot(CT_NEWLINE)
                && (ref = ref->GetNext())) // TODO: is the assignment of ref wanted here?, better move it to the loop
          {
             if (chunk_is_token(ref, CT_BRACE_CLOSE))


### PR DESCRIPTION
This makes the code more consistent, and these comparisons will now
automatically get the benefits of any improvements made to IsNot().
