### PR TITLE
Fix align_assign* when multiple definitions are encountered

### DIFF
--- a/tests/c.test
+++ b/tests/c.test
@@ -374,6 +374,7 @@
 
 02504  c/align_keep_extra.cfg                     c/align_keep_extra.c
 02505  c/align_multi.cfg                          c/align_assigns.c
+02506  c/align-4.cfg                              c/align_assign_var_defs.c
 
 02510  c/ben_093.cfg                              c/asm.c
 

--- a/tests/config/c/align-4.cfg
+++ b/tests/config/c/align-4.cfg
@@ -1,0 +1,1 @@
+align_assign_span=2

--- a/tests/expected/c/02506-align_assign_var_defs.c
+++ b/tests/expected/c/02506-align_assign_var_defs.c
@@ -1,0 +1,9 @@
+int foo(void) {
+	unsigned a                = 123;
+	unsigned abcde            = 456;
+	unsigned abcdefghijklmnop = 789;
+	unsigned w, x, y, z;
+	unsigned u                = 16730;
+	unsigned vvvvv            = 4917;
+	unsigned wwwwwwwwww       = 12428;
+}

--- a/tests/input/c/align_assign_var_defs.c
+++ b/tests/input/c/align_assign_var_defs.c
@@ -1,0 +1,9 @@
+int foo(void) {
+    unsigned a = 123;
+    unsigned abcde = 456;
+    unsigned abcdefghijklmnop = 789;
+    unsigned w, x, y, z;
+    unsigned u = 16730;
+    unsigned vvvvv = 4917;
+    unsigned wwwwwwwwww = 12428;
+}


### PR DESCRIPTION
If assignment aligning is happening for a group of variable definition lines, and a line with multiple definitions is encountered, then align_assign.c will not align the most recent assignments before that line.

Without this fix, the unit test fails like:
```cpp
int foo(void) {
	unsigned a = 123;
	unsigned abcde = 456;
	unsigned abcdefghijklmnop = 789;
	unsigned w, x, y, z;
	unsigned u          = 16730;
	unsigned vvvvv      = 4917;
	unsigned wwwwwwwwww = 12428;
}
```