### PR TITLE
Fix incorrectly detecting enum declaration

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -799,6 +799,24 @@ void do_symbol_check(Chunk *prev, Chunk *pc, Chunk *next)
    if (  pc->IsClassEnumStructOrUnion()
       && prev->IsNot(CT_TYPEDEF))
    {
+      // Issue #3811
+      // Sometimes the enum chunk can exist in a parameter (ie. `void foo(enum EnumType param)`)
+      // In this case we don't need to run the parser since we are not declaring an enum.
+      if (pc->IsEnum())
+      {
+         const size_t level = pc->level;
+         Chunk        *tmp  = pc;
+
+         while (tmp->level == level && tmp->IsNotNullChunk())
+         {
+            tmp = tmp->GetNextNcNnl();
+         }
+
+         if (tmp->level < level)
+         {
+            return;
+         }
+      }
       EnumStructUnionParser parser;
       parser.parse(pc);
       return;

--- a/tests/config/oc/3811.cfg
+++ b/tests/config/oc/3811.cfg
@@ -1,0 +1,3 @@
+mod_enum_last_comma             = force
+indent_with_tabs                = 0
+indent_columns                  = 2

--- a/tests/expected/oc/50911-3811.mm
+++ b/tests/expected/oc/50911-3811.mm
@@ -1,0 +1,6 @@
+int main()
+{
+  test([](enum TestEnum lhs) {
+    return lhs.first < rhs;
+  });
+}

--- a/tests/input/oc/3811.mm
+++ b/tests/input/oc/3811.mm
@@ -1,0 +1,6 @@
+int main()
+{
+  test([](enum TestEnum lhs) {
+    return lhs.first < rhs;
+  });
+}

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -178,6 +178,7 @@
 50908  oc/align_colon_with_ternary_2.cfg        oc/align_colon_with_ternary_2.m
 50909  oc/3766.cfg                              oc/3766.m
 50910  oc/3767.cfg                              oc/3767.mm                          OC+
+50911  oc/3811.cfg                              oc/3811.mm                          OC+
 
 # test the options sp_ with the value "ignore"
 51000  oc/sp_cond_ternary_short.cfg             oc/sp_cond_ternary_short.m


### PR DESCRIPTION
It's valid to have `enum` prefix a type in parameter. In this case `enum` does not define a new enum. This PR adds a check to prevent the enum code from running in these cases.

input
```
int main()
{
  test2(
    [](enum TestEnum lhs) {
      return lhs.first < rhs;
    }
  );
}
```

bad output (expected to be same as input)
```
int main()
{
  test2(
    [](enum TestEnum lhs) {
      return lhs.first < rhs;,
    }
  );
}
```
