### PR TITLE
Only set CT_PP_INCLUDE when appropriate

### DIFF
--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -2370,7 +2370,11 @@ static bool parse_next(tok_ctx &ctx, Chunk &pc, const Chunk *prev_pc)
             && cpd.in_preproc == CT_PP_INCLUDE))
       {
          parse_string(ctx, pc, unc_isalpha(ch) ? 1 : 0, true);
-         pc.SetParentType(CT_PP_INCLUDE);
+
+         if (cpd.in_preproc == CT_PP_INCLUDE)
+         {
+            pc.SetParentType(CT_PP_INCLUDE);
+         }
          return(true);
       }
 

--- a/tests/cli/output/class_enum_struct_union.csv
+++ b/tests/cli/output/class_enum_struct_union.csv
@@ -48,7 +48,7 @@ Line,Tag,Parent_type,Type of the parent,Column,Orig Col Strt,Orig Col End,Orig S
 26,PAREN_OPEN,NONE,PARENT_NOT_SET,35,35,36,0,1,2,1,"IN_PREPROC,EXPR_START,PUNCTUATOR",0,0,"                                   ("
 26,FUNC_CALL,NONE,PARENT_NOT_SET,36,36,46,0,1,3,1,"IN_PREPROC,EXPR_START",0,0,"                                    visibility"
 26,FPAREN_OPEN,FUNC_CALL,PARENT_NOT_SET,46,46,47,0,1,3,1,"IN_PREPROC,PUNCTUATOR",0,0,"                                              ("
-26,STRING,PP_INCLUDE,PARENT_NOT_SET,47,47,56,0,1,4,1,"IN_PREPROC,IN_FCN_CALL,EXPR_START",0,0,"                                               ""default"""
+26,STRING,NONE,PARENT_NOT_SET,47,47,56,0,1,4,1,"IN_PREPROC,IN_FCN_CALL,EXPR_START",0,0,"                                               ""default"""
 26,FPAREN_CLOSE,FUNC_CALL,PARENT_NOT_SET,56,56,57,0,1,3,1,"IN_PREPROC,IN_FCN_CALL,PUNCTUATOR",0,0,"                                                        )"
 26,PAREN_CLOSE,NONE,PARENT_NOT_SET,57,57,58,0,1,2,1,"IN_PREPROC,PUNCTUATOR",0,0,"                                                         )"
 26,FPAREN_CLOSE,ATTRIBUTE,PARENT_NOT_SET,58,58,59,0,1,1,1,"IN_PREPROC,PUNCTUATOR",0,0,"                                                          )"

--- a/tests/cli/output/class_enum_struct_union.txt
+++ b/tests/cli/output/class_enum_struct_union.txt
@@ -54,7 +54,7 @@
 #  26>         PAREN_OPEN|               NONE|     PARENT_NOT_SET[ 35/ 35/ 36/  0][1/2/1][   2 0008 0001][0-0]                                   (
 #  26>          FUNC_CALL|               NONE|     PARENT_NOT_SET[ 36/ 36/ 46/  0][1/3/1][        8 0001][0-0]                                    visibility
 #  26>        FPAREN_OPEN|          FUNC_CALL|     PARENT_NOT_SET[ 46/ 46/ 47/  0][1/3/1][   2 0000 0001][0-0]                                              (
-#  26>             STRING|         PP_INCLUDE|     PARENT_NOT_SET[ 47/ 47/ 56/  0][1/4/1][        8 0011][0-0]                                               "default"
+#  26>             STRING|               NONE|     PARENT_NOT_SET[ 47/ 47/ 56/  0][1/4/1][        8 0011][0-0]                                               "default"
 #  26>       FPAREN_CLOSE|          FUNC_CALL|     PARENT_NOT_SET[ 56/ 56/ 57/  0][1/3/1][   2 0000 0011][0-0]                                                        )
 #  26>        PAREN_CLOSE|               NONE|     PARENT_NOT_SET[ 57/ 57/ 58/  0][1/2/1][   2 0000 0001][0-0]                                                         )
 #  26>       FPAREN_CLOSE|          ATTRIBUTE|     PARENT_NOT_SET[ 58/ 58/ 59/  0][1/1/1][   2 0000 0001][0-0]                                                          )


### PR DESCRIPTION
This should not pose any real threat but it is certainly strange to look inside .p files and see a bunch of regular strings having `PP_INCLUDE` as their parent type:
```
# Line                Tag         Parent_type  Type of the parent         Columns Br/Lvl/pp         Flag   Nl  Text
#   1>          FUNC_CALL|               NONE|     PARENT_NOT_SET[  1/  1/  7/  0][0/0/0][        c 0000][0-0] printf
#   1>        FPAREN_OPEN|          FUNC_CALL|     PARENT_NOT_SET[  7/  7/  8/  0][0/0/0][   2 0000 0000][0-0]       (
#   1>             STRING|         PP_INCLUDE|     PARENT_NOT_SET[  8/  8/ 15/  0][0/1/0][        8 0010][0-0]        "foo\n"
#   1>       FPAREN_CLOSE|          FUNC_CALL|     PARENT_NOT_SET[ 15/ 15/ 16/  0][0/0/0][   2 0000 0010][0-0]               )
#   1>          SEMICOLON|               NONE|     PARENT_NOT_SET[ 16/ 16/ 17/  0][0/0/0][   2 0000 0000][0-0]                ;
#   1>            NEWLINE|               NONE|     PARENT_NOT_SET[ 17/ 17/  1/  0][0/0/0][             0][1-0]
# -=====-
```