### PR TITLE
Stop altering spaces when nl cont disabled

### DIFF
--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -1984,7 +1984,7 @@ static bool parse_macro(tok_ctx &ctx, Chunk &pc, const Chunk *prev_pc)
                && nl))
          && pc.str.size() > 0)
       {
-         pc.SetType(CT_IGNORED);
+         pc.SetType(CT_PP_IGNORE);
          return(true);
       }
       else if (nl)

--- a/tests/config/cpp/disable_nl_cont.cfg
+++ b/tests/config/cpp/disable_nl_cont.cfg
@@ -3,4 +3,4 @@ sp_compare                    = force
 sp_assign                     = force
 sp_arith                      = force
 indent_class                  = true
-sp_before_nl_cont             = ignore
+sp_before_nl_cont             = add


### PR DESCRIPTION
If ```disable_processing_nl_cont=true``` and ```sp_before_nl_cont=add```, then spaces will be
added before continuation characters regardless. Furthermore, every loop through
```do_space()``` will add another one, so in some unlucky cases this will lead to hilarious diffs like:

```diff
-#define HASH_FLAGS                                     \
+#define HASH_FLAGS                                                                                                 \
```