### PR TITLE
Make mod_*_int ignore qualifiers that come after the 'int' keyword

### DIFF
--- a/src/change_int_types.cpp
+++ b/src/change_int_types.cpp
@@ -14,20 +14,26 @@
 using namespace uncrustify;
 
 
-static void add_or_remove_int_keyword(Chunk *pc, iarf_e action)
+static bool is_int_qualifier(Chunk *pc)
+{
+   return(  strcmp(pc->Text(), "const") == 0
+         || strcmp(pc->Text(), "long") == 0
+         || strcmp(pc->Text(), "short") == 0
+         || strcmp(pc->Text(), "signed") == 0
+         || strcmp(pc->Text(), "static") == 0
+         || strcmp(pc->Text(), "unsigned") == 0
+         || strcmp(pc->Text(), "volatile") == 0);
+}
+
+
+static bool add_or_remove_int_keyword(Chunk *pc, iarf_e action)
 {
    Chunk *next = pc->GetNextNcNnl();
 
-   // Skip over all but the final type qualifier
-   if (  strcmp(next->Text(), "const") == 0
-      || strcmp(next->Text(), "long") == 0
-      || strcmp(next->Text(), "short") == 0
-      || strcmp(next->Text(), "signed") == 0
-      || strcmp(next->Text(), "static") == 0
-      || strcmp(next->Text(), "unsigned") == 0
-      || strcmp(next->Text(), "volatile") == 0)
+   // Skip over all but the last qualifier before the 'int' keyword
+   if (is_int_qualifier(next))
    {
-      return;
+      return(false);
    }
 
    if (strcmp(next->Text(), "int") == 0)
@@ -47,6 +53,7 @@ static void add_or_remove_int_keyword(Chunk *pc, iarf_e action)
          int_keyword->str = "int";
       }
    }
+   return(true);
 }
 
 
@@ -54,23 +61,40 @@ void change_int_types()
 {
    LOG_FUNC_ENTRY();
 
+   bool found_int = false;
+
    for (Chunk *pc = Chunk::GetHead(); pc->IsNotNullChunk(); pc = pc->GetNextNcNnl())
    {
+      // Skip any 'int' keyword that has already been processed, as well as any qualifiers after it
+      if (found_int)
+      {
+         if (  strcmp(pc->Text(), "int") != 0
+            && !is_int_qualifier(pc))
+         {
+            found_int = false;
+         }
+         continue;
+      }
+
       if (strcmp(pc->Text(), "short") == 0)
       {
-         add_or_remove_int_keyword(pc, options::mod_short_int());
+         found_int = add_or_remove_int_keyword(pc, options::mod_short_int());
       }
       else if (strcmp(pc->Text(), "long") == 0)
       {
-         add_or_remove_int_keyword(pc, options::mod_long_int());
+         found_int = add_or_remove_int_keyword(pc, options::mod_long_int());
       }
       else if (strcmp(pc->Text(), "signed") == 0)
       {
-         add_or_remove_int_keyword(pc, options::mod_signed_int());
+         found_int = add_or_remove_int_keyword(pc, options::mod_signed_int());
       }
       else if (strcmp(pc->Text(), "unsigned") == 0)
       {
-         add_or_remove_int_keyword(pc, options::mod_unsigned_int());
+         found_int = add_or_remove_int_keyword(pc, options::mod_unsigned_int());
+      }
+      else if (strcmp(pc->Text(), "int") == 0)
+      {
+         found_int = true;
       }
    }
 }

--- a/tests/expected/c/10091-int-types.c
+++ b/tests/expected/c/10091-int-types.c
@@ -2,36 +2,50 @@ int int_var;
 
 short int short_var;
 short int short_int_var;
+int short int_short_var;
 
 long long_var;
 long int long_int_var;
+int long int_long_var;
 
 long long long_long_var;
 long long int long_long_int_var;
+int long long int_long_long_var;
+long int long long_int_long_var;
 
 signed signed_var;
 signed int signed_int_var;
+int signed int_signed_var;
 
 unsigned unsigned_var;
 unsigned int unsigned_int_var;
+int unsigned int_unsigned_var;
 
 short int /* comment */ short_comment_var;
 short /* comment */ int short_comment_int_var;
 
 const long const_long_var;
-const long int const_long_int_var;
-
 long const long_const_var;
-long const int long_const_int_var;
 
 unsigned long unsigned_long_var;
-unsigned long int unsigned_long_int_var;
-
 long unsigned long_unsigned_var;
-long unsigned int long_unsigned_int_var;
 
 unsigned const long unsigned_const_long_var;
 unsigned const long int unsigned_const_long_int_var;
