### PR TITLE
Fix parsing of a postfix incdec operator before a multiply

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1472,15 +1472,22 @@ void do_symbol_check(Chunk *prev, Chunk *pc, Chunk *next)
             log_flush(true);
             exit(EX_SOFTWARE);
          }
+         else if (  !prev->TestFlags(PCF_PUNCTUATOR)
+                 || prev->Is(CT_INCDEC_AFTER)
+                 || prev->Is(CT_SQUARE_CLOSE)
+                 || prev->Is(CT_DC_MEMBER)) // Issue 1402
+         {
+            pc->SetType(CT_ARITH);
+         }
+         else if (  !prev->IsParenClose()
+                 || prev->Is(CT_SPAREN_CLOSE)
+                 || prev->GetParentType() == CT_MACRO_FUNC)
+         {
+            pc->SetType(CT_DEREF);
+         }
          else
          {
-            // Issue 1402
-            pc->SetType((  prev->TestFlags(PCF_PUNCTUATOR)
-                        && (  !prev->IsParenClose()
-                           || prev->Is(CT_SPAREN_CLOSE)
-                           || prev->GetParentType() == CT_MACRO_FUNC)
-                        && prev->IsNot(CT_SQUARE_CLOSE)
-                        && prev->IsNot(CT_DC_MEMBER)) ? CT_DEREF : CT_ARITH);
+            pc->SetType(CT_ARITH);
          }
 
          if (pc->TestFlags(PCF_IN_TYPEDEF))  // Issue #1255/#633

--- a/tests/c.test
+++ b/tests/c.test
@@ -406,6 +406,7 @@
 09621  c/preproc-cleanup.cfg                      c/pp-before-func-def.c
 09622  c/Issue_3356.cfg                           c/Issue_3356.c
 
+10003  common/empty.cfg                           c/incdec_postfix_multiply.c
 10004  c/ben_094.cfg                              c/pragma_asm.c
 10005  common/empty.cfg                           c/i1270.c
 10006  c/bug_2331.cfg                             c/bug_2331.c

--- a/tests/expected/c/10003-incdec_postfix_multiply.c
+++ b/tests/expected/c/10003-incdec_postfix_multiply.c
@@ -1,0 +1,1 @@
+unsigned result = *var++ * int(0x1111);

--- a/tests/input/c/incdec_postfix_multiply.c
+++ b/tests/input/c/incdec_postfix_multiply.c
@@ -1,0 +1,1 @@
+unsigned result = *var++ * int(0x1111);


### PR DESCRIPTION
Without this fix, `result = *var++ * int(0x1111);` will have the second star parsed as `CT_DEREF` instead of the correct `CT_ARITH`.

The only functional change here is the addition of `prev->Is(CT_INCDEC_AFTER)`. The remainder is just a reformatting of the existing code so it is much easier to read.

I looked through the other C++ postfix operators and didn't see any other easy-to-add-and-test cases.