### PR TITLE
Ensure that switch statements inside lambdas are indented correctly

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1905,7 +1905,8 @@ void indent_text()
 
             frm.prev().indent_tmp = frm.top().indent_tmp;
          }
-         else if (frm.paren_count != 0)
+         else if (  frm.paren_count != 0
+                 && !pc->TestFlags(PCF_IN_LAMBDA)) // Issue #3761
          {
             if (frm.top().pc->GetParentType() == CT_OC_BLOCK_EXPR)
             {

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -1112,3 +1112,4 @@
 60085  cpp/Issue_3576-b.cfg                                 cpp/Issue_3576.h
 60086  cpp/indent_namespace_inner_only.cfg                  cpp/indent_namespace_inner_only.h
 60087  cpp/Issue_3550.cfg                                   cpp/Issue_3550.cpp
+60088  common/empty.cfg                                     cpp/Issue_3761.cpp

--- a/tests/expected/cpp/60088-Issue_3761.cpp
+++ b/tests/expected/cpp/60088-Issue_3761.cpp
@@ -1,0 +1,14 @@
+void f(void (*g)())
+{
+}
+
+int main()
+{
+	f([]() {
+		int x = 1;
+		switch (x) {
+		case 1:
+			break;
+		}
+	});
+}

--- a/tests/input/cpp/Issue_3761.cpp
+++ b/tests/input/cpp/Issue_3761.cpp
@@ -1,0 +1,14 @@
+void f(void (*g)())
+{
+}
+
+int main()
+{
+	f([]() {
+		int x = 1;
+		switch (x) {
+		case 1:
+			break;
+		}
+	});
+}


### PR DESCRIPTION
Fixes #3761

I am not sure that this solution is entirely correct, but it's probably an improvement over the status quo.