### PR TITLE
Recognize more keywords in is_storage_keyword

### DIFF
--- a/src/change_int_types.cpp
+++ b/src/change_int_types.cpp
@@ -16,9 +16,17 @@ using namespace uncrustify;
 
 static bool is_storage_keyword(const Chunk *pc)
 {
-   return(  strcmp(pc->Text(), "const") == 0
+   return(  strcmp(pc->Text(), "auto") == 0
+         || strcmp(pc->Text(), "const") == 0
+         || strcmp(pc->Text(), "extern") == 0
+         || strcmp(pc->Text(), "mutable") == 0
+         || strcmp(pc->Text(), "register") == 0
          || strcmp(pc->Text(), "static") == 0
-         || strcmp(pc->Text(), "volatile") == 0);
+         || strcmp(pc->Text(), "thread_local") == 0
+         || strcmp(pc->Text(), "typedef") == 0
+         || strcmp(pc->Text(), "volatile") == 0
+         || strcmp(pc->Text(), "_Atomic") == 0
+         || strcmp(pc->Text(), "_Thread_local") == 0);
 }
 
 


### PR DESCRIPTION
I put together this list based on the following pages on cppreference.com:

* [C documentation for storage class specifiers](https://en.cppreference.com/w/c/language/storage_duration)
* [C++ documentation for storage class specifiers](https://en.cppreference.com/w/cpp/language/storage_duration)
* [C documentation for const type qualifier](https://en.cppreference.com/w/c/language/const)
* [C documentation for volatile type qualifier](https://en.cppreference.com/w/c/language/volatile)
* [C documentation for _Atomic type qualifier](https://en.cppreference.com/w/c/language/atomic)
* [C++ documentation for const and volatile type qualifier](https://en.cppreference.com/w/cpp/language/cv)

I think that covers all of the keywords that need to be skipped when searching for the `int` keyword that belongs to a `short`, `long`, `signed`, or `unsigned` keyword. (We could skip `_Pragma()` too, but that's a bit more complicated and I don't think anyone cares.)