### PR TITLE
Fix OC+ lambda not being detected

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -556,7 +556,13 @@ void do_symbol_check(Chunk *prev, Chunk *pc, Chunk *next)
          if (pc->Is(CT_SQUARE_OPEN))
          {
             handle_oc_message_send(pc);
-            return;                  // objective-c_50003
+
+            // Only return early if the '[' was determined to be an OC MSG
+            // Otherwise, it could have been a lambda capture list (ie '[&]')
+            if (pc->GetParentType() == CT_OC_MSG)
+            {
+               return;  // objective-c_50003
+            }
          }
       }
 

--- a/tests/config/oc/3767.cfg
+++ b/tests/config/oc/3767.cfg
@@ -1,0 +1,11 @@
+input_tab_size                  = 2
+output_tab_size                 = 2
+sp_arith                        = force
+sp_assign                       = force
+sp_cpp_lambda_assign            = remove
+sp_cpp_lambda_square_paren      = remove
+sp_cpp_lambda_square_brace      = force
+sp_cpp_lambda_paren_brace       = force
+sp_cpp_lambda_fparen            = remove
+sp_after_ptr_star               = remove
+nl_cpp_lambda_leave_one_liners  = true

--- a/tests/expected/oc/50910-3767.mm
+++ b/tests/expected/oc/50910-3767.mm
@@ -1,0 +1,7 @@
+const auto test = [=](NSString *param) {};
+const auto test = [&](NSString *param) {};
+const auto test = [](NSString *param) {};
+func([=](NSString *param) {});
+func([&](NSString *param) {});
+func([](NSString *param) {});
+func(param1, [=](NSString *param) {});

--- a/tests/input/oc/3767.mm
+++ b/tests/input/oc/3767.mm
@@ -1,0 +1,7 @@
+const auto test = [ = ] (NSString *param) {};
+const auto test =       [&](NSString *param) {};
+const auto test = []           (NSString *param) {};
+func([=](NSString *     param) {});
+func([&](NSString *param) {});
+func([](NSString *param) {});
+func(param1, [=](NSString *param) {});

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -177,6 +177,7 @@
 50907  oc/align_colon_with_ternary_1.cfg        oc/align_colon_with_ternary_1.m
 50908  oc/align_colon_with_ternary_2.cfg        oc/align_colon_with_ternary_2.m
 50909  oc/3766.cfg                              oc/3766.m
+50910  oc/3767.cfg                              oc/3767.mm                          OC+
 
 # test the options sp_ with the value "ignore"
 51000  oc/sp_cond_ternary_short.cfg             oc/sp_cond_ternary_short.m


### PR DESCRIPTION
#3768 

input
```
const auto test = [=](NSString *param) {};
```

Bad output (expected to not change)
```
const auto test = [ = ] (NSString * param) {};
```

config: https://pastebin.com/DU2e0VXB

Issue is objective c has additional bracket logic, but is incorrectly applied to lambda capture lists.