### PR TITLE
Stop indent_ignore_asm_block indenting pp lines

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2613,8 +2613,11 @@ void indent_text()
 
          do
          {
-            pc->column = pc->orig_col + move;
-            pc         = pc->GetNext();
+            if (!pc->TestFlags(PCF_IN_PREPROC))
+            {
+               pc->column = pc->orig_col + move;
+            }
+            pc = pc->GetNext();
          } while (pc != tmp);
 
          reindent_line(pc, indent_column);

--- a/tests/config/cpp/asm_block_pp.cfg
+++ b/tests/config/cpp/asm_block_pp.cfg
@@ -1,0 +1,2 @@
+indent_columns                  = 8
+indent_ignore_asm_block         = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -931,6 +931,8 @@
 34360  cpp/nl_before_struct.cfg                             cpp/nl_before_struct_struct.cpp
 34361  cpp/nl_before_struct.cfg                             cpp/nl_before_struct_scoped_enum.cpp
 
+34370  cpp/asm_block_pp.cfg                                 cpp/asm_block_pp.cpp
+
 # test the options sp_ with the value "ignore"
 34500  cpp/sp_before_case_colon.cfg                         cpp/sp_before_case_colon.cpp
 34501  cpp/sp_endif_cmt.cfg                                 cpp/sp_endif_cmt.cpp

--- a/tests/expected/cpp/34370-asm_block_pp.cpp
+++ b/tests/expected/cpp/34370-asm_block_pp.cpp
@@ -1,0 +1,20 @@
+
+void add128( uint64_t & rlo, uint64_t & rhi, uint64_t addlo ) {
+#if defined(HAVE_X86_64_ASM)
+	__asm__ ("addq %2, %0\n"
+                 "adcq $0, %1\n"
+#if defined(__clang__)
+	           // clang cannot work properly with "g" and silently
+	           // produces hardly-workging code, if "g" is specified;
+                 : "+r" (rlo), "+r" (rhi)
+                 : "m" (addlo)
+#else
+                 : "+g" (rlo), "+g" (rhi)
+                 : "g" (addlo)
+#endif
+        );
+#else
+	rlo += addlo;
+	rhi += (rlo < addlo);
+#endif
+}

--- a/tests/input/cpp/asm_block_pp.cpp
+++ b/tests/input/cpp/asm_block_pp.cpp
@@ -1,0 +1,20 @@
+
+void add128( uint64_t & rlo, uint64_t & rhi, uint64_t addlo ) {
+#if defined(HAVE_X86_64_ASM)
+  __asm__ ("addq %2, %0\n"
+           "adcq $0, %1\n"
+#if defined(__clang__)
+             // clang cannot work properly with "g" and silently
+             // produces hardly-workging code, if "g" is specified;
+           : "+r" (rlo), "+r" (rhi)
+           : "m" (addlo)
+#else
+           : "+g" (rlo), "+g" (rhi)
+           : "g" (addlo)
+#endif
+    );
+#else
+    rlo += addlo;
+    rhi += (rlo < addlo);
+#endif
+}


### PR DESCRIPTION
When asm blocks are indented as code and indent_ignore_asm_block is true, then
preprocessor lines inside the asm block are indented along with the asm body.