+
+const long int const_long_int_var;
+const int long const_int_long_var;
+long const int long_const_int_var;
+long int const long_int_const_var;
+int const long int_const_long_var;
+int long const const_long_int_var;
+
+unsigned long int unsigned_long_int_var;
+unsigned int long unsigned_int_long_var;
+long unsigned int long_unsigned_int_var;
+long int unsigned long_int_unsigned_var;
+int unsigned long int_unsigned_long_var;
+int long unsigned unsigned_long_int_var;
 
 char char_var;
 signed char signed_char_var;

--- a/tests/expected/c/10092-int-types.c
+++ b/tests/expected/c/10092-int-types.c
@@ -2,36 +2,50 @@ int int_var;
 
 short short_var;
 short short_int_var;
+int short int_short_var;
 
 long long_var;
 long int long_int_var;
+int long int_long_var;
 
 long long long_long_var;
 long long int long_long_int_var;
+int long long int_long_long_var;
+long int long long_int_long_var;
 
 signed signed_var;
 signed int signed_int_var;
+int signed int_signed_var;
 
 unsigned unsigned_var;
 unsigned int unsigned_int_var;
+int unsigned int_unsigned_var;
 
 short /* comment */ short_comment_var;
 short /* comment */ short_comment_int_var;
 
 const long const_long_var;
-const long int const_long_int_var;
-
 long const long_const_var;
-long const int long_const_int_var;
 
 unsigned long unsigned_long_var;
-unsigned long int unsigned_long_int_var;
-
 long unsigned long_unsigned_var;
-long unsigned int long_unsigned_int_var;
 
 unsigned const long unsigned_const_long_var;
 unsigned const long int unsigned_const_long_int_var;
+
+const long int const_long_int_var;
+const int long const_int_long_var;
+long const int long_const_int_var;
+long int const long_int_const_var;
+int const long int_const_long_var;
+int long const const_long_int_var;
+
+unsigned long int unsigned_long_int_var;
+unsigned int long unsigned_int_long_var;
+long unsigned int long_unsigned_int_var;
+long int unsigned long_int_unsigned_var;
+int unsigned long int_unsigned_long_var;
+int long unsigned unsigned_long_int_var;
 
 char char_var;
 signed char signed_char_var;

--- a/tests/expected/c/10093-int-types.c
+++ b/tests/expected/c/10093-int-types.c
@@ -2,36 +2,50 @@ int int_var;
 
 short short_var;
 short int short_int_var;
+int short int_short_var;
 
 long int long_var;
 long int long_int_var;
+int long int_long_var;
 
 long long int long_long_var;
 long long int long_long_int_var;
+int long long int_long_long_var;
+long int long long_int_long_var;
 
 signed signed_var;
 signed int signed_int_var;
+int signed int_signed_var;
 
 unsigned unsigned_var;
 unsigned int unsigned_int_var;
+int unsigned int_unsigned_var;
 
 short /* comment */ short_comment_var;
 short /* comment */ int short_comment_int_var;
 
 const long int const_long_var;
-const long int const_long_int_var;
-
 long const long_const_var;
-long const int long_const_int_var;
 
 unsigned long int unsigned_long_var;
-unsigned long int unsigned_long_int_var;
-
 long unsigned long_unsigned_var;
-long unsigned int long_unsigned_int_var;
 
 unsigned const long int unsigned_const_long_var;
 unsigned const long int unsigned_const_long_int_var;
+
+const long int const_long_int_var;
+const int long const_int_long_var;
+long const int long_const_int_var;
+long int const long_int_const_var;
+int const long int_const_long_var;
+int long const const_long_int_var;
+
+unsigned long int unsigned_long_int_var;
+unsigned int long unsigned_int_long_var;
+long unsigned int long_unsigned_int_var;
+long int unsigned long_int_unsigned_var;
+int unsigned long int_unsigned_long_var;
+int long unsigned unsigned_long_int_var;
 
 char char_var;
 signed char signed_char_var;

--- a/tests/expected/c/10094-int-types.c
+++ b/tests/expected/c/10094-int-types.c
@@ -2,36 +2,50 @@ int int_var;
 
 short short_var;
 short int short_int_var;
+int short int_short_var;
 
 long long_var;
 long long_int_var;
+int long int_long_var;
 
 long long long_long_var;
 long long long_long_int_var;
+int long long int_long_long_var;
+long long long_int_long_var;
 
 signed signed_var;
 signed int signed_int_var;
+int signed int_signed_var;
 
 unsigned unsigned_var;
 unsigned int unsigned_int_var;
+int unsigned int_unsigned_var;
 
 short /* comment */ short_comment_var;
 short /* comment */ int short_comment_int_var;
 
 const long const_long_var;
-const long const_long_int_var;
-
 long const long_const_var;
