### PR TITLE
Fix include-related errors from clang-tidy.

### DIFF
--- a/src/add_space_table.h
+++ b/src/add_space_table.h
@@ -1,4 +1,22 @@
 // *INDENT-OFF*
+
+#include "token_enum.h"
+
+//! type that stores two chunks between those no space shall occur
+struct no_space_table_t
+{
+   E_Token first;  //! first  chunk
+   E_Token second; //! second chunk
+};
+
+/**
+ * this table lists out all combos where a space MUST be present
+ * CT_UNKNOWN is a wildcard.
+ *
+ * TODO: some of these are no longer needed.
+ */
+const no_space_table_t add_space_table[] =
+{
    { CT_ACCESS,                CT_TYPE                  },
    { CT_ACCESS,                CT_WORD                  },
    { CT_ALIGN,                 CT_PAREN_OPEN            },
@@ -298,4 +316,51 @@
    { CT_WORD,                  CT_WHERE_COLON           },
    { CT_WORD,                  CT_WHERE_SPEC            },
    { CT_WORD,                  CT_WORD                  },
+};
+
+/**
+ * this table lists out all combos where a space should NOT be present
+ * CT_UNKNOWN is a wildcard.
+ *
+ * TODO: some of these are no longer needed.
+ */
+const no_space_table_t no_space_table[] =
+{
+   { CT_OC_AT,          CT_UNKNOWN      },
+   { CT_INCDEC_BEFORE,  CT_WORD         },
+   { CT_UNKNOWN,        CT_INCDEC_AFTER },
+   { CT_UNKNOWN,        CT_LABEL_COLON  },
+   { CT_UNKNOWN,        CT_ACCESS_COLON },
+   { CT_UNKNOWN,        CT_SEMICOLON    },
+   { CT_UNKNOWN,        CT_D_TEMPLATE   },
+   { CT_D_TEMPLATE,     CT_UNKNOWN      },
+   { CT_MACRO_FUNC,     CT_FPAREN_OPEN  },
+   { CT_PAREN_OPEN,     CT_UNKNOWN      },
+   { CT_UNKNOWN,        CT_PAREN_CLOSE  },
+   { CT_FPAREN_OPEN,    CT_UNKNOWN      },
+   { CT_UNKNOWN,        CT_SPAREN_CLOSE },
+   { CT_SPAREN_OPEN,    CT_UNKNOWN      },
+   { CT_UNKNOWN,        CT_FPAREN_CLOSE },
+   { CT_UNKNOWN,        CT_COMMA        },
+   { CT_POS,            CT_UNKNOWN      },
+   { CT_STAR,           CT_UNKNOWN      },
+   { CT_VBRACE_CLOSE,   CT_UNKNOWN      },
+   { CT_VBRACE_OPEN,    CT_UNKNOWN      },
+   { CT_UNKNOWN,        CT_VBRACE_CLOSE },
+   { CT_UNKNOWN,        CT_VBRACE_OPEN  },
+   { CT_PREPROC,        CT_UNKNOWN      },
+   { CT_PREPROC_INDENT, CT_UNKNOWN      },
+   { CT_NEG,            CT_UNKNOWN      },
+   { CT_UNKNOWN,        CT_SQUARE_OPEN  },
+   { CT_UNKNOWN,        CT_SQUARE_CLOSE },
+   { CT_SQUARE_OPEN,    CT_UNKNOWN      },
+   { CT_PAREN_CLOSE,    CT_WORD         },
+   { CT_PAREN_CLOSE,    CT_FUNC_DEF     },
+   { CT_PAREN_CLOSE,    CT_FUNC_CALL    },
+   { CT_PAREN_CLOSE,    CT_ADDR         },
+   { CT_PAREN_CLOSE,    CT_FPAREN_OPEN  },
+   { CT_OC_SEL_NAME,    CT_OC_SEL_NAME  },
+   { CT_TYPENAME,       CT_TYPE         },
+};
+
 // *INDENT-ON*

--- a/src/backup.h
+++ b/src/backup.h
@@ -21,6 +21,9 @@
 #ifndef BACKUP_H_INCLUDED
 #define BACKUP_H_INCLUDED
 
+#include "base_types.h"
+#include <vector>
+
 #define UNC_BACKUP_SUFFIX        ".unc-backup~"
 #define UNC_BACKUP_MD5_SUFFIX    ".unc-backup.md5~"
 

--- a/src/char_table.h
+++ b/src/char_table.h
@@ -10,6 +10,9 @@
 #ifndef CHAR_TABLE_H_INCLUDED
 #define CHAR_TABLE_H_INCLUDED
 
