### PR TITLE
Improve detection of non-keyword identifiers in Vala

### DIFF
--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -2218,10 +2218,16 @@ static bool parse_next(tok_ctx &ctx, Chunk &pc, const Chunk *prev_pc)
       {
          return(true);
       }
+   }
 
+   if (language_is_set(LANG_CS | LANG_VALA))
+   {
       // check for non-keyword identifiers such as @if @switch, etc
-      if (  (ctx.peek() == '@')
-         && CharTable::IsKw1(ctx.peek(1)))
+      // Vala also allows numeric identifiers if prefixed with '@'
+      if (  ctx.peek() == '@'
+         && (  CharTable::IsKw1(ctx.peek(1))
+            || (  language_is_set(LANG_VALA)
+               && CharTable::IsKw2(ctx.peek(1)))))
       {
          parse_word(ctx, pc, true);
          return(true);
@@ -2391,8 +2397,22 @@ static bool parse_next(tok_ctx &ctx, Chunk &pc, const Chunk *prev_pc)
       }
    }
 
-   // Check for Objective C literals and VALA identifiers ('@1', '@if')
-   if (  language_is_set(LANG_OC | LANG_VALA)
+   // Check for Vala string templates
+   if (  language_is_set(LANG_VALA)
+      && (ctx.peek() == '@'))
+   {
+      size_t nc = ctx.peek(1);
+
+      if (nc == '"')
+      {
+         // literal string
+         parse_string(ctx, pc, 1, true);
+         return(true);
+      }
+   }
+
+   // Check for Objective C literals
+   if (  language_is_set(LANG_OC)
       && (ctx.peek() == '@'))
    {
       size_t nc = ctx.peek(1);

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -948,6 +948,20 @@ void tokenize_cleanup()
          }
       }
 
+      // Vala allows keywords to be used as identifiers
+      if (language_is_set(LANG_VALA))
+      {
+         if (  find_keyword_type(pc->Text(), pc->Len()) != CT_WORD
+            && (  prev->Is(CT_DOT)
+               || next->Is(CT_DOT)
+               || prev->Is(CT_MEMBER)
+               || next->Is(CT_MEMBER)
+               || prev->Is(CT_TYPE)))
+         {
+            set_chunk_type(pc, CT_WORD);
+         }
+      }
+
       // Another hack to clean up more keyword abuse
       if (  pc->Is(CT_CLASS)
          && (  prev->Is(CT_DOT)

--- a/tests/expected/vala/70304-identifier.vala
+++ b/tests/expected/vala/70304-identifier.vala
@@ -1,0 +1,47 @@
+namespace ns
+{
+// You can omit '@' in trivial 'type func-name' definitions.
+void if() {
+}
+void else() {
+}
+void foreach() {
+}
+
+// Numeric identifiers require '@'.
+int @123star() {
+}
+
+// Non-primitive return types require '@'.
+Foo @while() {
+}
+}
+
+public static int main()
+{
+	// You can omit '@' in trivial 'type var;' declarations.
+	int for;
+	int while = 1;
+	int do;
+
+	// Non-primitive types always require '@'.
+	Foo @do;
+
+	// Slightly more complex 'type var_list;' require '@'.
+	int @if, @else, @for, @do, @while;
+
+	// This will complain about missing '(' etc.
+	// int if, else, for, do, while;
+
+	// It is common to omit '@' when accessing methods.
+	ns.if();
+	ns.else();
+	ns.do();
+	ns.while();
+	ns.foreach();
+
+	// Numeric methods always require '@'.
+	ns.@123star();
+
+	return 0;
+}

--- a/tests/input/vala/identifier.vala
+++ b/tests/input/vala/identifier.vala
@@ -1,0 +1,47 @@
+namespace ns
+{
+// You can omit '@' in trivial 'type func-name' definitions.
+void if() {
+}
+void else() {
+}
+void foreach() {
+}
+
+// Numeric identifiers require '@'.
+int @123star() {
+}
+
+// Non-primitive return types require '@'.
+Foo @while() {
+}
+}
+
+public static int main()
+{
+	// You can omit '@' in trivial 'type var;' declarations.
+	int for;
+	int while = 1;
+	int do;
+
+	// Non-primitive types always require '@'.
+	Foo @do;
+
+	// Slightly more complex 'type var_list;' require '@'.
+	int @if, @else, @for, @do, @while;
+
+	// This will complain about missing '(' etc.
+	// int if, else, for, do, while;
+
+	// It is common to omit '@' when accessing methods.
+	ns.if();
+	ns.else();
+	ns.do();
+	ns.while();
+	ns.foreach();
+
+	// Numeric methods always require '@'.
+	ns.@123star();
+
+	return 0;
+}

--- a/tests/vala.test
+++ b/tests/vala.test
@@ -15,3 +15,4 @@
 70301  vala/Issue_2270.cfg                  vala/Issue_2270.vala
 70302  common/sp_after_cast.cfg             vala/cast.vala
 70303  vala/nullable.cfg                    vala/nullable.vala
+70304  common/empty.cfg                     vala/identifier.vala


### PR DESCRIPTION
This PR fixes detection of various non-keyword identifiers in Vala.

Previously, expressions such as `ns.foreach();` for example, were detected as a for loop:
```
#  41>               TYPE|               NONE|     PARENT_NOT_SET[  9/  9/ 11/  0][1/1/0][     8c0000][0-1]         ns
#  41>             MEMBER|               NONE|     PARENT_NOT_SET[ 11/ 11/ 12/  0][1/1/0][  200000000][0-0]           .
#  41>                FOR|               NONE|     PARENT_NOT_SET[ 12/ 12/ 19/  0][1/1/0][          0][0-0]            foreach
#  41>        SPAREN_OPEN|                FOR|     PARENT_NOT_SET[ 19/ 19/ 20/  0][1/1/0][  200000000][0-0]                   (
#  41>       SPAREN_CLOSE|                FOR|     PARENT_NOT_SET[ 20/ 20/ 21/  0][1/1/0][  200002000][0-0]                    )
#  41>        VBRACE_OPEN|                FOR|     PARENT_NOT_SET[ 21/ 20/  0/  0][1/1/0][   40000000][0-0]
#  41>          SEMICOLON|               NONE|     PARENT_NOT_SET[ 21/ 21/ 22/  0][2/2/0][  2400c0000][0-0]                     ;
```

After this PR:
```
#  41>               TYPE|               NONE|     PARENT_NOT_SET[  9/  9/ 11/  0][1/1/0][       8c 0000][0-1]         ns
#  41>             MEMBER|               NONE|     PARENT_NOT_SET[ 11/ 11/ 12/  0][1/1/0][   2 0000 0000][0-0]           .
#  41>          FUNC_CALL|               NONE|     PARENT_NOT_SET[ 12/ 12/ 19/  0][1/1/0][             0][0-0]            foreach
#  41>        FPAREN_OPEN|          FUNC_CALL|     PARENT_NOT_SET[ 19/ 19/ 20/  0][1/1/0][   2 0000 0000][0-0]                   (
#  41>       FPAREN_CLOSE|          FUNC_CALL|     PARENT_NOT_SET[ 20/ 20/ 21/  0][1/1/0][   2 0000 0010][0-0]                    )
#  41>          SEMICOLON|               NONE|     PARENT_NOT_SET[ 21/ 21/ 22/  0][1/1/0][   2 0000 0000][0-0]                     ;
```