### PR TITLE
Fix func proto with qualifier in OC

### DIFF
--- a/src/combine_tools.cpp
+++ b/src/combine_tools.cpp
@@ -150,6 +150,14 @@ bool can_be_full_param(Chunk *start, Chunk *end)
          }
          Chunk *tmp2 = tmp1->GetNextNcNnl(E_Scope::PREPROC);
 
+         if (tmp2->Is(CT_QUALIFIER))
+         {
+            // tmp2 is the "nullable" qualifier in this case:
+            // void (^nullable name)(params)
+            // skip the qualifier
+            tmp2 = tmp2->GetNextNcNnl(E_Scope::PREPROC);
+         }
+
          if (tmp2->IsNullChunk())
          {
             return(false);

--- a/tests/config/oc/3766.cfg
+++ b/tests/config/oc/3766.cfg
@@ -1,0 +1,3 @@
+sp_arith                        = force
+sp_before_ptr_star              = force
+sp_after_ptr_star               = remove

--- a/tests/expected/oc/50909-3766.m
+++ b/tests/expected/oc/50909-3766.m
@@ -1,0 +1,15 @@
+void test(NSString *param1, void (^_Nullable completionBlock)(int));
+
+void test(NSString *param1, void (^_Nullable completionBlock)(int));
+
+void test(void (^_Nullable completionBlock)(int), NSString *param1);
+
+void test(void (^_Nullable completionBlock)(int), NSString *param1, void (^_Nullable completionBlock)(int));
+
+void test(
+	void (^_Nullable completionBlock)(int),
+	NSString *param1,
+	void (^_Nullable completionBlock)(int)
+	);
+
+void test(NSString *param1, void (^_Nullable completionBlock)(NSString *, NSString *, void (^_Nullable completionBlock2)(int)));

--- a/tests/input/oc/3766.m
+++ b/tests/input/oc/3766.m
@@ -1,0 +1,15 @@
+void test(NSString *             param1, void (^_Nullable completionBlock)(int));
+
+void test(NSString * param1, void (^_Nullable completionBlock)(int));
+
+void test(void (^_Nullable completionBlock)(int), NSString *param1);
+
+void test(void (^_Nullable completionBlock)(int), NSString *param1, void (^_Nullable completionBlock)(int));
+
+void test(
+	void (^_Nullable completionBlock)(int),
+	NSString * param1,
+	void (^_Nullable completionBlock)(int)
+	);
+
+void test(NSString *param1, void (^_Nullable completionBlock)(NSString *, NSString *, void (^_Nullable completionBlock2)(int)));

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -175,6 +175,7 @@
 
 50907  oc/align_colon_with_ternary_1.cfg        oc/align_colon_with_ternary_1.m
 50908  oc/align_colon_with_ternary_2.cfg        oc/align_colon_with_ternary_2.m
+50909  oc/3766.cfg                              oc/3766.m
 
 # test the options sp_ with the value "ignore"
 51000  oc/sp_cond_ternary_short.cfg             oc/sp_cond_ternary_short.m


### PR DESCRIPTION
This PR fixes #3766 

Similar issue to #2656, but with qualifiers. See example below:

cfg file
```
sp_arith                        = force
```

input
```
void test(NSString *param1, void (^_Nullable completionBlock)(int));
```

output
```
void test(NSString * param1, void (^_Nullable completionBlock)(int));
```

The * is being detected incorrectly as ARITH.