+#include "base_types.h"
+#include <cstddef>
+
 /**
  * bit0-7 = paired char
  * bit8 = OK for keyword 1st char

--- a/src/flag_braced_init_list.h
+++ b/src/flag_braced_init_list.h
@@ -7,6 +7,8 @@
 #ifndef FLAG_BRACED_INIT_LIST_INCLUDED
 #define FLAG_BRACED_INIT_LIST_INCLUDED
 
+#include "chunk.h"
+
 
 /**
  * Detect a cpp braced init list

--- a/src/flag_decltype.h
+++ b/src/flag_decltype.h
@@ -7,6 +7,7 @@
 #ifndef FLAG_DECLTYPE_INCLUDED
 #define FLAG_DECLTYPE_INCLUDED
 
+#include "chunk.h"
 
 /**
  * Flags all chunks within a cpp decltype expression from the opening

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -19,6 +19,7 @@
 
 #include "space.h"
 
+#include "add_space_table.h"
 #include "log_rules.h"
 #include "options_for_QT.h"
 #include "punctuators.h"
@@ -53,71 +54,6 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp);
  * @return IARF_IGNORE, IARF_ADD, IARF_REMOVE or IARF_FORCE
  */
 static iarf_e ensure_force_space(Chunk *first, Chunk *second, iarf_e av);
-
-//! type that stores two chunks between those no space shall occur
-struct no_space_table_t
-{
-   E_Token first;  //! first  chunk
-   E_Token second; //! second chunk
-};
-
-
-/**
- * this table lists out all combos where a space MUST be present
- * CT_UNKNOWN is a wildcard.
- *
- * TODO: some of these are no longer needed.
- */
-const no_space_table_t add_space_table[] =
-{
-#include "add_space_table.h"
-};
-
-
-/**
- * this table lists out all combos where a space should NOT be present
- * CT_UNKNOWN is a wildcard.
- *
- * TODO: some of these are no longer needed.
- */
-const no_space_table_t no_space_table[] =
-{
-   { CT_OC_AT,          CT_UNKNOWN      },
-   { CT_INCDEC_BEFORE,  CT_WORD         },
-   { CT_UNKNOWN,        CT_INCDEC_AFTER },
-   { CT_UNKNOWN,        CT_LABEL_COLON  },
-   { CT_UNKNOWN,        CT_ACCESS_COLON },
-   { CT_UNKNOWN,        CT_SEMICOLON    },
-   { CT_UNKNOWN,        CT_D_TEMPLATE   },
-   { CT_D_TEMPLATE,     CT_UNKNOWN      },
-   { CT_MACRO_FUNC,     CT_FPAREN_OPEN  },
-   { CT_PAREN_OPEN,     CT_UNKNOWN      },
-   { CT_UNKNOWN,        CT_PAREN_CLOSE  },
-   { CT_FPAREN_OPEN,    CT_UNKNOWN      },
-   { CT_UNKNOWN,        CT_SPAREN_CLOSE },
-   { CT_SPAREN_OPEN,    CT_UNKNOWN      },
-   { CT_UNKNOWN,        CT_FPAREN_CLOSE },
-   { CT_UNKNOWN,        CT_COMMA        },
-   { CT_POS,            CT_UNKNOWN      },
-   { CT_STAR,           CT_UNKNOWN      },
-   { CT_VBRACE_CLOSE,   CT_UNKNOWN      },
-   { CT_VBRACE_OPEN,    CT_UNKNOWN      },
-   { CT_UNKNOWN,        CT_VBRACE_CLOSE },
-   { CT_UNKNOWN,        CT_VBRACE_OPEN  },
-   { CT_PREPROC,        CT_UNKNOWN      },
-   { CT_PREPROC_INDENT, CT_UNKNOWN      },
-   { CT_NEG,            CT_UNKNOWN      },
-   { CT_UNKNOWN,        CT_SQUARE_OPEN  },
-   { CT_UNKNOWN,        CT_SQUARE_CLOSE },
-   { CT_SQUARE_OPEN,    CT_UNKNOWN      },
-   { CT_PAREN_CLOSE,    CT_WORD         },
-   { CT_PAREN_CLOSE,    CT_FUNC_DEF     },
-   { CT_PAREN_CLOSE,    CT_FUNC_CALL    },
-   { CT_PAREN_CLOSE,    CT_ADDR         },
-   { CT_PAREN_CLOSE,    CT_FPAREN_OPEN  },
-   { CT_OC_SEL_NAME,    CT_OC_SEL_NAME  },
-   { CT_TYPENAME,       CT_TYPE         },
-};
 
 
 bool token_is_within_trailing_return(Chunk *pc)

--- a/src/symbols_table.h
+++ b/src/symbols_table.h
@@ -13,6 +13,8 @@
  *   NOTE: the tables below do not need to be sorted.
  */
 
+#include "uncrustify_types.h"
+
 // 6-char symbols
 static const chunk_tag_t symbols6[] =
 {

--- a/src/windows_compat.h
+++ b/src/windows_compat.h
@@ -13,7 +13,10 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
+
+#ifdef WIN32
 #include "windows.h"
+#endif
 
 #define HAVE_SYS_STAT_H
 
@@ -85,9 +88,11 @@ typedef unsigned long long   UINT64;
 #define fileno         _fileno
 
 // includes for _setmode()
+#ifdef WIN32
 #include <direct.h>
-#include <fcntl.h>
 #include <io.h>
+#endif
+#include <fcntl.h>
 
 // on windows the file permissions have no meaning thus neglect them
 #define mkdir(x, y)    _mkdir(x)


### PR DESCRIPTION
Clang-tidy requires all relevant headers to be included, even if the
program compiles without a problem. This won't make a practical
difference in behavior, it's just to suppress errors.
