### PR TITLE
Adds sp_func_call_inside_fparen option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 A source code beautifier for C, C++, C#, Objective-C, D, Java, Pawn and Vala.
 
 ## Features
-* Highly configurable - 824 configurable options as of version 0.75.0
+* Highly configurable - 825 configurable options as of version 0.75.0
 - <details><summary>add/remove spaces</summary>
 
   - `sp_before_sparen`: _Add or remove space before '(' of 'if', 'for', 'switch', 'while', etc._

--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -628,6 +628,11 @@ sp_inside_fparens               = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space inside function '(' and ')'.
 sp_inside_fparen                = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space inside function call '(' and ')'. Default is to use
+# sp_inside_fparen. Note that sp_paren_paren and sp_inside_fparens can each
+# override this setting.
+sp_func_call_inside_fparen      = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space inside the first parentheses in a function type, as in
 # 'void (*x)(...)'.
 sp_inside_tparen                = ignore   # ignore/add/remove/force/not_defined

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -628,6 +628,11 @@ sp_inside_fparens               = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space inside function '(' and ')'.
 sp_inside_fparen                = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space inside function call '(' and ')'. Default is to use
+# sp_inside_fparen. Note that sp_paren_paren and sp_inside_fparens can each
+# override this setting.
+sp_func_call_inside_fparen      = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space inside the first parentheses in a function type, as in
 # 'void (*x)(...)'.
 sp_inside_tparen                = ignore   # ignore/add/remove/force/not_defined

--- a/documentation/htdocs/index.html
+++ b/documentation/htdocs/index.html
@@ -54,7 +54,7 @@ Create a highly configurable, easily modifiable source code beautifier.</p>
    <li>Add or remove parens on return statements</li>
    <li>Add or remove braces on single-statement if/do/while/for statements</li>
    <li>Supports embedded SQL 'EXEC SQL' stuff</li>
-   <li>Highly configurable - 824 configurable options as of version 0.75.0</li>
+   <li>Highly configurable - 825 configurable options as of version 0.75.0</li>
 </ul>
 
 <p>

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -628,6 +628,11 @@ sp_inside_fparens               = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space inside function '(' and ')'.
 sp_inside_fparen                = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space inside function call '(' and ')'. Default is to use
+# sp_inside_fparen. Note that sp_paren_paren and sp_inside_fparens can each
+# override this setting.
+sp_func_call_inside_fparen      = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space inside the first parentheses in a function type, as in
 # 'void (*x)(...)'.
 sp_inside_tparen                = ignore   # ignore/add/remove/force/not_defined

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -1441,6 +1441,15 @@ Choices=sp_inside_fparen=ignore|sp_inside_fparen=add|sp_inside_fparen=remove|sp_
 ChoicesReadable="Ignore Sp Inside Fparen|Add Sp Inside Fparen|Remove Sp Inside Fparen|Force Sp Inside Fparen"
 ValueDefault=ignore
 
+[Sp Func Call Inside Fparen]
+Category=1
+Description="<html>Add or remove space inside function call '(' and ')'. Default is to use<br/>sp_inside_fparen. Note that sp_paren_paren and sp_inside_fparens can each<br/>override this setting.</html>"
+Enabled=false
+EditorType=multiple
+Choices=sp_func_call_inside_fparen=ignore|sp_func_call_inside_fparen=add|sp_func_call_inside_fparen=remove|sp_func_call_inside_fparen=force|sp_func_call_inside_fparen=not_defined
+ChoicesReadable="Ignore Sp Func Call Inside Fparen|Add Sp Func Call Inside Fparen|Remove Sp Func Call Inside Fparen|Force Sp Func Call Inside Fparen"
+ValueDefault=ignore
+
 [Sp Inside Tparen]
 Category=1
 Description="<html>Add or remove space inside the first parentheses in a function type, as in<br/>'void (*x)(...)'.</html>"

--- a/src/options.h
+++ b/src/options.h
@@ -789,6 +789,12 @@ sp_inside_fparens;
 extern Option<iarf_e>
 sp_inside_fparen;
 
