### PR TITLE
Prevents adding duplicate long class comments

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -4702,7 +4702,25 @@ void newlines_cleanup_braces(bool first)
 
             if (options::nl_after_class() > 0)
             {
-               newline_iarf(pc, IARF_ADD);
+               /*
+                * If there is already a "class" comment, then don't add a newline if
+                * one exists after the comment. or else this will interfere with the
+                * mod_add_long_class_closebrace_comment option.
+                */
+               iarf_e mode  = IARF_ADD;
+               Chunk  *next = pc->GetNext();
+
+               if (next->IsComment())
+               {
+                  pc   = next;
+                  next = pc->GetNext();
+
+                  if (next->IsNewline())
+                  {
+                     mode = IARF_IGNORE;
+                  }
+               }
+               newline_iarf(pc, mode);
             }
          }
       }

--- a/tests/config/cpp/mod_add_long_class_closebrace_comment.cfg
+++ b/tests/config/cpp/mod_add_long_class_closebrace_comment.cfg
@@ -1,0 +1,2 @@
+mod_add_long_class_closebrace_comment = 1
+nl_after_class                        = 1

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -857,6 +857,7 @@
 # TODO: Find relevant test cases for 'override'.
 34210  common/empty.cfg                                     cpp/override_virtual.cpp
 34211  cpp/anonymous_enum.cfg                               cpp/anonymous_enum.cpp
+34212  cpp/mod_add_long_class_closebrace_comment.cfg        cpp/func_class.h
 
 34250  common/empty.cfg                                     cpp/bug_1607.cpp
 34251  cpp/bug_1649.cfg                                     cpp/bug_1649.cpp

--- a/tests/expected/cpp/34212-func_class.h
+++ b/tests/expected/cpp/34212-func_class.h
@@ -1,0 +1,16 @@
+void MD5::reverse_u32(UINT8 *buf, int n_u32);
+
+MD5::MD5();
+
+class AlignStack
+{
+public:
+bool m_skip_first;
+
+AlignStack();
+
+
+~AlignStack();
+
+void End();
+}; // class AlignStack


### PR DESCRIPTION
If `mod_add_long_class_closebrace_comment` is enabled together with `nl_after_class`,
then the added newline will mean that the added class comment will not be detected on
a re-run of uncrustify, and it will add a second class comment. This will look like:
```cpp
class FooClass {
}; // class FooClass
   // class FooClass
```
and the `ctest` failure will look like:
```
1/1 Test #3: cpp ..............................***Failed   46.86 sec
Tests: ['cpp']
Processing /home/fwojcik/progs/uncrustify/tests/cpp.test
diff --git a/home/fwojcik/progs/uncrustify/tests/expected/cpp/34212-func_class.h b/home/fwojcik/progs/uncrustify/build/tests/results_2/cpp/34212-func_class.h
index 2035b634..34a6db29 100644
--- a/home/fwojcik/progs/uncrustify/tests/expected/cpp/34212-func_class.h
+++ b/home/fwojcik/progs/uncrustify/build/tests/results_2/cpp/34212-func_class.h
@@ -14,3 +14,4 @@ AlignStack();
 
 void End();
 }; // class AlignStack
+   // class AlignStack
UNSTABLE: cpp:34212 (re-run)
949 / 950 tests passed
1 tests were unstableu
```