-long const int long_const_int_var;
 
 unsigned long unsigned_long_var;
-unsigned long unsigned_long_int_var;
-
 long unsigned long_unsigned_var;
-long unsigned int long_unsigned_int_var;
 
 unsigned const long unsigned_const_long_var;
 unsigned const long unsigned_const_long_int_var;
+
+const long const_long_int_var;
+const int long const_int_long_var;
+long const int long_const_int_var;
+long const long_int_const_var;
+int const long int_const_long_var;
+int long const const_long_int_var;
+
+unsigned long unsigned_long_int_var;
+unsigned int long unsigned_int_long_var;
+long unsigned int long_unsigned_int_var;
+long unsigned long_int_unsigned_var;
+int unsigned long int_unsigned_long_var;
+int long unsigned unsigned_long_int_var;
 
 char char_var;
 signed char signed_char_var;

--- a/tests/expected/c/10095-int-types.c
+++ b/tests/expected/c/10095-int-types.c
@@ -2,36 +2,50 @@ int int_var;
 
 short short_var;
 short int short_int_var;
+int short int_short_var;
 
 long long_var;
 long int long_int_var;
+int long int_long_var;
 
 long long long_long_var;
 long long int long_long_int_var;
+int long long int_long_long_var;
+long int long long_int_long_var;
 
 signed int signed_var;
 signed int signed_int_var;
+int signed int_signed_var;
 
 unsigned unsigned_var;
 unsigned int unsigned_int_var;
+int unsigned int_unsigned_var;
 
 short /* comment */ short_comment_var;
 short /* comment */ int short_comment_int_var;
 
 const long const_long_var;
-const long int const_long_int_var;
-
 long const long_const_var;
-long const int long_const_int_var;
 
 unsigned long unsigned_long_var;
-unsigned long int unsigned_long_int_var;
-
 long unsigned long_unsigned_var;
-long unsigned int long_unsigned_int_var;
 
 unsigned const long unsigned_const_long_var;
 unsigned const long int unsigned_const_long_int_var;
+
+const long int const_long_int_var;
+const int long const_int_long_var;
+long const int long_const_int_var;
+long int const long_int_const_var;
+int const long int_const_long_var;
+int long const const_long_int_var;
+
+unsigned long int unsigned_long_int_var;
+unsigned int long unsigned_int_long_var;
+long unsigned int long_unsigned_int_var;
+long int unsigned long_int_unsigned_var;
+int unsigned long int_unsigned_long_var;
+int long unsigned unsigned_long_int_var;
 
 char char_var;
 signed char signed_char_var;

--- a/tests/expected/c/10096-int-types.c
+++ b/tests/expected/c/10096-int-types.c
@@ -2,36 +2,50 @@ int int_var;
 
 short short_var;
 short int short_int_var;
+int short int_short_var;
 
 long long_var;
 long int long_int_var;
+int long int_long_var;
 
 long long long_long_var;
 long long int long_long_int_var;
+int long long int_long_long_var;
+long int long long_int_long_var;
 
 signed signed_var;
 signed signed_int_var;
+int signed int_signed_var;
 
 unsigned unsigned_var;
 unsigned int unsigned_int_var;
+int unsigned int_unsigned_var;
 
 short /* comment */ short_comment_var;
 short /* comment */ int short_comment_int_var;
 
 const long const_long_var;
-const long int const_long_int_var;
-
 long const long_const_var;
-long const int long_const_int_var;
 
 unsigned long unsigned_long_var;
-unsigned long int unsigned_long_int_var;
-
 long unsigned long_unsigned_var;
-long unsigned int long_unsigned_int_var;
 
 unsigned const long unsigned_const_long_var;
 unsigned const long int unsigned_const_long_int_var;
+
+const long int const_long_int_var;
+const int long const_int_long_var;
+long const int long_const_int_var;
+long int const long_int_const_var;
+int const long int_const_long_var;
+int long const const_long_int_var;
+
+unsigned long int unsigned_long_int_var;
+unsigned int long unsigned_int_long_var;
+long unsigned int long_unsigned_int_var;
+long int unsigned long_int_unsigned_var;
+int unsigned long int_unsigned_long_var;
+int long unsigned unsigned_long_int_var;
 
 char char_var;
 signed char signed_char_var;

--- a/tests/expected/c/10097-int-types.c
+++ b/tests/expected/c/10097-int-types.c
@@ -2,36 +2,50 @@ int int_var;
 
 short short_var;
 short int short_int_var;
+int short int_short_var;
 
 long long_var;
 long int long_int_var;
+int long int_long_var;
 
 long long long_long_var;
 long long int long_long_int_var;
+int long long int_long_long_var;
+long int long long_int_long_var;
 
 signed signed_var;
 signed int signed_int_var;
