### PR TITLE
Remove unnecessary pp_space_before option.

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -3310,10 +3310,7 @@ pp_indent_count                 = 1        # unsigned number
 # Add or remove space after # based on pp_level of #if blocks.
 pp_space_after                  = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space before # based on pp_level of #if blocks.
-pp_space_before                 = ignore   # ignore/add/remove/force/not_defined
-
-# Sets the number of spaces per level added with pp_space_after and pp_space_before.
+# Sets the number of spaces per level added with pp_space_after.
 pp_space_count                  = 0        # unsigned number
 
 # The indent for '#region' and '#endregion' in C# and '#pragma region' in

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -3310,10 +3310,7 @@ pp_indent_count                 = 1        # unsigned number
 # Add or remove space after # based on pp_level of #if blocks.
 pp_space_after                  = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space before # based on pp_level of #if blocks.
-pp_space_before                 = ignore   # ignore/add/remove/force/not_defined
-
-# Sets the number of spaces per level added with pp_space_after and pp_space_before.
+# Sets the number of spaces per level added with pp_space_after.
 pp_space_count                  = 0        # unsigned number
 
 # The indent for '#region' and '#endregion' in C# and '#pragma region' in

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -3310,10 +3310,7 @@ pp_indent_count                 = 1        # unsigned number
 # Add or remove space after # based on pp_level of #if blocks.
 pp_space_after                  = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space before # based on pp_level of #if blocks.
-pp_space_before                 = ignore   # ignore/add/remove/force/not_defined
-
-# Sets the number of spaces per level added with pp_space_after and pp_space_before.
+# Sets the number of spaces per level added with pp_space_after.
 pp_space_count                  = 0        # unsigned number
 
 # The indent for '#region' and '#endregion' in C# and '#pragma region' in

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -7089,18 +7089,9 @@ Choices=pp_space_after=ignore|pp_space_after=add|pp_space_after=remove|pp_space_
 ChoicesReadable="(793)Ignore Pp Space After|(793)Add Pp Space After|(793)Remove Pp Space After|(793)Force Pp Space After"
 ValueDefault=ignore
 
-[Pp Space Before]
-Category=10
-Description="<html>(794)Add or remove space before # based on pp_level of #if blocks.</html>"
-Enabled=false
-EditorType=multiple
-Choices=pp_space_before=ignore|pp_space_before=add|pp_space_before=remove|pp_space_before=force|pp_space_before=not_defined
-ChoicesReadable="(794)Ignore Pp Space Before|(794)Add Pp Space Before|(794)Remove Pp Space Before|(794)Force Pp Space Before"
-ValueDefault=ignore
-
 [Pp Space Count]
 Category=10
-Description="<html>(795)Sets the number of spaces per level added with pp_space_after and pp_space_before.</html>"
+Description="<html>(795)Sets the number of spaces per level added with pp_space_after.</html>"
 Enabled=false
 EditorType=numeric
 CallName="pp_space_count="

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -4720,34 +4720,15 @@ void indent_preproc()
                               ? pc->pp_level - pp_level_sub : 0;
 
       // Adjust the indent of the '#'
-      log_rule_B("pp_indent");
-
       if (options::pp_indent() & IARF_ADD)
       {
-         log_rule_B("pp_indent_count");
+         log_rule_B("pp_indent ADD");
          reindent_line(pc, 1 + pp_level * options::pp_indent_count());
       }
       else if (options::pp_indent() & IARF_REMOVE)
       {
-         log_rule_B("pp_indent");
+         log_rule_B("pp_indent REMOVE");
          reindent_line(pc, 1);
-      }
-      // Add spacing by adjusting the length
-      log_rule_B("pp_space_before");
-
-      if (options::pp_space_before() != IARF_IGNORE)
-      {
-         if (options::pp_space_before() & IARF_ADD)
-         {
-            log_rule_B("pp_space_before ADD");
-            const size_t mult = max<size_t>(options::pp_space_count(), 1);
-            reindent_line(pc, 1 + pp_level * mult);
-         }
-         else if (options::pp_space_before() & IARF_REMOVE)
-         {
-            log_rule_B("pp_space_before REMOVE");
-            reindent_line(pc, pc->column);
-         }
       }
       // Add spacing by adjusting the length
       log_rule_B("pp_space_after");
