### PR TITLE
Fix mod_remove_extra_semicolon generating invalid code in Vala

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -603,8 +603,7 @@ void do_symbol_check(Chunk *prev, Chunk *pc, Chunk *next)
          return;
       }
 
-      if (  language_is_set(LANG_CS)
-         && (  pc->Is(CT_LAMBDA)
+      if (  (  pc->Is(CT_LAMBDA)
             || pc->Is(CT_DELEGATE))
          && next->Is(CT_BRACE_OPEN))
       {

--- a/tests/expected/vala/70001-advanced.vala
+++ b/tests/expected/vala/70001-advanced.vala
@@ -10,7 +10,7 @@ public class Sample : Object {
    {
       foo += s => {
          stdout.printf("Lambda expression %s!\n", name);
-      }
+      };
 
       /* Calling lambda expression */
       foo();

--- a/tests/expected/vala/70010-verbatim_str.vala
+++ b/tests/expected/vala/70010-verbatim_str.vala
@@ -10,7 +10,7 @@ public class Sample : Object {
    {
       foo += s => {
          stdout.printf("Lambda expression %s!\n", name);
-      }
+      };
 
       /* Calling lambda expression */
       foo();

--- a/tests/expected/vala/70011-verbatim_str2.vala
+++ b/tests/expected/vala/70011-verbatim_str2.vala
@@ -10,7 +10,7 @@ public class Sample : Object {
    {
       foo += s => {
          stdout.printf("Lambda expression %s!\n", name);
-      }
+      };
 
       /* Calling lambda expression */
       foo();

--- a/tests/expected/vala/70012-verbatim_str2.vala
+++ b/tests/expected/vala/70012-verbatim_str2.vala
@@ -10,7 +10,7 @@ public class Sample : Object {
    {
       foo += s => {
          stdout.printf("Lambda expression %s!\n", name);
-      }
+      };
 
       /* Calling lambda expression */
       foo();


### PR DESCRIPTION
Fixes Uncrustify generating invalid lambda code in some cases when ``mod_remove_extra_semicolon = true`` in Vala.