+int signed int_signed_var;
 
 unsigned int unsigned_var;
 unsigned int unsigned_int_var;
+int unsigned int_unsigned_var;
 
 short /* comment */ short_comment_var;
 short /* comment */ int short_comment_int_var;
 
 const long const_long_var;
-const long int const_long_int_var;
-
 long const long_const_var;
-long const int long_const_int_var;
 
 unsigned long unsigned_long_var;
-unsigned long int unsigned_long_int_var;
-
 long unsigned int long_unsigned_var;
-long unsigned int long_unsigned_int_var;
 
 unsigned const long unsigned_const_long_var;
 unsigned const long int unsigned_const_long_int_var;
+
+const long int const_long_int_var;
+const int long const_int_long_var;
+long const int long_const_int_var;
+long int const long_int_const_var;
+int const long int_const_long_var;
+int long const const_long_int_var;
+
+unsigned long int unsigned_long_int_var;
+unsigned int long unsigned_int_long_var;
+long unsigned int long_unsigned_int_var;
+long int unsigned long_int_unsigned_var;
+int unsigned long int_unsigned_long_var;
+int long unsigned unsigned_long_int_var;
 
 char char_var;
 signed char signed_char_var;

--- a/tests/expected/c/10098-int-types.c
+++ b/tests/expected/c/10098-int-types.c
@@ -2,36 +2,50 @@ int int_var;
 
 short short_var;
 short int short_int_var;
+int short int_short_var;
 
 long long_var;
 long int long_int_var;
+int long int_long_var;
 
 long long long_long_var;
 long long int long_long_int_var;
+int long long int_long_long_var;
+long int long long_int_long_var;
 
 signed signed_var;
 signed int signed_int_var;
+int signed int_signed_var;
 
 unsigned unsigned_var;
 unsigned unsigned_int_var;
+int unsigned int_unsigned_var;
 
 short /* comment */ short_comment_var;
 short /* comment */ int short_comment_int_var;
 
 const long const_long_var;
-const long int const_long_int_var;
-
 long const long_const_var;
-long const int long_const_int_var;
 
 unsigned long unsigned_long_var;
-unsigned long int unsigned_long_int_var;
-
 long unsigned long_unsigned_var;
-long unsigned long_unsigned_int_var;
 
 unsigned const long unsigned_const_long_var;
 unsigned const long int unsigned_const_long_int_var;
+
+const long int const_long_int_var;
+const int long const_int_long_var;
+long const int long_const_int_var;
+long int const long_int_const_var;
+int const long int_const_long_var;
+int long const const_long_int_var;
+
+unsigned long int unsigned_long_int_var;
+unsigned long unsigned_int_long_var;
+long unsigned long_unsigned_int_var;
+long int unsigned long_int_unsigned_var;
+int unsigned long int_unsigned_long_var;
+int long unsigned unsigned_long_int_var;
 
 char char_var;
 signed char signed_char_var;

--- a/tests/input/c/int-types.c
+++ b/tests/input/c/int-types.c
@@ -2,36 +2,50 @@ int int_var;
 
 short short_var;
 short int short_int_var;
+int short int_short_var;
 
 long long_var;
 long int long_int_var;
+int long int_long_var;
 
 long long long_long_var;
 long long int long_long_int_var;
+int long long int_long_long_var;
+long int long long_int_long_var;
 
 signed signed_var;
 signed int signed_int_var;
+int signed int_signed_var;
 
 unsigned unsigned_var;
 unsigned int unsigned_int_var;
+int unsigned int_unsigned_var;
 
 short /* comment */ short_comment_var;
 short /* comment */ int short_comment_int_var;
 
 const long const_long_var;
-const long int const_long_int_var;
-
 long const long_const_var;
-long const int long_const_int_var;
 
 unsigned long unsigned_long_var;
-unsigned long int unsigned_long_int_var;
-
 long unsigned long_unsigned_var;
-long unsigned int long_unsigned_int_var;
 
 unsigned const long unsigned_const_long_var;
 unsigned const long int unsigned_const_long_int_var;
+
+const long int const_long_int_var;
+const int long const_int_long_var;
+long const int long_const_int_var;
+long int const long_int_const_var;
+int const long int_const_long_var;
+int long const const_long_int_var;
+
+unsigned long int unsigned_long_int_var;
+unsigned int long unsigned_int_long_var;
+long unsigned int long_unsigned_int_var;
+long int unsigned long_int_unsigned_var;
+int unsigned long int_unsigned_long_var;
+int long unsigned unsigned_long_int_var;
 
 char char_var;
 signed char signed_char_var;


### PR DESCRIPTION
Fixes #3724

My apologies for the chaotic development of this feature. I think this is the last patch it needs.