### PR TITLE
Code impr/line functions

### DIFF
--- a/src/ParseFrame.cpp
+++ b/src/ParseFrame.cpp
@@ -36,6 +36,8 @@ static ContainerType genDummy()
    tmp_dummy.indent_tmp = 1;
    tmp_dummy.indent_tab = 1;
    tmp_dummy.type       = CT_EOF;
+   tmp_dummy.pc         = Chunk::NullChunkPtr;
+   tmp_dummy.pop_pc     = Chunk::NullChunkPtr;
 
    return(tmp_dummy);
 }
@@ -151,7 +153,7 @@ void ParseFrame::push(std::nullptr_t, brace_stage_e stage)
    static Chunk dummy;
 
    push(&dummy, __func__, __LINE__, stage);
-   top().pc = nullptr;
+   top().pc = Chunk::NullChunkPtr;
 }
 
 
@@ -174,7 +176,7 @@ void ParseFrame::push(Chunk *pc, const char *func, int line, brace_stage_e stage
    new_entry.in_preproc = pc->flags.test(PCF_IN_PREPROC);
    new_entry.non_vardef = false;
    new_entry.ip         = top().ip;
-   new_entry.pop_pc     = nullptr;
+   new_entry.pop_pc     = Chunk::NullChunkPtr;
 
    pse.push_back(new_entry);
 

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -1430,7 +1430,8 @@ bool close_statement(ParseFrame &frm, Chunk *pc, const BraceState &braceState)
 {
    LOG_FUNC_ENTRY();
 
-   if (pc == nullptr)
+   if (  pc == nullptr
+      || pc->IsNullChunk())
    {
       throw invalid_argument(string(__func__) + ":" + to_string(__LINE__)
                              + "args cannot be nullptr");

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -299,19 +299,18 @@ Chunk *Chunk::Search(const T_CheckFnPtr checkFn, const E_Scope scope,
 }
 
 
-bool are_chunks_in_same_line(Chunk *start, Chunk *end)
+bool Chunk::IsOnSameLine(const Chunk *end) const
 {
-   if (  start == nullptr
-      || start->IsNullChunk())
+   if (this->IsNullChunk())
    {
       return(false);
    }
-   Chunk *tmp = start->GetNext();
+   Chunk *tmp = this->GetNext();
 
    while (  tmp->IsNotNullChunk()
          && tmp != end)
    {
-      if (chunk_is_token(tmp, CT_NEWLINE))
+      if (tmp->Is(CT_NEWLINE))
       {
          return(false);
       }

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -301,7 +301,8 @@ Chunk *Chunk::Search(const T_CheckFnPtr checkFn, const E_Scope scope,
 
 bool are_chunks_in_same_line(Chunk *start, Chunk *end)
 {
-   if (start == nullptr)
+   if (  start == nullptr
+      || start->IsNullChunk())
    {
       return(false);
    }

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -627,38 +627,32 @@ void Chunk::Swap(Chunk *other)
 }
 
 
-// TODO: the following function shall be made similar to the search functions
-Chunk *chunk_first_on_line(Chunk *pc)
+Chunk *Chunk::GetFirstChunkOnLine() const
 {
-   if (  pc == nullptr
-      || pc->IsNullChunk())
-   {
-      return(Chunk::NullChunkPtr);
-   }
+   Chunk *pc    = const_cast<Chunk *>(this);
    Chunk *first = pc;
 
-   while (  (pc = pc->GetPrev())->IsNotNullChunk()
+   pc = pc->GetPrev();
+
+   while (  pc->IsNotNullChunk()
          && !pc->IsNewline())
    {
       first = pc;
+      pc    = pc->GetPrev();
    }
    return(first);
 }
 
 
-bool chunk_is_last_on_line(const Chunk *pc)
+bool Chunk::IsLastChunkOnLine() const
 {
-   // check if pc is the very last chunk of the file
-   const Chunk *end = Chunk::GetTail();
-
-   if (pc == end)
+   if (this == Chunk::GetTail())
    {
       return(true);
    }
-   // if the next chunk is a newline then pc is the last chunk on its line
-   const Chunk *next = pc->GetNext();
 
-   if (chunk_is_token(next, CT_NEWLINE))
+   // if the next chunk is a newline then pc is the last chunk on its line
+   if (this->GetNext()->Is(CT_NEWLINE))
    {
       return(true);
    }
@@ -669,8 +663,8 @@ bool chunk_is_last_on_line(const Chunk *pc)
 void Chunk::SwapLines(Chunk *other)
 {
    // to swap lines we need to find the first chunk of the lines
-   Chunk *pc1 = chunk_first_on_line(this);
-   Chunk *pc2 = chunk_first_on_line(other);
+   Chunk *pc1 = this->GetFirstChunkOnLine();
+   Chunk *pc2 = other->GetFirstChunkOnLine();
 
    if (  pc1->IsNullChunk()
       || pc2->IsNullChunk()

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -562,6 +562,24 @@ public:
     */
    void SwapLines(Chunk *other);
 
+   /**
+    * @brief Finds the first chunk on the line the current chunk is on.
+    * This just backs up until a newline or nullptr is hit.
+    *
+    * given: [ a - b - c - n1 - d - e - n2 ]
+    * input: [ a | b | c | n1 ] => a
+    * input: [ d | e | n2 ]     => d
+    *
+    * @return pointer to the first chunk on the line the current chunk is on.
+    */
+   Chunk *GetFirstChunkOnLine() const;
+
+   /**
+    * @brief Checks if a given chunk is the last on its line
+    * @return true or false depending on whether a given chunk is the last on its line
+    */
+   bool IsLastChunkOnLine() const;
+
 
    // --------- Data members
 
@@ -615,23 +633,6 @@ protected:
 private:
    const bool null_chunk;                      //! true for null chunks
 };
-
-
-/**
- * Finds the first chunk on the line that pc is on.
- * This just backs up until a newline or nullptr is hit.
- *
- * given: [ a - b - c - n1 - d - e - n2 ]
- * input: [ a | b | c | n1 ] => a
- * input: [ d | e | n2 ]     => d
- *
- * @param pc  chunk to start with
- */
-Chunk *chunk_first_on_line(Chunk *pc);
-
-
-//! check if a given chunk is the last on its line
-bool chunk_is_last_on_line(const Chunk *pc);
 
 
 /**

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -580,6 +580,14 @@ public:
     */
    bool IsLastChunkOnLine() const;
 
+   /**
+    * @brief checks whether the current chunk is on same line of the given 'end' chunk.
+    * The current chunk must be before the 'end' chunk
+    * @param end the end chunk
+    * @return true if there is no newline between the current chunk and end chunk
+    */
+   bool IsOnSameLine(const Chunk *end) const;
+
 
    // --------- Data members
 
@@ -633,17 +641,6 @@ protected:
 private:
    const bool null_chunk;                      //! true for null chunks
 };
-
-
-/**
- * @brief checks whether two chunks are in same line
- *
- * @param  start
- * @param  end
- *
- * @return true if there is no newline between start and end chunks
- */
-bool are_chunks_in_same_line(Chunk *start, Chunk *end);
 
 
 inline bool Chunk::IsTypeAndLevel(const E_Token cType, const int cLevel) const

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -936,7 +936,7 @@ void indent_text()
             else if (get_chunk_parent_type(pc) == CT_PP_ELSE)
             {
                if (  frm.top().type == CT_MEMBER
-                  && frm.top().pop_pc != nullptr
+                  && frm.top().pop_pc->IsNotNullChunk()
                   && frm.top().pc != frmbkup.top().pc)
                {
                   Chunk *tmp = pc->GetNextNcNnlNpp();
@@ -1288,7 +1288,7 @@ void indent_text()
                frm.pop(__func__, __LINE__, pc);
             }
 
-            if (frm.top().pop_pc != nullptr)
+            if (frm.top().pop_pc->IsNotNullChunk())
             {
                LOG_FMT(LINDLINE, "%s(%d): pop_pc->orig_line is %zu, orig_col is %zu, Text() is '%s', type is %s\n",
                        __func__, __LINE__, frm.top().pop_pc->orig_line, frm.top().pop_pc->orig_col,
@@ -4189,7 +4189,7 @@ void indent_text()
                      {
                         Chunk *before_Assign = frm.at(temp_ttidx - 1).pc;
 
-                        if (before_Assign == nullptr)
+                        if (before_Assign->IsNullChunk())
                         {
                            indent_column = 1 + indent_size;
                         }

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -469,7 +469,7 @@ static size_t calc_indent_continue(const ParseFrame &frm)
 
 static Chunk *candidate_chunk_first_on_line(Chunk *pc)
 {
-   Chunk *first = chunk_first_on_line(pc);
+   Chunk *first = pc->GetFirstChunkOnLine();
 
    log_rule_B("indent_inside_ternary_operator");
 

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1658,7 +1658,7 @@ void indent_text()
             {
                if (it->pc && it->pc != frm.top().pc)
                {
-                  linematch &= are_chunks_in_same_line(it->pc, head);
+                  linematch &= it->pc->IsOnSameLine(head);
                }
                Chunk *match = it->pc->SkipToMatch();
 
@@ -1746,14 +1746,14 @@ void indent_text()
             // 2a. If it's an assignment, check that both sides of the assignment operator are on the same line
             // 2b. If it's inside some closure, check that all the frames are on the same line,
             //     and it is in the top level closure, and indent_continue is non-zero
-            bool sameLine = are_chunks_in_same_line(frm.top().pc->SkipToMatch(), tail);
+            bool sameLine = frm.top().pc->SkipToMatch()->IsOnSameLine(tail);
 
             bool isAssignSameLine =
                !enclosure
                && options::align_assign_span() == 0
                && !options::indent_align_assign()
-               && are_chunks_in_same_line(frm.prev().pc->GetPrevNcNnlNpp(), frm.prev().pc)
-               && are_chunks_in_same_line(frm.prev().pc, frm.prev().pc->GetNextNcNnlNpp());
+               && frm.prev().pc->GetPrevNcNnlNpp()->IsOnSameLine(frm.prev().pc)
+               && frm.prev().pc->IsOnSameLine(frm.prev().pc->GetNextNcNnlNpp());
 
             bool closureSameLineTopLevel =
                (options::indent_continue() > 0)
@@ -1844,7 +1844,7 @@ void indent_text()
             frm.top().brace_indent = frm.prev().indent;
 
             // Issue # 1620, UNI-24090.cs
-            if (are_chunks_in_same_line(frm.prev().pc, frm.top().pc->GetPrevNcNnlNpp()))
+            if (frm.prev().pc->IsOnSameLine(frm.top().pc->GetPrevNcNnlNpp()))
             {
                frm.top().brace_indent -= indent_size;
             }
@@ -2004,7 +2004,7 @@ void indent_text()
                log_indent();
             }
             // Issue # 1620, UNI-24090.cs
-            else if (  are_chunks_in_same_line(frm.prev().pc, frm.top().pc)
+            else if (  frm.prev().pc->IsOnSameLine(frm.top().pc)
                     && !options::indent_align_paren()
                     && chunk_is_paren_open(frm.prev().pc)
                     && !pc->flags.test(PCF_ONE_LINER))
@@ -2017,7 +2017,7 @@ void indent_text()
                frm.top().indent = frm.prev().indent_tmp;
                log_indent();
             }
-            else if (  are_chunks_in_same_line(frm.prev().pc, frm.top().pc->GetPrevNcNnlNpp())
+            else if (  frm.prev().pc->IsOnSameLine(frm.top().pc->GetPrevNcNnlNpp())
                     && !options::indent_align_paren()
                     && chunk_is_paren_open(frm.prev().pc)
                     && !pc->flags.test(PCF_ONE_LINER))
@@ -2709,7 +2709,7 @@ void indent_text()
                         && frm.at(idx).type != CT_COND_COLON
                         && frm.at(idx).type != CT_LAMBDA
                         && frm.at(idx).type != CT_ASSIGN_NL)
-                     || are_chunks_in_same_line(frm.at(idx).pc, frm.top().pc))
+                     || frm.at(idx).pc->IsOnSameLine(frm.top().pc))
                   && (  frm.at(idx).type != CT_CLASS_COLON
                      && frm.at(idx).type != CT_CONSTR_COLON
                      && !(  frm.at(idx).type == CT_LAMBDA
@@ -2774,7 +2774,7 @@ void indent_text()
             int idx = static_cast<int>(frm.size()) - 2;
 
             while (  idx > 0
-                  && are_chunks_in_same_line(frm.at(idx).pc, frm.top().pc))
+                  && frm.at(idx).pc->IsOnSameLine(frm.top().pc))
             {
                idx--;
                skipped = true;
@@ -2825,7 +2825,7 @@ void indent_text()
                   sub = static_cast<int>(frm.size()) - 2;
 
                   while (  sub > 0
-                        && are_chunks_in_same_line(frm.at(sub).pc, frm.top().pc))
+                        && frm.at(sub).pc->IsOnSameLine(frm.top().pc))
                   {
                      sub--;
                      skipped = true;
@@ -2987,7 +2987,7 @@ void indent_text()
             frm.push(pc, __func__, __LINE__);
             Chunk *tmp = frm.top().pc->GetPrevNcNnlNpp();
 
-            if (are_chunks_in_same_line(frm.prev().pc, tmp))
+            if (frm.prev().pc->IsOnSameLine(tmp))
             {
                frm.top().indent = frm.prev().indent;
             }
@@ -3319,7 +3319,7 @@ void indent_text()
          log_indent();
 
          if (  pc->GetPrevNc()->IsNewline()
-            && !are_chunks_in_same_line(frm.prev().pc, pc->GetPrevNcNnl()))
+            && !frm.prev().pc->IsOnSameLine(pc->GetPrevNcNnl()))
          {
             frm.top().indent = frm.prev().indent + indent_size;
             log_indent();
@@ -3327,7 +3327,7 @@ void indent_text()
             did_newline = false;
          }
          else if (  pc->GetNextNc()->IsNewline()
-                 && !are_chunks_in_same_line(frm.prev().pc, frm.top().pc))
+                 && !frm.prev().pc->IsOnSameLine(frm.top().pc))
          {
             frm.top().indent = frm.prev().indent + indent_size;
          }

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -899,7 +899,7 @@ void newlines_sparens()
       Chunk *sparen_content_end   = sparen_close->GetPrevNnl();
       bool  is_multiline          = (
          sparen_content_start != sparen_content_end
-                                    && !are_chunks_in_same_line(sparen_content_start, sparen_content_end));
+                                    && !sparen_content_start->IsOnSameLine(sparen_content_end));
 
       // Add a newline after '(' if an if/for/while/switch condition spans multiple lines,
       // as e.g. required by the ROS 2 development style guidelines:
@@ -2274,7 +2274,7 @@ static void newlines_brace_pair(Chunk *br_open)
 
       if (chunk_brace_close->IsNotNullChunk())
       {
-         if (are_chunks_in_same_line(br_open, chunk_brace_close))
+         if (br_open->IsOnSameLine(chunk_brace_close))
          {
             log_rule_B("nl_namespace_two_to_one_liner - 1");
 
@@ -5349,9 +5349,9 @@ void newlines_squeeze_paren_close()
 
          if (flag)
          {
-            if (are_chunks_in_same_line(next_op, prev_op))
+            if (next_op->IsOnSameLine(prev_op))
             {
-               if (chunk_is_token(pc, CT_NEWLINE))
+               if (pc->Is(CT_NEWLINE))
                {
                   pc = next;
                }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -44,7 +44,7 @@ struct cmt_reflow
 // for tracking line numbering
 bool numbering_status = false;
 int  line_number;
-char char_number[12] = { 0 };
+char char_number[16] = { 0 };
 
 
 void set_numbering(bool status)

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1777,7 +1777,7 @@ static Chunk *output_comment_c(Chunk *first)
 
       log_rule_B("cmt_trailing_single_line_c_to_cpp");
 
-      if (options::cmt_trailing_single_line_c_to_cpp() && chunk_is_last_on_line(first))
+      if (options::cmt_trailing_single_line_c_to_cpp() && first->IsLastChunkOnLine())
       {
          add_text("//");
 

--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -427,7 +427,7 @@ static void delete_chunks_on_line_having_chunk(Chunk *chunk)
 {
    LOG_FUNC_ENTRY();
 
-   Chunk *pc = chunk_first_on_line(chunk);
+   Chunk *pc = chunk->GetFirstChunkOnLine();
 
    while (  pc->IsNotNullChunk()
          && !pc->IsComment())
@@ -482,7 +482,7 @@ static void dedupe_imports(Chunk **chunks, size_t num_chunks)
  */
 static void blankline_add_before(Chunk *pc)
 {
-   Chunk *newline = newline_add_before(chunk_first_on_line(pc));
+   Chunk *newline = newline_add_before(pc->GetFirstChunkOnLine());
 
    if (newline->nl_count < 2)
    {

--- a/src/width.cpp
+++ b/src/width.cpp
@@ -167,7 +167,7 @@ void do_code_width()
          && is_past_width(pc))
       {
          if (  chunk_is_token(pc, CT_VBRACE_CLOSE) // don't break if a vbrace close
-            && chunk_is_last_on_line(pc))          // is the last chunk on its line
+            && pc->IsLastChunkOnLine())            // is the last chunk on its line
          {
             continue;
          }


### PR DESCRIPTION
Replace some line-related functions. This also required to use Chunk::NullChunkPtr in the parenthesis stack, which is a plus.
Side commit: fix a warning message that recently started to appear during building.