### PR TITLE
Fix newline handling in align_assign()

### DIFF
--- a/tests/c.test
+++ b/tests/c.test
@@ -371,6 +371,7 @@
 #02503  ger.cfg                                    c/pp_concat_asn1.h
 
 02504  c/align_keep_extra.cfg                     c/align_keep_extra.c
+02505  c/align_multi.cfg                          c/align_assigns.c
 
 02510  c/ben_093.cfg                              c/asm.c
 

--- a/tests/config/c/align_multi.cfg
+++ b/tests/config/c/align_multi.cfg
@@ -1,0 +1,2 @@
+align_assign_span              = 3
+align_assign_on_multi_var_defs = true

--- a/tests/expected/c/02505-align_assigns.c
+++ b/tests/expected/c/02505-align_assigns.c
@@ -1,0 +1,43 @@
+unsigned foo(unsigned in1, unsigned in2, unsigned in3, unsigned in4) {
+	unsigned a     = 0xa;
+	unsigned b     = 0xb;
+	unsigned c     = 0xc;
+	unsigned x[10] = {0};
+	{
+		unsigned xyz = (
+			1
+			+
+			2
+			+
+			3
+			+
+			4
+			+
+			5
+			);
+	}
+	unsigned r1       = in1 * in3;
+	unsigned r2first  = in1 * in4;
+	unsigned r2second = in2 * in3;
+	unsigned r3       = in2 * in4;
+
+	a            ^=
+		b; c += d;
+
+
+
+	a             += (
+		b); c += d;
+
+
+
+	a             += x[
+		0]; c += d;
+
+
+
+	a    += b; {
+	}; c += d;
+
+	return r1 * r2first + r3 * r2second + a * b + c;
+}

--- a/tests/input/c/align_assigns.c
+++ b/tests/input/c/align_assigns.c
@@ -1,0 +1,43 @@
+unsigned foo(unsigned in1, unsigned in2, unsigned in3, unsigned in4) {
+    unsigned a = 0xa;
+    unsigned b   = 0xb;
+    unsigned c         = 0xc;
+    unsigned x[10] = {0};
+    {
+    unsigned xyz = (
+                    1
+                    +
+                    2
+                    +
+                    3
+                    +
+                    4
+                    +
+                    5
+                    );
+    }
+    unsigned r1 = in1 * in3;
+    unsigned r2first = in1 * in4;
+    unsigned r2second = in2 * in3;
+    unsigned r3 = in2 * in4;
+
+    a ^=
+    b; c += d;
+
+
+
+    a += (
+    b); c += d;
+
+
+
+    a += x[
+    0]; c += d;
+
+
+
+    a += b; {
+    }; c += d;
+
+    return r1 * r2first + r3 * r2second + a * b + c;
+}


### PR DESCRIPTION
This merges the 3 slightly-divergent copies of newline handling in `align_assign()` into a single copy. By doing that, the `var_def_cnt` and `equ_count` variables are tracked correctly across brace pairs and across "SPAREN, PAREN or SQUARE groups". This means the `align_assign_span` and `align_assign_on_multi_var_defs` settings no longer get thrown off if those structures appear in the code.

Without this fix, the unit test file below will have all of the '=' signs in the top-level variable definition lines be aligned, even though the span setting is greatly exceeded between `a`/`b`/`c`/`x[10]` and `r1`. Also, the multi-assignment lines will not be aligned as they should be:
```cpp
unsigned foo(unsigned in1, unsigned in2, unsigned in3, unsigned in4) {
	unsigned a        = 0xa;
	unsigned b        = 0xb;
	unsigned c        = 0xc;
	unsigned x[10]    = {0};
	{
		unsigned xyz = (
			1
			+
			2
			+
			3
			+
			4
			+
			5
			);
	}
	unsigned r1       = in1 * in3;
	unsigned r2first  = in1 * in4;
	unsigned xyzzy    = 123,
	         bar      = 444,
	         d        = 9;
	unsigned r2second = in2 * in3;
	unsigned r3       = in2 * in4;

	a            ^=
		b; c += d;



	a += (
		b); c += d;



	a += x[
		0]; c += d;



	a += b; {
	}; c += d;

	return r1 * r2first + r3 * r2second + a * b + c;
}
```