@@ -4758,8 +4739,7 @@ void indent_preproc()
          if (options::pp_space_after() & IARF_ADD)
          {
             log_rule_B("pp_space_after ADD");
-            // Issue #3055
-            const size_t mult = max<size_t>(options::pp_space_count(), 1);
+            const size_t mult = options::pp_space_count();
             reindent_line(next, pc->column + pc->Len() + (pp_level * mult));
          }
          else if (options::pp_space_after() & IARF_REMOVE)

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -395,9 +395,18 @@ bool process_option_line_compat_0_75(const std::string &cmd, const char *filenam
    if (cmd == "pp_space")
    {
       OptionWarning w{ filename, OptionWarning::MINOR };
-      w("option '%s' is deprecated; it has been replaced by '%s'.\n"
-        "You can also use '%s' for additional functionality",
-        cmd.c_str(), options::pp_space_after.name(), options::pp_space_before.name());
+      w("option '%s' is deprecated; it has been replaced by '%s'.",
+        cmd.c_str(), options::pp_space_after.name());
+
+      return(true);
+   }
+
+   if (cmd == "pp_space_before")
+   {
+      OptionWarning w{ filename, OptionWarning::MINOR };
+      w("option '%s' is deprecated; it was a temporary option used\n"
+        "during the development of version 0.76. Use '%s' and '%s' instead.",
+        cmd.c_str(), options::pp_indent.name(), options::pp_indent_count.name());
 
       return(true);
    }

--- a/src/options.h
+++ b/src/options.h
@@ -4043,11 +4043,7 @@ pp_indent_count; // = 1
 extern Option<iarf_e>
 pp_space_after;
 
-// Add or remove space before # based on pp_level of #if blocks.
-extern Option<iarf_e>
-pp_space_before;
-
-// Sets the number of spaces per level added with pp_space_after and pp_space_before.
+// Sets the number of spaces per level added with pp_space_after.
 extern BoundedOption<unsigned, 0, 16>
 pp_space_count;
 

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -338,9 +338,9 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
    if (second->Is(CT_PREPROC))
    {
       // Remove spaces, unless we are ignoring. See indent_preproc()
-      log_rule("pp_space_before");
+      log_rule("pp_indent");
 
-      if (options::pp_space_before() == IARF_IGNORE)
+      if (options::pp_indent() == IARF_IGNORE)
       {
          log_rule("IGNORE");
          return(IARF_IGNORE);

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -7089,18 +7089,9 @@ Choices=pp_space_after=ignore|pp_space_after=add|pp_space_after=remove|pp_space_
 ChoicesReadable="Ignore Pp Space After|Add Pp Space After|Remove Pp Space After|Force Pp Space After"
 ValueDefault=ignore
 
-[Pp Space Before]
-Category=10
-Description="<html>Add or remove space before # based on pp_level of #if blocks.</html>"
-Enabled=false
-EditorType=multiple
-Choices=pp_space_before=ignore|pp_space_before=add|pp_space_before=remove|pp_space_before=force|pp_space_before=not_defined
-ChoicesReadable="Ignore Pp Space Before|Add Pp Space Before|Remove Pp Space Before|Force Pp Space Before"
-ValueDefault=ignore
-
 [Pp Space Count]
 Category=10
-Description="<html>Sets the number of spaces per level added with pp_space_after and pp_space_before.</html>"
+Description="<html>Sets the number of spaces per level added with pp_space_after.</html>"
 Enabled=false
 EditorType=numeric
 CallName="pp_space_count="

--- a/tests/config/c/pp_space_after.cfg
+++ b/tests/config/c/pp_space_after.cfg
@@ -1,2 +1,3 @@
+pp_indent       = remove
 pp_space_after  = force
-pp_space_before = remove
+pp_space_count  = 1

--- a/tests/config/c/pp_space_before.cfg
+++ b/tests/config/c/pp_space_before.cfg
@@ -1,2 +1,3 @@
+pp_indent       = force
+pp_indent_count = 1
 pp_space_after  = remove
-pp_space_before = force

--- a/tests/config/c/pp_space_before_after.cfg
+++ b/tests/config/c/pp_space_before_after.cfg
@@ -1,2 +1,4 @@
+pp_indent       = force
+pp_indent_count = 1
 pp_space_after  = force
-pp_space_before = force
+pp_space_count  = 1

--- a/tests/config/c/pp_space_none.cfg
+++ b/tests/config/c/pp_space_none.cfg
@@ -1,2 +1,2 @@
+pp_indent       = remove
 pp_space_after  = remove
-pp_space_before = remove


### PR DESCRIPTION
1. PR # 3749 introduced the option pp_space_before. This is not needed, since pp_indent was already doing the exact same thing. This PR removes such option.

2. Using pp_space_after = force and pp_space_count = 0 was actually using a count of 1 for each level. This has now been fixed: the actual value of pp_space_count is used in all cases.
