### PR TITLE
Fix .editorconfig's src/* pattern

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,3 @@
-[{src}/*]
+[src/*]
 indent_style = space
 indent_size = 3


### PR DESCRIPTION
Removes unnecessary braces that prevent (at least some versions of) vim-editorconfig and probably other editors/plugins from applying the config.