### PR TITLE
Fix typo in log_rule_B statement

### DIFF
--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -2176,7 +2176,7 @@ void uncrustify_file(const file_mem &fm, FILE *pfout, const char *parsed_file,
          change_int_types();
       }
       // Remove duplicate include
-      log_rule_B("mod_duplicate_include");
+      log_rule_B("mod_remove_duplicate_include");
 
       if (options::mod_remove_duplicate_include())
       {


### PR DESCRIPTION
This makes the logged rule name match the real rule name for
"mod_remove_duplicate_include".