### PR TITLE
Support conditionally newlining objc params based on a number of args

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -2027,7 +2027,7 @@ nl_template_end                 = false    # true/false
 nl_oc_msg_args                  = false    # true/false
 
 # (OC) Minimum number of Objective-C message parameters before applying nl_oc_msg_args.
-nl_oc_msg_args_min_params       = 0
+nl_oc_msg_args_min_params       = 0        # unsigned number
 
 # Add or remove newline between function signature and '{'.
 nl_fdef_brace                   = ignore   # ignore/add/remove/force/not_defined

--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -2026,6 +2026,9 @@ nl_template_end                 = false    # true/false
 # See nl_oc_msg_leave_one_liner.
 nl_oc_msg_args                  = false    # true/false
 
+# (OC) Minimum number of Objective-C message parameters before applying nl_oc_msg_args.
+nl_oc_msg_args_min_params       = 0
+
 # Add or remove newline between function signature and '{'.
 nl_fdef_brace                   = ignore   # ignore/add/remove/force/not_defined
 

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -2026,6 +2026,9 @@ nl_template_end                 = false    # true/false
 # See nl_oc_msg_leave_one_liner.
 nl_oc_msg_args                  = false    # true/false
 
+# (OC) Minimum number of Objective-C message parameters before applying nl_oc_msg_args.
+nl_oc_msg_args_min_params       = 0        # unsigned number
+
 # Add or remove newline between function signature and '{'.
 nl_fdef_brace                   = ignore   # ignore/add/remove/force/not_defined
 

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -2027,7 +2027,7 @@ nl_template_end                 = false    # true/false
 nl_oc_msg_args                  = false    # true/false
 
 # (OC) Minimum number of Objective-C message parameters before applying nl_oc_msg_args.
-nl_oc_msg_args_min_params       = 0
+nl_oc_msg_args_min_params       = 0        # unsigned number
 
 # Add or remove newline between function signature and '{'.
 nl_fdef_brace                   = ignore   # ignore/add/remove/force/not_defined

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -2026,6 +2026,9 @@ nl_template_end                 = false    # true/false
 # See nl_oc_msg_leave_one_liner.
 nl_oc_msg_args                  = false    # true/false
 
+# (OC) Minimum number of Objective-C message parameters before applying nl_oc_msg_args.
+nl_oc_msg_args_min_params       = 0
+
 # Add or remove newline between function signature and '{'.
 nl_fdef_brace                   = ignore   # ignore/add/remove/force/not_defined
 

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -7310,13 +7310,3 @@ Enabled=false
 EditorType=boolean
 TrueFalse=set_numbering_for_html_output=true|set_numbering_for_html_output=false
 ValueDefault=false
-
-[Nl Oc Msg Args Min Params]
-Category=3
-Description="<html>(810)Minimum number of Objective-C message parameters before applying nl_oc_msg_args.</html>"
-Enabled=false
-EditorType=numeric
-CallName="nl_oc_msg_args_min_params="
-MinVal=0
-MaxVal=16
-ValueDefault=0

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -7310,3 +7310,13 @@ Enabled=false
 EditorType=boolean
 TrueFalse=set_numbering_for_html_output=true|set_numbering_for_html_output=false
 ValueDefault=false
+
+[Nl Oc Msg Args Min Params]
+Category=3
+Description="<html>(810)Minimum number of Objective-C message parameters before applying nl_oc_msg_args.</html>"
+Enabled=false
+EditorType=numeric
+CallName="nl_oc_msg_args_min_params="
+MinVal=0
+MaxVal=16
+ValueDefault=0

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3453,9 +3453,8 @@ static void newline_oc_msg(Chunk *start)
    {
       return;
    }
-
    // Get count of parameters
-   size_t  parameter_count = 0;
+   size_t parameter_count = 0;
 
    for (Chunk *pc = start->GetNextNcNnl(); pc->IsNotNullChunk(); pc = pc->GetNextNcNnl())
    {
@@ -3470,9 +3469,10 @@ static void newline_oc_msg(Chunk *start)
       }
    }
 
-   int    min_params = options::nl_oc_msg_args_min_params();
+   int min_params = options::nl_oc_msg_args_min_params();
 
-   if (parameter_count < min_params && min_params != 0) {
+   if (parameter_count < min_params && min_params != 0)
+   {
       return;
    }
 

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3471,7 +3471,8 @@ static void newline_oc_msg(Chunk *start)
 
    int min_params = options::nl_oc_msg_args_min_params();
 
-   if (parameter_count < min_params && min_params != 0)
+   if (  parameter_count < min_params
+      && min_params != 0)
    {
       return;
    }

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3454,6 +3454,28 @@ static void newline_oc_msg(Chunk *start)
       return;
    }
 
+   // Get count of parameters
+   size_t  parameter_count = 0;
+
+   for (Chunk *pc = start->GetNextNcNnl(); pc->IsNotNullChunk(); pc = pc->GetNextNcNnl())
+   {
+      if (pc->level <= start->level)
+      {
+         break;
+      }
+
+      if (pc->Is(CT_OC_MSG_NAME))
+      {
+         parameter_count++;
+      }
+   }
+
+   int    min_params = options::nl_oc_msg_args_min_params();
+
+   if (parameter_count < min_params && min_params != 0) {
+      return;
+   }
+
    for (Chunk *pc = start->GetNextNcNnl(); pc->IsNotNullChunk(); pc = pc->GetNextNcNnl())
    {
       if (pc->level <= start->level)

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -3463,7 +3463,7 @@ static void newline_oc_msg(Chunk *start)
          break;
       }
 