+// Add or remove space inside function call '(' and ')'. Default is to use
+// sp_inside_fparen. Note that sp_paren_paren and sp_inside_fparens can each
+// override this setting.
+extern Option<iarf_e>
+sp_func_call_inside_fparen;
+
 // Add or remove space inside the first parentheses in a function type, as in
 // 'void (*x)(...)'.
 extern Option<iarf_e>

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1331,12 +1331,20 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
          // historic behavior, but is probably not the desired behavior, so this is off
          // by default.
          if (  second->Is(CT_FPAREN_CLOSE)
-            && options::sp_inside_fparen() != IARF_IGNORE
             && !options::use_sp_after_angle_always())
          {
             // Add or remove space between '>' and ')'.
-            log_rule("sp_inside_fparen");
-            return(options::sp_inside_fparen());
+            if (  second->GetParentType() == CT_FUNC_CALL
+               && options::sp_func_call_inside_fparen() != IARF_IGNORE)
+            {
+               log_rule("sp_func_call_inside_fparen");
+               return(options::sp_func_call_inside_fparen());
+            }
+            else if (options::sp_inside_fparen() != IARF_IGNORE)
+            {
+               log_rule("sp_inside_fparen");
+               return(options::sp_inside_fparen());
+            }
          }
          // Add or remove space after '>'.
          log_rule("sp_after_angle");
@@ -2067,6 +2075,14 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
          // Add or remove space inside empty function '()'.
          log_rule("sp_inside_fparens");
          return(options::sp_inside_fparens());
+      }
+      else if (  options::sp_func_call_inside_fparen() != IARF_IGNORE
+              && (  (first->GetParentType() == CT_FUNC_CALL)
+                 || (second->GetParentType() == CT_FUNC_CALL)))
+      {
+         // Add or remove space inside function call '(' and ')'.
+         log_rule("sp_func_call_inside_fparen");
+         return(options::sp_func_call_inside_fparen());
       }
       // Add or remove space inside function '(' and ')'.
       log_rule("sp_inside_fparen");

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -1441,6 +1441,15 @@ Choices=sp_inside_fparen=ignore|sp_inside_fparen=add|sp_inside_fparen=remove|sp_
 ChoicesReadable="Ignore Sp Inside Fparen|Add Sp Inside Fparen|Remove Sp Inside Fparen|Force Sp Inside Fparen"
 ValueDefault=ignore
 
+[Sp Func Call Inside Fparen]
+Category=1
+Description="<html>Add or remove space inside function call '(' and ')'. Default is to use<br/>sp_inside_fparen. Note that sp_paren_paren and sp_inside_fparens can each<br/>override this setting.</html>"
+Enabled=false
+EditorType=multiple
+Choices=sp_func_call_inside_fparen=ignore|sp_func_call_inside_fparen=add|sp_func_call_inside_fparen=remove|sp_func_call_inside_fparen=force|sp_func_call_inside_fparen=not_defined
+ChoicesReadable="Ignore Sp Func Call Inside Fparen|Add Sp Func Call Inside Fparen|Remove Sp Func Call Inside Fparen|Force Sp Func Call Inside Fparen"
+ValueDefault=ignore
+
 [Sp Inside Tparen]
 Category=1
 Description="<html>Add or remove space inside the first parentheses in a function type, as in<br/>'void (*x)(...)'.</html>"

--- a/tests/config/cpp/sp_inside_fparen-1.cfg
+++ b/tests/config/cpp/sp_inside_fparen-1.cfg
@@ -1,0 +1,4 @@
+sp_inside_fparen             = add
+sp_func_call_inside_fparen   = force
+sp_paren_paren               = force
+mod_paren_on_return          = remove

--- a/tests/config/cpp/sp_inside_fparen-2.cfg
+++ b/tests/config/cpp/sp_inside_fparen-2.cfg
@@ -1,0 +1,4 @@
+sp_inside_fparen             = add
+sp_func_call_inside_fparen   = remove
+sp_paren_paren               = force
+mod_paren_on_return          = remove

