### PR TITLE
Ignore storage keywords when searching for last keyword in mod_*_int

### DIFF
--- a/src/change_int_types.cpp
+++ b/src/change_int_types.cpp
@@ -14,24 +14,23 @@
 using namespace uncrustify;
 
 
-static bool is_int_qualifier(Chunk *pc)
-{
-   return(  strcmp(pc->Text(), "const") == 0
-         || strcmp(pc->Text(), "long") == 0
-         || strcmp(pc->Text(), "short") == 0
-         || strcmp(pc->Text(), "signed") == 0
-         || strcmp(pc->Text(), "static") == 0
-         || strcmp(pc->Text(), "unsigned") == 0
-         || strcmp(pc->Text(), "volatile") == 0);
-}
-
-
 static bool add_or_remove_int_keyword(Chunk *pc, iarf_e action)
 {
    Chunk *next = pc->GetNextNcNnl();
 
-   // Skip over all but the last qualifier before the 'int' keyword
-   if (is_int_qualifier(next))
+   // Find the next token that is not a storage keyword
+   while (  strcmp(next->Text(), "const") == 0
+         || strcmp(next->Text(), "static") == 0
+         || strcmp(next->Text(), "volatile") == 0)
+   {
+      next = next->GetNextNcNnl();
+   }
+
+   // Skip over all but the last size/sign qualifier before the 'int' keyword
+   if (  strcmp(next->Text(), "long") == 0
+      || strcmp(next->Text(), "short") == 0
+      || strcmp(next->Text(), "signed") == 0
+      || strcmp(next->Text(), "unsigned") == 0)
    {
       return(false);
    }
@@ -69,7 +68,13 @@ void change_int_types()
       if (found_int)
       {
          if (  strcmp(pc->Text(), "int") != 0
-            && !is_int_qualifier(pc))
+            && strcmp(pc->Text(), "const") != 0
+            && strcmp(pc->Text(), "long") != 0
+            && strcmp(pc->Text(), "short") != 0
+            && strcmp(pc->Text(), "signed") != 0
+            && strcmp(pc->Text(), "static") != 0
+            && strcmp(pc->Text(), "unsigned") != 0
+            && strcmp(pc->Text(), "volatile") != 0)
          {
             found_int = false;
          }
@@ -97,4 +102,4 @@ void change_int_types()
          found_int = true;
       }
    }
-}
+} // change_int_types

--- a/tests/expected/c/10093-int-types.c
+++ b/tests/expected/c/10093-int-types.c
@@ -25,7 +25,7 @@ short /* comment */ short_comment_var;
 short /* comment */ int short_comment_int_var;
 
 const long int const_long_var;
-long const long_const_var;
+long int const long_const_var;
 
 unsigned long int unsigned_long_var;
 long unsigned long_unsigned_var;

--- a/tests/expected/c/10094-int-types.c
+++ b/tests/expected/c/10094-int-types.c
@@ -35,7 +35,7 @@ unsigned const long unsigned_const_long_int_var;
 
 const long const_long_int_var;
 const int long const_int_long_var;
-long const int long_const_int_var;
+long const long_const_int_var;
 long const long_int_const_var;
 int const long int_const_long_var;
 int long const const_long_int_var;


### PR DESCRIPTION
Fixes #3728

Thanks @micheleCTDE for your feedback last night. Your comment made me realize that it wouldn't be that hard to handle these cases better.