### PR TITLE
Fix trailing cmt alignment when braces move

### DIFF
--- a/src/align_trailing_comments.cpp
+++ b/src/align_trailing_comments.cpp
@@ -185,14 +185,12 @@ void align_right_comments()
       {
          if (pc->GetParentType() == CT_COMMENT_END)
          {
-            Chunk *prev = pc->GetPrev();
-
             log_rule_B("align_right_cmt_gap");
 
-            if (pc->orig_col < prev->orig_col_end + options::align_right_cmt_gap())
+            if (pc->orig_prev_sp < options::align_right_cmt_gap())
             {
-               LOG_FMT(LALTC, "NOT changing END comment on line %zu (%zu <= %zu + %u)\n",
-                       pc->orig_line, pc->orig_col, prev->orig_col_end,
+               LOG_FMT(LALTC, "NOT changing END comment on line %zu (%u < %u)\n",
+                       pc->orig_line, pc->orig_prev_sp,
                        options::align_right_cmt_gap());
             }
             else

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -274,7 +274,7 @@ void align_to_column(Chunk *pc, size_t column)
       else if (almod == align_mode_e::KEEP_REL)
       {
          // Keep same relative column
-         auto orig_delta = static_cast<int>(pc->orig_col) - static_cast<int>(prev->orig_col);
+         int orig_delta = static_cast<int>(pc->orig_prev_sp) + static_cast<int>(prev->Len());
          orig_delta = max<int>(orig_delta, min_delta);  // keeps orig_delta positive
 
          pc->column = prev->column + static_cast<size_t>(orig_delta);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -750,7 +750,7 @@ void output_text(FILE *pfile)
                      && prev->IsNotNullChunk()
                      && prev->nl_count == 0)
                   {
-                     int orig_sp = (pc->orig_col - prev->orig_col_end);
+                     int orig_sp = pc->orig_prev_sp;
 
                      if ((int)(cpd.column + orig_sp) < 0)
                      {

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -1797,6 +1797,7 @@ static bool parse_whitespace(tok_ctx &ctx, Chunk &pc)
    while (  ctx.more()
          && unc_isspace(ctx.peek()))
    {
+      int lastcol = ctx.c.col;
       ch = ctx.get();   // throw away the whitespace char
 
       switch (ch)
@@ -1825,8 +1826,7 @@ static bool parse_whitespace(tok_ctx &ctx, Chunk &pc)
          break;
 
       case '\t':
-         log_rule_B("input_tab_size");
-         pc.orig_prev_sp += calc_next_tab_column(cpd.column, options::input_tab_size()) - cpd.column;
+         pc.orig_prev_sp += ctx.c.col - lastcol;
          break;
 
       case ' ':
@@ -2732,6 +2732,9 @@ void tokenize(const deque<int> &data, Chunk *ref)
       }
       // Store off the end column
       chunk.orig_col_end = ctx.c.col - num_stripped; // Issue #1966 and #3565
+
+      // Make the whitespace we disposed of be attributed to the next chunk
+      prev_sp = num_stripped;
 
       // Add the chunk to the list
       rprev = pc;

--- a/tests/c.test
+++ b/tests/c.test
@@ -193,6 +193,8 @@
 00468  c/align_func_proto_star_amp-8.cfg          c/align_func_proto_star_amp.h
 00469  c/align_func_proto_star_amp-9.cfg          c/align_func_proto_star_amp.h
 
+00470  c/align_trailing_do_cmt.cfg                c/align_trailing_do_cmt.c
+
 # boolean and comma positioning
 
 00501  c/bool-pos-eol.cfg                         c/bool-pos.c

--- a/tests/config/c/align_trailing_do_cmt.cfg
+++ b/tests/config/c/align_trailing_do_cmt.cfg
@@ -1,0 +1,6 @@
+align_right_cmt_span = 10
+nl_brace_while       = remove
+nl_do_brace          = remove
+sp_do_brace_open     = add
+sp_brace_close_while = add
+sp_while_paren_open  = add

--- a/tests/expected/c/00470-align_trailing_do_cmt.c
+++ b/tests/expected/c/00470-align_trailing_do_cmt.c
@@ -1,0 +1,10 @@
+int foo(void) {
+	int r;
+	do { // this comment should be aligned with the one below
+		r = bar();
+	} while (r);
+
+	do { // this comment should be aligned with the one above
+		r = baz();
+	} while (r);
+}

--- a/tests/input/c/align_trailing_do_cmt.c
+++ b/tests/input/c/align_trailing_do_cmt.c
@@ -1,0 +1,14 @@
+int foo(void) {
+    int r;
+    do // this comment should be aligned with the one below
+    {
+        r = bar();
+    }
+    while (r);
+
+    do            // this comment should be aligned with the one above
+    {
+        r = baz();
+    }
+    while (r);
+}


### PR DESCRIPTION
If a newline is deleted before a brace, the brace may move to be before a comment
which was on the previous line. For example: `do //comment\n{` may become
`do { //comment`. This breaks the existing logic for aligning comments.

This change skips over any tokens that are currently earlier in the line than a to-be-aligned comment, but are originally from later lines. In this way, `prev` will point to the previous token from the same original line, and so accurate original spacing can be determined.

Without this change, the included test case fails like:
```
 2/14 Test  #2: c ................................***Failed   30.76 sec
Tests: ['c']
Processing /home/fwojcik/progs/uncrustify/tests/c.test
diff --git a/home/fwojcik/progs/uncrustify/tests/expected/c/00470-align_trailing_do_cmt.c b/home/fwojcik/progs/uncrustify/build/tests/results/c/00470-align_trailing_do_cmt.c
index 7c21b3d9..453ba441 100644
--- a/home/fwojcik/progs/uncrustify/tests/expected/c/00470-align_trailing_do_cmt.c
+++ b/home/fwojcik/progs/uncrustify/build/tests/results/c/00470-align_trailing_do_cmt.c
@@ -4,7 +4,7 @@ int foo(void) {
                r = bar();
        } while (r);
 
-       do { // this comment should be aligned with the one above
+       do {      // this comment should be aligned with the one above
                r = baz();
        } while (r);
 }
MISMATCH: c:00470
389 / 390 tests passed
1 tests did not match the expected outputm
```

I feel like this change is a little _too_ targeted and special-case; my instinct is that a more general fix would be better so that when braces are moved it won't break other options also, not just comment-aligning. However, when I tried a patch like:
```diff
diff --git a/src/newlines.cpp b/src/newlines.cpp
index f9eb105c..9854005b 100644
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -874,7 +874,18 @@ void newline_del_between(Chunk *start, Chunk *end)
          || start->Is(CT_DO)
          || start->Is(CT_ELSE)))
    {
+      // move the brace to be just after start; this adjusts its orig_col* variables
       end->MoveAfter(start);
+      // bump out the orig_col* variables for the remaining chunks on this line
+      size_t delta = end->orig_col_end - start->orig_col_end;
+      pc = end->GetNext();
+      while (  !pc->IsNewline()
+            && (pc->orig_line == start->orig_line))
+      {
+          pc->orig_col     += delta;
+          pc->orig_col_end += delta;
+          pc                = pc->GetNext();
+      }
    }
 } // newline_del_between
 ```
many things broke in the unit tests. So maybe this patch is OK?