--- a/tests/config/cpp/sp_inside_fparen-3.cfg
+++ b/tests/config/cpp/sp_inside_fparen-3.cfg
@@ -1,0 +1,4 @@
+sp_inside_fparen             = add
+sp_func_call_inside_fparen   = force
+sp_paren_paren               = remove
+mod_paren_on_return          = remove

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -984,6 +984,9 @@
 34534  cpp/templates-r.cfg                                  cpp/templates.cpp
 34535  cpp/template_sp-ignore.cfg                           cpp/sp_after_angle.cpp
 34536  cpp/template_sp-remove.cfg                           cpp/sp_after_angle.cpp
+34537  cpp/sp_inside_fparen-1.cfg                           cpp/class_fn_call_angle.cpp
+34538  cpp/sp_inside_fparen-2.cfg                           cpp/class_fn_call_angle.cpp
+34539  cpp/sp_inside_fparen-3.cfg                           cpp/class_fn_call_angle.cpp
 
 34540  cpp/sp_byref_paren-i.cfg                             cpp/byref-4.cpp
 34541  cpp/sp_byref_paren-a.cfg                             cpp/byref-4.cpp

--- a/tests/expected/cpp/34537-class_fn_call_angle.cpp
+++ b/tests/expected/cpp/34537-class_fn_call_angle.cpp
@@ -1,0 +1,15 @@
+class FooClass {
+private:
+int member;
+public:
+FooClass(   int in     ) : member(   in     ) {
+};
+};
+
+class FooClass foo(   void     ) {
+	bar( 1, 2,   99999 );
+	baz( 887766 );
+	quux( 1, "iliketrains" );
+	quack( "asdf", -1 );
+	return FooClass( one( two( three( four( five( 0,1,2,3,type<int> ) ) ) ) ) );
+}

--- a/tests/expected/cpp/34538-class_fn_call_angle.cpp
+++ b/tests/expected/cpp/34538-class_fn_call_angle.cpp
@@ -1,0 +1,15 @@
+class FooClass {
+private:
+int member;
+public:
+FooClass(   int in     ) : member(   in     ) {
+};
+};
+
+class FooClass foo(   void     ) {
+	bar(1, 2,   99999);
+	baz(887766);
+	quux(1, "iliketrains");
+	quack("asdf", -1);
+	return FooClass(one(two(three(four(five(0,1,2,3,type<int>) ) ) ) ) );
+}

--- a/tests/expected/cpp/34539-class_fn_call_angle.cpp
+++ b/tests/expected/cpp/34539-class_fn_call_angle.cpp
@@ -1,0 +1,15 @@
+class FooClass {
+private:
+int member;
+public:
+FooClass(   int in     ) : member(   in     ) {
+};
+};
+
+class FooClass foo(   void     ) {
+	bar( 1, 2,   99999 );
+	baz( 887766 );
+	quux( 1, "iliketrains" );
+	quack( "asdf", -1 );
+	return FooClass( one( two( three( four( five( 0,1,2,3,type<int> ))))));
+}

--- a/tests/input/cpp/class_fn_call_angle.cpp
+++ b/tests/input/cpp/class_fn_call_angle.cpp
@@ -1,0 +1,14 @@
+class FooClass {
+private:
+    int member;
+public:
+    FooClass(   int in     ) : member(   in     ) {};
+};
+
+class FooClass foo(   void     ) {
+    bar(   1, 2,   99999 );
+    baz(887766);
+    quux(1, "iliketrains" );
+    quack( "asdf", -1);
+    return (   FooClass(   one(   two(   three(   four(   five(   0,1,2,3,type<int>     )     )     )     )     )     )     );
+}


### PR DESCRIPTION
This adds an option to add or remove space inside function _call_ '(' and ')' specifically.

This option overrides `sp_inside_fparen` for function calls only. This will allow for extra spaces in things like function definitons and ctor initializer lists, but not when just calling functions with data or variables.

While this _is_ in some sense a real pull request, and will someday be promoted to such, for right now I'll use this as a test/demo for PR #3801.