### PR TITLE
Fix typo in docs for indent_ternary_operator

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -1537,7 +1537,7 @@ indent_using_block              = true     # true/false
 # How to indent the continuation of ternary operator.
 #
 # 0: Off (default)
-# 1: When the `if_false` is a continuation, indent it under `if_false`
+# 1: When the `if_false` is a continuation, indent it under the `if_true` branch
 # 2: When the `:` is a continuation, indent it under `?`
 indent_ternary_operator         = 0        # unsigned number
 

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -1537,7 +1537,7 @@ indent_using_block              = true     # true/false
 # How to indent the continuation of ternary operator.
 #
 # 0: Off (default)
-# 1: When the `if_false` is a continuation, indent it under `if_false`
+# 1: When the `if_false` is a continuation, indent it under the `if_true` branch
 # 2: When the `:` is a continuation, indent it under `?`
 indent_ternary_operator         = 0        # unsigned number
 

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1537,7 +1537,7 @@ indent_using_block              = true     # true/false
 # How to indent the continuation of ternary operator.
 #
 # 0: Off (default)
-# 1: When the `if_false` is a continuation, indent it under `if_false`
+# 1: When the `if_false` is a continuation, indent it under the `if_true` branch
 # 2: When the `:` is a continuation, indent it under `?`
 indent_ternary_operator         = 0        # unsigned number
 

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -3339,7 +3339,7 @@ ValueDefault=true
 
 [Indent Ternary Operator]
 Category=2
-Description="<html>(374)How to indent the continuation of ternary operator.<br/><br/>0: Off (default)<br/>1: When the `if_false` is a continuation, indent it under `if_false`<br/>2: When the `:` is a continuation, indent it under `?`</html>"
+Description="<html>(374)How to indent the continuation of ternary operator.<br/><br/>0: Off (default)<br/>1: When the `if_false` is a continuation, indent it under the `if_true` branch<br/>2: When the `:` is a continuation, indent it under `?`</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_ternary_operator="

--- a/src/options.h
+++ b/src/options.h
@@ -1848,7 +1848,7 @@ indent_using_block; // = true
 // How to indent the continuation of ternary operator.
 //
 // 0: Off (default)
-// 1: When the `if_false` is a continuation, indent it under `if_false`
+// 1: When the `if_false` is a continuation, indent it under the `if_true` branch
 // 2: When the `:` is a continuation, indent it under `?`
 extern BoundedOption<unsigned, 0, 2>
 indent_ternary_operator;

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -3339,7 +3339,7 @@ ValueDefault=true
 
 [Indent Ternary Operator]
 Category=2
-Description="<html>How to indent the continuation of ternary operator.<br/><br/>0: Off (default)<br/>1: When the `if_false` is a continuation, indent it under `if_false`<br/>2: When the `:` is a continuation, indent it under `?`</html>"
+Description="<html>How to indent the continuation of ternary operator.<br/><br/>0: Off (default)<br/>1: When the `if_false` is a continuation, indent it under the `if_true` branch<br/>2: When the `:` is a continuation, indent it under `?`</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_ternary_operator="


### PR DESCRIPTION
This just more accurately describes what the '1' option does.