### PR TITLE
Make --check output more readable and relevant.

### DIFF
--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1441,9 +1441,8 @@ static bool bout_content_matches(const file_mem &fm, bool report_status)
    {
       if (report_status)
       {
-         fprintf(stderr, "FAIL: %s (File size changed from %u to %u)\n",
-                 cpd.filename.c_str(), static_cast<int>(fm.raw.size()),
-                 static_cast<int>(cpd.bout->size()));
+         fprintf(stderr, "FAIL: %s\n",
+                 cpd.filename.c_str());
          log_flush(true);
       }
       is_same = false;
@@ -1464,13 +1463,6 @@ static bool bout_content_matches(const file_mem &fm, bool report_status)
             break;
          }
       }
-   }
-
-   if (  is_same
-      && report_status)
-   {
-      fprintf(stdout, "PASS: %s (%u bytes)\n",
-              cpd.filename.c_str(), static_cast<int>(fm.raw.size()));
    }
    return(is_same);
 } // bout_content_matches

--- a/tests/cli/output/replace.txt
+++ b/tests/cli/output/replace.txt
@@ -1,2 +1,2 @@
-do_source_file(1507): Parsing: input/I-3310.c as language C
-do_source_file(1507): Parsing: input/backup.h as language C-Header
+do_source_file(1499): Parsing: input/I-3310.c as language C
+do_source_file(1499): Parsing: input/backup.h as language C-Header


### PR DESCRIPTION
The current behavior of the --check flag is very suboptimal. It shows
the number of bytes that has changed or the current number of bytes,
which I don't believe is relevant for the user.

Additionally, it also shows which files have passed alongside those that
have failed. This is fine for a small project but becomes practically
impossible to read for projects with hundreds of files. Not using the -q
flag already tells us which files are being parsed, it's obvious files
that aren't shown to have failed have passed.
