### PR TITLE
Makes mod_full_brace_if keep commented one liners

### DIFF
--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -875,11 +875,13 @@ static void convert_vbrace(Chunk *vbr)
       /*
        * If the next chunk is a comment, followed by a newline, then
        * move the brace after the newline and add another newline after
-       * the close brace.
+       * the close brace, unless we're keeping a one-liner.
        */
       Chunk *tmp = vbr->GetNext();
 
-      if (tmp->IsComment())
+      if (  tmp->IsComment()
+         && (  !vbr->TestFlags(PCF_ONE_LINER)
+            || !options::nl_if_leave_one_liners()))
       {
          tmp = tmp->GetNext();
 

--- a/tests/c.test
+++ b/tests/c.test
@@ -405,6 +405,7 @@
 09620  c/Issue_2640.cfg                           c/Issue_2640.c
 09621  c/preproc-cleanup.cfg                      c/pp-before-func-def.c
 09622  c/Issue_3356.cfg                           c/Issue_3356.c
+09623  c/convert_cmt_vbrace_one_line.cfg          c/vbrace_one_liner.c
 
 10004  c/ben_094.cfg                              c/pragma_asm.c
 10005  common/empty.cfg                           c/i1270.c

--- a/tests/config/c/convert_cmt_vbrace_one_line.cfg
+++ b/tests/config/c/convert_cmt_vbrace_one_line.cfg
@@ -1,0 +1,4 @@
+mod_full_brace_if      = add
+nl_after_brace_open    = true
+nl_if_leave_one_liners = true
+sp_inside_braces       = add

--- a/tests/expected/c/09623-vbrace_one_liner.c
+++ b/tests/expected/c/09623-vbrace_one_liner.c
@@ -1,0 +1,9 @@
+unsigned a;
+
+int foo(void) {
+	if (a == 1) { printf("It's 1\n"); }
+}
+
+int bar(void) {
+	if (a == 2) { printf("It's 2\n"); } /* comment */
+}

--- a/tests/input/c/vbrace_one_liner.c
+++ b/tests/input/c/vbrace_one_liner.c
@@ -1,0 +1,9 @@
+unsigned a;
+
+int foo(void) {
+    if (a == 1) printf("It's 1\n");
+}
+
+int bar(void) {
+    if (a == 2) printf("It's 2\n");  /* comment */
+}


### PR DESCRIPTION
If `mod_full_brace_if = add` and an unbraced `if()` statement has a trailing comment,
then the added brace will be on a new line after the comment. However, this is true
even when `nl_if_leave_one_liners = true`.

This change will keep the added brace on the same line as the `if()`, before the
comment, if it was a one-liner that was configured to be left.

Without this patch, the result looks like:
```cpp
unsigned a;

int foo(void) {
        if (a == 1) { printf("It's 1\n"); }
}

int bar(void) {
        if (a == 2) { printf("It's 2\n"); /* comment */
        }
}
```