-      if (pc->Is(CT_OC_MSG_NAME))
+      if (pc->Is(CT_OC_COLON))
       {
          parameter_count++;
       }

--- a/src/options.h
+++ b/src/options.h
@@ -2476,6 +2476,10 @@ nl_template_end;
 extern Option<bool>
 nl_oc_msg_args;
 
+// (OC) Minimum number of Objective-C message parameters before applying nl_oc_msg_args.
+extern BoundedOption<unsigned, 0, 16>
+nl_oc_msg_args_min_params;
+
 // Add or remove newline between function signature and '{'.
 extern Option<iarf_e>
 nl_fdef_brace;

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -4544,6 +4544,16 @@ EditorType=boolean
 TrueFalse=nl_oc_msg_args=true|nl_oc_msg_args=false
 ValueDefault=false
 
+[Nl Oc Msg Args Min Params]
+Category=3
+Description="<html>(OC) Minimum number of Objective-C message parameters before applying nl_oc_msg_args.</html>"
+Enabled=false
+EditorType=numeric
+CallName="nl_oc_msg_args_min_params="
+MinVal=0
+MaxVal=16
+ValueDefault=0
+
 [Nl Fdef Brace]
 Category=3
 Description="<html>Add or remove newline between function signature and '{'.</html>"
@@ -7310,13 +7320,3 @@ Enabled=false
 EditorType=boolean
 TrueFalse=set_numbering_for_html_output=true|set_numbering_for_html_output=false
 ValueDefault=false
-
-[Nl Oc Msg Args Min Params]
-Category=3
-Description="<html>(810)Minimum number of Objective-C message parameters before applying nl_oc_msg_args.</html>"
-Enabled=false
-EditorType=numeric
-CallName="nl_oc_msg_args_min_params="
-MinVal=0
-MaxVal=16
-ValueDefault=0

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -7310,3 +7310,13 @@ Enabled=false
 EditorType=boolean
 TrueFalse=set_numbering_for_html_output=true|set_numbering_for_html_output=false
 ValueDefault=false
+
+[Nl Oc Msg Args Min Params]
+Category=3
+Description="<html>(810)Minimum number of Objective-C message parameters before applying nl_oc_msg_args.</html>"
+Enabled=false
+EditorType=numeric
+CallName="nl_oc_msg_args_min_params="
+MinVal=0
+MaxVal=16
+ValueDefault=0

--- a/tests/config/oc/nl_oc_msg_args_min_params.cfg
+++ b/tests/config/oc/nl_oc_msg_args_min_params.cfg
@@ -1,0 +1,2 @@
+nl_oc_msg_args                  = true
+nl_oc_msg_args_min_params       = 3

--- a/tests/expected/oc/50631-nl_oc_msg_args_min_params.m
+++ b/tests/expected/oc/50631-nl_oc_msg_args_min_params.m
@@ -4,5 +4,13 @@ static void function() {
 	 param3:nil
 	 param4:nil];
 
-	[object param1:nil param2:nil param3:nil];
+	[object param1:nil
+	 param2:nil
+	 param3:nil];
+
+	[object param1:nil param2:nil];
+
+	[object param1:nil];
+
+	[object func];
 }

--- a/tests/expected/oc/50631-nl_oc_msg_args_min_params.m
+++ b/tests/expected/oc/50631-nl_oc_msg_args_min_params.m
@@ -1,0 +1,8 @@
+static void function() {
+	[object param1:nil
+	 param2:nil
+	 param3:nil
+	 param4:nil];
+
+	[object param1:nil param2:nil param3:nil];
+}

--- a/tests/input/oc/nl_oc_msg_args_min_params.m
+++ b/tests/input/oc/nl_oc_msg_args_min_params.m
@@ -1,0 +1,5 @@
+static void function() {
+    [object param1:nil param2:nil param3:nil param4:nil];
+
+    [object param1:nil param2:nil param3:nil];
+}

--- a/tests/input/oc/nl_oc_msg_args_min_params.m
+++ b/tests/input/oc/nl_oc_msg_args_min_params.m
@@ -2,4 +2,10 @@ static void function() {
     [object param1:nil param2:nil param3:nil param4:nil];
 
     [object param1:nil param2:nil param3:nil];
+
+    [object param1:nil param2:nil];
+
+    [object param1:nil];
+
+    [object func];
 }

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -140,6 +140,8 @@
 
 50630  oc/nl_func_call_args_multi_line_ignore_closures.cfg oc/nl_func_call_args_multi_line_ignore_closures.m
 
+50631  oc/nl_oc_msg_args_min_params.cfg         oc/nl_oc_msg_args_min_params.m
+
 50700  common/cmt_insert-0.cfg                  oc/cmt_insert.m
 50701  common/cmt_insert-0.cfg                  oc/cmt_insert2.m
 


### PR DESCRIPTION
Currently we only support an "all or nothing" approach to new-lining Objective-C message parameters. This is not ideal because some would argue functions such as `[object param1:nil param2:nil]` are more readable in a single line.

This change supports configuring `nl_oc_msg_args` based on a number of parameters, a new option `nl_oc_msg_args_min_params`.

Issue: https://github.com/uncrustify/uncrustify/issues/3734