### PR TITLE
Fix indent_cpp_lambda_body in some circumnstances

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1759,7 +1759,8 @@ void indent_text()
                (options::indent_continue() > 0)
                && enclosure
                && linematch
-               && toplevel;
+               && toplevel
+               && frm.top().pc->SkipToMatch()->IsOnSameLine(frm.top().pc);
 
             if (sameLine && ((isAssignSameLine) || (closureSameLineTopLevel)))
             {

--- a/tests/expected/cpp/60055-issue_3116.cpp
+++ b/tests/expected/cpp/60055-issue_3116.cpp
@@ -129,8 +129,8 @@ A(
 // Inside scope
 {
     std::thread([](const char *c) {
-        std::cout << c << std::endl;
-    }).detach();
+            std::cout << c << std::endl;
+        }).detach();
 
     std::thread(
         [](const char *c) {
@@ -149,8 +149,8 @@ A(
 }
 
 Func(std::count_if(v.begin(), v.end(), [&](const auto &a) {
-    return a == 3;
-}));
+        return a == 3;
+    }));
 
 Func(
     std::count_if(v.begin(), v.end(), [&](const auto &a)
@@ -210,14 +210,14 @@ else
 
 // Test case from issue 1296 and some variants
 obj->Func([&](int a)
-{
-    return b;
-});
+    {
+        return b;
+    });
 
 obj->Func([] -> int
-{
-    return b;
-});
+    {
+        return b;
+    });
 
 obj->Func([]
     {

--- a/tests/expected/cpp/60056-issue_3116-2.cpp
+++ b/tests/expected/cpp/60056-issue_3116-2.cpp
@@ -1,10 +1,10 @@
 obj.AddObject(Object::UniqueName(), 10, [this] {
-    holder.Access([this](const auto &info) {
-        if (IsGood(info)) {
-            Add(info);
-        }
+        holder.Access([this](const auto &info) {
+            if (IsGood(info)) {
+                Add(info);
+            }
+        });
     });
-});
 
 obj.AddObject(
     Object::UniqueName(),
@@ -20,12 +20,12 @@ obj.AddObject(
 
 {
     obj.AddObject(Object::UniqueName(), 10, [this] {
-        holder.Access([this](const auto &info) {
-            if (IsGood(info)) {
-                Add(info);
-            }
+            holder.Access([this](const auto &info) {
+                if (IsGood(info)) {
+                    Add(info);
+                }
+            });
         });
-    });
 
     obj.AddObject(
         Object::UniqueName(),


### PR DESCRIPTION
This PR fixes the indentation of lambda bodies in cases similar to the following:
```
a([]() {
        b();
    });
```

Previously, the above would have been indented like this:
```
a([]() {
    b();
});
```
which is inconsistent with how an almost identical expression is and was indented instead (you would've put `);` below `}` to trigger the correct lambda body indentation):
```
a([]() {
        b();
    }
);
```

Please notice that some indents are still wrong (see tests/expected/cpp/60055-issue_3116.cpp:151 or tests/expected/cpp/60056-issue_3116-2.cpp:3) but that is a different issue (#3752) that will be fixed in a separate PR.