### PR TITLE
Keep vars with '[]' types in variable blocks

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -2082,6 +2082,11 @@ static Chunk *newline_def_blk(Chunk *start, bool fn_top)
             next = next->GetNextNcNnl();
          }
 
+         while (next->Is(CT_TSQUARE))
+         {
+            next = next->GetNextNcNnl();
+         }
+
          if (next->IsNullChunk())
          {
             break;

--- a/tests/expected/d/40000-HashMap.d
+++ b/tests/expected/d/40000-HashMap.d
@@ -547,10 +547,11 @@ class HashMap
                 rehash();
 
             HashEntry[] tab;
+
             volatile tab = table;
-            uint        index = hash & (tab.length - 1);
-            HashEntry   first = tab[index];
-            HashEntry   e     = first;
+            uint      index = hash & (tab.length - 1);
+            HashEntry first = tab[index];
+            HashEntry e     = first;
 
             while (e && (e.hash != hash || !matchKey(key, e.key)))
                 e = e.next;
@@ -600,8 +601,9 @@ class HashMap
              */
 
             HashEntry[] newTable = new HashEntry[oldCapacity << 1];
+
             threshold = cast(int)(newTable.length * loadFactor);
-            int         sizeMask = newTable.length - 1;
+            int sizeMask = newTable.length - 1;
 
             for (int i = 0; i < oldCapacity; ++i)
             {
@@ -655,7 +657,6 @@ class HashMap
         final synchronized V remove(K key, uint hash, V value)
         {
             int         c;
-
             HashEntry[] tab;
 
             volatile c = count - 1;
@@ -701,6 +702,7 @@ class HashMap
             if (count)
             {
                 HashEntry[] tab;
+
                 volatile tab = table;
 
                 for (int i = 0; i < tab.length; i++)
@@ -987,6 +989,7 @@ class HashMap
         while (iterator.hasNext)
         {
             char[] ca = cast(char[])iterator.next;
+
             if ((result = dg(ca)) != 0)
                 break;
         }
@@ -1007,8 +1010,8 @@ class HashMap
         while (iterator.hasNext)
         {
             HashEntry he = iterator.nextElement;
-
             char[]    ca = cast(char[])he.key;
+
             if ((result = dg(ca, he.value)) != 0)
                 break;
         }
@@ -1022,7 +1025,6 @@ class HashMap
     {
         int         nextSegmentIndex;
         int         nextTableIndex;
-
         HashEntry[] currentTable;
         HashEntry   nextEntry;
         HashEntry   lastReturned;

--- a/tests/expected/d/40006-Lexer.d
+++ b/tests/expected/d/40006-Lexer.d
@@ -157,6 +157,7 @@ class Lexer
     static char[] combineComments(char[] c1, char[] c2)
     {
         char[] c = c2;
+
         if (c1.length)
         {
             c = c1;
@@ -471,6 +472,7 @@ class Lexer
 
 //					sv = stringtable.update((char *)t.ptr, p - t.ptr);
                     char[] tmp;
+
                     tmp.length = p - t.ptr;
                     memcpy(tmp.ptr, t.ptr, p - t.ptr);
                     Identifier id;
@@ -2179,7 +2181,6 @@ class Lexer
     {
         Token  tok;
         int    linnum;
-
         char[] filespec;
         Loc    loc = this.loc;
 

--- a/tests/expected/d/40007-Lexer.d
+++ b/tests/expected/d/40007-Lexer.d
@@ -2099,7 +2099,6 @@ done:
     void Pragma() {
         Token  tok;
         int    linnum;
-
         char[] filespec;
         Loc    loc = this.loc;
 

--- a/tests/expected/d/40051-numbers.d
+++ b/tests/expected/d/40051-numbers.d
@@ -42,5 +42,6 @@ int foo(int bar)
 void main()
 {
     char[] c = "kkkkkkkkkkkkkkkkkkkkk";
+
     writefln("%s", c[2 .. 3]);
 }


### PR DESCRIPTION
Variable definitions which have square braces in their types are not parsed as being variable definitions for purposes of newline addition.

For example, ```char[] ca = cast(char[])iterator.next;``` would not be considered a variable definition, and ```nl_var_def_blk_end``` would not handle it correctly.

For another example:
```
         Token  tok;
         int    linnum;
         char[] filespec;
         Loc    loc = this.loc;
```
would be considered 2 different variable definition blocks.