### PR TITLE
Fix alignment of strings with preprocessor concatenations

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -3686,11 +3686,26 @@ void indent_text()
                  && options::indent_align_string())
          {
             log_rule_B("indent_align_string");
-            const int tmp = (xml_indent != 0) ? xml_indent : prev->column;
+            int indent;
 
+            if (xml_indent != 0)
+            {
+               indent = xml_indent;
+            }
+            else
+            {
+               Chunk *tmp = prev;
+
+               while (  tmp->prev
+                     && (tmp->prev->Is(CT_WORD) || tmp->prev->Is(CT_STRING)))
+               {
+                  tmp = tmp->prev;
+               }
+               indent = tmp->column;
+            }
             LOG_FMT(LINDENT, "%s(%d): orig_line is %zu, String => %d\n",
-                    __func__, __LINE__, pc->orig_line, tmp);
-            reindent_line(pc, tmp);
+                    __func__, __LINE__, pc->orig_line, indent);
+            reindent_line(pc, indent);
          }
          else if (pc->IsComment())
          {

--- a/tests/expected/c/02201-align-string.c
+++ b/tests/expected/c/02201-align-string.c
@@ -10,5 +10,8 @@ void foo(void)
 
    fprintf(stderr, "Format string: %s", "This is the first line\n"
                                         "And this is the second.\n");
+
+   fprintf(stderr, "Format string: %s", "This is the first line\n" __FILE__ "\n"
+                                        "And this is the second.\n");
 }
 

--- a/tests/input/c/align-string.c
+++ b/tests/input/c/align-string.c
@@ -10,5 +10,8 @@ void foo(void)
 
    fprintf(stderr, "Format string: %s", "This is the first line\n"
      "And this is the second.\n");
+
+   fprintf(stderr, "Format string: %s", "This is the first line\n" __FILE__ "\n"
+     "And this is the second.\n");
 }
 


### PR DESCRIPTION
Fixes #3086

As described in the related issue, the alignment of strings in a new line after a string which is concatenated by the C/C++ preprocessor is unintuitive in the current version of the code. This PR addresses that by aligning the string in the new line to the start of the string of the previous line, taking into account the possible concatenations, making the indentation/alignment much more intuitive.