### PR TITLE
Fix version string in option docs

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -1,4 +1,4 @@
-# Uncrustify_d-0.75.0-245-6f360ab1
+# Uncrustify-0.75.1-dev
 
 #
 # General options

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -1,4 +1,4 @@
-# Uncrustify_d-0.75.0-245-6f360ab1
+# Uncrustify-0.75.1-dev
 
 #
 # General options

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1,4 +1,4 @@
-# Uncrustify_d-0.75.0-245-6f360ab1
+# Uncrustify-0.75.1-dev
 
 #
 # General options

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -1,5 +1,5 @@
 [header]
-categories=(0)General options|(15)Spacing options|(265)Indenting options|(381)Newline adding and removing options|(566)Blank line options|(616)Positioning options|(628)Line splitting options|(632)Code alignment options (not left column spaces/tabs)|(704)Comment modification options|(733)Code modifying options (non-whitespace)|(789)Preprocessor options|(808)Sort includes options|(811)Use or Do not Use options|(817)Warn levels - 1: error, 2: warning (default), 3: note
+categories=General options|Spacing options|Indenting options|Newline adding and removing options|Blank line options|Positioning options|Line splitting options|Code alignment options (not left column spaces/tabs)|Comment modification options|Code modifying options (non-whitespace)|Preprocessor options|Sort includes options|Use or Do not Use options|Warn levels - 1: error, 2: warning (default), 3: note
 cfgFileParameterEnding=cr
 configFilename=uncrustify.cfg
 fileTypes=*.c|*.c++|*.cc|*.cp|*.cpp|*.cs|*.cxx|*.d|*.di|*.es|*.h|*.h++|*.hh|*.hp|*.hpp|*.hxx|*.inl|*.java|*.js|*.m|*.mm|*.p|*.pawn|*.sma|*.sqc|*.sql|*.vala
@@ -15,20 +15,20 @@ parameterOrder=ipo
 showHelpParameter=-h
 stringparaminquotes=false
 useCfgFileParameter="-c "
-version=Uncrustify_d-0.75.0-245-6f360ab1
+version=Uncrustify-0.75.1-dev
 
 [Newlines]
 Category=0
-Description="<html>(0)The type of line endings.<br/><br/>Default: auto</html>"
+Description="<html>The type of line endings.<br/><br/>Default: auto</html>"
 Enabled=false
 EditorType=multiple
 Choices=newlines=lf|newlines=crlf|newlines=cr|newlines=auto
-ChoicesReadable="(0)Newlines Unix|(0)Newlines Win|(0)Newlines Mac|(0)Newlines Auto"
+ChoicesReadable="Newlines Unix|Newlines Win|Newlines Mac|Newlines Auto"
 ValueDefault=auto
 
 [Input Tab Size]
 Category=0
-Description="<html>(1)The original size of tabs in the input.<br/><br/>Default: 8</html>"
+Description="<html>The original size of tabs in the input.<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
 CallName="input_tab_size="
@@ -38,7 +38,7 @@ ValueDefault=8
 
 [Output Tab Size]
 Category=0
-Description="<html>(2)The size of tabs in the output (only used if align_with_tabs=true).<br/><br/>Default: 8</html>"
+Description="<html>The size of tabs in the output (only used if align_with_tabs=true).<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
 CallName="output_tab_size="
@@ -48,7 +48,7 @@ ValueDefault=8
 
 [String Escape Char]
 Category=0
-Description="<html>(3)The ASCII value of the string escape char, usually 92 (\) or (Pawn) 94 (^).<br/><br/>Default: 92</html>"
+Description="<html>The ASCII value of the string escape char, usually 92 (\) or (Pawn) 94 (^).<br/><br/>Default: 92</html>"
 Enabled=false
 EditorType=numeric
 CallName="string_escape_char="
@@ -58,7 +58,7 @@ ValueDefault=92
 
 [String Escape Char2]
 Category=0
-Description="<html>(4)Alternate string escape char (usually only used for Pawn).<br/>Only works right before the quote char.</html>"
+Description="<html>Alternate string escape char (usually only used for Pawn).<br/>Only works right before the quote char.</html>"
 Enabled=false
 EditorType=numeric
 CallName="string_escape_char2="
@@ -68,7 +68,7 @@ ValueDefault=0
 
 [String Replace Tab Chars]
 Category=0
-Description="<html>(5)Replace tab characters found in string literals with the escape sequence \t<br/>instead.</html>"
+Description="<html>Replace tab characters found in string literals with the escape sequence \t<br/>instead.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=string_replace_tab_chars=true|string_replace_tab_chars=false
@@ -76,7 +76,7 @@ ValueDefault=false
 
 [Tok Split Gte]
 Category=0
-Description="<html>(6)Allow interpreting '&gt;=' and '&gt;&gt;=' as part of a template in code like<br/>'void f(list&lt;list&lt;B&gt;&gt;=val);'. If true, 'assert(x&lt;0 &amp;&amp; y&gt;=3)' will be broken.<br/>Improvements to template detection may make this option obsolete.</html>"
+Description="<html>Allow interpreting '&gt;=' and '&gt;&gt;=' as part of a template in code like<br/>'void f(list&lt;list&lt;B&gt;&gt;=val);'. If true, 'assert(x&lt;0 &amp;&amp; y&gt;=3)' will be broken.<br/>Improvements to template detection may make this option obsolete.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=tok_split_gte=true|tok_split_gte=false
@@ -84,7 +84,7 @@ ValueDefault=false
 
 [Disable Processing Nl Cont]
 Category=0
-Description="<html>(7)Disable formatting of NL_CONT ('\\n') ended lines (e.g. multi-line macros).</html>"
+Description="<html>Disable formatting of NL_CONT ('\\n') ended lines (e.g. multi-line macros).</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=disable_processing_nl_cont=true|disable_processing_nl_cont=false
@@ -92,7 +92,7 @@ ValueDefault=false
 
 [Disable Processing Cmt]
 Category=0
-Description="<html>(8)Specify the marker used in comments to disable processing of part of the<br/>file.<br/><br/>Default:  *INDENT-OFF*</html>"
+Description="<html>Specify the marker used in comments to disable processing of part of the<br/>file.<br/><br/>Default:  *INDENT-OFF*</html>"
 Enabled=false
 CallName=disable_processing_cmt=
 EditorType=string
@@ -100,7 +100,7 @@ ValueDefault= *INDENT-OFF*
 
 [Enable Processing Cmt]
 Category=0
-Description="<html>(9)Specify the marker used in comments to (re)enable processing in a file.<br/><br/>Default:  *INDENT-ON*</html>"
+Description="<html>Specify the marker used in comments to (re)enable processing in a file.<br/><br/>Default:  *INDENT-ON*</html>"
 Enabled=false
 CallName=enable_processing_cmt=
 EditorType=string
@@ -108,7 +108,7 @@ ValueDefault= *INDENT-ON*
 
 [Enable Digraphs]
 Category=0
-Description="<html>(10)Enable parsing of digraphs.</html>"
+Description="<html>Enable parsing of digraphs.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=enable_digraphs=true|enable_digraphs=false
@@ -116,7 +116,7 @@ ValueDefault=false
 
 [Processing Cmt As Regex]
 Category=0
-Description="<html>(11)Option to allow both disable_processing_cmt and enable_processing_cmt<br/>strings, if specified, to be interpreted as ECMAScript regular expressions.<br/>If true, a regex search will be performed within comments according to the<br/>specified patterns in order to disable/enable processing.</html>"
+Description="<html>Option to allow both disable_processing_cmt and enable_processing_cmt<br/>strings, if specified, to be interpreted as ECMAScript regular expressions.<br/>If true, a regex search will be performed within comments according to the<br/>specified patterns in order to disable/enable processing.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=processing_cmt_as_regex=true|processing_cmt_as_regex=false
@@ -124,16 +124,16 @@ ValueDefault=false
 
 [Utf8 Bom]
 Category=0
-Description="<html>(12)Add or remove the UTF-8 BOM (recommend 'remove').</html>"
+Description="<html>Add or remove the UTF-8 BOM (recommend 'remove').</html>"
 Enabled=false
 EditorType=multiple
 Choices=utf8_bom=ignore|utf8_bom=add|utf8_bom=remove|utf8_bom=force|utf8_bom=not_defined
-ChoicesReadable="(12)Ignore Utf8 Bom|(12)Add Utf8 Bom|(12)Remove Utf8 Bom|(12)Force Utf8 Bom"
+ChoicesReadable="Ignore Utf8 Bom|Add Utf8 Bom|Remove Utf8 Bom|Force Utf8 Bom"
 ValueDefault=ignore
 
 [Utf8 Byte]
 Category=0
-Description="<html>(13)If the file contains bytes with values between 128 and 255, but is not<br/>UTF-8, then output as UTF-8.</html>"
+Description="<html>If the file contains bytes with values between 128 and 255, but is not<br/>UTF-8, then output as UTF-8.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=utf8_byte=true|utf8_byte=false
@@ -141,7 +141,7 @@ ValueDefault=false
 
 [Utf8 Force]
 Category=0
-Description="<html>(14)Force the output encoding to UTF-8.</html>"
+Description="<html>Force the output encoding to UTF-8.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=utf8_force=true|utf8_force=false
@@ -149,241 +149,241 @@ ValueDefault=false
 
 [Sp Arith]
 Category=1
-Description="<html>(15)Add or remove space around non-assignment symbolic operators ('+', '/', '%',<br/>'&lt;&lt;', and so forth).</html>"
+Description="<html>Add or remove space around non-assignment symbolic operators ('+', '/', '%',<br/>'&lt;&lt;', and so forth).</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_arith=ignore|sp_arith=add|sp_arith=remove|sp_arith=force|sp_arith=not_defined
-ChoicesReadable="(15)Ignore Sp Arith|(15)Add Sp Arith|(15)Remove Sp Arith|(15)Force Sp Arith"
+ChoicesReadable="Ignore Sp Arith|Add Sp Arith|Remove Sp Arith|Force Sp Arith"
 ValueDefault=ignore
 
 [Sp Arith Additive]
 Category=1
-Description="<html>(16)Add or remove space around arithmetic operators '+' and '-'.<br/><br/>Overrides sp_arith.</html>"
+Description="<html>Add or remove space around arithmetic operators '+' and '-'.<br/><br/>Overrides sp_arith.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_arith_additive=ignore|sp_arith_additive=add|sp_arith_additive=remove|sp_arith_additive=force|sp_arith_additive=not_defined
-ChoicesReadable="(16)Ignore Sp Arith Additive|(16)Add Sp Arith Additive|(16)Remove Sp Arith Additive|(16)Force Sp Arith Additive"
+ChoicesReadable="Ignore Sp Arith Additive|Add Sp Arith Additive|Remove Sp Arith Additive|Force Sp Arith Additive"
 ValueDefault=ignore
 
 [Sp Assign]
 Category=1
-Description="<html>(17)Add or remove space around assignment operator '=', '+=', etc.</html>"
+Description="<html>Add or remove space around assignment operator '=', '+=', etc.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_assign=ignore|sp_assign=add|sp_assign=remove|sp_assign=force|sp_assign=not_defined
-ChoicesReadable="(17)Ignore Sp Assign|(17)Add Sp Assign|(17)Remove Sp Assign|(17)Force Sp Assign"
+ChoicesReadable="Ignore Sp Assign|Add Sp Assign|Remove Sp Assign|Force Sp Assign"
 ValueDefault=ignore
 
 [Sp Cpp Lambda Assign]
 Category=1
-Description="<html>(18)Add or remove space around '=' in C++11 lambda capture specifications.<br/><br/>Overrides sp_assign.</html>"
+Description="<html>Add or remove space around '=' in C++11 lambda capture specifications.<br/><br/>Overrides sp_assign.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cpp_lambda_assign=ignore|sp_cpp_lambda_assign=add|sp_cpp_lambda_assign=remove|sp_cpp_lambda_assign=force|sp_cpp_lambda_assign=not_defined
-ChoicesReadable="(18)Ignore Sp Cpp Lambda Assign|(18)Add Sp Cpp Lambda Assign|(18)Remove Sp Cpp Lambda Assign|(18)Force Sp Cpp Lambda Assign"
+ChoicesReadable="Ignore Sp Cpp Lambda Assign|Add Sp Cpp Lambda Assign|Remove Sp Cpp Lambda Assign|Force Sp Cpp Lambda Assign"
 ValueDefault=ignore
 
 [Sp Cpp Lambda Square Paren]
 Category=1
-Description="<html>(19)Add or remove space after the capture specification of a C++11 lambda when<br/>an argument list is present, as in '[] &lt;here&gt; (int x){ ... }'.</html>"
+Description="<html>Add or remove space after the capture specification of a C++11 lambda when<br/>an argument list is present, as in '[] &lt;here&gt; (int x){ ... }'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cpp_lambda_square_paren=ignore|sp_cpp_lambda_square_paren=add|sp_cpp_lambda_square_paren=remove|sp_cpp_lambda_square_paren=force|sp_cpp_lambda_square_paren=not_defined
-ChoicesReadable="(19)Ignore Sp Cpp Lambda Square Paren|(19)Add Sp Cpp Lambda Square Paren|(19)Remove Sp Cpp Lambda Square Paren|(19)Force Sp Cpp Lambda Square Paren"
+ChoicesReadable="Ignore Sp Cpp Lambda Square Paren|Add Sp Cpp Lambda Square Paren|Remove Sp Cpp Lambda Square Paren|Force Sp Cpp Lambda Square Paren"
 ValueDefault=ignore
 
 [Sp Cpp Lambda Square Brace]
 Category=1
-Description="<html>(20)Add or remove space after the capture specification of a C++11 lambda with<br/>no argument list is present, as in '[] &lt;here&gt; { ... }'.</html>"
+Description="<html>Add or remove space after the capture specification of a C++11 lambda with<br/>no argument list is present, as in '[] &lt;here&gt; { ... }'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cpp_lambda_square_brace=ignore|sp_cpp_lambda_square_brace=add|sp_cpp_lambda_square_brace=remove|sp_cpp_lambda_square_brace=force|sp_cpp_lambda_square_brace=not_defined
-ChoicesReadable="(20)Ignore Sp Cpp Lambda Square Brace|(20)Add Sp Cpp Lambda Square Brace|(20)Remove Sp Cpp Lambda Square Brace|(20)Force Sp Cpp Lambda Square Brace"
+ChoicesReadable="Ignore Sp Cpp Lambda Square Brace|Add Sp Cpp Lambda Square Brace|Remove Sp Cpp Lambda Square Brace|Force Sp Cpp Lambda Square Brace"
 ValueDefault=ignore
 
 [Sp Cpp Lambda Argument List]
 Category=1
-Description="<html>(21)Add or remove space after the opening parenthesis and before the closing<br/>parenthesis of a argument list of a C++11 lambda, as in<br/>'[]( &lt;here&gt; int x &lt;here&gt; ){ ... }'.</html>"
+Description="<html>Add or remove space after the opening parenthesis and before the closing<br/>parenthesis of a argument list of a C++11 lambda, as in<br/>'[]( &lt;here&gt; int x &lt;here&gt; ){ ... }'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cpp_lambda_argument_list=ignore|sp_cpp_lambda_argument_list=add|sp_cpp_lambda_argument_list=remove|sp_cpp_lambda_argument_list=force|sp_cpp_lambda_argument_list=not_defined
-ChoicesReadable="(21)Ignore Sp Cpp Lambda Argument List|(21)Add Sp Cpp Lambda Argument List|(21)Remove Sp Cpp Lambda Argument List|(21)Force Sp Cpp Lambda Argument List"
+ChoicesReadable="Ignore Sp Cpp Lambda Argument List|Add Sp Cpp Lambda Argument List|Remove Sp Cpp Lambda Argument List|Force Sp Cpp Lambda Argument List"
 ValueDefault=ignore
 
 [Sp Cpp Lambda Paren Brace]
 Category=1
-Description="<html>(22)Add or remove space after the argument list of a C++11 lambda, as in<br/>'[](int x) &lt;here&gt; { ... }'.</html>"
+Description="<html>Add or remove space after the argument list of a C++11 lambda, as in<br/>'[](int x) &lt;here&gt; { ... }'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cpp_lambda_paren_brace=ignore|sp_cpp_lambda_paren_brace=add|sp_cpp_lambda_paren_brace=remove|sp_cpp_lambda_paren_brace=force|sp_cpp_lambda_paren_brace=not_defined
-ChoicesReadable="(22)Ignore Sp Cpp Lambda Paren Brace|(22)Add Sp Cpp Lambda Paren Brace|(22)Remove Sp Cpp Lambda Paren Brace|(22)Force Sp Cpp Lambda Paren Brace"
+ChoicesReadable="Ignore Sp Cpp Lambda Paren Brace|Add Sp Cpp Lambda Paren Brace|Remove Sp Cpp Lambda Paren Brace|Force Sp Cpp Lambda Paren Brace"
 ValueDefault=ignore
 
 [Sp Cpp Lambda Fparen]
 Category=1
-Description="<html>(23)Add or remove space between a lambda body and its call operator of an<br/>immediately invoked lambda, as in '[]( ... ){ ... } &lt;here&gt; ( ... )'.</html>"
+Description="<html>Add or remove space between a lambda body and its call operator of an<br/>immediately invoked lambda, as in '[]( ... ){ ... } &lt;here&gt; ( ... )'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cpp_lambda_fparen=ignore|sp_cpp_lambda_fparen=add|sp_cpp_lambda_fparen=remove|sp_cpp_lambda_fparen=force|sp_cpp_lambda_fparen=not_defined
-ChoicesReadable="(23)Ignore Sp Cpp Lambda Fparen|(23)Add Sp Cpp Lambda Fparen|(23)Remove Sp Cpp Lambda Fparen|(23)Force Sp Cpp Lambda Fparen"
+ChoicesReadable="Ignore Sp Cpp Lambda Fparen|Add Sp Cpp Lambda Fparen|Remove Sp Cpp Lambda Fparen|Force Sp Cpp Lambda Fparen"
 ValueDefault=ignore
 
 [Sp Assign Default]
 Category=1
-Description="<html>(24)Add or remove space around assignment operator '=' in a prototype.<br/><br/>If set to ignore, use sp_assign.</html>"
+Description="<html>Add or remove space around assignment operator '=' in a prototype.<br/><br/>If set to ignore, use sp_assign.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_assign_default=ignore|sp_assign_default=add|sp_assign_default=remove|sp_assign_default=force|sp_assign_default=not_defined
-ChoicesReadable="(24)Ignore Sp Assign Default|(24)Add Sp Assign Default|(24)Remove Sp Assign Default|(24)Force Sp Assign Default"
+ChoicesReadable="Ignore Sp Assign Default|Add Sp Assign Default|Remove Sp Assign Default|Force Sp Assign Default"
 ValueDefault=ignore
 
 [Sp Before Assign]
 Category=1
-Description="<html>(25)Add or remove space before assignment operator '=', '+=', etc.<br/><br/>Overrides sp_assign.</html>"
+Description="<html>Add or remove space before assignment operator '=', '+=', etc.<br/><br/>Overrides sp_assign.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_assign=ignore|sp_before_assign=add|sp_before_assign=remove|sp_before_assign=force|sp_before_assign=not_defined
-ChoicesReadable="(25)Ignore Sp Before Assign|(25)Add Sp Before Assign|(25)Remove Sp Before Assign|(25)Force Sp Before Assign"
+ChoicesReadable="Ignore Sp Before Assign|Add Sp Before Assign|Remove Sp Before Assign|Force Sp Before Assign"
 ValueDefault=ignore
 
 [Sp After Assign]
 Category=1
-Description="<html>(26)Add or remove space after assignment operator '=', '+=', etc.<br/><br/>Overrides sp_assign.</html>"
+Description="<html>Add or remove space after assignment operator '=', '+=', etc.<br/><br/>Overrides sp_assign.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_assign=ignore|sp_after_assign=add|sp_after_assign=remove|sp_after_assign=force|sp_after_assign=not_defined
-ChoicesReadable="(26)Ignore Sp After Assign|(26)Add Sp After Assign|(26)Remove Sp After Assign|(26)Force Sp After Assign"
+ChoicesReadable="Ignore Sp After Assign|Add Sp After Assign|Remove Sp After Assign|Force Sp After Assign"
 ValueDefault=ignore
 
 [Sp Enum Brace]
 Category=1
-Description="<html>(27)Add or remove space in 'enum {'.<br/><br/>Default: add</html>"
+Description="<html>Add or remove space in 'enum {'.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_enum_brace=ignore|sp_enum_brace=add|sp_enum_brace=remove|sp_enum_brace=force|sp_enum_brace=not_defined
-ChoicesReadable="(27)Ignore Sp Enum Brace|(27)Add Sp Enum Brace|(27)Remove Sp Enum Brace|(27)Force Sp Enum Brace"
+ChoicesReadable="Ignore Sp Enum Brace|Add Sp Enum Brace|Remove Sp Enum Brace|Force Sp Enum Brace"
 ValueDefault=add
 
 [Sp Enum Paren]
 Category=1
-Description="<html>(28)Add or remove space in 'NS_ENUM ('.</html>"
+Description="<html>Add or remove space in 'NS_ENUM ('.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_enum_paren=ignore|sp_enum_paren=add|sp_enum_paren=remove|sp_enum_paren=force|sp_enum_paren=not_defined
-ChoicesReadable="(28)Ignore Sp Enum Paren|(28)Add Sp Enum Paren|(28)Remove Sp Enum Paren|(28)Force Sp Enum Paren"
+ChoicesReadable="Ignore Sp Enum Paren|Add Sp Enum Paren|Remove Sp Enum Paren|Force Sp Enum Paren"
 ValueDefault=ignore
 
 [Sp Enum Assign]
 Category=1
-Description="<html>(29)Add or remove space around assignment '=' in enum.</html>"
+Description="<html>Add or remove space around assignment '=' in enum.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_enum_assign=ignore|sp_enum_assign=add|sp_enum_assign=remove|sp_enum_assign=force|sp_enum_assign=not_defined
-ChoicesReadable="(29)Ignore Sp Enum Assign|(29)Add Sp Enum Assign|(29)Remove Sp Enum Assign|(29)Force Sp Enum Assign"
+ChoicesReadable="Ignore Sp Enum Assign|Add Sp Enum Assign|Remove Sp Enum Assign|Force Sp Enum Assign"
 ValueDefault=ignore
 
 [Sp Enum Before Assign]
 Category=1
-Description="<html>(30)Add or remove space before assignment '=' in enum.<br/><br/>Overrides sp_enum_assign.</html>"
+Description="<html>Add or remove space before assignment '=' in enum.<br/><br/>Overrides sp_enum_assign.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_enum_before_assign=ignore|sp_enum_before_assign=add|sp_enum_before_assign=remove|sp_enum_before_assign=force|sp_enum_before_assign=not_defined
-ChoicesReadable="(30)Ignore Sp Enum Before Assign|(30)Add Sp Enum Before Assign|(30)Remove Sp Enum Before Assign|(30)Force Sp Enum Before Assign"
+ChoicesReadable="Ignore Sp Enum Before Assign|Add Sp Enum Before Assign|Remove Sp Enum Before Assign|Force Sp Enum Before Assign"
 ValueDefault=ignore
 
 [Sp Enum After Assign]
 Category=1
-Description="<html>(31)Add or remove space after assignment '=' in enum.<br/><br/>Overrides sp_enum_assign.</html>"
+Description="<html>Add or remove space after assignment '=' in enum.<br/><br/>Overrides sp_enum_assign.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_enum_after_assign=ignore|sp_enum_after_assign=add|sp_enum_after_assign=remove|sp_enum_after_assign=force|sp_enum_after_assign=not_defined
-ChoicesReadable="(31)Ignore Sp Enum After Assign|(31)Add Sp Enum After Assign|(31)Remove Sp Enum After Assign|(31)Force Sp Enum After Assign"
+ChoicesReadable="Ignore Sp Enum After Assign|Add Sp Enum After Assign|Remove Sp Enum After Assign|Force Sp Enum After Assign"
 ValueDefault=ignore
 
 [Sp Enum Colon]
 Category=1
-Description="<html>(32)Add or remove space around assignment ':' in enum.</html>"
+Description="<html>Add or remove space around assignment ':' in enum.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_enum_colon=ignore|sp_enum_colon=add|sp_enum_colon=remove|sp_enum_colon=force|sp_enum_colon=not_defined
-ChoicesReadable="(32)Ignore Sp Enum Colon|(32)Add Sp Enum Colon|(32)Remove Sp Enum Colon|(32)Force Sp Enum Colon"
+ChoicesReadable="Ignore Sp Enum Colon|Add Sp Enum Colon|Remove Sp Enum Colon|Force Sp Enum Colon"
 ValueDefault=ignore
 
 [Sp Pp Concat]
 Category=1
-Description="<html>(33)Add or remove space around preprocessor '##' concatenation operator.<br/><br/>Default: add</html>"
+Description="<html>Add or remove space around preprocessor '##' concatenation operator.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_pp_concat=ignore|sp_pp_concat=add|sp_pp_concat=remove|sp_pp_concat=force|sp_pp_concat=not_defined
-ChoicesReadable="(33)Ignore Sp Pp Concat|(33)Add Sp Pp Concat|(33)Remove Sp Pp Concat|(33)Force Sp Pp Concat"
+ChoicesReadable="Ignore Sp Pp Concat|Add Sp Pp Concat|Remove Sp Pp Concat|Force Sp Pp Concat"
 ValueDefault=add
 
 [Sp Pp Stringify]
 Category=1
-Description="<html>(34)Add or remove space after preprocessor '#' stringify operator.<br/>Also affects the '#@' charizing operator.</html>"
+Description="<html>Add or remove space after preprocessor '#' stringify operator.<br/>Also affects the '#@' charizing operator.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_pp_stringify=ignore|sp_pp_stringify=add|sp_pp_stringify=remove|sp_pp_stringify=force|sp_pp_stringify=not_defined
-ChoicesReadable="(34)Ignore Sp Pp Stringify|(34)Add Sp Pp Stringify|(34)Remove Sp Pp Stringify|(34)Force Sp Pp Stringify"
+ChoicesReadable="Ignore Sp Pp Stringify|Add Sp Pp Stringify|Remove Sp Pp Stringify|Force Sp Pp Stringify"
 ValueDefault=ignore
 
 [Sp Before Pp Stringify]
 Category=1
-Description="<html>(35)Add or remove space before preprocessor '#' stringify operator<br/>as in '#define x(y) L#y'.</html>"
+Description="<html>Add or remove space before preprocessor '#' stringify operator<br/>as in '#define x(y) L#y'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_pp_stringify=ignore|sp_before_pp_stringify=add|sp_before_pp_stringify=remove|sp_before_pp_stringify=force|sp_before_pp_stringify=not_defined
-ChoicesReadable="(35)Ignore Sp Before Pp Stringify|(35)Add Sp Before Pp Stringify|(35)Remove Sp Before Pp Stringify|(35)Force Sp Before Pp Stringify"
+ChoicesReadable="Ignore Sp Before Pp Stringify|Add Sp Before Pp Stringify|Remove Sp Before Pp Stringify|Force Sp Before Pp Stringify"
 ValueDefault=ignore
 
 [Sp Bool]
 Category=1
-Description="<html>(36)Add or remove space around boolean operators '&amp;&amp;' and '||'.</html>"
+Description="<html>Add or remove space around boolean operators '&amp;&amp;' and '||'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_bool=ignore|sp_bool=add|sp_bool=remove|sp_bool=force|sp_bool=not_defined
-ChoicesReadable="(36)Ignore Sp Bool|(36)Add Sp Bool|(36)Remove Sp Bool|(36)Force Sp Bool"
+ChoicesReadable="Ignore Sp Bool|Add Sp Bool|Remove Sp Bool|Force Sp Bool"
 ValueDefault=ignore
 
 [Sp Compare]
 Category=1
-Description="<html>(37)Add or remove space around compare operator '&lt;', '&gt;', '==', etc.</html>"
+Description="<html>Add or remove space around compare operator '&lt;', '&gt;', '==', etc.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_compare=ignore|sp_compare=add|sp_compare=remove|sp_compare=force|sp_compare=not_defined
-ChoicesReadable="(37)Ignore Sp Compare|(37)Add Sp Compare|(37)Remove Sp Compare|(37)Force Sp Compare"
+ChoicesReadable="Ignore Sp Compare|Add Sp Compare|Remove Sp Compare|Force Sp Compare"
 ValueDefault=ignore
 
 [Sp Inside Paren]
 Category=1
-Description="<html>(38)Add or remove space inside '(' and ')'.</html>"
+Description="<html>Add or remove space inside '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_paren=ignore|sp_inside_paren=add|sp_inside_paren=remove|sp_inside_paren=force|sp_inside_paren=not_defined
-ChoicesReadable="(38)Ignore Sp Inside Paren|(38)Add Sp Inside Paren|(38)Remove Sp Inside Paren|(38)Force Sp Inside Paren"
+ChoicesReadable="Ignore Sp Inside Paren|Add Sp Inside Paren|Remove Sp Inside Paren|Force Sp Inside Paren"
 ValueDefault=ignore
 
 [Sp Paren Paren]
 Category=1
-Description="<html>(39)Add or remove space between nested parentheses, i.e. '((' vs. ') )'.</html>"
+Description="<html>Add or remove space between nested parentheses, i.e. '((' vs. ') )'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_paren_paren=ignore|sp_paren_paren=add|sp_paren_paren=remove|sp_paren_paren=force|sp_paren_paren=not_defined
-ChoicesReadable="(39)Ignore Sp Paren Paren|(39)Add Sp Paren Paren|(39)Remove Sp Paren Paren|(39)Force Sp Paren Paren"
+ChoicesReadable="Ignore Sp Paren Paren|Add Sp Paren Paren|Remove Sp Paren Paren|Force Sp Paren Paren"
 ValueDefault=ignore
 
 [Sp Cparen Oparen]
 Category=1
-Description="<html>(40)Add or remove space between back-to-back parentheses, i.e. ')(' vs. ') ('.</html>"
+Description="<html>Add or remove space between back-to-back parentheses, i.e. ')(' vs. ') ('.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cparen_oparen=ignore|sp_cparen_oparen=add|sp_cparen_oparen=remove|sp_cparen_oparen=force|sp_cparen_oparen=not_defined
-ChoicesReadable="(40)Ignore Sp Cparen Oparen|(40)Add Sp Cparen Oparen|(40)Remove Sp Cparen Oparen|(40)Force Sp Cparen Oparen"
+ChoicesReadable="Ignore Sp Cparen Oparen|Add Sp Cparen Oparen|Remove Sp Cparen Oparen|Force Sp Cparen Oparen"
 ValueDefault=ignore
 
 [Sp Balance Nested Parens]
 Category=1
-Description="<html>(41)Whether to balance spaces inside nested parentheses.</html>"
+Description="<html>Whether to balance spaces inside nested parentheses.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=sp_balance_nested_parens=true|sp_balance_nested_parens=false
@@ -391,313 +391,313 @@ ValueDefault=false
 
 [Sp Paren Brace]
 Category=1
-Description="<html>(42)Add or remove space between ')' and '{'.</html>"
+Description="<html>Add or remove space between ')' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_paren_brace=ignore|sp_paren_brace=add|sp_paren_brace=remove|sp_paren_brace=force|sp_paren_brace=not_defined
-ChoicesReadable="(42)Ignore Sp Paren Brace|(42)Add Sp Paren Brace|(42)Remove Sp Paren Brace|(42)Force Sp Paren Brace"
+ChoicesReadable="Ignore Sp Paren Brace|Add Sp Paren Brace|Remove Sp Paren Brace|Force Sp Paren Brace"
 ValueDefault=ignore
 
 [Sp Brace Brace]
 Category=1
-Description="<html>(43)Add or remove space between nested braces, i.e. '{{' vs. '{ {'.</html>"
+Description="<html>Add or remove space between nested braces, i.e. '{{' vs. '{ {'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_brace_brace=ignore|sp_brace_brace=add|sp_brace_brace=remove|sp_brace_brace=force|sp_brace_brace=not_defined
-ChoicesReadable="(43)Ignore Sp Brace Brace|(43)Add Sp Brace Brace|(43)Remove Sp Brace Brace|(43)Force Sp Brace Brace"
+ChoicesReadable="Ignore Sp Brace Brace|Add Sp Brace Brace|Remove Sp Brace Brace|Force Sp Brace Brace"
 ValueDefault=ignore
 
 [Sp Before Ptr Star]
 Category=1
-Description="<html>(44)Add or remove space before pointer star '*'.</html>"
+Description="<html>Add or remove space before pointer star '*'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_ptr_star=ignore|sp_before_ptr_star=add|sp_before_ptr_star=remove|sp_before_ptr_star=force|sp_before_ptr_star=not_defined
-ChoicesReadable="(44)Ignore Sp Before Ptr Star|(44)Add Sp Before Ptr Star|(44)Remove Sp Before Ptr Star|(44)Force Sp Before Ptr Star"
+ChoicesReadable="Ignore Sp Before Ptr Star|Add Sp Before Ptr Star|Remove Sp Before Ptr Star|Force Sp Before Ptr Star"
 ValueDefault=ignore
 
 [Sp Before Unnamed Ptr Star]
 Category=1
-Description="<html>(45)Add or remove space before pointer star '*' that isn't followed by a<br/>variable name. If set to ignore, sp_before_ptr_star is used instead.</html>"
+Description="<html>Add or remove space before pointer star '*' that isn't followed by a<br/>variable name. If set to ignore, sp_before_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_unnamed_ptr_star=ignore|sp_before_unnamed_ptr_star=add|sp_before_unnamed_ptr_star=remove|sp_before_unnamed_ptr_star=force|sp_before_unnamed_ptr_star=not_defined
-ChoicesReadable="(45)Ignore Sp Before Unnamed Ptr Star|(45)Add Sp Before Unnamed Ptr Star|(45)Remove Sp Before Unnamed Ptr Star|(45)Force Sp Before Unnamed Ptr Star"
+ChoicesReadable="Ignore Sp Before Unnamed Ptr Star|Add Sp Before Unnamed Ptr Star|Remove Sp Before Unnamed Ptr Star|Force Sp Before Unnamed Ptr Star"
 ValueDefault=ignore
 
 [Sp Between Ptr Star]
 Category=1
-Description="<html>(46)Add or remove space between pointer stars '*', as in 'int ***a;'.</html>"
+Description="<html>Add or remove space between pointer stars '*', as in 'int ***a;'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_between_ptr_star=ignore|sp_between_ptr_star=add|sp_between_ptr_star=remove|sp_between_ptr_star=force|sp_between_ptr_star=not_defined
-ChoicesReadable="(46)Ignore Sp Between Ptr Star|(46)Add Sp Between Ptr Star|(46)Remove Sp Between Ptr Star|(46)Force Sp Between Ptr Star"
+ChoicesReadable="Ignore Sp Between Ptr Star|Add Sp Between Ptr Star|Remove Sp Between Ptr Star|Force Sp Between Ptr Star"
 ValueDefault=ignore
 
 [Sp After Ptr Star]
 Category=1
-Description="<html>(47)Add or remove space after pointer star '*', if followed by a word.<br/><br/>Overrides sp_type_func.</html>"
+Description="<html>Add or remove space after pointer star '*', if followed by a word.<br/><br/>Overrides sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_ptr_star=ignore|sp_after_ptr_star=add|sp_after_ptr_star=remove|sp_after_ptr_star=force|sp_after_ptr_star=not_defined
-ChoicesReadable="(47)Ignore Sp After Ptr Star|(47)Add Sp After Ptr Star|(47)Remove Sp After Ptr Star|(47)Force Sp After Ptr Star"
+ChoicesReadable="Ignore Sp After Ptr Star|Add Sp After Ptr Star|Remove Sp After Ptr Star|Force Sp After Ptr Star"
 ValueDefault=ignore
 
 [Sp After Ptr Block Caret]
 Category=1
-Description="<html>(48)Add or remove space after pointer caret '^', if followed by a word.</html>"
+Description="<html>Add or remove space after pointer caret '^', if followed by a word.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_ptr_block_caret=ignore|sp_after_ptr_block_caret=add|sp_after_ptr_block_caret=remove|sp_after_ptr_block_caret=force|sp_after_ptr_block_caret=not_defined
-ChoicesReadable="(48)Ignore Sp After Ptr Block Caret|(48)Add Sp After Ptr Block Caret|(48)Remove Sp After Ptr Block Caret|(48)Force Sp After Ptr Block Caret"
+ChoicesReadable="Ignore Sp After Ptr Block Caret|Add Sp After Ptr Block Caret|Remove Sp After Ptr Block Caret|Force Sp After Ptr Block Caret"
 ValueDefault=ignore
 
 [Sp After Ptr Star Qualifier]
 Category=1
-Description="<html>(49)Add or remove space after pointer star '*', if followed by a qualifier.</html>"
+Description="<html>Add or remove space after pointer star '*', if followed by a qualifier.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_ptr_star_qualifier=ignore|sp_after_ptr_star_qualifier=add|sp_after_ptr_star_qualifier=remove|sp_after_ptr_star_qualifier=force|sp_after_ptr_star_qualifier=not_defined
-ChoicesReadable="(49)Ignore Sp After Ptr Star Qualifier|(49)Add Sp After Ptr Star Qualifier|(49)Remove Sp After Ptr Star Qualifier|(49)Force Sp After Ptr Star Qualifier"
+ChoicesReadable="Ignore Sp After Ptr Star Qualifier|Add Sp After Ptr Star Qualifier|Remove Sp After Ptr Star Qualifier|Force Sp After Ptr Star Qualifier"
 ValueDefault=ignore
 
 [Sp After Ptr Star Func]
 Category=1
-Description="<html>(50)Add or remove space after a pointer star '*', if followed by a function<br/>prototype or function definition.<br/><br/>Overrides sp_after_ptr_star and sp_type_func.</html>"
+Description="<html>Add or remove space after a pointer star '*', if followed by a function<br/>prototype or function definition.<br/><br/>Overrides sp_after_ptr_star and sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_ptr_star_func=ignore|sp_after_ptr_star_func=add|sp_after_ptr_star_func=remove|sp_after_ptr_star_func=force|sp_after_ptr_star_func=not_defined
-ChoicesReadable="(50)Ignore Sp After Ptr Star Func|(50)Add Sp After Ptr Star Func|(50)Remove Sp After Ptr Star Func|(50)Force Sp After Ptr Star Func"
+ChoicesReadable="Ignore Sp After Ptr Star Func|Add Sp After Ptr Star Func|Remove Sp After Ptr Star Func|Force Sp After Ptr Star Func"
 ValueDefault=ignore
 
 [Sp After Ptr Star Trailing]
 Category=1
-Description="<html>(51)Add or remove space after a pointer star '*' in the trailing return of a<br/>function prototype or function definition.</html>"
+Description="<html>Add or remove space after a pointer star '*' in the trailing return of a<br/>function prototype or function definition.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_ptr_star_trailing=ignore|sp_after_ptr_star_trailing=add|sp_after_ptr_star_trailing=remove|sp_after_ptr_star_trailing=force|sp_after_ptr_star_trailing=not_defined
-ChoicesReadable="(51)Ignore Sp After Ptr Star Trailing|(51)Add Sp After Ptr Star Trailing|(51)Remove Sp After Ptr Star Trailing|(51)Force Sp After Ptr Star Trailing"
+ChoicesReadable="Ignore Sp After Ptr Star Trailing|Add Sp After Ptr Star Trailing|Remove Sp After Ptr Star Trailing|Force Sp After Ptr Star Trailing"
 ValueDefault=ignore
 
 [Sp Ptr Star Func Var]
 Category=1
-Description="<html>(52)Add or remove space between the pointer star '*' and the name of the variable<br/>in a function pointer definition.</html>"
+Description="<html>Add or remove space between the pointer star '*' and the name of the variable<br/>in a function pointer definition.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_ptr_star_func_var=ignore|sp_ptr_star_func_var=add|sp_ptr_star_func_var=remove|sp_ptr_star_func_var=force|sp_ptr_star_func_var=not_defined
-ChoicesReadable="(52)Ignore Sp Ptr Star Func Var|(52)Add Sp Ptr Star Func Var|(52)Remove Sp Ptr Star Func Var|(52)Force Sp Ptr Star Func Var"
+ChoicesReadable="Ignore Sp Ptr Star Func Var|Add Sp Ptr Star Func Var|Remove Sp Ptr Star Func Var|Force Sp Ptr Star Func Var"
 ValueDefault=ignore
 
 [Sp Ptr Star Func Type]
 Category=1
-Description="<html>(53)Add or remove space between the pointer star '*' and the name of the type<br/>in a function pointer type definition.</html>"
+Description="<html>Add or remove space between the pointer star '*' and the name of the type<br/>in a function pointer type definition.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_ptr_star_func_type=ignore|sp_ptr_star_func_type=add|sp_ptr_star_func_type=remove|sp_ptr_star_func_type=force|sp_ptr_star_func_type=not_defined
-ChoicesReadable="(53)Ignore Sp Ptr Star Func Type|(53)Add Sp Ptr Star Func Type|(53)Remove Sp Ptr Star Func Type|(53)Force Sp Ptr Star Func Type"
+ChoicesReadable="Ignore Sp Ptr Star Func Type|Add Sp Ptr Star Func Type|Remove Sp Ptr Star Func Type|Force Sp Ptr Star Func Type"
 ValueDefault=ignore
 
 [Sp Ptr Star Paren]
 Category=1
-Description="<html>(54)Add or remove space after a pointer star '*', if followed by an open<br/>parenthesis, as in 'void* (*)()'.</html>"
+Description="<html>Add or remove space after a pointer star '*', if followed by an open<br/>parenthesis, as in 'void* (*)()'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_ptr_star_paren=ignore|sp_ptr_star_paren=add|sp_ptr_star_paren=remove|sp_ptr_star_paren=force|sp_ptr_star_paren=not_defined
-ChoicesReadable="(54)Ignore Sp Ptr Star Paren|(54)Add Sp Ptr Star Paren|(54)Remove Sp Ptr Star Paren|(54)Force Sp Ptr Star Paren"
+ChoicesReadable="Ignore Sp Ptr Star Paren|Add Sp Ptr Star Paren|Remove Sp Ptr Star Paren|Force Sp Ptr Star Paren"
 ValueDefault=ignore
 
 [Sp Before Ptr Star Func]
 Category=1
-Description="<html>(55)Add or remove space before a pointer star '*', if followed by a function<br/>prototype or function definition.</html>"
+Description="<html>Add or remove space before a pointer star '*', if followed by a function<br/>prototype or function definition.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_ptr_star_func=ignore|sp_before_ptr_star_func=add|sp_before_ptr_star_func=remove|sp_before_ptr_star_func=force|sp_before_ptr_star_func=not_defined
-ChoicesReadable="(55)Ignore Sp Before Ptr Star Func|(55)Add Sp Before Ptr Star Func|(55)Remove Sp Before Ptr Star Func|(55)Force Sp Before Ptr Star Func"
+ChoicesReadable="Ignore Sp Before Ptr Star Func|Add Sp Before Ptr Star Func|Remove Sp Before Ptr Star Func|Force Sp Before Ptr Star Func"
 ValueDefault=ignore
 
 [Sp Before Ptr Star Trailing]
 Category=1
-Description="<html>(56)Add or remove space before a pointer star '*' in the trailing return of a<br/>function prototype or function definition.</html>"
+Description="<html>Add or remove space before a pointer star '*' in the trailing return of a<br/>function prototype or function definition.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_ptr_star_trailing=ignore|sp_before_ptr_star_trailing=add|sp_before_ptr_star_trailing=remove|sp_before_ptr_star_trailing=force|sp_before_ptr_star_trailing=not_defined
-ChoicesReadable="(56)Ignore Sp Before Ptr Star Trailing|(56)Add Sp Before Ptr Star Trailing|(56)Remove Sp Before Ptr Star Trailing|(56)Force Sp Before Ptr Star Trailing"
+ChoicesReadable="Ignore Sp Before Ptr Star Trailing|Add Sp Before Ptr Star Trailing|Remove Sp Before Ptr Star Trailing|Force Sp Before Ptr Star Trailing"
 ValueDefault=ignore
 
 [Sp Before Byref]
 Category=1
-Description="<html>(57)Add or remove space before a reference sign '&amp;'.</html>"
+Description="<html>Add or remove space before a reference sign '&amp;'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_byref=ignore|sp_before_byref=add|sp_before_byref=remove|sp_before_byref=force|sp_before_byref=not_defined
-ChoicesReadable="(57)Ignore Sp Before Byref|(57)Add Sp Before Byref|(57)Remove Sp Before Byref|(57)Force Sp Before Byref"
+ChoicesReadable="Ignore Sp Before Byref|Add Sp Before Byref|Remove Sp Before Byref|Force Sp Before Byref"
 ValueDefault=ignore
 
 [Sp Before Unnamed Byref]
 Category=1
-Description="<html>(58)Add or remove space before a reference sign '&amp;' that isn't followed by a<br/>variable name. If set to ignore, sp_before_byref is used instead.</html>"
+Description="<html>Add or remove space before a reference sign '&amp;' that isn't followed by a<br/>variable name. If set to ignore, sp_before_byref is used instead.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_unnamed_byref=ignore|sp_before_unnamed_byref=add|sp_before_unnamed_byref=remove|sp_before_unnamed_byref=force|sp_before_unnamed_byref=not_defined
-ChoicesReadable="(58)Ignore Sp Before Unnamed Byref|(58)Add Sp Before Unnamed Byref|(58)Remove Sp Before Unnamed Byref|(58)Force Sp Before Unnamed Byref"
+ChoicesReadable="Ignore Sp Before Unnamed Byref|Add Sp Before Unnamed Byref|Remove Sp Before Unnamed Byref|Force Sp Before Unnamed Byref"
 ValueDefault=ignore
 
 [Sp After Byref]
 Category=1
-Description="<html>(59)Add or remove space after reference sign '&amp;', if followed by a word.<br/><br/>Overrides sp_type_func.</html>"
+Description="<html>Add or remove space after reference sign '&amp;', if followed by a word.<br/><br/>Overrides sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_byref=ignore|sp_after_byref=add|sp_after_byref=remove|sp_after_byref=force|sp_after_byref=not_defined
-ChoicesReadable="(59)Ignore Sp After Byref|(59)Add Sp After Byref|(59)Remove Sp After Byref|(59)Force Sp After Byref"
+ChoicesReadable="Ignore Sp After Byref|Add Sp After Byref|Remove Sp After Byref|Force Sp After Byref"
 ValueDefault=ignore
 
 [Sp After Byref Func]
 Category=1
-Description="<html>(60)Add or remove space after a reference sign '&amp;', if followed by a function<br/>prototype or function definition.<br/><br/>Overrides sp_after_byref and sp_type_func.</html>"
+Description="<html>Add or remove space after a reference sign '&amp;', if followed by a function<br/>prototype or function definition.<br/><br/>Overrides sp_after_byref and sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_byref_func=ignore|sp_after_byref_func=add|sp_after_byref_func=remove|sp_after_byref_func=force|sp_after_byref_func=not_defined
-ChoicesReadable="(60)Ignore Sp After Byref Func|(60)Add Sp After Byref Func|(60)Remove Sp After Byref Func|(60)Force Sp After Byref Func"
+ChoicesReadable="Ignore Sp After Byref Func|Add Sp After Byref Func|Remove Sp After Byref Func|Force Sp After Byref Func"
 ValueDefault=ignore
 
 [Sp Before Byref Func]
 Category=1
-Description="<html>(61)Add or remove space before a reference sign '&amp;', if followed by a function<br/>prototype or function definition.</html>"
+Description="<html>Add or remove space before a reference sign '&amp;', if followed by a function<br/>prototype or function definition.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_byref_func=ignore|sp_before_byref_func=add|sp_before_byref_func=remove|sp_before_byref_func=force|sp_before_byref_func=not_defined
-ChoicesReadable="(61)Ignore Sp Before Byref Func|(61)Add Sp Before Byref Func|(61)Remove Sp Before Byref Func|(61)Force Sp Before Byref Func"
+ChoicesReadable="Ignore Sp Before Byref Func|Add Sp Before Byref Func|Remove Sp Before Byref Func|Force Sp Before Byref Func"
 ValueDefault=ignore
 
 [Sp Byref Paren]
 Category=1
-Description="<html>(62)Add or remove space after a reference sign '&amp;', if followed by an open<br/>parenthesis, as in 'char&amp; (*)()'.</html>"
+Description="<html>Add or remove space after a reference sign '&amp;', if followed by an open<br/>parenthesis, as in 'char&amp; (*)()'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_byref_paren=ignore|sp_byref_paren=add|sp_byref_paren=remove|sp_byref_paren=force|sp_byref_paren=not_defined
-ChoicesReadable="(62)Ignore Sp Byref Paren|(62)Add Sp Byref Paren|(62)Remove Sp Byref Paren|(62)Force Sp Byref Paren"
+ChoicesReadable="Ignore Sp Byref Paren|Add Sp Byref Paren|Remove Sp Byref Paren|Force Sp Byref Paren"
 ValueDefault=ignore
 
 [Sp After Type]
 Category=1
-Description="<html>(63)Add or remove space between type and word. In cases where total removal of<br/>whitespace would be a syntax error, a value of 'remove' is treated the same<br/>as 'force'.<br/><br/>This also affects some other instances of space following a type that are<br/>not covered by other options; for example, between the return type and<br/>parenthesis of a function type template argument, between the type and<br/>parenthesis of an array parameter, or between 'decltype(...)' and the<br/>following word.<br/><br/>Default: force</html>"
+Description="<html>Add or remove space between type and word. In cases where total removal of<br/>whitespace would be a syntax error, a value of 'remove' is treated the same<br/>as 'force'.<br/><br/>This also affects some other instances of space following a type that are<br/>not covered by other options; for example, between the return type and<br/>parenthesis of a function type template argument, between the type and<br/>parenthesis of an array parameter, or between 'decltype(...)' and the<br/>following word.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_type=ignore|sp_after_type=add|sp_after_type=remove|sp_after_type=force|sp_after_type=not_defined
-ChoicesReadable="(63)Ignore Sp After Type|(63)Add Sp After Type|(63)Remove Sp After Type|(63)Force Sp After Type"
+ChoicesReadable="Ignore Sp After Type|Add Sp After Type|Remove Sp After Type|Force Sp After Type"
 ValueDefault=force
 
 [Sp After Decltype]
 Category=1
-Description="<html>(64)Add or remove space between 'decltype(...)' and word,<br/>brace or function call.</html>"
+Description="<html>Add or remove space between 'decltype(...)' and word,<br/>brace or function call.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_decltype=ignore|sp_after_decltype=add|sp_after_decltype=remove|sp_after_decltype=force|sp_after_decltype=not_defined
-ChoicesReadable="(64)Ignore Sp After Decltype|(64)Add Sp After Decltype|(64)Remove Sp After Decltype|(64)Force Sp After Decltype"
+ChoicesReadable="Ignore Sp After Decltype|Add Sp After Decltype|Remove Sp After Decltype|Force Sp After Decltype"
 ValueDefault=ignore
 
 [Sp Before Template Paren]
 Category=1
-Description="<html>(65)(D) Add or remove space before the parenthesis in the D constructs<br/>'template Foo(' and 'class Foo('.</html>"
+Description="<html>(D) Add or remove space before the parenthesis in the D constructs<br/>'template Foo(' and 'class Foo('.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_template_paren=ignore|sp_before_template_paren=add|sp_before_template_paren=remove|sp_before_template_paren=force|sp_before_template_paren=not_defined
-ChoicesReadable="(65)Ignore Sp Before Template Paren|(65)Add Sp Before Template Paren|(65)Remove Sp Before Template Paren|(65)Force Sp Before Template Paren"
+ChoicesReadable="Ignore Sp Before Template Paren|Add Sp Before Template Paren|Remove Sp Before Template Paren|Force Sp Before Template Paren"
 ValueDefault=ignore
 
 [Sp Template Angle]
 Category=1
-Description="<html>(66)Add or remove space between 'template' and '&lt;'.<br/>If set to ignore, sp_before_angle is used.</html>"
+Description="<html>Add or remove space between 'template' and '&lt;'.<br/>If set to ignore, sp_before_angle is used.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_template_angle=ignore|sp_template_angle=add|sp_template_angle=remove|sp_template_angle=force|sp_template_angle=not_defined
-ChoicesReadable="(66)Ignore Sp Template Angle|(66)Add Sp Template Angle|(66)Remove Sp Template Angle|(66)Force Sp Template Angle"
+ChoicesReadable="Ignore Sp Template Angle|Add Sp Template Angle|Remove Sp Template Angle|Force Sp Template Angle"
 ValueDefault=ignore
 
 [Sp Before Angle]
 Category=1
-Description="<html>(67)Add or remove space before '&lt;'.</html>"
+Description="<html>Add or remove space before '&lt;'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_angle=ignore|sp_before_angle=add|sp_before_angle=remove|sp_before_angle=force|sp_before_angle=not_defined
-ChoicesReadable="(67)Ignore Sp Before Angle|(67)Add Sp Before Angle|(67)Remove Sp Before Angle|(67)Force Sp Before Angle"
+ChoicesReadable="Ignore Sp Before Angle|Add Sp Before Angle|Remove Sp Before Angle|Force Sp Before Angle"
 ValueDefault=ignore
 
 [Sp Inside Angle]
 Category=1
-Description="<html>(68)Add or remove space inside '&lt;' and '&gt;'.</html>"
+Description="<html>Add or remove space inside '&lt;' and '&gt;'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_angle=ignore|sp_inside_angle=add|sp_inside_angle=remove|sp_inside_angle=force|sp_inside_angle=not_defined
-ChoicesReadable="(68)Ignore Sp Inside Angle|(68)Add Sp Inside Angle|(68)Remove Sp Inside Angle|(68)Force Sp Inside Angle"
+ChoicesReadable="Ignore Sp Inside Angle|Add Sp Inside Angle|Remove Sp Inside Angle|Force Sp Inside Angle"
 ValueDefault=ignore
 
 [Sp Inside Angle Empty]
 Category=1
-Description="<html>(69)Add or remove space inside '&lt;&gt;'.</html>"
+Description="<html>Add or remove space inside '&lt;&gt;'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_angle_empty=ignore|sp_inside_angle_empty=add|sp_inside_angle_empty=remove|sp_inside_angle_empty=force|sp_inside_angle_empty=not_defined
-ChoicesReadable="(69)Ignore Sp Inside Angle Empty|(69)Add Sp Inside Angle Empty|(69)Remove Sp Inside Angle Empty|(69)Force Sp Inside Angle Empty"
+ChoicesReadable="Ignore Sp Inside Angle Empty|Add Sp Inside Angle Empty|Remove Sp Inside Angle Empty|Force Sp Inside Angle Empty"
 ValueDefault=ignore
 
 [Sp Angle Colon]
 Category=1
-Description="<html>(70)Add or remove space between '&gt;' and ':'.</html>"
+Description="<html>Add or remove space between '&gt;' and ':'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_angle_colon=ignore|sp_angle_colon=add|sp_angle_colon=remove|sp_angle_colon=force|sp_angle_colon=not_defined
-ChoicesReadable="(70)Ignore Sp Angle Colon|(70)Add Sp Angle Colon|(70)Remove Sp Angle Colon|(70)Force Sp Angle Colon"
+ChoicesReadable="Ignore Sp Angle Colon|Add Sp Angle Colon|Remove Sp Angle Colon|Force Sp Angle Colon"
 ValueDefault=ignore
 
 [Sp After Angle]
 Category=1
-Description="<html>(71)Add or remove space after '&gt;'.</html>"
+Description="<html>Add or remove space after '&gt;'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_angle=ignore|sp_after_angle=add|sp_after_angle=remove|sp_after_angle=force|sp_after_angle=not_defined
-ChoicesReadable="(71)Ignore Sp After Angle|(71)Add Sp After Angle|(71)Remove Sp After Angle|(71)Force Sp After Angle"
+ChoicesReadable="Ignore Sp After Angle|Add Sp After Angle|Remove Sp After Angle|Force Sp After Angle"
 ValueDefault=ignore
 
 [Sp Angle Paren]
 Category=1
-Description="<html>(72)Add or remove space between '&gt;' and '(' as found in 'new List&lt;byte&gt;(foo);'.</html>"
+Description="<html>Add or remove space between '&gt;' and '(' as found in 'new List&lt;byte&gt;(foo);'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_angle_paren=ignore|sp_angle_paren=add|sp_angle_paren=remove|sp_angle_paren=force|sp_angle_paren=not_defined
-ChoicesReadable="(72)Ignore Sp Angle Paren|(72)Add Sp Angle Paren|(72)Remove Sp Angle Paren|(72)Force Sp Angle Paren"
+ChoicesReadable="Ignore Sp Angle Paren|Add Sp Angle Paren|Remove Sp Angle Paren|Force Sp Angle Paren"
 ValueDefault=ignore
 
 [Sp Angle Paren Empty]
 Category=1
-Description="<html>(73)Add or remove space between '&gt;' and '()' as found in 'new List&lt;byte&gt;();'.</html>"
+Description="<html>Add or remove space between '&gt;' and '()' as found in 'new List&lt;byte&gt;();'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_angle_paren_empty=ignore|sp_angle_paren_empty=add|sp_angle_paren_empty=remove|sp_angle_paren_empty=force|sp_angle_paren_empty=not_defined
-ChoicesReadable="(73)Ignore Sp Angle Paren Empty|(73)Add Sp Angle Paren Empty|(73)Remove Sp Angle Paren Empty|(73)Force Sp Angle Paren Empty"
+ChoicesReadable="Ignore Sp Angle Paren Empty|Add Sp Angle Paren Empty|Remove Sp Angle Paren Empty|Force Sp Angle Paren Empty"
 ValueDefault=ignore
 
 [Sp Angle Word]
 Category=1
-Description="<html>(74)Add or remove space between '&gt;' and a word as in 'List&lt;byte&gt; m;' or<br/>'template &lt;typename T&gt; static ...'.</html>"
+Description="<html>Add or remove space between '&gt;' and a word as in 'List&lt;byte&gt; m;' or<br/>'template &lt;typename T&gt; static ...'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_angle_word=ignore|sp_angle_word=add|sp_angle_word=remove|sp_angle_word=force|sp_angle_word=not_defined
-ChoicesReadable="(74)Ignore Sp Angle Word|(74)Add Sp Angle Word|(74)Remove Sp Angle Word|(74)Force Sp Angle Word"
+ChoicesReadable="Ignore Sp Angle Word|Add Sp Angle Word|Remove Sp Angle Word|Force Sp Angle Word"
 ValueDefault=ignore
 
 [Sp Angle Shift]
 Category=1
-Description="<html>(75)Add or remove space between '&gt;' and '&gt;' in '&gt;&gt;' (template stuff).<br/><br/>Default: add</html>"
+Description="<html>Add or remove space between '&gt;' and '&gt;' in '&gt;&gt;' (template stuff).<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_angle_shift=ignore|sp_angle_shift=add|sp_angle_shift=remove|sp_angle_shift=force|sp_angle_shift=not_defined
-ChoicesReadable="(75)Ignore Sp Angle Shift|(75)Add Sp Angle Shift|(75)Remove Sp Angle Shift|(75)Force Sp Angle Shift"
+ChoicesReadable="Ignore Sp Angle Shift|Add Sp Angle Shift|Remove Sp Angle Shift|Force Sp Angle Shift"
 ValueDefault=add
 
 [Sp Permit Cpp11 Shift]
 Category=1
-Description="<html>(76)(C++11) Permit removal of the space between '&gt;&gt;' in 'foo&lt;bar&lt;int&gt; &gt;'. Note<br/>that sp_angle_shift cannot remove the space without this option.</html>"
+Description="<html>(C++11) Permit removal of the space between '&gt;&gt;' in 'foo&lt;bar&lt;int&gt; &gt;'. Note<br/>that sp_angle_shift cannot remove the space without this option.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=sp_permit_cpp11_shift=true|sp_permit_cpp11_shift=false
@@ -705,1519 +705,1519 @@ ValueDefault=false
 
 [Sp Before Sparen]
 Category=1
-Description="<html>(77)Add or remove space before '(' of control statements ('if', 'for', 'switch',<br/>'while', etc.).</html>"
+Description="<html>Add or remove space before '(' of control statements ('if', 'for', 'switch',<br/>'while', etc.).</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_sparen=ignore|sp_before_sparen=add|sp_before_sparen=remove|sp_before_sparen=force|sp_before_sparen=not_defined
-ChoicesReadable="(77)Ignore Sp Before Sparen|(77)Add Sp Before Sparen|(77)Remove Sp Before Sparen|(77)Force Sp Before Sparen"
+ChoicesReadable="Ignore Sp Before Sparen|Add Sp Before Sparen|Remove Sp Before Sparen|Force Sp Before Sparen"
 ValueDefault=ignore
 
 [Sp Inside Sparen]
 Category=1
-Description="<html>(78)Add or remove space inside '(' and ')' of control statements other than<br/>'for'.</html>"
+Description="<html>Add or remove space inside '(' and ')' of control statements other than<br/>'for'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_sparen=ignore|sp_inside_sparen=add|sp_inside_sparen=remove|sp_inside_sparen=force|sp_inside_sparen=not_defined
-ChoicesReadable="(78)Ignore Sp Inside Sparen|(78)Add Sp Inside Sparen|(78)Remove Sp Inside Sparen|(78)Force Sp Inside Sparen"
+ChoicesReadable="Ignore Sp Inside Sparen|Add Sp Inside Sparen|Remove Sp Inside Sparen|Force Sp Inside Sparen"
 ValueDefault=ignore
 
 [Sp Inside Sparen Open]
 Category=1
-Description="<html>(79)Add or remove space after '(' of control statements other than 'for'.<br/><br/>Overrides sp_inside_sparen.</html>"
+Description="<html>Add or remove space after '(' of control statements other than 'for'.<br/><br/>Overrides sp_inside_sparen.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_sparen_open=ignore|sp_inside_sparen_open=add|sp_inside_sparen_open=remove|sp_inside_sparen_open=force|sp_inside_sparen_open=not_defined
-ChoicesReadable="(79)Ignore Sp Inside Sparen Open|(79)Add Sp Inside Sparen Open|(79)Remove Sp Inside Sparen Open|(79)Force Sp Inside Sparen Open"
+ChoicesReadable="Ignore Sp Inside Sparen Open|Add Sp Inside Sparen Open|Remove Sp Inside Sparen Open|Force Sp Inside Sparen Open"
 ValueDefault=ignore
 
 [Sp Inside Sparen Close]
 Category=1
-Description="<html>(80)Add or remove space before ')' of control statements other than 'for'.<br/><br/>Overrides sp_inside_sparen.</html>"
+Description="<html>Add or remove space before ')' of control statements other than 'for'.<br/><br/>Overrides sp_inside_sparen.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_sparen_close=ignore|sp_inside_sparen_close=add|sp_inside_sparen_close=remove|sp_inside_sparen_close=force|sp_inside_sparen_close=not_defined
-ChoicesReadable="(80)Ignore Sp Inside Sparen Close|(80)Add Sp Inside Sparen Close|(80)Remove Sp Inside Sparen Close|(80)Force Sp Inside Sparen Close"
+ChoicesReadable="Ignore Sp Inside Sparen Close|Add Sp Inside Sparen Close|Remove Sp Inside Sparen Close|Force Sp Inside Sparen Close"
 ValueDefault=ignore
 
 [Sp Inside For]
 Category=1
-Description="<html>(81)Add or remove space inside '(' and ')' of 'for' statements.</html>"
+Description="<html>Add or remove space inside '(' and ')' of 'for' statements.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_for=ignore|sp_inside_for=add|sp_inside_for=remove|sp_inside_for=force|sp_inside_for=not_defined
-ChoicesReadable="(81)Ignore Sp Inside For|(81)Add Sp Inside For|(81)Remove Sp Inside For|(81)Force Sp Inside For"
+ChoicesReadable="Ignore Sp Inside For|Add Sp Inside For|Remove Sp Inside For|Force Sp Inside For"
 ValueDefault=ignore
 
 [Sp Inside For Open]
 Category=1
-Description="<html>(82)Add or remove space after '(' of 'for' statements.<br/><br/>Overrides sp_inside_for.</html>"
+Description="<html>Add or remove space after '(' of 'for' statements.<br/><br/>Overrides sp_inside_for.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_for_open=ignore|sp_inside_for_open=add|sp_inside_for_open=remove|sp_inside_for_open=force|sp_inside_for_open=not_defined
-ChoicesReadable="(82)Ignore Sp Inside For Open|(82)Add Sp Inside For Open|(82)Remove Sp Inside For Open|(82)Force Sp Inside For Open"
+ChoicesReadable="Ignore Sp Inside For Open|Add Sp Inside For Open|Remove Sp Inside For Open|Force Sp Inside For Open"
 ValueDefault=ignore
 
 [Sp Inside For Close]
 Category=1
-Description="<html>(83)Add or remove space before ')' of 'for' statements.<br/><br/>Overrides sp_inside_for.</html>"
+Description="<html>Add or remove space before ')' of 'for' statements.<br/><br/>Overrides sp_inside_for.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_for_close=ignore|sp_inside_for_close=add|sp_inside_for_close=remove|sp_inside_for_close=force|sp_inside_for_close=not_defined
-ChoicesReadable="(83)Ignore Sp Inside For Close|(83)Add Sp Inside For Close|(83)Remove Sp Inside For Close|(83)Force Sp Inside For Close"
+ChoicesReadable="Ignore Sp Inside For Close|Add Sp Inside For Close|Remove Sp Inside For Close|Force Sp Inside For Close"
 ValueDefault=ignore
 
 [Sp Sparen Paren]
 Category=1
-Description="<html>(84)Add or remove space between '((' or '))' of control statements.</html>"
+Description="<html>Add or remove space between '((' or '))' of control statements.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_sparen_paren=ignore|sp_sparen_paren=add|sp_sparen_paren=remove|sp_sparen_paren=force|sp_sparen_paren=not_defined
-ChoicesReadable="(84)Ignore Sp Sparen Paren|(84)Add Sp Sparen Paren|(84)Remove Sp Sparen Paren|(84)Force Sp Sparen Paren"
+ChoicesReadable="Ignore Sp Sparen Paren|Add Sp Sparen Paren|Remove Sp Sparen Paren|Force Sp Sparen Paren"
 ValueDefault=ignore
 
 [Sp After Sparen]
 Category=1
-Description="<html>(85)Add or remove space after ')' of control statements.</html>"
+Description="<html>Add or remove space after ')' of control statements.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_sparen=ignore|sp_after_sparen=add|sp_after_sparen=remove|sp_after_sparen=force|sp_after_sparen=not_defined
-ChoicesReadable="(85)Ignore Sp After Sparen|(85)Add Sp After Sparen|(85)Remove Sp After Sparen|(85)Force Sp After Sparen"
+ChoicesReadable="Ignore Sp After Sparen|Add Sp After Sparen|Remove Sp After Sparen|Force Sp After Sparen"
 ValueDefault=ignore
 
 [Sp Sparen Brace]
 Category=1
-Description="<html>(86)Add or remove space between ')' and '{' of control statements.</html>"
+Description="<html>Add or remove space between ')' and '{' of control statements.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_sparen_brace=ignore|sp_sparen_brace=add|sp_sparen_brace=remove|sp_sparen_brace=force|sp_sparen_brace=not_defined
-ChoicesReadable="(86)Ignore Sp Sparen Brace|(86)Add Sp Sparen Brace|(86)Remove Sp Sparen Brace|(86)Force Sp Sparen Brace"
+ChoicesReadable="Ignore Sp Sparen Brace|Add Sp Sparen Brace|Remove Sp Sparen Brace|Force Sp Sparen Brace"
 ValueDefault=ignore
 
 [Sp Do Brace Open]
 Category=1
-Description="<html>(87)Add or remove space between 'do' and '{'.</html>"
+Description="<html>Add or remove space between 'do' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_do_brace_open=ignore|sp_do_brace_open=add|sp_do_brace_open=remove|sp_do_brace_open=force|sp_do_brace_open=not_defined
-ChoicesReadable="(87)Ignore Sp Do Brace Open|(87)Add Sp Do Brace Open|(87)Remove Sp Do Brace Open|(87)Force Sp Do Brace Open"
+ChoicesReadable="Ignore Sp Do Brace Open|Add Sp Do Brace Open|Remove Sp Do Brace Open|Force Sp Do Brace Open"
 ValueDefault=ignore
 
 [Sp Brace Close While]
 Category=1
-Description="<html>(88)Add or remove space between '}' and 'while'.</html>"
+Description="<html>Add or remove space between '}' and 'while'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_brace_close_while=ignore|sp_brace_close_while=add|sp_brace_close_while=remove|sp_brace_close_while=force|sp_brace_close_while=not_defined
-ChoicesReadable="(88)Ignore Sp Brace Close While|(88)Add Sp Brace Close While|(88)Remove Sp Brace Close While|(88)Force Sp Brace Close While"
+ChoicesReadable="Ignore Sp Brace Close While|Add Sp Brace Close While|Remove Sp Brace Close While|Force Sp Brace Close While"
 ValueDefault=ignore
 
 [Sp While Paren Open]
 Category=1
-Description="<html>(89)Add or remove space between 'while' and '('. Overrides sp_before_sparen.</html>"
+Description="<html>Add or remove space between 'while' and '('. Overrides sp_before_sparen.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_while_paren_open=ignore|sp_while_paren_open=add|sp_while_paren_open=remove|sp_while_paren_open=force|sp_while_paren_open=not_defined
-ChoicesReadable="(89)Ignore Sp While Paren Open|(89)Add Sp While Paren Open|(89)Remove Sp While Paren Open|(89)Force Sp While Paren Open"
+ChoicesReadable="Ignore Sp While Paren Open|Add Sp While Paren Open|Remove Sp While Paren Open|Force Sp While Paren Open"
 ValueDefault=ignore
 
 [Sp Invariant Paren]
 Category=1
-Description="<html>(90)(D) Add or remove space between 'invariant' and '('.</html>"
+Description="<html>(D) Add or remove space between 'invariant' and '('.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_invariant_paren=ignore|sp_invariant_paren=add|sp_invariant_paren=remove|sp_invariant_paren=force|sp_invariant_paren=not_defined
-ChoicesReadable="(90)Ignore Sp Invariant Paren|(90)Add Sp Invariant Paren|(90)Remove Sp Invariant Paren|(90)Force Sp Invariant Paren"
+ChoicesReadable="Ignore Sp Invariant Paren|Add Sp Invariant Paren|Remove Sp Invariant Paren|Force Sp Invariant Paren"
 ValueDefault=ignore
 
 [Sp After Invariant Paren]
 Category=1
-Description="<html>(91)(D) Add or remove space after the ')' in 'invariant (C) c'.</html>"
+Description="<html>(D) Add or remove space after the ')' in 'invariant (C) c'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_invariant_paren=ignore|sp_after_invariant_paren=add|sp_after_invariant_paren=remove|sp_after_invariant_paren=force|sp_after_invariant_paren=not_defined
-ChoicesReadable="(91)Ignore Sp After Invariant Paren|(91)Add Sp After Invariant Paren|(91)Remove Sp After Invariant Paren|(91)Force Sp After Invariant Paren"
+ChoicesReadable="Ignore Sp After Invariant Paren|Add Sp After Invariant Paren|Remove Sp After Invariant Paren|Force Sp After Invariant Paren"
 ValueDefault=ignore
 
 [Sp Special Semi]
 Category=1
-Description="<html>(92)Add or remove space before empty statement ';' on 'if', 'for' and 'while'.</html>"
+Description="<html>Add or remove space before empty statement ';' on 'if', 'for' and 'while'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_special_semi=ignore|sp_special_semi=add|sp_special_semi=remove|sp_special_semi=force|sp_special_semi=not_defined
-ChoicesReadable="(92)Ignore Sp Special Semi|(92)Add Sp Special Semi|(92)Remove Sp Special Semi|(92)Force Sp Special Semi"
+ChoicesReadable="Ignore Sp Special Semi|Add Sp Special Semi|Remove Sp Special Semi|Force Sp Special Semi"
 ValueDefault=ignore
 
 [Sp Before Semi]
 Category=1
-Description="<html>(93)Add or remove space before ';'.<br/><br/>Default: remove</html>"
+Description="<html>Add or remove space before ';'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_semi=ignore|sp_before_semi=add|sp_before_semi=remove|sp_before_semi=force|sp_before_semi=not_defined
-ChoicesReadable="(93)Ignore Sp Before Semi|(93)Add Sp Before Semi|(93)Remove Sp Before Semi|(93)Force Sp Before Semi"
+ChoicesReadable="Ignore Sp Before Semi|Add Sp Before Semi|Remove Sp Before Semi|Force Sp Before Semi"
 ValueDefault=remove
 
 [Sp Before Semi For]
 Category=1
-Description="<html>(94)Add or remove space before ';' in non-empty 'for' statements.</html>"
+Description="<html>Add or remove space before ';' in non-empty 'for' statements.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_semi_for=ignore|sp_before_semi_for=add|sp_before_semi_for=remove|sp_before_semi_for=force|sp_before_semi_for=not_defined
-ChoicesReadable="(94)Ignore Sp Before Semi For|(94)Add Sp Before Semi For|(94)Remove Sp Before Semi For|(94)Force Sp Before Semi For"
+ChoicesReadable="Ignore Sp Before Semi For|Add Sp Before Semi For|Remove Sp Before Semi For|Force Sp Before Semi For"
 ValueDefault=ignore
 
 [Sp Before Semi For Empty]
 Category=1
-Description="<html>(95)Add or remove space before a semicolon of an empty left part of a for<br/>statement, as in 'for ( &lt;here&gt; ; ; )'.</html>"
+Description="<html>Add or remove space before a semicolon of an empty left part of a for<br/>statement, as in 'for ( &lt;here&gt; ; ; )'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_semi_for_empty=ignore|sp_before_semi_for_empty=add|sp_before_semi_for_empty=remove|sp_before_semi_for_empty=force|sp_before_semi_for_empty=not_defined
-ChoicesReadable="(95)Ignore Sp Before Semi For Empty|(95)Add Sp Before Semi For Empty|(95)Remove Sp Before Semi For Empty|(95)Force Sp Before Semi For Empty"
+ChoicesReadable="Ignore Sp Before Semi For Empty|Add Sp Before Semi For Empty|Remove Sp Before Semi For Empty|Force Sp Before Semi For Empty"
 ValueDefault=ignore
 
 [Sp Between Semi For Empty]
 Category=1
-Description="<html>(96)Add or remove space between the semicolons of an empty middle part of a for<br/>statement, as in 'for ( ; &lt;here&gt; ; )'.</html>"
+Description="<html>Add or remove space between the semicolons of an empty middle part of a for<br/>statement, as in 'for ( ; &lt;here&gt; ; )'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_between_semi_for_empty=ignore|sp_between_semi_for_empty=add|sp_between_semi_for_empty=remove|sp_between_semi_for_empty=force|sp_between_semi_for_empty=not_defined
-ChoicesReadable="(96)Ignore Sp Between Semi For Empty|(96)Add Sp Between Semi For Empty|(96)Remove Sp Between Semi For Empty|(96)Force Sp Between Semi For Empty"
+ChoicesReadable="Ignore Sp Between Semi For Empty|Add Sp Between Semi For Empty|Remove Sp Between Semi For Empty|Force Sp Between Semi For Empty"
 ValueDefault=ignore
 
 [Sp After Semi]
 Category=1
-Description="<html>(97)Add or remove space after ';', except when followed by a comment.<br/><br/>Default: add</html>"
+Description="<html>Add or remove space after ';', except when followed by a comment.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_semi=ignore|sp_after_semi=add|sp_after_semi=remove|sp_after_semi=force|sp_after_semi=not_defined
-ChoicesReadable="(97)Ignore Sp After Semi|(97)Add Sp After Semi|(97)Remove Sp After Semi|(97)Force Sp After Semi"
+ChoicesReadable="Ignore Sp After Semi|Add Sp After Semi|Remove Sp After Semi|Force Sp After Semi"
 ValueDefault=add
 
 [Sp After Semi For]
 Category=1
-Description="<html>(98)Add or remove space after ';' in non-empty 'for' statements.<br/><br/>Default: force</html>"
+Description="<html>Add or remove space after ';' in non-empty 'for' statements.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_semi_for=ignore|sp_after_semi_for=add|sp_after_semi_for=remove|sp_after_semi_for=force|sp_after_semi_for=not_defined
-ChoicesReadable="(98)Ignore Sp After Semi For|(98)Add Sp After Semi For|(98)Remove Sp After Semi For|(98)Force Sp After Semi For"
+ChoicesReadable="Ignore Sp After Semi For|Add Sp After Semi For|Remove Sp After Semi For|Force Sp After Semi For"
 ValueDefault=force
 
 [Sp After Semi For Empty]
 Category=1
-Description="<html>(99)Add or remove space after the final semicolon of an empty part of a for<br/>statement, as in 'for ( ; ; &lt;here&gt; )'.</html>"
+Description="<html>Add or remove space after the final semicolon of an empty part of a for<br/>statement, as in 'for ( ; ; &lt;here&gt; )'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_semi_for_empty=ignore|sp_after_semi_for_empty=add|sp_after_semi_for_empty=remove|sp_after_semi_for_empty=force|sp_after_semi_for_empty=not_defined
-ChoicesReadable="(99)Ignore Sp After Semi For Empty|(99)Add Sp After Semi For Empty|(99)Remove Sp After Semi For Empty|(99)Force Sp After Semi For Empty"
+ChoicesReadable="Ignore Sp After Semi For Empty|Add Sp After Semi For Empty|Remove Sp After Semi For Empty|Force Sp After Semi For Empty"
 ValueDefault=ignore
 
 [Sp Before Square]
 Category=1
-Description="<html>(100)Add or remove space before '[' (except '[]').</html>"
+Description="<html>Add or remove space before '[' (except '[]').</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_square=ignore|sp_before_square=add|sp_before_square=remove|sp_before_square=force|sp_before_square=not_defined
-ChoicesReadable="(100)Ignore Sp Before Square|(100)Add Sp Before Square|(100)Remove Sp Before Square|(100)Force Sp Before Square"
+ChoicesReadable="Ignore Sp Before Square|Add Sp Before Square|Remove Sp Before Square|Force Sp Before Square"
 ValueDefault=ignore
 
 [Sp Before Vardef Square]
 Category=1
-Description="<html>(101)Add or remove space before '[' for a variable definition.<br/><br/>Default: remove</html>"
+Description="<html>Add or remove space before '[' for a variable definition.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_vardef_square=ignore|sp_before_vardef_square=add|sp_before_vardef_square=remove|sp_before_vardef_square=force|sp_before_vardef_square=not_defined
-ChoicesReadable="(101)Ignore Sp Before Vardef Square|(101)Add Sp Before Vardef Square|(101)Remove Sp Before Vardef Square|(101)Force Sp Before Vardef Square"
+ChoicesReadable="Ignore Sp Before Vardef Square|Add Sp Before Vardef Square|Remove Sp Before Vardef Square|Force Sp Before Vardef Square"
 ValueDefault=remove
 
 [Sp Before Square Asm Block]
 Category=1
-Description="<html>(102)Add or remove space before '[' for asm block.</html>"
+Description="<html>Add or remove space before '[' for asm block.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_square_asm_block=ignore|sp_before_square_asm_block=add|sp_before_square_asm_block=remove|sp_before_square_asm_block=force|sp_before_square_asm_block=not_defined
-ChoicesReadable="(102)Ignore Sp Before Square Asm Block|(102)Add Sp Before Square Asm Block|(102)Remove Sp Before Square Asm Block|(102)Force Sp Before Square Asm Block"
+ChoicesReadable="Ignore Sp Before Square Asm Block|Add Sp Before Square Asm Block|Remove Sp Before Square Asm Block|Force Sp Before Square Asm Block"
 ValueDefault=ignore
 
 [Sp Before Squares]
 Category=1
-Description="<html>(103)Add or remove space before '[]'.</html>"
+Description="<html>Add or remove space before '[]'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_squares=ignore|sp_before_squares=add|sp_before_squares=remove|sp_before_squares=force|sp_before_squares=not_defined
-ChoicesReadable="(103)Ignore Sp Before Squares|(103)Add Sp Before Squares|(103)Remove Sp Before Squares|(103)Force Sp Before Squares"
+ChoicesReadable="Ignore Sp Before Squares|Add Sp Before Squares|Remove Sp Before Squares|Force Sp Before Squares"
 ValueDefault=ignore
 
 [Sp Cpp Before Struct Binding]
 Category=1
-Description="<html>(104)Add or remove space before C++17 structured bindings.</html>"
+Description="<html>Add or remove space before C++17 structured bindings.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cpp_before_struct_binding=ignore|sp_cpp_before_struct_binding=add|sp_cpp_before_struct_binding=remove|sp_cpp_before_struct_binding=force|sp_cpp_before_struct_binding=not_defined
-ChoicesReadable="(104)Ignore Sp Cpp Before Struct Binding|(104)Add Sp Cpp Before Struct Binding|(104)Remove Sp Cpp Before Struct Binding|(104)Force Sp Cpp Before Struct Binding"
+ChoicesReadable="Ignore Sp Cpp Before Struct Binding|Add Sp Cpp Before Struct Binding|Remove Sp Cpp Before Struct Binding|Force Sp Cpp Before Struct Binding"
 ValueDefault=ignore
 
 [Sp Inside Square]
 Category=1
-Description="<html>(105)Add or remove space inside a non-empty '[' and ']'.</html>"
+Description="<html>Add or remove space inside a non-empty '[' and ']'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_square=ignore|sp_inside_square=add|sp_inside_square=remove|sp_inside_square=force|sp_inside_square=not_defined
-ChoicesReadable="(105)Ignore Sp Inside Square|(105)Add Sp Inside Square|(105)Remove Sp Inside Square|(105)Force Sp Inside Square"
+ChoicesReadable="Ignore Sp Inside Square|Add Sp Inside Square|Remove Sp Inside Square|Force Sp Inside Square"
 ValueDefault=ignore
 
 [Sp Inside Square Empty]
 Category=1
-Description="<html>(106)Add or remove space inside '[]'.</html>"
+Description="<html>Add or remove space inside '[]'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_square_empty=ignore|sp_inside_square_empty=add|sp_inside_square_empty=remove|sp_inside_square_empty=force|sp_inside_square_empty=not_defined
-ChoicesReadable="(106)Ignore Sp Inside Square Empty|(106)Add Sp Inside Square Empty|(106)Remove Sp Inside Square Empty|(106)Force Sp Inside Square Empty"
+ChoicesReadable="Ignore Sp Inside Square Empty|Add Sp Inside Square Empty|Remove Sp Inside Square Empty|Force Sp Inside Square Empty"
 ValueDefault=ignore
 
 [Sp Inside Square Oc Array]
 Category=1
-Description="<html>(107)(OC) Add or remove space inside a non-empty Objective-C boxed array '@[' and<br/>']'. If set to ignore, sp_inside_square is used.</html>"
+Description="<html>(OC) Add or remove space inside a non-empty Objective-C boxed array '@[' and<br/>']'. If set to ignore, sp_inside_square is used.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_square_oc_array=ignore|sp_inside_square_oc_array=add|sp_inside_square_oc_array=remove|sp_inside_square_oc_array=force|sp_inside_square_oc_array=not_defined
-ChoicesReadable="(107)Ignore Sp Inside Square Oc Array|(107)Add Sp Inside Square Oc Array|(107)Remove Sp Inside Square Oc Array|(107)Force Sp Inside Square Oc Array"
+ChoicesReadable="Ignore Sp Inside Square Oc Array|Add Sp Inside Square Oc Array|Remove Sp Inside Square Oc Array|Force Sp Inside Square Oc Array"
 ValueDefault=ignore
 
 [Sp After Comma]
 Category=1
-Description="<html>(108)Add or remove space after ',', i.e. 'a,b' vs. 'a, b'.</html>"
+Description="<html>Add or remove space after ',', i.e. 'a,b' vs. 'a, b'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_comma=ignore|sp_after_comma=add|sp_after_comma=remove|sp_after_comma=force|sp_after_comma=not_defined
-ChoicesReadable="(108)Ignore Sp After Comma|(108)Add Sp After Comma|(108)Remove Sp After Comma|(108)Force Sp After Comma"
+ChoicesReadable="Ignore Sp After Comma|Add Sp After Comma|Remove Sp After Comma|Force Sp After Comma"
 ValueDefault=ignore
 
 [Sp Before Comma]
 Category=1
-Description="<html>(109)Add or remove space before ',', i.e. 'a,b' vs. 'a ,b'.<br/><br/>Default: remove</html>"
+Description="<html>Add or remove space before ',', i.e. 'a,b' vs. 'a ,b'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_comma=ignore|sp_before_comma=add|sp_before_comma=remove|sp_before_comma=force|sp_before_comma=not_defined
-ChoicesReadable="(109)Ignore Sp Before Comma|(109)Add Sp Before Comma|(109)Remove Sp Before Comma|(109)Force Sp Before Comma"
+ChoicesReadable="Ignore Sp Before Comma|Add Sp Before Comma|Remove Sp Before Comma|Force Sp Before Comma"
 ValueDefault=remove
 
 [Sp After Mdatype Commas]
 Category=1
-Description="<html>(110)(C#, Vala) Add or remove space between ',' and ']' in multidimensional array type<br/>like 'int[,,]'.</html>"
+Description="<html>(C#, Vala) Add or remove space between ',' and ']' in multidimensional array type<br/>like 'int[,,]'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_mdatype_commas=ignore|sp_after_mdatype_commas=add|sp_after_mdatype_commas=remove|sp_after_mdatype_commas=force|sp_after_mdatype_commas=not_defined
-ChoicesReadable="(110)Ignore Sp After Mdatype Commas|(110)Add Sp After Mdatype Commas|(110)Remove Sp After Mdatype Commas|(110)Force Sp After Mdatype Commas"
+ChoicesReadable="Ignore Sp After Mdatype Commas|Add Sp After Mdatype Commas|Remove Sp After Mdatype Commas|Force Sp After Mdatype Commas"
 ValueDefault=ignore
 
 [Sp Before Mdatype Commas]
 Category=1
-Description="<html>(111)(C#, Vala) Add or remove space between '[' and ',' in multidimensional array type<br/>like 'int[,,]'.</html>"
+Description="<html>(C#, Vala) Add or remove space between '[' and ',' in multidimensional array type<br/>like 'int[,,]'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_mdatype_commas=ignore|sp_before_mdatype_commas=add|sp_before_mdatype_commas=remove|sp_before_mdatype_commas=force|sp_before_mdatype_commas=not_defined
-ChoicesReadable="(111)Ignore Sp Before Mdatype Commas|(111)Add Sp Before Mdatype Commas|(111)Remove Sp Before Mdatype Commas|(111)Force Sp Before Mdatype Commas"
+ChoicesReadable="Ignore Sp Before Mdatype Commas|Add Sp Before Mdatype Commas|Remove Sp Before Mdatype Commas|Force Sp Before Mdatype Commas"
 ValueDefault=ignore
 
 [Sp Between Mdatype Commas]
 Category=1
-Description="<html>(112)(C#, Vala) Add or remove space between ',' in multidimensional array type<br/>like 'int[,,]'.</html>"
+Description="<html>(C#, Vala) Add or remove space between ',' in multidimensional array type<br/>like 'int[,,]'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_between_mdatype_commas=ignore|sp_between_mdatype_commas=add|sp_between_mdatype_commas=remove|sp_between_mdatype_commas=force|sp_between_mdatype_commas=not_defined
-ChoicesReadable="(112)Ignore Sp Between Mdatype Commas|(112)Add Sp Between Mdatype Commas|(112)Remove Sp Between Mdatype Commas|(112)Force Sp Between Mdatype Commas"
+ChoicesReadable="Ignore Sp Between Mdatype Commas|Add Sp Between Mdatype Commas|Remove Sp Between Mdatype Commas|Force Sp Between Mdatype Commas"
 ValueDefault=ignore
 
 [Sp Paren Comma]
 Category=1
-Description="<html>(113)Add or remove space between an open parenthesis and comma,<br/>i.e. '(,' vs. '( ,'.<br/><br/>Default: force</html>"
+Description="<html>Add or remove space between an open parenthesis and comma,<br/>i.e. '(,' vs. '( ,'.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_paren_comma=ignore|sp_paren_comma=add|sp_paren_comma=remove|sp_paren_comma=force|sp_paren_comma=not_defined
-ChoicesReadable="(113)Ignore Sp Paren Comma|(113)Add Sp Paren Comma|(113)Remove Sp Paren Comma|(113)Force Sp Paren Comma"
+ChoicesReadable="Ignore Sp Paren Comma|Add Sp Paren Comma|Remove Sp Paren Comma|Force Sp Paren Comma"
 ValueDefault=force
 
 [Sp Type Colon]
 Category=1
-Description="<html>(114)Add or remove space between a type and ':'.</html>"
+Description="<html>Add or remove space between a type and ':'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_type_colon=ignore|sp_type_colon=add|sp_type_colon=remove|sp_type_colon=force|sp_type_colon=not_defined
-ChoicesReadable="(114)Ignore Sp Type Colon|(114)Add Sp Type Colon|(114)Remove Sp Type Colon|(114)Force Sp Type Colon"
+ChoicesReadable="Ignore Sp Type Colon|Add Sp Type Colon|Remove Sp Type Colon|Force Sp Type Colon"
 ValueDefault=ignore
 
 [Sp After Ellipsis]
 Category=1
-Description="<html>(115)Add or remove space after the variadic '...' when preceded by a<br/>non-punctuator.<br/>The value REMOVE will be overridden with FORCE</html>"
+Description="<html>Add or remove space after the variadic '...' when preceded by a<br/>non-punctuator.<br/>The value REMOVE will be overridden with FORCE</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_ellipsis=ignore|sp_after_ellipsis=add|sp_after_ellipsis=remove|sp_after_ellipsis=force|sp_after_ellipsis=not_defined
-ChoicesReadable="(115)Ignore Sp After Ellipsis|(115)Add Sp After Ellipsis|(115)Remove Sp After Ellipsis|(115)Force Sp After Ellipsis"
+ChoicesReadable="Ignore Sp After Ellipsis|Add Sp After Ellipsis|Remove Sp After Ellipsis|Force Sp After Ellipsis"
 ValueDefault=ignore
 
 [Sp Before Ellipsis]
 Category=1
-Description="<html>(116)Add or remove space before the variadic '...' when preceded by a<br/>non-punctuator.<br/>The value REMOVE will be overridden with FORCE</html>"
+Description="<html>Add or remove space before the variadic '...' when preceded by a<br/>non-punctuator.<br/>The value REMOVE will be overridden with FORCE</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_ellipsis=ignore|sp_before_ellipsis=add|sp_before_ellipsis=remove|sp_before_ellipsis=force|sp_before_ellipsis=not_defined
-ChoicesReadable="(116)Ignore Sp Before Ellipsis|(116)Add Sp Before Ellipsis|(116)Remove Sp Before Ellipsis|(116)Force Sp Before Ellipsis"
+ChoicesReadable="Ignore Sp Before Ellipsis|Add Sp Before Ellipsis|Remove Sp Before Ellipsis|Force Sp Before Ellipsis"
 ValueDefault=ignore
 
 [Sp Type Ellipsis]
 Category=1
-Description="<html>(117)Add or remove space between a type and '...'.</html>"
+Description="<html>Add or remove space between a type and '...'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_type_ellipsis=ignore|sp_type_ellipsis=add|sp_type_ellipsis=remove|sp_type_ellipsis=force|sp_type_ellipsis=not_defined
-ChoicesReadable="(117)Ignore Sp Type Ellipsis|(117)Add Sp Type Ellipsis|(117)Remove Sp Type Ellipsis|(117)Force Sp Type Ellipsis"
+ChoicesReadable="Ignore Sp Type Ellipsis|Add Sp Type Ellipsis|Remove Sp Type Ellipsis|Force Sp Type Ellipsis"
 ValueDefault=ignore
 
 [Sp Ptr Type Ellipsis]
 Category=1
-Description="<html>(118)Add or remove space between a '*' and '...'.</html>"
+Description="<html>Add or remove space between a '*' and '...'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_ptr_type_ellipsis=ignore|sp_ptr_type_ellipsis=add|sp_ptr_type_ellipsis=remove|sp_ptr_type_ellipsis=force|sp_ptr_type_ellipsis=not_defined
-ChoicesReadable="(118)Ignore Sp Ptr Type Ellipsis|(118)Add Sp Ptr Type Ellipsis|(118)Remove Sp Ptr Type Ellipsis|(118)Force Sp Ptr Type Ellipsis"
+ChoicesReadable="Ignore Sp Ptr Type Ellipsis|Add Sp Ptr Type Ellipsis|Remove Sp Ptr Type Ellipsis|Force Sp Ptr Type Ellipsis"
 ValueDefault=ignore
 
 [Sp Paren Ellipsis]
 Category=1
-Description="<html>(119)Add or remove space between ')' and '...'.</html>"
+Description="<html>Add or remove space between ')' and '...'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_paren_ellipsis=ignore|sp_paren_ellipsis=add|sp_paren_ellipsis=remove|sp_paren_ellipsis=force|sp_paren_ellipsis=not_defined
-ChoicesReadable="(119)Ignore Sp Paren Ellipsis|(119)Add Sp Paren Ellipsis|(119)Remove Sp Paren Ellipsis|(119)Force Sp Paren Ellipsis"
+ChoicesReadable="Ignore Sp Paren Ellipsis|Add Sp Paren Ellipsis|Remove Sp Paren Ellipsis|Force Sp Paren Ellipsis"
 ValueDefault=ignore
 
 [Sp Byref Ellipsis]
 Category=1
-Description="<html>(120)Add or remove space between '&amp;&amp;' and '...'.</html>"
+Description="<html>Add or remove space between '&amp;&amp;' and '...'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_byref_ellipsis=ignore|sp_byref_ellipsis=add|sp_byref_ellipsis=remove|sp_byref_ellipsis=force|sp_byref_ellipsis=not_defined
-ChoicesReadable="(120)Ignore Sp Byref Ellipsis|(120)Add Sp Byref Ellipsis|(120)Remove Sp Byref Ellipsis|(120)Force Sp Byref Ellipsis"
+ChoicesReadable="Ignore Sp Byref Ellipsis|Add Sp Byref Ellipsis|Remove Sp Byref Ellipsis|Force Sp Byref Ellipsis"
 ValueDefault=ignore
 
 [Sp Paren Qualifier]
 Category=1
-Description="<html>(121)Add or remove space between ')' and a qualifier such as 'const'.</html>"
+Description="<html>Add or remove space between ')' and a qualifier such as 'const'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_paren_qualifier=ignore|sp_paren_qualifier=add|sp_paren_qualifier=remove|sp_paren_qualifier=force|sp_paren_qualifier=not_defined
-ChoicesReadable="(121)Ignore Sp Paren Qualifier|(121)Add Sp Paren Qualifier|(121)Remove Sp Paren Qualifier|(121)Force Sp Paren Qualifier"
+ChoicesReadable="Ignore Sp Paren Qualifier|Add Sp Paren Qualifier|Remove Sp Paren Qualifier|Force Sp Paren Qualifier"
 ValueDefault=ignore
 
 [Sp Paren Noexcept]
 Category=1
-Description="<html>(122)Add or remove space between ')' and 'noexcept'.</html>"
+Description="<html>Add or remove space between ')' and 'noexcept'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_paren_noexcept=ignore|sp_paren_noexcept=add|sp_paren_noexcept=remove|sp_paren_noexcept=force|sp_paren_noexcept=not_defined
-ChoicesReadable="(122)Ignore Sp Paren Noexcept|(122)Add Sp Paren Noexcept|(122)Remove Sp Paren Noexcept|(122)Force Sp Paren Noexcept"
+ChoicesReadable="Ignore Sp Paren Noexcept|Add Sp Paren Noexcept|Remove Sp Paren Noexcept|Force Sp Paren Noexcept"
 ValueDefault=ignore
 
 [Sp After Class Colon]
 Category=1
-Description="<html>(123)Add or remove space after class ':'.</html>"
+Description="<html>Add or remove space after class ':'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_class_colon=ignore|sp_after_class_colon=add|sp_after_class_colon=remove|sp_after_class_colon=force|sp_after_class_colon=not_defined
-ChoicesReadable="(123)Ignore Sp After Class Colon|(123)Add Sp After Class Colon|(123)Remove Sp After Class Colon|(123)Force Sp After Class Colon"
+ChoicesReadable="Ignore Sp After Class Colon|Add Sp After Class Colon|Remove Sp After Class Colon|Force Sp After Class Colon"
 ValueDefault=ignore
 
 [Sp Before Class Colon]
 Category=1
-Description="<html>(124)Add or remove space before class ':'.</html>"
+Description="<html>Add or remove space before class ':'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_class_colon=ignore|sp_before_class_colon=add|sp_before_class_colon=remove|sp_before_class_colon=force|sp_before_class_colon=not_defined
-ChoicesReadable="(124)Ignore Sp Before Class Colon|(124)Add Sp Before Class Colon|(124)Remove Sp Before Class Colon|(124)Force Sp Before Class Colon"
+ChoicesReadable="Ignore Sp Before Class Colon|Add Sp Before Class Colon|Remove Sp Before Class Colon|Force Sp Before Class Colon"
 ValueDefault=ignore
 
 [Sp After Constr Colon]
 Category=1
-Description="<html>(125)Add or remove space after class constructor ':'.<br/><br/>Default: add</html>"
+Description="<html>Add or remove space after class constructor ':'.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_constr_colon=ignore|sp_after_constr_colon=add|sp_after_constr_colon=remove|sp_after_constr_colon=force|sp_after_constr_colon=not_defined
-ChoicesReadable="(125)Ignore Sp After Constr Colon|(125)Add Sp After Constr Colon|(125)Remove Sp After Constr Colon|(125)Force Sp After Constr Colon"
+ChoicesReadable="Ignore Sp After Constr Colon|Add Sp After Constr Colon|Remove Sp After Constr Colon|Force Sp After Constr Colon"
 ValueDefault=add
 
 [Sp Before Constr Colon]
 Category=1
-Description="<html>(126)Add or remove space before class constructor ':'.<br/><br/>Default: add</html>"
+Description="<html>Add or remove space before class constructor ':'.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_constr_colon=ignore|sp_before_constr_colon=add|sp_before_constr_colon=remove|sp_before_constr_colon=force|sp_before_constr_colon=not_defined
-ChoicesReadable="(126)Ignore Sp Before Constr Colon|(126)Add Sp Before Constr Colon|(126)Remove Sp Before Constr Colon|(126)Force Sp Before Constr Colon"
+ChoicesReadable="Ignore Sp Before Constr Colon|Add Sp Before Constr Colon|Remove Sp Before Constr Colon|Force Sp Before Constr Colon"
 ValueDefault=add
 
 [Sp Before Case Colon]
 Category=1
-Description="<html>(127)Add or remove space before case ':'.<br/><br/>Default: remove</html>"
+Description="<html>Add or remove space before case ':'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_case_colon=ignore|sp_before_case_colon=add|sp_before_case_colon=remove|sp_before_case_colon=force|sp_before_case_colon=not_defined
-ChoicesReadable="(127)Ignore Sp Before Case Colon|(127)Add Sp Before Case Colon|(127)Remove Sp Before Case Colon|(127)Force Sp Before Case Colon"
+ChoicesReadable="Ignore Sp Before Case Colon|Add Sp Before Case Colon|Remove Sp Before Case Colon|Force Sp Before Case Colon"
 ValueDefault=remove
 
 [Sp After Operator]
 Category=1
-Description="<html>(128)Add or remove space between 'operator' and operator sign.</html>"
+Description="<html>Add or remove space between 'operator' and operator sign.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_operator=ignore|sp_after_operator=add|sp_after_operator=remove|sp_after_operator=force|sp_after_operator=not_defined
-ChoicesReadable="(128)Ignore Sp After Operator|(128)Add Sp After Operator|(128)Remove Sp After Operator|(128)Force Sp After Operator"
+ChoicesReadable="Ignore Sp After Operator|Add Sp After Operator|Remove Sp After Operator|Force Sp After Operator"
 ValueDefault=ignore
 
 [Sp After Operator Sym]
 Category=1
-Description="<html>(129)Add or remove space between the operator symbol and the open parenthesis, as<br/>in 'operator ++('.</html>"
+Description="<html>Add or remove space between the operator symbol and the open parenthesis, as<br/>in 'operator ++('.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_operator_sym=ignore|sp_after_operator_sym=add|sp_after_operator_sym=remove|sp_after_operator_sym=force|sp_after_operator_sym=not_defined
-ChoicesReadable="(129)Ignore Sp After Operator Sym|(129)Add Sp After Operator Sym|(129)Remove Sp After Operator Sym|(129)Force Sp After Operator Sym"
+ChoicesReadable="Ignore Sp After Operator Sym|Add Sp After Operator Sym|Remove Sp After Operator Sym|Force Sp After Operator Sym"
 ValueDefault=ignore
 
 [Sp After Operator Sym Empty]
 Category=1
-Description="<html>(130)Overrides sp_after_operator_sym when the operator has no arguments, as in<br/>'operator *()'.</html>"
+Description="<html>Overrides sp_after_operator_sym when the operator has no arguments, as in<br/>'operator *()'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_operator_sym_empty=ignore|sp_after_operator_sym_empty=add|sp_after_operator_sym_empty=remove|sp_after_operator_sym_empty=force|sp_after_operator_sym_empty=not_defined
-ChoicesReadable="(130)Ignore Sp After Operator Sym Empty|(130)Add Sp After Operator Sym Empty|(130)Remove Sp After Operator Sym Empty|(130)Force Sp After Operator Sym Empty"
+ChoicesReadable="Ignore Sp After Operator Sym Empty|Add Sp After Operator Sym Empty|Remove Sp After Operator Sym Empty|Force Sp After Operator Sym Empty"
 ValueDefault=ignore
 
 [Sp After Cast]
 Category=1
-Description="<html>(131)Add or remove space after C/D cast, i.e. 'cast(int)a' vs. 'cast(int) a' or<br/>'(int)a' vs. '(int) a'.</html>"
+Description="<html>Add or remove space after C/D cast, i.e. 'cast(int)a' vs. 'cast(int) a' or<br/>'(int)a' vs. '(int) a'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_cast=ignore|sp_after_cast=add|sp_after_cast=remove|sp_after_cast=force|sp_after_cast=not_defined
-ChoicesReadable="(131)Ignore Sp After Cast|(131)Add Sp After Cast|(131)Remove Sp After Cast|(131)Force Sp After Cast"
+ChoicesReadable="Ignore Sp After Cast|Add Sp After Cast|Remove Sp After Cast|Force Sp After Cast"
 ValueDefault=ignore
 
 [Sp Inside Paren Cast]
 Category=1
-Description="<html>(132)Add or remove spaces inside cast parentheses.</html>"
+Description="<html>Add or remove spaces inside cast parentheses.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_paren_cast=ignore|sp_inside_paren_cast=add|sp_inside_paren_cast=remove|sp_inside_paren_cast=force|sp_inside_paren_cast=not_defined
-ChoicesReadable="(132)Ignore Sp Inside Paren Cast|(132)Add Sp Inside Paren Cast|(132)Remove Sp Inside Paren Cast|(132)Force Sp Inside Paren Cast"
+ChoicesReadable="Ignore Sp Inside Paren Cast|Add Sp Inside Paren Cast|Remove Sp Inside Paren Cast|Force Sp Inside Paren Cast"
 ValueDefault=ignore
 
 [Sp Cpp Cast Paren]
 Category=1
-Description="<html>(133)Add or remove space between the type and open parenthesis in a C++ cast,<br/>i.e. 'int(exp)' vs. 'int (exp)'.</html>"
+Description="<html>Add or remove space between the type and open parenthesis in a C++ cast,<br/>i.e. 'int(exp)' vs. 'int (exp)'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cpp_cast_paren=ignore|sp_cpp_cast_paren=add|sp_cpp_cast_paren=remove|sp_cpp_cast_paren=force|sp_cpp_cast_paren=not_defined
-ChoicesReadable="(133)Ignore Sp Cpp Cast Paren|(133)Add Sp Cpp Cast Paren|(133)Remove Sp Cpp Cast Paren|(133)Force Sp Cpp Cast Paren"
+ChoicesReadable="Ignore Sp Cpp Cast Paren|Add Sp Cpp Cast Paren|Remove Sp Cpp Cast Paren|Force Sp Cpp Cast Paren"
 ValueDefault=ignore
 
 [Sp Sizeof Paren]
 Category=1
-Description="<html>(134)Add or remove space between 'sizeof' and '('.</html>"
+Description="<html>Add or remove space between 'sizeof' and '('.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_sizeof_paren=ignore|sp_sizeof_paren=add|sp_sizeof_paren=remove|sp_sizeof_paren=force|sp_sizeof_paren=not_defined
-ChoicesReadable="(134)Ignore Sp Sizeof Paren|(134)Add Sp Sizeof Paren|(134)Remove Sp Sizeof Paren|(134)Force Sp Sizeof Paren"
+ChoicesReadable="Ignore Sp Sizeof Paren|Add Sp Sizeof Paren|Remove Sp Sizeof Paren|Force Sp Sizeof Paren"
 ValueDefault=ignore
 
 [Sp Sizeof Ellipsis]
 Category=1
-Description="<html>(135)Add or remove space between 'sizeof' and '...'.</html>"
+Description="<html>Add or remove space between 'sizeof' and '...'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_sizeof_ellipsis=ignore|sp_sizeof_ellipsis=add|sp_sizeof_ellipsis=remove|sp_sizeof_ellipsis=force|sp_sizeof_ellipsis=not_defined
-ChoicesReadable="(135)Ignore Sp Sizeof Ellipsis|(135)Add Sp Sizeof Ellipsis|(135)Remove Sp Sizeof Ellipsis|(135)Force Sp Sizeof Ellipsis"
+ChoicesReadable="Ignore Sp Sizeof Ellipsis|Add Sp Sizeof Ellipsis|Remove Sp Sizeof Ellipsis|Force Sp Sizeof Ellipsis"
 ValueDefault=ignore
 
 [Sp Sizeof Ellipsis Paren]
 Category=1
-Description="<html>(136)Add or remove space between 'sizeof...' and '('.</html>"
+Description="<html>Add or remove space between 'sizeof...' and '('.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_sizeof_ellipsis_paren=ignore|sp_sizeof_ellipsis_paren=add|sp_sizeof_ellipsis_paren=remove|sp_sizeof_ellipsis_paren=force|sp_sizeof_ellipsis_paren=not_defined
-ChoicesReadable="(136)Ignore Sp Sizeof Ellipsis Paren|(136)Add Sp Sizeof Ellipsis Paren|(136)Remove Sp Sizeof Ellipsis Paren|(136)Force Sp Sizeof Ellipsis Paren"
+ChoicesReadable="Ignore Sp Sizeof Ellipsis Paren|Add Sp Sizeof Ellipsis Paren|Remove Sp Sizeof Ellipsis Paren|Force Sp Sizeof Ellipsis Paren"
 ValueDefault=ignore
 
 [Sp Ellipsis Parameter Pack]
 Category=1
-Description="<html>(137)Add or remove space between '...' and a parameter pack.</html>"
+Description="<html>Add or remove space between '...' and a parameter pack.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_ellipsis_parameter_pack=ignore|sp_ellipsis_parameter_pack=add|sp_ellipsis_parameter_pack=remove|sp_ellipsis_parameter_pack=force|sp_ellipsis_parameter_pack=not_defined
-ChoicesReadable="(137)Ignore Sp Ellipsis Parameter Pack|(137)Add Sp Ellipsis Parameter Pack|(137)Remove Sp Ellipsis Parameter Pack|(137)Force Sp Ellipsis Parameter Pack"
+ChoicesReadable="Ignore Sp Ellipsis Parameter Pack|Add Sp Ellipsis Parameter Pack|Remove Sp Ellipsis Parameter Pack|Force Sp Ellipsis Parameter Pack"
 ValueDefault=ignore
 
 [Sp Parameter Pack Ellipsis]
 Category=1
-Description="<html>(138)Add or remove space between a parameter pack and '...'.</html>"
+Description="<html>Add or remove space between a parameter pack and '...'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_parameter_pack_ellipsis=ignore|sp_parameter_pack_ellipsis=add|sp_parameter_pack_ellipsis=remove|sp_parameter_pack_ellipsis=force|sp_parameter_pack_ellipsis=not_defined
-ChoicesReadable="(138)Ignore Sp Parameter Pack Ellipsis|(138)Add Sp Parameter Pack Ellipsis|(138)Remove Sp Parameter Pack Ellipsis|(138)Force Sp Parameter Pack Ellipsis"
+ChoicesReadable="Ignore Sp Parameter Pack Ellipsis|Add Sp Parameter Pack Ellipsis|Remove Sp Parameter Pack Ellipsis|Force Sp Parameter Pack Ellipsis"
 ValueDefault=ignore
 
 [Sp Decltype Paren]
 Category=1
-Description="<html>(139)Add or remove space between 'decltype' and '('.</html>"
+Description="<html>Add or remove space between 'decltype' and '('.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_decltype_paren=ignore|sp_decltype_paren=add|sp_decltype_paren=remove|sp_decltype_paren=force|sp_decltype_paren=not_defined
-ChoicesReadable="(139)Ignore Sp Decltype Paren|(139)Add Sp Decltype Paren|(139)Remove Sp Decltype Paren|(139)Force Sp Decltype Paren"
+ChoicesReadable="Ignore Sp Decltype Paren|Add Sp Decltype Paren|Remove Sp Decltype Paren|Force Sp Decltype Paren"
 ValueDefault=ignore
 
 [Sp After Tag]
 Category=1
-Description="<html>(140)(Pawn) Add or remove space after the tag keyword.</html>"
+Description="<html>(Pawn) Add or remove space after the tag keyword.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_tag=ignore|sp_after_tag=add|sp_after_tag=remove|sp_after_tag=force|sp_after_tag=not_defined
-ChoicesReadable="(140)Ignore Sp After Tag|(140)Add Sp After Tag|(140)Remove Sp After Tag|(140)Force Sp After Tag"
+ChoicesReadable="Ignore Sp After Tag|Add Sp After Tag|Remove Sp After Tag|Force Sp After Tag"
 ValueDefault=ignore
 
 [Sp Inside Braces Enum]
 Category=1
-Description="<html>(141)Add or remove space inside enum '{' and '}'.</html>"
+Description="<html>Add or remove space inside enum '{' and '}'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_braces_enum=ignore|sp_inside_braces_enum=add|sp_inside_braces_enum=remove|sp_inside_braces_enum=force|sp_inside_braces_enum=not_defined
-ChoicesReadable="(141)Ignore Sp Inside Braces Enum|(141)Add Sp Inside Braces Enum|(141)Remove Sp Inside Braces Enum|(141)Force Sp Inside Braces Enum"
+ChoicesReadable="Ignore Sp Inside Braces Enum|Add Sp Inside Braces Enum|Remove Sp Inside Braces Enum|Force Sp Inside Braces Enum"
 ValueDefault=ignore
 
 [Sp Inside Braces Struct]
 Category=1
-Description="<html>(142)Add or remove space inside struct/union '{' and '}'.</html>"
+Description="<html>Add or remove space inside struct/union '{' and '}'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_braces_struct=ignore|sp_inside_braces_struct=add|sp_inside_braces_struct=remove|sp_inside_braces_struct=force|sp_inside_braces_struct=not_defined
-ChoicesReadable="(142)Ignore Sp Inside Braces Struct|(142)Add Sp Inside Braces Struct|(142)Remove Sp Inside Braces Struct|(142)Force Sp Inside Braces Struct"
+ChoicesReadable="Ignore Sp Inside Braces Struct|Add Sp Inside Braces Struct|Remove Sp Inside Braces Struct|Force Sp Inside Braces Struct"
 ValueDefault=ignore
 
 [Sp Inside Braces Oc Dict]
 Category=1
-Description="<html>(143)(OC) Add or remove space inside Objective-C boxed dictionary '{' and '}'</html>"
+Description="<html>(OC) Add or remove space inside Objective-C boxed dictionary '{' and '}'</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_braces_oc_dict=ignore|sp_inside_braces_oc_dict=add|sp_inside_braces_oc_dict=remove|sp_inside_braces_oc_dict=force|sp_inside_braces_oc_dict=not_defined
-ChoicesReadable="(143)Ignore Sp Inside Braces Oc Dict|(143)Add Sp Inside Braces Oc Dict|(143)Remove Sp Inside Braces Oc Dict|(143)Force Sp Inside Braces Oc Dict"
+ChoicesReadable="Ignore Sp Inside Braces Oc Dict|Add Sp Inside Braces Oc Dict|Remove Sp Inside Braces Oc Dict|Force Sp Inside Braces Oc Dict"
 ValueDefault=ignore
 
 [Sp After Type Brace Init Lst Open]
 Category=1
-Description="<html>(144)Add or remove space after open brace in an unnamed temporary<br/>direct-list-initialization<br/>if statement is a brace_init_lst<br/>works only if sp_brace_brace is set to ignore.</html>"
+Description="<html>Add or remove space after open brace in an unnamed temporary<br/>direct-list-initialization<br/>if statement is a brace_init_lst<br/>works only if sp_brace_brace is set to ignore.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_type_brace_init_lst_open=ignore|sp_after_type_brace_init_lst_open=add|sp_after_type_brace_init_lst_open=remove|sp_after_type_brace_init_lst_open=force|sp_after_type_brace_init_lst_open=not_defined
-ChoicesReadable="(144)Ignore Sp After Type Brace Init Lst Open|(144)Add Sp After Type Brace Init Lst Open|(144)Remove Sp After Type Brace Init Lst Open|(144)Force Sp After Type Brace Init Lst Open"
+ChoicesReadable="Ignore Sp After Type Brace Init Lst Open|Add Sp After Type Brace Init Lst Open|Remove Sp After Type Brace Init Lst Open|Force Sp After Type Brace Init Lst Open"
 ValueDefault=ignore
 
 [Sp Before Type Brace Init Lst Close]
 Category=1
-Description="<html>(145)Add or remove space before close brace in an unnamed temporary<br/>direct-list-initialization<br/>if statement is a brace_init_lst<br/>works only if sp_brace_brace is set to ignore.</html>"
+Description="<html>Add or remove space before close brace in an unnamed temporary<br/>direct-list-initialization<br/>if statement is a brace_init_lst<br/>works only if sp_brace_brace is set to ignore.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_type_brace_init_lst_close=ignore|sp_before_type_brace_init_lst_close=add|sp_before_type_brace_init_lst_close=remove|sp_before_type_brace_init_lst_close=force|sp_before_type_brace_init_lst_close=not_defined
-ChoicesReadable="(145)Ignore Sp Before Type Brace Init Lst Close|(145)Add Sp Before Type Brace Init Lst Close|(145)Remove Sp Before Type Brace Init Lst Close|(145)Force Sp Before Type Brace Init Lst Close"
+ChoicesReadable="Ignore Sp Before Type Brace Init Lst Close|Add Sp Before Type Brace Init Lst Close|Remove Sp Before Type Brace Init Lst Close|Force Sp Before Type Brace Init Lst Close"
 ValueDefault=ignore
 
 [Sp Inside Type Brace Init Lst]
 Category=1
-Description="<html>(146)Add or remove space inside an unnamed temporary direct-list-initialization<br/>if statement is a brace_init_lst<br/>works only if sp_brace_brace is set to ignore<br/>works only if sp_before_type_brace_init_lst_close is set to ignore.</html>"
+Description="<html>Add or remove space inside an unnamed temporary direct-list-initialization<br/>if statement is a brace_init_lst<br/>works only if sp_brace_brace is set to ignore<br/>works only if sp_before_type_brace_init_lst_close is set to ignore.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_type_brace_init_lst=ignore|sp_inside_type_brace_init_lst=add|sp_inside_type_brace_init_lst=remove|sp_inside_type_brace_init_lst=force|sp_inside_type_brace_init_lst=not_defined
-ChoicesReadable="(146)Ignore Sp Inside Type Brace Init Lst|(146)Add Sp Inside Type Brace Init Lst|(146)Remove Sp Inside Type Brace Init Lst|(146)Force Sp Inside Type Brace Init Lst"
+ChoicesReadable="Ignore Sp Inside Type Brace Init Lst|Add Sp Inside Type Brace Init Lst|Remove Sp Inside Type Brace Init Lst|Force Sp Inside Type Brace Init Lst"
 ValueDefault=ignore
 
 [Sp Inside Braces]
 Category=1
-Description="<html>(147)Add or remove space inside '{' and '}'.</html>"
+Description="<html>Add or remove space inside '{' and '}'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_braces=ignore|sp_inside_braces=add|sp_inside_braces=remove|sp_inside_braces=force|sp_inside_braces=not_defined
-ChoicesReadable="(147)Ignore Sp Inside Braces|(147)Add Sp Inside Braces|(147)Remove Sp Inside Braces|(147)Force Sp Inside Braces"
+ChoicesReadable="Ignore Sp Inside Braces|Add Sp Inside Braces|Remove Sp Inside Braces|Force Sp Inside Braces"
 ValueDefault=ignore
 
 [Sp Inside Braces Empty]
 Category=1
-Description="<html>(148)Add or remove space inside '{}'.</html>"
+Description="<html>Add or remove space inside '{}'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_braces_empty=ignore|sp_inside_braces_empty=add|sp_inside_braces_empty=remove|sp_inside_braces_empty=force|sp_inside_braces_empty=not_defined
-ChoicesReadable="(148)Ignore Sp Inside Braces Empty|(148)Add Sp Inside Braces Empty|(148)Remove Sp Inside Braces Empty|(148)Force Sp Inside Braces Empty"
+ChoicesReadable="Ignore Sp Inside Braces Empty|Add Sp Inside Braces Empty|Remove Sp Inside Braces Empty|Force Sp Inside Braces Empty"
 ValueDefault=ignore
 
 [Sp Trailing Return]
 Category=1
-Description="<html>(149)Add or remove space around trailing return operator '-&gt;'.</html>"
+Description="<html>Add or remove space around trailing return operator '-&gt;'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_trailing_return=ignore|sp_trailing_return=add|sp_trailing_return=remove|sp_trailing_return=force|sp_trailing_return=not_defined
-ChoicesReadable="(149)Ignore Sp Trailing Return|(149)Add Sp Trailing Return|(149)Remove Sp Trailing Return|(149)Force Sp Trailing Return"
+ChoicesReadable="Ignore Sp Trailing Return|Add Sp Trailing Return|Remove Sp Trailing Return|Force Sp Trailing Return"
 ValueDefault=ignore
 
 [Sp Type Func]
 Category=1
-Description="<html>(150)Add or remove space between return type and function name. A minimum of 1<br/>is forced except for pointer return types.</html>"
+Description="<html>Add or remove space between return type and function name. A minimum of 1<br/>is forced except for pointer return types.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_type_func=ignore|sp_type_func=add|sp_type_func=remove|sp_type_func=force|sp_type_func=not_defined
-ChoicesReadable="(150)Ignore Sp Type Func|(150)Add Sp Type Func|(150)Remove Sp Type Func|(150)Force Sp Type Func"
+ChoicesReadable="Ignore Sp Type Func|Add Sp Type Func|Remove Sp Type Func|Force Sp Type Func"
 ValueDefault=ignore
 
 [Sp Type Brace Init Lst]
 Category=1
-Description="<html>(151)Add or remove space between type and open brace of an unnamed temporary<br/>direct-list-initialization.</html>"
+Description="<html>Add or remove space between type and open brace of an unnamed temporary<br/>direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_type_brace_init_lst=ignore|sp_type_brace_init_lst=add|sp_type_brace_init_lst=remove|sp_type_brace_init_lst=force|sp_type_brace_init_lst=not_defined
-ChoicesReadable="(151)Ignore Sp Type Brace Init Lst|(151)Add Sp Type Brace Init Lst|(151)Remove Sp Type Brace Init Lst|(151)Force Sp Type Brace Init Lst"
+ChoicesReadable="Ignore Sp Type Brace Init Lst|Add Sp Type Brace Init Lst|Remove Sp Type Brace Init Lst|Force Sp Type Brace Init Lst"
 ValueDefault=ignore
 
 [Sp Func Proto Paren]
 Category=1
-Description="<html>(152)Add or remove space between function name and '(' on function declaration.</html>"
+Description="<html>Add or remove space between function name and '(' on function declaration.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_func_proto_paren=ignore|sp_func_proto_paren=add|sp_func_proto_paren=remove|sp_func_proto_paren=force|sp_func_proto_paren=not_defined
-ChoicesReadable="(152)Ignore Sp Func Proto Paren|(152)Add Sp Func Proto Paren|(152)Remove Sp Func Proto Paren|(152)Force Sp Func Proto Paren"
+ChoicesReadable="Ignore Sp Func Proto Paren|Add Sp Func Proto Paren|Remove Sp Func Proto Paren|Force Sp Func Proto Paren"
 ValueDefault=ignore
 
 [Sp Func Proto Paren Empty]
 Category=1
-Description="<html>(153)Add or remove space between function name and '()' on function declaration<br/>without parameters.</html>"
+Description="<html>Add or remove space between function name and '()' on function declaration<br/>without parameters.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_func_proto_paren_empty=ignore|sp_func_proto_paren_empty=add|sp_func_proto_paren_empty=remove|sp_func_proto_paren_empty=force|sp_func_proto_paren_empty=not_defined
-ChoicesReadable="(153)Ignore Sp Func Proto Paren Empty|(153)Add Sp Func Proto Paren Empty|(153)Remove Sp Func Proto Paren Empty|(153)Force Sp Func Proto Paren Empty"
+ChoicesReadable="Ignore Sp Func Proto Paren Empty|Add Sp Func Proto Paren Empty|Remove Sp Func Proto Paren Empty|Force Sp Func Proto Paren Empty"
 ValueDefault=ignore
 
 [Sp Func Type Paren]
 Category=1
-Description="<html>(154)Add or remove space between function name and '(' with a typedef specifier.</html>"
+Description="<html>Add or remove space between function name and '(' with a typedef specifier.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_func_type_paren=ignore|sp_func_type_paren=add|sp_func_type_paren=remove|sp_func_type_paren=force|sp_func_type_paren=not_defined
-ChoicesReadable="(154)Ignore Sp Func Type Paren|(154)Add Sp Func Type Paren|(154)Remove Sp Func Type Paren|(154)Force Sp Func Type Paren"
+ChoicesReadable="Ignore Sp Func Type Paren|Add Sp Func Type Paren|Remove Sp Func Type Paren|Force Sp Func Type Paren"
 ValueDefault=ignore
 
 [Sp Func Def Paren]
 Category=1
-Description="<html>(155)Add or remove space between alias name and '(' of a non-pointer function type typedef.</html>"
+Description="<html>Add or remove space between alias name and '(' of a non-pointer function type typedef.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_func_def_paren=ignore|sp_func_def_paren=add|sp_func_def_paren=remove|sp_func_def_paren=force|sp_func_def_paren=not_defined
-ChoicesReadable="(155)Ignore Sp Func Def Paren|(155)Add Sp Func Def Paren|(155)Remove Sp Func Def Paren|(155)Force Sp Func Def Paren"
+ChoicesReadable="Ignore Sp Func Def Paren|Add Sp Func Def Paren|Remove Sp Func Def Paren|Force Sp Func Def Paren"
 ValueDefault=ignore
 
 [Sp Func Def Paren Empty]
 Category=1
-Description="<html>(156)Add or remove space between function name and '()' on function definition<br/>without parameters.</html>"
+Description="<html>Add or remove space between function name and '()' on function definition<br/>without parameters.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_func_def_paren_empty=ignore|sp_func_def_paren_empty=add|sp_func_def_paren_empty=remove|sp_func_def_paren_empty=force|sp_func_def_paren_empty=not_defined
-ChoicesReadable="(156)Ignore Sp Func Def Paren Empty|(156)Add Sp Func Def Paren Empty|(156)Remove Sp Func Def Paren Empty|(156)Force Sp Func Def Paren Empty"
+ChoicesReadable="Ignore Sp Func Def Paren Empty|Add Sp Func Def Paren Empty|Remove Sp Func Def Paren Empty|Force Sp Func Def Paren Empty"
 ValueDefault=ignore
 
 [Sp Inside Fparens]
 Category=1
-Description="<html>(157)Add or remove space inside empty function '()'.<br/>Overrides sp_after_angle unless use_sp_after_angle_always is set to true.</html>"
+Description="<html>Add or remove space inside empty function '()'.<br/>Overrides sp_after_angle unless use_sp_after_angle_always is set to true.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_fparens=ignore|sp_inside_fparens=add|sp_inside_fparens=remove|sp_inside_fparens=force|sp_inside_fparens=not_defined
-ChoicesReadable="(157)Ignore Sp Inside Fparens|(157)Add Sp Inside Fparens|(157)Remove Sp Inside Fparens|(157)Force Sp Inside Fparens"
+ChoicesReadable="Ignore Sp Inside Fparens|Add Sp Inside Fparens|Remove Sp Inside Fparens|Force Sp Inside Fparens"
 ValueDefault=ignore
 
 [Sp Inside Fparen]
 Category=1
-Description="<html>(158)Add or remove space inside function '(' and ')'.</html>"
+Description="<html>Add or remove space inside function '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_fparen=ignore|sp_inside_fparen=add|sp_inside_fparen=remove|sp_inside_fparen=force|sp_inside_fparen=not_defined
-ChoicesReadable="(158)Ignore Sp Inside Fparen|(158)Add Sp Inside Fparen|(158)Remove Sp Inside Fparen|(158)Force Sp Inside Fparen"
+ChoicesReadable="Ignore Sp Inside Fparen|Add Sp Inside Fparen|Remove Sp Inside Fparen|Force Sp Inside Fparen"
 ValueDefault=ignore
 
 [Sp Inside Tparen]
 Category=1
-Description="<html>(159)Add or remove space inside the first parentheses in a function type, as in<br/>'void (*x)(...)'.</html>"
+Description="<html>Add or remove space inside the first parentheses in a function type, as in<br/>'void (*x)(...)'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_tparen=ignore|sp_inside_tparen=add|sp_inside_tparen=remove|sp_inside_tparen=force|sp_inside_tparen=not_defined
-ChoicesReadable="(159)Ignore Sp Inside Tparen|(159)Add Sp Inside Tparen|(159)Remove Sp Inside Tparen|(159)Force Sp Inside Tparen"
+ChoicesReadable="Ignore Sp Inside Tparen|Add Sp Inside Tparen|Remove Sp Inside Tparen|Force Sp Inside Tparen"
 ValueDefault=ignore
 
 [Sp After Tparen Close]
 Category=1
-Description="<html>(160)Add or remove space between the ')' and '(' in a function type, as in<br/>'void (*x)(...)'.</html>"
+Description="<html>Add or remove space between the ')' and '(' in a function type, as in<br/>'void (*x)(...)'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_tparen_close=ignore|sp_after_tparen_close=add|sp_after_tparen_close=remove|sp_after_tparen_close=force|sp_after_tparen_close=not_defined
-ChoicesReadable="(160)Ignore Sp After Tparen Close|(160)Add Sp After Tparen Close|(160)Remove Sp After Tparen Close|(160)Force Sp After Tparen Close"
+ChoicesReadable="Ignore Sp After Tparen Close|Add Sp After Tparen Close|Remove Sp After Tparen Close|Force Sp After Tparen Close"
 ValueDefault=ignore
 
 [Sp Square Fparen]
 Category=1
-Description="<html>(161)Add or remove space between ']' and '(' when part of a function call.</html>"
+Description="<html>Add or remove space between ']' and '(' when part of a function call.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_square_fparen=ignore|sp_square_fparen=add|sp_square_fparen=remove|sp_square_fparen=force|sp_square_fparen=not_defined
-ChoicesReadable="(161)Ignore Sp Square Fparen|(161)Add Sp Square Fparen|(161)Remove Sp Square Fparen|(161)Force Sp Square Fparen"
+ChoicesReadable="Ignore Sp Square Fparen|Add Sp Square Fparen|Remove Sp Square Fparen|Force Sp Square Fparen"
 ValueDefault=ignore
 
 [Sp Fparen Brace]
 Category=1
-Description="<html>(162)Add or remove space between ')' and '{' of function.</html>"
+Description="<html>Add or remove space between ')' and '{' of function.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_fparen_brace=ignore|sp_fparen_brace=add|sp_fparen_brace=remove|sp_fparen_brace=force|sp_fparen_brace=not_defined
-ChoicesReadable="(162)Ignore Sp Fparen Brace|(162)Add Sp Fparen Brace|(162)Remove Sp Fparen Brace|(162)Force Sp Fparen Brace"
+ChoicesReadable="Ignore Sp Fparen Brace|Add Sp Fparen Brace|Remove Sp Fparen Brace|Force Sp Fparen Brace"
 ValueDefault=ignore
 
 [Sp Fparen Brace Initializer]
 Category=1
-Description="<html>(163)Add or remove space between ')' and '{' of a function call in object<br/>initialization.<br/><br/>Overrides sp_fparen_brace.</html>"
+Description="<html>Add or remove space between ')' and '{' of a function call in object<br/>initialization.<br/><br/>Overrides sp_fparen_brace.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_fparen_brace_initializer=ignore|sp_fparen_brace_initializer=add|sp_fparen_brace_initializer=remove|sp_fparen_brace_initializer=force|sp_fparen_brace_initializer=not_defined
-ChoicesReadable="(163)Ignore Sp Fparen Brace Initializer|(163)Add Sp Fparen Brace Initializer|(163)Remove Sp Fparen Brace Initializer|(163)Force Sp Fparen Brace Initializer"
+ChoicesReadable="Ignore Sp Fparen Brace Initializer|Add Sp Fparen Brace Initializer|Remove Sp Fparen Brace Initializer|Force Sp Fparen Brace Initializer"
 ValueDefault=ignore
 
 [Sp Fparen Dbrace]
 Category=1
-Description="<html>(164)(Java) Add or remove space between ')' and '{{' of double brace initializer.</html>"
+Description="<html>(Java) Add or remove space between ')' and '{{' of double brace initializer.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_fparen_dbrace=ignore|sp_fparen_dbrace=add|sp_fparen_dbrace=remove|sp_fparen_dbrace=force|sp_fparen_dbrace=not_defined
-ChoicesReadable="(164)Ignore Sp Fparen Dbrace|(164)Add Sp Fparen Dbrace|(164)Remove Sp Fparen Dbrace|(164)Force Sp Fparen Dbrace"
+ChoicesReadable="Ignore Sp Fparen Dbrace|Add Sp Fparen Dbrace|Remove Sp Fparen Dbrace|Force Sp Fparen Dbrace"
 ValueDefault=ignore
 
 [Sp Func Call Paren]
 Category=1
-Description="<html>(165)Add or remove space between function name and '(' on function calls.</html>"
+Description="<html>Add or remove space between function name and '(' on function calls.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_func_call_paren=ignore|sp_func_call_paren=add|sp_func_call_paren=remove|sp_func_call_paren=force|sp_func_call_paren=not_defined
-ChoicesReadable="(165)Ignore Sp Func Call Paren|(165)Add Sp Func Call Paren|(165)Remove Sp Func Call Paren|(165)Force Sp Func Call Paren"
+ChoicesReadable="Ignore Sp Func Call Paren|Add Sp Func Call Paren|Remove Sp Func Call Paren|Force Sp Func Call Paren"
 ValueDefault=ignore
 
 [Sp Func Call Paren Empty]
 Category=1
-Description="<html>(166)Add or remove space between function name and '()' on function calls without<br/>parameters. If set to ignore (the default), sp_func_call_paren is used.</html>"
+Description="<html>Add or remove space between function name and '()' on function calls without<br/>parameters. If set to ignore (the default), sp_func_call_paren is used.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_func_call_paren_empty=ignore|sp_func_call_paren_empty=add|sp_func_call_paren_empty=remove|sp_func_call_paren_empty=force|sp_func_call_paren_empty=not_defined
-ChoicesReadable="(166)Ignore Sp Func Call Paren Empty|(166)Add Sp Func Call Paren Empty|(166)Remove Sp Func Call Paren Empty|(166)Force Sp Func Call Paren Empty"
+ChoicesReadable="Ignore Sp Func Call Paren Empty|Add Sp Func Call Paren Empty|Remove Sp Func Call Paren Empty|Force Sp Func Call Paren Empty"
 ValueDefault=ignore
 
 [Sp Func Call User Paren]
 Category=1
-Description="<html>(167)Add or remove space between the user function name and '(' on function<br/>calls. You need to set a keyword to be a user function in the config file,<br/>like:<br/>  set func_call_user tr _ i18n</html>"
+Description="<html>Add or remove space between the user function name and '(' on function<br/>calls. You need to set a keyword to be a user function in the config file,<br/>like:<br/>  set func_call_user tr _ i18n</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_func_call_user_paren=ignore|sp_func_call_user_paren=add|sp_func_call_user_paren=remove|sp_func_call_user_paren=force|sp_func_call_user_paren=not_defined
-ChoicesReadable="(167)Ignore Sp Func Call User Paren|(167)Add Sp Func Call User Paren|(167)Remove Sp Func Call User Paren|(167)Force Sp Func Call User Paren"
+ChoicesReadable="Ignore Sp Func Call User Paren|Add Sp Func Call User Paren|Remove Sp Func Call User Paren|Force Sp Func Call User Paren"
 ValueDefault=ignore
 
 [Sp Func Call User Inside Fparen]
 Category=1
-Description="<html>(168)Add or remove space inside user function '(' and ')'.</html>"
+Description="<html>Add or remove space inside user function '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_func_call_user_inside_fparen=ignore|sp_func_call_user_inside_fparen=add|sp_func_call_user_inside_fparen=remove|sp_func_call_user_inside_fparen=force|sp_func_call_user_inside_fparen=not_defined
-ChoicesReadable="(168)Ignore Sp Func Call User Inside Fparen|(168)Add Sp Func Call User Inside Fparen|(168)Remove Sp Func Call User Inside Fparen|(168)Force Sp Func Call User Inside Fparen"
+ChoicesReadable="Ignore Sp Func Call User Inside Fparen|Add Sp Func Call User Inside Fparen|Remove Sp Func Call User Inside Fparen|Force Sp Func Call User Inside Fparen"
 ValueDefault=ignore
 
 [Sp Func Call User Paren Paren]
 Category=1
-Description="<html>(169)Add or remove space between nested parentheses with user functions,<br/>i.e. '((' vs. '( ('.</html>"
+Description="<html>Add or remove space between nested parentheses with user functions,<br/>i.e. '((' vs. '( ('.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_func_call_user_paren_paren=ignore|sp_func_call_user_paren_paren=add|sp_func_call_user_paren_paren=remove|sp_func_call_user_paren_paren=force|sp_func_call_user_paren_paren=not_defined
-ChoicesReadable="(169)Ignore Sp Func Call User Paren Paren|(169)Add Sp Func Call User Paren Paren|(169)Remove Sp Func Call User Paren Paren|(169)Force Sp Func Call User Paren Paren"
+ChoicesReadable="Ignore Sp Func Call User Paren Paren|Add Sp Func Call User Paren Paren|Remove Sp Func Call User Paren Paren|Force Sp Func Call User Paren Paren"
 ValueDefault=ignore
 
 [Sp Func Class Paren]
 Category=1
-Description="<html>(170)Add or remove space between a constructor/destructor and the open<br/>parenthesis.</html>"
+Description="<html>Add or remove space between a constructor/destructor and the open<br/>parenthesis.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_func_class_paren=ignore|sp_func_class_paren=add|sp_func_class_paren=remove|sp_func_class_paren=force|sp_func_class_paren=not_defined
-ChoicesReadable="(170)Ignore Sp Func Class Paren|(170)Add Sp Func Class Paren|(170)Remove Sp Func Class Paren|(170)Force Sp Func Class Paren"
+ChoicesReadable="Ignore Sp Func Class Paren|Add Sp Func Class Paren|Remove Sp Func Class Paren|Force Sp Func Class Paren"
 ValueDefault=ignore
 
 [Sp Func Class Paren Empty]
 Category=1
-Description="<html>(171)Add or remove space between a constructor without parameters or destructor<br/>and '()'.</html>"
+Description="<html>Add or remove space between a constructor without parameters or destructor<br/>and '()'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_func_class_paren_empty=ignore|sp_func_class_paren_empty=add|sp_func_class_paren_empty=remove|sp_func_class_paren_empty=force|sp_func_class_paren_empty=not_defined
-ChoicesReadable="(171)Ignore Sp Func Class Paren Empty|(171)Add Sp Func Class Paren Empty|(171)Remove Sp Func Class Paren Empty|(171)Force Sp Func Class Paren Empty"
+ChoicesReadable="Ignore Sp Func Class Paren Empty|Add Sp Func Class Paren Empty|Remove Sp Func Class Paren Empty|Force Sp Func Class Paren Empty"
 ValueDefault=ignore
 
 [Sp Return]
 Category=1
-Description="<html>(172)Add or remove space after 'return'.<br/><br/>Default: force</html>"
+Description="<html>Add or remove space after 'return'.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_return=ignore|sp_return=add|sp_return=remove|sp_return=force|sp_return=not_defined
-ChoicesReadable="(172)Ignore Sp Return|(172)Add Sp Return|(172)Remove Sp Return|(172)Force Sp Return"
+ChoicesReadable="Ignore Sp Return|Add Sp Return|Remove Sp Return|Force Sp Return"
 ValueDefault=force
 
 [Sp Return Paren]
 Category=1
-Description="<html>(173)Add or remove space between 'return' and '('.</html>"
+Description="<html>Add or remove space between 'return' and '('.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_return_paren=ignore|sp_return_paren=add|sp_return_paren=remove|sp_return_paren=force|sp_return_paren=not_defined
-ChoicesReadable="(173)Ignore Sp Return Paren|(173)Add Sp Return Paren|(173)Remove Sp Return Paren|(173)Force Sp Return Paren"
+ChoicesReadable="Ignore Sp Return Paren|Add Sp Return Paren|Remove Sp Return Paren|Force Sp Return Paren"
 ValueDefault=ignore
 
 [Sp Return Brace]
 Category=1
-Description="<html>(174)Add or remove space between 'return' and '{'.</html>"
+Description="<html>Add or remove space between 'return' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_return_brace=ignore|sp_return_brace=add|sp_return_brace=remove|sp_return_brace=force|sp_return_brace=not_defined
-ChoicesReadable="(174)Ignore Sp Return Brace|(174)Add Sp Return Brace|(174)Remove Sp Return Brace|(174)Force Sp Return Brace"
+ChoicesReadable="Ignore Sp Return Brace|Add Sp Return Brace|Remove Sp Return Brace|Force Sp Return Brace"
 ValueDefault=ignore
 
 [Sp Attribute Paren]
 Category=1
-Description="<html>(175)Add or remove space between '__attribute__' and '('.</html>"
+Description="<html>Add or remove space between '__attribute__' and '('.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_attribute_paren=ignore|sp_attribute_paren=add|sp_attribute_paren=remove|sp_attribute_paren=force|sp_attribute_paren=not_defined
-ChoicesReadable="(175)Ignore Sp Attribute Paren|(175)Add Sp Attribute Paren|(175)Remove Sp Attribute Paren|(175)Force Sp Attribute Paren"
+ChoicesReadable="Ignore Sp Attribute Paren|Add Sp Attribute Paren|Remove Sp Attribute Paren|Force Sp Attribute Paren"
 ValueDefault=ignore
 
 [Sp Defined Paren]
 Category=1
-Description="<html>(176)Add or remove space between 'defined' and '(' in '#if defined (FOO)'.</html>"
+Description="<html>Add or remove space between 'defined' and '(' in '#if defined (FOO)'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_defined_paren=ignore|sp_defined_paren=add|sp_defined_paren=remove|sp_defined_paren=force|sp_defined_paren=not_defined
-ChoicesReadable="(176)Ignore Sp Defined Paren|(176)Add Sp Defined Paren|(176)Remove Sp Defined Paren|(176)Force Sp Defined Paren"
+ChoicesReadable="Ignore Sp Defined Paren|Add Sp Defined Paren|Remove Sp Defined Paren|Force Sp Defined Paren"
 ValueDefault=ignore
 
 [Sp Throw Paren]
 Category=1
-Description="<html>(177)Add or remove space between 'throw' and '(' in 'throw (something)'.</html>"
+Description="<html>Add or remove space between 'throw' and '(' in 'throw (something)'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_throw_paren=ignore|sp_throw_paren=add|sp_throw_paren=remove|sp_throw_paren=force|sp_throw_paren=not_defined
-ChoicesReadable="(177)Ignore Sp Throw Paren|(177)Add Sp Throw Paren|(177)Remove Sp Throw Paren|(177)Force Sp Throw Paren"
+ChoicesReadable="Ignore Sp Throw Paren|Add Sp Throw Paren|Remove Sp Throw Paren|Force Sp Throw Paren"
 ValueDefault=ignore
 
 [Sp After Throw]
 Category=1
-Description="<html>(178)Add or remove space between 'throw' and anything other than '(' as in<br/>'@throw [...];'.</html>"
+Description="<html>Add or remove space between 'throw' and anything other than '(' as in<br/>'@throw [...];'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_throw=ignore|sp_after_throw=add|sp_after_throw=remove|sp_after_throw=force|sp_after_throw=not_defined
-ChoicesReadable="(178)Ignore Sp After Throw|(178)Add Sp After Throw|(178)Remove Sp After Throw|(178)Force Sp After Throw"
+ChoicesReadable="Ignore Sp After Throw|Add Sp After Throw|Remove Sp After Throw|Force Sp After Throw"
 ValueDefault=ignore
 
 [Sp Catch Paren]
 Category=1
-Description="<html>(179)Add or remove space between 'catch' and '(' in 'catch (something) { }'.<br/>If set to ignore, sp_before_sparen is used.</html>"
+Description="<html>Add or remove space between 'catch' and '(' in 'catch (something) { }'.<br/>If set to ignore, sp_before_sparen is used.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_catch_paren=ignore|sp_catch_paren=add|sp_catch_paren=remove|sp_catch_paren=force|sp_catch_paren=not_defined
-ChoicesReadable="(179)Ignore Sp Catch Paren|(179)Add Sp Catch Paren|(179)Remove Sp Catch Paren|(179)Force Sp Catch Paren"
+ChoicesReadable="Ignore Sp Catch Paren|Add Sp Catch Paren|Remove Sp Catch Paren|Force Sp Catch Paren"
 ValueDefault=ignore
 
 [Sp Oc Catch Paren]
 Category=1
-Description="<html>(180)(OC) Add or remove space between '@catch' and '('<br/>in '@catch (something) { }'. If set to ignore, sp_catch_paren is used.</html>"
+Description="<html>(OC) Add or remove space between '@catch' and '('<br/>in '@catch (something) { }'. If set to ignore, sp_catch_paren is used.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_oc_catch_paren=ignore|sp_oc_catch_paren=add|sp_oc_catch_paren=remove|sp_oc_catch_paren=force|sp_oc_catch_paren=not_defined
-ChoicesReadable="(180)Ignore Sp Oc Catch Paren|(180)Add Sp Oc Catch Paren|(180)Remove Sp Oc Catch Paren|(180)Force Sp Oc Catch Paren"
+ChoicesReadable="Ignore Sp Oc Catch Paren|Add Sp Oc Catch Paren|Remove Sp Oc Catch Paren|Force Sp Oc Catch Paren"
 ValueDefault=ignore
 
 [Sp Before Oc Proto List]
 Category=1
-Description="<html>(181)(OC) Add or remove space before Objective-C protocol list<br/>as in '@protocol Protocol&lt;here&gt;&lt;Protocol_A&gt;' or '@interface MyClass : NSObject&lt;here&gt;&lt;MyProtocol&gt;'.</html>"
+Description="<html>(OC) Add or remove space before Objective-C protocol list<br/>as in '@protocol Protocol&lt;here&gt;&lt;Protocol_A&gt;' or '@interface MyClass : NSObject&lt;here&gt;&lt;MyProtocol&gt;'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_oc_proto_list=ignore|sp_before_oc_proto_list=add|sp_before_oc_proto_list=remove|sp_before_oc_proto_list=force|sp_before_oc_proto_list=not_defined
-ChoicesReadable="(181)Ignore Sp Before Oc Proto List|(181)Add Sp Before Oc Proto List|(181)Remove Sp Before Oc Proto List|(181)Force Sp Before Oc Proto List"
+ChoicesReadable="Ignore Sp Before Oc Proto List|Add Sp Before Oc Proto List|Remove Sp Before Oc Proto List|Force Sp Before Oc Proto List"
 ValueDefault=ignore
 
 [Sp Oc Classname Paren]
 Category=1
-Description="<html>(182)(OC) Add or remove space between class name and '('<br/>in '@interface className(categoryName)&lt;ProtocolName&gt;:BaseClass'</html>"
+Description="<html>(OC) Add or remove space between class name and '('<br/>in '@interface className(categoryName)&lt;ProtocolName&gt;:BaseClass'</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_oc_classname_paren=ignore|sp_oc_classname_paren=add|sp_oc_classname_paren=remove|sp_oc_classname_paren=force|sp_oc_classname_paren=not_defined
-ChoicesReadable="(182)Ignore Sp Oc Classname Paren|(182)Add Sp Oc Classname Paren|(182)Remove Sp Oc Classname Paren|(182)Force Sp Oc Classname Paren"
+ChoicesReadable="Ignore Sp Oc Classname Paren|Add Sp Oc Classname Paren|Remove Sp Oc Classname Paren|Force Sp Oc Classname Paren"
 ValueDefault=ignore
 
 [Sp Version Paren]
 Category=1
-Description="<html>(183)(D) Add or remove space between 'version' and '('<br/>in 'version (something) { }'. If set to ignore, sp_before_sparen is used.</html>"
+Description="<html>(D) Add or remove space between 'version' and '('<br/>in 'version (something) { }'. If set to ignore, sp_before_sparen is used.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_version_paren=ignore|sp_version_paren=add|sp_version_paren=remove|sp_version_paren=force|sp_version_paren=not_defined
-ChoicesReadable="(183)Ignore Sp Version Paren|(183)Add Sp Version Paren|(183)Remove Sp Version Paren|(183)Force Sp Version Paren"
+ChoicesReadable="Ignore Sp Version Paren|Add Sp Version Paren|Remove Sp Version Paren|Force Sp Version Paren"
 ValueDefault=ignore
 
 [Sp Scope Paren]
 Category=1
-Description="<html>(184)(D) Add or remove space between 'scope' and '('<br/>in 'scope (something) { }'. If set to ignore, sp_before_sparen is used.</html>"
+Description="<html>(D) Add or remove space between 'scope' and '('<br/>in 'scope (something) { }'. If set to ignore, sp_before_sparen is used.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_scope_paren=ignore|sp_scope_paren=add|sp_scope_paren=remove|sp_scope_paren=force|sp_scope_paren=not_defined
-ChoicesReadable="(184)Ignore Sp Scope Paren|(184)Add Sp Scope Paren|(184)Remove Sp Scope Paren|(184)Force Sp Scope Paren"
+ChoicesReadable="Ignore Sp Scope Paren|Add Sp Scope Paren|Remove Sp Scope Paren|Force Sp Scope Paren"
 ValueDefault=ignore
 
 [Sp Super Paren]
 Category=1
-Description="<html>(185)Add or remove space between 'super' and '(' in 'super (something)'.<br/><br/>Default: remove</html>"
+Description="<html>Add or remove space between 'super' and '(' in 'super (something)'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_super_paren=ignore|sp_super_paren=add|sp_super_paren=remove|sp_super_paren=force|sp_super_paren=not_defined
-ChoicesReadable="(185)Ignore Sp Super Paren|(185)Add Sp Super Paren|(185)Remove Sp Super Paren|(185)Force Sp Super Paren"
+ChoicesReadable="Ignore Sp Super Paren|Add Sp Super Paren|Remove Sp Super Paren|Force Sp Super Paren"
 ValueDefault=remove
 
 [Sp This Paren]
 Category=1
-Description="<html>(186)Add or remove space between 'this' and '(' in 'this (something)'.<br/><br/>Default: remove</html>"
+Description="<html>Add or remove space between 'this' and '(' in 'this (something)'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_this_paren=ignore|sp_this_paren=add|sp_this_paren=remove|sp_this_paren=force|sp_this_paren=not_defined
-ChoicesReadable="(186)Ignore Sp This Paren|(186)Add Sp This Paren|(186)Remove Sp This Paren|(186)Force Sp This Paren"
+ChoicesReadable="Ignore Sp This Paren|Add Sp This Paren|Remove Sp This Paren|Force Sp This Paren"
 ValueDefault=remove
 
 [Sp Macro]
 Category=1
-Description="<html>(187)Add or remove space between a macro name and its definition.</html>"
+Description="<html>Add or remove space between a macro name and its definition.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_macro=ignore|sp_macro=add|sp_macro=remove|sp_macro=force|sp_macro=not_defined
-ChoicesReadable="(187)Ignore Sp Macro|(187)Add Sp Macro|(187)Remove Sp Macro|(187)Force Sp Macro"
+ChoicesReadable="Ignore Sp Macro|Add Sp Macro|Remove Sp Macro|Force Sp Macro"
 ValueDefault=ignore
 
 [Sp Macro Func]
 Category=1
-Description="<html>(188)Add or remove space between a macro function ')' and its definition.</html>"
+Description="<html>Add or remove space between a macro function ')' and its definition.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_macro_func=ignore|sp_macro_func=add|sp_macro_func=remove|sp_macro_func=force|sp_macro_func=not_defined
-ChoicesReadable="(188)Ignore Sp Macro Func|(188)Add Sp Macro Func|(188)Remove Sp Macro Func|(188)Force Sp Macro Func"
+ChoicesReadable="Ignore Sp Macro Func|Add Sp Macro Func|Remove Sp Macro Func|Force Sp Macro Func"
 ValueDefault=ignore
 
 [Sp Else Brace]
 Category=1
-Description="<html>(189)Add or remove space between 'else' and '{' if on the same line.</html>"
+Description="<html>Add or remove space between 'else' and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_else_brace=ignore|sp_else_brace=add|sp_else_brace=remove|sp_else_brace=force|sp_else_brace=not_defined
-ChoicesReadable="(189)Ignore Sp Else Brace|(189)Add Sp Else Brace|(189)Remove Sp Else Brace|(189)Force Sp Else Brace"
+ChoicesReadable="Ignore Sp Else Brace|Add Sp Else Brace|Remove Sp Else Brace|Force Sp Else Brace"
 ValueDefault=ignore
 
 [Sp Brace Else]
 Category=1
-Description="<html>(190)Add or remove space between '}' and 'else' if on the same line.</html>"
+Description="<html>Add or remove space between '}' and 'else' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_brace_else=ignore|sp_brace_else=add|sp_brace_else=remove|sp_brace_else=force|sp_brace_else=not_defined
-ChoicesReadable="(190)Ignore Sp Brace Else|(190)Add Sp Brace Else|(190)Remove Sp Brace Else|(190)Force Sp Brace Else"
+ChoicesReadable="Ignore Sp Brace Else|Add Sp Brace Else|Remove Sp Brace Else|Force Sp Brace Else"
 ValueDefault=ignore
 
 [Sp Brace Typedef]
 Category=1
-Description="<html>(191)Add or remove space between '}' and the name of a typedef on the same line.</html>"
+Description="<html>Add or remove space between '}' and the name of a typedef on the same line.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_brace_typedef=ignore|sp_brace_typedef=add|sp_brace_typedef=remove|sp_brace_typedef=force|sp_brace_typedef=not_defined
-ChoicesReadable="(191)Ignore Sp Brace Typedef|(191)Add Sp Brace Typedef|(191)Remove Sp Brace Typedef|(191)Force Sp Brace Typedef"
+ChoicesReadable="Ignore Sp Brace Typedef|Add Sp Brace Typedef|Remove Sp Brace Typedef|Force Sp Brace Typedef"
 ValueDefault=ignore
 
 [Sp Catch Brace]
 Category=1
-Description="<html>(192)Add or remove space before the '{' of a 'catch' statement, if the '{' and<br/>'catch' are on the same line, as in 'catch (decl) &lt;here&gt; {'.</html>"
+Description="<html>Add or remove space before the '{' of a 'catch' statement, if the '{' and<br/>'catch' are on the same line, as in 'catch (decl) &lt;here&gt; {'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_catch_brace=ignore|sp_catch_brace=add|sp_catch_brace=remove|sp_catch_brace=force|sp_catch_brace=not_defined
-ChoicesReadable="(192)Ignore Sp Catch Brace|(192)Add Sp Catch Brace|(192)Remove Sp Catch Brace|(192)Force Sp Catch Brace"
+ChoicesReadable="Ignore Sp Catch Brace|Add Sp Catch Brace|Remove Sp Catch Brace|Force Sp Catch Brace"
 ValueDefault=ignore
 
 [Sp Oc Catch Brace]
 Category=1
-Description="<html>(193)(OC) Add or remove space before the '{' of a '@catch' statement, if the '{'<br/>and '@catch' are on the same line, as in '@catch (decl) &lt;here&gt; {'.<br/>If set to ignore, sp_catch_brace is used.</html>"
+Description="<html>(OC) Add or remove space before the '{' of a '@catch' statement, if the '{'<br/>and '@catch' are on the same line, as in '@catch (decl) &lt;here&gt; {'.<br/>If set to ignore, sp_catch_brace is used.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_oc_catch_brace=ignore|sp_oc_catch_brace=add|sp_oc_catch_brace=remove|sp_oc_catch_brace=force|sp_oc_catch_brace=not_defined
-ChoicesReadable="(193)Ignore Sp Oc Catch Brace|(193)Add Sp Oc Catch Brace|(193)Remove Sp Oc Catch Brace|(193)Force Sp Oc Catch Brace"
+ChoicesReadable="Ignore Sp Oc Catch Brace|Add Sp Oc Catch Brace|Remove Sp Oc Catch Brace|Force Sp Oc Catch Brace"
 ValueDefault=ignore
 
 [Sp Brace Catch]
 Category=1
-Description="<html>(194)Add or remove space between '}' and 'catch' if on the same line.</html>"
+Description="<html>Add or remove space between '}' and 'catch' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_brace_catch=ignore|sp_brace_catch=add|sp_brace_catch=remove|sp_brace_catch=force|sp_brace_catch=not_defined
-ChoicesReadable="(194)Ignore Sp Brace Catch|(194)Add Sp Brace Catch|(194)Remove Sp Brace Catch|(194)Force Sp Brace Catch"
+ChoicesReadable="Ignore Sp Brace Catch|Add Sp Brace Catch|Remove Sp Brace Catch|Force Sp Brace Catch"
 ValueDefault=ignore
 
 [Sp Oc Brace Catch]
 Category=1
-Description="<html>(195)(OC) Add or remove space between '}' and '@catch' if on the same line.<br/>If set to ignore, sp_brace_catch is used.</html>"
+Description="<html>(OC) Add or remove space between '}' and '@catch' if on the same line.<br/>If set to ignore, sp_brace_catch is used.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_oc_brace_catch=ignore|sp_oc_brace_catch=add|sp_oc_brace_catch=remove|sp_oc_brace_catch=force|sp_oc_brace_catch=not_defined
-ChoicesReadable="(195)Ignore Sp Oc Brace Catch|(195)Add Sp Oc Brace Catch|(195)Remove Sp Oc Brace Catch|(195)Force Sp Oc Brace Catch"
+ChoicesReadable="Ignore Sp Oc Brace Catch|Add Sp Oc Brace Catch|Remove Sp Oc Brace Catch|Force Sp Oc Brace Catch"
 ValueDefault=ignore
 
 [Sp Finally Brace]
 Category=1
-Description="<html>(196)Add or remove space between 'finally' and '{' if on the same line.</html>"
+Description="<html>Add or remove space between 'finally' and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_finally_brace=ignore|sp_finally_brace=add|sp_finally_brace=remove|sp_finally_brace=force|sp_finally_brace=not_defined
-ChoicesReadable="(196)Ignore Sp Finally Brace|(196)Add Sp Finally Brace|(196)Remove Sp Finally Brace|(196)Force Sp Finally Brace"
+ChoicesReadable="Ignore Sp Finally Brace|Add Sp Finally Brace|Remove Sp Finally Brace|Force Sp Finally Brace"
 ValueDefault=ignore
 
 [Sp Brace Finally]
 Category=1
-Description="<html>(197)Add or remove space between '}' and 'finally' if on the same line.</html>"
+Description="<html>Add or remove space between '}' and 'finally' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_brace_finally=ignore|sp_brace_finally=add|sp_brace_finally=remove|sp_brace_finally=force|sp_brace_finally=not_defined
-ChoicesReadable="(197)Ignore Sp Brace Finally|(197)Add Sp Brace Finally|(197)Remove Sp Brace Finally|(197)Force Sp Brace Finally"
+ChoicesReadable="Ignore Sp Brace Finally|Add Sp Brace Finally|Remove Sp Brace Finally|Force Sp Brace Finally"
 ValueDefault=ignore
 
 [Sp Try Brace]
 Category=1
-Description="<html>(198)Add or remove space between 'try' and '{' if on the same line.</html>"
+Description="<html>Add or remove space between 'try' and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_try_brace=ignore|sp_try_brace=add|sp_try_brace=remove|sp_try_brace=force|sp_try_brace=not_defined
-ChoicesReadable="(198)Ignore Sp Try Brace|(198)Add Sp Try Brace|(198)Remove Sp Try Brace|(198)Force Sp Try Brace"
+ChoicesReadable="Ignore Sp Try Brace|Add Sp Try Brace|Remove Sp Try Brace|Force Sp Try Brace"
 ValueDefault=ignore
 
 [Sp Getset Brace]
 Category=1
-Description="<html>(199)Add or remove space between get/set and '{' if on the same line.</html>"
+Description="<html>Add or remove space between get/set and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_getset_brace=ignore|sp_getset_brace=add|sp_getset_brace=remove|sp_getset_brace=force|sp_getset_brace=not_defined
-ChoicesReadable="(199)Ignore Sp Getset Brace|(199)Add Sp Getset Brace|(199)Remove Sp Getset Brace|(199)Force Sp Getset Brace"
+ChoicesReadable="Ignore Sp Getset Brace|Add Sp Getset Brace|Remove Sp Getset Brace|Force Sp Getset Brace"
 ValueDefault=ignore
 
 [Sp Word Brace Init Lst]
 Category=1
-Description="<html>(200)Add or remove space between a variable and '{' for C++ uniform<br/>initialization.</html>"
+Description="<html>Add or remove space between a variable and '{' for C++ uniform<br/>initialization.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_word_brace_init_lst=ignore|sp_word_brace_init_lst=add|sp_word_brace_init_lst=remove|sp_word_brace_init_lst=force|sp_word_brace_init_lst=not_defined
-ChoicesReadable="(200)Ignore Sp Word Brace Init Lst|(200)Add Sp Word Brace Init Lst|(200)Remove Sp Word Brace Init Lst|(200)Force Sp Word Brace Init Lst"
+ChoicesReadable="Ignore Sp Word Brace Init Lst|Add Sp Word Brace Init Lst|Remove Sp Word Brace Init Lst|Force Sp Word Brace Init Lst"
 ValueDefault=ignore
 
 [Sp Word Brace Ns]
 Category=1
-Description="<html>(201)Add or remove space between a variable and '{' for a namespace.<br/><br/>Default: add</html>"
+Description="<html>Add or remove space between a variable and '{' for a namespace.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_word_brace_ns=ignore|sp_word_brace_ns=add|sp_word_brace_ns=remove|sp_word_brace_ns=force|sp_word_brace_ns=not_defined
-ChoicesReadable="(201)Ignore Sp Word Brace Ns|(201)Add Sp Word Brace Ns|(201)Remove Sp Word Brace Ns|(201)Force Sp Word Brace Ns"
+ChoicesReadable="Ignore Sp Word Brace Ns|Add Sp Word Brace Ns|Remove Sp Word Brace Ns|Force Sp Word Brace Ns"
 ValueDefault=add
 
 [Sp Before Dc]
 Category=1
-Description="<html>(202)Add or remove space before the '::' operator.</html>"
+Description="<html>Add or remove space before the '::' operator.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_dc=ignore|sp_before_dc=add|sp_before_dc=remove|sp_before_dc=force|sp_before_dc=not_defined
-ChoicesReadable="(202)Ignore Sp Before Dc|(202)Add Sp Before Dc|(202)Remove Sp Before Dc|(202)Force Sp Before Dc"
+ChoicesReadable="Ignore Sp Before Dc|Add Sp Before Dc|Remove Sp Before Dc|Force Sp Before Dc"
 ValueDefault=ignore
 
 [Sp After Dc]
 Category=1
-Description="<html>(203)Add or remove space after the '::' operator.</html>"
+Description="<html>Add or remove space after the '::' operator.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_dc=ignore|sp_after_dc=add|sp_after_dc=remove|sp_after_dc=force|sp_after_dc=not_defined
-ChoicesReadable="(203)Ignore Sp After Dc|(203)Add Sp After Dc|(203)Remove Sp After Dc|(203)Force Sp After Dc"
+ChoicesReadable="Ignore Sp After Dc|Add Sp After Dc|Remove Sp After Dc|Force Sp After Dc"
 ValueDefault=ignore
 
 [Sp D Array Colon]
 Category=1
-Description="<html>(204)(D) Add or remove around the D named array initializer ':' operator.</html>"
+Description="<html>(D) Add or remove around the D named array initializer ':' operator.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_d_array_colon=ignore|sp_d_array_colon=add|sp_d_array_colon=remove|sp_d_array_colon=force|sp_d_array_colon=not_defined
-ChoicesReadable="(204)Ignore Sp D Array Colon|(204)Add Sp D Array Colon|(204)Remove Sp D Array Colon|(204)Force Sp D Array Colon"
+ChoicesReadable="Ignore Sp D Array Colon|Add Sp D Array Colon|Remove Sp D Array Colon|Force Sp D Array Colon"
 ValueDefault=ignore
 
 [Sp Not]
 Category=1
-Description="<html>(205)Add or remove space after the '!' (not) unary operator.<br/><br/>Default: remove</html>"
+Description="<html>Add or remove space after the '!' (not) unary operator.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_not=ignore|sp_not=add|sp_not=remove|sp_not=force|sp_not=not_defined
-ChoicesReadable="(205)Ignore Sp Not|(205)Add Sp Not|(205)Remove Sp Not|(205)Force Sp Not"
+ChoicesReadable="Ignore Sp Not|Add Sp Not|Remove Sp Not|Force Sp Not"
 ValueDefault=remove
 
 [Sp Not Not]
 Category=1
-Description="<html>(206)Add or remove space between two '!' (not) unary operators.<br/>If set to ignore, sp_not will be used.</html>"
+Description="<html>Add or remove space between two '!' (not) unary operators.<br/>If set to ignore, sp_not will be used.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_not_not=ignore|sp_not_not=add|sp_not_not=remove|sp_not_not=force|sp_not_not=not_defined
-ChoicesReadable="(206)Ignore Sp Not Not|(206)Add Sp Not Not|(206)Remove Sp Not Not|(206)Force Sp Not Not"
+ChoicesReadable="Ignore Sp Not Not|Add Sp Not Not|Remove Sp Not Not|Force Sp Not Not"
 ValueDefault=ignore
 
 [Sp Inv]
 Category=1
-Description="<html>(207)Add or remove space after the '~' (invert) unary operator.<br/><br/>Default: remove</html>"
+Description="<html>Add or remove space after the '~' (invert) unary operator.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inv=ignore|sp_inv=add|sp_inv=remove|sp_inv=force|sp_inv=not_defined
-ChoicesReadable="(207)Ignore Sp Inv|(207)Add Sp Inv|(207)Remove Sp Inv|(207)Force Sp Inv"
+ChoicesReadable="Ignore Sp Inv|Add Sp Inv|Remove Sp Inv|Force Sp Inv"
 ValueDefault=remove
 
 [Sp Addr]
 Category=1
-Description="<html>(208)Add or remove space after the '&amp;' (address-of) unary operator. This does not<br/>affect the spacing after a '&amp;' that is part of a type.<br/><br/>Default: remove</html>"
+Description="<html>Add or remove space after the '&amp;' (address-of) unary operator. This does not<br/>affect the spacing after a '&amp;' that is part of a type.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_addr=ignore|sp_addr=add|sp_addr=remove|sp_addr=force|sp_addr=not_defined
-ChoicesReadable="(208)Ignore Sp Addr|(208)Add Sp Addr|(208)Remove Sp Addr|(208)Force Sp Addr"
+ChoicesReadable="Ignore Sp Addr|Add Sp Addr|Remove Sp Addr|Force Sp Addr"
 ValueDefault=remove
 
 [Sp Member]
 Category=1
-Description="<html>(209)Add or remove space around the '.' or '-&gt;' operators.<br/><br/>Default: remove</html>"
+Description="<html>Add or remove space around the '.' or '-&gt;' operators.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_member=ignore|sp_member=add|sp_member=remove|sp_member=force|sp_member=not_defined
-ChoicesReadable="(209)Ignore Sp Member|(209)Add Sp Member|(209)Remove Sp Member|(209)Force Sp Member"
+ChoicesReadable="Ignore Sp Member|Add Sp Member|Remove Sp Member|Force Sp Member"
 ValueDefault=remove
 
 [Sp Deref]
 Category=1
-Description="<html>(210)Add or remove space after the '*' (dereference) unary operator. This does<br/>not affect the spacing after a '*' that is part of a type.<br/><br/>Default: remove</html>"
+Description="<html>Add or remove space after the '*' (dereference) unary operator. This does<br/>not affect the spacing after a '*' that is part of a type.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_deref=ignore|sp_deref=add|sp_deref=remove|sp_deref=force|sp_deref=not_defined
-ChoicesReadable="(210)Ignore Sp Deref|(210)Add Sp Deref|(210)Remove Sp Deref|(210)Force Sp Deref"
+ChoicesReadable="Ignore Sp Deref|Add Sp Deref|Remove Sp Deref|Force Sp Deref"
 ValueDefault=remove
 
 [Sp Sign]
 Category=1
-Description="<html>(211)Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'.<br/><br/>Default: remove</html>"
+Description="<html>Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_sign=ignore|sp_sign=add|sp_sign=remove|sp_sign=force|sp_sign=not_defined
-ChoicesReadable="(211)Ignore Sp Sign|(211)Add Sp Sign|(211)Remove Sp Sign|(211)Force Sp Sign"
+ChoicesReadable="Ignore Sp Sign|Add Sp Sign|Remove Sp Sign|Force Sp Sign"
 ValueDefault=remove
 
 [Sp Incdec]
 Category=1
-Description="<html>(212)Add or remove space between '++' and '--' the word to which it is being<br/>applied, as in '(--x)' or 'y++;'.<br/><br/>Default: remove</html>"
+Description="<html>Add or remove space between '++' and '--' the word to which it is being<br/>applied, as in '(--x)' or 'y++;'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_incdec=ignore|sp_incdec=add|sp_incdec=remove|sp_incdec=force|sp_incdec=not_defined
-ChoicesReadable="(212)Ignore Sp Incdec|(212)Add Sp Incdec|(212)Remove Sp Incdec|(212)Force Sp Incdec"
+ChoicesReadable="Ignore Sp Incdec|Add Sp Incdec|Remove Sp Incdec|Force Sp Incdec"
 ValueDefault=remove
 
 [Sp Before Nl Cont]
 Category=1
-Description="<html>(213)Add or remove space before a backslash-newline at the end of a line.<br/><br/>Default: add</html>"
+Description="<html>Add or remove space before a backslash-newline at the end of a line.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_nl_cont=ignore|sp_before_nl_cont=add|sp_before_nl_cont=remove|sp_before_nl_cont=force|sp_before_nl_cont=not_defined
-ChoicesReadable="(213)Ignore Sp Before Nl Cont|(213)Add Sp Before Nl Cont|(213)Remove Sp Before Nl Cont|(213)Force Sp Before Nl Cont"
+ChoicesReadable="Ignore Sp Before Nl Cont|Add Sp Before Nl Cont|Remove Sp Before Nl Cont|Force Sp Before Nl Cont"
 ValueDefault=add
 
 [Sp After Oc Scope]
 Category=1
-Description="<html>(214)(OC) Add or remove space after the scope '+' or '-', as in '-(void) foo;'<br/>or '+(int) bar;'.</html>"
+Description="<html>(OC) Add or remove space after the scope '+' or '-', as in '-(void) foo;'<br/>or '+(int) bar;'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_oc_scope=ignore|sp_after_oc_scope=add|sp_after_oc_scope=remove|sp_after_oc_scope=force|sp_after_oc_scope=not_defined
-ChoicesReadable="(214)Ignore Sp After Oc Scope|(214)Add Sp After Oc Scope|(214)Remove Sp After Oc Scope|(214)Force Sp After Oc Scope"
+ChoicesReadable="Ignore Sp After Oc Scope|Add Sp After Oc Scope|Remove Sp After Oc Scope|Force Sp After Oc Scope"
 ValueDefault=ignore
 
 [Sp After Oc Colon]
 Category=1
-Description="<html>(215)(OC) Add or remove space after the colon in message specs,<br/>i.e. '-(int) f:(int) x;' vs. '-(int) f: (int) x;'.</html>"
+Description="<html>(OC) Add or remove space after the colon in message specs,<br/>i.e. '-(int) f:(int) x;' vs. '-(int) f: (int) x;'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_oc_colon=ignore|sp_after_oc_colon=add|sp_after_oc_colon=remove|sp_after_oc_colon=force|sp_after_oc_colon=not_defined
-ChoicesReadable="(215)Ignore Sp After Oc Colon|(215)Add Sp After Oc Colon|(215)Remove Sp After Oc Colon|(215)Force Sp After Oc Colon"
+ChoicesReadable="Ignore Sp After Oc Colon|Add Sp After Oc Colon|Remove Sp After Oc Colon|Force Sp After Oc Colon"
 ValueDefault=ignore
 
 [Sp Before Oc Colon]
 Category=1
-Description="<html>(216)(OC) Add or remove space before the colon in message specs,<br/>i.e. '-(int) f: (int) x;' vs. '-(int) f : (int) x;'.</html>"
+Description="<html>(OC) Add or remove space before the colon in message specs,<br/>i.e. '-(int) f: (int) x;' vs. '-(int) f : (int) x;'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_oc_colon=ignore|sp_before_oc_colon=add|sp_before_oc_colon=remove|sp_before_oc_colon=force|sp_before_oc_colon=not_defined
-ChoicesReadable="(216)Ignore Sp Before Oc Colon|(216)Add Sp Before Oc Colon|(216)Remove Sp Before Oc Colon|(216)Force Sp Before Oc Colon"
+ChoicesReadable="Ignore Sp Before Oc Colon|Add Sp Before Oc Colon|Remove Sp Before Oc Colon|Force Sp Before Oc Colon"
 ValueDefault=ignore
 
 [Sp After Oc Dict Colon]
 Category=1
-Description="<html>(217)(OC) Add or remove space after the colon in immutable dictionary expression<br/>'NSDictionary *test = @{@"foo" :@"bar"};'.</html>"
+Description="<html>(OC) Add or remove space after the colon in immutable dictionary expression<br/>'NSDictionary *test = @{@"foo" :@"bar"};'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_oc_dict_colon=ignore|sp_after_oc_dict_colon=add|sp_after_oc_dict_colon=remove|sp_after_oc_dict_colon=force|sp_after_oc_dict_colon=not_defined
-ChoicesReadable="(217)Ignore Sp After Oc Dict Colon|(217)Add Sp After Oc Dict Colon|(217)Remove Sp After Oc Dict Colon|(217)Force Sp After Oc Dict Colon"
+ChoicesReadable="Ignore Sp After Oc Dict Colon|Add Sp After Oc Dict Colon|Remove Sp After Oc Dict Colon|Force Sp After Oc Dict Colon"
 ValueDefault=ignore
 
 [Sp Before Oc Dict Colon]
 Category=1
-Description="<html>(218)(OC) Add or remove space before the colon in immutable dictionary expression<br/>'NSDictionary *test = @{@"foo" :@"bar"};'.</html>"
+Description="<html>(OC) Add or remove space before the colon in immutable dictionary expression<br/>'NSDictionary *test = @{@"foo" :@"bar"};'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_oc_dict_colon=ignore|sp_before_oc_dict_colon=add|sp_before_oc_dict_colon=remove|sp_before_oc_dict_colon=force|sp_before_oc_dict_colon=not_defined
-ChoicesReadable="(218)Ignore Sp Before Oc Dict Colon|(218)Add Sp Before Oc Dict Colon|(218)Remove Sp Before Oc Dict Colon|(218)Force Sp Before Oc Dict Colon"
+ChoicesReadable="Ignore Sp Before Oc Dict Colon|Add Sp Before Oc Dict Colon|Remove Sp Before Oc Dict Colon|Force Sp Before Oc Dict Colon"
 ValueDefault=ignore
 
 [Sp After Send Oc Colon]
 Category=1
-Description="<html>(219)(OC) Add or remove space after the colon in message specs,<br/>i.e. '[object setValue:1];' vs. '[object setValue: 1];'.</html>"
+Description="<html>(OC) Add or remove space after the colon in message specs,<br/>i.e. '[object setValue:1];' vs. '[object setValue: 1];'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_send_oc_colon=ignore|sp_after_send_oc_colon=add|sp_after_send_oc_colon=remove|sp_after_send_oc_colon=force|sp_after_send_oc_colon=not_defined
-ChoicesReadable="(219)Ignore Sp After Send Oc Colon|(219)Add Sp After Send Oc Colon|(219)Remove Sp After Send Oc Colon|(219)Force Sp After Send Oc Colon"
+ChoicesReadable="Ignore Sp After Send Oc Colon|Add Sp After Send Oc Colon|Remove Sp After Send Oc Colon|Force Sp After Send Oc Colon"
 ValueDefault=ignore
 
 [Sp Before Send Oc Colon]
 Category=1
-Description="<html>(220)(OC) Add or remove space before the colon in message specs,<br/>i.e. '[object setValue:1];' vs. '[object setValue :1];'.</html>"
+Description="<html>(OC) Add or remove space before the colon in message specs,<br/>i.e. '[object setValue:1];' vs. '[object setValue :1];'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_send_oc_colon=ignore|sp_before_send_oc_colon=add|sp_before_send_oc_colon=remove|sp_before_send_oc_colon=force|sp_before_send_oc_colon=not_defined
-ChoicesReadable="(220)Ignore Sp Before Send Oc Colon|(220)Add Sp Before Send Oc Colon|(220)Remove Sp Before Send Oc Colon|(220)Force Sp Before Send Oc Colon"
+ChoicesReadable="Ignore Sp Before Send Oc Colon|Add Sp Before Send Oc Colon|Remove Sp Before Send Oc Colon|Force Sp Before Send Oc Colon"
 ValueDefault=ignore
 
 [Sp After Oc Type]
 Category=1
-Description="<html>(221)(OC) Add or remove space after the (type) in message specs,<br/>i.e. '-(int)f: (int) x;' vs. '-(int)f: (int)x;'.</html>"
+Description="<html>(OC) Add or remove space after the (type) in message specs,<br/>i.e. '-(int)f: (int) x;' vs. '-(int)f: (int)x;'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_oc_type=ignore|sp_after_oc_type=add|sp_after_oc_type=remove|sp_after_oc_type=force|sp_after_oc_type=not_defined
-ChoicesReadable="(221)Ignore Sp After Oc Type|(221)Add Sp After Oc Type|(221)Remove Sp After Oc Type|(221)Force Sp After Oc Type"
+ChoicesReadable="Ignore Sp After Oc Type|Add Sp After Oc Type|Remove Sp After Oc Type|Force Sp After Oc Type"
 ValueDefault=ignore
 
 [Sp After Oc Return Type]
 Category=1
-Description="<html>(222)(OC) Add or remove space after the first (type) in message specs,<br/>i.e. '-(int) f:(int)x;' vs. '-(int)f:(int)x;'.</html>"
+Description="<html>(OC) Add or remove space after the first (type) in message specs,<br/>i.e. '-(int) f:(int)x;' vs. '-(int)f:(int)x;'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_oc_return_type=ignore|sp_after_oc_return_type=add|sp_after_oc_return_type=remove|sp_after_oc_return_type=force|sp_after_oc_return_type=not_defined
-ChoicesReadable="(222)Ignore Sp After Oc Return Type|(222)Add Sp After Oc Return Type|(222)Remove Sp After Oc Return Type|(222)Force Sp After Oc Return Type"
+ChoicesReadable="Ignore Sp After Oc Return Type|Add Sp After Oc Return Type|Remove Sp After Oc Return Type|Force Sp After Oc Return Type"
 ValueDefault=ignore
 
 [Sp After Oc At Sel]
 Category=1
-Description="<html>(223)(OC) Add or remove space between '@selector' and '(',<br/>i.e. '@selector(msgName)' vs. '@selector (msgName)'.<br/>Also applies to '@protocol()' constructs.</html>"
+Description="<html>(OC) Add or remove space between '@selector' and '(',<br/>i.e. '@selector(msgName)' vs. '@selector (msgName)'.<br/>Also applies to '@protocol()' constructs.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_oc_at_sel=ignore|sp_after_oc_at_sel=add|sp_after_oc_at_sel=remove|sp_after_oc_at_sel=force|sp_after_oc_at_sel=not_defined
-ChoicesReadable="(223)Ignore Sp After Oc At Sel|(223)Add Sp After Oc At Sel|(223)Remove Sp After Oc At Sel|(223)Force Sp After Oc At Sel"
+ChoicesReadable="Ignore Sp After Oc At Sel|Add Sp After Oc At Sel|Remove Sp After Oc At Sel|Force Sp After Oc At Sel"
 ValueDefault=ignore
 
 [Sp After Oc At Sel Parens]
 Category=1
-Description="<html>(224)(OC) Add or remove space between '@selector(x)' and the following word,<br/>i.e. '@selector(foo) a:' vs. '@selector(foo)a:'.</html>"
+Description="<html>(OC) Add or remove space between '@selector(x)' and the following word,<br/>i.e. '@selector(foo) a:' vs. '@selector(foo)a:'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_oc_at_sel_parens=ignore|sp_after_oc_at_sel_parens=add|sp_after_oc_at_sel_parens=remove|sp_after_oc_at_sel_parens=force|sp_after_oc_at_sel_parens=not_defined
-ChoicesReadable="(224)Ignore Sp After Oc At Sel Parens|(224)Add Sp After Oc At Sel Parens|(224)Remove Sp After Oc At Sel Parens|(224)Force Sp After Oc At Sel Parens"
+ChoicesReadable="Ignore Sp After Oc At Sel Parens|Add Sp After Oc At Sel Parens|Remove Sp After Oc At Sel Parens|Force Sp After Oc At Sel Parens"
 ValueDefault=ignore
 
 [Sp Inside Oc At Sel Parens]
 Category=1
-Description="<html>(225)(OC) Add or remove space inside '@selector' parentheses,<br/>i.e. '@selector(foo)' vs. '@selector( foo )'.<br/>Also applies to '@protocol()' constructs.</html>"
+Description="<html>(OC) Add or remove space inside '@selector' parentheses,<br/>i.e. '@selector(foo)' vs. '@selector( foo )'.<br/>Also applies to '@protocol()' constructs.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_oc_at_sel_parens=ignore|sp_inside_oc_at_sel_parens=add|sp_inside_oc_at_sel_parens=remove|sp_inside_oc_at_sel_parens=force|sp_inside_oc_at_sel_parens=not_defined
-ChoicesReadable="(225)Ignore Sp Inside Oc At Sel Parens|(225)Add Sp Inside Oc At Sel Parens|(225)Remove Sp Inside Oc At Sel Parens|(225)Force Sp Inside Oc At Sel Parens"
+ChoicesReadable="Ignore Sp Inside Oc At Sel Parens|Add Sp Inside Oc At Sel Parens|Remove Sp Inside Oc At Sel Parens|Force Sp Inside Oc At Sel Parens"
 ValueDefault=ignore
 
 [Sp Before Oc Block Caret]
 Category=1
-Description="<html>(226)(OC) Add or remove space before a block pointer caret,<br/>i.e. '^int (int arg){...}' vs. ' ^int (int arg){...}'.</html>"
+Description="<html>(OC) Add or remove space before a block pointer caret,<br/>i.e. '^int (int arg){...}' vs. ' ^int (int arg){...}'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_oc_block_caret=ignore|sp_before_oc_block_caret=add|sp_before_oc_block_caret=remove|sp_before_oc_block_caret=force|sp_before_oc_block_caret=not_defined
-ChoicesReadable="(226)Ignore Sp Before Oc Block Caret|(226)Add Sp Before Oc Block Caret|(226)Remove Sp Before Oc Block Caret|(226)Force Sp Before Oc Block Caret"
+ChoicesReadable="Ignore Sp Before Oc Block Caret|Add Sp Before Oc Block Caret|Remove Sp Before Oc Block Caret|Force Sp Before Oc Block Caret"
 ValueDefault=ignore
 
 [Sp After Oc Block Caret]
 Category=1
-Description="<html>(227)(OC) Add or remove space after a block pointer caret,<br/>i.e. '^int (int arg){...}' vs. '^ int (int arg){...}'.</html>"
+Description="<html>(OC) Add or remove space after a block pointer caret,<br/>i.e. '^int (int arg){...}' vs. '^ int (int arg){...}'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_oc_block_caret=ignore|sp_after_oc_block_caret=add|sp_after_oc_block_caret=remove|sp_after_oc_block_caret=force|sp_after_oc_block_caret=not_defined
-ChoicesReadable="(227)Ignore Sp After Oc Block Caret|(227)Add Sp After Oc Block Caret|(227)Remove Sp After Oc Block Caret|(227)Force Sp After Oc Block Caret"
+ChoicesReadable="Ignore Sp After Oc Block Caret|Add Sp After Oc Block Caret|Remove Sp After Oc Block Caret|Force Sp After Oc Block Caret"
 ValueDefault=ignore
 
 [Sp After Oc Msg Receiver]
 Category=1
-Description="<html>(228)(OC) Add or remove space between the receiver and selector in a message,<br/>as in '[receiver selector ...]'.</html>"
+Description="<html>(OC) Add or remove space between the receiver and selector in a message,<br/>as in '[receiver selector ...]'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_oc_msg_receiver=ignore|sp_after_oc_msg_receiver=add|sp_after_oc_msg_receiver=remove|sp_after_oc_msg_receiver=force|sp_after_oc_msg_receiver=not_defined
-ChoicesReadable="(228)Ignore Sp After Oc Msg Receiver|(228)Add Sp After Oc Msg Receiver|(228)Remove Sp After Oc Msg Receiver|(228)Force Sp After Oc Msg Receiver"
+ChoicesReadable="Ignore Sp After Oc Msg Receiver|Add Sp After Oc Msg Receiver|Remove Sp After Oc Msg Receiver|Force Sp After Oc Msg Receiver"
 ValueDefault=ignore
 
 [Sp After Oc Property]
 Category=1
-Description="<html>(229)(OC) Add or remove space after '@property'.</html>"
+Description="<html>(OC) Add or remove space after '@property'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_oc_property=ignore|sp_after_oc_property=add|sp_after_oc_property=remove|sp_after_oc_property=force|sp_after_oc_property=not_defined
-ChoicesReadable="(229)Ignore Sp After Oc Property|(229)Add Sp After Oc Property|(229)Remove Sp After Oc Property|(229)Force Sp After Oc Property"
+ChoicesReadable="Ignore Sp After Oc Property|Add Sp After Oc Property|Remove Sp After Oc Property|Force Sp After Oc Property"
 ValueDefault=ignore
 
 [Sp After Oc Synchronized]
 Category=1
-Description="<html>(230)(OC) Add or remove space between '@synchronized' and the open parenthesis,<br/>i.e. '@synchronized(foo)' vs. '@synchronized (foo)'.</html>"
+Description="<html>(OC) Add or remove space between '@synchronized' and the open parenthesis,<br/>i.e. '@synchronized(foo)' vs. '@synchronized (foo)'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_oc_synchronized=ignore|sp_after_oc_synchronized=add|sp_after_oc_synchronized=remove|sp_after_oc_synchronized=force|sp_after_oc_synchronized=not_defined
-ChoicesReadable="(230)Ignore Sp After Oc Synchronized|(230)Add Sp After Oc Synchronized|(230)Remove Sp After Oc Synchronized|(230)Force Sp After Oc Synchronized"
+ChoicesReadable="Ignore Sp After Oc Synchronized|Add Sp After Oc Synchronized|Remove Sp After Oc Synchronized|Force Sp After Oc Synchronized"
 ValueDefault=ignore
 
 [Sp Cond Colon]
 Category=1
-Description="<html>(231)Add or remove space around the ':' in 'b ? t : f'.</html>"
+Description="<html>Add or remove space around the ':' in 'b ? t : f'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cond_colon=ignore|sp_cond_colon=add|sp_cond_colon=remove|sp_cond_colon=force|sp_cond_colon=not_defined
-ChoicesReadable="(231)Ignore Sp Cond Colon|(231)Add Sp Cond Colon|(231)Remove Sp Cond Colon|(231)Force Sp Cond Colon"
+ChoicesReadable="Ignore Sp Cond Colon|Add Sp Cond Colon|Remove Sp Cond Colon|Force Sp Cond Colon"
 ValueDefault=ignore
 
 [Sp Cond Colon Before]
 Category=1
-Description="<html>(232)Add or remove space before the ':' in 'b ? t : f'.<br/><br/>Overrides sp_cond_colon.</html>"
+Description="<html>Add or remove space before the ':' in 'b ? t : f'.<br/><br/>Overrides sp_cond_colon.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cond_colon_before=ignore|sp_cond_colon_before=add|sp_cond_colon_before=remove|sp_cond_colon_before=force|sp_cond_colon_before=not_defined
-ChoicesReadable="(232)Ignore Sp Cond Colon Before|(232)Add Sp Cond Colon Before|(232)Remove Sp Cond Colon Before|(232)Force Sp Cond Colon Before"
+ChoicesReadable="Ignore Sp Cond Colon Before|Add Sp Cond Colon Before|Remove Sp Cond Colon Before|Force Sp Cond Colon Before"
 ValueDefault=ignore
 
 [Sp Cond Colon After]
 Category=1
-Description="<html>(233)Add or remove space after the ':' in 'b ? t : f'.<br/><br/>Overrides sp_cond_colon.</html>"
+Description="<html>Add or remove space after the ':' in 'b ? t : f'.<br/><br/>Overrides sp_cond_colon.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cond_colon_after=ignore|sp_cond_colon_after=add|sp_cond_colon_after=remove|sp_cond_colon_after=force|sp_cond_colon_after=not_defined
-ChoicesReadable="(233)Ignore Sp Cond Colon After|(233)Add Sp Cond Colon After|(233)Remove Sp Cond Colon After|(233)Force Sp Cond Colon After"
+ChoicesReadable="Ignore Sp Cond Colon After|Add Sp Cond Colon After|Remove Sp Cond Colon After|Force Sp Cond Colon After"
 ValueDefault=ignore
 
 [Sp Cond Question]
 Category=1
-Description="<html>(234)Add or remove space around the '?' in 'b ? t : f'.</html>"
+Description="<html>Add or remove space around the '?' in 'b ? t : f'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cond_question=ignore|sp_cond_question=add|sp_cond_question=remove|sp_cond_question=force|sp_cond_question=not_defined
-ChoicesReadable="(234)Ignore Sp Cond Question|(234)Add Sp Cond Question|(234)Remove Sp Cond Question|(234)Force Sp Cond Question"
+ChoicesReadable="Ignore Sp Cond Question|Add Sp Cond Question|Remove Sp Cond Question|Force Sp Cond Question"
 ValueDefault=ignore
 
 [Sp Cond Question Before]
 Category=1
-Description="<html>(235)Add or remove space before the '?' in 'b ? t : f'.<br/><br/>Overrides sp_cond_question.</html>"
+Description="<html>Add or remove space before the '?' in 'b ? t : f'.<br/><br/>Overrides sp_cond_question.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cond_question_before=ignore|sp_cond_question_before=add|sp_cond_question_before=remove|sp_cond_question_before=force|sp_cond_question_before=not_defined
-ChoicesReadable="(235)Ignore Sp Cond Question Before|(235)Add Sp Cond Question Before|(235)Remove Sp Cond Question Before|(235)Force Sp Cond Question Before"
+ChoicesReadable="Ignore Sp Cond Question Before|Add Sp Cond Question Before|Remove Sp Cond Question Before|Force Sp Cond Question Before"
 ValueDefault=ignore
 
 [Sp Cond Question After]
 Category=1
-Description="<html>(236)Add or remove space after the '?' in 'b ? t : f'.<br/><br/>Overrides sp_cond_question.</html>"
+Description="<html>Add or remove space after the '?' in 'b ? t : f'.<br/><br/>Overrides sp_cond_question.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cond_question_after=ignore|sp_cond_question_after=add|sp_cond_question_after=remove|sp_cond_question_after=force|sp_cond_question_after=not_defined
-ChoicesReadable="(236)Ignore Sp Cond Question After|(236)Add Sp Cond Question After|(236)Remove Sp Cond Question After|(236)Force Sp Cond Question After"
+ChoicesReadable="Ignore Sp Cond Question After|Add Sp Cond Question After|Remove Sp Cond Question After|Force Sp Cond Question After"
 ValueDefault=ignore
 
 [Sp Cond Ternary Short]
 Category=1
-Description="<html>(237)In the abbreviated ternary form '(a ?: b)', add or remove space between '?'<br/>and ':'.<br/><br/>Overrides all other sp_cond_* options.</html>"
+Description="<html>In the abbreviated ternary form '(a ?: b)', add or remove space between '?'<br/>and ':'.<br/><br/>Overrides all other sp_cond_* options.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cond_ternary_short=ignore|sp_cond_ternary_short=add|sp_cond_ternary_short=remove|sp_cond_ternary_short=force|sp_cond_ternary_short=not_defined
-ChoicesReadable="(237)Ignore Sp Cond Ternary Short|(237)Add Sp Cond Ternary Short|(237)Remove Sp Cond Ternary Short|(237)Force Sp Cond Ternary Short"
+ChoicesReadable="Ignore Sp Cond Ternary Short|Add Sp Cond Ternary Short|Remove Sp Cond Ternary Short|Force Sp Cond Ternary Short"
 ValueDefault=ignore
 
 [Sp Case Label]
 Category=1
-Description="<html>(238)Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make<br/>sense here.</html>"
+Description="<html>Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make<br/>sense here.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_case_label=ignore|sp_case_label=add|sp_case_label=remove|sp_case_label=force|sp_case_label=not_defined
-ChoicesReadable="(238)Ignore Sp Case Label|(238)Add Sp Case Label|(238)Remove Sp Case Label|(238)Force Sp Case Label"
+ChoicesReadable="Ignore Sp Case Label|Add Sp Case Label|Remove Sp Case Label|Force Sp Case Label"
 ValueDefault=ignore
 
 [Sp Range]
 Category=1
-Description="<html>(239)(D) Add or remove space around the D '..' operator.</html>"
+Description="<html>(D) Add or remove space around the D '..' operator.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_range=ignore|sp_range=add|sp_range=remove|sp_range=force|sp_range=not_defined
-ChoicesReadable="(239)Ignore Sp Range|(239)Add Sp Range|(239)Remove Sp Range|(239)Force Sp Range"
+ChoicesReadable="Ignore Sp Range|Add Sp Range|Remove Sp Range|Force Sp Range"
 ValueDefault=ignore
 
 [Sp After For Colon]
 Category=1
-Description="<html>(240)Add or remove space after ':' in a Java/C++11 range-based 'for',<br/>as in 'for (Type var : &lt;here&gt; expr)'.</html>"
+Description="<html>Add or remove space after ':' in a Java/C++11 range-based 'for',<br/>as in 'for (Type var : &lt;here&gt; expr)'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_for_colon=ignore|sp_after_for_colon=add|sp_after_for_colon=remove|sp_after_for_colon=force|sp_after_for_colon=not_defined
-ChoicesReadable="(240)Ignore Sp After For Colon|(240)Add Sp After For Colon|(240)Remove Sp After For Colon|(240)Force Sp After For Colon"
+ChoicesReadable="Ignore Sp After For Colon|Add Sp After For Colon|Remove Sp After For Colon|Force Sp After For Colon"
 ValueDefault=ignore
 
 [Sp Before For Colon]
 Category=1
-Description="<html>(241)Add or remove space before ':' in a Java/C++11 range-based 'for',<br/>as in 'for (Type var &lt;here&gt; : expr)'.</html>"
+Description="<html>Add or remove space before ':' in a Java/C++11 range-based 'for',<br/>as in 'for (Type var &lt;here&gt; : expr)'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_for_colon=ignore|sp_before_for_colon=add|sp_before_for_colon=remove|sp_before_for_colon=force|sp_before_for_colon=not_defined
-ChoicesReadable="(241)Ignore Sp Before For Colon|(241)Add Sp Before For Colon|(241)Remove Sp Before For Colon|(241)Force Sp Before For Colon"
+ChoicesReadable="Ignore Sp Before For Colon|Add Sp Before For Colon|Remove Sp Before For Colon|Force Sp Before For Colon"
 ValueDefault=ignore
 
 [Sp Extern Paren]
 Category=1
-Description="<html>(242)(D) Add or remove space between 'extern' and '(' as in 'extern &lt;here&gt; (C)'.</html>"
+Description="<html>(D) Add or remove space between 'extern' and '(' as in 'extern &lt;here&gt; (C)'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_extern_paren=ignore|sp_extern_paren=add|sp_extern_paren=remove|sp_extern_paren=force|sp_extern_paren=not_defined
-ChoicesReadable="(242)Ignore Sp Extern Paren|(242)Add Sp Extern Paren|(242)Remove Sp Extern Paren|(242)Force Sp Extern Paren"
+ChoicesReadable="Ignore Sp Extern Paren|Add Sp Extern Paren|Remove Sp Extern Paren|Force Sp Extern Paren"
 ValueDefault=ignore
 
 [Sp Cmt Cpp Start]
 Category=1
-Description="<html>(243)Add or remove space after the opening of a C++ comment, as in '// &lt;here&gt; A'.</html>"
+Description="<html>Add or remove space after the opening of a C++ comment, as in '// &lt;here&gt; A'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cmt_cpp_start=ignore|sp_cmt_cpp_start=add|sp_cmt_cpp_start=remove|sp_cmt_cpp_start=force|sp_cmt_cpp_start=not_defined
-ChoicesReadable="(243)Ignore Sp Cmt Cpp Start|(243)Add Sp Cmt Cpp Start|(243)Remove Sp Cmt Cpp Start|(243)Force Sp Cmt Cpp Start"
+ChoicesReadable="Ignore Sp Cmt Cpp Start|Add Sp Cmt Cpp Start|Remove Sp Cmt Cpp Start|Force Sp Cmt Cpp Start"
 ValueDefault=ignore
 
 [Sp Cmt Cpp Region]
 Category=1
-Description="<html>(244)Add or remove space in a C++ region marker comment, as in '// &lt;here&gt; BEGIN'.<br/>A region marker is defined as a comment which is not preceded by other text<br/>(i.e. the comment is the first non-whitespace on the line), and which starts<br/>with either 'BEGIN' or 'END'.<br/><br/>Overrides sp_cmt_cpp_start.</html>"
+Description="<html>Add or remove space in a C++ region marker comment, as in '// &lt;here&gt; BEGIN'.<br/>A region marker is defined as a comment which is not preceded by other text<br/>(i.e. the comment is the first non-whitespace on the line), and which starts<br/>with either 'BEGIN' or 'END'.<br/><br/>Overrides sp_cmt_cpp_start.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_cmt_cpp_region=ignore|sp_cmt_cpp_region=add|sp_cmt_cpp_region=remove|sp_cmt_cpp_region=force|sp_cmt_cpp_region=not_defined
-ChoicesReadable="(244)Ignore Sp Cmt Cpp Region|(244)Add Sp Cmt Cpp Region|(244)Remove Sp Cmt Cpp Region|(244)Force Sp Cmt Cpp Region"
+ChoicesReadable="Ignore Sp Cmt Cpp Region|Add Sp Cmt Cpp Region|Remove Sp Cmt Cpp Region|Force Sp Cmt Cpp Region"
 ValueDefault=ignore
 
 [Sp Cmt Cpp Doxygen]
 Category=1
-Description="<html>(245)If true, space added with sp_cmt_cpp_start will be added after Doxygen<br/>sequences like '///', '///&lt;', '//!' and '//!&lt;'.</html>"
+Description="<html>If true, space added with sp_cmt_cpp_start will be added after Doxygen<br/>sequences like '///', '///&lt;', '//!' and '//!&lt;'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=sp_cmt_cpp_doxygen=true|sp_cmt_cpp_doxygen=false
@@ -2225,7 +2225,7 @@ ValueDefault=false
 
 [Sp Cmt Cpp Qttr]
 Category=1
-Description="<html>(246)If true, space added with sp_cmt_cpp_start will be added after Qt translator<br/>or meta-data comments like '//:', '//=', and '//~'.</html>"
+Description="<html>If true, space added with sp_cmt_cpp_start will be added after Qt translator<br/>or meta-data comments like '//:', '//=', and '//~'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=sp_cmt_cpp_qttr=true|sp_cmt_cpp_qttr=false
@@ -2233,79 +2233,79 @@ ValueDefault=false
 
 [Sp Endif Cmt]
 Category=1
-Description="<html>(247)Add or remove space between #else or #endif and a trailing comment.</html>"
+Description="<html>Add or remove space between #else or #endif and a trailing comment.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_endif_cmt=ignore|sp_endif_cmt=add|sp_endif_cmt=remove|sp_endif_cmt=force|sp_endif_cmt=not_defined
-ChoicesReadable="(247)Ignore Sp Endif Cmt|(247)Add Sp Endif Cmt|(247)Remove Sp Endif Cmt|(247)Force Sp Endif Cmt"
+ChoicesReadable="Ignore Sp Endif Cmt|Add Sp Endif Cmt|Remove Sp Endif Cmt|Force Sp Endif Cmt"
 ValueDefault=ignore
 
 [Sp After New]
 Category=1
-Description="<html>(248)Add or remove space after 'new', 'delete' and 'delete[]'.</html>"
+Description="<html>Add or remove space after 'new', 'delete' and 'delete[]'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_new=ignore|sp_after_new=add|sp_after_new=remove|sp_after_new=force|sp_after_new=not_defined
-ChoicesReadable="(248)Ignore Sp After New|(248)Add Sp After New|(248)Remove Sp After New|(248)Force Sp After New"
+ChoicesReadable="Ignore Sp After New|Add Sp After New|Remove Sp After New|Force Sp After New"
 ValueDefault=ignore
 
 [Sp Between New Paren]
 Category=1
-Description="<html>(249)Add or remove space between 'new' and '(' in 'new()'.</html>"
+Description="<html>Add or remove space between 'new' and '(' in 'new()'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_between_new_paren=ignore|sp_between_new_paren=add|sp_between_new_paren=remove|sp_between_new_paren=force|sp_between_new_paren=not_defined
-ChoicesReadable="(249)Ignore Sp Between New Paren|(249)Add Sp Between New Paren|(249)Remove Sp Between New Paren|(249)Force Sp Between New Paren"
+ChoicesReadable="Ignore Sp Between New Paren|Add Sp Between New Paren|Remove Sp Between New Paren|Force Sp Between New Paren"
 ValueDefault=ignore
 
 [Sp After Newop Paren]
 Category=1
-Description="<html>(250)Add or remove space between ')' and type in 'new(foo) BAR'.</html>"
+Description="<html>Add or remove space between ')' and type in 'new(foo) BAR'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_newop_paren=ignore|sp_after_newop_paren=add|sp_after_newop_paren=remove|sp_after_newop_paren=force|sp_after_newop_paren=not_defined
-ChoicesReadable="(250)Ignore Sp After Newop Paren|(250)Add Sp After Newop Paren|(250)Remove Sp After Newop Paren|(250)Force Sp After Newop Paren"
+ChoicesReadable="Ignore Sp After Newop Paren|Add Sp After Newop Paren|Remove Sp After Newop Paren|Force Sp After Newop Paren"
 ValueDefault=ignore
 
 [Sp Inside Newop Paren]
 Category=1
-Description="<html>(251)Add or remove space inside parentheses of the new operator<br/>as in 'new(foo) BAR'.</html>"
+Description="<html>Add or remove space inside parentheses of the new operator<br/>as in 'new(foo) BAR'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_newop_paren=ignore|sp_inside_newop_paren=add|sp_inside_newop_paren=remove|sp_inside_newop_paren=force|sp_inside_newop_paren=not_defined
-ChoicesReadable="(251)Ignore Sp Inside Newop Paren|(251)Add Sp Inside Newop Paren|(251)Remove Sp Inside Newop Paren|(251)Force Sp Inside Newop Paren"
+ChoicesReadable="Ignore Sp Inside Newop Paren|Add Sp Inside Newop Paren|Remove Sp Inside Newop Paren|Force Sp Inside Newop Paren"
 ValueDefault=ignore
 
 [Sp Inside Newop Paren Open]
 Category=1
-Description="<html>(252)Add or remove space after the open parenthesis of the new operator,<br/>as in 'new(foo) BAR'.<br/><br/>Overrides sp_inside_newop_paren.</html>"
+Description="<html>Add or remove space after the open parenthesis of the new operator,<br/>as in 'new(foo) BAR'.<br/><br/>Overrides sp_inside_newop_paren.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_newop_paren_open=ignore|sp_inside_newop_paren_open=add|sp_inside_newop_paren_open=remove|sp_inside_newop_paren_open=force|sp_inside_newop_paren_open=not_defined
-ChoicesReadable="(252)Ignore Sp Inside Newop Paren Open|(252)Add Sp Inside Newop Paren Open|(252)Remove Sp Inside Newop Paren Open|(252)Force Sp Inside Newop Paren Open"
+ChoicesReadable="Ignore Sp Inside Newop Paren Open|Add Sp Inside Newop Paren Open|Remove Sp Inside Newop Paren Open|Force Sp Inside Newop Paren Open"
 ValueDefault=ignore
 
 [Sp Inside Newop Paren Close]
 Category=1
-Description="<html>(253)Add or remove space before the close parenthesis of the new operator,<br/>as in 'new(foo) BAR'.<br/><br/>Overrides sp_inside_newop_paren.</html>"
+Description="<html>Add or remove space before the close parenthesis of the new operator,<br/>as in 'new(foo) BAR'.<br/><br/>Overrides sp_inside_newop_paren.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_inside_newop_paren_close=ignore|sp_inside_newop_paren_close=add|sp_inside_newop_paren_close=remove|sp_inside_newop_paren_close=force|sp_inside_newop_paren_close=not_defined
-ChoicesReadable="(253)Ignore Sp Inside Newop Paren Close|(253)Add Sp Inside Newop Paren Close|(253)Remove Sp Inside Newop Paren Close|(253)Force Sp Inside Newop Paren Close"
+ChoicesReadable="Ignore Sp Inside Newop Paren Close|Add Sp Inside Newop Paren Close|Remove Sp Inside Newop Paren Close|Force Sp Inside Newop Paren Close"
 ValueDefault=ignore
 
 [Sp Before Tr Cmt]
 Category=1
-Description="<html>(254)Add or remove space before a trailing comment.</html>"
+Description="<html>Add or remove space before a trailing comment.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_tr_cmt=ignore|sp_before_tr_cmt=add|sp_before_tr_cmt=remove|sp_before_tr_cmt=force|sp_before_tr_cmt=not_defined
-ChoicesReadable="(254)Ignore Sp Before Tr Cmt|(254)Add Sp Before Tr Cmt|(254)Remove Sp Before Tr Cmt|(254)Force Sp Before Tr Cmt"
+ChoicesReadable="Ignore Sp Before Tr Cmt|Add Sp Before Tr Cmt|Remove Sp Before Tr Cmt|Force Sp Before Tr Cmt"
 ValueDefault=ignore
 
 [Sp Num Before Tr Cmt]
 Category=1
-Description="<html>(255)Number of spaces before a trailing comment.</html>"
+Description="<html>Number of spaces before a trailing comment.</html>"
 Enabled=false
 EditorType=numeric
 CallName="sp_num_before_tr_cmt="
@@ -2315,16 +2315,16 @@ ValueDefault=0
 
 [Sp Before Emb Cmt]
 Category=1
-Description="<html>(256)Add or remove space before an embedded comment.<br/><br/>Default: force</html>"
+Description="<html>Add or remove space before an embedded comment.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_before_emb_cmt=ignore|sp_before_emb_cmt=add|sp_before_emb_cmt=remove|sp_before_emb_cmt=force|sp_before_emb_cmt=not_defined
-ChoicesReadable="(256)Ignore Sp Before Emb Cmt|(256)Add Sp Before Emb Cmt|(256)Remove Sp Before Emb Cmt|(256)Force Sp Before Emb Cmt"
+ChoicesReadable="Ignore Sp Before Emb Cmt|Add Sp Before Emb Cmt|Remove Sp Before Emb Cmt|Force Sp Before Emb Cmt"
 ValueDefault=force
 
 [Sp Num Before Emb Cmt]
 Category=1
-Description="<html>(257)Number of spaces before an embedded comment.<br/><br/>Default: 1</html>"
+Description="<html>Number of spaces before an embedded comment.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
 CallName="sp_num_before_emb_cmt="
@@ -2334,16 +2334,16 @@ ValueDefault=1
 
 [Sp After Emb Cmt]
 Category=1
-Description="<html>(258)Add or remove space after an embedded comment.<br/><br/>Default: force</html>"
+Description="<html>Add or remove space after an embedded comment.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_emb_cmt=ignore|sp_after_emb_cmt=add|sp_after_emb_cmt=remove|sp_after_emb_cmt=force|sp_after_emb_cmt=not_defined
-ChoicesReadable="(258)Ignore Sp After Emb Cmt|(258)Add Sp After Emb Cmt|(258)Remove Sp After Emb Cmt|(258)Force Sp After Emb Cmt"
+ChoicesReadable="Ignore Sp After Emb Cmt|Add Sp After Emb Cmt|Remove Sp After Emb Cmt|Force Sp After Emb Cmt"
 ValueDefault=force
 
 [Sp Num After Emb Cmt]
 Category=1
-Description="<html>(259)Number of spaces after an embedded comment.<br/><br/>Default: 1</html>"
+Description="<html>Number of spaces after an embedded comment.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
 CallName="sp_num_after_emb_cmt="
@@ -2353,16 +2353,16 @@ ValueDefault=1
 
 [Sp Annotation Paren]
 Category=1
-Description="<html>(260)(Java) Add or remove space between an annotation and the open parenthesis.</html>"
+Description="<html>(Java) Add or remove space between an annotation and the open parenthesis.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_annotation_paren=ignore|sp_annotation_paren=add|sp_annotation_paren=remove|sp_annotation_paren=force|sp_annotation_paren=not_defined
-ChoicesReadable="(260)Ignore Sp Annotation Paren|(260)Add Sp Annotation Paren|(260)Remove Sp Annotation Paren|(260)Force Sp Annotation Paren"
+ChoicesReadable="Ignore Sp Annotation Paren|Add Sp Annotation Paren|Remove Sp Annotation Paren|Force Sp Annotation Paren"
 ValueDefault=ignore
 
 [Sp Skip Vbrace Tokens]
 Category=1
-Description="<html>(261)If true, vbrace tokens are dropped to the previous token and skipped.</html>"
+Description="<html>If true, vbrace tokens are dropped to the previous token and skipped.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=sp_skip_vbrace_tokens=true|sp_skip_vbrace_tokens=false
@@ -2370,25 +2370,25 @@ ValueDefault=false
 
 [Sp After Noexcept]
 Category=1
-Description="<html>(262)Add or remove space after 'noexcept'.</html>"
+Description="<html>Add or remove space after 'noexcept'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_after_noexcept=ignore|sp_after_noexcept=add|sp_after_noexcept=remove|sp_after_noexcept=force|sp_after_noexcept=not_defined
-ChoicesReadable="(262)Ignore Sp After Noexcept|(262)Add Sp After Noexcept|(262)Remove Sp After Noexcept|(262)Force Sp After Noexcept"
+ChoicesReadable="Ignore Sp After Noexcept|Add Sp After Noexcept|Remove Sp After Noexcept|Force Sp After Noexcept"
 ValueDefault=ignore
 
 [Sp Vala After Translation]
 Category=1
-Description="<html>(263)Add or remove space after '_'.</html>"
+Description="<html>Add or remove space after '_'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_vala_after_translation=ignore|sp_vala_after_translation=add|sp_vala_after_translation=remove|sp_vala_after_translation=force|sp_vala_after_translation=not_defined
-ChoicesReadable="(263)Ignore Sp Vala After Translation|(263)Add Sp Vala After Translation|(263)Remove Sp Vala After Translation|(263)Force Sp Vala After Translation"
+ChoicesReadable="Ignore Sp Vala After Translation|Add Sp Vala After Translation|Remove Sp Vala After Translation|Force Sp Vala After Translation"
 ValueDefault=ignore
 
 [Force Tab After Define]
 Category=1
-Description="<html>(264)If true, a &lt;TAB&gt; is inserted after #define.</html>"
+Description="<html>If true, a &lt;TAB&gt; is inserted after #define.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=force_tab_after_define=true|force_tab_after_define=false
@@ -2396,7 +2396,7 @@ ValueDefault=false
 
 [Indent Columns]
 Category=2
-Description="<html>(265)The number of columns to indent per level. Usually 2, 3, 4, or 8.<br/><br/>Default: 8</html>"
+Description="<html>The number of columns to indent per level. Usually 2, 3, 4, or 8.<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_columns="
@@ -2406,7 +2406,7 @@ ValueDefault=8
 
 [Indent Ignore First Continue]
 Category=2
-Description="<html>(266)Whether to ignore indent for the first continuation line. Subsequent<br/>continuation lines will still be indented to match the first.</html>"
+Description="<html>Whether to ignore indent for the first continuation line. Subsequent<br/>continuation lines will still be indented to match the first.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_ignore_first_continue=true|indent_ignore_first_continue=false
@@ -2414,7 +2414,7 @@ ValueDefault=false
 
 [Indent Continue]
 Category=2
-Description="<html>(267)The continuation indent. If non-zero, this overrides the indent of '(', '['<br/>and '=' continuation indents. Negative values are OK; negative value is<br/>absolute and not increased for each '(' or '[' level.<br/><br/>For FreeBSD, this is set to 4.<br/>Requires indent_ignore_first_continue=false.</html>"
+Description="<html>The continuation indent. If non-zero, this overrides the indent of '(', '['<br/>and '=' continuation indents. Negative values are OK; negative value is<br/>absolute and not increased for each '(' or '[' level.<br/><br/>For FreeBSD, this is set to 4.<br/>Requires indent_ignore_first_continue=false.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_continue="
@@ -2424,7 +2424,7 @@ ValueDefault=0
 
 [Indent Continue Class Head]
 Category=2
-Description="<html>(268)The continuation indent, only for class header line(s). If non-zero, this<br/>overrides the indent of 'class' continuation indents.<br/>Requires indent_ignore_first_continue=false.</html>"
+Description="<html>The continuation indent, only for class header line(s). If non-zero, this<br/>overrides the indent of 'class' continuation indents.<br/>Requires indent_ignore_first_continue=false.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_continue_class_head="
@@ -2434,7 +2434,7 @@ ValueDefault=0
 
 [Indent Single Newlines]
 Category=2
-Description="<html>(269)Whether to indent empty lines (i.e. lines which contain only spaces before<br/>the newline character).</html>"
+Description="<html>Whether to indent empty lines (i.e. lines which contain only spaces before<br/>the newline character).</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_single_newlines=true|indent_single_newlines=false
@@ -2442,7 +2442,7 @@ ValueDefault=false
 
 [Indent Param]
 Category=2
-Description="<html>(270)The continuation indent for func_*_param if they are true. If non-zero, this<br/>overrides the indent.</html>"
+Description="<html>The continuation indent for func_*_param if they are true. If non-zero, this<br/>overrides the indent.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_param="
@@ -2452,16 +2452,16 @@ ValueDefault=0
 
 [Indent With Tabs]
 Category=2
-Description="<html>(271)How to use tabs when indenting code.<br/><br/>0: Spaces only<br/>1: Indent with tabs to brace level, align with spaces (default)<br/>2: Indent and align with tabs, using spaces when not on a tabstop<br/><br/>Default: 1</html>"
+Description="<html>How to use tabs when indenting code.<br/><br/>0: Spaces only<br/>1: Indent with tabs to brace level, align with spaces (default)<br/>2: Indent and align with tabs, using spaces when not on a tabstop<br/><br/>Default: 1</html>"
 Enabled=true
 EditorType=multiple
 Choices="indent_with_tabs=0|indent_with_tabs=1|indent_with_tabs=2"
-ChoicesReadable="(271)Spaces only|(271)Indent with tabs, align with spaces|(271)Indent and align with tabs"
+ChoicesReadable="Spaces only|Indent with tabs, align with spaces|Indent and align with tabs"
 ValueDefault=1
 
 [Indent Cmt With Tabs]
 Category=2
-Description="<html>(272)Whether to indent comments that are not at a brace level with tabs on a<br/>tabstop. Requires indent_with_tabs=2. If false, will use spaces.</html>"
+Description="<html>Whether to indent comments that are not at a brace level with tabs on a<br/>tabstop. Requires indent_with_tabs=2. If false, will use spaces.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_cmt_with_tabs=true|indent_cmt_with_tabs=false
@@ -2469,7 +2469,7 @@ ValueDefault=false
 
 [Indent Align String]
 Category=2
-Description="<html>(273)Whether to indent strings broken by '\' so that they line up.</html>"
+Description="<html>Whether to indent strings broken by '\' so that they line up.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_align_string=true|indent_align_string=false
@@ -2477,7 +2477,7 @@ ValueDefault=false
 
 [Indent Xml String]
 Category=2
-Description="<html>(274)The number of spaces to indent multi-line XML strings.<br/>Requires indent_align_string=true.</html>"
+Description="<html>The number of spaces to indent multi-line XML strings.<br/>Requires indent_align_string=true.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_xml_string="
@@ -2487,7 +2487,7 @@ ValueDefault=0
 
 [Indent Brace]
 Category=2
-Description="<html>(275)Spaces to indent '{' from level.</html>"
+Description="<html>Spaces to indent '{' from level.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_brace="
@@ -2497,7 +2497,7 @@ ValueDefault=0
 
 [Indent Braces]
 Category=2
-Description="<html>(276)Whether braces are indented to the body level.</html>"
+Description="<html>Whether braces are indented to the body level.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_braces=true|indent_braces=false
@@ -2505,7 +2505,7 @@ ValueDefault=false
 
 [Indent Braces No Func]
 Category=2
-Description="<html>(277)Whether to disable indenting function braces if indent_braces=true.</html>"
+Description="<html>Whether to disable indenting function braces if indent_braces=true.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_braces_no_func=true|indent_braces_no_func=false
@@ -2513,7 +2513,7 @@ ValueDefault=false
 
 [Indent Braces No Class]
 Category=2
-Description="<html>(278)Whether to disable indenting class braces if indent_braces=true.</html>"
+Description="<html>Whether to disable indenting class braces if indent_braces=true.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_braces_no_class=true|indent_braces_no_class=false
@@ -2521,7 +2521,7 @@ ValueDefault=false
 
 [Indent Braces No Struct]
 Category=2
-Description="<html>(279)Whether to disable indenting struct braces if indent_braces=true.</html>"
+Description="<html>Whether to disable indenting struct braces if indent_braces=true.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_braces_no_struct=true|indent_braces_no_struct=false
@@ -2529,7 +2529,7 @@ ValueDefault=false
 
 [Indent Brace Parent]
 Category=2
-Description="<html>(280)Whether to indent based on the size of the brace parent,<br/>i.e. 'if' =&gt; 3 spaces, 'for' =&gt; 4 spaces, etc.</html>"
+Description="<html>Whether to indent based on the size of the brace parent,<br/>i.e. 'if' =&gt; 3 spaces, 'for' =&gt; 4 spaces, etc.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_brace_parent=true|indent_brace_parent=false
@@ -2537,7 +2537,7 @@ ValueDefault=false
 
 [Indent Paren Open Brace]
 Category=2
-Description="<html>(281)Whether to indent based on the open parenthesis instead of the open brace<br/>in '({\n'.</html>"
+Description="<html>Whether to indent based on the open parenthesis instead of the open brace<br/>in '({\n'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_paren_open_brace=true|indent_paren_open_brace=false
@@ -2545,7 +2545,7 @@ ValueDefault=false
 
 [Indent Cs Delegate Brace]
 Category=2
-Description="<html>(282)(C#) Whether to indent the brace of a C# delegate by another level.</html>"
+Description="<html>(C#) Whether to indent the brace of a C# delegate by another level.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_cs_delegate_brace=true|indent_cs_delegate_brace=false
@@ -2553,7 +2553,7 @@ ValueDefault=false
 
 [Indent Cs Delegate Body]
 Category=2
-Description="<html>(283)(C#) Whether to indent a C# delegate (to handle delegates with no brace) by<br/>another level.</html>"
+Description="<html>(C#) Whether to indent a C# delegate (to handle delegates with no brace) by<br/>another level.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_cs_delegate_body=true|indent_cs_delegate_body=false
@@ -2561,7 +2561,7 @@ ValueDefault=false
 
 [Indent Namespace]
 Category=2
-Description="<html>(284)Whether to indent the body of a 'namespace'.</html>"
+Description="<html>Whether to indent the body of a 'namespace'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_namespace=true|indent_namespace=false
@@ -2569,7 +2569,7 @@ ValueDefault=false
 
 [Indent Namespace Single Indent]
 Category=2
-Description="<html>(285)Whether to indent only the first namespace, and not any nested namespaces.<br/>Requires indent_namespace=true.</html>"
+Description="<html>Whether to indent only the first namespace, and not any nested namespaces.<br/>Requires indent_namespace=true.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_namespace_single_indent=true|indent_namespace_single_indent=false
@@ -2577,7 +2577,7 @@ ValueDefault=false
 
 [Indent Namespace Level]
 Category=2
-Description="<html>(286)The number of spaces to indent a namespace block.<br/>If set to zero, use the value indent_columns</html>"
+Description="<html>The number of spaces to indent a namespace block.<br/>If set to zero, use the value indent_columns</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_namespace_level="
@@ -2587,7 +2587,7 @@ ValueDefault=0
 
 [Indent Namespace Limit]
 Category=2
-Description="<html>(287)If the body of the namespace is longer than this number, it won't be<br/>indented. Requires indent_namespace=true. 0 means no limit.</html>"
+Description="<html>If the body of the namespace is longer than this number, it won't be<br/>indented. Requires indent_namespace=true. 0 means no limit.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_namespace_limit="
@@ -2597,7 +2597,7 @@ ValueDefault=0
 
 [Indent Namespace Inner Only]
 Category=2
-Description="<html>(288)Whether to indent only in inner namespaces (nested in other namespaces).<br/>Requires indent_namespace=true.</html>"
+Description="<html>Whether to indent only in inner namespaces (nested in other namespaces).<br/>Requires indent_namespace=true.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_namespace_inner_only=true|indent_namespace_inner_only=false
@@ -2605,7 +2605,7 @@ ValueDefault=false
 
 [Indent Extern]
 Category=2
-Description="<html>(289)Whether the 'extern "C"' body is indented.</html>"
+Description="<html>Whether the 'extern "C"' body is indented.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_extern=true|indent_extern=false
@@ -2613,7 +2613,7 @@ ValueDefault=false
 
 [Indent Class]
 Category=2
-Description="<html>(290)Whether the 'class' body is indented.</html>"
+Description="<html>Whether the 'class' body is indented.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_class=true|indent_class=false
@@ -2621,7 +2621,7 @@ ValueDefault=false
 
 [Indent Ignore Before Class Colon]
 Category=2
-Description="<html>(291)Whether to ignore indent for the leading base class colon.</html>"
+Description="<html>Whether to ignore indent for the leading base class colon.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_ignore_before_class_colon=true|indent_ignore_before_class_colon=false
@@ -2629,7 +2629,7 @@ ValueDefault=false
 
 [Indent Before Class Colon]
 Category=2
-Description="<html>(292)Additional indent before the leading base class colon.<br/>Negative values decrease indent down to the first column.<br/>Requires indent_ignore_before_class_colon=false and a newline break before<br/>the colon (see pos_class_colon and nl_class_colon)</html>"
+Description="<html>Additional indent before the leading base class colon.<br/>Negative values decrease indent down to the first column.<br/>Requires indent_ignore_before_class_colon=false and a newline break before<br/>the colon (see pos_class_colon and nl_class_colon)</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_before_class_colon="
@@ -2639,7 +2639,7 @@ ValueDefault=0
 
 [Indent Class Colon]
 Category=2
-Description="<html>(293)Whether to indent the stuff after a leading base class colon.</html>"
+Description="<html>Whether to indent the stuff after a leading base class colon.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_class_colon=true|indent_class_colon=false
@@ -2647,7 +2647,7 @@ ValueDefault=false
 
 [Indent Class On Colon]
 Category=2
-Description="<html>(294)Whether to indent based on a class colon instead of the stuff after the<br/>colon. Requires indent_class_colon=true.</html>"
+Description="<html>Whether to indent based on a class colon instead of the stuff after the<br/>colon. Requires indent_class_colon=true.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_class_on_colon=true|indent_class_on_colon=false
@@ -2655,7 +2655,7 @@ ValueDefault=false
 
 [Indent Ignore Before Constr Colon]
 Category=2
-Description="<html>(295)Whether to ignore indent for a leading class initializer colon.</html>"
+Description="<html>Whether to ignore indent for a leading class initializer colon.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_ignore_before_constr_colon=true|indent_ignore_before_constr_colon=false
@@ -2663,7 +2663,7 @@ ValueDefault=false
 
 [Indent Constr Colon]
 Category=2
-Description="<html>(296)Whether to indent the stuff after a leading class initializer colon.</html>"
+Description="<html>Whether to indent the stuff after a leading class initializer colon.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_constr_colon=true|indent_constr_colon=false
@@ -2671,7 +2671,7 @@ ValueDefault=false
 
 [Indent Ctor Init Leading]
 Category=2
-Description="<html>(297)Virtual indent from the ':' for leading member initializers.<br/><br/>Default: 2</html>"
+Description="<html>Virtual indent from the ':' for leading member initializers.<br/><br/>Default: 2</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_ctor_init_leading="
@@ -2681,7 +2681,7 @@ ValueDefault=2
 
 [Indent Ctor Init Following]
 Category=2
-Description="<html>(298)Virtual indent from the ':' for following member initializers.<br/><br/>Default: 2</html>"
+Description="<html>Virtual indent from the ':' for following member initializers.<br/><br/>Default: 2</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_ctor_init_following="
@@ -2691,7 +2691,7 @@ ValueDefault=2
 
 [Indent Ctor Init]
 Category=2
-Description="<html>(299)Additional indent for constructor initializer list.<br/>Negative values decrease indent down to the first column.</html>"
+Description="<html>Additional indent for constructor initializer list.<br/>Negative values decrease indent down to the first column.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_ctor_init="
@@ -2701,7 +2701,7 @@ ValueDefault=0
 
 [Indent Else If]
 Category=2
-Description="<html>(300)Whether to indent 'if' following 'else' as a new block under the 'else'.<br/>If false, 'else\nif' is treated as 'else if' for indenting purposes.</html>"
+Description="<html>Whether to indent 'if' following 'else' as a new block under the 'else'.<br/>If false, 'else\nif' is treated as 'else if' for indenting purposes.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_else_if=true|indent_else_if=false
@@ -2709,7 +2709,7 @@ ValueDefault=false
 
 [Indent Var Def Blk]
 Category=2
-Description="<html>(301)Amount to indent variable declarations after a open brace.<br/><br/> &lt;0: Relative<br/>&gt;=0: Absolute</html>"
+Description="<html>Amount to indent variable declarations after a open brace.<br/><br/> &lt;0: Relative<br/>&gt;=0: Absolute</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_var_def_blk="
@@ -2719,7 +2719,7 @@ ValueDefault=0
 
 [Indent Var Def Cont]
 Category=2
-Description="<html>(302)Whether to indent continued variable declarations instead of aligning.</html>"
+Description="<html>Whether to indent continued variable declarations instead of aligning.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_var_def_cont=true|indent_var_def_cont=false
@@ -2727,7 +2727,7 @@ ValueDefault=false
 
 [Indent Shift]
 Category=2
-Description="<html>(303)How to indent continued shift expressions ('&lt;&lt;' and '&gt;&gt;').<br/>Set align_left_shift=false when using this.<br/> 0: Align shift operators instead of indenting them (default)<br/> 1: Indent by one level<br/>-1: Preserve original indentation</html>"
+Description="<html>How to indent continued shift expressions ('&lt;&lt;' and '&gt;&gt;').<br/>Set align_left_shift=false when using this.<br/> 0: Align shift operators instead of indenting them (default)<br/> 1: Indent by one level<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_shift="
@@ -2737,7 +2737,7 @@ ValueDefault=0
 
 [Indent Func Def Force Col1]
 Category=2
-Description="<html>(304)Whether to force indentation of function definitions to start in column 1.</html>"
+Description="<html>Whether to force indentation of function definitions to start in column 1.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_func_def_force_col1=true|indent_func_def_force_col1=false
@@ -2745,7 +2745,7 @@ ValueDefault=false
 
 [Indent Func Call Param]
 Category=2
-Description="<html>(305)Whether to indent continued function call parameters one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
+Description="<html>Whether to indent continued function call parameters one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_func_call_param=true|indent_func_call_param=false
@@ -2753,7 +2753,7 @@ ValueDefault=false
 
 [Indent Func Def Param]
 Category=2
-Description="<html>(306)Whether to indent continued function definition parameters one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
+Description="<html>Whether to indent continued function definition parameters one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_func_def_param=true|indent_func_def_param=false
@@ -2761,7 +2761,7 @@ ValueDefault=false
 
 [Indent Func Def Param Paren Pos Threshold]
 Category=2
-Description="<html>(307)for function definitions, only if indent_func_def_param is false<br/>Allows to align params when appropriate and indent them when not<br/>behave as if it was true if paren position is more than this value<br/>if paren position is more than the option value</html>"
+Description="<html>for function definitions, only if indent_func_def_param is false<br/>Allows to align params when appropriate and indent them when not<br/>behave as if it was true if paren position is more than this value<br/>if paren position is more than the option value</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_func_def_param_paren_pos_threshold="
@@ -2771,7 +2771,7 @@ ValueDefault=0
 
 [Indent Func Proto Param]
 Category=2
-Description="<html>(308)Whether to indent continued function call prototype one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
+Description="<html>Whether to indent continued function call prototype one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_func_proto_param=true|indent_func_proto_param=false
@@ -2779,7 +2779,7 @@ ValueDefault=false
 
 [Indent Func Class Param]
 Category=2
-Description="<html>(309)Whether to indent continued function call declaration one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
+Description="<html>Whether to indent continued function call declaration one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_func_class_param=true|indent_func_class_param=false
@@ -2787,7 +2787,7 @@ ValueDefault=false
 
 [Indent Func Ctor Var Param]
 Category=2
-Description="<html>(310)Whether to indent continued class variable constructors one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
+Description="<html>Whether to indent continued class variable constructors one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_func_ctor_var_param=true|indent_func_ctor_var_param=false
@@ -2795,7 +2795,7 @@ ValueDefault=false
 
 [Indent Template Param]
 Category=2
-Description="<html>(311)Whether to indent continued template parameter list one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
+Description="<html>Whether to indent continued template parameter list one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_template_param=true|indent_template_param=false
@@ -2803,7 +2803,7 @@ ValueDefault=false
 
 [Indent Func Param Double]
 Category=2
-Description="<html>(312)Double the indent for indent_func_xxx_param options.<br/>Use both values of the options indent_columns and indent_param.</html>"
+Description="<html>Double the indent for indent_func_xxx_param options.<br/>Use both values of the options indent_columns and indent_param.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_func_param_double=true|indent_func_param_double=false
@@ -2811,7 +2811,7 @@ ValueDefault=false
 
 [Indent Func Const]
 Category=2
-Description="<html>(313)Indentation column for standalone 'const' qualifier on a function<br/>prototype.</html>"
+Description="<html>Indentation column for standalone 'const' qualifier on a function<br/>prototype.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_func_const="
@@ -2821,7 +2821,7 @@ ValueDefault=0
 
 [Indent Func Throw]
 Category=2
-Description="<html>(314)Indentation column for standalone 'throw' qualifier on a function<br/>prototype.</html>"
+Description="<html>Indentation column for standalone 'throw' qualifier on a function<br/>prototype.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_func_throw="
@@ -2831,7 +2831,7 @@ ValueDefault=0
 
 [Indent Macro Brace]
 Category=2
-Description="<html>(315)How to indent within a macro followed by a brace on the same line<br/>This allows reducing the indent in macros that have (for example)<br/>`do { ... } while (0)` blocks bracketing them.<br/><br/>true:  add an indent for the brace on the same line as the macro<br/>false: do not add an indent for the brace on the same line as the macro<br/><br/>Default: true</html>"
+Description="<html>How to indent within a macro followed by a brace on the same line<br/>This allows reducing the indent in macros that have (for example)<br/>`do { ... } while (0)` blocks bracketing them.<br/><br/>true:  add an indent for the brace on the same line as the macro<br/>false: do not add an indent for the brace on the same line as the macro<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_macro_brace=true|indent_macro_brace=false
@@ -2839,7 +2839,7 @@ ValueDefault=true
 
 [Indent Member]
 Category=2
-Description="<html>(316)The number of spaces to indent a continued '-&gt;' or '.'.<br/>Usually set to 0, 1, or indent_columns.</html>"
+Description="<html>The number of spaces to indent a continued '-&gt;' or '.'.<br/>Usually set to 0, 1, or indent_columns.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_member="
@@ -2849,7 +2849,7 @@ ValueDefault=0
 
 [Indent Member Single]
 Category=2
-Description="<html>(317)Whether lines broken at '.' or '-&gt;' should be indented by a single indent.<br/>The indent_member option will not be effective if this is set to true.</html>"
+Description="<html>Whether lines broken at '.' or '-&gt;' should be indented by a single indent.<br/>The indent_member option will not be effective if this is set to true.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_member_single=true|indent_member_single=false
@@ -2857,7 +2857,7 @@ ValueDefault=false
 
 [Indent Single Line Comments Before]
 Category=2
-Description="<html>(318)Spaces to indent single line ('//') comments on lines before code.</html>"
+Description="<html>Spaces to indent single line ('//') comments on lines before code.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_single_line_comments_before="
@@ -2867,7 +2867,7 @@ ValueDefault=0
 
 [Indent Single Line Comments After]
 Category=2
-Description="<html>(319)Spaces to indent single line ('//') comments on lines after code.</html>"
+Description="<html>Spaces to indent single line ('//') comments on lines after code.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_single_line_comments_after="
@@ -2877,7 +2877,7 @@ ValueDefault=0
 
 [Indent Sparen Extra]
 Category=2
-Description="<html>(320)When opening a paren for a control statement (if, for, while, etc), increase<br/>the indent level by this value. Negative values decrease the indent level.</html>"
+Description="<html>When opening a paren for a control statement (if, for, while, etc), increase<br/>the indent level by this value. Negative values decrease the indent level.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_sparen_extra="
@@ -2887,7 +2887,7 @@ ValueDefault=0
 
 [Indent Relative Single Line Comments]
 Category=2
-Description="<html>(321)Whether to indent trailing single line ('//') comments relative to the code<br/>instead of trying to keep the same absolute column.</html>"
+Description="<html>Whether to indent trailing single line ('//') comments relative to the code<br/>instead of trying to keep the same absolute column.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_relative_single_line_comments=true|indent_relative_single_line_comments=false
@@ -2895,7 +2895,7 @@ ValueDefault=false
 
 [Indent Switch Case]
 Category=2
-Description="<html>(322)Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.<br/>It might be wise to choose the same value for the option indent_case_brace.</html>"
+Description="<html>Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.<br/>It might be wise to choose the same value for the option indent_case_brace.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_switch_case="
@@ -2905,7 +2905,7 @@ ValueDefault=0
 
 [Indent Switch Body]
 Category=2
-Description="<html>(323)Spaces to indent the body of a 'switch' before any 'case'.<br/>Usually the same as indent_columns or indent_switch_case.</html>"
+Description="<html>Spaces to indent the body of a 'switch' before any 'case'.<br/>Usually the same as indent_columns or indent_switch_case.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_switch_body="
@@ -2915,7 +2915,7 @@ ValueDefault=0
 
 [Indent Ignore Case Brace]
 Category=2
-Description="<html>(324)Whether to ignore indent for '{' following 'case'.</html>"
+Description="<html>Whether to ignore indent for '{' following 'case'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_ignore_case_brace=true|indent_ignore_case_brace=false
@@ -2923,7 +2923,7 @@ ValueDefault=false
 
 [Indent Case Brace]
 Category=2
-Description="<html>(325)Spaces to indent '{' from 'case'. By default, the brace will appear under<br/>the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.<br/>It might be wise to choose the same value for the option indent_switch_case.</html>"
+Description="<html>Spaces to indent '{' from 'case'. By default, the brace will appear under<br/>the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.<br/>It might be wise to choose the same value for the option indent_switch_case.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_case_brace="
@@ -2933,7 +2933,7 @@ ValueDefault=0
 
 [Indent Switch Break With Case]
 Category=2
-Description="<html>(326)indent 'break' with 'case' from 'switch'.</html>"
+Description="<html>indent 'break' with 'case' from 'switch'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_switch_break_with_case=true|indent_switch_break_with_case=false
@@ -2941,7 +2941,7 @@ ValueDefault=false
 
 [Indent Switch Pp]
 Category=2
-Description="<html>(327)Whether to indent preprocessor statements inside of switch statements.<br/><br/>Default: true</html>"
+Description="<html>Whether to indent preprocessor statements inside of switch statements.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_switch_pp=true|indent_switch_pp=false
@@ -2949,7 +2949,7 @@ ValueDefault=true
 
 [Indent Case Shift]
 Category=2
-Description="<html>(328)Spaces to shift the 'case' line, without affecting any other lines.<br/>Usually 0.</html>"
+Description="<html>Spaces to shift the 'case' line, without affecting any other lines.<br/>Usually 0.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_case_shift="
@@ -2959,7 +2959,7 @@ ValueDefault=0
 
 [Indent Case Comment]
 Category=2
-Description="<html>(329)Whether to align comments before 'case' with the 'case'.<br/><br/>Default: true</html>"
+Description="<html>Whether to align comments before 'case' with the 'case'.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_case_comment=true|indent_case_comment=false
@@ -2967,7 +2967,7 @@ ValueDefault=true
 
 [Indent Comment]
 Category=2
-Description="<html>(330)Whether to indent comments not found in first column.<br/><br/>Default: true</html>"
+Description="<html>Whether to indent comments not found in first column.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_comment=true|indent_comment=false
@@ -2975,7 +2975,7 @@ ValueDefault=true
 
 [Indent Col1 Comment]
 Category=2
-Description="<html>(331)Whether to indent comments found in first column.</html>"
+Description="<html>Whether to indent comments found in first column.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_col1_comment=true|indent_col1_comment=false
@@ -2983,7 +2983,7 @@ ValueDefault=false
 
 [Indent Col1 Multi String Literal]
 Category=2
-Description="<html>(332)Whether to indent multi string literal in first column.</html>"
+Description="<html>Whether to indent multi string literal in first column.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_col1_multi_string_literal=true|indent_col1_multi_string_literal=false
@@ -2991,7 +2991,7 @@ ValueDefault=false
 
 [Indent Comment Align Thresh]
 Category=2
-Description="<html>(333)Align comments on adjacent lines that are this many columns apart or less.<br/><br/>Default: 3</html>"
+Description="<html>Align comments on adjacent lines that are this many columns apart or less.<br/><br/>Default: 3</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_comment_align_thresh="
@@ -3001,7 +3001,7 @@ ValueDefault=3
 
 [Indent Ignore Label]
 Category=2
-Description="<html>(334)Whether to ignore indent for goto labels.</html>"
+Description="<html>Whether to ignore indent for goto labels.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_ignore_label=true|indent_ignore_label=false
@@ -3009,7 +3009,7 @@ ValueDefault=false
 
 [Indent Label]
 Category=2
-Description="<html>(335)How to indent goto labels. Requires indent_ignore_label=false.<br/><br/> &gt;0: Absolute column where 1 is the leftmost column<br/>&lt;=0: Subtract from brace indent<br/><br/>Default: 1</html>"
+Description="<html>How to indent goto labels. Requires indent_ignore_label=false.<br/><br/> &gt;0: Absolute column where 1 is the leftmost column<br/>&lt;=0: Subtract from brace indent<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_label="
@@ -3019,7 +3019,7 @@ ValueDefault=1
 
 [Indent Access Spec]
 Category=2
-Description="<html>(336)How to indent access specifiers that are followed by a<br/>colon.<br/><br/> &gt;0: Absolute column where 1 is the leftmost column<br/>&lt;=0: Subtract from brace indent<br/><br/>Default: 1</html>"
+Description="<html>How to indent access specifiers that are followed by a<br/>colon.<br/><br/> &gt;0: Absolute column where 1 is the leftmost column<br/>&lt;=0: Subtract from brace indent<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_access_spec="
@@ -3029,7 +3029,7 @@ ValueDefault=1
 
 [Indent Access Spec Body]
 Category=2
-Description="<html>(337)Whether to indent the code after an access specifier by one level.<br/>If true, this option forces 'indent_access_spec=0'.</html>"
+Description="<html>Whether to indent the code after an access specifier by one level.<br/>If true, this option forces 'indent_access_spec=0'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_access_spec_body=true|indent_access_spec_body=false
@@ -3037,7 +3037,7 @@ ValueDefault=false
 
 [Indent Paren Nl]
 Category=2
-Description="<html>(338)If an open parenthesis is followed by a newline, whether to indent the next<br/>line so that it lines up after the open parenthesis (not recommended).</html>"
+Description="<html>If an open parenthesis is followed by a newline, whether to indent the next<br/>line so that it lines up after the open parenthesis (not recommended).</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_paren_nl=true|indent_paren_nl=false
@@ -3045,7 +3045,7 @@ ValueDefault=false
 
 [Indent Paren Close]
 Category=2
-Description="<html>(339)How to indent a close parenthesis after a newline.<br/><br/> 0: Indent to body level (default)<br/> 1: Align under the open parenthesis<br/> 2: Indent to the brace level<br/>-1: Preserve original indentation</html>"
+Description="<html>How to indent a close parenthesis after a newline.<br/><br/> 0: Indent to body level (default)<br/> 1: Align under the open parenthesis<br/> 2: Indent to the brace level<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_paren_close="
@@ -3055,7 +3055,7 @@ ValueDefault=0
 
 [Indent Paren After Func Def]
 Category=2
-Description="<html>(340)Whether to indent the open parenthesis of a function definition,<br/>if the parenthesis is on its own line.</html>"
+Description="<html>Whether to indent the open parenthesis of a function definition,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_paren_after_func_def=true|indent_paren_after_func_def=false
@@ -3063,7 +3063,7 @@ ValueDefault=false
 
 [Indent Paren After Func Decl]
 Category=2
-Description="<html>(341)Whether to indent the open parenthesis of a function declaration,<br/>if the parenthesis is on its own line.</html>"
+Description="<html>Whether to indent the open parenthesis of a function declaration,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_paren_after_func_decl=true|indent_paren_after_func_decl=false
@@ -3071,7 +3071,7 @@ ValueDefault=false
 
 [Indent Paren After Func Call]
 Category=2
-Description="<html>(342)Whether to indent the open parenthesis of a function call,<br/>if the parenthesis is on its own line.</html>"
+Description="<html>Whether to indent the open parenthesis of a function call,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_paren_after_func_call=true|indent_paren_after_func_call=false
@@ -3079,7 +3079,7 @@ ValueDefault=false
 
 [Indent Comma Brace]
 Category=2
-Description="<html>(343)How to indent a comma when inside braces.<br/> 0: Indent by one level (default)<br/> 1: Align under the open brace<br/>-1: Preserve original indentation</html>"
+Description="<html>How to indent a comma when inside braces.<br/> 0: Indent by one level (default)<br/> 1: Align under the open brace<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_comma_brace="
@@ -3089,7 +3089,7 @@ ValueDefault=0
 
 [Indent Comma Paren]
 Category=2
-Description="<html>(344)How to indent a comma when inside parentheses.<br/> 0: Indent by one level (default)<br/> 1: Align under the open parenthesis<br/>-1: Preserve original indentation</html>"
+Description="<html>How to indent a comma when inside parentheses.<br/> 0: Indent by one level (default)<br/> 1: Align under the open parenthesis<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_comma_paren="
@@ -3099,7 +3099,7 @@ ValueDefault=0
 
 [Indent Bool Paren]
 Category=2
-Description="<html>(345)How to indent a Boolean operator when inside parentheses.<br/> 0: Indent by one level (default)<br/> 1: Align under the open parenthesis<br/>-1: Preserve original indentation</html>"
+Description="<html>How to indent a Boolean operator when inside parentheses.<br/> 0: Indent by one level (default)<br/> 1: Align under the open parenthesis<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_bool_paren="
@@ -3109,7 +3109,7 @@ ValueDefault=0
 
 [Indent Ignore Bool]
 Category=2
-Description="<html>(346)Whether to ignore the indentation of a Boolean operator when outside<br/>parentheses.</html>"
+Description="<html>Whether to ignore the indentation of a Boolean operator when outside<br/>parentheses.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_ignore_bool=true|indent_ignore_bool=false
@@ -3117,7 +3117,7 @@ ValueDefault=false
 
 [Indent Ignore Arith]
 Category=2
-Description="<html>(347)Whether to ignore the indentation of an arithmetic operator.</html>"
+Description="<html>Whether to ignore the indentation of an arithmetic operator.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_ignore_arith=true|indent_ignore_arith=false
@@ -3125,7 +3125,7 @@ ValueDefault=false
 
 [Indent Semicolon For Paren]
 Category=2
-Description="<html>(348)Whether to indent a semicolon when inside a for parenthesis.<br/>If true, aligns under the open for parenthesis.</html>"
+Description="<html>Whether to indent a semicolon when inside a for parenthesis.<br/>If true, aligns under the open for parenthesis.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_semicolon_for_paren=true|indent_semicolon_for_paren=false
@@ -3133,7 +3133,7 @@ ValueDefault=false
 
 [Indent Ignore Semicolon]
 Category=2
-Description="<html>(349)Whether to ignore the indentation of a semicolon outside of a 'for'<br/>statement.</html>"
+Description="<html>Whether to ignore the indentation of a semicolon outside of a 'for'<br/>statement.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_ignore_semicolon=true|indent_ignore_semicolon=false
@@ -3141,7 +3141,7 @@ ValueDefault=false
 
 [Indent First Bool Expr]
 Category=2
-Description="<html>(350)Whether to align the first expression to following ones<br/>if indent_bool_paren=1.</html>"
+Description="<html>Whether to align the first expression to following ones<br/>if indent_bool_paren=1.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_first_bool_expr=true|indent_first_bool_expr=false
@@ -3149,7 +3149,7 @@ ValueDefault=false
 
 [Indent First For Expr]
 Category=2
-Description="<html>(351)Whether to align the first expression to following ones<br/>if indent_semicolon_for_paren=true.</html>"
+Description="<html>Whether to align the first expression to following ones<br/>if indent_semicolon_for_paren=true.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_first_for_expr=true|indent_first_for_expr=false
@@ -3157,7 +3157,7 @@ ValueDefault=false
 
 [Indent Square Nl]
 Category=2
-Description="<html>(352)If an open square is followed by a newline, whether to indent the next line<br/>so that it lines up after the open square (not recommended).</html>"
+Description="<html>If an open square is followed by a newline, whether to indent the next line<br/>so that it lines up after the open square (not recommended).</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_square_nl=true|indent_square_nl=false
@@ -3165,7 +3165,7 @@ ValueDefault=false
 
 [Indent Preserve Sql]
 Category=2
-Description="<html>(353)(ESQL/C) Whether to preserve the relative indent of 'EXEC SQL' bodies.</html>"
+Description="<html>(ESQL/C) Whether to preserve the relative indent of 'EXEC SQL' bodies.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_preserve_sql=true|indent_preserve_sql=false
@@ -3173,7 +3173,7 @@ ValueDefault=false
 
 [Indent Ignore Assign]
 Category=2
-Description="<html>(354)Whether to ignore the indentation of an assignment operator.</html>"
+Description="<html>Whether to ignore the indentation of an assignment operator.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_ignore_assign=true|indent_ignore_assign=false
@@ -3181,7 +3181,7 @@ ValueDefault=false
 
 [Indent Align Assign]
 Category=2
-Description="<html>(355)Whether to align continued statements at the '='. If false or if the '=' is<br/>followed by a newline, the next line is indent one tab.<br/><br/>Default: true</html>"
+Description="<html>Whether to align continued statements at the '='. If false or if the '=' is<br/>followed by a newline, the next line is indent one tab.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_align_assign=true|indent_align_assign=false
@@ -3189,7 +3189,7 @@ ValueDefault=true
 
 [Indent Off After Assign]
 Category=2
-Description="<html>(356)If true, the indentation of the chunks after a '=' sequence will be set at<br/>LHS token indentation column before '='.</html>"
+Description="<html>If true, the indentation of the chunks after a '=' sequence will be set at<br/>LHS token indentation column before '='.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_off_after_assign=true|indent_off_after_assign=false
@@ -3197,7 +3197,7 @@ ValueDefault=false
 
 [Indent Align Paren]
 Category=2
-Description="<html>(357)Whether to align continued statements at the '('. If false or the '(' is<br/>followed by a newline, the next line indent is one tab.<br/><br/>Default: true</html>"
+Description="<html>Whether to align continued statements at the '('. If false or the '(' is<br/>followed by a newline, the next line indent is one tab.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_align_paren=true|indent_align_paren=false
@@ -3205,7 +3205,7 @@ ValueDefault=true
 
 [Indent Oc Inside Msg Sel]
 Category=2
-Description="<html>(358)(OC) Whether to indent Objective-C code inside message selectors.</html>"
+Description="<html>(OC) Whether to indent Objective-C code inside message selectors.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_oc_inside_msg_sel=true|indent_oc_inside_msg_sel=false
@@ -3213,7 +3213,7 @@ ValueDefault=false
 
 [Indent Oc Block]
 Category=2
-Description="<html>(359)(OC) Whether to indent Objective-C blocks at brace level instead of usual<br/>rules.</html>"
+Description="<html>(OC) Whether to indent Objective-C blocks at brace level instead of usual<br/>rules.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_oc_block=true|indent_oc_block=false
@@ -3221,7 +3221,7 @@ ValueDefault=false
 
 [Indent Oc Block Msg]
 Category=2
-Description="<html>(360)(OC) Indent for Objective-C blocks in a message relative to the parameter<br/>name.<br/><br/>=0: Use indent_oc_block rules<br/>&gt;0: Use specified number of spaces to indent</html>"
+Description="<html>(OC) Indent for Objective-C blocks in a message relative to the parameter<br/>name.<br/><br/>=0: Use indent_oc_block rules<br/>&gt;0: Use specified number of spaces to indent</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_oc_block_msg="
@@ -3231,7 +3231,7 @@ ValueDefault=0
 
 [Indent Oc Msg Colon]
 Category=2
-Description="<html>(361)(OC) Minimum indent for subsequent parameters</html>"
+Description="<html>(OC) Minimum indent for subsequent parameters</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_oc_msg_colon="
@@ -3241,7 +3241,7 @@ ValueDefault=0
 
 [Indent Oc Msg Prioritize First Colon]
 Category=2
-Description="<html>(362)(OC) Whether to prioritize aligning with initial colon (and stripping spaces<br/>from lines, if necessary).<br/><br/>Default: true</html>"
+Description="<html>(OC) Whether to prioritize aligning with initial colon (and stripping spaces<br/>from lines, if necessary).<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_oc_msg_prioritize_first_colon=true|indent_oc_msg_prioritize_first_colon=false
@@ -3249,7 +3249,7 @@ ValueDefault=true
 
 [Indent Oc Block Msg Xcode Style]
 Category=2
-Description="<html>(363)(OC) Whether to indent blocks the way that Xcode does by default<br/>(from the keyword if the parameter is on its own line; otherwise, from the<br/>previous indentation level). Requires indent_oc_block_msg=true.</html>"
+Description="<html>(OC) Whether to indent blocks the way that Xcode does by default<br/>(from the keyword if the parameter is on its own line; otherwise, from the<br/>previous indentation level). Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_oc_block_msg_xcode_style=true|indent_oc_block_msg_xcode_style=false
@@ -3257,7 +3257,7 @@ ValueDefault=false
 
 [Indent Oc Block Msg From Keyword]
 Category=2
-Description="<html>(364)(OC) Whether to indent blocks from where the brace is, relative to a<br/>message keyword. Requires indent_oc_block_msg=true.</html>"
+Description="<html>(OC) Whether to indent blocks from where the brace is, relative to a<br/>message keyword. Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_oc_block_msg_from_keyword=true|indent_oc_block_msg_from_keyword=false
@@ -3265,7 +3265,7 @@ ValueDefault=false
 
 [Indent Oc Block Msg From Colon]
 Category=2
-Description="<html>(365)(OC) Whether to indent blocks from where the brace is, relative to a message<br/>colon. Requires indent_oc_block_msg=true.</html>"
+Description="<html>(OC) Whether to indent blocks from where the brace is, relative to a message<br/>colon. Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_oc_block_msg_from_colon=true|indent_oc_block_msg_from_colon=false
@@ -3273,7 +3273,7 @@ ValueDefault=false
 
 [Indent Oc Block Msg From Caret]
 Category=2
-Description="<html>(366)(OC) Whether to indent blocks from where the block caret is.<br/>Requires indent_oc_block_msg=true.</html>"
+Description="<html>(OC) Whether to indent blocks from where the block caret is.<br/>Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_oc_block_msg_from_caret=true|indent_oc_block_msg_from_caret=false
@@ -3281,7 +3281,7 @@ ValueDefault=false
 
 [Indent Oc Block Msg From Brace]
 Category=2
-Description="<html>(367)(OC) Whether to indent blocks from where the brace caret is.<br/>Requires indent_oc_block_msg=true.</html>"
+Description="<html>(OC) Whether to indent blocks from where the brace caret is.<br/>Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_oc_block_msg_from_brace=true|indent_oc_block_msg_from_brace=false
@@ -3289,7 +3289,7 @@ ValueDefault=false
 
 [Indent Min Vbrace Open]
 Category=2
-Description="<html>(368)When indenting after virtual brace open and newline add further spaces to<br/>reach this minimum indent.</html>"
+Description="<html>When indenting after virtual brace open and newline add further spaces to<br/>reach this minimum indent.</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_min_vbrace_open="
@@ -3299,7 +3299,7 @@ ValueDefault=0
 
 [Indent Vbrace Open On Tabstop]
 Category=2
-Description="<html>(369)Whether to add further spaces after regular indent to reach next tabstop<br/>when indenting after virtual brace open and newline.</html>"
+Description="<html>Whether to add further spaces after regular indent to reach next tabstop<br/>when indenting after virtual brace open and newline.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_vbrace_open_on_tabstop=true|indent_vbrace_open_on_tabstop=false
@@ -3307,7 +3307,7 @@ ValueDefault=false
 
 [Indent Token After Brace]
 Category=2
-Description="<html>(370)How to indent after a brace followed by another token (not a newline).<br/>true:  indent all contained lines to match the token<br/>false: indent all contained lines to match the brace<br/><br/>Default: true</html>"
+Description="<html>How to indent after a brace followed by another token (not a newline).<br/>true:  indent all contained lines to match the token<br/>false: indent all contained lines to match the brace<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_token_after_brace=true|indent_token_after_brace=false
@@ -3315,7 +3315,7 @@ ValueDefault=true
 
 [Indent Cpp Lambda Body]
 Category=2
-Description="<html>(371)Whether to indent the body of a C++11 lambda.</html>"
+Description="<html>Whether to indent the body of a C++11 lambda.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_cpp_lambda_body=true|indent_cpp_lambda_body=false
@@ -3323,7 +3323,7 @@ ValueDefault=false
 
 [Indent Compound Literal Return]
 Category=2
-Description="<html>(372)How to indent compound literals that are being returned.<br/>true: add both the indent from return &amp; the compound literal open brace<br/>      (i.e. 2 indent levels)<br/>false: only indent 1 level, don't add the indent for the open brace, only<br/>       add the indent for the return.<br/><br/>Default: true</html>"
+Description="<html>How to indent compound literals that are being returned.<br/>true: add both the indent from return &amp; the compound literal open brace<br/>      (i.e. 2 indent levels)<br/>false: only indent 1 level, don't add the indent for the open brace, only<br/>       add the indent for the return.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_compound_literal_return=true|indent_compound_literal_return=false
@@ -3331,7 +3331,7 @@ ValueDefault=true
 
 [Indent Using Block]
 Category=2
-Description="<html>(373)(C#) Whether to indent a 'using' block if no braces are used.<br/><br/>Default: true</html>"
+Description="<html>(C#) Whether to indent a 'using' block if no braces are used.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_using_block=true|indent_using_block=false
@@ -3339,7 +3339,7 @@ ValueDefault=true
 
 [Indent Ternary Operator]
 Category=2
-Description="<html>(374)How to indent the continuation of ternary operator.<br/><br/>0: Off (default)<br/>1: When the `if_false` is a continuation, indent it under the `if_true` branch<br/>2: When the `:` is a continuation, indent it under `?`</html>"
+Description="<html>How to indent the continuation of ternary operator.<br/><br/>0: Off (default)<br/>1: When the `if_false` is a continuation, indent it under the `if_true` branch<br/>2: When the `:` is a continuation, indent it under `?`</html>"
 Enabled=false
 EditorType=numeric
 CallName="indent_ternary_operator="
@@ -3349,7 +3349,7 @@ ValueDefault=0
 
 [Indent Inside Ternary Operator]
 Category=2
-Description="<html>(375)Whether to indent the statements inside ternary operator.</html>"
+Description="<html>Whether to indent the statements inside ternary operator.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_inside_ternary_operator=true|indent_inside_ternary_operator=false
@@ -3357,7 +3357,7 @@ ValueDefault=false
 
 [Indent Off After Return]
 Category=2
-Description="<html>(376)If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.</html>"
+Description="<html>If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_off_after_return=true|indent_off_after_return=false
@@ -3365,7 +3365,7 @@ ValueDefault=false
 
 [Indent Off After Return New]
 Category=2
-Description="<html>(377)If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.</html>"
+Description="<html>If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_off_after_return_new=true|indent_off_after_return_new=false
@@ -3373,7 +3373,7 @@ ValueDefault=false
 
 [Indent Single After Return]
 Category=2
-Description="<html>(378)If true, the tokens after return are indented with regular single indentation. By default (false) the indentation is after the return token.</html>"
+Description="<html>If true, the tokens after return are indented with regular single indentation. By default (false) the indentation is after the return token.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_single_after_return=true|indent_single_after_return=false
@@ -3381,7 +3381,7 @@ ValueDefault=false
 
 [Indent Ignore Asm Block]
 Category=2
-Description="<html>(379)Whether to ignore indent and alignment for 'asm' blocks (i.e. assume they<br/>have their own indentation).</html>"
+Description="<html>Whether to ignore indent and alignment for 'asm' blocks (i.e. assume they<br/>have their own indentation).</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_ignore_asm_block=true|indent_ignore_asm_block=false
@@ -3389,7 +3389,7 @@ ValueDefault=false
 
 [Donot Indent Func Def Close Paren]
 Category=2
-Description="<html>(380)Don't indent the close parenthesis of a function definition,<br/>if the parenthesis is on its own line.</html>"
+Description="<html>Don't indent the close parenthesis of a function definition,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=donot_indent_func_def_close_paren=true|donot_indent_func_def_close_paren=false
@@ -3397,7 +3397,7 @@ ValueDefault=false
 
 [Nl Collapse Empty Body]
 Category=3
-Description="<html>(381)Whether to collapse empty blocks between '{' and '}' except for functions.<br/>Use nl_collapse_empty_body_functions to specify how empty function braces<br/>should be formatted.</html>"
+Description="<html>Whether to collapse empty blocks between '{' and '}' except for functions.<br/>Use nl_collapse_empty_body_functions to specify how empty function braces<br/>should be formatted.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_collapse_empty_body=true|nl_collapse_empty_body=false
@@ -3405,7 +3405,7 @@ ValueDefault=false
 
 [Nl Collapse Empty Body Functions]
 Category=3
-Description="<html>(382)Whether to collapse empty blocks between '{' and '}' for functions only.<br/>If true, overrides nl_inside_empty_func.</html>"
+Description="<html>Whether to collapse empty blocks between '{' and '}' for functions only.<br/>If true, overrides nl_inside_empty_func.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_collapse_empty_body_functions=true|nl_collapse_empty_body_functions=false
@@ -3413,7 +3413,7 @@ ValueDefault=false
 
 [Nl Assign Leave One Liners]
 Category=3
-Description="<html>(383)Don't split one-line braced assignments, as in 'foo_t f = { 1, 2 };'.</html>"
+Description="<html>Don't split one-line braced assignments, as in 'foo_t f = { 1, 2 };'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_assign_leave_one_liners=true|nl_assign_leave_one_liners=false
@@ -3421,7 +3421,7 @@ ValueDefault=false
 
 [Nl Class Leave One Liners]
 Category=3
-Description="<html>(384)Don't split one-line braced statements inside a 'class xx { }' body.</html>"
+Description="<html>Don't split one-line braced statements inside a 'class xx { }' body.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_class_leave_one_liners=true|nl_class_leave_one_liners=false
@@ -3429,7 +3429,7 @@ ValueDefault=false
 
 [Nl Enum Leave One Liners]
 Category=3
-Description="<html>(385)Don't split one-line enums, as in 'enum foo { BAR = 15 };'</html>"
+Description="<html>Don't split one-line enums, as in 'enum foo { BAR = 15 };'</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_enum_leave_one_liners=true|nl_enum_leave_one_liners=false
@@ -3437,7 +3437,7 @@ ValueDefault=false
 
 [Nl Getset Leave One Liners]
 Category=3
-Description="<html>(386)Don't split one-line get or set functions.</html>"
+Description="<html>Don't split one-line get or set functions.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_getset_leave_one_liners=true|nl_getset_leave_one_liners=false
@@ -3445,7 +3445,7 @@ ValueDefault=false
 
 [Nl Cs Property Leave One Liners]
 Category=3
-Description="<html>(387)(C#) Don't split one-line property get or set functions.</html>"
+Description="<html>(C#) Don't split one-line property get or set functions.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_cs_property_leave_one_liners=true|nl_cs_property_leave_one_liners=false
@@ -3453,7 +3453,7 @@ ValueDefault=false
 
 [Nl Func Leave One Liners]
 Category=3
-Description="<html>(388)Don't split one-line function definitions, as in 'int foo() { return 0; }'.<br/>might modify nl_func_type_name</html>"
+Description="<html>Don't split one-line function definitions, as in 'int foo() { return 0; }'.<br/>might modify nl_func_type_name</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_func_leave_one_liners=true|nl_func_leave_one_liners=false
@@ -3461,7 +3461,7 @@ ValueDefault=false
 
 [Nl Cpp Lambda Leave One Liners]
 Category=3
-Description="<html>(389)Don't split one-line C++11 lambdas, as in '[]() { return 0; }'.</html>"
+Description="<html>Don't split one-line C++11 lambdas, as in '[]() { return 0; }'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_cpp_lambda_leave_one_liners=true|nl_cpp_lambda_leave_one_liners=false
@@ -3469,7 +3469,7 @@ ValueDefault=false
 
 [Nl If Leave One Liners]
 Category=3
-Description="<html>(390)Don't split one-line if/else statements, as in 'if(...) b++;'.</html>"
+Description="<html>Don't split one-line if/else statements, as in 'if(...) b++;'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_if_leave_one_liners=true|nl_if_leave_one_liners=false
@@ -3477,7 +3477,7 @@ ValueDefault=false
 
 [Nl While Leave One Liners]
 Category=3
-Description="<html>(391)Don't split one-line while statements, as in 'while(...) b++;'.</html>"
+Description="<html>Don't split one-line while statements, as in 'while(...) b++;'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_while_leave_one_liners=true|nl_while_leave_one_liners=false
@@ -3485,7 +3485,7 @@ ValueDefault=false
 
 [Nl Do Leave One Liners]
 Category=3
-Description="<html>(392)Don't split one-line do statements, as in 'do { b++; } while(...);'.</html>"
+Description="<html>Don't split one-line do statements, as in 'do { b++; } while(...);'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_do_leave_one_liners=true|nl_do_leave_one_liners=false
@@ -3493,7 +3493,7 @@ ValueDefault=false
 
 [Nl For Leave One Liners]
 Category=3
-Description="<html>(393)Don't split one-line for statements, as in 'for(...) b++;'.</html>"
+Description="<html>Don't split one-line for statements, as in 'for(...) b++;'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_for_leave_one_liners=true|nl_for_leave_one_liners=false
@@ -3501,7 +3501,7 @@ ValueDefault=false
 
 [Nl Oc Msg Leave One Liner]
 Category=3
-Description="<html>(394)(OC) Don't split one-line Objective-C messages.</html>"
+Description="<html>(OC) Don't split one-line Objective-C messages.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_oc_msg_leave_one_liner=true|nl_oc_msg_leave_one_liner=false
@@ -3509,79 +3509,79 @@ ValueDefault=false
 
 [Nl Oc Mdef Brace]
 Category=3
-Description="<html>(395)(OC) Add or remove newline between method declaration and '{'.</html>"
+Description="<html>(OC) Add or remove newline between method declaration and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_oc_mdef_brace=ignore|nl_oc_mdef_brace=add|nl_oc_mdef_brace=remove|nl_oc_mdef_brace=force|nl_oc_mdef_brace=not_defined
-ChoicesReadable="(395)Ignore Nl Oc Mdef Brace|(395)Add Nl Oc Mdef Brace|(395)Remove Nl Oc Mdef Brace|(395)Force Nl Oc Mdef Brace"
+ChoicesReadable="Ignore Nl Oc Mdef Brace|Add Nl Oc Mdef Brace|Remove Nl Oc Mdef Brace|Force Nl Oc Mdef Brace"
 ValueDefault=ignore
 
 [Nl Oc Block Brace]
 Category=3
-Description="<html>(396)(OC) Add or remove newline between Objective-C block signature and '{'.</html>"
+Description="<html>(OC) Add or remove newline between Objective-C block signature and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_oc_block_brace=ignore|nl_oc_block_brace=add|nl_oc_block_brace=remove|nl_oc_block_brace=force|nl_oc_block_brace=not_defined
-ChoicesReadable="(396)Ignore Nl Oc Block Brace|(396)Add Nl Oc Block Brace|(396)Remove Nl Oc Block Brace|(396)Force Nl Oc Block Brace"
+ChoicesReadable="Ignore Nl Oc Block Brace|Add Nl Oc Block Brace|Remove Nl Oc Block Brace|Force Nl Oc Block Brace"
 ValueDefault=ignore
 
 [Nl Oc Before Interface]
 Category=3
-Description="<html>(397)(OC) Add or remove blank line before '@interface' statement.</html>"
+Description="<html>(OC) Add or remove blank line before '@interface' statement.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_oc_before_interface=ignore|nl_oc_before_interface=add|nl_oc_before_interface=remove|nl_oc_before_interface=force|nl_oc_before_interface=not_defined
-ChoicesReadable="(397)Ignore Nl Oc Before Interface|(397)Add Nl Oc Before Interface|(397)Remove Nl Oc Before Interface|(397)Force Nl Oc Before Interface"
+ChoicesReadable="Ignore Nl Oc Before Interface|Add Nl Oc Before Interface|Remove Nl Oc Before Interface|Force Nl Oc Before Interface"
 ValueDefault=ignore
 
 [Nl Oc Before Implementation]
 Category=3
-Description="<html>(398)(OC) Add or remove blank line before '@implementation' statement.</html>"
+Description="<html>(OC) Add or remove blank line before '@implementation' statement.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_oc_before_implementation=ignore|nl_oc_before_implementation=add|nl_oc_before_implementation=remove|nl_oc_before_implementation=force|nl_oc_before_implementation=not_defined
-ChoicesReadable="(398)Ignore Nl Oc Before Implementation|(398)Add Nl Oc Before Implementation|(398)Remove Nl Oc Before Implementation|(398)Force Nl Oc Before Implementation"
+ChoicesReadable="Ignore Nl Oc Before Implementation|Add Nl Oc Before Implementation|Remove Nl Oc Before Implementation|Force Nl Oc Before Implementation"
 ValueDefault=ignore
 
 [Nl Oc Before End]
 Category=3
-Description="<html>(399)(OC) Add or remove blank line before '@end' statement.</html>"
+Description="<html>(OC) Add or remove blank line before '@end' statement.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_oc_before_end=ignore|nl_oc_before_end=add|nl_oc_before_end=remove|nl_oc_before_end=force|nl_oc_before_end=not_defined
-ChoicesReadable="(399)Ignore Nl Oc Before End|(399)Add Nl Oc Before End|(399)Remove Nl Oc Before End|(399)Force Nl Oc Before End"
+ChoicesReadable="Ignore Nl Oc Before End|Add Nl Oc Before End|Remove Nl Oc Before End|Force Nl Oc Before End"
 ValueDefault=ignore
 
 [Nl Oc Interface Brace]
 Category=3
-Description="<html>(400)(OC) Add or remove newline between '@interface' and '{'.</html>"
+Description="<html>(OC) Add or remove newline between '@interface' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_oc_interface_brace=ignore|nl_oc_interface_brace=add|nl_oc_interface_brace=remove|nl_oc_interface_brace=force|nl_oc_interface_brace=not_defined
-ChoicesReadable="(400)Ignore Nl Oc Interface Brace|(400)Add Nl Oc Interface Brace|(400)Remove Nl Oc Interface Brace|(400)Force Nl Oc Interface Brace"
+ChoicesReadable="Ignore Nl Oc Interface Brace|Add Nl Oc Interface Brace|Remove Nl Oc Interface Brace|Force Nl Oc Interface Brace"
 ValueDefault=ignore
 
 [Nl Oc Implementation Brace]
 Category=3
-Description="<html>(401)(OC) Add or remove newline between '@implementation' and '{'.</html>"
+Description="<html>(OC) Add or remove newline between '@implementation' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_oc_implementation_brace=ignore|nl_oc_implementation_brace=add|nl_oc_implementation_brace=remove|nl_oc_implementation_brace=force|nl_oc_implementation_brace=not_defined
-ChoicesReadable="(401)Ignore Nl Oc Implementation Brace|(401)Add Nl Oc Implementation Brace|(401)Remove Nl Oc Implementation Brace|(401)Force Nl Oc Implementation Brace"
+ChoicesReadable="Ignore Nl Oc Implementation Brace|Add Nl Oc Implementation Brace|Remove Nl Oc Implementation Brace|Force Nl Oc Implementation Brace"
 ValueDefault=ignore
 
 [Nl Start Of File]
 Category=3
-Description="<html>(402)Add or remove newlines at the start of the file.</html>"
+Description="<html>Add or remove newlines at the start of the file.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_start_of_file=ignore|nl_start_of_file=add|nl_start_of_file=remove|nl_start_of_file=force|nl_start_of_file=not_defined
-ChoicesReadable="(402)Ignore Nl Start Of File|(402)Add Nl Start Of File|(402)Remove Nl Start Of File|(402)Force Nl Start Of File"
+ChoicesReadable="Ignore Nl Start Of File|Add Nl Start Of File|Remove Nl Start Of File|Force Nl Start Of File"
 ValueDefault=ignore
 
 [Nl Start Of File Min]
 Category=3
-Description="<html>(403)The minimum number of newlines at the start of the file (only used if<br/>nl_start_of_file is 'add' or 'force').</html>"
+Description="<html>The minimum number of newlines at the start of the file (only used if<br/>nl_start_of_file is 'add' or 'force').</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_start_of_file_min="
@@ -3591,16 +3591,16 @@ ValueDefault=0
 
 [Nl End Of File]
 Category=3
-Description="<html>(404)Add or remove newline at the end of the file.</html>"
+Description="<html>Add or remove newline at the end of the file.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_end_of_file=ignore|nl_end_of_file=add|nl_end_of_file=remove|nl_end_of_file=force|nl_end_of_file=not_defined
-ChoicesReadable="(404)Ignore Nl End Of File|(404)Add Nl End Of File|(404)Remove Nl End Of File|(404)Force Nl End Of File"
+ChoicesReadable="Ignore Nl End Of File|Add Nl End Of File|Remove Nl End Of File|Force Nl End Of File"
 ValueDefault=ignore
 
 [Nl End Of File Min]
 Category=3
-Description="<html>(405)The minimum number of newlines at the end of the file (only used if<br/>nl_end_of_file is 'add' or 'force').</html>"
+Description="<html>The minimum number of newlines at the end of the file (only used if<br/>nl_end_of_file is 'add' or 'force').</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_end_of_file_min="
@@ -3610,367 +3610,367 @@ ValueDefault=0
 
 [Nl Assign Brace]
 Category=3
-Description="<html>(406)Add or remove newline between '=' and '{'.</html>"
+Description="<html>Add or remove newline between '=' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_assign_brace=ignore|nl_assign_brace=add|nl_assign_brace=remove|nl_assign_brace=force|nl_assign_brace=not_defined
-ChoicesReadable="(406)Ignore Nl Assign Brace|(406)Add Nl Assign Brace|(406)Remove Nl Assign Brace|(406)Force Nl Assign Brace"
+ChoicesReadable="Ignore Nl Assign Brace|Add Nl Assign Brace|Remove Nl Assign Brace|Force Nl Assign Brace"
 ValueDefault=ignore
 
 [Nl Assign Square]
 Category=3
-Description="<html>(407)(D) Add or remove newline between '=' and '['.</html>"
+Description="<html>(D) Add or remove newline between '=' and '['.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_assign_square=ignore|nl_assign_square=add|nl_assign_square=remove|nl_assign_square=force|nl_assign_square=not_defined
-ChoicesReadable="(407)Ignore Nl Assign Square|(407)Add Nl Assign Square|(407)Remove Nl Assign Square|(407)Force Nl Assign Square"
+ChoicesReadable="Ignore Nl Assign Square|Add Nl Assign Square|Remove Nl Assign Square|Force Nl Assign Square"
 ValueDefault=ignore
 
 [Nl Tsquare Brace]
 Category=3
-Description="<html>(408)Add or remove newline between '[]' and '{'.</html>"
+Description="<html>Add or remove newline between '[]' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_tsquare_brace=ignore|nl_tsquare_brace=add|nl_tsquare_brace=remove|nl_tsquare_brace=force|nl_tsquare_brace=not_defined
-ChoicesReadable="(408)Ignore Nl Tsquare Brace|(408)Add Nl Tsquare Brace|(408)Remove Nl Tsquare Brace|(408)Force Nl Tsquare Brace"
+ChoicesReadable="Ignore Nl Tsquare Brace|Add Nl Tsquare Brace|Remove Nl Tsquare Brace|Force Nl Tsquare Brace"
 ValueDefault=ignore
 
 [Nl After Square Assign]
 Category=3
-Description="<html>(409)(D) Add or remove newline after '= ['. Will also affect the newline before<br/>the ']'.</html>"
+Description="<html>(D) Add or remove newline after '= ['. Will also affect the newline before<br/>the ']'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_after_square_assign=ignore|nl_after_square_assign=add|nl_after_square_assign=remove|nl_after_square_assign=force|nl_after_square_assign=not_defined
-ChoicesReadable="(409)Ignore Nl After Square Assign|(409)Add Nl After Square Assign|(409)Remove Nl After Square Assign|(409)Force Nl After Square Assign"
+ChoicesReadable="Ignore Nl After Square Assign|Add Nl After Square Assign|Remove Nl After Square Assign|Force Nl After Square Assign"
 ValueDefault=ignore
 
 [Nl Fcall Brace]
 Category=3
-Description="<html>(410)Add or remove newline between a function call's ')' and '{', as in<br/>'list_for_each(item, &amp;list) { }'.</html>"
+Description="<html>Add or remove newline between a function call's ')' and '{', as in<br/>'list_for_each(item, &amp;list) { }'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_fcall_brace=ignore|nl_fcall_brace=add|nl_fcall_brace=remove|nl_fcall_brace=force|nl_fcall_brace=not_defined
-ChoicesReadable="(410)Ignore Nl Fcall Brace|(410)Add Nl Fcall Brace|(410)Remove Nl Fcall Brace|(410)Force Nl Fcall Brace"
+ChoicesReadable="Ignore Nl Fcall Brace|Add Nl Fcall Brace|Remove Nl Fcall Brace|Force Nl Fcall Brace"
 ValueDefault=ignore
 
 [Nl Enum Brace]
 Category=3
-Description="<html>(411)Add or remove newline between 'enum' and '{'.</html>"
+Description="<html>Add or remove newline between 'enum' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_enum_brace=ignore|nl_enum_brace=add|nl_enum_brace=remove|nl_enum_brace=force|nl_enum_brace=not_defined
-ChoicesReadable="(411)Ignore Nl Enum Brace|(411)Add Nl Enum Brace|(411)Remove Nl Enum Brace|(411)Force Nl Enum Brace"
+ChoicesReadable="Ignore Nl Enum Brace|Add Nl Enum Brace|Remove Nl Enum Brace|Force Nl Enum Brace"
 ValueDefault=ignore
 
 [Nl Enum Class]
 Category=3
-Description="<html>(412)Add or remove newline between 'enum' and 'class'.</html>"
+Description="<html>Add or remove newline between 'enum' and 'class'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_enum_class=ignore|nl_enum_class=add|nl_enum_class=remove|nl_enum_class=force|nl_enum_class=not_defined
-ChoicesReadable="(412)Ignore Nl Enum Class|(412)Add Nl Enum Class|(412)Remove Nl Enum Class|(412)Force Nl Enum Class"
+ChoicesReadable="Ignore Nl Enum Class|Add Nl Enum Class|Remove Nl Enum Class|Force Nl Enum Class"
 ValueDefault=ignore
 
 [Nl Enum Class Identifier]
 Category=3
-Description="<html>(413)Add or remove newline between 'enum class' and the identifier.</html>"
+Description="<html>Add or remove newline between 'enum class' and the identifier.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_enum_class_identifier=ignore|nl_enum_class_identifier=add|nl_enum_class_identifier=remove|nl_enum_class_identifier=force|nl_enum_class_identifier=not_defined
-ChoicesReadable="(413)Ignore Nl Enum Class Identifier|(413)Add Nl Enum Class Identifier|(413)Remove Nl Enum Class Identifier|(413)Force Nl Enum Class Identifier"
+ChoicesReadable="Ignore Nl Enum Class Identifier|Add Nl Enum Class Identifier|Remove Nl Enum Class Identifier|Force Nl Enum Class Identifier"
 ValueDefault=ignore
 
 [Nl Enum Identifier Colon]
 Category=3
-Description="<html>(414)Add or remove newline between 'enum class' type and ':'.</html>"
+Description="<html>Add or remove newline between 'enum class' type and ':'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_enum_identifier_colon=ignore|nl_enum_identifier_colon=add|nl_enum_identifier_colon=remove|nl_enum_identifier_colon=force|nl_enum_identifier_colon=not_defined
-ChoicesReadable="(414)Ignore Nl Enum Identifier Colon|(414)Add Nl Enum Identifier Colon|(414)Remove Nl Enum Identifier Colon|(414)Force Nl Enum Identifier Colon"
+ChoicesReadable="Ignore Nl Enum Identifier Colon|Add Nl Enum Identifier Colon|Remove Nl Enum Identifier Colon|Force Nl Enum Identifier Colon"
 ValueDefault=ignore
 
 [Nl Enum Colon Type]
 Category=3
-Description="<html>(415)Add or remove newline between 'enum class identifier :' and type.</html>"
+Description="<html>Add or remove newline between 'enum class identifier :' and type.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_enum_colon_type=ignore|nl_enum_colon_type=add|nl_enum_colon_type=remove|nl_enum_colon_type=force|nl_enum_colon_type=not_defined
-ChoicesReadable="(415)Ignore Nl Enum Colon Type|(415)Add Nl Enum Colon Type|(415)Remove Nl Enum Colon Type|(415)Force Nl Enum Colon Type"
+ChoicesReadable="Ignore Nl Enum Colon Type|Add Nl Enum Colon Type|Remove Nl Enum Colon Type|Force Nl Enum Colon Type"
 ValueDefault=ignore
 
 [Nl Struct Brace]
 Category=3
-Description="<html>(416)Add or remove newline between 'struct and '{'.</html>"
+Description="<html>Add or remove newline between 'struct and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_struct_brace=ignore|nl_struct_brace=add|nl_struct_brace=remove|nl_struct_brace=force|nl_struct_brace=not_defined
-ChoicesReadable="(416)Ignore Nl Struct Brace|(416)Add Nl Struct Brace|(416)Remove Nl Struct Brace|(416)Force Nl Struct Brace"
+ChoicesReadable="Ignore Nl Struct Brace|Add Nl Struct Brace|Remove Nl Struct Brace|Force Nl Struct Brace"
 ValueDefault=ignore
 
 [Nl Union Brace]
 Category=3
-Description="<html>(417)Add or remove newline between 'union' and '{'.</html>"
+Description="<html>Add or remove newline between 'union' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_union_brace=ignore|nl_union_brace=add|nl_union_brace=remove|nl_union_brace=force|nl_union_brace=not_defined
-ChoicesReadable="(417)Ignore Nl Union Brace|(417)Add Nl Union Brace|(417)Remove Nl Union Brace|(417)Force Nl Union Brace"
+ChoicesReadable="Ignore Nl Union Brace|Add Nl Union Brace|Remove Nl Union Brace|Force Nl Union Brace"
 ValueDefault=ignore
 
 [Nl If Brace]
 Category=3
-Description="<html>(418)Add or remove newline between 'if' and '{'.</html>"
+Description="<html>Add or remove newline between 'if' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_if_brace=ignore|nl_if_brace=add|nl_if_brace=remove|nl_if_brace=force|nl_if_brace=not_defined
-ChoicesReadable="(418)Ignore Nl If Brace|(418)Add Nl If Brace|(418)Remove Nl If Brace|(418)Force Nl If Brace"
+ChoicesReadable="Ignore Nl If Brace|Add Nl If Brace|Remove Nl If Brace|Force Nl If Brace"
 ValueDefault=ignore
 
 [Nl Brace Else]
 Category=3
-Description="<html>(419)Add or remove newline between '}' and 'else'.</html>"
+Description="<html>Add or remove newline between '}' and 'else'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_brace_else=ignore|nl_brace_else=add|nl_brace_else=remove|nl_brace_else=force|nl_brace_else=not_defined
-ChoicesReadable="(419)Ignore Nl Brace Else|(419)Add Nl Brace Else|(419)Remove Nl Brace Else|(419)Force Nl Brace Else"
+ChoicesReadable="Ignore Nl Brace Else|Add Nl Brace Else|Remove Nl Brace Else|Force Nl Brace Else"
 ValueDefault=ignore
 
 [Nl Elseif Brace]
 Category=3
-Description="<html>(420)Add or remove newline between 'else if' and '{'. If set to ignore,<br/>nl_if_brace is used instead.</html>"
+Description="<html>Add or remove newline between 'else if' and '{'. If set to ignore,<br/>nl_if_brace is used instead.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_elseif_brace=ignore|nl_elseif_brace=add|nl_elseif_brace=remove|nl_elseif_brace=force|nl_elseif_brace=not_defined
-ChoicesReadable="(420)Ignore Nl Elseif Brace|(420)Add Nl Elseif Brace|(420)Remove Nl Elseif Brace|(420)Force Nl Elseif Brace"
+ChoicesReadable="Ignore Nl Elseif Brace|Add Nl Elseif Brace|Remove Nl Elseif Brace|Force Nl Elseif Brace"
 ValueDefault=ignore
 
 [Nl Else Brace]
 Category=3
-Description="<html>(421)Add or remove newline between 'else' and '{'.</html>"
+Description="<html>Add or remove newline between 'else' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_else_brace=ignore|nl_else_brace=add|nl_else_brace=remove|nl_else_brace=force|nl_else_brace=not_defined
-ChoicesReadable="(421)Ignore Nl Else Brace|(421)Add Nl Else Brace|(421)Remove Nl Else Brace|(421)Force Nl Else Brace"
+ChoicesReadable="Ignore Nl Else Brace|Add Nl Else Brace|Remove Nl Else Brace|Force Nl Else Brace"
 ValueDefault=ignore
 
 [Nl Else If]
 Category=3
-Description="<html>(422)Add or remove newline between 'else' and 'if'.</html>"
+Description="<html>Add or remove newline between 'else' and 'if'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_else_if=ignore|nl_else_if=add|nl_else_if=remove|nl_else_if=force|nl_else_if=not_defined
-ChoicesReadable="(422)Ignore Nl Else If|(422)Add Nl Else If|(422)Remove Nl Else If|(422)Force Nl Else If"
+ChoicesReadable="Ignore Nl Else If|Add Nl Else If|Remove Nl Else If|Force Nl Else If"
 ValueDefault=ignore
 
 [Nl Before Opening Brace Func Class Def]
 Category=3
-Description="<html>(423)Add or remove newline before '{' opening brace</html>"
+Description="<html>Add or remove newline before '{' opening brace</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_before_opening_brace_func_class_def=ignore|nl_before_opening_brace_func_class_def=add|nl_before_opening_brace_func_class_def=remove|nl_before_opening_brace_func_class_def=force|nl_before_opening_brace_func_class_def=not_defined
-ChoicesReadable="(423)Ignore Nl Before Opening Brace Func Class Def|(423)Add Nl Before Opening Brace Func Class Def|(423)Remove Nl Before Opening Brace Func Class Def|(423)Force Nl Before Opening Brace Func Class Def"
+ChoicesReadable="Ignore Nl Before Opening Brace Func Class Def|Add Nl Before Opening Brace Func Class Def|Remove Nl Before Opening Brace Func Class Def|Force Nl Before Opening Brace Func Class Def"
 ValueDefault=ignore
 
 [Nl Before If Closing Paren]
 Category=3
-Description="<html>(424)Add or remove newline before 'if'/'else if' closing parenthesis.</html>"
+Description="<html>Add or remove newline before 'if'/'else if' closing parenthesis.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_before_if_closing_paren=ignore|nl_before_if_closing_paren=add|nl_before_if_closing_paren=remove|nl_before_if_closing_paren=force|nl_before_if_closing_paren=not_defined
-ChoicesReadable="(424)Ignore Nl Before If Closing Paren|(424)Add Nl Before If Closing Paren|(424)Remove Nl Before If Closing Paren|(424)Force Nl Before If Closing Paren"
+ChoicesReadable="Ignore Nl Before If Closing Paren|Add Nl Before If Closing Paren|Remove Nl Before If Closing Paren|Force Nl Before If Closing Paren"
 ValueDefault=ignore
 
 [Nl Brace Finally]
 Category=3
-Description="<html>(425)Add or remove newline between '}' and 'finally'.</html>"
+Description="<html>Add or remove newline between '}' and 'finally'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_brace_finally=ignore|nl_brace_finally=add|nl_brace_finally=remove|nl_brace_finally=force|nl_brace_finally=not_defined
-ChoicesReadable="(425)Ignore Nl Brace Finally|(425)Add Nl Brace Finally|(425)Remove Nl Brace Finally|(425)Force Nl Brace Finally"
+ChoicesReadable="Ignore Nl Brace Finally|Add Nl Brace Finally|Remove Nl Brace Finally|Force Nl Brace Finally"
 ValueDefault=ignore
 
 [Nl Finally Brace]
 Category=3
-Description="<html>(426)Add or remove newline between 'finally' and '{'.</html>"
+Description="<html>Add or remove newline between 'finally' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_finally_brace=ignore|nl_finally_brace=add|nl_finally_brace=remove|nl_finally_brace=force|nl_finally_brace=not_defined
-ChoicesReadable="(426)Ignore Nl Finally Brace|(426)Add Nl Finally Brace|(426)Remove Nl Finally Brace|(426)Force Nl Finally Brace"
+ChoicesReadable="Ignore Nl Finally Brace|Add Nl Finally Brace|Remove Nl Finally Brace|Force Nl Finally Brace"
 ValueDefault=ignore
 
 [Nl Try Brace]
 Category=3
-Description="<html>(427)Add or remove newline between 'try' and '{'.</html>"
+Description="<html>Add or remove newline between 'try' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_try_brace=ignore|nl_try_brace=add|nl_try_brace=remove|nl_try_brace=force|nl_try_brace=not_defined
-ChoicesReadable="(427)Ignore Nl Try Brace|(427)Add Nl Try Brace|(427)Remove Nl Try Brace|(427)Force Nl Try Brace"
+ChoicesReadable="Ignore Nl Try Brace|Add Nl Try Brace|Remove Nl Try Brace|Force Nl Try Brace"
 ValueDefault=ignore
 
 [Nl Getset Brace]
 Category=3
-Description="<html>(428)Add or remove newline between get/set and '{'.</html>"
+Description="<html>Add or remove newline between get/set and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_getset_brace=ignore|nl_getset_brace=add|nl_getset_brace=remove|nl_getset_brace=force|nl_getset_brace=not_defined
-ChoicesReadable="(428)Ignore Nl Getset Brace|(428)Add Nl Getset Brace|(428)Remove Nl Getset Brace|(428)Force Nl Getset Brace"
+ChoicesReadable="Ignore Nl Getset Brace|Add Nl Getset Brace|Remove Nl Getset Brace|Force Nl Getset Brace"
 ValueDefault=ignore
 
 [Nl For Brace]
 Category=3
-Description="<html>(429)Add or remove newline between 'for' and '{'.</html>"
+Description="<html>Add or remove newline between 'for' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_for_brace=ignore|nl_for_brace=add|nl_for_brace=remove|nl_for_brace=force|nl_for_brace=not_defined
-ChoicesReadable="(429)Ignore Nl For Brace|(429)Add Nl For Brace|(429)Remove Nl For Brace|(429)Force Nl For Brace"
+ChoicesReadable="Ignore Nl For Brace|Add Nl For Brace|Remove Nl For Brace|Force Nl For Brace"
 ValueDefault=ignore
 
 [Nl Catch Brace]
 Category=3
-Description="<html>(430)Add or remove newline before the '{' of a 'catch' statement, as in<br/>'catch (decl) &lt;here&gt; {'.</html>"
+Description="<html>Add or remove newline before the '{' of a 'catch' statement, as in<br/>'catch (decl) &lt;here&gt; {'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_catch_brace=ignore|nl_catch_brace=add|nl_catch_brace=remove|nl_catch_brace=force|nl_catch_brace=not_defined
-ChoicesReadable="(430)Ignore Nl Catch Brace|(430)Add Nl Catch Brace|(430)Remove Nl Catch Brace|(430)Force Nl Catch Brace"
+ChoicesReadable="Ignore Nl Catch Brace|Add Nl Catch Brace|Remove Nl Catch Brace|Force Nl Catch Brace"
 ValueDefault=ignore
 
 [Nl Oc Catch Brace]
 Category=3
-Description="<html>(431)(OC) Add or remove newline before the '{' of a '@catch' statement, as in<br/>'@catch (decl) &lt;here&gt; {'. If set to ignore, nl_catch_brace is used.</html>"
+Description="<html>(OC) Add or remove newline before the '{' of a '@catch' statement, as in<br/>'@catch (decl) &lt;here&gt; {'. If set to ignore, nl_catch_brace is used.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_oc_catch_brace=ignore|nl_oc_catch_brace=add|nl_oc_catch_brace=remove|nl_oc_catch_brace=force|nl_oc_catch_brace=not_defined
-ChoicesReadable="(431)Ignore Nl Oc Catch Brace|(431)Add Nl Oc Catch Brace|(431)Remove Nl Oc Catch Brace|(431)Force Nl Oc Catch Brace"
+ChoicesReadable="Ignore Nl Oc Catch Brace|Add Nl Oc Catch Brace|Remove Nl Oc Catch Brace|Force Nl Oc Catch Brace"
 ValueDefault=ignore
 
 [Nl Brace Catch]
 Category=3
-Description="<html>(432)Add or remove newline between '}' and 'catch'.</html>"
+Description="<html>Add or remove newline between '}' and 'catch'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_brace_catch=ignore|nl_brace_catch=add|nl_brace_catch=remove|nl_brace_catch=force|nl_brace_catch=not_defined
-ChoicesReadable="(432)Ignore Nl Brace Catch|(432)Add Nl Brace Catch|(432)Remove Nl Brace Catch|(432)Force Nl Brace Catch"
+ChoicesReadable="Ignore Nl Brace Catch|Add Nl Brace Catch|Remove Nl Brace Catch|Force Nl Brace Catch"
 ValueDefault=ignore
 
 [Nl Oc Brace Catch]
 Category=3
-Description="<html>(433)(OC) Add or remove newline between '}' and '@catch'. If set to ignore,<br/>nl_brace_catch is used.</html>"
+Description="<html>(OC) Add or remove newline between '}' and '@catch'. If set to ignore,<br/>nl_brace_catch is used.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_oc_brace_catch=ignore|nl_oc_brace_catch=add|nl_oc_brace_catch=remove|nl_oc_brace_catch=force|nl_oc_brace_catch=not_defined
-ChoicesReadable="(433)Ignore Nl Oc Brace Catch|(433)Add Nl Oc Brace Catch|(433)Remove Nl Oc Brace Catch|(433)Force Nl Oc Brace Catch"
+ChoicesReadable="Ignore Nl Oc Brace Catch|Add Nl Oc Brace Catch|Remove Nl Oc Brace Catch|Force Nl Oc Brace Catch"
 ValueDefault=ignore
 
 [Nl Brace Square]
 Category=3
-Description="<html>(434)Add or remove newline between '}' and ']'.</html>"
+Description="<html>Add or remove newline between '}' and ']'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_brace_square=ignore|nl_brace_square=add|nl_brace_square=remove|nl_brace_square=force|nl_brace_square=not_defined
-ChoicesReadable="(434)Ignore Nl Brace Square|(434)Add Nl Brace Square|(434)Remove Nl Brace Square|(434)Force Nl Brace Square"
+ChoicesReadable="Ignore Nl Brace Square|Add Nl Brace Square|Remove Nl Brace Square|Force Nl Brace Square"
 ValueDefault=ignore
 
 [Nl Brace Fparen]
 Category=3
-Description="<html>(435)Add or remove newline between '}' and ')' in a function invocation.</html>"
+Description="<html>Add or remove newline between '}' and ')' in a function invocation.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_brace_fparen=ignore|nl_brace_fparen=add|nl_brace_fparen=remove|nl_brace_fparen=force|nl_brace_fparen=not_defined
-ChoicesReadable="(435)Ignore Nl Brace Fparen|(435)Add Nl Brace Fparen|(435)Remove Nl Brace Fparen|(435)Force Nl Brace Fparen"
+ChoicesReadable="Ignore Nl Brace Fparen|Add Nl Brace Fparen|Remove Nl Brace Fparen|Force Nl Brace Fparen"
 ValueDefault=ignore
 
 [Nl While Brace]
 Category=3
-Description="<html>(436)Add or remove newline between 'while' and '{'.</html>"
+Description="<html>Add or remove newline between 'while' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_while_brace=ignore|nl_while_brace=add|nl_while_brace=remove|nl_while_brace=force|nl_while_brace=not_defined
-ChoicesReadable="(436)Ignore Nl While Brace|(436)Add Nl While Brace|(436)Remove Nl While Brace|(436)Force Nl While Brace"
+ChoicesReadable="Ignore Nl While Brace|Add Nl While Brace|Remove Nl While Brace|Force Nl While Brace"
 ValueDefault=ignore
 
 [Nl Scope Brace]
 Category=3
-Description="<html>(437)(D) Add or remove newline between 'scope (x)' and '{'.</html>"
+Description="<html>(D) Add or remove newline between 'scope (x)' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_scope_brace=ignore|nl_scope_brace=add|nl_scope_brace=remove|nl_scope_brace=force|nl_scope_brace=not_defined
-ChoicesReadable="(437)Ignore Nl Scope Brace|(437)Add Nl Scope Brace|(437)Remove Nl Scope Brace|(437)Force Nl Scope Brace"
+ChoicesReadable="Ignore Nl Scope Brace|Add Nl Scope Brace|Remove Nl Scope Brace|Force Nl Scope Brace"
 ValueDefault=ignore
 
 [Nl Unittest Brace]
 Category=3
-Description="<html>(438)(D) Add or remove newline between 'unittest' and '{'.</html>"
+Description="<html>(D) Add or remove newline between 'unittest' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_unittest_brace=ignore|nl_unittest_brace=add|nl_unittest_brace=remove|nl_unittest_brace=force|nl_unittest_brace=not_defined
-ChoicesReadable="(438)Ignore Nl Unittest Brace|(438)Add Nl Unittest Brace|(438)Remove Nl Unittest Brace|(438)Force Nl Unittest Brace"
+ChoicesReadable="Ignore Nl Unittest Brace|Add Nl Unittest Brace|Remove Nl Unittest Brace|Force Nl Unittest Brace"
 ValueDefault=ignore
 
 [Nl Version Brace]
 Category=3
-Description="<html>(439)(D) Add or remove newline between 'version (x)' and '{'.</html>"
+Description="<html>(D) Add or remove newline between 'version (x)' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_version_brace=ignore|nl_version_brace=add|nl_version_brace=remove|nl_version_brace=force|nl_version_brace=not_defined
-ChoicesReadable="(439)Ignore Nl Version Brace|(439)Add Nl Version Brace|(439)Remove Nl Version Brace|(439)Force Nl Version Brace"
+ChoicesReadable="Ignore Nl Version Brace|Add Nl Version Brace|Remove Nl Version Brace|Force Nl Version Brace"
 ValueDefault=ignore
 
 [Nl Using Brace]
 Category=3
-Description="<html>(440)(C#) Add or remove newline between 'using' and '{'.</html>"
+Description="<html>(C#) Add or remove newline between 'using' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_using_brace=ignore|nl_using_brace=add|nl_using_brace=remove|nl_using_brace=force|nl_using_brace=not_defined
-ChoicesReadable="(440)Ignore Nl Using Brace|(440)Add Nl Using Brace|(440)Remove Nl Using Brace|(440)Force Nl Using Brace"
+ChoicesReadable="Ignore Nl Using Brace|Add Nl Using Brace|Remove Nl Using Brace|Force Nl Using Brace"
 ValueDefault=ignore
 
 [Nl Brace Brace]
 Category=3
-Description="<html>(441)Add or remove newline between two open or close braces. Due to general<br/>newline/brace handling, REMOVE may not work.</html>"
+Description="<html>Add or remove newline between two open or close braces. Due to general<br/>newline/brace handling, REMOVE may not work.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_brace_brace=ignore|nl_brace_brace=add|nl_brace_brace=remove|nl_brace_brace=force|nl_brace_brace=not_defined
-ChoicesReadable="(441)Ignore Nl Brace Brace|(441)Add Nl Brace Brace|(441)Remove Nl Brace Brace|(441)Force Nl Brace Brace"
+ChoicesReadable="Ignore Nl Brace Brace|Add Nl Brace Brace|Remove Nl Brace Brace|Force Nl Brace Brace"
 ValueDefault=ignore
 
 [Nl Do Brace]
 Category=3
-Description="<html>(442)Add or remove newline between 'do' and '{'.</html>"
+Description="<html>Add or remove newline between 'do' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_do_brace=ignore|nl_do_brace=add|nl_do_brace=remove|nl_do_brace=force|nl_do_brace=not_defined
-ChoicesReadable="(442)Ignore Nl Do Brace|(442)Add Nl Do Brace|(442)Remove Nl Do Brace|(442)Force Nl Do Brace"
+ChoicesReadable="Ignore Nl Do Brace|Add Nl Do Brace|Remove Nl Do Brace|Force Nl Do Brace"
 ValueDefault=ignore
 
 [Nl Brace While]
 Category=3
-Description="<html>(443)Add or remove newline between '}' and 'while' of 'do' statement.</html>"
+Description="<html>Add or remove newline between '}' and 'while' of 'do' statement.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_brace_while=ignore|nl_brace_while=add|nl_brace_while=remove|nl_brace_while=force|nl_brace_while=not_defined
-ChoicesReadable="(443)Ignore Nl Brace While|(443)Add Nl Brace While|(443)Remove Nl Brace While|(443)Force Nl Brace While"
+ChoicesReadable="Ignore Nl Brace While|Add Nl Brace While|Remove Nl Brace While|Force Nl Brace While"
 ValueDefault=ignore
 
 [Nl Switch Brace]
 Category=3
-Description="<html>(444)Add or remove newline between 'switch' and '{'.</html>"
+Description="<html>Add or remove newline between 'switch' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_switch_brace=ignore|nl_switch_brace=add|nl_switch_brace=remove|nl_switch_brace=force|nl_switch_brace=not_defined
-ChoicesReadable="(444)Ignore Nl Switch Brace|(444)Add Nl Switch Brace|(444)Remove Nl Switch Brace|(444)Force Nl Switch Brace"
+ChoicesReadable="Ignore Nl Switch Brace|Add Nl Switch Brace|Remove Nl Switch Brace|Force Nl Switch Brace"
 ValueDefault=ignore
 
 [Nl Synchronized Brace]
 Category=3
-Description="<html>(445)Add or remove newline between 'synchronized' and '{'.</html>"
+Description="<html>Add or remove newline between 'synchronized' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_synchronized_brace=ignore|nl_synchronized_brace=add|nl_synchronized_brace=remove|nl_synchronized_brace=force|nl_synchronized_brace=not_defined
-ChoicesReadable="(445)Ignore Nl Synchronized Brace|(445)Add Nl Synchronized Brace|(445)Remove Nl Synchronized Brace|(445)Force Nl Synchronized Brace"
+ChoicesReadable="Ignore Nl Synchronized Brace|Add Nl Synchronized Brace|Remove Nl Synchronized Brace|Force Nl Synchronized Brace"
 ValueDefault=ignore
 
 [Nl Multi Line Cond]
 Category=3
-Description="<html>(446)Add a newline between ')' and '{' if the ')' is on a different line than the<br/>if/for/etc.<br/><br/>Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch and<br/>nl_catch_brace.</html>"
+Description="<html>Add a newline between ')' and '{' if the ')' is on a different line than the<br/>if/for/etc.<br/><br/>Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch and<br/>nl_catch_brace.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_multi_line_cond=true|nl_multi_line_cond=false
@@ -3978,25 +3978,25 @@ ValueDefault=false
 
 [Nl Multi Line Sparen Open]
 Category=3
-Description="<html>(447)Add a newline after '(' if an if/for/while/switch condition spans multiple<br/>lines</html>"
+Description="<html>Add a newline after '(' if an if/for/while/switch condition spans multiple<br/>lines</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_multi_line_sparen_open=ignore|nl_multi_line_sparen_open=add|nl_multi_line_sparen_open=remove|nl_multi_line_sparen_open=force|nl_multi_line_sparen_open=not_defined
-ChoicesReadable="(447)Ignore Nl Multi Line Sparen Open|(447)Add Nl Multi Line Sparen Open|(447)Remove Nl Multi Line Sparen Open|(447)Force Nl Multi Line Sparen Open"
+ChoicesReadable="Ignore Nl Multi Line Sparen Open|Add Nl Multi Line Sparen Open|Remove Nl Multi Line Sparen Open|Force Nl Multi Line Sparen Open"
 ValueDefault=ignore
 
 [Nl Multi Line Sparen Close]
 Category=3
-Description="<html>(448)Add a newline before ')' if an if/for/while/switch condition spans multiple<br/>lines. Overrides nl_before_if_closing_paren if both are specified.</html>"
+Description="<html>Add a newline before ')' if an if/for/while/switch condition spans multiple<br/>lines. Overrides nl_before_if_closing_paren if both are specified.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_multi_line_sparen_close=ignore|nl_multi_line_sparen_close=add|nl_multi_line_sparen_close=remove|nl_multi_line_sparen_close=force|nl_multi_line_sparen_close=not_defined
-ChoicesReadable="(448)Ignore Nl Multi Line Sparen Close|(448)Add Nl Multi Line Sparen Close|(448)Remove Nl Multi Line Sparen Close|(448)Force Nl Multi Line Sparen Close"
+ChoicesReadable="Ignore Nl Multi Line Sparen Close|Add Nl Multi Line Sparen Close|Remove Nl Multi Line Sparen Close|Force Nl Multi Line Sparen Close"
 ValueDefault=ignore
 
 [Nl Multi Line Define]
 Category=3
-Description="<html>(449)Force a newline in a define after the macro name for multi-line defines.</html>"
+Description="<html>Force a newline in a define after the macro name for multi-line defines.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_multi_line_define=true|nl_multi_line_define=false
@@ -4004,7 +4004,7 @@ ValueDefault=false
 
 [Nl Before Case]
 Category=3
-Description="<html>(450)Whether to add a newline before 'case', and a blank line before a 'case'<br/>statement that follows a ';' or '}'.</html>"
+Description="<html>Whether to add a newline before 'case', and a blank line before a 'case'<br/>statement that follows a ';' or '}'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_before_case=true|nl_before_case=false
@@ -4012,7 +4012,7 @@ ValueDefault=false
 
 [Nl After Case]
 Category=3
-Description="<html>(451)Whether to add a newline after a 'case' statement.</html>"
+Description="<html>Whether to add a newline after a 'case' statement.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_case=true|nl_after_case=false
@@ -4020,313 +4020,313 @@ ValueDefault=false
 
 [Nl Case Colon Brace]
 Category=3
-Description="<html>(452)Add or remove newline between a case ':' and '{'.<br/><br/>Overrides nl_after_case.</html>"
+Description="<html>Add or remove newline between a case ':' and '{'.<br/><br/>Overrides nl_after_case.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_case_colon_brace=ignore|nl_case_colon_brace=add|nl_case_colon_brace=remove|nl_case_colon_brace=force|nl_case_colon_brace=not_defined
-ChoicesReadable="(452)Ignore Nl Case Colon Brace|(452)Add Nl Case Colon Brace|(452)Remove Nl Case Colon Brace|(452)Force Nl Case Colon Brace"
+ChoicesReadable="Ignore Nl Case Colon Brace|Add Nl Case Colon Brace|Remove Nl Case Colon Brace|Force Nl Case Colon Brace"
 ValueDefault=ignore
 
 [Nl Before Throw]
 Category=3
-Description="<html>(453)Add or remove newline between ')' and 'throw'.</html>"
+Description="<html>Add or remove newline between ')' and 'throw'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_before_throw=ignore|nl_before_throw=add|nl_before_throw=remove|nl_before_throw=force|nl_before_throw=not_defined
-ChoicesReadable="(453)Ignore Nl Before Throw|(453)Add Nl Before Throw|(453)Remove Nl Before Throw|(453)Force Nl Before Throw"
+ChoicesReadable="Ignore Nl Before Throw|Add Nl Before Throw|Remove Nl Before Throw|Force Nl Before Throw"
 ValueDefault=ignore
 
 [Nl Namespace Brace]
 Category=3
-Description="<html>(454)Add or remove newline between 'namespace' and '{'.</html>"
+Description="<html>Add or remove newline between 'namespace' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_namespace_brace=ignore|nl_namespace_brace=add|nl_namespace_brace=remove|nl_namespace_brace=force|nl_namespace_brace=not_defined
-ChoicesReadable="(454)Ignore Nl Namespace Brace|(454)Add Nl Namespace Brace|(454)Remove Nl Namespace Brace|(454)Force Nl Namespace Brace"
+ChoicesReadable="Ignore Nl Namespace Brace|Add Nl Namespace Brace|Remove Nl Namespace Brace|Force Nl Namespace Brace"
 ValueDefault=ignore
 
 [Nl Template Class]
 Category=3
-Description="<html>(455)Add or remove newline after 'template&lt;...&gt;' of a template class.</html>"
+Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template class.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_template_class=ignore|nl_template_class=add|nl_template_class=remove|nl_template_class=force|nl_template_class=not_defined
-ChoicesReadable="(455)Ignore Nl Template Class|(455)Add Nl Template Class|(455)Remove Nl Template Class|(455)Force Nl Template Class"
+ChoicesReadable="Ignore Nl Template Class|Add Nl Template Class|Remove Nl Template Class|Force Nl Template Class"
 ValueDefault=ignore
 
 [Nl Template Class Decl]
 Category=3
-Description="<html>(456)Add or remove newline after 'template&lt;...&gt;' of a template class declaration.<br/><br/>Overrides nl_template_class.</html>"
+Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template class declaration.<br/><br/>Overrides nl_template_class.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_template_class_decl=ignore|nl_template_class_decl=add|nl_template_class_decl=remove|nl_template_class_decl=force|nl_template_class_decl=not_defined
-ChoicesReadable="(456)Ignore Nl Template Class Decl|(456)Add Nl Template Class Decl|(456)Remove Nl Template Class Decl|(456)Force Nl Template Class Decl"
+ChoicesReadable="Ignore Nl Template Class Decl|Add Nl Template Class Decl|Remove Nl Template Class Decl|Force Nl Template Class Decl"
 ValueDefault=ignore
 
 [Nl Template Class Decl Special]
 Category=3
-Description="<html>(457)Add or remove newline after 'template&lt;&gt;' of a specialized class declaration.<br/><br/>Overrides nl_template_class_decl.</html>"
+Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized class declaration.<br/><br/>Overrides nl_template_class_decl.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_template_class_decl_special=ignore|nl_template_class_decl_special=add|nl_template_class_decl_special=remove|nl_template_class_decl_special=force|nl_template_class_decl_special=not_defined
-ChoicesReadable="(457)Ignore Nl Template Class Decl Special|(457)Add Nl Template Class Decl Special|(457)Remove Nl Template Class Decl Special|(457)Force Nl Template Class Decl Special"
+ChoicesReadable="Ignore Nl Template Class Decl Special|Add Nl Template Class Decl Special|Remove Nl Template Class Decl Special|Force Nl Template Class Decl Special"
 ValueDefault=ignore
 
 [Nl Template Class Def]
 Category=3
-Description="<html>(458)Add or remove newline after 'template&lt;...&gt;' of a template class definition.<br/><br/>Overrides nl_template_class.</html>"
+Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template class definition.<br/><br/>Overrides nl_template_class.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_template_class_def=ignore|nl_template_class_def=add|nl_template_class_def=remove|nl_template_class_def=force|nl_template_class_def=not_defined
-ChoicesReadable="(458)Ignore Nl Template Class Def|(458)Add Nl Template Class Def|(458)Remove Nl Template Class Def|(458)Force Nl Template Class Def"
+ChoicesReadable="Ignore Nl Template Class Def|Add Nl Template Class Def|Remove Nl Template Class Def|Force Nl Template Class Def"
 ValueDefault=ignore
 
 [Nl Template Class Def Special]
 Category=3
-Description="<html>(459)Add or remove newline after 'template&lt;&gt;' of a specialized class definition.<br/><br/>Overrides nl_template_class_def.</html>"
+Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized class definition.<br/><br/>Overrides nl_template_class_def.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_template_class_def_special=ignore|nl_template_class_def_special=add|nl_template_class_def_special=remove|nl_template_class_def_special=force|nl_template_class_def_special=not_defined
-ChoicesReadable="(459)Ignore Nl Template Class Def Special|(459)Add Nl Template Class Def Special|(459)Remove Nl Template Class Def Special|(459)Force Nl Template Class Def Special"
+ChoicesReadable="Ignore Nl Template Class Def Special|Add Nl Template Class Def Special|Remove Nl Template Class Def Special|Force Nl Template Class Def Special"
 ValueDefault=ignore
 
 [Nl Template Func]
 Category=3
-Description="<html>(460)Add or remove newline after 'template&lt;...&gt;' of a template function.</html>"
+Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template function.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_template_func=ignore|nl_template_func=add|nl_template_func=remove|nl_template_func=force|nl_template_func=not_defined
-ChoicesReadable="(460)Ignore Nl Template Func|(460)Add Nl Template Func|(460)Remove Nl Template Func|(460)Force Nl Template Func"
+ChoicesReadable="Ignore Nl Template Func|Add Nl Template Func|Remove Nl Template Func|Force Nl Template Func"
 ValueDefault=ignore
 
 [Nl Template Func Decl]
 Category=3
-Description="<html>(461)Add or remove newline after 'template&lt;...&gt;' of a template function<br/>declaration.<br/><br/>Overrides nl_template_func.</html>"
+Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template function<br/>declaration.<br/><br/>Overrides nl_template_func.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_template_func_decl=ignore|nl_template_func_decl=add|nl_template_func_decl=remove|nl_template_func_decl=force|nl_template_func_decl=not_defined
-ChoicesReadable="(461)Ignore Nl Template Func Decl|(461)Add Nl Template Func Decl|(461)Remove Nl Template Func Decl|(461)Force Nl Template Func Decl"
+ChoicesReadable="Ignore Nl Template Func Decl|Add Nl Template Func Decl|Remove Nl Template Func Decl|Force Nl Template Func Decl"
 ValueDefault=ignore
 
 [Nl Template Func Decl Special]
 Category=3
-Description="<html>(462)Add or remove newline after 'template&lt;&gt;' of a specialized function<br/>declaration.<br/><br/>Overrides nl_template_func_decl.</html>"
+Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized function<br/>declaration.<br/><br/>Overrides nl_template_func_decl.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_template_func_decl_special=ignore|nl_template_func_decl_special=add|nl_template_func_decl_special=remove|nl_template_func_decl_special=force|nl_template_func_decl_special=not_defined
-ChoicesReadable="(462)Ignore Nl Template Func Decl Special|(462)Add Nl Template Func Decl Special|(462)Remove Nl Template Func Decl Special|(462)Force Nl Template Func Decl Special"
+ChoicesReadable="Ignore Nl Template Func Decl Special|Add Nl Template Func Decl Special|Remove Nl Template Func Decl Special|Force Nl Template Func Decl Special"
 ValueDefault=ignore
 
 [Nl Template Func Def]
 Category=3
-Description="<html>(463)Add or remove newline after 'template&lt;...&gt;' of a template function<br/>definition.<br/><br/>Overrides nl_template_func.</html>"
+Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template function<br/>definition.<br/><br/>Overrides nl_template_func.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_template_func_def=ignore|nl_template_func_def=add|nl_template_func_def=remove|nl_template_func_def=force|nl_template_func_def=not_defined
-ChoicesReadable="(463)Ignore Nl Template Func Def|(463)Add Nl Template Func Def|(463)Remove Nl Template Func Def|(463)Force Nl Template Func Def"
+ChoicesReadable="Ignore Nl Template Func Def|Add Nl Template Func Def|Remove Nl Template Func Def|Force Nl Template Func Def"
 ValueDefault=ignore
 
 [Nl Template Func Def Special]
 Category=3
-Description="<html>(464)Add or remove newline after 'template&lt;&gt;' of a specialized function<br/>definition.<br/><br/>Overrides nl_template_func_def.</html>"
+Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized function<br/>definition.<br/><br/>Overrides nl_template_func_def.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_template_func_def_special=ignore|nl_template_func_def_special=add|nl_template_func_def_special=remove|nl_template_func_def_special=force|nl_template_func_def_special=not_defined
-ChoicesReadable="(464)Ignore Nl Template Func Def Special|(464)Add Nl Template Func Def Special|(464)Remove Nl Template Func Def Special|(464)Force Nl Template Func Def Special"
+ChoicesReadable="Ignore Nl Template Func Def Special|Add Nl Template Func Def Special|Remove Nl Template Func Def Special|Force Nl Template Func Def Special"
 ValueDefault=ignore
 
 [Nl Template Var]
 Category=3
-Description="<html>(465)Add or remove newline after 'template&lt;...&gt;' of a template variable.</html>"
+Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template variable.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_template_var=ignore|nl_template_var=add|nl_template_var=remove|nl_template_var=force|nl_template_var=not_defined
-ChoicesReadable="(465)Ignore Nl Template Var|(465)Add Nl Template Var|(465)Remove Nl Template Var|(465)Force Nl Template Var"
+ChoicesReadable="Ignore Nl Template Var|Add Nl Template Var|Remove Nl Template Var|Force Nl Template Var"
 ValueDefault=ignore
 
 [Nl Template Using]
 Category=3
-Description="<html>(466)Add or remove newline between 'template&lt;...&gt;' and 'using' of a templated<br/>type alias.</html>"
+Description="<html>Add or remove newline between 'template&lt;...&gt;' and 'using' of a templated<br/>type alias.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_template_using=ignore|nl_template_using=add|nl_template_using=remove|nl_template_using=force|nl_template_using=not_defined
-ChoicesReadable="(466)Ignore Nl Template Using|(466)Add Nl Template Using|(466)Remove Nl Template Using|(466)Force Nl Template Using"
+ChoicesReadable="Ignore Nl Template Using|Add Nl Template Using|Remove Nl Template Using|Force Nl Template Using"
 ValueDefault=ignore
 
 [Nl Class Brace]
 Category=3
-Description="<html>(467)Add or remove newline between 'class' and '{'.</html>"
+Description="<html>Add or remove newline between 'class' and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_class_brace=ignore|nl_class_brace=add|nl_class_brace=remove|nl_class_brace=force|nl_class_brace=not_defined
-ChoicesReadable="(467)Ignore Nl Class Brace|(467)Add Nl Class Brace|(467)Remove Nl Class Brace|(467)Force Nl Class Brace"
+ChoicesReadable="Ignore Nl Class Brace|Add Nl Class Brace|Remove Nl Class Brace|Force Nl Class Brace"
 ValueDefault=ignore
 
 [Nl Class Init Args]
 Category=3
-Description="<html>(468)Add or remove newline before or after (depending on pos_class_comma,<br/>may not be IGNORE) each',' in the base class list.</html>"
+Description="<html>Add or remove newline before or after (depending on pos_class_comma,<br/>may not be IGNORE) each',' in the base class list.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_class_init_args=ignore|nl_class_init_args=add|nl_class_init_args=remove|nl_class_init_args=force|nl_class_init_args=not_defined
-ChoicesReadable="(468)Ignore Nl Class Init Args|(468)Add Nl Class Init Args|(468)Remove Nl Class Init Args|(468)Force Nl Class Init Args"
+ChoicesReadable="Ignore Nl Class Init Args|Add Nl Class Init Args|Remove Nl Class Init Args|Force Nl Class Init Args"
 ValueDefault=ignore
 
 [Nl Constr Init Args]
 Category=3
-Description="<html>(469)Add or remove newline after each ',' in the constructor member<br/>initialization. Related to nl_constr_colon, pos_constr_colon and<br/>pos_constr_comma.</html>"
+Description="<html>Add or remove newline after each ',' in the constructor member<br/>initialization. Related to nl_constr_colon, pos_constr_colon and<br/>pos_constr_comma.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_constr_init_args=ignore|nl_constr_init_args=add|nl_constr_init_args=remove|nl_constr_init_args=force|nl_constr_init_args=not_defined
-ChoicesReadable="(469)Ignore Nl Constr Init Args|(469)Add Nl Constr Init Args|(469)Remove Nl Constr Init Args|(469)Force Nl Constr Init Args"
+ChoicesReadable="Ignore Nl Constr Init Args|Add Nl Constr Init Args|Remove Nl Constr Init Args|Force Nl Constr Init Args"
 ValueDefault=ignore
 
 [Nl Enum Own Lines]
 Category=3
-Description="<html>(470)Add or remove newline before first element, after comma, and after last<br/>element, in 'enum'.</html>"
+Description="<html>Add or remove newline before first element, after comma, and after last<br/>element, in 'enum'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_enum_own_lines=ignore|nl_enum_own_lines=add|nl_enum_own_lines=remove|nl_enum_own_lines=force|nl_enum_own_lines=not_defined
-ChoicesReadable="(470)Ignore Nl Enum Own Lines|(470)Add Nl Enum Own Lines|(470)Remove Nl Enum Own Lines|(470)Force Nl Enum Own Lines"
+ChoicesReadable="Ignore Nl Enum Own Lines|Add Nl Enum Own Lines|Remove Nl Enum Own Lines|Force Nl Enum Own Lines"
 ValueDefault=ignore
 
 [Nl Func Type Name]
 Category=3
-Description="<html>(471)Add or remove newline between return type and function name in a function<br/>definition.<br/>might be modified by nl_func_leave_one_liners</html>"
+Description="<html>Add or remove newline between return type and function name in a function<br/>definition.<br/>might be modified by nl_func_leave_one_liners</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_type_name=ignore|nl_func_type_name=add|nl_func_type_name=remove|nl_func_type_name=force|nl_func_type_name=not_defined
-ChoicesReadable="(471)Ignore Nl Func Type Name|(471)Add Nl Func Type Name|(471)Remove Nl Func Type Name|(471)Force Nl Func Type Name"
+ChoicesReadable="Ignore Nl Func Type Name|Add Nl Func Type Name|Remove Nl Func Type Name|Force Nl Func Type Name"
 ValueDefault=ignore
 
 [Nl Func Type Name Class]
 Category=3
-Description="<html>(472)Add or remove newline between return type and function name inside a class<br/>definition. If set to ignore, nl_func_type_name or nl_func_proto_type_name<br/>is used instead.</html>"
+Description="<html>Add or remove newline between return type and function name inside a class<br/>definition. If set to ignore, nl_func_type_name or nl_func_proto_type_name<br/>is used instead.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_type_name_class=ignore|nl_func_type_name_class=add|nl_func_type_name_class=remove|nl_func_type_name_class=force|nl_func_type_name_class=not_defined
-ChoicesReadable="(472)Ignore Nl Func Type Name Class|(472)Add Nl Func Type Name Class|(472)Remove Nl Func Type Name Class|(472)Force Nl Func Type Name Class"
+ChoicesReadable="Ignore Nl Func Type Name Class|Add Nl Func Type Name Class|Remove Nl Func Type Name Class|Force Nl Func Type Name Class"
 ValueDefault=ignore
 
 [Nl Func Class Scope]
 Category=3
-Description="<html>(473)Add or remove newline between class specification and '::'<br/>in 'void A::f() { }'. Only appears in separate member implementation (does<br/>not appear with in-line implementation).</html>"
+Description="<html>Add or remove newline between class specification and '::'<br/>in 'void A::f() { }'. Only appears in separate member implementation (does<br/>not appear with in-line implementation).</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_class_scope=ignore|nl_func_class_scope=add|nl_func_class_scope=remove|nl_func_class_scope=force|nl_func_class_scope=not_defined
-ChoicesReadable="(473)Ignore Nl Func Class Scope|(473)Add Nl Func Class Scope|(473)Remove Nl Func Class Scope|(473)Force Nl Func Class Scope"
+ChoicesReadable="Ignore Nl Func Class Scope|Add Nl Func Class Scope|Remove Nl Func Class Scope|Force Nl Func Class Scope"
 ValueDefault=ignore
 
 [Nl Func Scope Name]
 Category=3
-Description="<html>(474)Add or remove newline between function scope and name, as in<br/>'void A :: &lt;here&gt; f() { }'.</html>"
+Description="<html>Add or remove newline between function scope and name, as in<br/>'void A :: &lt;here&gt; f() { }'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_scope_name=ignore|nl_func_scope_name=add|nl_func_scope_name=remove|nl_func_scope_name=force|nl_func_scope_name=not_defined
-ChoicesReadable="(474)Ignore Nl Func Scope Name|(474)Add Nl Func Scope Name|(474)Remove Nl Func Scope Name|(474)Force Nl Func Scope Name"
+ChoicesReadable="Ignore Nl Func Scope Name|Add Nl Func Scope Name|Remove Nl Func Scope Name|Force Nl Func Scope Name"
 ValueDefault=ignore
 
 [Nl Func Proto Type Name]
 Category=3
-Description="<html>(475)Add or remove newline between return type and function name in a prototype.</html>"
+Description="<html>Add or remove newline between return type and function name in a prototype.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_proto_type_name=ignore|nl_func_proto_type_name=add|nl_func_proto_type_name=remove|nl_func_proto_type_name=force|nl_func_proto_type_name=not_defined
-ChoicesReadable="(475)Ignore Nl Func Proto Type Name|(475)Add Nl Func Proto Type Name|(475)Remove Nl Func Proto Type Name|(475)Force Nl Func Proto Type Name"
+ChoicesReadable="Ignore Nl Func Proto Type Name|Add Nl Func Proto Type Name|Remove Nl Func Proto Type Name|Force Nl Func Proto Type Name"
 ValueDefault=ignore
 
 [Nl Func Paren]
 Category=3
-Description="<html>(476)Add or remove newline between a function name and the opening '(' in the<br/>declaration.</html>"
+Description="<html>Add or remove newline between a function name and the opening '(' in the<br/>declaration.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_paren=ignore|nl_func_paren=add|nl_func_paren=remove|nl_func_paren=force|nl_func_paren=not_defined
-ChoicesReadable="(476)Ignore Nl Func Paren|(476)Add Nl Func Paren|(476)Remove Nl Func Paren|(476)Force Nl Func Paren"
+ChoicesReadable="Ignore Nl Func Paren|Add Nl Func Paren|Remove Nl Func Paren|Force Nl Func Paren"
 ValueDefault=ignore
 
 [Nl Func Paren Empty]
 Category=3
-Description="<html>(477)Overrides nl_func_paren for functions with no parameters.</html>"
+Description="<html>Overrides nl_func_paren for functions with no parameters.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_paren_empty=ignore|nl_func_paren_empty=add|nl_func_paren_empty=remove|nl_func_paren_empty=force|nl_func_paren_empty=not_defined
-ChoicesReadable="(477)Ignore Nl Func Paren Empty|(477)Add Nl Func Paren Empty|(477)Remove Nl Func Paren Empty|(477)Force Nl Func Paren Empty"
+ChoicesReadable="Ignore Nl Func Paren Empty|Add Nl Func Paren Empty|Remove Nl Func Paren Empty|Force Nl Func Paren Empty"
 ValueDefault=ignore
 
 [Nl Func Def Paren]
 Category=3
-Description="<html>(478)Add or remove newline between a function name and the opening '(' in the<br/>definition.</html>"
+Description="<html>Add or remove newline between a function name and the opening '(' in the<br/>definition.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_def_paren=ignore|nl_func_def_paren=add|nl_func_def_paren=remove|nl_func_def_paren=force|nl_func_def_paren=not_defined
-ChoicesReadable="(478)Ignore Nl Func Def Paren|(478)Add Nl Func Def Paren|(478)Remove Nl Func Def Paren|(478)Force Nl Func Def Paren"
+ChoicesReadable="Ignore Nl Func Def Paren|Add Nl Func Def Paren|Remove Nl Func Def Paren|Force Nl Func Def Paren"
 ValueDefault=ignore
 
 [Nl Func Def Paren Empty]
 Category=3
-Description="<html>(479)Overrides nl_func_def_paren for functions with no parameters.</html>"
+Description="<html>Overrides nl_func_def_paren for functions with no parameters.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_def_paren_empty=ignore|nl_func_def_paren_empty=add|nl_func_def_paren_empty=remove|nl_func_def_paren_empty=force|nl_func_def_paren_empty=not_defined
-ChoicesReadable="(479)Ignore Nl Func Def Paren Empty|(479)Add Nl Func Def Paren Empty|(479)Remove Nl Func Def Paren Empty|(479)Force Nl Func Def Paren Empty"
+ChoicesReadable="Ignore Nl Func Def Paren Empty|Add Nl Func Def Paren Empty|Remove Nl Func Def Paren Empty|Force Nl Func Def Paren Empty"
 ValueDefault=ignore
 
 [Nl Func Call Paren]
 Category=3
-Description="<html>(480)Add or remove newline between a function name and the opening '(' in the<br/>call.</html>"
+Description="<html>Add or remove newline between a function name and the opening '(' in the<br/>call.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_call_paren=ignore|nl_func_call_paren=add|nl_func_call_paren=remove|nl_func_call_paren=force|nl_func_call_paren=not_defined
-ChoicesReadable="(480)Ignore Nl Func Call Paren|(480)Add Nl Func Call Paren|(480)Remove Nl Func Call Paren|(480)Force Nl Func Call Paren"
+ChoicesReadable="Ignore Nl Func Call Paren|Add Nl Func Call Paren|Remove Nl Func Call Paren|Force Nl Func Call Paren"
 ValueDefault=ignore
 
 [Nl Func Call Paren Empty]
 Category=3
-Description="<html>(481)Overrides nl_func_call_paren for functions with no parameters.</html>"
+Description="<html>Overrides nl_func_call_paren for functions with no parameters.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_call_paren_empty=ignore|nl_func_call_paren_empty=add|nl_func_call_paren_empty=remove|nl_func_call_paren_empty=force|nl_func_call_paren_empty=not_defined
-ChoicesReadable="(481)Ignore Nl Func Call Paren Empty|(481)Add Nl Func Call Paren Empty|(481)Remove Nl Func Call Paren Empty|(481)Force Nl Func Call Paren Empty"
+ChoicesReadable="Ignore Nl Func Call Paren Empty|Add Nl Func Call Paren Empty|Remove Nl Func Call Paren Empty|Force Nl Func Call Paren Empty"
 ValueDefault=ignore
 
 [Nl Func Decl Start]
 Category=3
-Description="<html>(482)Add or remove newline after '(' in a function declaration.</html>"
+Description="<html>Add or remove newline after '(' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_decl_start=ignore|nl_func_decl_start=add|nl_func_decl_start=remove|nl_func_decl_start=force|nl_func_decl_start=not_defined
-ChoicesReadable="(482)Ignore Nl Func Decl Start|(482)Add Nl Func Decl Start|(482)Remove Nl Func Decl Start|(482)Force Nl Func Decl Start"
+ChoicesReadable="Ignore Nl Func Decl Start|Add Nl Func Decl Start|Remove Nl Func Decl Start|Force Nl Func Decl Start"
 ValueDefault=ignore
 
 [Nl Func Def Start]
 Category=3
-Description="<html>(483)Add or remove newline after '(' in a function definition.</html>"
+Description="<html>Add or remove newline after '(' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_def_start=ignore|nl_func_def_start=add|nl_func_def_start=remove|nl_func_def_start=force|nl_func_def_start=not_defined
-ChoicesReadable="(483)Ignore Nl Func Def Start|(483)Add Nl Func Def Start|(483)Remove Nl Func Def Start|(483)Force Nl Func Def Start"
+ChoicesReadable="Ignore Nl Func Def Start|Add Nl Func Def Start|Remove Nl Func Def Start|Force Nl Func Def Start"
 ValueDefault=ignore
 
 [Nl Func Decl Start Single]
 Category=3
-Description="<html>(484)Overrides nl_func_decl_start when there is only one parameter.</html>"
+Description="<html>Overrides nl_func_decl_start when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_decl_start_single=ignore|nl_func_decl_start_single=add|nl_func_decl_start_single=remove|nl_func_decl_start_single=force|nl_func_decl_start_single=not_defined
-ChoicesReadable="(484)Ignore Nl Func Decl Start Single|(484)Add Nl Func Decl Start Single|(484)Remove Nl Func Decl Start Single|(484)Force Nl Func Decl Start Single"
+ChoicesReadable="Ignore Nl Func Decl Start Single|Add Nl Func Decl Start Single|Remove Nl Func Decl Start Single|Force Nl Func Decl Start Single"
 ValueDefault=ignore
 
 [Nl Func Def Start Single]
 Category=3
-Description="<html>(485)Overrides nl_func_def_start when there is only one parameter.</html>"
+Description="<html>Overrides nl_func_def_start when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_def_start_single=ignore|nl_func_def_start_single=add|nl_func_def_start_single=remove|nl_func_def_start_single=force|nl_func_def_start_single=not_defined
-ChoicesReadable="(485)Ignore Nl Func Def Start Single|(485)Add Nl Func Def Start Single|(485)Remove Nl Func Def Start Single|(485)Force Nl Func Def Start Single"
+ChoicesReadable="Ignore Nl Func Def Start Single|Add Nl Func Def Start Single|Remove Nl Func Def Start Single|Force Nl Func Def Start Single"
 ValueDefault=ignore
 
 [Nl Func Decl Start Multi Line]
 Category=3
-Description="<html>(486)Whether to add a newline after '(' in a function declaration if '(' and ')'<br/>are in different lines. If false, nl_func_decl_start is used instead.</html>"
+Description="<html>Whether to add a newline after '(' in a function declaration if '(' and ')'<br/>are in different lines. If false, nl_func_decl_start is used instead.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_func_decl_start_multi_line=true|nl_func_decl_start_multi_line=false
@@ -4334,7 +4334,7 @@ ValueDefault=false
 
 [Nl Func Def Start Multi Line]
 Category=3
-Description="<html>(487)Whether to add a newline after '(' in a function definition if '(' and ')'<br/>are in different lines. If false, nl_func_def_start is used instead.</html>"
+Description="<html>Whether to add a newline after '(' in a function definition if '(' and ')'<br/>are in different lines. If false, nl_func_def_start is used instead.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_func_def_start_multi_line=true|nl_func_def_start_multi_line=false
@@ -4342,34 +4342,34 @@ ValueDefault=false
 
 [Nl Func Decl Args]
 Category=3
-Description="<html>(488)Add or remove newline after each ',' in a function declaration.</html>"
+Description="<html>Add or remove newline after each ',' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_decl_args=ignore|nl_func_decl_args=add|nl_func_decl_args=remove|nl_func_decl_args=force|nl_func_decl_args=not_defined
-ChoicesReadable="(488)Ignore Nl Func Decl Args|(488)Add Nl Func Decl Args|(488)Remove Nl Func Decl Args|(488)Force Nl Func Decl Args"
+ChoicesReadable="Ignore Nl Func Decl Args|Add Nl Func Decl Args|Remove Nl Func Decl Args|Force Nl Func Decl Args"
 ValueDefault=ignore
 
 [Nl Func Def Args]
 Category=3
-Description="<html>(489)Add or remove newline after each ',' in a function definition.</html>"
+Description="<html>Add or remove newline after each ',' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_def_args=ignore|nl_func_def_args=add|nl_func_def_args=remove|nl_func_def_args=force|nl_func_def_args=not_defined
-ChoicesReadable="(489)Ignore Nl Func Def Args|(489)Add Nl Func Def Args|(489)Remove Nl Func Def Args|(489)Force Nl Func Def Args"
+ChoicesReadable="Ignore Nl Func Def Args|Add Nl Func Def Args|Remove Nl Func Def Args|Force Nl Func Def Args"
 ValueDefault=ignore
 
 [Nl Func Call Args]
 Category=3
-Description="<html>(490)Add or remove newline after each ',' in a function call.</html>"
+Description="<html>Add or remove newline after each ',' in a function call.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_call_args=ignore|nl_func_call_args=add|nl_func_call_args=remove|nl_func_call_args=force|nl_func_call_args=not_defined
-ChoicesReadable="(490)Ignore Nl Func Call Args|(490)Add Nl Func Call Args|(490)Remove Nl Func Call Args|(490)Force Nl Func Call Args"
+ChoicesReadable="Ignore Nl Func Call Args|Add Nl Func Call Args|Remove Nl Func Call Args|Force Nl Func Call Args"
 ValueDefault=ignore
 
 [Nl Func Decl Args Multi Line]
 Category=3
-Description="<html>(491)Whether to add a newline after each ',' in a function declaration if '('<br/>and ')' are in different lines. If false, nl_func_decl_args is used instead.</html>"
+Description="<html>Whether to add a newline after each ',' in a function declaration if '('<br/>and ')' are in different lines. If false, nl_func_decl_args is used instead.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_func_decl_args_multi_line=true|nl_func_decl_args_multi_line=false
@@ -4377,7 +4377,7 @@ ValueDefault=false
 
 [Nl Func Def Args Multi Line]
 Category=3
-Description="<html>(492)Whether to add a newline after each ',' in a function definition if '('<br/>and ')' are in different lines. If false, nl_func_def_args is used instead.</html>"
+Description="<html>Whether to add a newline after each ',' in a function definition if '('<br/>and ')' are in different lines. If false, nl_func_def_args is used instead.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_func_def_args_multi_line=true|nl_func_def_args_multi_line=false
@@ -4385,43 +4385,43 @@ ValueDefault=false
 
 [Nl Func Decl End]
 Category=3
-Description="<html>(493)Add or remove newline before the ')' in a function declaration.</html>"
+Description="<html>Add or remove newline before the ')' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_decl_end=ignore|nl_func_decl_end=add|nl_func_decl_end=remove|nl_func_decl_end=force|nl_func_decl_end=not_defined
-ChoicesReadable="(493)Ignore Nl Func Decl End|(493)Add Nl Func Decl End|(493)Remove Nl Func Decl End|(493)Force Nl Func Decl End"
+ChoicesReadable="Ignore Nl Func Decl End|Add Nl Func Decl End|Remove Nl Func Decl End|Force Nl Func Decl End"
 ValueDefault=ignore
 
 [Nl Func Def End]
 Category=3
-Description="<html>(494)Add or remove newline before the ')' in a function definition.</html>"
+Description="<html>Add or remove newline before the ')' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_def_end=ignore|nl_func_def_end=add|nl_func_def_end=remove|nl_func_def_end=force|nl_func_def_end=not_defined
-ChoicesReadable="(494)Ignore Nl Func Def End|(494)Add Nl Func Def End|(494)Remove Nl Func Def End|(494)Force Nl Func Def End"
+ChoicesReadable="Ignore Nl Func Def End|Add Nl Func Def End|Remove Nl Func Def End|Force Nl Func Def End"
 ValueDefault=ignore
 
 [Nl Func Decl End Single]
 Category=3
-Description="<html>(495)Overrides nl_func_decl_end when there is only one parameter.</html>"
+Description="<html>Overrides nl_func_decl_end when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_decl_end_single=ignore|nl_func_decl_end_single=add|nl_func_decl_end_single=remove|nl_func_decl_end_single=force|nl_func_decl_end_single=not_defined
-ChoicesReadable="(495)Ignore Nl Func Decl End Single|(495)Add Nl Func Decl End Single|(495)Remove Nl Func Decl End Single|(495)Force Nl Func Decl End Single"
+ChoicesReadable="Ignore Nl Func Decl End Single|Add Nl Func Decl End Single|Remove Nl Func Decl End Single|Force Nl Func Decl End Single"
 ValueDefault=ignore
 
 [Nl Func Def End Single]
 Category=3
-Description="<html>(496)Overrides nl_func_def_end when there is only one parameter.</html>"
+Description="<html>Overrides nl_func_def_end when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_def_end_single=ignore|nl_func_def_end_single=add|nl_func_def_end_single=remove|nl_func_def_end_single=force|nl_func_def_end_single=not_defined
-ChoicesReadable="(496)Ignore Nl Func Def End Single|(496)Add Nl Func Def End Single|(496)Remove Nl Func Def End Single|(496)Force Nl Func Def End Single"
+ChoicesReadable="Ignore Nl Func Def End Single|Add Nl Func Def End Single|Remove Nl Func Def End Single|Force Nl Func Def End Single"
 ValueDefault=ignore
 
 [Nl Func Decl End Multi Line]
 Category=3
-Description="<html>(497)Whether to add a newline before ')' in a function declaration if '(' and ')'<br/>are in different lines. If false, nl_func_decl_end is used instead.</html>"
+Description="<html>Whether to add a newline before ')' in a function declaration if '(' and ')'<br/>are in different lines. If false, nl_func_decl_end is used instead.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_func_decl_end_multi_line=true|nl_func_decl_end_multi_line=false
@@ -4429,7 +4429,7 @@ ValueDefault=false
 
 [Nl Func Def End Multi Line]
 Category=3
-Description="<html>(498)Whether to add a newline before ')' in a function definition if '(' and ')'<br/>are in different lines. If false, nl_func_def_end is used instead.</html>"
+Description="<html>Whether to add a newline before ')' in a function definition if '(' and ')'<br/>are in different lines. If false, nl_func_def_end is used instead.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_func_def_end_multi_line=true|nl_func_def_end_multi_line=false
@@ -4437,52 +4437,52 @@ ValueDefault=false
 
 [Nl Func Decl Empty]
 Category=3
-Description="<html>(499)Add or remove newline between '()' in a function declaration.</html>"
+Description="<html>Add or remove newline between '()' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_decl_empty=ignore|nl_func_decl_empty=add|nl_func_decl_empty=remove|nl_func_decl_empty=force|nl_func_decl_empty=not_defined
-ChoicesReadable="(499)Ignore Nl Func Decl Empty|(499)Add Nl Func Decl Empty|(499)Remove Nl Func Decl Empty|(499)Force Nl Func Decl Empty"
+ChoicesReadable="Ignore Nl Func Decl Empty|Add Nl Func Decl Empty|Remove Nl Func Decl Empty|Force Nl Func Decl Empty"
 ValueDefault=ignore
 
 [Nl Func Def Empty]
 Category=3
-Description="<html>(500)Add or remove newline between '()' in a function definition.</html>"
+Description="<html>Add or remove newline between '()' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_def_empty=ignore|nl_func_def_empty=add|nl_func_def_empty=remove|nl_func_def_empty=force|nl_func_def_empty=not_defined
-ChoicesReadable="(500)Ignore Nl Func Def Empty|(500)Add Nl Func Def Empty|(500)Remove Nl Func Def Empty|(500)Force Nl Func Def Empty"
+ChoicesReadable="Ignore Nl Func Def Empty|Add Nl Func Def Empty|Remove Nl Func Def Empty|Force Nl Func Def Empty"
 ValueDefault=ignore
 
 [Nl Func Call Empty]
 Category=3
-Description="<html>(501)Add or remove newline between '()' in a function call.</html>"
+Description="<html>Add or remove newline between '()' in a function call.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_call_empty=ignore|nl_func_call_empty=add|nl_func_call_empty=remove|nl_func_call_empty=force|nl_func_call_empty=not_defined
-ChoicesReadable="(501)Ignore Nl Func Call Empty|(501)Add Nl Func Call Empty|(501)Remove Nl Func Call Empty|(501)Force Nl Func Call Empty"
+ChoicesReadable="Ignore Nl Func Call Empty|Add Nl Func Call Empty|Remove Nl Func Call Empty|Force Nl Func Call Empty"
 ValueDefault=ignore
 
 [Nl Func Call Start]
 Category=3
-Description="<html>(502)Whether to add a newline after '(' in a function call,<br/>has preference over nl_func_call_start_multi_line.</html>"
+Description="<html>Whether to add a newline after '(' in a function call,<br/>has preference over nl_func_call_start_multi_line.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_call_start=ignore|nl_func_call_start=add|nl_func_call_start=remove|nl_func_call_start=force|nl_func_call_start=not_defined
-ChoicesReadable="(502)Ignore Nl Func Call Start|(502)Add Nl Func Call Start|(502)Remove Nl Func Call Start|(502)Force Nl Func Call Start"
+ChoicesReadable="Ignore Nl Func Call Start|Add Nl Func Call Start|Remove Nl Func Call Start|Force Nl Func Call Start"
 ValueDefault=ignore
 
 [Nl Func Call End]
 Category=3
-Description="<html>(503)Whether to add a newline before ')' in a function call.</html>"
+Description="<html>Whether to add a newline before ')' in a function call.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_func_call_end=ignore|nl_func_call_end=add|nl_func_call_end=remove|nl_func_call_end=force|nl_func_call_end=not_defined
-ChoicesReadable="(503)Ignore Nl Func Call End|(503)Add Nl Func Call End|(503)Remove Nl Func Call End|(503)Force Nl Func Call End"
+ChoicesReadable="Ignore Nl Func Call End|Add Nl Func Call End|Remove Nl Func Call End|Force Nl Func Call End"
 ValueDefault=ignore
 
 [Nl Func Call Start Multi Line]
 Category=3
-Description="<html>(504)Whether to add a newline after '(' in a function call if '(' and ')' are in<br/>different lines.</html>"
+Description="<html>Whether to add a newline after '(' in a function call if '(' and ')' are in<br/>different lines.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_func_call_start_multi_line=true|nl_func_call_start_multi_line=false
@@ -4490,7 +4490,7 @@ ValueDefault=false
 
 [Nl Func Call Args Multi Line]
 Category=3
-Description="<html>(505)Whether to add a newline after each ',' in a function call if '(' and ')'<br/>are in different lines.</html>"
+Description="<html>Whether to add a newline after each ',' in a function call if '(' and ')'<br/>are in different lines.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_func_call_args_multi_line=true|nl_func_call_args_multi_line=false
@@ -4498,7 +4498,7 @@ ValueDefault=false
 
 [Nl Func Call End Multi Line]
 Category=3
-Description="<html>(506)Whether to add a newline before ')' in a function call if '(' and ')' are in<br/>different lines.</html>"
+Description="<html>Whether to add a newline before ')' in a function call if '(' and ')' are in<br/>different lines.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_func_call_end_multi_line=true|nl_func_call_end_multi_line=false
@@ -4506,7 +4506,7 @@ ValueDefault=false
 
 [Nl Func Call Args Multi Line Ignore Closures]
 Category=3
-Description="<html>(507)Whether to respect nl_func_call_XXX option in case of closure args.</html>"
+Description="<html>Whether to respect nl_func_call_XXX option in case of closure args.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_func_call_args_multi_line_ignore_closures=true|nl_func_call_args_multi_line_ignore_closures=false
@@ -4514,7 +4514,7 @@ ValueDefault=false
 
 [Nl Template Start]
 Category=3
-Description="<html>(508)Whether to add a newline after '&lt;' of a template parameter list.</html>"
+Description="<html>Whether to add a newline after '&lt;' of a template parameter list.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_template_start=true|nl_template_start=false
@@ -4522,7 +4522,7 @@ ValueDefault=false
 
 [Nl Template Args]
 Category=3
-Description="<html>(509)Whether to add a newline after each ',' in a template parameter list.</html>"
+Description="<html>Whether to add a newline after each ',' in a template parameter list.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_template_args=true|nl_template_args=false
@@ -4530,7 +4530,7 @@ ValueDefault=false
 
 [Nl Template End]
 Category=3
-Description="<html>(510)Whether to add a newline before '&gt;' of a template parameter list.</html>"
+Description="<html>Whether to add a newline before '&gt;' of a template parameter list.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_template_end=true|nl_template_end=false
@@ -4538,7 +4538,7 @@ ValueDefault=false
 
 [Nl Oc Msg Args]
 Category=3
-Description="<html>(511)(OC) Whether to put each Objective-C message parameter on a separate line.<br/>See nl_oc_msg_leave_one_liner.</html>"
+Description="<html>(OC) Whether to put each Objective-C message parameter on a separate line.<br/>See nl_oc_msg_leave_one_liner.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_oc_msg_args=true|nl_oc_msg_args=false
@@ -4546,7 +4546,7 @@ ValueDefault=false
 
 [Nl Oc Msg Args Min Params]
 Category=3
-Description="<html>(512)(OC) Minimum number of Objective-C message parameters before applying nl_oc_msg_args.</html>"
+Description="<html>(OC) Minimum number of Objective-C message parameters before applying nl_oc_msg_args.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_oc_msg_args_min_params="
@@ -4556,52 +4556,52 @@ ValueDefault=0
 
 [Nl Fdef Brace]
 Category=3
-Description="<html>(513)Add or remove newline between function signature and '{'.</html>"
+Description="<html>Add or remove newline between function signature and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_fdef_brace=ignore|nl_fdef_brace=add|nl_fdef_brace=remove|nl_fdef_brace=force|nl_fdef_brace=not_defined
-ChoicesReadable="(513)Ignore Nl Fdef Brace|(513)Add Nl Fdef Brace|(513)Remove Nl Fdef Brace|(513)Force Nl Fdef Brace"
+ChoicesReadable="Ignore Nl Fdef Brace|Add Nl Fdef Brace|Remove Nl Fdef Brace|Force Nl Fdef Brace"
 ValueDefault=ignore
 
 [Nl Fdef Brace Cond]
 Category=3
-Description="<html>(514)Add or remove newline between function signature and '{',<br/>if signature ends with ')'. Overrides nl_fdef_brace.</html>"
+Description="<html>Add or remove newline between function signature and '{',<br/>if signature ends with ')'. Overrides nl_fdef_brace.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_fdef_brace_cond=ignore|nl_fdef_brace_cond=add|nl_fdef_brace_cond=remove|nl_fdef_brace_cond=force|nl_fdef_brace_cond=not_defined
-ChoicesReadable="(514)Ignore Nl Fdef Brace Cond|(514)Add Nl Fdef Brace Cond|(514)Remove Nl Fdef Brace Cond|(514)Force Nl Fdef Brace Cond"
+ChoicesReadable="Ignore Nl Fdef Brace Cond|Add Nl Fdef Brace Cond|Remove Nl Fdef Brace Cond|Force Nl Fdef Brace Cond"
 ValueDefault=ignore
 
 [Nl Cpp Ldef Brace]
 Category=3
-Description="<html>(515)Add or remove newline between C++11 lambda signature and '{'.</html>"
+Description="<html>Add or remove newline between C++11 lambda signature and '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_cpp_ldef_brace=ignore|nl_cpp_ldef_brace=add|nl_cpp_ldef_brace=remove|nl_cpp_ldef_brace=force|nl_cpp_ldef_brace=not_defined
-ChoicesReadable="(515)Ignore Nl Cpp Ldef Brace|(515)Add Nl Cpp Ldef Brace|(515)Remove Nl Cpp Ldef Brace|(515)Force Nl Cpp Ldef Brace"
+ChoicesReadable="Ignore Nl Cpp Ldef Brace|Add Nl Cpp Ldef Brace|Remove Nl Cpp Ldef Brace|Force Nl Cpp Ldef Brace"
 ValueDefault=ignore
 
 [Nl Return Expr]
 Category=3
-Description="<html>(516)Add or remove newline between 'return' and the return expression.</html>"
+Description="<html>Add or remove newline between 'return' and the return expression.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_return_expr=ignore|nl_return_expr=add|nl_return_expr=remove|nl_return_expr=force|nl_return_expr=not_defined
-ChoicesReadable="(516)Ignore Nl Return Expr|(516)Add Nl Return Expr|(516)Remove Nl Return Expr|(516)Force Nl Return Expr"
+ChoicesReadable="Ignore Nl Return Expr|Add Nl Return Expr|Remove Nl Return Expr|Force Nl Return Expr"
 ValueDefault=ignore
 
 [Nl Throw Expr]
 Category=3
-Description="<html>(517)Add or remove newline between 'throw' and the throw expression.</html>"
+Description="<html>Add or remove newline between 'throw' and the throw expression.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_throw_expr=ignore|nl_throw_expr=add|nl_throw_expr=remove|nl_throw_expr=force|nl_throw_expr=not_defined
-ChoicesReadable="(517)Ignore Nl Throw Expr|(517)Add Nl Throw Expr|(517)Remove Nl Throw Expr|(517)Force Nl Throw Expr"
+ChoicesReadable="Ignore Nl Throw Expr|Add Nl Throw Expr|Remove Nl Throw Expr|Force Nl Throw Expr"
 ValueDefault=ignore
 
 [Nl After Semicolon]
 Category=3
-Description="<html>(518)Whether to add a newline after semicolons, except in 'for' statements.</html>"
+Description="<html>Whether to add a newline after semicolons, except in 'for' statements.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_semicolon=true|nl_after_semicolon=false
@@ -4609,43 +4609,43 @@ ValueDefault=false
 
 [Nl Paren Dbrace Open]
 Category=3
-Description="<html>(519)(Java) Add or remove newline between the ')' and '{{' of the double brace<br/>initializer.</html>"
+Description="<html>(Java) Add or remove newline between the ')' and '{{' of the double brace<br/>initializer.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_paren_dbrace_open=ignore|nl_paren_dbrace_open=add|nl_paren_dbrace_open=remove|nl_paren_dbrace_open=force|nl_paren_dbrace_open=not_defined
-ChoicesReadable="(519)Ignore Nl Paren Dbrace Open|(519)Add Nl Paren Dbrace Open|(519)Remove Nl Paren Dbrace Open|(519)Force Nl Paren Dbrace Open"
+ChoicesReadable="Ignore Nl Paren Dbrace Open|Add Nl Paren Dbrace Open|Remove Nl Paren Dbrace Open|Force Nl Paren Dbrace Open"
 ValueDefault=ignore
 
 [Nl Type Brace Init Lst]
 Category=3
-Description="<html>(520)Whether to add a newline after the type in an unnamed temporary<br/>direct-list-initialization, better:<br/>before a direct-list-initialization.</html>"
+Description="<html>Whether to add a newline after the type in an unnamed temporary<br/>direct-list-initialization, better:<br/>before a direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_type_brace_init_lst=ignore|nl_type_brace_init_lst=add|nl_type_brace_init_lst=remove|nl_type_brace_init_lst=force|nl_type_brace_init_lst=not_defined
-ChoicesReadable="(520)Ignore Nl Type Brace Init Lst|(520)Add Nl Type Brace Init Lst|(520)Remove Nl Type Brace Init Lst|(520)Force Nl Type Brace Init Lst"
+ChoicesReadable="Ignore Nl Type Brace Init Lst|Add Nl Type Brace Init Lst|Remove Nl Type Brace Init Lst|Force Nl Type Brace Init Lst"
 ValueDefault=ignore
 
 [Nl Type Brace Init Lst Open]
 Category=3
-Description="<html>(521)Whether to add a newline after the open brace in an unnamed temporary<br/>direct-list-initialization.</html>"
+Description="<html>Whether to add a newline after the open brace in an unnamed temporary<br/>direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_type_brace_init_lst_open=ignore|nl_type_brace_init_lst_open=add|nl_type_brace_init_lst_open=remove|nl_type_brace_init_lst_open=force|nl_type_brace_init_lst_open=not_defined
-ChoicesReadable="(521)Ignore Nl Type Brace Init Lst Open|(521)Add Nl Type Brace Init Lst Open|(521)Remove Nl Type Brace Init Lst Open|(521)Force Nl Type Brace Init Lst Open"
+ChoicesReadable="Ignore Nl Type Brace Init Lst Open|Add Nl Type Brace Init Lst Open|Remove Nl Type Brace Init Lst Open|Force Nl Type Brace Init Lst Open"
 ValueDefault=ignore
 
 [Nl Type Brace Init Lst Close]
 Category=3
-Description="<html>(522)Whether to add a newline before the close brace in an unnamed temporary<br/>direct-list-initialization.</html>"
+Description="<html>Whether to add a newline before the close brace in an unnamed temporary<br/>direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_type_brace_init_lst_close=ignore|nl_type_brace_init_lst_close=add|nl_type_brace_init_lst_close=remove|nl_type_brace_init_lst_close=force|nl_type_brace_init_lst_close=not_defined
-ChoicesReadable="(522)Ignore Nl Type Brace Init Lst Close|(522)Add Nl Type Brace Init Lst Close|(522)Remove Nl Type Brace Init Lst Close|(522)Force Nl Type Brace Init Lst Close"
+ChoicesReadable="Ignore Nl Type Brace Init Lst Close|Add Nl Type Brace Init Lst Close|Remove Nl Type Brace Init Lst Close|Force Nl Type Brace Init Lst Close"
 ValueDefault=ignore
 
 [Nl Before Brace Open]
 Category=3
-Description="<html>(523)Whether to add a newline before '{'.</html>"
+Description="<html>Whether to add a newline before '{'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_before_brace_open=true|nl_before_brace_open=false
@@ -4653,7 +4653,7 @@ ValueDefault=false
 
 [Nl After Brace Open]
 Category=3
-Description="<html>(524)Whether to add a newline after '{'.</html>"
+Description="<html>Whether to add a newline after '{'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_brace_open=true|nl_after_brace_open=false
@@ -4661,7 +4661,7 @@ ValueDefault=false
 
 [Nl After Brace Open Cmt]
 Category=3
-Description="<html>(525)Whether to add a newline between the open brace and a trailing single-line<br/>comment. Requires nl_after_brace_open=true.</html>"
+Description="<html>Whether to add a newline between the open brace and a trailing single-line<br/>comment. Requires nl_after_brace_open=true.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_brace_open_cmt=true|nl_after_brace_open_cmt=false
@@ -4669,7 +4669,7 @@ ValueDefault=false
 
 [Nl After Vbrace Open]
 Category=3
-Description="<html>(526)Whether to add a newline after a virtual brace open with a non-empty body.<br/>These occur in un-braced if/while/do/for statement bodies.</html>"
+Description="<html>Whether to add a newline after a virtual brace open with a non-empty body.<br/>These occur in un-braced if/while/do/for statement bodies.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_vbrace_open=true|nl_after_vbrace_open=false
@@ -4677,7 +4677,7 @@ ValueDefault=false
 
 [Nl After Vbrace Open Empty]
 Category=3
-Description="<html>(527)Whether to add a newline after a virtual brace open with an empty body.<br/>These occur in un-braced if/while/do/for statement bodies.</html>"
+Description="<html>Whether to add a newline after a virtual brace open with an empty body.<br/>These occur in un-braced if/while/do/for statement bodies.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_vbrace_open_empty=true|nl_after_vbrace_open_empty=false
@@ -4685,7 +4685,7 @@ ValueDefault=false
 
 [Nl After Brace Close]
 Category=3
-Description="<html>(528)Whether to add a newline after '}'. Does not apply if followed by a<br/>necessary ';'.</html>"
+Description="<html>Whether to add a newline after '}'. Does not apply if followed by a<br/>necessary ';'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_brace_close=true|nl_after_brace_close=false
@@ -4693,7 +4693,7 @@ ValueDefault=false
 
 [Nl After Vbrace Close]
 Category=3
-Description="<html>(529)Whether to add a newline after a virtual brace close,<br/>as in 'if (foo) a++; &lt;here&gt; return;'.</html>"
+Description="<html>Whether to add a newline after a virtual brace close,<br/>as in 'if (foo) a++; &lt;here&gt; return;'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_vbrace_close=true|nl_after_vbrace_close=false
@@ -4701,16 +4701,16 @@ ValueDefault=false
 
 [Nl Brace Struct Var]
 Category=3
-Description="<html>(530)Add or remove newline between the close brace and identifier,<br/>as in 'struct { int a; } &lt;here&gt; b;'. Affects enumerations, unions and<br/>structures. If set to ignore, uses nl_after_brace_close.</html>"
+Description="<html>Add or remove newline between the close brace and identifier,<br/>as in 'struct { int a; } &lt;here&gt; b;'. Affects enumerations, unions and<br/>structures. If set to ignore, uses nl_after_brace_close.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_brace_struct_var=ignore|nl_brace_struct_var=add|nl_brace_struct_var=remove|nl_brace_struct_var=force|nl_brace_struct_var=not_defined
-ChoicesReadable="(530)Ignore Nl Brace Struct Var|(530)Add Nl Brace Struct Var|(530)Remove Nl Brace Struct Var|(530)Force Nl Brace Struct Var"
+ChoicesReadable="Ignore Nl Brace Struct Var|Add Nl Brace Struct Var|Remove Nl Brace Struct Var|Force Nl Brace Struct Var"
 ValueDefault=ignore
 
 [Nl Define Macro]
 Category=3
-Description="<html>(531)Whether to alter newlines in '#define' macros.</html>"
+Description="<html>Whether to alter newlines in '#define' macros.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_define_macro=true|nl_define_macro=false
@@ -4718,7 +4718,7 @@ ValueDefault=false
 
 [Nl Squeeze Paren Close]
 Category=3
-Description="<html>(532)Whether to alter newlines between consecutive parenthesis closes. The number<br/>of closing parentheses in a line will depend on respective open parenthesis<br/>lines.</html>"
+Description="<html>Whether to alter newlines between consecutive parenthesis closes. The number<br/>of closing parentheses in a line will depend on respective open parenthesis<br/>lines.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_squeeze_paren_close=true|nl_squeeze_paren_close=false
@@ -4726,7 +4726,7 @@ ValueDefault=false
 
 [Nl Squeeze Ifdef]
 Category=3
-Description="<html>(533)Whether to remove blanks after '#ifxx' and '#elxx', or before '#elxx' and<br/>'#endif'. Does not affect top-level #ifdefs.</html>"
+Description="<html>Whether to remove blanks after '#ifxx' and '#elxx', or before '#elxx' and<br/>'#endif'. Does not affect top-level #ifdefs.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_squeeze_ifdef=true|nl_squeeze_ifdef=false
@@ -4734,7 +4734,7 @@ ValueDefault=false
 
 [Nl Squeeze Ifdef Top Level]
 Category=3
-Description="<html>(534)Makes the nl_squeeze_ifdef option affect the top-level #ifdefs as well.</html>"
+Description="<html>Makes the nl_squeeze_ifdef option affect the top-level #ifdefs as well.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_squeeze_ifdef_top_level=true|nl_squeeze_ifdef_top_level=false
@@ -4742,115 +4742,115 @@ ValueDefault=false
 
 [Nl Before If]
 Category=3
-Description="<html>(535)Add or remove blank line before 'if'.</html>"
+Description="<html>Add or remove blank line before 'if'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_before_if=ignore|nl_before_if=add|nl_before_if=remove|nl_before_if=force|nl_before_if=not_defined
-ChoicesReadable="(535)Ignore Nl Before If|(535)Add Nl Before If|(535)Remove Nl Before If|(535)Force Nl Before If"
+ChoicesReadable="Ignore Nl Before If|Add Nl Before If|Remove Nl Before If|Force Nl Before If"
 ValueDefault=ignore
 
 [Nl After If]
 Category=3
-Description="<html>(536)Add or remove blank line after 'if' statement. Add/Force work only if the<br/>next token is not a closing brace.</html>"
+Description="<html>Add or remove blank line after 'if' statement. Add/Force work only if the<br/>next token is not a closing brace.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_after_if=ignore|nl_after_if=add|nl_after_if=remove|nl_after_if=force|nl_after_if=not_defined
-ChoicesReadable="(536)Ignore Nl After If|(536)Add Nl After If|(536)Remove Nl After If|(536)Force Nl After If"
+ChoicesReadable="Ignore Nl After If|Add Nl After If|Remove Nl After If|Force Nl After If"
 ValueDefault=ignore
 
 [Nl Before For]
 Category=3
-Description="<html>(537)Add or remove blank line before 'for'.</html>"
+Description="<html>Add or remove blank line before 'for'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_before_for=ignore|nl_before_for=add|nl_before_for=remove|nl_before_for=force|nl_before_for=not_defined
-ChoicesReadable="(537)Ignore Nl Before For|(537)Add Nl Before For|(537)Remove Nl Before For|(537)Force Nl Before For"
+ChoicesReadable="Ignore Nl Before For|Add Nl Before For|Remove Nl Before For|Force Nl Before For"
 ValueDefault=ignore
 
 [Nl After For]
 Category=3
-Description="<html>(538)Add or remove blank line after 'for' statement.</html>"
+Description="<html>Add or remove blank line after 'for' statement.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_after_for=ignore|nl_after_for=add|nl_after_for=remove|nl_after_for=force|nl_after_for=not_defined
-ChoicesReadable="(538)Ignore Nl After For|(538)Add Nl After For|(538)Remove Nl After For|(538)Force Nl After For"
+ChoicesReadable="Ignore Nl After For|Add Nl After For|Remove Nl After For|Force Nl After For"
 ValueDefault=ignore
 
 [Nl Before While]
 Category=3
-Description="<html>(539)Add or remove blank line before 'while'.</html>"
+Description="<html>Add or remove blank line before 'while'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_before_while=ignore|nl_before_while=add|nl_before_while=remove|nl_before_while=force|nl_before_while=not_defined
-ChoicesReadable="(539)Ignore Nl Before While|(539)Add Nl Before While|(539)Remove Nl Before While|(539)Force Nl Before While"
+ChoicesReadable="Ignore Nl Before While|Add Nl Before While|Remove Nl Before While|Force Nl Before While"
 ValueDefault=ignore
 
 [Nl After While]
 Category=3
-Description="<html>(540)Add or remove blank line after 'while' statement.</html>"
+Description="<html>Add or remove blank line after 'while' statement.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_after_while=ignore|nl_after_while=add|nl_after_while=remove|nl_after_while=force|nl_after_while=not_defined
-ChoicesReadable="(540)Ignore Nl After While|(540)Add Nl After While|(540)Remove Nl After While|(540)Force Nl After While"
+ChoicesReadable="Ignore Nl After While|Add Nl After While|Remove Nl After While|Force Nl After While"
 ValueDefault=ignore
 
 [Nl Before Switch]
 Category=3
-Description="<html>(541)Add or remove blank line before 'switch'.</html>"
+Description="<html>Add or remove blank line before 'switch'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_before_switch=ignore|nl_before_switch=add|nl_before_switch=remove|nl_before_switch=force|nl_before_switch=not_defined
-ChoicesReadable="(541)Ignore Nl Before Switch|(541)Add Nl Before Switch|(541)Remove Nl Before Switch|(541)Force Nl Before Switch"
+ChoicesReadable="Ignore Nl Before Switch|Add Nl Before Switch|Remove Nl Before Switch|Force Nl Before Switch"
 ValueDefault=ignore
 
 [Nl After Switch]
 Category=3
-Description="<html>(542)Add or remove blank line after 'switch' statement.</html>"
+Description="<html>Add or remove blank line after 'switch' statement.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_after_switch=ignore|nl_after_switch=add|nl_after_switch=remove|nl_after_switch=force|nl_after_switch=not_defined
-ChoicesReadable="(542)Ignore Nl After Switch|(542)Add Nl After Switch|(542)Remove Nl After Switch|(542)Force Nl After Switch"
+ChoicesReadable="Ignore Nl After Switch|Add Nl After Switch|Remove Nl After Switch|Force Nl After Switch"
 ValueDefault=ignore
 
 [Nl Before Synchronized]
 Category=3
-Description="<html>(543)Add or remove blank line before 'synchronized'.</html>"
+Description="<html>Add or remove blank line before 'synchronized'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_before_synchronized=ignore|nl_before_synchronized=add|nl_before_synchronized=remove|nl_before_synchronized=force|nl_before_synchronized=not_defined
-ChoicesReadable="(543)Ignore Nl Before Synchronized|(543)Add Nl Before Synchronized|(543)Remove Nl Before Synchronized|(543)Force Nl Before Synchronized"
+ChoicesReadable="Ignore Nl Before Synchronized|Add Nl Before Synchronized|Remove Nl Before Synchronized|Force Nl Before Synchronized"
 ValueDefault=ignore
 
 [Nl After Synchronized]
 Category=3
-Description="<html>(544)Add or remove blank line after 'synchronized' statement.</html>"
+Description="<html>Add or remove blank line after 'synchronized' statement.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_after_synchronized=ignore|nl_after_synchronized=add|nl_after_synchronized=remove|nl_after_synchronized=force|nl_after_synchronized=not_defined
-ChoicesReadable="(544)Ignore Nl After Synchronized|(544)Add Nl After Synchronized|(544)Remove Nl After Synchronized|(544)Force Nl After Synchronized"
+ChoicesReadable="Ignore Nl After Synchronized|Add Nl After Synchronized|Remove Nl After Synchronized|Force Nl After Synchronized"
 ValueDefault=ignore
 
 [Nl Before Do]
 Category=3
-Description="<html>(545)Add or remove blank line before 'do'.</html>"
+Description="<html>Add or remove blank line before 'do'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_before_do=ignore|nl_before_do=add|nl_before_do=remove|nl_before_do=force|nl_before_do=not_defined
-ChoicesReadable="(545)Ignore Nl Before Do|(545)Add Nl Before Do|(545)Remove Nl Before Do|(545)Force Nl Before Do"
+ChoicesReadable="Ignore Nl Before Do|Add Nl Before Do|Remove Nl Before Do|Force Nl Before Do"
 ValueDefault=ignore
 
 [Nl After Do]
 Category=3
-Description="<html>(546)Add or remove blank line after 'do/while' statement.</html>"
+Description="<html>Add or remove blank line after 'do/while' statement.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_after_do=ignore|nl_after_do=add|nl_after_do=remove|nl_after_do=force|nl_after_do=not_defined
-ChoicesReadable="(546)Ignore Nl After Do|(546)Add Nl After Do|(546)Remove Nl After Do|(546)Force Nl After Do"
+ChoicesReadable="Ignore Nl After Do|Add Nl After Do|Remove Nl After Do|Force Nl After Do"
 ValueDefault=ignore
 
 [Nl Before Ignore After Case]
 Category=3
-Description="<html>(547)Ignore nl_before_{if,for,switch,do,synchronized} if the control<br/>statement is immediately after a case statement.<br/>if nl_before_{if,for,switch,do} is set to remove, this option<br/>does nothing.</html>"
+Description="<html>Ignore nl_before_{if,for,switch,do,synchronized} if the control<br/>statement is immediately after a case statement.<br/>if nl_before_{if,for,switch,do} is set to remove, this option<br/>does nothing.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_before_ignore_after_case=true|nl_before_ignore_after_case=false
@@ -4858,7 +4858,7 @@ ValueDefault=false
 
 [Nl Before Return]
 Category=3
-Description="<html>(548)Whether to put a blank line before 'return' statements, unless after an open<br/>brace.</html>"
+Description="<html>Whether to put a blank line before 'return' statements, unless after an open<br/>brace.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_before_return=true|nl_before_return=false
@@ -4866,7 +4866,7 @@ ValueDefault=false
 
 [Nl After Return]
 Category=3
-Description="<html>(549)Whether to put a blank line after 'return' statements, unless followed by a<br/>close brace.</html>"
+Description="<html>Whether to put a blank line after 'return' statements, unless followed by a<br/>close brace.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_return=true|nl_after_return=false
@@ -4874,25 +4874,25 @@ ValueDefault=false
 
 [Nl Before Member]
 Category=3
-Description="<html>(550)Whether to put a blank line before a member '.' or '-&gt;' operators.</html>"
+Description="<html>Whether to put a blank line before a member '.' or '-&gt;' operators.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_before_member=ignore|nl_before_member=add|nl_before_member=remove|nl_before_member=force|nl_before_member=not_defined
-ChoicesReadable="(550)Ignore Nl Before Member|(550)Add Nl Before Member|(550)Remove Nl Before Member|(550)Force Nl Before Member"
+ChoicesReadable="Ignore Nl Before Member|Add Nl Before Member|Remove Nl Before Member|Force Nl Before Member"
 ValueDefault=ignore
 
 [Nl After Member]
 Category=3
-Description="<html>(551)(Java) Whether to put a blank line after a member '.' or '-&gt;' operators.</html>"
+Description="<html>(Java) Whether to put a blank line after a member '.' or '-&gt;' operators.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_after_member=ignore|nl_after_member=add|nl_after_member=remove|nl_after_member=force|nl_after_member=not_defined
-ChoicesReadable="(551)Ignore Nl After Member|(551)Add Nl After Member|(551)Remove Nl After Member|(551)Force Nl After Member"
+ChoicesReadable="Ignore Nl After Member|Add Nl After Member|Remove Nl After Member|Force Nl After Member"
 ValueDefault=ignore
 
 [Nl Ds Struct Enum Cmt]
 Category=3
-Description="<html>(552)Whether to double-space commented-entries in 'struct'/'union'/'enum'.</html>"
+Description="<html>Whether to double-space commented-entries in 'struct'/'union'/'enum'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_ds_struct_enum_cmt=true|nl_ds_struct_enum_cmt=false
@@ -4900,7 +4900,7 @@ ValueDefault=false
 
 [Nl Ds Struct Enum Close Brace]
 Category=3
-Description="<html>(553)Whether to force a newline before '}' of a 'struct'/'union'/'enum'.<br/>(Lower priority than eat_blanks_before_close_brace.)</html>"
+Description="<html>Whether to force a newline before '}' of a 'struct'/'union'/'enum'.<br/>(Lower priority than eat_blanks_before_close_brace.)</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_ds_struct_enum_close_brace=true|nl_ds_struct_enum_close_brace=false
@@ -4908,25 +4908,25 @@ ValueDefault=false
 
 [Nl Class Colon]
 Category=3
-Description="<html>(554)Add or remove newline before or after (depending on pos_class_colon) a class<br/>colon, as in 'class Foo &lt;here&gt; : &lt;or here&gt; public Bar'.</html>"
+Description="<html>Add or remove newline before or after (depending on pos_class_colon) a class<br/>colon, as in 'class Foo &lt;here&gt; : &lt;or here&gt; public Bar'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_class_colon=ignore|nl_class_colon=add|nl_class_colon=remove|nl_class_colon=force|nl_class_colon=not_defined
-ChoicesReadable="(554)Ignore Nl Class Colon|(554)Add Nl Class Colon|(554)Remove Nl Class Colon|(554)Force Nl Class Colon"
+ChoicesReadable="Ignore Nl Class Colon|Add Nl Class Colon|Remove Nl Class Colon|Force Nl Class Colon"
 ValueDefault=ignore
 
 [Nl Constr Colon]
 Category=3
-Description="<html>(555)Add or remove newline around a class constructor colon. The exact position<br/>depends on nl_constr_init_args, pos_constr_colon and pos_constr_comma.</html>"
+Description="<html>Add or remove newline around a class constructor colon. The exact position<br/>depends on nl_constr_init_args, pos_constr_colon and pos_constr_comma.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_constr_colon=ignore|nl_constr_colon=add|nl_constr_colon=remove|nl_constr_colon=force|nl_constr_colon=not_defined
-ChoicesReadable="(555)Ignore Nl Constr Colon|(555)Add Nl Constr Colon|(555)Remove Nl Constr Colon|(555)Force Nl Constr Colon"
+ChoicesReadable="Ignore Nl Constr Colon|Add Nl Constr Colon|Remove Nl Constr Colon|Force Nl Constr Colon"
 ValueDefault=ignore
 
 [Nl Namespace Two To One Liner]
 Category=3
-Description="<html>(556)Whether to collapse a two-line namespace, like 'namespace foo\n{ decl; }'<br/>into a single line. If true, prevents other brace newline rules from turning<br/>such code into four lines. If true, it also preserves one-liner namespaces.</html>"
+Description="<html>Whether to collapse a two-line namespace, like 'namespace foo\n{ decl; }'<br/>into a single line. If true, prevents other brace newline rules from turning<br/>such code into four lines. If true, it also preserves one-liner namespaces.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_namespace_two_to_one_liner=true|nl_namespace_two_to_one_liner=false
@@ -4934,7 +4934,7 @@ ValueDefault=false
 
 [Nl Create If One Liner]
 Category=3
-Description="<html>(557)Whether to remove a newline in simple unbraced if statements, turning them<br/>into one-liners, as in 'if(b)\n i++;' =&gt; 'if(b) i++;'.</html>"
+Description="<html>Whether to remove a newline in simple unbraced if statements, turning them<br/>into one-liners, as in 'if(b)\n i++;' =&gt; 'if(b) i++;'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_create_if_one_liner=true|nl_create_if_one_liner=false
@@ -4942,7 +4942,7 @@ ValueDefault=false
 
 [Nl Create For One Liner]
 Category=3
-Description="<html>(558)Whether to remove a newline in simple unbraced for statements, turning them<br/>into one-liners, as in 'for (...)\n stmt;' =&gt; 'for (...) stmt;'.</html>"
+Description="<html>Whether to remove a newline in simple unbraced for statements, turning them<br/>into one-liners, as in 'for (...)\n stmt;' =&gt; 'for (...) stmt;'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_create_for_one_liner=true|nl_create_for_one_liner=false
@@ -4950,7 +4950,7 @@ ValueDefault=false
 
 [Nl Create While One Liner]
 Category=3
-Description="<html>(559)Whether to remove a newline in simple unbraced while statements, turning<br/>them into one-liners, as in 'while (expr)\n stmt;' =&gt; 'while (expr) stmt;'.</html>"
+Description="<html>Whether to remove a newline in simple unbraced while statements, turning<br/>them into one-liners, as in 'while (expr)\n stmt;' =&gt; 'while (expr) stmt;'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_create_while_one_liner=true|nl_create_while_one_liner=false
@@ -4958,7 +4958,7 @@ ValueDefault=false
 
 [Nl Create Func Def One Liner]
 Category=3
-Description="<html>(560)Whether to collapse a function definition whose body (not counting braces)<br/>is only one line so that the entire definition (prototype, braces, body) is<br/>a single line.</html>"
+Description="<html>Whether to collapse a function definition whose body (not counting braces)<br/>is only one line so that the entire definition (prototype, braces, body) is<br/>a single line.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_create_func_def_one_liner=true|nl_create_func_def_one_liner=false
@@ -4966,7 +4966,7 @@ ValueDefault=false
 
 [Nl Create List One Liner]
 Category=3
-Description="<html>(561)Whether to split one-line simple list definitions into three lines by<br/>adding newlines, as in 'int a[12] = { &lt;here&gt; 0 &lt;here&gt; };'.</html>"
+Description="<html>Whether to split one-line simple list definitions into three lines by<br/>adding newlines, as in 'int a[12] = { &lt;here&gt; 0 &lt;here&gt; };'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_create_list_one_liner=true|nl_create_list_one_liner=false
@@ -4974,7 +4974,7 @@ ValueDefault=false
 
 [Nl Split If One Liner]
 Category=3
-Description="<html>(562)Whether to split one-line simple unbraced if statements into two lines by<br/>adding a newline, as in 'if(b) &lt;here&gt; i++;'.</html>"
+Description="<html>Whether to split one-line simple unbraced if statements into two lines by<br/>adding a newline, as in 'if(b) &lt;here&gt; i++;'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_split_if_one_liner=true|nl_split_if_one_liner=false
@@ -4982,7 +4982,7 @@ ValueDefault=false
 
 [Nl Split For One Liner]
 Category=3
-Description="<html>(563)Whether to split one-line simple unbraced for statements into two lines by<br/>adding a newline, as in 'for (...) &lt;here&gt; stmt;'.</html>"
+Description="<html>Whether to split one-line simple unbraced for statements into two lines by<br/>adding a newline, as in 'for (...) &lt;here&gt; stmt;'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_split_for_one_liner=true|nl_split_for_one_liner=false
@@ -4990,7 +4990,7 @@ ValueDefault=false
 
 [Nl Split While One Liner]
 Category=3
-Description="<html>(564)Whether to split one-line simple unbraced while statements into two lines by<br/>adding a newline, as in 'while (expr) &lt;here&gt; stmt;'.</html>"
+Description="<html>Whether to split one-line simple unbraced while statements into two lines by<br/>adding a newline, as in 'while (expr) &lt;here&gt; stmt;'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_split_while_one_liner=true|nl_split_while_one_liner=false
@@ -4998,7 +4998,7 @@ ValueDefault=false
 
 [Donot Add Nl Before Cpp Comment]
 Category=3
-Description="<html>(565)Don't add a newline before a cpp-comment in a parameter list of a function<br/>call.</html>"
+Description="<html>Don't add a newline before a cpp-comment in a parameter list of a function<br/>call.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=donot_add_nl_before_cpp_comment=true|donot_add_nl_before_cpp_comment=false
@@ -5006,7 +5006,7 @@ ValueDefault=false
 
 [Nl Max]
 Category=4
-Description="<html>(566)The maximum number of consecutive newlines (3 = 2 blank lines).</html>"
+Description="<html>The maximum number of consecutive newlines (3 = 2 blank lines).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_max="
@@ -5016,7 +5016,7 @@ ValueDefault=0
 
 [Nl Max Blank In Func]
 Category=4
-Description="<html>(567)The maximum number of consecutive newlines in a function.</html>"
+Description="<html>The maximum number of consecutive newlines in a function.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_max_blank_in_func="
@@ -5026,7 +5026,7 @@ ValueDefault=0
 
 [Nl Inside Empty Func]
 Category=4
-Description="<html>(568)The number of newlines inside an empty function body.<br/>This option overrides eat_blanks_after_open_brace and<br/>eat_blanks_before_close_brace, but is ignored when<br/>nl_collapse_empty_body_functions=true</html>"
+Description="<html>The number of newlines inside an empty function body.<br/>This option overrides eat_blanks_after_open_brace and<br/>eat_blanks_before_close_brace, but is ignored when<br/>nl_collapse_empty_body_functions=true</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_inside_empty_func="
@@ -5036,7 +5036,7 @@ ValueDefault=0
 
 [Nl Before Func Body Proto]
 Category=4
-Description="<html>(569)The number of newlines before a function prototype.</html>"
+Description="<html>The number of newlines before a function prototype.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_before_func_body_proto="
@@ -5046,7 +5046,7 @@ ValueDefault=0
 
 [Nl Before Func Body Def]
 Category=4
-Description="<html>(570)The number of newlines before a multi-line function definition. Where<br/>applicable, this option is overridden with eat_blanks_after_open_brace=true</html>"
+Description="<html>The number of newlines before a multi-line function definition. Where<br/>applicable, this option is overridden with eat_blanks_after_open_brace=true</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_before_func_body_def="
@@ -5056,7 +5056,7 @@ ValueDefault=0
 
 [Nl Before Func Class Proto]
 Category=4
-Description="<html>(571)The number of newlines before a class constructor/destructor prototype.</html>"
+Description="<html>The number of newlines before a class constructor/destructor prototype.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_before_func_class_proto="
@@ -5066,7 +5066,7 @@ ValueDefault=0
 
 [Nl Before Func Class Def]
 Category=4
-Description="<html>(572)The number of newlines before a class constructor/destructor definition.</html>"
+Description="<html>The number of newlines before a class constructor/destructor definition.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_before_func_class_def="
@@ -5076,7 +5076,7 @@ ValueDefault=0
 
 [Nl After Func Proto]
 Category=4
-Description="<html>(573)The number of newlines after a function prototype.</html>"
+Description="<html>The number of newlines after a function prototype.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_after_func_proto="
@@ -5086,7 +5086,7 @@ ValueDefault=0
 
 [Nl After Func Proto Group]
 Category=4
-Description="<html>(574)The number of newlines after a function prototype, if not followed by<br/>another function prototype.</html>"
+Description="<html>The number of newlines after a function prototype, if not followed by<br/>another function prototype.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_after_func_proto_group="
@@ -5096,7 +5096,7 @@ ValueDefault=0
 
 [Nl After Func Class Proto]
 Category=4
-Description="<html>(575)The number of newlines after a class constructor/destructor prototype.</html>"
+Description="<html>The number of newlines after a class constructor/destructor prototype.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_after_func_class_proto="
@@ -5106,7 +5106,7 @@ ValueDefault=0
 
 [Nl After Func Class Proto Group]
 Category=4
-Description="<html>(576)The number of newlines after a class constructor/destructor prototype,<br/>if not followed by another constructor/destructor prototype.</html>"
+Description="<html>The number of newlines after a class constructor/destructor prototype,<br/>if not followed by another constructor/destructor prototype.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_after_func_class_proto_group="
@@ -5116,7 +5116,7 @@ ValueDefault=0
 
 [Nl Class Leave One Liner Groups]
 Category=4
-Description="<html>(577)Whether one-line method definitions inside a class body should be treated<br/>as if they were prototypes for the purposes of adding newlines.<br/><br/>Requires nl_class_leave_one_liners=true. Overrides nl_before_func_body_def<br/>and nl_before_func_class_def for one-liners.</html>"
+Description="<html>Whether one-line method definitions inside a class body should be treated<br/>as if they were prototypes for the purposes of adding newlines.<br/><br/>Requires nl_class_leave_one_liners=true. Overrides nl_before_func_body_def<br/>and nl_before_func_class_def for one-liners.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_class_leave_one_liner_groups=true|nl_class_leave_one_liner_groups=false
@@ -5124,7 +5124,7 @@ ValueDefault=false
 
 [Nl After Func Body]
 Category=4
-Description="<html>(578)The number of newlines after '}' of a multi-line function body.</html>"
+Description="<html>The number of newlines after '}' of a multi-line function body.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_after_func_body="
@@ -5134,7 +5134,7 @@ ValueDefault=0
 
 [Nl After Func Body Class]
 Category=4
-Description="<html>(579)The number of newlines after '}' of a multi-line function body in a class<br/>declaration. Also affects class constructors/destructors.<br/><br/>Overrides nl_after_func_body.</html>"
+Description="<html>The number of newlines after '}' of a multi-line function body in a class<br/>declaration. Also affects class constructors/destructors.<br/><br/>Overrides nl_after_func_body.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_after_func_body_class="
@@ -5144,7 +5144,7 @@ ValueDefault=0
 
 [Nl After Func Body One Liner]
 Category=4
-Description="<html>(580)The number of newlines after '}' of a single line function body. Also<br/>affects class constructors/destructors.<br/><br/>Overrides nl_after_func_body and nl_after_func_body_class.</html>"
+Description="<html>The number of newlines after '}' of a single line function body. Also<br/>affects class constructors/destructors.<br/><br/>Overrides nl_after_func_body and nl_after_func_body_class.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_after_func_body_one_liner="
@@ -5154,7 +5154,7 @@ ValueDefault=0
 
 [Nl Typedef Blk Start]
 Category=4
-Description="<html>(581)The number of newlines before a block of typedefs. If nl_after_access_spec<br/>is non-zero, that option takes precedence.<br/><br/>0: No change (default).</html>"
+Description="<html>The number of newlines before a block of typedefs. If nl_after_access_spec<br/>is non-zero, that option takes precedence.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_typedef_blk_start="
@@ -5164,7 +5164,7 @@ ValueDefault=0
 
 [Nl Typedef Blk End]
 Category=4
-Description="<html>(582)The number of newlines after a block of typedefs.<br/><br/>0: No change (default).</html>"
+Description="<html>The number of newlines after a block of typedefs.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_typedef_blk_end="
@@ -5174,7 +5174,7 @@ ValueDefault=0
 
 [Nl Typedef Blk In]
 Category=4
-Description="<html>(583)The maximum number of consecutive newlines within a block of typedefs.<br/><br/>0: No change (default).</html>"
+Description="<html>The maximum number of consecutive newlines within a block of typedefs.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_typedef_blk_in="
@@ -5184,7 +5184,7 @@ ValueDefault=0
 
 [Nl Var Def Blk End Func Top]
 Category=4
-Description="<html>(584)The minimum number of blank lines after a block of variable definitions<br/>at the top of a function body. If any preprocessor directives appear<br/>between the opening brace of the function and the variable block, then<br/>it is considered as not at the top of the function.Newlines are added<br/>before trailing preprocessor directives, if any exist.<br/><br/>0: No change (default).</html>"
+Description="<html>The minimum number of blank lines after a block of variable definitions<br/>at the top of a function body. If any preprocessor directives appear<br/>between the opening brace of the function and the variable block, then<br/>it is considered as not at the top of the function.Newlines are added<br/>before trailing preprocessor directives, if any exist.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_var_def_blk_end_func_top="
@@ -5194,7 +5194,7 @@ ValueDefault=0
 
 [Nl Var Def Blk Start]
 Category=4
-Description="<html>(585)The minimum number of empty newlines before a block of variable definitions<br/>not at the top of a function body. If nl_after_access_spec is non-zero,<br/>that option takes precedence. Newlines are not added at the top of the<br/>file or just after an opening brace. Newlines are added above any<br/>preprocessor directives before the block.<br/><br/>0: No change (default).</html>"
+Description="<html>The minimum number of empty newlines before a block of variable definitions<br/>not at the top of a function body. If nl_after_access_spec is non-zero,<br/>that option takes precedence. Newlines are not added at the top of the<br/>file or just after an opening brace. Newlines are added above any<br/>preprocessor directives before the block.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_var_def_blk_start="
@@ -5204,7 +5204,7 @@ ValueDefault=0
 
 [Nl Var Def Blk End]
 Category=4
-Description="<html>(586)The minimum number of empty newlines after a block of variable definitions<br/>not at the top of a function body. Newlines are not added if the block<br/>is at the bottom of the file or just before a preprocessor directive.<br/><br/>0: No change (default).</html>"
+Description="<html>The minimum number of empty newlines after a block of variable definitions<br/>not at the top of a function body. Newlines are not added if the block<br/>is at the bottom of the file or just before a preprocessor directive.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_var_def_blk_end="
@@ -5214,7 +5214,7 @@ ValueDefault=0
 
 [Nl Var Def Blk In]
 Category=4
-Description="<html>(587)The maximum number of consecutive newlines within a block of variable<br/>definitions.<br/><br/>0: No change (default).</html>"
+Description="<html>The maximum number of consecutive newlines within a block of variable<br/>definitions.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_var_def_blk_in="
@@ -5224,7 +5224,7 @@ ValueDefault=0
 
 [Nl Before Block Comment]
 Category=4
-Description="<html>(588)The minimum number of newlines before a multi-line comment.<br/>Doesn't apply if after a brace open or another multi-line comment.</html>"
+Description="<html>The minimum number of newlines before a multi-line comment.<br/>Doesn't apply if after a brace open or another multi-line comment.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_before_block_comment="
@@ -5234,7 +5234,7 @@ ValueDefault=0
 
 [Nl Before C Comment]
 Category=4
-Description="<html>(589)The minimum number of newlines before a single-line C comment.<br/>Doesn't apply if after a brace open or other single-line C comments.</html>"
+Description="<html>The minimum number of newlines before a single-line C comment.<br/>Doesn't apply if after a brace open or other single-line C comments.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_before_c_comment="
@@ -5244,7 +5244,7 @@ ValueDefault=0
 
 [Nl Before Cpp Comment]
 Category=4
-Description="<html>(590)The minimum number of newlines before a CPP comment.<br/>Doesn't apply if after a brace open or other CPP comments.</html>"
+Description="<html>The minimum number of newlines before a CPP comment.<br/>Doesn't apply if after a brace open or other CPP comments.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_before_cpp_comment="
@@ -5254,7 +5254,7 @@ ValueDefault=0
 
 [Nl After Multiline Comment]
 Category=4
-Description="<html>(591)Whether to force a newline after a multi-line comment.</html>"
+Description="<html>Whether to force a newline after a multi-line comment.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_multiline_comment=true|nl_after_multiline_comment=false
@@ -5262,7 +5262,7 @@ ValueDefault=false
 
 [Nl After Label Colon]
 Category=4
-Description="<html>(592)Whether to force a newline after a label's colon.</html>"
+Description="<html>Whether to force a newline after a label's colon.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_label_colon=true|nl_after_label_colon=false
@@ -5270,7 +5270,7 @@ ValueDefault=false
 
 [Nl Before Struct]
 Category=4
-Description="<html>(593)The number of newlines before a struct definition.</html>"
+Description="<html>The number of newlines before a struct definition.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_before_struct="
@@ -5280,7 +5280,7 @@ ValueDefault=0
 
 [Nl After Struct]
 Category=4
-Description="<html>(594)The number of newlines after '}' or ';' of a struct/enum/union definition.</html>"
+Description="<html>The number of newlines after '}' or ';' of a struct/enum/union definition.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_after_struct="
@@ -5290,7 +5290,7 @@ ValueDefault=0
 
 [Nl Before Class]
 Category=4
-Description="<html>(595)The number of newlines before a class definition.</html>"
+Description="<html>The number of newlines before a class definition.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_before_class="
@@ -5300,7 +5300,7 @@ ValueDefault=0
 
 [Nl After Class]
 Category=4
-Description="<html>(596)The number of newlines after '}' or ';' of a class definition.</html>"
+Description="<html>The number of newlines after '}' or ';' of a class definition.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_after_class="
@@ -5310,7 +5310,7 @@ ValueDefault=0
 
 [Nl Before Namespace]
 Category=4
-Description="<html>(597)The number of newlines before a namespace.</html>"
+Description="<html>The number of newlines before a namespace.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_before_namespace="
@@ -5320,7 +5320,7 @@ ValueDefault=0
 
 [Nl Inside Namespace]
 Category=4
-Description="<html>(598)The number of newlines after '{' of a namespace. This also adds newlines<br/>before the matching '}'.<br/><br/>0: Apply eat_blanks_after_open_brace or eat_blanks_before_close_brace if<br/>    applicable, otherwise no change.<br/><br/>Overrides eat_blanks_after_open_brace and eat_blanks_before_close_brace.</html>"
+Description="<html>The number of newlines after '{' of a namespace. This also adds newlines<br/>before the matching '}'.<br/><br/>0: Apply eat_blanks_after_open_brace or eat_blanks_before_close_brace if<br/>    applicable, otherwise no change.<br/><br/>Overrides eat_blanks_after_open_brace and eat_blanks_before_close_brace.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_inside_namespace="
@@ -5330,7 +5330,7 @@ ValueDefault=0
 
 [Nl After Namespace]
 Category=4
-Description="<html>(599)The number of newlines after '}' of a namespace.</html>"
+Description="<html>The number of newlines after '}' of a namespace.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_after_namespace="
@@ -5340,7 +5340,7 @@ ValueDefault=0
 
 [Nl Before Access Spec]
 Category=4
-Description="<html>(600)The number of newlines before an access specifier label. This also includes<br/>the Qt-specific 'signals:' and 'slots:'. Will not change the newline count<br/>if after a brace open.<br/><br/>0: No change (default).</html>"
+Description="<html>The number of newlines before an access specifier label. This also includes<br/>the Qt-specific 'signals:' and 'slots:'. Will not change the newline count<br/>if after a brace open.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_before_access_spec="
@@ -5350,7 +5350,7 @@ ValueDefault=0
 
 [Nl After Access Spec]
 Category=4
-Description="<html>(601)The number of newlines after an access specifier label. This also includes<br/>the Qt-specific 'signals:' and 'slots:'. Will not change the newline count<br/>if after a brace open.<br/><br/>0: No change (default).<br/><br/>Overrides nl_typedef_blk_start and nl_var_def_blk_start.</html>"
+Description="<html>The number of newlines after an access specifier label. This also includes<br/>the Qt-specific 'signals:' and 'slots:'. Will not change the newline count<br/>if after a brace open.<br/><br/>0: No change (default).<br/><br/>Overrides nl_typedef_blk_start and nl_var_def_blk_start.</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_after_access_spec="
@@ -5360,7 +5360,7 @@ ValueDefault=0
 
 [Nl Comment Func Def]
 Category=4
-Description="<html>(602)The number of newlines between a function definition and the function<br/>comment, as in '// comment\n &lt;here&gt; void foo() {...}'.<br/><br/>0: No change (default).</html>"
+Description="<html>The number of newlines between a function definition and the function<br/>comment, as in '// comment\n &lt;here&gt; void foo() {...}'.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_comment_func_def="
@@ -5370,7 +5370,7 @@ ValueDefault=0
 
 [Nl After Try Catch Finally]
 Category=4
-Description="<html>(603)The number of newlines after a try-catch-finally block that isn't followed<br/>by a brace close.<br/><br/>0: No change (default).</html>"
+Description="<html>The number of newlines after a try-catch-finally block that isn't followed<br/>by a brace close.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_after_try_catch_finally="
@@ -5380,7 +5380,7 @@ ValueDefault=0
 
 [Nl Around Cs Property]
 Category=4
-Description="<html>(604)(C#) The number of newlines before and after a property, indexer or event<br/>declaration.<br/><br/>0: No change (default).</html>"
+Description="<html>(C#) The number of newlines before and after a property, indexer or event<br/>declaration.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_around_cs_property="
@@ -5390,7 +5390,7 @@ ValueDefault=0
 
 [Nl Between Get Set]
 Category=4
-Description="<html>(605)(C#) The number of newlines between the get/set/add/remove handlers.<br/><br/>0: No change (default).</html>"
+Description="<html>(C#) The number of newlines between the get/set/add/remove handlers.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_between_get_set="
@@ -5400,16 +5400,16 @@ ValueDefault=0
 
 [Nl Property Brace]
 Category=4
-Description="<html>(606)(C#) Add or remove newline between property and the '{'.</html>"
+Description="<html>(C#) Add or remove newline between property and the '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_property_brace=ignore|nl_property_brace=add|nl_property_brace=remove|nl_property_brace=force|nl_property_brace=not_defined
-ChoicesReadable="(606)Ignore Nl Property Brace|(606)Add Nl Property Brace|(606)Remove Nl Property Brace|(606)Force Nl Property Brace"
+ChoicesReadable="Ignore Nl Property Brace|Add Nl Property Brace|Remove Nl Property Brace|Force Nl Property Brace"
 ValueDefault=ignore
 
 [Eat Blanks After Open Brace]
 Category=4
-Description="<html>(607)Whether to remove blank lines after '{'.</html>"
+Description="<html>Whether to remove blank lines after '{'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=eat_blanks_after_open_brace=true|eat_blanks_after_open_brace=false
@@ -5417,7 +5417,7 @@ ValueDefault=false
 
 [Eat Blanks Before Close Brace]
 Category=4
-Description="<html>(608)Whether to remove blank lines before '}'.</html>"
+Description="<html>Whether to remove blank lines before '}'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=eat_blanks_before_close_brace=true|eat_blanks_before_close_brace=false
@@ -5425,7 +5425,7 @@ ValueDefault=false
 
 [Nl Remove Extra Newlines]
 Category=4
-Description="<html>(609)How aggressively to remove extra newlines not in preprocessor.<br/><br/>0: No change (default)<br/>1: Remove most newlines not handled by other config<br/>2: Remove all newlines and reformat completely by config</html>"
+Description="<html>How aggressively to remove extra newlines not in preprocessor.<br/><br/>0: No change (default)<br/>1: Remove most newlines not handled by other config<br/>2: Remove all newlines and reformat completely by config</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_remove_extra_newlines="
@@ -5435,25 +5435,25 @@ ValueDefault=0
 
 [Nl After Annotation]
 Category=4
-Description="<html>(610)(Java) Add or remove newline after an annotation statement. Only affects<br/>annotations that are after a newline.</html>"
+Description="<html>(Java) Add or remove newline after an annotation statement. Only affects<br/>annotations that are after a newline.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_after_annotation=ignore|nl_after_annotation=add|nl_after_annotation=remove|nl_after_annotation=force|nl_after_annotation=not_defined
-ChoicesReadable="(610)Ignore Nl After Annotation|(610)Add Nl After Annotation|(610)Remove Nl After Annotation|(610)Force Nl After Annotation"
+ChoicesReadable="Ignore Nl After Annotation|Add Nl After Annotation|Remove Nl After Annotation|Force Nl After Annotation"
 ValueDefault=ignore
 
 [Nl Between Annotation]
 Category=4
-Description="<html>(611)(Java) Add or remove newline between two annotations.</html>"
+Description="<html>(Java) Add or remove newline between two annotations.</html>"
 Enabled=false
 EditorType=multiple
 Choices=nl_between_annotation=ignore|nl_between_annotation=add|nl_between_annotation=remove|nl_between_annotation=force|nl_between_annotation=not_defined
-ChoicesReadable="(611)Ignore Nl Between Annotation|(611)Add Nl Between Annotation|(611)Remove Nl Between Annotation|(611)Force Nl Between Annotation"
+ChoicesReadable="Ignore Nl Between Annotation|Add Nl Between Annotation|Remove Nl Between Annotation|Force Nl Between Annotation"
 ValueDefault=ignore
 
 [Nl Before Whole File Ifdef]
 Category=4
-Description="<html>(612)The number of newlines before a whole-file #ifdef.<br/><br/>0: No change (default).</html>"
+Description="<html>The number of newlines before a whole-file #ifdef.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_before_whole_file_ifdef="
@@ -5463,7 +5463,7 @@ ValueDefault=0
 
 [Nl After Whole File Ifdef]
 Category=4
-Description="<html>(613)The number of newlines after a whole-file #ifdef.<br/><br/>0: No change (default).</html>"
+Description="<html>The number of newlines after a whole-file #ifdef.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_after_whole_file_ifdef="
@@ -5473,7 +5473,7 @@ ValueDefault=0
 
 [Nl Before Whole File Endif]
 Category=4
-Description="<html>(614)The number of newlines before a whole-file #endif.<br/><br/>0: No change (default).</html>"
+Description="<html>The number of newlines before a whole-file #endif.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_before_whole_file_endif="
@@ -5483,7 +5483,7 @@ ValueDefault=0
 
 [Nl After Whole File Endif]
 Category=4
-Description="<html>(615)The number of newlines after a whole-file #endif.<br/><br/>0: No change (default).</html>"
+Description="<html>The number of newlines after a whole-file #endif.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="nl_after_whole_file_endif="
@@ -5493,115 +5493,115 @@ ValueDefault=0
 
 [Pos Arith]
 Category=5
-Description="<html>(616)The position of arithmetic operators in wrapped expressions.</html>"
+Description="<html>The position of arithmetic operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
 Choices=pos_arith=ignore|pos_arith=break|pos_arith=force|pos_arith=lead|pos_arith=trail|pos_arith=join|pos_arith=lead_break|pos_arith=lead_force|pos_arith=trail_break|pos_arith=trail_force
-ChoicesReadable="(616)Ignore Pos Arith|(616)Break Pos Arith|(616)Force Pos Arith|(616)Lead Pos Arith|(616)Trail Pos Arith|(616)Join Pos Arith|(616)Lead Break Pos Arith|(616)Lead Force Pos Arith|(616)Trail Break Pos Arith|(616)Trail Force Pos Arith"
+ChoicesReadable="Ignore Pos Arith|Break Pos Arith|Force Pos Arith|Lead Pos Arith|Trail Pos Arith|Join Pos Arith|Lead Break Pos Arith|Lead Force Pos Arith|Trail Break Pos Arith|Trail Force Pos Arith"
 ValueDefault=ignore
 
 [Pos Assign]
 Category=5
-Description="<html>(617)The position of assignment in wrapped expressions. Do not affect '='<br/>followed by '{'.</html>"
+Description="<html>The position of assignment in wrapped expressions. Do not affect '='<br/>followed by '{'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=pos_assign=ignore|pos_assign=break|pos_assign=force|pos_assign=lead|pos_assign=trail|pos_assign=join|pos_assign=lead_break|pos_assign=lead_force|pos_assign=trail_break|pos_assign=trail_force
-ChoicesReadable="(617)Ignore Pos Assign|(617)Break Pos Assign|(617)Force Pos Assign|(617)Lead Pos Assign|(617)Trail Pos Assign|(617)Join Pos Assign|(617)Lead Break Pos Assign|(617)Lead Force Pos Assign|(617)Trail Break Pos Assign|(617)Trail Force Pos Assign"
+ChoicesReadable="Ignore Pos Assign|Break Pos Assign|Force Pos Assign|Lead Pos Assign|Trail Pos Assign|Join Pos Assign|Lead Break Pos Assign|Lead Force Pos Assign|Trail Break Pos Assign|Trail Force Pos Assign"
 ValueDefault=ignore
 
 [Pos Bool]
 Category=5
-Description="<html>(618)The position of Boolean operators in wrapped expressions.</html>"
+Description="<html>The position of Boolean operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
 Choices=pos_bool=ignore|pos_bool=break|pos_bool=force|pos_bool=lead|pos_bool=trail|pos_bool=join|pos_bool=lead_break|pos_bool=lead_force|pos_bool=trail_break|pos_bool=trail_force
-ChoicesReadable="(618)Ignore Pos Bool|(618)Break Pos Bool|(618)Force Pos Bool|(618)Lead Pos Bool|(618)Trail Pos Bool|(618)Join Pos Bool|(618)Lead Break Pos Bool|(618)Lead Force Pos Bool|(618)Trail Break Pos Bool|(618)Trail Force Pos Bool"
+ChoicesReadable="Ignore Pos Bool|Break Pos Bool|Force Pos Bool|Lead Pos Bool|Trail Pos Bool|Join Pos Bool|Lead Break Pos Bool|Lead Force Pos Bool|Trail Break Pos Bool|Trail Force Pos Bool"
 ValueDefault=ignore
 
 [Pos Compare]
 Category=5
-Description="<html>(619)The position of comparison operators in wrapped expressions.</html>"
+Description="<html>The position of comparison operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
 Choices=pos_compare=ignore|pos_compare=break|pos_compare=force|pos_compare=lead|pos_compare=trail|pos_compare=join|pos_compare=lead_break|pos_compare=lead_force|pos_compare=trail_break|pos_compare=trail_force
-ChoicesReadable="(619)Ignore Pos Compare|(619)Break Pos Compare|(619)Force Pos Compare|(619)Lead Pos Compare|(619)Trail Pos Compare|(619)Join Pos Compare|(619)Lead Break Pos Compare|(619)Lead Force Pos Compare|(619)Trail Break Pos Compare|(619)Trail Force Pos Compare"
+ChoicesReadable="Ignore Pos Compare|Break Pos Compare|Force Pos Compare|Lead Pos Compare|Trail Pos Compare|Join Pos Compare|Lead Break Pos Compare|Lead Force Pos Compare|Trail Break Pos Compare|Trail Force Pos Compare"
 ValueDefault=ignore
 
 [Pos Conditional]
 Category=5
-Description="<html>(620)The position of conditional operators, as in the '?' and ':' of<br/>'expr ? stmt : stmt', in wrapped expressions.</html>"
+Description="<html>The position of conditional operators, as in the '?' and ':' of<br/>'expr ? stmt : stmt', in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
 Choices=pos_conditional=ignore|pos_conditional=break|pos_conditional=force|pos_conditional=lead|pos_conditional=trail|pos_conditional=join|pos_conditional=lead_break|pos_conditional=lead_force|pos_conditional=trail_break|pos_conditional=trail_force
-ChoicesReadable="(620)Ignore Pos Conditional|(620)Break Pos Conditional|(620)Force Pos Conditional|(620)Lead Pos Conditional|(620)Trail Pos Conditional|(620)Join Pos Conditional|(620)Lead Break Pos Conditional|(620)Lead Force Pos Conditional|(620)Trail Break Pos Conditional|(620)Trail Force Pos Conditional"
+ChoicesReadable="Ignore Pos Conditional|Break Pos Conditional|Force Pos Conditional|Lead Pos Conditional|Trail Pos Conditional|Join Pos Conditional|Lead Break Pos Conditional|Lead Force Pos Conditional|Trail Break Pos Conditional|Trail Force Pos Conditional"
 ValueDefault=ignore
 
 [Pos Comma]
 Category=5
-Description="<html>(621)The position of the comma in wrapped expressions.</html>"
+Description="<html>The position of the comma in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
 Choices=pos_comma=ignore|pos_comma=break|pos_comma=force|pos_comma=lead|pos_comma=trail|pos_comma=join|pos_comma=lead_break|pos_comma=lead_force|pos_comma=trail_break|pos_comma=trail_force
-ChoicesReadable="(621)Ignore Pos Comma|(621)Break Pos Comma|(621)Force Pos Comma|(621)Lead Pos Comma|(621)Trail Pos Comma|(621)Join Pos Comma|(621)Lead Break Pos Comma|(621)Lead Force Pos Comma|(621)Trail Break Pos Comma|(621)Trail Force Pos Comma"
+ChoicesReadable="Ignore Pos Comma|Break Pos Comma|Force Pos Comma|Lead Pos Comma|Trail Pos Comma|Join Pos Comma|Lead Break Pos Comma|Lead Force Pos Comma|Trail Break Pos Comma|Trail Force Pos Comma"
 ValueDefault=ignore
 
 [Pos Enum Comma]
 Category=5
-Description="<html>(622)The position of the comma in enum entries.</html>"
+Description="<html>The position of the comma in enum entries.</html>"
 Enabled=false
 EditorType=multiple
 Choices=pos_enum_comma=ignore|pos_enum_comma=break|pos_enum_comma=force|pos_enum_comma=lead|pos_enum_comma=trail|pos_enum_comma=join|pos_enum_comma=lead_break|pos_enum_comma=lead_force|pos_enum_comma=trail_break|pos_enum_comma=trail_force
-ChoicesReadable="(622)Ignore Pos Enum Comma|(622)Break Pos Enum Comma|(622)Force Pos Enum Comma|(622)Lead Pos Enum Comma|(622)Trail Pos Enum Comma|(622)Join Pos Enum Comma|(622)Lead Break Pos Enum Comma|(622)Lead Force Pos Enum Comma|(622)Trail Break Pos Enum Comma|(622)Trail Force Pos Enum Comma"
+ChoicesReadable="Ignore Pos Enum Comma|Break Pos Enum Comma|Force Pos Enum Comma|Lead Pos Enum Comma|Trail Pos Enum Comma|Join Pos Enum Comma|Lead Break Pos Enum Comma|Lead Force Pos Enum Comma|Trail Break Pos Enum Comma|Trail Force Pos Enum Comma"
 ValueDefault=ignore
 
 [Pos Class Comma]
 Category=5
-Description="<html>(623)The position of the comma in the base class list if there is more than one<br/>line. Affects nl_class_init_args.</html>"
+Description="<html>The position of the comma in the base class list if there is more than one<br/>line. Affects nl_class_init_args.</html>"
 Enabled=false
 EditorType=multiple
 Choices=pos_class_comma=ignore|pos_class_comma=break|pos_class_comma=force|pos_class_comma=lead|pos_class_comma=trail|pos_class_comma=join|pos_class_comma=lead_break|pos_class_comma=lead_force|pos_class_comma=trail_break|pos_class_comma=trail_force
-ChoicesReadable="(623)Ignore Pos Class Comma|(623)Break Pos Class Comma|(623)Force Pos Class Comma|(623)Lead Pos Class Comma|(623)Trail Pos Class Comma|(623)Join Pos Class Comma|(623)Lead Break Pos Class Comma|(623)Lead Force Pos Class Comma|(623)Trail Break Pos Class Comma|(623)Trail Force Pos Class Comma"
+ChoicesReadable="Ignore Pos Class Comma|Break Pos Class Comma|Force Pos Class Comma|Lead Pos Class Comma|Trail Pos Class Comma|Join Pos Class Comma|Lead Break Pos Class Comma|Lead Force Pos Class Comma|Trail Break Pos Class Comma|Trail Force Pos Class Comma"
 ValueDefault=ignore
 
 [Pos Constr Comma]
 Category=5
-Description="<html>(624)The position of the comma in the constructor initialization list.<br/>Related to nl_constr_colon, nl_constr_init_args and pos_constr_colon.</html>"
+Description="<html>The position of the comma in the constructor initialization list.<br/>Related to nl_constr_colon, nl_constr_init_args and pos_constr_colon.</html>"
 Enabled=false
 EditorType=multiple
 Choices=pos_constr_comma=ignore|pos_constr_comma=break|pos_constr_comma=force|pos_constr_comma=lead|pos_constr_comma=trail|pos_constr_comma=join|pos_constr_comma=lead_break|pos_constr_comma=lead_force|pos_constr_comma=trail_break|pos_constr_comma=trail_force
-ChoicesReadable="(624)Ignore Pos Constr Comma|(624)Break Pos Constr Comma|(624)Force Pos Constr Comma|(624)Lead Pos Constr Comma|(624)Trail Pos Constr Comma|(624)Join Pos Constr Comma|(624)Lead Break Pos Constr Comma|(624)Lead Force Pos Constr Comma|(624)Trail Break Pos Constr Comma|(624)Trail Force Pos Constr Comma"
+ChoicesReadable="Ignore Pos Constr Comma|Break Pos Constr Comma|Force Pos Constr Comma|Lead Pos Constr Comma|Trail Pos Constr Comma|Join Pos Constr Comma|Lead Break Pos Constr Comma|Lead Force Pos Constr Comma|Trail Break Pos Constr Comma|Trail Force Pos Constr Comma"
 ValueDefault=ignore
 
 [Pos Class Colon]
 Category=5
-Description="<html>(625)The position of trailing/leading class colon, between class and base class<br/>list. Affects nl_class_colon.</html>"
+Description="<html>The position of trailing/leading class colon, between class and base class<br/>list. Affects nl_class_colon.</html>"
 Enabled=false
 EditorType=multiple
 Choices=pos_class_colon=ignore|pos_class_colon=break|pos_class_colon=force|pos_class_colon=lead|pos_class_colon=trail|pos_class_colon=join|pos_class_colon=lead_break|pos_class_colon=lead_force|pos_class_colon=trail_break|pos_class_colon=trail_force
-ChoicesReadable="(625)Ignore Pos Class Colon|(625)Break Pos Class Colon|(625)Force Pos Class Colon|(625)Lead Pos Class Colon|(625)Trail Pos Class Colon|(625)Join Pos Class Colon|(625)Lead Break Pos Class Colon|(625)Lead Force Pos Class Colon|(625)Trail Break Pos Class Colon|(625)Trail Force Pos Class Colon"
+ChoicesReadable="Ignore Pos Class Colon|Break Pos Class Colon|Force Pos Class Colon|Lead Pos Class Colon|Trail Pos Class Colon|Join Pos Class Colon|Lead Break Pos Class Colon|Lead Force Pos Class Colon|Trail Break Pos Class Colon|Trail Force Pos Class Colon"
 ValueDefault=ignore
 
 [Pos Constr Colon]
 Category=5
-Description="<html>(626)The position of colons between constructor and member initialization.<br/>Related to nl_constr_colon, nl_constr_init_args and pos_constr_comma.</html>"
+Description="<html>The position of colons between constructor and member initialization.<br/>Related to nl_constr_colon, nl_constr_init_args and pos_constr_comma.</html>"
 Enabled=false
 EditorType=multiple
 Choices=pos_constr_colon=ignore|pos_constr_colon=break|pos_constr_colon=force|pos_constr_colon=lead|pos_constr_colon=trail|pos_constr_colon=join|pos_constr_colon=lead_break|pos_constr_colon=lead_force|pos_constr_colon=trail_break|pos_constr_colon=trail_force
-ChoicesReadable="(626)Ignore Pos Constr Colon|(626)Break Pos Constr Colon|(626)Force Pos Constr Colon|(626)Lead Pos Constr Colon|(626)Trail Pos Constr Colon|(626)Join Pos Constr Colon|(626)Lead Break Pos Constr Colon|(626)Lead Force Pos Constr Colon|(626)Trail Break Pos Constr Colon|(626)Trail Force Pos Constr Colon"
+ChoicesReadable="Ignore Pos Constr Colon|Break Pos Constr Colon|Force Pos Constr Colon|Lead Pos Constr Colon|Trail Pos Constr Colon|Join Pos Constr Colon|Lead Break Pos Constr Colon|Lead Force Pos Constr Colon|Trail Break Pos Constr Colon|Trail Force Pos Constr Colon"
 ValueDefault=ignore
 
 [Pos Shift]
 Category=5
-Description="<html>(627)The position of shift operators in wrapped expressions.</html>"
+Description="<html>The position of shift operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
 Choices=pos_shift=ignore|pos_shift=break|pos_shift=force|pos_shift=lead|pos_shift=trail|pos_shift=join|pos_shift=lead_break|pos_shift=lead_force|pos_shift=trail_break|pos_shift=trail_force
-ChoicesReadable="(627)Ignore Pos Shift|(627)Break Pos Shift|(627)Force Pos Shift|(627)Lead Pos Shift|(627)Trail Pos Shift|(627)Join Pos Shift|(627)Lead Break Pos Shift|(627)Lead Force Pos Shift|(627)Trail Break Pos Shift|(627)Trail Force Pos Shift"
+ChoicesReadable="Ignore Pos Shift|Break Pos Shift|Force Pos Shift|Lead Pos Shift|Trail Pos Shift|Join Pos Shift|Lead Break Pos Shift|Lead Force Pos Shift|Trail Break Pos Shift|Trail Force Pos Shift"
 ValueDefault=ignore
 
 [Code Width]
 Category=6
-Description="<html>(628)Try to limit code width to N columns.</html>"
+Description="<html>Try to limit code width to N columns.</html>"
 Enabled=false
 EditorType=numeric
 CallName="code_width="
@@ -5611,7 +5611,7 @@ ValueDefault=0
 
 [Ls For Split Full]
 Category=6
-Description="<html>(629)Whether to fully split long 'for' statements at semi-colons.</html>"
+Description="<html>Whether to fully split long 'for' statements at semi-colons.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=ls_for_split_full=true|ls_for_split_full=false
@@ -5619,7 +5619,7 @@ ValueDefault=false
 
 [Ls Func Split Full]
 Category=6
-Description="<html>(630)Whether to fully split long function prototypes/calls at commas.<br/>The option ls_code_width has priority over the option ls_func_split_full.</html>"
+Description="<html>Whether to fully split long function prototypes/calls at commas.<br/>The option ls_code_width has priority over the option ls_func_split_full.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=ls_func_split_full=true|ls_func_split_full=false
@@ -5627,7 +5627,7 @@ ValueDefault=false
 
 [Ls Code Width]
 Category=6
-Description="<html>(631)Whether to split lines as close to code_width as possible and ignore some<br/>groupings.<br/>The option ls_code_width has priority over the option ls_func_split_full.</html>"
+Description="<html>Whether to split lines as close to code_width as possible and ignore some<br/>groupings.<br/>The option ls_code_width has priority over the option ls_func_split_full.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=ls_code_width=true|ls_code_width=false
@@ -5635,7 +5635,7 @@ ValueDefault=false
 
 [Align Keep Tabs]
 Category=7
-Description="<html>(632)Whether to keep non-indenting tabs.</html>"
+Description="<html>Whether to keep non-indenting tabs.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_keep_tabs=true|align_keep_tabs=false
@@ -5643,7 +5643,7 @@ ValueDefault=false
 
 [Align With Tabs]
 Category=7
-Description="<html>(633)Whether to use tabs for aligning.</html>"
+Description="<html>Whether to use tabs for aligning.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_with_tabs=true|align_with_tabs=false
@@ -5651,7 +5651,7 @@ ValueDefault=false
 
 [Align On Tabstop]
 Category=7
-Description="<html>(634)Whether to bump out to the next tab when aligning.</html>"
+Description="<html>Whether to bump out to the next tab when aligning.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_on_tabstop=true|align_on_tabstop=false
@@ -5659,7 +5659,7 @@ ValueDefault=false
 
 [Align Number Right]
 Category=7
-Description="<html>(635)Whether to right-align numbers.</html>"
+Description="<html>Whether to right-align numbers.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_number_right=true|align_number_right=false
@@ -5667,7 +5667,7 @@ ValueDefault=false
 
 [Align Keep Extra Space]
 Category=7
-Description="<html>(636)Whether to keep whitespace not required for alignment.</html>"
+Description="<html>Whether to keep whitespace not required for alignment.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_keep_extra_space=true|align_keep_extra_space=false
@@ -5675,7 +5675,7 @@ ValueDefault=false
 
 [Align Func Params]
 Category=7
-Description="<html>(637)Whether to align variable definitions in prototypes and functions.</html>"
+Description="<html>Whether to align variable definitions in prototypes and functions.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_func_params=true|align_func_params=false
@@ -5683,7 +5683,7 @@ ValueDefault=false
 
 [Align Func Params Span]
 Category=7
-Description="<html>(638)The span for aligning parameter definitions in function on parameter name.<br/><br/>0: Don't align (default).</html>"
+Description="<html>The span for aligning parameter definitions in function on parameter name.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_func_params_span="
@@ -5693,7 +5693,7 @@ ValueDefault=0
 
 [Align Func Params Thresh]
 Category=7
-Description="<html>(639)The threshold for aligning function parameter definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
+Description="<html>The threshold for aligning function parameter definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_func_params_thresh="
@@ -5703,7 +5703,7 @@ ValueDefault=0
 
 [Align Func Params Gap]
 Category=7
-Description="<html>(640)The gap for aligning function parameter definitions.</html>"
+Description="<html>The gap for aligning function parameter definitions.</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_func_params_gap="
@@ -5713,7 +5713,7 @@ ValueDefault=0
 
 [Align Constr Value Span]
 Category=7
-Description="<html>(641)The span for aligning constructor value.<br/><br/>0: Don't align (default).</html>"
+Description="<html>The span for aligning constructor value.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_constr_value_span="
@@ -5723,7 +5723,7 @@ ValueDefault=0
 
 [Align Constr Value Thresh]
 Category=7
-Description="<html>(642)The threshold for aligning constructor value.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
+Description="<html>The threshold for aligning constructor value.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_constr_value_thresh="
@@ -5733,7 +5733,7 @@ ValueDefault=0
 
 [Align Constr Value Gap]
 Category=7
-Description="<html>(643)The gap for aligning constructor value.</html>"
+Description="<html>The gap for aligning constructor value.</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_constr_value_gap="
@@ -5743,7 +5743,7 @@ ValueDefault=0
 
 [Align Same Func Call Params]
 Category=7
-Description="<html>(644)Whether to align parameters in single-line functions that have the same<br/>name. The function names must already be aligned with each other.</html>"
+Description="<html>Whether to align parameters in single-line functions that have the same<br/>name. The function names must already be aligned with each other.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_same_func_call_params=true|align_same_func_call_params=false
@@ -5751,7 +5751,7 @@ ValueDefault=false
 
 [Align Same Func Call Params Span]
 Category=7
-Description="<html>(645)The span for aligning function-call parameters for single line functions.<br/><br/>0: Don't align (default).</html>"
+Description="<html>The span for aligning function-call parameters for single line functions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_same_func_call_params_span="
@@ -5761,7 +5761,7 @@ ValueDefault=0
 
 [Align Same Func Call Params Thresh]
 Category=7
-Description="<html>(646)The threshold for aligning function-call parameters for single line<br/>functions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
+Description="<html>The threshold for aligning function-call parameters for single line<br/>functions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_same_func_call_params_thresh="
@@ -5771,7 +5771,7 @@ ValueDefault=0
 
 [Align Var Def Span]
 Category=7
-Description="<html>(647)The span for aligning variable definitions.<br/><br/>0: Don't align (default).</html>"
+Description="<html>The span for aligning variable definitions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_var_def_span="
@@ -5781,7 +5781,7 @@ ValueDefault=0
 
 [Align Var Def Star Style]
 Category=7
-Description="<html>(648)How to consider (or treat) the '*' in the alignment of variable definitions.<br/><br/>0: Part of the type     'void *   foo;' (default)<br/>1: Part of the variable 'void     *foo;'<br/>2: Dangling             'void    *foo;'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"
+Description="<html>How to consider (or treat) the '*' in the alignment of variable definitions.<br/><br/>0: Part of the type     'void *   foo;' (default)<br/>1: Part of the variable 'void     *foo;'<br/>2: Dangling             'void    *foo;'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_var_def_star_style="
@@ -5791,7 +5791,7 @@ ValueDefault=0
 
 [Align Var Def Amp Style]
 Category=7
-Description="<html>(649)How to consider (or treat) the '&amp;' in the alignment of variable definitions.<br/><br/>0: Part of the type     'long &amp;   foo;' (default)<br/>1: Part of the variable 'long     &amp;foo;'<br/>2: Dangling             'long    &amp;foo;'<br/>Dangling: the '&amp;' will not be taken into account when aligning.</html>"
+Description="<html>How to consider (or treat) the '&amp;' in the alignment of variable definitions.<br/><br/>0: Part of the type     'long &amp;   foo;' (default)<br/>1: Part of the variable 'long     &amp;foo;'<br/>2: Dangling             'long    &amp;foo;'<br/>Dangling: the '&amp;' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_var_def_amp_style="
@@ -5801,7 +5801,7 @@ ValueDefault=0
 
 [Align Var Def Thresh]
 Category=7
-Description="<html>(650)The threshold for aligning variable definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
+Description="<html>The threshold for aligning variable definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_var_def_thresh="
@@ -5811,7 +5811,7 @@ ValueDefault=0
 
 [Align Var Def Gap]
 Category=7
-Description="<html>(651)The gap for aligning variable definitions.</html>"
+Description="<html>The gap for aligning variable definitions.</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_var_def_gap="
@@ -5821,7 +5821,7 @@ ValueDefault=0
 
 [Align Var Def Colon]
 Category=7
-Description="<html>(652)Whether to align the colon in struct bit fields.</html>"
+Description="<html>Whether to align the colon in struct bit fields.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_var_def_colon=true|align_var_def_colon=false
@@ -5829,7 +5829,7 @@ ValueDefault=false
 
 [Align Var Def Colon Gap]
 Category=7
-Description="<html>(653)The gap for aligning the colon in struct bit fields.</html>"
+Description="<html>The gap for aligning the colon in struct bit fields.</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_var_def_colon_gap="
@@ -5839,7 +5839,7 @@ ValueDefault=0
 
 [Align Var Def Attribute]
 Category=7
-Description="<html>(654)Whether to align any attribute after the variable name.</html>"
+Description="<html>Whether to align any attribute after the variable name.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_var_def_attribute=true|align_var_def_attribute=false
@@ -5847,7 +5847,7 @@ ValueDefault=false
 
 [Align Var Def Inline]
 Category=7
-Description="<html>(655)Whether to align inline struct/enum/union variable definitions.</html>"
+Description="<html>Whether to align inline struct/enum/union variable definitions.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_var_def_inline=true|align_var_def_inline=false
@@ -5855,7 +5855,7 @@ ValueDefault=false
 
 [Align Assign Span]
 Category=7
-Description="<html>(656)The span for aligning on '=' in assignments.<br/><br/>0: Don't align (default).</html>"
+Description="<html>The span for aligning on '=' in assignments.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_assign_span="
@@ -5865,7 +5865,7 @@ ValueDefault=0
 
 [Align Assign Func Proto Span]
 Category=7
-Description="<html>(657)The span for aligning on '=' in function prototype modifier.<br/><br/>0: Don't align (default).</html>"
+Description="<html>The span for aligning on '=' in function prototype modifier.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_assign_func_proto_span="
@@ -5875,7 +5875,7 @@ ValueDefault=0
 
 [Align Assign Thresh]
 Category=7
-Description="<html>(658)The threshold for aligning on '=' in assignments.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
+Description="<html>The threshold for aligning on '=' in assignments.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_assign_thresh="
@@ -5885,7 +5885,7 @@ ValueDefault=0
 
 [Align Assign On Multi Var Defs]
 Category=7
-Description="<html>(659)Whether to align on the left most assignment when multiple<br/>definitions are found on the same line.<br/>Depends on 'align_assign_span' and 'align_assign_thresh' settings.</html>"
+Description="<html>Whether to align on the left most assignment when multiple<br/>definitions are found on the same line.<br/>Depends on 'align_assign_span' and 'align_assign_thresh' settings.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_assign_on_multi_var_defs=true|align_assign_on_multi_var_defs=false
@@ -5893,7 +5893,7 @@ ValueDefault=false
 
 [Align Braced Init List Span]
 Category=7
-Description="<html>(660)The span for aligning on '{' in braced init list.<br/><br/>0: Don't align (default).</html>"
+Description="<html>The span for aligning on '{' in braced init list.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_braced_init_list_span="
@@ -5903,7 +5903,7 @@ ValueDefault=0
 
 [Align Braced Init List Thresh]
 Category=7
-Description="<html>(661)The threshold for aligning on '{' in braced init list.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
+Description="<html>The threshold for aligning on '{' in braced init list.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_braced_init_list_thresh="
@@ -5913,7 +5913,7 @@ ValueDefault=0
 
 [Align Assign Decl Func]
 Category=7
-Description="<html>(662)How to apply align_assign_span to function declaration "assignments", i.e.<br/>'virtual void foo() = 0' or '~foo() = {default|delete}'.<br/><br/>0: Align with other assignments (default)<br/>1: Align with each other, ignoring regular assignments<br/>2: Don't align</html>"
+Description="<html>How to apply align_assign_span to function declaration "assignments", i.e.<br/>'virtual void foo() = 0' or '~foo() = {default|delete}'.<br/><br/>0: Align with other assignments (default)<br/>1: Align with each other, ignoring regular assignments<br/>2: Don't align</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_assign_decl_func="
@@ -5923,7 +5923,7 @@ ValueDefault=0
 
 [Align Enum Equ Span]
 Category=7
-Description="<html>(663)The span for aligning on '=' in enums.<br/><br/>0: Don't align (default).</html>"
+Description="<html>The span for aligning on '=' in enums.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_enum_equ_span="
@@ -5933,7 +5933,7 @@ ValueDefault=0
 
 [Align Enum Equ Thresh]
 Category=7
-Description="<html>(664)The threshold for aligning on '=' in enums.<br/>Use a negative number for absolute thresholds.<br/><br/>0: no limit (default).</html>"
+Description="<html>The threshold for aligning on '=' in enums.<br/>Use a negative number for absolute thresholds.<br/><br/>0: no limit (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_enum_equ_thresh="
@@ -5943,7 +5943,7 @@ ValueDefault=0
 
 [Align Var Class Span]
 Category=7
-Description="<html>(665)The span for aligning class member definitions.<br/><br/>0: Don't align (default).</html>"
+Description="<html>The span for aligning class member definitions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_var_class_span="
@@ -5953,7 +5953,7 @@ ValueDefault=0
 
 [Align Var Class Thresh]
 Category=7
-Description="<html>(666)The threshold for aligning class member definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
+Description="<html>The threshold for aligning class member definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_var_class_thresh="
@@ -5963,7 +5963,7 @@ ValueDefault=0
 
 [Align Var Class Gap]
 Category=7
-Description="<html>(667)The gap for aligning class member definitions.</html>"
+Description="<html>The gap for aligning class member definitions.</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_var_class_gap="
@@ -5973,7 +5973,7 @@ ValueDefault=0
 
 [Align Var Struct Span]
 Category=7
-Description="<html>(668)The span for aligning struct/union member definitions.<br/><br/>0: Don't align (default).</html>"
+Description="<html>The span for aligning struct/union member definitions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_var_struct_span="
@@ -5983,7 +5983,7 @@ ValueDefault=0
 
 [Align Var Struct Thresh]
 Category=7
-Description="<html>(669)The threshold for aligning struct/union member definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
+Description="<html>The threshold for aligning struct/union member definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_var_struct_thresh="
@@ -5993,7 +5993,7 @@ ValueDefault=0
 
 [Align Var Struct Gap]
 Category=7
-Description="<html>(670)The gap for aligning struct/union member definitions.</html>"
+Description="<html>The gap for aligning struct/union member definitions.</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_var_struct_gap="
@@ -6003,7 +6003,7 @@ ValueDefault=0
 
 [Align Struct Init Span]
 Category=7
-Description="<html>(671)The span for aligning struct initializer values.<br/><br/>0: Don't align (default).</html>"
+Description="<html>The span for aligning struct initializer values.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_struct_init_span="
@@ -6013,7 +6013,7 @@ ValueDefault=0
 
 [Align Typedef Span]
 Category=7
-Description="<html>(672)The span for aligning single-line typedefs.<br/><br/>0: Don't align (default).</html>"
+Description="<html>The span for aligning single-line typedefs.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_typedef_span="
@@ -6023,7 +6023,7 @@ ValueDefault=0
 
 [Align Typedef Gap]
 Category=7
-Description="<html>(673)The minimum space between the type and the synonym of a typedef.</html>"
+Description="<html>The minimum space between the type and the synonym of a typedef.</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_typedef_gap="
@@ -6033,7 +6033,7 @@ ValueDefault=0
 
 [Align Typedef Func]
 Category=7
-Description="<html>(674)How to align typedef'd functions with other typedefs.<br/><br/>0: Don't mix them at all (default)<br/>1: Align the open parenthesis with the types<br/>2: Align the function type name with the other type names</html>"
+Description="<html>How to align typedef'd functions with other typedefs.<br/><br/>0: Don't mix them at all (default)<br/>1: Align the open parenthesis with the types<br/>2: Align the function type name with the other type names</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_typedef_func="
@@ -6043,7 +6043,7 @@ ValueDefault=0
 
 [Align Typedef Star Style]
 Category=7
-Description="<html>(675)How to consider (or treat) the '*' in the alignment of typedefs.<br/><br/>0: Part of the typedef type, 'typedef int * pint;' (default)<br/>1: Part of type name:        'typedef int   *pint;'<br/>2: Dangling:                 'typedef int  *pint;'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"
+Description="<html>How to consider (or treat) the '*' in the alignment of typedefs.<br/><br/>0: Part of the typedef type, 'typedef int * pint;' (default)<br/>1: Part of type name:        'typedef int   *pint;'<br/>2: Dangling:                 'typedef int  *pint;'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_typedef_star_style="
@@ -6053,7 +6053,7 @@ ValueDefault=0
 
 [Align Typedef Amp Style]
 Category=7
-Description="<html>(676)How to consider (or treat) the '&amp;' in the alignment of typedefs.<br/><br/>0: Part of the typedef type, 'typedef int &amp; intref;' (default)<br/>1: Part of type name:        'typedef int   &amp;intref;'<br/>2: Dangling:                 'typedef int  &amp;intref;'<br/>Dangling: the '&amp;' will not be taken into account when aligning.</html>"
+Description="<html>How to consider (or treat) the '&amp;' in the alignment of typedefs.<br/><br/>0: Part of the typedef type, 'typedef int &amp; intref;' (default)<br/>1: Part of type name:        'typedef int   &amp;intref;'<br/>2: Dangling:                 'typedef int  &amp;intref;'<br/>Dangling: the '&amp;' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_typedef_amp_style="
@@ -6063,7 +6063,7 @@ ValueDefault=0
 
 [Align Right Cmt Span]
 Category=7
-Description="<html>(677)The span for aligning comments that end lines.<br/><br/>0: Don't align (default).</html>"
+Description="<html>The span for aligning comments that end lines.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_right_cmt_span="
@@ -6073,7 +6073,7 @@ ValueDefault=0
 
 [Align Right Cmt Gap]
 Category=7
-Description="<html>(678)Minimum number of columns between preceding text and a trailing comment in<br/>order for the comment to qualify for being aligned. Must be non-zero to have<br/>an effect.</html>"
+Description="<html>Minimum number of columns between preceding text and a trailing comment in<br/>order for the comment to qualify for being aligned. Must be non-zero to have<br/>an effect.</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_right_cmt_gap="
@@ -6083,7 +6083,7 @@ ValueDefault=0
 
 [Align Right Cmt Mix]
 Category=7
-Description="<html>(679)If aligning comments, whether to mix with comments after '}' and #endif with<br/>less than three spaces before the comment.</html>"
+Description="<html>If aligning comments, whether to mix with comments after '}' and #endif with<br/>less than three spaces before the comment.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_right_cmt_mix=true|align_right_cmt_mix=false
@@ -6091,7 +6091,7 @@ ValueDefault=false
 
 [Align Right Cmt Same Level]
 Category=7
-Description="<html>(680)Whether to only align trailing comments that are at the same brace level.</html>"
+Description="<html>Whether to only align trailing comments that are at the same brace level.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_right_cmt_same_level=true|align_right_cmt_same_level=false
@@ -6099,7 +6099,7 @@ ValueDefault=false
 
 [Align Right Cmt At Col]
 Category=7
-Description="<html>(681)Minimum column at which to align trailing comments. Comments which are<br/>aligned beyond this column, but which can be aligned in a lesser column,<br/>may be "pulled in".<br/><br/>0: Ignore (default).</html>"
+Description="<html>Minimum column at which to align trailing comments. Comments which are<br/>aligned beyond this column, but which can be aligned in a lesser column,<br/>may be "pulled in".<br/><br/>0: Ignore (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_right_cmt_at_col="
@@ -6109,7 +6109,7 @@ ValueDefault=0
 
 [Align Func Proto Span]
 Category=7
-Description="<html>(682)The span for aligning function prototypes.<br/><br/>0: Don't align (default).</html>"
+Description="<html>The span for aligning function prototypes.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_func_proto_span="
@@ -6119,7 +6119,7 @@ ValueDefault=0
 
 [Align Func Proto Star Style]
 Category=7
-Description="<html>(683)How to consider (or treat) the '*' in the alignment of function prototypes.<br/><br/>0: Part of the type     'void *   foo();' (default)<br/>1: Part of the function 'void     *foo();'<br/>2: Dangling             'void    *foo();'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"
+Description="<html>How to consider (or treat) the '*' in the alignment of function prototypes.<br/><br/>0: Part of the type     'void *   foo();' (default)<br/>1: Part of the function 'void     *foo();'<br/>2: Dangling             'void    *foo();'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_func_proto_star_style="
@@ -6129,7 +6129,7 @@ ValueDefault=0
 
 [Align Func Proto Amp Style]
 Category=7
-Description="<html>(684)How to consider (or treat) the '&amp;' in the alignment of function prototypes.<br/><br/>0: Part of the type     'long &amp;   foo();' (default)<br/>1: Part of the function 'long     &amp;foo();'<br/>2: Dangling             'long    &amp;foo();'<br/>Dangling: the '&amp;' will not be taken into account when aligning.</html>"
+Description="<html>How to consider (or treat) the '&amp;' in the alignment of function prototypes.<br/><br/>0: Part of the type     'long &amp;   foo();' (default)<br/>1: Part of the function 'long     &amp;foo();'<br/>2: Dangling             'long    &amp;foo();'<br/>Dangling: the '&amp;' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_func_proto_amp_style="
@@ -6139,7 +6139,7 @@ ValueDefault=0
 
 [Align Func Proto Thresh]
 Category=7
-Description="<html>(685)The threshold for aligning function prototypes.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
+Description="<html>The threshold for aligning function prototypes.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_func_proto_thresh="
@@ -6149,7 +6149,7 @@ ValueDefault=0
 
 [Align Func Proto Gap]
 Category=7
-Description="<html>(686)Minimum gap between the return type and the function name.</html>"
+Description="<html>Minimum gap between the return type and the function name.</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_func_proto_gap="
@@ -6159,7 +6159,7 @@ ValueDefault=0
 
 [Align On Operator]
 Category=7
-Description="<html>(687)Whether to align function prototypes on the 'operator' keyword instead of<br/>what follows.</html>"
+Description="<html>Whether to align function prototypes on the 'operator' keyword instead of<br/>what follows.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_on_operator=true|align_on_operator=false
@@ -6167,7 +6167,7 @@ ValueDefault=false
 
 [Align Mix Var Proto]
 Category=7
-Description="<html>(688)Whether to mix aligning prototype and variable declarations. If true,<br/>align_var_def_XXX options are used instead of align_func_proto_XXX options.</html>"
+Description="<html>Whether to mix aligning prototype and variable declarations. If true,<br/>align_var_def_XXX options are used instead of align_func_proto_XXX options.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_mix_var_proto=true|align_mix_var_proto=false
@@ -6175,7 +6175,7 @@ ValueDefault=false
 
 [Align Single Line Func]
 Category=7
-Description="<html>(689)Whether to align single-line functions with function prototypes.<br/>Uses align_func_proto_span.</html>"
+Description="<html>Whether to align single-line functions with function prototypes.<br/>Uses align_func_proto_span.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_single_line_func=true|align_single_line_func=false
@@ -6183,7 +6183,7 @@ ValueDefault=false
 
 [Align Single Line Brace]
 Category=7
-Description="<html>(690)Whether to align the open brace of single-line functions.<br/>Requires align_single_line_func=true. Uses align_func_proto_span.</html>"
+Description="<html>Whether to align the open brace of single-line functions.<br/>Requires align_single_line_func=true. Uses align_func_proto_span.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_single_line_brace=true|align_single_line_brace=false
@@ -6191,7 +6191,7 @@ ValueDefault=false
 
 [Align Single Line Brace Gap]
 Category=7
-Description="<html>(691)Gap for align_single_line_brace.</html>"
+Description="<html>Gap for align_single_line_brace.</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_single_line_brace_gap="
@@ -6201,7 +6201,7 @@ ValueDefault=0
 
 [Align Oc Msg Spec Span]
 Category=7
-Description="<html>(692)(OC) The span for aligning Objective-C message specifications.<br/><br/>0: Don't align (default).</html>"
+Description="<html>(OC) The span for aligning Objective-C message specifications.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_oc_msg_spec_span="
@@ -6211,7 +6211,7 @@ ValueDefault=0
 
 [Align Nl Cont]
 Category=7
-Description="<html>(693)Whether to align macros wrapped with a backslash and a newline. This will<br/>not work right if the macro contains a multi-line comment.</html>"
+Description="<html>Whether to align macros wrapped with a backslash and a newline. This will<br/>not work right if the macro contains a multi-line comment.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_nl_cont=true|align_nl_cont=false
@@ -6219,7 +6219,7 @@ ValueDefault=false
 
 [Align Pp Define Together]
 Category=7
-Description="<html>(694)Whether to align macro functions and variables together.</html>"
+Description="<html>Whether to align macro functions and variables together.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_pp_define_together=true|align_pp_define_together=false
@@ -6227,7 +6227,7 @@ ValueDefault=false
 
 [Align Pp Define Span]
 Category=7
-Description="<html>(695)The span for aligning on '#define' bodies.<br/><br/>=0: Don't align (default)<br/>&gt;0: Number of lines (including comments) between blocks</html>"
+Description="<html>The span for aligning on '#define' bodies.<br/><br/>=0: Don't align (default)<br/>&gt;0: Number of lines (including comments) between blocks</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_pp_define_span="
@@ -6237,7 +6237,7 @@ ValueDefault=0
 
 [Align Pp Define Gap]
 Category=7
-Description="<html>(696)The minimum space between label and value of a preprocessor define.</html>"
+Description="<html>The minimum space between label and value of a preprocessor define.</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_pp_define_gap="
@@ -6247,7 +6247,7 @@ ValueDefault=0
 
 [Align Left Shift]
 Category=7
-Description="<html>(697)Whether to align lines that start with '&lt;&lt;' with previous '&lt;&lt;'.<br/><br/>Default: true</html>"
+Description="<html>Whether to align lines that start with '&lt;&lt;' with previous '&lt;&lt;'.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_left_shift=true|align_left_shift=false
@@ -6255,7 +6255,7 @@ ValueDefault=true
 
 [Align Eigen Comma Init]
 Category=7
-Description="<html>(698)Whether to align comma-separated statements following '&lt;&lt;' (as used to<br/>initialize Eigen matrices).</html>"
+Description="<html>Whether to align comma-separated statements following '&lt;&lt;' (as used to<br/>initialize Eigen matrices).</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_eigen_comma_init=true|align_eigen_comma_init=false
@@ -6263,7 +6263,7 @@ ValueDefault=false
 
 [Align Asm Colon]
 Category=7
-Description="<html>(699)Whether to align text after 'asm volatile ()' colons.</html>"
+Description="<html>Whether to align text after 'asm volatile ()' colons.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_asm_colon=true|align_asm_colon=false
@@ -6271,7 +6271,7 @@ ValueDefault=false
 
 [Align Oc Msg Colon Span]
 Category=7
-Description="<html>(700)(OC) Span for aligning parameters in an Objective-C message call<br/>on the ':'.<br/><br/>0: Don't align.</html>"
+Description="<html>(OC) Span for aligning parameters in an Objective-C message call<br/>on the ':'.<br/><br/>0: Don't align.</html>"
 Enabled=false
 EditorType=numeric
 CallName="align_oc_msg_colon_span="
@@ -6281,7 +6281,7 @@ ValueDefault=0
 
 [Align Oc Msg Colon First]
 Category=7
-Description="<html>(701)(OC) Whether to always align with the first parameter, even if it is too<br/>short.</html>"
+Description="<html>(OC) Whether to always align with the first parameter, even if it is too<br/>short.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_oc_msg_colon_first=true|align_oc_msg_colon_first=false
@@ -6289,7 +6289,7 @@ ValueDefault=false
 
 [Align Oc Decl Colon]
 Category=7
-Description="<html>(702)(OC) Whether to align parameters in an Objective-C '+' or '-' declaration<br/>on the ':'.</html>"
+Description="<html>(OC) Whether to align parameters in an Objective-C '+' or '-' declaration<br/>on the ':'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_oc_decl_colon=true|align_oc_decl_colon=false
@@ -6297,7 +6297,7 @@ ValueDefault=false
 
 [Align Oc Msg Colon Xcode Like]
 Category=7
-Description="<html>(703)(OC) Whether to not align parameters in an Objectve-C message call if first<br/>colon is not on next line of the message call (the same way Xcode does<br/>alignment)</html>"
+Description="<html>(OC) Whether to not align parameters in an Objectve-C message call if first<br/>colon is not on next line of the message call (the same way Xcode does<br/>alignment)</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=align_oc_msg_colon_xcode_like=true|align_oc_msg_colon_xcode_like=false
@@ -6305,7 +6305,7 @@ ValueDefault=false
 
 [Cmt Width]
 Category=8
-Description="<html>(704)Try to wrap comments at N columns.</html>"
+Description="<html>Try to wrap comments at N columns.</html>"
 Enabled=false
 EditorType=numeric
 CallName="cmt_width="
@@ -6315,7 +6315,7 @@ ValueDefault=0
 
 [Cmt Reflow Mode]
 Category=8
-Description="<html>(705)How to reflow comments.<br/><br/>0: No reflowing (apart from the line wrapping due to cmt_width) (default)<br/>1: No touching at all<br/>2: Full reflow (enable cmt_indent_multi for indent with line wrapping due to cmt_width)</html>"
+Description="<html>How to reflow comments.<br/><br/>0: No reflowing (apart from the line wrapping due to cmt_width) (default)<br/>1: No touching at all<br/>2: Full reflow (enable cmt_indent_multi for indent with line wrapping due to cmt_width)</html>"
 Enabled=false
 EditorType=numeric
 CallName="cmt_reflow_mode="
@@ -6325,7 +6325,7 @@ ValueDefault=0
 
 [Cmt Reflow Fold Regex File]
 Category=8
-Description="<html>(706)Path to a file that contains regular expressions describing patterns for<br/>which the end of one line and the beginning of the next will be folded into<br/>the same sentence or paragraph during full comment reflow. The regular<br/>expressions are described using ECMAScript syntax. The syntax for this<br/>specification is as follows, where "..." indicates the custom regular<br/>expression and "n" indicates the nth end_of_prev_line_regex and<br/>beg_of_next_line_regex regular expression pair:<br/><br/>end_of_prev_line_regex[1] = "...$"<br/>beg_of_next_line_regex[1] = "^..."<br/>end_of_prev_line_regex[2] = "...$"<br/>beg_of_next_line_regex[2] = "^..."<br/>            .<br/>            .<br/>            .<br/>end_of_prev_line_regex[n] = "...$"<br/>beg_of_next_line_regex[n] = "^..."<br/><br/>Note that use of this option overrides the default reflow fold regular<br/>expressions, which are internally defined as follows:<br/><br/>end_of_prev_line_regex[1] = "[\w,\]\)]$"<br/>beg_of_next_line_regex[1] = "^[\w,\[\(]"<br/>end_of_prev_line_regex[2] = "\.$"<br/>beg_of_next_line_regex[2] = "^[A-Z]"</html>"
+Description="<html>Path to a file that contains regular expressions describing patterns for<br/>which the end of one line and the beginning of the next will be folded into<br/>the same sentence or paragraph during full comment reflow. The regular<br/>expressions are described using ECMAScript syntax. The syntax for this<br/>specification is as follows, where "..." indicates the custom regular<br/>expression and "n" indicates the nth end_of_prev_line_regex and<br/>beg_of_next_line_regex regular expression pair:<br/><br/>end_of_prev_line_regex[1] = "...$"<br/>beg_of_next_line_regex[1] = "^..."<br/>end_of_prev_line_regex[2] = "...$"<br/>beg_of_next_line_regex[2] = "^..."<br/>            .<br/>            .<br/>            .<br/>end_of_prev_line_regex[n] = "...$"<br/>beg_of_next_line_regex[n] = "^..."<br/><br/>Note that use of this option overrides the default reflow fold regular<br/>expressions, which are internally defined as follows:<br/><br/>end_of_prev_line_regex[1] = "[\w,\]\)]$"<br/>beg_of_next_line_regex[1] = "^[\w,\[\(]"<br/>end_of_prev_line_regex[2] = "\.$"<br/>beg_of_next_line_regex[2] = "^[A-Z]"</html>"
 Enabled=false
 CallName=cmt_reflow_fold_regex_file=
 EditorType=string
@@ -6333,7 +6333,7 @@ ValueDefault=
 
 [Cmt Reflow Indent To Paragraph Start]
 Category=8
-Description="<html>(707)Whether to indent wrapped lines to the start of the encompassing paragraph<br/>during full comment reflow (cmt_reflow_mode = 2). Overrides the value<br/>specified by cmt_sp_after_star_cont.<br/><br/>Note that cmt_align_doxygen_javadoc_tags overrides this option for<br/>paragraphs associated with javadoc tags</html>"
+Description="<html>Whether to indent wrapped lines to the start of the encompassing paragraph<br/>during full comment reflow (cmt_reflow_mode = 2). Overrides the value<br/>specified by cmt_sp_after_star_cont.<br/><br/>Note that cmt_align_doxygen_javadoc_tags overrides this option for<br/>paragraphs associated with javadoc tags</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=cmt_reflow_indent_to_paragraph_start=true|cmt_reflow_indent_to_paragraph_start=false
@@ -6341,7 +6341,7 @@ ValueDefault=false
 
 [Cmt Convert Tab To Spaces]
 Category=8
-Description="<html>(708)Whether to convert all tabs to spaces in comments. If false, tabs in<br/>comments are left alone, unless used for indenting.</html>"
+Description="<html>Whether to convert all tabs to spaces in comments. If false, tabs in<br/>comments are left alone, unless used for indenting.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=cmt_convert_tab_to_spaces=true|cmt_convert_tab_to_spaces=false
@@ -6349,7 +6349,7 @@ ValueDefault=false
 
 [Cmt Indent Multi]
 Category=8
-Description="<html>(709)Whether to apply changes to multi-line comments, including cmt_width,<br/>keyword substitution and leading chars.<br/><br/>Default: true</html>"
+Description="<html>Whether to apply changes to multi-line comments, including cmt_width,<br/>keyword substitution and leading chars.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=cmt_indent_multi=true|cmt_indent_multi=false
@@ -6357,7 +6357,7 @@ ValueDefault=true
 
 [Cmt Align Doxygen Javadoc Tags]
 Category=8
-Description="<html>(710)Whether to align doxygen javadoc-style tags ('@param', '@return', etc.)<br/>and corresponding fields such that groups of consecutive block tags,<br/>parameter names, and descriptions align with one another. Overrides that<br/>which is specified by the cmt_sp_after_star_cont. If cmt_width &gt; 0, it may<br/>be necessary to enable cmt_indent_multi and set cmt_reflow_mode = 2<br/>in order to achieve the desired alignment for line-wrapping.</html>"
+Description="<html>Whether to align doxygen javadoc-style tags ('@param', '@return', etc.)<br/>and corresponding fields such that groups of consecutive block tags,<br/>parameter names, and descriptions align with one another. Overrides that<br/>which is specified by the cmt_sp_after_star_cont. If cmt_width &gt; 0, it may<br/>be necessary to enable cmt_indent_multi and set cmt_reflow_mode = 2<br/>in order to achieve the desired alignment for line-wrapping.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=cmt_align_doxygen_javadoc_tags=true|cmt_align_doxygen_javadoc_tags=false
@@ -6365,7 +6365,7 @@ ValueDefault=false
 
 [Cmt Sp Before Doxygen Javadoc Tags]
 Category=8
-Description="<html>(711)The number of spaces to insert after the star and before doxygen<br/>javadoc-style tags (@param, @return, etc). Requires enabling<br/>cmt_align_doxygen_javadoc_tags. Overrides that which is specified by the<br/>cmt_sp_after_star_cont.<br/><br/>Default: 1</html>"
+Description="<html>The number of spaces to insert after the star and before doxygen<br/>javadoc-style tags (@param, @return, etc). Requires enabling<br/>cmt_align_doxygen_javadoc_tags. Overrides that which is specified by the<br/>cmt_sp_after_star_cont.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
 CallName="cmt_sp_before_doxygen_javadoc_tags="
@@ -6375,7 +6375,7 @@ ValueDefault=1
 
 [Cmt Trailing Single Line C To Cpp]
 Category=8
-Description="<html>(712)Whether to change trailing, single-line c-comments into cpp-comments.</html>"
+Description="<html>Whether to change trailing, single-line c-comments into cpp-comments.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=cmt_trailing_single_line_c_to_cpp=true|cmt_trailing_single_line_c_to_cpp=false
@@ -6383,7 +6383,7 @@ ValueDefault=false
 
 [Cmt C Group]
 Category=8
-Description="<html>(713)Whether to group c-comments that look like they are in a block.</html>"
+Description="<html>Whether to group c-comments that look like they are in a block.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=cmt_c_group=true|cmt_c_group=false
@@ -6391,7 +6391,7 @@ ValueDefault=false
 
 [Cmt C Nl Start]
 Category=8
-Description="<html>(714)Whether to put an empty '/*' on the first line of the combined c-comment.</html>"
+Description="<html>Whether to put an empty '/*' on the first line of the combined c-comment.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=cmt_c_nl_start=true|cmt_c_nl_start=false
@@ -6399,7 +6399,7 @@ ValueDefault=false
 
 [Cmt C Nl End]
 Category=8
-Description="<html>(715)Whether to add a newline before the closing '*/' of the combined c-comment.</html>"
+Description="<html>Whether to add a newline before the closing '*/' of the combined c-comment.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=cmt_c_nl_end=true|cmt_c_nl_end=false
@@ -6407,7 +6407,7 @@ ValueDefault=false
 
 [Cmt Cpp To C]
 Category=8
-Description="<html>(716)Whether to change cpp-comments into c-comments.</html>"
+Description="<html>Whether to change cpp-comments into c-comments.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=cmt_cpp_to_c=true|cmt_cpp_to_c=false
@@ -6415,7 +6415,7 @@ ValueDefault=false
 
 [Cmt Cpp Group]
 Category=8
-Description="<html>(717)Whether to group cpp-comments that look like they are in a block. Only<br/>meaningful if cmt_cpp_to_c=true.</html>"
+Description="<html>Whether to group cpp-comments that look like they are in a block. Only<br/>meaningful if cmt_cpp_to_c=true.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=cmt_cpp_group=true|cmt_cpp_group=false
@@ -6423,7 +6423,7 @@ ValueDefault=false
 
 [Cmt Cpp Nl Start]
 Category=8
-Description="<html>(718)Whether to put an empty '/*' on the first line of the combined cpp-comment<br/>when converting to a c-comment.<br/><br/>Requires cmt_cpp_to_c=true and cmt_cpp_group=true.</html>"
+Description="<html>Whether to put an empty '/*' on the first line of the combined cpp-comment<br/>when converting to a c-comment.<br/><br/>Requires cmt_cpp_to_c=true and cmt_cpp_group=true.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=cmt_cpp_nl_start=true|cmt_cpp_nl_start=false
@@ -6431,7 +6431,7 @@ ValueDefault=false
 
 [Cmt Cpp Nl End]
 Category=8
-Description="<html>(719)Whether to add a newline before the closing '*/' of the combined cpp-comment<br/>when converting to a c-comment.<br/><br/>Requires cmt_cpp_to_c=true and cmt_cpp_group=true.</html>"
+Description="<html>Whether to add a newline before the closing '*/' of the combined cpp-comment<br/>when converting to a c-comment.<br/><br/>Requires cmt_cpp_to_c=true and cmt_cpp_group=true.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=cmt_cpp_nl_end=true|cmt_cpp_nl_end=false
@@ -6439,7 +6439,7 @@ ValueDefault=false
 
 [Cmt Star Cont]
 Category=8
-Description="<html>(720)Whether to put a star on subsequent comment lines.</html>"
+Description="<html>Whether to put a star on subsequent comment lines.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=cmt_star_cont=true|cmt_star_cont=false
@@ -6447,7 +6447,7 @@ ValueDefault=false
 
 [Cmt Sp Before Star Cont]
 Category=8
-Description="<html>(721)The number of spaces to insert at the start of subsequent comment lines.</html>"
+Description="<html>The number of spaces to insert at the start of subsequent comment lines.</html>"
 Enabled=false
 EditorType=numeric
 CallName="cmt_sp_before_star_cont="
@@ -6457,7 +6457,7 @@ ValueDefault=0
 
 [Cmt Sp After Star Cont]
 Category=8
-Description="<html>(722)The number of spaces to insert after the star on subsequent comment lines.</html>"
+Description="<html>The number of spaces to insert after the star on subsequent comment lines.</html>"
 Enabled=false
 EditorType=numeric
 CallName="cmt_sp_after_star_cont="
@@ -6467,7 +6467,7 @@ ValueDefault=0
 
 [Cmt Multi Check Last]
 Category=8
-Description="<html>(723)For multi-line comments with a '*' lead, remove leading spaces if the first<br/>and last lines of the comment are the same length.<br/><br/>Default: true</html>"
+Description="<html>For multi-line comments with a '*' lead, remove leading spaces if the first<br/>and last lines of the comment are the same length.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=cmt_multi_check_last=true|cmt_multi_check_last=false
@@ -6475,7 +6475,7 @@ ValueDefault=true
 
 [Cmt Multi First Len Minimum]
 Category=8
-Description="<html>(724)For multi-line comments with a '*' lead, remove leading spaces if the first<br/>and last lines of the comment are the same length AND if the length is<br/>bigger as the first_len minimum.<br/><br/>Default: 4</html>"
+Description="<html>For multi-line comments with a '*' lead, remove leading spaces if the first<br/>and last lines of the comment are the same length AND if the length is<br/>bigger as the first_len minimum.<br/><br/>Default: 4</html>"
 Enabled=false
 EditorType=numeric
 CallName="cmt_multi_first_len_minimum="
@@ -6485,7 +6485,7 @@ ValueDefault=4
 
 [Cmt Insert File Header]
 Category=8
-Description="<html>(725)Path to a file that contains text to insert at the beginning of a file if<br/>the file doesn't start with a C/C++ comment. If the inserted text contains<br/>'$(filename)', that will be replaced with the current file's name.</html>"
+Description="<html>Path to a file that contains text to insert at the beginning of a file if<br/>the file doesn't start with a C/C++ comment. If the inserted text contains<br/>'$(filename)', that will be replaced with the current file's name.</html>"
 Enabled=false
 CallName=cmt_insert_file_header=
 EditorType=string
@@ -6493,7 +6493,7 @@ ValueDefault=
 
 [Cmt Insert File Footer]
 Category=8
-Description="<html>(726)Path to a file that contains text to insert at the end of a file if the<br/>file doesn't end with a C/C++ comment. If the inserted text contains<br/>'$(filename)', that will be replaced with the current file's name.</html>"
+Description="<html>Path to a file that contains text to insert at the end of a file if the<br/>file doesn't end with a C/C++ comment. If the inserted text contains<br/>'$(filename)', that will be replaced with the current file's name.</html>"
 Enabled=false
 CallName=cmt_insert_file_footer=
 EditorType=string
@@ -6501,7 +6501,7 @@ ValueDefault=
 
 [Cmt Insert Func Header]
 Category=8
-Description="<html>(727)Path to a file that contains text to insert before a function definition if<br/>the function isn't preceded by a C/C++ comment. If the inserted text<br/>contains '$(function)', '$(javaparam)' or '$(fclass)', these will be<br/>replaced with, respectively, the name of the function, the javadoc '@param'<br/>and '@return' stuff, or the name of the class to which the member function<br/>belongs.</html>"
+Description="<html>Path to a file that contains text to insert before a function definition if<br/>the function isn't preceded by a C/C++ comment. If the inserted text<br/>contains '$(function)', '$(javaparam)' or '$(fclass)', these will be<br/>replaced with, respectively, the name of the function, the javadoc '@param'<br/>and '@return' stuff, or the name of the class to which the member function<br/>belongs.</html>"
 Enabled=false
 CallName=cmt_insert_func_header=
 EditorType=string
@@ -6509,7 +6509,7 @@ ValueDefault=
 
 [Cmt Insert Class Header]
 Category=8
-Description="<html>(728)Path to a file that contains text to insert before a class if the class<br/>isn't preceded by a C/C++ comment. If the inserted text contains '$(class)',<br/>that will be replaced with the class name.</html>"
+Description="<html>Path to a file that contains text to insert before a class if the class<br/>isn't preceded by a C/C++ comment. If the inserted text contains '$(class)',<br/>that will be replaced with the class name.</html>"
 Enabled=false
 CallName=cmt_insert_class_header=
 EditorType=string
@@ -6517,7 +6517,7 @@ ValueDefault=
 
 [Cmt Insert Oc Msg Header]
 Category=8
-Description="<html>(729)Path to a file that contains text to insert before an Objective-C message<br/>specification, if the method isn't preceded by a C/C++ comment. If the<br/>inserted text contains '$(message)' or '$(javaparam)', these will be<br/>replaced with, respectively, the name of the function, or the javadoc<br/>'@param' and '@return' stuff.</html>"
+Description="<html>Path to a file that contains text to insert before an Objective-C message<br/>specification, if the method isn't preceded by a C/C++ comment. If the<br/>inserted text contains '$(message)' or '$(javaparam)', these will be<br/>replaced with, respectively, the name of the function, or the javadoc<br/>'@param' and '@return' stuff.</html>"
 Enabled=false
 CallName=cmt_insert_oc_msg_header=
 EditorType=string
@@ -6525,7 +6525,7 @@ ValueDefault=
 
 [Cmt Insert Before Preproc]
 Category=8
-Description="<html>(730)Whether a comment should be inserted if a preprocessor is encountered when<br/>stepping backwards from a function name.<br/><br/>Applies to cmt_insert_oc_msg_header, cmt_insert_func_header and<br/>cmt_insert_class_header.</html>"
+Description="<html>Whether a comment should be inserted if a preprocessor is encountered when<br/>stepping backwards from a function name.<br/><br/>Applies to cmt_insert_oc_msg_header, cmt_insert_func_header and<br/>cmt_insert_class_header.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=cmt_insert_before_preproc=true|cmt_insert_before_preproc=false
@@ -6533,7 +6533,7 @@ ValueDefault=false
 
 [Cmt Insert Before Inlines]
 Category=8
-Description="<html>(731)Whether a comment should be inserted if a function is declared inline to a<br/>class definition.<br/><br/>Applies to cmt_insert_func_header.<br/><br/>Default: true</html>"
+Description="<html>Whether a comment should be inserted if a function is declared inline to a<br/>class definition.<br/><br/>Applies to cmt_insert_func_header.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=cmt_insert_before_inlines=true|cmt_insert_before_inlines=false
@@ -6541,7 +6541,7 @@ ValueDefault=true
 
 [Cmt Insert Before Ctor Dtor]
 Category=8
-Description="<html>(732)Whether a comment should be inserted if the function is a class constructor<br/>or destructor.<br/><br/>Applies to cmt_insert_func_header.</html>"
+Description="<html>Whether a comment should be inserted if the function is a class constructor<br/>or destructor.<br/><br/>Applies to cmt_insert_func_header.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=cmt_insert_before_ctor_dtor=true|cmt_insert_before_ctor_dtor=false
@@ -6549,43 +6549,43 @@ ValueDefault=false
 
 [Mod Full Brace Do]
 Category=9
-Description="<html>(733)Add or remove braces on a single-line 'do' statement.</html>"
+Description="<html>Add or remove braces on a single-line 'do' statement.</html>"
 Enabled=false
 EditorType=multiple
 Choices=mod_full_brace_do=ignore|mod_full_brace_do=add|mod_full_brace_do=remove|mod_full_brace_do=force|mod_full_brace_do=not_defined
-ChoicesReadable="(733)Ignore Mod Full Brace Do|(733)Add Mod Full Brace Do|(733)Remove Mod Full Brace Do|(733)Force Mod Full Brace Do"
+ChoicesReadable="Ignore Mod Full Brace Do|Add Mod Full Brace Do|Remove Mod Full Brace Do|Force Mod Full Brace Do"
 ValueDefault=ignore
 
 [Mod Full Brace For]
 Category=9
-Description="<html>(734)Add or remove braces on a single-line 'for' statement.</html>"
+Description="<html>Add or remove braces on a single-line 'for' statement.</html>"
 Enabled=false
 EditorType=multiple
 Choices=mod_full_brace_for=ignore|mod_full_brace_for=add|mod_full_brace_for=remove|mod_full_brace_for=force|mod_full_brace_for=not_defined
-ChoicesReadable="(734)Ignore Mod Full Brace For|(734)Add Mod Full Brace For|(734)Remove Mod Full Brace For|(734)Force Mod Full Brace For"
+ChoicesReadable="Ignore Mod Full Brace For|Add Mod Full Brace For|Remove Mod Full Brace For|Force Mod Full Brace For"
 ValueDefault=ignore
 
 [Mod Full Brace Function]
 Category=9
-Description="<html>(735)(Pawn) Add or remove braces on a single-line function definition.</html>"
+Description="<html>(Pawn) Add or remove braces on a single-line function definition.</html>"
 Enabled=false
 EditorType=multiple
 Choices=mod_full_brace_function=ignore|mod_full_brace_function=add|mod_full_brace_function=remove|mod_full_brace_function=force|mod_full_brace_function=not_defined
-ChoicesReadable="(735)Ignore Mod Full Brace Function|(735)Add Mod Full Brace Function|(735)Remove Mod Full Brace Function|(735)Force Mod Full Brace Function"
+ChoicesReadable="Ignore Mod Full Brace Function|Add Mod Full Brace Function|Remove Mod Full Brace Function|Force Mod Full Brace Function"
 ValueDefault=ignore
 
 [Mod Full Brace If]
 Category=9
-Description="<html>(736)Add or remove braces on a single-line 'if' statement. Braces will not be<br/>removed if the braced statement contains an 'else'.</html>"
+Description="<html>Add or remove braces on a single-line 'if' statement. Braces will not be<br/>removed if the braced statement contains an 'else'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=mod_full_brace_if=ignore|mod_full_brace_if=add|mod_full_brace_if=remove|mod_full_brace_if=force|mod_full_brace_if=not_defined
-ChoicesReadable="(736)Ignore Mod Full Brace If|(736)Add Mod Full Brace If|(736)Remove Mod Full Brace If|(736)Force Mod Full Brace If"
+ChoicesReadable="Ignore Mod Full Brace If|Add Mod Full Brace If|Remove Mod Full Brace If|Force Mod Full Brace If"
 ValueDefault=ignore
 
 [Mod Full Brace If Chain]
 Category=9
-Description="<html>(737)Whether to enforce that all blocks of an 'if'/'else if'/'else' chain either<br/>have, or do not have, braces. Overrides mod_full_brace_if.<br/><br/>0: Don't override mod_full_brace_if<br/>1: Add braces to all blocks if any block needs braces and remove braces if<br/>   they can be removed from all blocks<br/>2: Add braces to all blocks if any block already has braces, regardless of<br/>   whether it needs them<br/>3: Add braces to all blocks if any block needs braces and remove braces if<br/>   they can be removed from all blocks, except if all blocks have braces<br/>   despite none needing them</html>"
+Description="<html>Whether to enforce that all blocks of an 'if'/'else if'/'else' chain either<br/>have, or do not have, braces. Overrides mod_full_brace_if.<br/><br/>0: Don't override mod_full_brace_if<br/>1: Add braces to all blocks if any block needs braces and remove braces if<br/>   they can be removed from all blocks<br/>2: Add braces to all blocks if any block already has braces, regardless of<br/>   whether it needs them<br/>3: Add braces to all blocks if any block needs braces and remove braces if<br/>   they can be removed from all blocks, except if all blocks have braces<br/>   despite none needing them</html>"
 Enabled=false
 EditorType=numeric
 CallName="mod_full_brace_if_chain="
@@ -6595,7 +6595,7 @@ ValueDefault=0
 
 [Mod Full Brace If Chain Only]
 Category=9
-Description="<html>(738)Whether to add braces to all blocks of an 'if'/'else if'/'else' chain.<br/>If true, mod_full_brace_if_chain will only remove braces from an 'if' that<br/>does not have an 'else if' or 'else'.</html>"
+Description="<html>Whether to add braces to all blocks of an 'if'/'else if'/'else' chain.<br/>If true, mod_full_brace_if_chain will only remove braces from an 'if' that<br/>does not have an 'else if' or 'else'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_full_brace_if_chain_only=true|mod_full_brace_if_chain_only=false
@@ -6603,25 +6603,25 @@ ValueDefault=false
 
 [Mod Full Brace While]
 Category=9
-Description="<html>(739)Add or remove braces on single-line 'while' statement.</html>"
+Description="<html>Add or remove braces on single-line 'while' statement.</html>"
 Enabled=false
 EditorType=multiple
 Choices=mod_full_brace_while=ignore|mod_full_brace_while=add|mod_full_brace_while=remove|mod_full_brace_while=force|mod_full_brace_while=not_defined
-ChoicesReadable="(739)Ignore Mod Full Brace While|(739)Add Mod Full Brace While|(739)Remove Mod Full Brace While|(739)Force Mod Full Brace While"
+ChoicesReadable="Ignore Mod Full Brace While|Add Mod Full Brace While|Remove Mod Full Brace While|Force Mod Full Brace While"
 ValueDefault=ignore
 
 [Mod Full Brace Using]
 Category=9
-Description="<html>(740)Add or remove braces on single-line 'using ()' statement.</html>"
+Description="<html>Add or remove braces on single-line 'using ()' statement.</html>"
 Enabled=false
 EditorType=multiple
 Choices=mod_full_brace_using=ignore|mod_full_brace_using=add|mod_full_brace_using=remove|mod_full_brace_using=force|mod_full_brace_using=not_defined
-ChoicesReadable="(740)Ignore Mod Full Brace Using|(740)Add Mod Full Brace Using|(740)Remove Mod Full Brace Using|(740)Force Mod Full Brace Using"
+ChoicesReadable="Ignore Mod Full Brace Using|Add Mod Full Brace Using|Remove Mod Full Brace Using|Force Mod Full Brace Using"
 ValueDefault=ignore
 
 [Mod Full Brace Nl]
 Category=9
-Description="<html>(741)Don't remove braces around statements that span N newlines</html>"
+Description="<html>Don't remove braces around statements that span N newlines</html>"
 Enabled=false
 EditorType=numeric
 CallName="mod_full_brace_nl="
@@ -6631,7 +6631,7 @@ ValueDefault=0
 
 [Mod Full Brace Nl Block Rem Mlcond]
 Category=9
-Description="<html>(742)Whether to prevent removal of braces from 'if'/'for'/'while'/etc. blocks<br/>which span multiple lines.<br/><br/>Affects:<br/>  mod_full_brace_for<br/>  mod_full_brace_if<br/>  mod_full_brace_if_chain<br/>  mod_full_brace_if_chain_only<br/>  mod_full_brace_while<br/>  mod_full_brace_using<br/><br/>Does not affect:<br/>  mod_full_brace_do<br/>  mod_full_brace_function</html>"
+Description="<html>Whether to prevent removal of braces from 'if'/'for'/'while'/etc. blocks<br/>which span multiple lines.<br/><br/>Affects:<br/>  mod_full_brace_for<br/>  mod_full_brace_if<br/>  mod_full_brace_if_chain<br/>  mod_full_brace_if_chain_only<br/>  mod_full_brace_while<br/>  mod_full_brace_using<br/><br/>Does not affect:<br/>  mod_full_brace_do<br/>  mod_full_brace_function</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_full_brace_nl_block_rem_mlcond=true|mod_full_brace_nl_block_rem_mlcond=false
@@ -6639,25 +6639,25 @@ ValueDefault=false
 
 [Mod Paren On Return]
 Category=9
-Description="<html>(743)Add or remove unnecessary parentheses on 'return' statement.</html>"
+Description="<html>Add or remove unnecessary parentheses on 'return' statement.</html>"
 Enabled=false
 EditorType=multiple
 Choices=mod_paren_on_return=ignore|mod_paren_on_return=add|mod_paren_on_return=remove|mod_paren_on_return=force|mod_paren_on_return=not_defined
-ChoicesReadable="(743)Ignore Mod Paren On Return|(743)Add Mod Paren On Return|(743)Remove Mod Paren On Return|(743)Force Mod Paren On Return"
+ChoicesReadable="Ignore Mod Paren On Return|Add Mod Paren On Return|Remove Mod Paren On Return|Force Mod Paren On Return"
 ValueDefault=ignore
 
 [Mod Paren On Throw]
 Category=9
-Description="<html>(744)Add or remove unnecessary parentheses on 'throw' statement.</html>"
+Description="<html>Add or remove unnecessary parentheses on 'throw' statement.</html>"
 Enabled=false
 EditorType=multiple
 Choices=mod_paren_on_throw=ignore|mod_paren_on_throw=add|mod_paren_on_throw=remove|mod_paren_on_throw=force|mod_paren_on_throw=not_defined
-ChoicesReadable="(744)Ignore Mod Paren On Throw|(744)Add Mod Paren On Throw|(744)Remove Mod Paren On Throw|(744)Force Mod Paren On Throw"
+ChoicesReadable="Ignore Mod Paren On Throw|Add Mod Paren On Throw|Remove Mod Paren On Throw|Force Mod Paren On Throw"
 ValueDefault=ignore
 
 [Mod Pawn Semicolon]
 Category=9
-Description="<html>(745)(Pawn) Whether to change optional semicolons to real semicolons.</html>"
+Description="<html>(Pawn) Whether to change optional semicolons to real semicolons.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_pawn_semicolon=true|mod_pawn_semicolon=false
@@ -6665,7 +6665,7 @@ ValueDefault=false
 
 [Mod Full Paren If Bool]
 Category=9
-Description="<html>(746)Whether to fully parenthesize Boolean expressions in 'while' and 'if'<br/>statement, as in 'if (a &amp;&amp; b &gt; c)' =&gt; 'if (a &amp;&amp; (b &gt; c))'.</html>"
+Description="<html>Whether to fully parenthesize Boolean expressions in 'while' and 'if'<br/>statement, as in 'if (a &amp;&amp; b &gt; c)' =&gt; 'if (a &amp;&amp; (b &gt; c))'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_full_paren_if_bool=true|mod_full_paren_if_bool=false
@@ -6673,7 +6673,7 @@ ValueDefault=false
 
 [Mod Full Paren Assign Bool]
 Category=9
-Description="<html>(747)Whether to fully parenthesize Boolean expressions after '='<br/>statement, as in 'x = a &amp;&amp; b &gt; c;' =&gt; 'x = (a &amp;&amp; (b &gt; c));'.</html>"
+Description="<html>Whether to fully parenthesize Boolean expressions after '='<br/>statement, as in 'x = a &amp;&amp; b &gt; c;' =&gt; 'x = (a &amp;&amp; (b &gt; c));'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_full_paren_assign_bool=true|mod_full_paren_assign_bool=false
@@ -6681,7 +6681,7 @@ ValueDefault=false
 
 [Mod Full Paren Return Bool]
 Category=9
-Description="<html>(748)Whether to fully parenthesize Boolean expressions after '='<br/>statement, as in 'return  a &amp;&amp; b &gt; c;' =&gt; 'return (a &amp;&amp; (b &gt; c));'.</html>"
+Description="<html>Whether to fully parenthesize Boolean expressions after '='<br/>statement, as in 'return  a &amp;&amp; b &gt; c;' =&gt; 'return (a &amp;&amp; (b &gt; c));'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_full_paren_return_bool=true|mod_full_paren_return_bool=false
@@ -6689,7 +6689,7 @@ ValueDefault=false
 
 [Mod Remove Extra Semicolon]
 Category=9
-Description="<html>(749)Whether to remove superfluous semicolons.</html>"
+Description="<html>Whether to remove superfluous semicolons.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_remove_extra_semicolon=true|mod_remove_extra_semicolon=false
@@ -6697,7 +6697,7 @@ ValueDefault=false
 
 [Mod Remove Duplicate Include]
 Category=9
-Description="<html>(750)Whether to remove duplicate include.</html>"
+Description="<html>Whether to remove duplicate include.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_remove_duplicate_include=true|mod_remove_duplicate_include=false
@@ -6705,7 +6705,7 @@ ValueDefault=false
 
 [Mod Add Long Function Closebrace Comment]
 Category=9
-Description="<html>(751)If a function body exceeds the specified number of newlines and doesn't have<br/>a comment after the close brace, a comment will be added.</html>"
+Description="<html>If a function body exceeds the specified number of newlines and doesn't have<br/>a comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
 CallName="mod_add_long_function_closebrace_comment="
@@ -6715,7 +6715,7 @@ ValueDefault=0
 
 [Mod Add Long Namespace Closebrace Comment]
 Category=9
-Description="<html>(752)If a namespace body exceeds the specified number of newlines and doesn't<br/>have a comment after the close brace, a comment will be added.</html>"
+Description="<html>If a namespace body exceeds the specified number of newlines and doesn't<br/>have a comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
 CallName="mod_add_long_namespace_closebrace_comment="
@@ -6725,7 +6725,7 @@ ValueDefault=0
 
 [Mod Add Long Class Closebrace Comment]
 Category=9
-Description="<html>(753)If a class body exceeds the specified number of newlines and doesn't have a<br/>comment after the close brace, a comment will be added.</html>"
+Description="<html>If a class body exceeds the specified number of newlines and doesn't have a<br/>comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
 CallName="mod_add_long_class_closebrace_comment="
@@ -6735,7 +6735,7 @@ ValueDefault=0
 
 [Mod Add Long Switch Closebrace Comment]
 Category=9
-Description="<html>(754)If a switch body exceeds the specified number of newlines and doesn't have a<br/>comment after the close brace, a comment will be added.</html>"
+Description="<html>If a switch body exceeds the specified number of newlines and doesn't have a<br/>comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
 CallName="mod_add_long_switch_closebrace_comment="
@@ -6745,7 +6745,7 @@ ValueDefault=0
 
 [Mod Add Long Ifdef Endif Comment]
 Category=9
-Description="<html>(755)If an #ifdef body exceeds the specified number of newlines and doesn't have<br/>a comment after the #endif, a comment will be added.</html>"
+Description="<html>If an #ifdef body exceeds the specified number of newlines and doesn't have<br/>a comment after the #endif, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
 CallName="mod_add_long_ifdef_endif_comment="
@@ -6755,7 +6755,7 @@ ValueDefault=0
 
 [Mod Add Long Ifdef Else Comment]
 Category=9
-Description="<html>(756)If an #ifdef or #else body exceeds the specified number of newlines and<br/>doesn't have a comment after the #else, a comment will be added.</html>"
+Description="<html>If an #ifdef or #else body exceeds the specified number of newlines and<br/>doesn't have a comment after the #else, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
 CallName="mod_add_long_ifdef_else_comment="
@@ -6765,7 +6765,7 @@ ValueDefault=0
 
 [Mod Sort Case Sensitive]
 Category=9
-Description="<html>(757)Whether to take care of the case by the mod_sort_xx options.</html>"
+Description="<html>Whether to take care of the case by the mod_sort_xx options.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_sort_case_sensitive=true|mod_sort_case_sensitive=false
@@ -6773,7 +6773,7 @@ ValueDefault=false
 
 [Mod Sort Import]
 Category=9
-Description="<html>(758)Whether to sort consecutive single-line 'import' statements.</html>"
+Description="<html>Whether to sort consecutive single-line 'import' statements.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_sort_import=true|mod_sort_import=false
@@ -6781,7 +6781,7 @@ ValueDefault=false
 
 [Mod Sort Using]
 Category=9
-Description="<html>(759)(C#) Whether to sort consecutive single-line 'using' statements.</html>"
+Description="<html>(C#) Whether to sort consecutive single-line 'using' statements.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_sort_using=true|mod_sort_using=false
@@ -6789,7 +6789,7 @@ ValueDefault=false
 
 [Mod Sort Include]
 Category=9
-Description="<html>(760)Whether to sort consecutive single-line '#include' statements (C/C++) and<br/>'#import' statements (Objective-C). Be aware that this has the potential to<br/>break your code if your includes/imports have ordering dependencies.</html>"
+Description="<html>Whether to sort consecutive single-line '#include' statements (C/C++) and<br/>'#import' statements (Objective-C). Be aware that this has the potential to<br/>break your code if your includes/imports have ordering dependencies.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_sort_include=true|mod_sort_include=false
@@ -6797,7 +6797,7 @@ ValueDefault=false
 
 [Mod Sort Incl Import Prioritize Filename]
 Category=9
-Description="<html>(761)Whether to prioritize '#include' and '#import' statements that contain<br/>filename without extension when sorting is enabled.</html>"
+Description="<html>Whether to prioritize '#include' and '#import' statements that contain<br/>filename without extension when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_sort_incl_import_prioritize_filename=true|mod_sort_incl_import_prioritize_filename=false
@@ -6805,7 +6805,7 @@ ValueDefault=false
 
 [Mod Sort Incl Import Prioritize Extensionless]
 Category=9
-Description="<html>(762)Whether to prioritize '#include' and '#import' statements that does not<br/>contain extensions when sorting is enabled.</html>"
+Description="<html>Whether to prioritize '#include' and '#import' statements that does not<br/>contain extensions when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_sort_incl_import_prioritize_extensionless=true|mod_sort_incl_import_prioritize_extensionless=false
@@ -6813,7 +6813,7 @@ ValueDefault=false
 
 [Mod Sort Incl Import Prioritize Angle Over Quotes]
 Category=9
-Description="<html>(763)Whether to prioritize '#include' and '#import' statements that contain<br/>angle over quotes when sorting is enabled.</html>"
+Description="<html>Whether to prioritize '#include' and '#import' statements that contain<br/>angle over quotes when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_sort_incl_import_prioritize_angle_over_quotes=true|mod_sort_incl_import_prioritize_angle_over_quotes=false
@@ -6821,7 +6821,7 @@ ValueDefault=false
 
 [Mod Sort Incl Import Ignore Extension]
 Category=9
-Description="<html>(764)Whether to ignore file extension in '#include' and '#import' statements<br/>for sorting comparison.</html>"
+Description="<html>Whether to ignore file extension in '#include' and '#import' statements<br/>for sorting comparison.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_sort_incl_import_ignore_extension=true|mod_sort_incl_import_ignore_extension=false
@@ -6829,7 +6829,7 @@ ValueDefault=false
 
 [Mod Sort Incl Import Grouping Enabled]
 Category=9
-Description="<html>(765)Whether to group '#include' and '#import' statements when sorting is enabled.</html>"
+Description="<html>Whether to group '#include' and '#import' statements when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_sort_incl_import_grouping_enabled=true|mod_sort_incl_import_grouping_enabled=false
@@ -6837,7 +6837,7 @@ ValueDefault=false
 
 [Mod Move Case Break]
 Category=9
-Description="<html>(766)Whether to move a 'break' that appears after a fully braced 'case' before<br/>the close brace, as in 'case X: { ... } break;' =&gt; 'case X: { ... break; }'.</html>"
+Description="<html>Whether to move a 'break' that appears after a fully braced 'case' before<br/>the close brace, as in 'case X: { ... } break;' =&gt; 'case X: { ... break; }'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_move_case_break=true|mod_move_case_break=false
@@ -6845,7 +6845,7 @@ ValueDefault=false
 
 [Mod Move Case Return]
 Category=9
-Description="<html>(767)Whether to move a 'return' that appears after a fully braced 'case' before<br/>the close brace, as in 'case X: { ... } return;' =&gt; 'case X: { ... return; }'.</html>"
+Description="<html>Whether to move a 'return' that appears after a fully braced 'case' before<br/>the close brace, as in 'case X: { ... } return;' =&gt; 'case X: { ... return; }'.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_move_case_return=true|mod_move_case_return=false
@@ -6853,16 +6853,16 @@ ValueDefault=false
 
 [Mod Case Brace]
 Category=9
-Description="<html>(768)Add or remove braces around a fully braced case statement. Will only remove<br/>braces if there are no variable declarations in the block.</html>"
+Description="<html>Add or remove braces around a fully braced case statement. Will only remove<br/>braces if there are no variable declarations in the block.</html>"
 Enabled=false
 EditorType=multiple
 Choices=mod_case_brace=ignore|mod_case_brace=add|mod_case_brace=remove|mod_case_brace=force|mod_case_brace=not_defined
-ChoicesReadable="(768)Ignore Mod Case Brace|(768)Add Mod Case Brace|(768)Remove Mod Case Brace|(768)Force Mod Case Brace"
+ChoicesReadable="Ignore Mod Case Brace|Add Mod Case Brace|Remove Mod Case Brace|Force Mod Case Brace"
 ValueDefault=ignore
 
 [Mod Remove Empty Return]
 Category=9
-Description="<html>(769)Whether to remove a void 'return;' that appears as the last statement in a<br/>function.</html>"
+Description="<html>Whether to remove a void 'return;' that appears as the last statement in a<br/>function.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_remove_empty_return=true|mod_remove_empty_return=false
@@ -6870,16 +6870,16 @@ ValueDefault=false
 
 [Mod Enum Last Comma]
 Category=9
-Description="<html>(770)Add or remove the comma after the last value of an enumeration.</html>"
+Description="<html>Add or remove the comma after the last value of an enumeration.</html>"
 Enabled=false
 EditorType=multiple
 Choices=mod_enum_last_comma=ignore|mod_enum_last_comma=add|mod_enum_last_comma=remove|mod_enum_last_comma=force|mod_enum_last_comma=not_defined
-ChoicesReadable="(770)Ignore Mod Enum Last Comma|(770)Add Mod Enum Last Comma|(770)Remove Mod Enum Last Comma|(770)Force Mod Enum Last Comma"
+ChoicesReadable="Ignore Mod Enum Last Comma|Add Mod Enum Last Comma|Remove Mod Enum Last Comma|Force Mod Enum Last Comma"
 ValueDefault=ignore
 
 [Mod Infinite Loop]
 Category=9
-Description="<html>(771)Syntax to use for infinite loops.<br/><br/>0: Leave syntax alone (default)<br/>1: Rewrite as `for(;;)`<br/>2: Rewrite as `while(true)`<br/>3: Rewrite as `do`...`while(true);`<br/>4: Rewrite as `while(1)`<br/>5: Rewrite as `do`...`while(1);`<br/><br/>Infinite loops that do not already match one of these syntaxes are ignored.<br/>Other options that affect loop formatting will be applied after transforming<br/>the syntax.</html>"
+Description="<html>Syntax to use for infinite loops.<br/><br/>0: Leave syntax alone (default)<br/>1: Rewrite as `for(;;)`<br/>2: Rewrite as `while(true)`<br/>3: Rewrite as `do`...`while(true);`<br/>4: Rewrite as `while(1)`<br/>5: Rewrite as `do`...`while(1);`<br/><br/>Infinite loops that do not already match one of these syntaxes are ignored.<br/>Other options that affect loop formatting will be applied after transforming<br/>the syntax.</html>"
 Enabled=false
 EditorType=numeric
 CallName="mod_infinite_loop="
@@ -6889,79 +6889,79 @@ ValueDefault=0
 
 [Mod Int Short]
 Category=9
-Description="<html>(772)Add or remove the 'int' keyword in 'int short'.</html>"
+Description="<html>Add or remove the 'int' keyword in 'int short'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=mod_int_short=ignore|mod_int_short=add|mod_int_short=remove|mod_int_short=force|mod_int_short=not_defined
-ChoicesReadable="(772)Ignore Mod Int Short|(772)Add Mod Int Short|(772)Remove Mod Int Short|(772)Force Mod Int Short"
+ChoicesReadable="Ignore Mod Int Short|Add Mod Int Short|Remove Mod Int Short|Force Mod Int Short"
 ValueDefault=ignore
 
 [Mod Short Int]
 Category=9
-Description="<html>(773)Add or remove the 'int' keyword in 'short int'.</html>"
+Description="<html>Add or remove the 'int' keyword in 'short int'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=mod_short_int=ignore|mod_short_int=add|mod_short_int=remove|mod_short_int=force|mod_short_int=not_defined
-ChoicesReadable="(773)Ignore Mod Short Int|(773)Add Mod Short Int|(773)Remove Mod Short Int|(773)Force Mod Short Int"
+ChoicesReadable="Ignore Mod Short Int|Add Mod Short Int|Remove Mod Short Int|Force Mod Short Int"
 ValueDefault=ignore
 
 [Mod Int Long]
 Category=9
-Description="<html>(774)Add or remove the 'int' keyword in 'int long'.</html>"
+Description="<html>Add or remove the 'int' keyword in 'int long'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=mod_int_long=ignore|mod_int_long=add|mod_int_long=remove|mod_int_long=force|mod_int_long=not_defined
-ChoicesReadable="(774)Ignore Mod Int Long|(774)Add Mod Int Long|(774)Remove Mod Int Long|(774)Force Mod Int Long"
+ChoicesReadable="Ignore Mod Int Long|Add Mod Int Long|Remove Mod Int Long|Force Mod Int Long"
 ValueDefault=ignore
 
 [Mod Long Int]
 Category=9
-Description="<html>(775)Add or remove the 'int' keyword in 'long int'.</html>"
+Description="<html>Add or remove the 'int' keyword in 'long int'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=mod_long_int=ignore|mod_long_int=add|mod_long_int=remove|mod_long_int=force|mod_long_int=not_defined
-ChoicesReadable="(775)Ignore Mod Long Int|(775)Add Mod Long Int|(775)Remove Mod Long Int|(775)Force Mod Long Int"
+ChoicesReadable="Ignore Mod Long Int|Add Mod Long Int|Remove Mod Long Int|Force Mod Long Int"
 ValueDefault=ignore
 
 [Mod Int Signed]
 Category=9
-Description="<html>(776)Add or remove the 'int' keyword in 'int signed'.</html>"
+Description="<html>Add or remove the 'int' keyword in 'int signed'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=mod_int_signed=ignore|mod_int_signed=add|mod_int_signed=remove|mod_int_signed=force|mod_int_signed=not_defined
-ChoicesReadable="(776)Ignore Mod Int Signed|(776)Add Mod Int Signed|(776)Remove Mod Int Signed|(776)Force Mod Int Signed"
+ChoicesReadable="Ignore Mod Int Signed|Add Mod Int Signed|Remove Mod Int Signed|Force Mod Int Signed"
 ValueDefault=ignore
 
 [Mod Signed Int]
 Category=9
-Description="<html>(777)Add or remove the 'int' keyword in 'signed int'.</html>"
+Description="<html>Add or remove the 'int' keyword in 'signed int'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=mod_signed_int=ignore|mod_signed_int=add|mod_signed_int=remove|mod_signed_int=force|mod_signed_int=not_defined
-ChoicesReadable="(777)Ignore Mod Signed Int|(777)Add Mod Signed Int|(777)Remove Mod Signed Int|(777)Force Mod Signed Int"
+ChoicesReadable="Ignore Mod Signed Int|Add Mod Signed Int|Remove Mod Signed Int|Force Mod Signed Int"
 ValueDefault=ignore
 
 [Mod Int Unsigned]
 Category=9
-Description="<html>(778)Add or remove the 'int' keyword in 'int unsigned'.</html>"
+Description="<html>Add or remove the 'int' keyword in 'int unsigned'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=mod_int_unsigned=ignore|mod_int_unsigned=add|mod_int_unsigned=remove|mod_int_unsigned=force|mod_int_unsigned=not_defined
-ChoicesReadable="(778)Ignore Mod Int Unsigned|(778)Add Mod Int Unsigned|(778)Remove Mod Int Unsigned|(778)Force Mod Int Unsigned"
+ChoicesReadable="Ignore Mod Int Unsigned|Add Mod Int Unsigned|Remove Mod Int Unsigned|Force Mod Int Unsigned"
 ValueDefault=ignore
 
 [Mod Unsigned Int]
 Category=9
-Description="<html>(779)Add or remove the 'int' keyword in 'unsigned int'.</html>"
+Description="<html>Add or remove the 'int' keyword in 'unsigned int'.</html>"
 Enabled=false
 EditorType=multiple
 Choices=mod_unsigned_int=ignore|mod_unsigned_int=add|mod_unsigned_int=remove|mod_unsigned_int=force|mod_unsigned_int=not_defined
-ChoicesReadable="(779)Ignore Mod Unsigned Int|(779)Add Mod Unsigned Int|(779)Remove Mod Unsigned Int|(779)Force Mod Unsigned Int"
+ChoicesReadable="Ignore Mod Unsigned Int|Add Mod Unsigned Int|Remove Mod Unsigned Int|Force Mod Unsigned Int"
 ValueDefault=ignore
 
 [Mod Int Prefer Int On Left]
 Category=9
-Description="<html>(780)If there is a situation where mod_int_* and mod_*_int would result in<br/>multiple int keywords, whether to keep the rightmost int (the default) or the<br/>leftmost int.</html>"
+Description="<html>If there is a situation where mod_int_* and mod_*_int would result in<br/>multiple int keywords, whether to keep the rightmost int (the default) or the<br/>leftmost int.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_int_prefer_int_on_left=true|mod_int_prefer_int_on_left=false
@@ -6969,7 +6969,7 @@ ValueDefault=false
 
 [Mod Sort Oc Properties]
 Category=9
-Description="<html>(781)(OC) Whether to organize the properties. If true, properties will be<br/>rearranged according to the mod_sort_oc_property_*_weight factors.</html>"
+Description="<html>(OC) Whether to organize the properties. If true, properties will be<br/>rearranged according to the mod_sort_oc_property_*_weight factors.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=mod_sort_oc_properties=true|mod_sort_oc_properties=false
@@ -6977,7 +6977,7 @@ ValueDefault=false
 
 [Mod Sort Oc Property Class Weight]
 Category=9
-Description="<html>(782)(OC) Weight of a class property modifier.</html>"
+Description="<html>(OC) Weight of a class property modifier.</html>"
 Enabled=false
 EditorType=numeric
 CallName="mod_sort_oc_property_class_weight="
@@ -6987,7 +6987,7 @@ ValueDefault=0
 
 [Mod Sort Oc Property Thread Safe Weight]
 Category=9
-Description="<html>(783)(OC) Weight of 'atomic' and 'nonatomic'.</html>"
+Description="<html>(OC) Weight of 'atomic' and 'nonatomic'.</html>"
 Enabled=false
 EditorType=numeric
 CallName="mod_sort_oc_property_thread_safe_weight="
@@ -6997,7 +6997,7 @@ ValueDefault=0
 
 [Mod Sort Oc Property Readwrite Weight]
 Category=9
-Description="<html>(784)(OC) Weight of 'readwrite' when organizing properties.</html>"
+Description="<html>(OC) Weight of 'readwrite' when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
 CallName="mod_sort_oc_property_readwrite_weight="
@@ -7007,7 +7007,7 @@ ValueDefault=0
 
 [Mod Sort Oc Property Reference Weight]
 Category=9
-Description="<html>(785)(OC) Weight of a reference type specifier ('retain', 'copy', 'assign',<br/>'weak', 'strong') when organizing properties.</html>"
+Description="<html>(OC) Weight of a reference type specifier ('retain', 'copy', 'assign',<br/>'weak', 'strong') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
 CallName="mod_sort_oc_property_reference_weight="
@@ -7017,7 +7017,7 @@ ValueDefault=0
 
 [Mod Sort Oc Property Getter Weight]
 Category=9
-Description="<html>(786)(OC) Weight of getter type ('getter=') when organizing properties.</html>"
+Description="<html>(OC) Weight of getter type ('getter=') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
 CallName="mod_sort_oc_property_getter_weight="
@@ -7027,7 +7027,7 @@ ValueDefault=0
 
 [Mod Sort Oc Property Setter Weight]
 Category=9
-Description="<html>(787)(OC) Weight of setter type ('setter=') when organizing properties.</html>"
+Description="<html>(OC) Weight of setter type ('setter=') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
 CallName="mod_sort_oc_property_setter_weight="
@@ -7037,7 +7037,7 @@ ValueDefault=0
 
 [Mod Sort Oc Property Nullability Weight]
 Category=9
-Description="<html>(788)(OC) Weight of nullability type ('nullable', 'nonnull', 'null_unspecified',<br/>'null_resettable') when organizing properties.</html>"
+Description="<html>(OC) Weight of nullability type ('nullable', 'nonnull', 'null_unspecified',<br/>'null_resettable') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
 CallName="mod_sort_oc_property_nullability_weight="
@@ -7047,16 +7047,16 @@ ValueDefault=0
 
 [Pp Indent]
 Category=10
-Description="<html>(789)Add or remove indentation of preprocessor directives inside #if blocks<br/>at brace level 0 (file-level).</html>"
+Description="<html>Add or remove indentation of preprocessor directives inside #if blocks<br/>at brace level 0 (file-level).</html>"
 Enabled=false
 EditorType=multiple
 Choices=pp_indent=ignore|pp_indent=add|pp_indent=remove|pp_indent=force|pp_indent=not_defined
-ChoicesReadable="(789)Ignore Pp Indent|(789)Add Pp Indent|(789)Remove Pp Indent|(789)Force Pp Indent"
+ChoicesReadable="Ignore Pp Indent|Add Pp Indent|Remove Pp Indent|Force Pp Indent"
 ValueDefault=ignore
 
 [Pp Indent At Level]
 Category=10
-Description="<html>(790)Whether to indent #if/#else/#endif at the brace level. If false, these are<br/>indented from column 1.</html>"
+Description="<html>Whether to indent #if/#else/#endif at the brace level. If false, these are<br/>indented from column 1.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=pp_indent_at_level=true|pp_indent_at_level=false
@@ -7064,7 +7064,7 @@ ValueDefault=false
 
 [Pp Indent At Level0]
 Category=10
-Description="<html>(791)Whether to indent #if/#else/#endif at the parenthesis level if the brace<br/>level is 0. If false, these are indented from column 1.</html>"
+Description="<html>Whether to indent #if/#else/#endif at the parenthesis level if the brace<br/>level is 0. If false, these are indented from column 1.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=pp_indent_at_level0=true|pp_indent_at_level0=false
@@ -7072,7 +7072,7 @@ ValueDefault=false
 
 [Pp Indent Count]
 Category=10
-Description="<html>(792)Specifies the number of columns to indent preprocessors per level<br/>at brace level 0 (file-level). If pp_indent_at_level=false, also specifies<br/>the number of columns to indent preprocessors per level<br/>at brace level &gt; 0 (function-level).<br/><br/>Default: 1</html>"
+Description="<html>Specifies the number of columns to indent preprocessors per level<br/>at brace level 0 (file-level). If pp_indent_at_level=false, also specifies<br/>the number of columns to indent preprocessors per level<br/>at brace level &gt; 0 (function-level).<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
 CallName="pp_indent_count="
@@ -7082,16 +7082,16 @@ ValueDefault=1
 
 [Pp Space After]
 Category=10
-Description="<html>(793)Add or remove space after # based on pp_level of #if blocks.</html>"
+Description="<html>Add or remove space after # based on pp_level of #if blocks.</html>"
 Enabled=false
 EditorType=multiple
 Choices=pp_space_after=ignore|pp_space_after=add|pp_space_after=remove|pp_space_after=force|pp_space_after=not_defined
-ChoicesReadable="(793)Ignore Pp Space After|(793)Add Pp Space After|(793)Remove Pp Space After|(793)Force Pp Space After"
+ChoicesReadable="Ignore Pp Space After|Add Pp Space After|Remove Pp Space After|Force Pp Space After"
 ValueDefault=ignore
 
 [Pp Space Count]
 Category=10
-Description="<html>(794)Sets the number of spaces per level added with pp_space_after.</html>"
+Description="<html>Sets the number of spaces per level added with pp_space_after.</html>"
 Enabled=false
 EditorType=numeric
 CallName="pp_space_count="
@@ -7101,7 +7101,7 @@ ValueDefault=0
 
 [Pp Indent Region]
 Category=10
-Description="<html>(795)The indent for '#region' and '#endregion' in C# and '#pragma region' in<br/>C/C++. Negative values decrease indent down to the first column.</html>"
+Description="<html>The indent for '#region' and '#endregion' in C# and '#pragma region' in<br/>C/C++. Negative values decrease indent down to the first column.</html>"
 Enabled=false
 EditorType=numeric
 CallName="pp_indent_region="
@@ -7111,7 +7111,7 @@ ValueDefault=0
 
 [Pp Region Indent Code]
 Category=10
-Description="<html>(796)Whether to indent the code between #region and #endregion.</html>"
+Description="<html>Whether to indent the code between #region and #endregion.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=pp_region_indent_code=true|pp_region_indent_code=false
@@ -7119,7 +7119,7 @@ ValueDefault=false
 
 [Pp Indent If]
 Category=10
-Description="<html>(797)If pp_indent_at_level=true, sets the indent for #if, #else and #endif when<br/>not at file-level. Negative values decrease indent down to the first column.<br/><br/>=0: Indent preprocessors using output_tab_size<br/>&gt;0: Column at which all preprocessors will be indented</html>"
+Description="<html>If pp_indent_at_level=true, sets the indent for #if, #else and #endif when<br/>not at file-level. Negative values decrease indent down to the first column.<br/><br/>=0: Indent preprocessors using output_tab_size<br/>&gt;0: Column at which all preprocessors will be indented</html>"
 Enabled=false
 EditorType=numeric
 CallName="pp_indent_if="
@@ -7129,7 +7129,7 @@ ValueDefault=0
 
 [Pp If Indent Code]
 Category=10
-Description="<html>(798)Whether to indent the code between #if, #else and #endif.</html>"
+Description="<html>Whether to indent the code between #if, #else and #endif.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=pp_if_indent_code=true|pp_if_indent_code=false
@@ -7137,7 +7137,7 @@ ValueDefault=false
 
 [Pp Indent In Guard]
 Category=10
-Description="<html>(799)Whether to indent the body of an #if that encompasses all the code in the file.</html>"
+Description="<html>Whether to indent the body of an #if that encompasses all the code in the file.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=pp_indent_in_guard=true|pp_indent_in_guard=false
@@ -7145,7 +7145,7 @@ ValueDefault=false
 
 [Pp Define At Level]
 Category=10
-Description="<html>(800)Whether to indent '#define' at the brace level. If false, these are<br/>indented from column 1.</html>"
+Description="<html>Whether to indent '#define' at the brace level. If false, these are<br/>indented from column 1.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=pp_define_at_level=true|pp_define_at_level=false
@@ -7153,7 +7153,7 @@ ValueDefault=false
 
 [Pp Include At Level]
 Category=10
-Description="<html>(801)Whether to indent '#include' at the brace level.</html>"
+Description="<html>Whether to indent '#include' at the brace level.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=pp_include_at_level=true|pp_include_at_level=false
@@ -7161,7 +7161,7 @@ ValueDefault=false
 
 [Pp Ignore Define Body]
 Category=10
-Description="<html>(802)Whether to ignore the '#define' body while formatting.</html>"
+Description="<html>Whether to ignore the '#define' body while formatting.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=pp_ignore_define_body=true|pp_ignore_define_body=false
@@ -7169,7 +7169,7 @@ ValueDefault=false
 
 [Pp Indent Case]
 Category=10
-Description="<html>(803)Whether to indent case statements between #if, #else, and #endif.<br/>Only applies to the indent of the preprocesser that the case statements<br/>directly inside of.<br/><br/>Default: true</html>"
+Description="<html>Whether to indent case statements between #if, #else, and #endif.<br/>Only applies to the indent of the preprocesser that the case statements<br/>directly inside of.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=pp_indent_case=true|pp_indent_case=false
@@ -7177,7 +7177,7 @@ ValueDefault=true
 
 [Pp Indent Func Def]
 Category=10
-Description="<html>(804)Whether to indent whole function definitions between #if, #else, and #endif.<br/>Only applies to the indent of the preprocesser that the function definition<br/>is directly inside of.<br/><br/>Default: true</html>"
+Description="<html>Whether to indent whole function definitions between #if, #else, and #endif.<br/>Only applies to the indent of the preprocesser that the function definition<br/>is directly inside of.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=pp_indent_func_def=true|pp_indent_func_def=false
@@ -7185,7 +7185,7 @@ ValueDefault=true
 
 [Pp Indent Extern]
 Category=10
-Description="<html>(805)Whether to indent extern C blocks between #if, #else, and #endif.<br/>Only applies to the indent of the preprocesser that the extern block is<br/>directly inside of.<br/><br/>Default: true</html>"
+Description="<html>Whether to indent extern C blocks between #if, #else, and #endif.<br/>Only applies to the indent of the preprocesser that the extern block is<br/>directly inside of.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=pp_indent_extern=true|pp_indent_extern=false
@@ -7193,7 +7193,7 @@ ValueDefault=true
 
 [Pp Indent Brace]
 Category=10
-Description="<html>(806)How to indent braces directly inside #if, #else, and #endif.<br/>Requires pp_if_indent_code=true and only applies to the indent of the<br/>preprocesser that the braces are directly inside of.<br/> 0: No extra indent<br/> 1: Indent by one level<br/>-1: Preserve original indentation<br/><br/>Default: 1</html>"
+Description="<html>How to indent braces directly inside #if, #else, and #endif.<br/>Requires pp_if_indent_code=true and only applies to the indent of the<br/>preprocesser that the braces are directly inside of.<br/> 0: No extra indent<br/> 1: Indent by one level<br/>-1: Preserve original indentation<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
 CallName="pp_indent_brace="
@@ -7203,7 +7203,7 @@ ValueDefault=1
 
 [Pp Warn Unbalanced If]
 Category=10
-Description="<html>(807)Whether to print warning messages for unbalanced #if and #else blocks.<br/>This will print a message in the following cases:<br/>- if an #ifdef block ends on a different indent level than<br/>  where it started from. Example:<br/><br/>   #ifdef TEST<br/>     int i;<br/>     {<br/>       int j;<br/>   #endif<br/><br/>- an #elif/#else block ends on a different indent level than<br/>  the corresponding #ifdef block. Example:<br/><br/>   #ifdef TEST<br/>       int i;<br/>   #else<br/>       }<br/>     int j;<br/>   #endif</html>"
+Description="<html>Whether to print warning messages for unbalanced #if and #else blocks.<br/>This will print a message in the following cases:<br/>- if an #ifdef block ends on a different indent level than<br/>  where it started from. Example:<br/><br/>   #ifdef TEST<br/>     int i;<br/>     {<br/>       int j;<br/>   #endif<br/><br/>- an #elif/#else block ends on a different indent level than<br/>  the corresponding #ifdef block. Example:<br/><br/>   #ifdef TEST<br/>       int i;<br/>   #else<br/>       }<br/>     int j;<br/>   #endif</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=pp_warn_unbalanced_if=true|pp_warn_unbalanced_if=false
@@ -7211,7 +7211,7 @@ ValueDefault=false
 
 [Include Category 0]
 Category=11
-Description="<html>(808)The regex for include category with priority 0.</html>"
+Description="<html>The regex for include category with priority 0.</html>"
 Enabled=false
 CallName=include_category_0=
 EditorType=string
@@ -7219,7 +7219,7 @@ ValueDefault=
 
 [Include Category 1]
 Category=11
-Description="<html>(809)The regex for include category with priority 1.</html>"
+Description="<html>The regex for include category with priority 1.</html>"
 Enabled=false
 CallName=include_category_1=
 EditorType=string
@@ -7227,7 +7227,7 @@ ValueDefault=
 
 [Include Category 2]
 Category=11
-Description="<html>(810)The regex for include category with priority 2.</html>"
+Description="<html>The regex for include category with priority 2.</html>"
 Enabled=false
 CallName=include_category_2=
 EditorType=string
@@ -7235,7 +7235,7 @@ ValueDefault=
 
 [Use Indent Func Call Param]
 Category=12
-Description="<html>(811)true:  indent_func_call_param will be used (default)<br/>false: indent_func_call_param will NOT be used<br/><br/>Default: true</html>"
+Description="<html>true:  indent_func_call_param will be used (default)<br/>false: indent_func_call_param will NOT be used<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=use_indent_func_call_param=true|use_indent_func_call_param=false
@@ -7243,7 +7243,7 @@ ValueDefault=true
 
 [Use Indent Continue Only Once]
 Category=12
-Description="<html>(812)The value of the indentation for a continuation line is calculated<br/>differently if the statement is:<br/>- a declaration: your case with QString fileName ...<br/>- an assignment: your case with pSettings = new QSettings( ...<br/><br/>At the second case the indentation value might be used twice:<br/>- at the assignment<br/>- at the function call (if present)<br/><br/>To prevent the double use of the indentation value, use this option with the<br/>value 'true'.<br/><br/>true:  indent_continue will be used only once<br/>false: indent_continue will be used every time (default)<br/><br/>Requires indent_ignore_first_continue=false.</html>"
+Description="<html>The value of the indentation for a continuation line is calculated<br/>differently if the statement is:<br/>- a declaration: your case with QString fileName ...<br/>- an assignment: your case with pSettings = new QSettings( ...<br/><br/>At the second case the indentation value might be used twice:<br/>- at the assignment<br/>- at the function call (if present)<br/><br/>To prevent the double use of the indentation value, use this option with the<br/>value 'true'.<br/><br/>true:  indent_continue will be used only once<br/>false: indent_continue will be used every time (default)<br/><br/>Requires indent_ignore_first_continue=false.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=use_indent_continue_only_once=true|use_indent_continue_only_once=false
@@ -7251,7 +7251,7 @@ ValueDefault=false
 
 [Indent Cpp Lambda Only Once]
 Category=12
-Description="<html>(813)The indentation can be:<br/>- after the assignment, at the '[' character<br/>- at the begin of the lambda body<br/><br/>true:  indentation will be after the assignment<br/>false: indentation will be at the begin of the lambda body (default)</html>"
+Description="<html>The indentation can be:<br/>- after the assignment, at the '[' character<br/>- at the begin of the lambda body<br/><br/>true:  indentation will be after the assignment<br/>false: indentation will be at the begin of the lambda body (default)</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_cpp_lambda_only_once=true|indent_cpp_lambda_only_once=false
@@ -7259,7 +7259,7 @@ ValueDefault=false
 
 [Use Sp After Angle Always]
 Category=12
-Description="<html>(814)Whether sp_after_angle takes precedence over sp_inside_fparen. This was the<br/>historic behavior, but is probably not the desired behavior, so this is off<br/>by default.</html>"
+Description="<html>Whether sp_after_angle takes precedence over sp_inside_fparen. This was the<br/>historic behavior, but is probably not the desired behavior, so this is off<br/>by default.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=use_sp_after_angle_always=true|use_sp_after_angle_always=false
@@ -7267,7 +7267,7 @@ ValueDefault=false
 
 [Use Options Overriding For Qt Macros]
 Category=12
-Description="<html>(815)Whether to apply special formatting for Qt SIGNAL/SLOT macros. Essentially,<br/>this tries to format these so that they match Qt's normalized form (i.e. the<br/>result of QMetaObject::normalizedSignature), which can slightly improve the<br/>performance of the QObject::connect call, rather than how they would<br/>otherwise be formatted.<br/><br/>See options_for_QT.cpp for details.<br/><br/>Default: true</html>"
+Description="<html>Whether to apply special formatting for Qt SIGNAL/SLOT macros. Essentially,<br/>this tries to format these so that they match Qt's normalized form (i.e. the<br/>result of QMetaObject::normalizedSignature), which can slightly improve the<br/>performance of the QObject::connect call, rather than how they would<br/>otherwise be formatted.<br/><br/>See options_for_QT.cpp for details.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=use_options_overriding_for_qt_macros=true|use_options_overriding_for_qt_macros=false
@@ -7275,7 +7275,7 @@ ValueDefault=true
 
 [Use Form Feed No More As Whitespace Character]
 Category=12
-Description="<html>(816)If true: the form feed character is removed from the list of whitespace<br/>characters. See https://en.cppreference.com/w/cpp/string/byte/isspace.</html>"
+Description="<html>If true: the form feed character is removed from the list of whitespace<br/>characters. See https://en.cppreference.com/w/cpp/string/byte/isspace.</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=use_form_feed_no_more_as_whitespace_character=true|use_form_feed_no_more_as_whitespace_character=false
@@ -7283,7 +7283,7 @@ ValueDefault=false
 
 [Warn Level Tabs Found In Verbatim String Literals]
 Category=13
-Description="<html>(817)(C#) Warning is given if doing tab-to-\t replacement and we have found one<br/>in a C# verbatim string literal.<br/><br/>Default: 2</html>"
+Description="<html>(C#) Warning is given if doing tab-to-\t replacement and we have found one<br/>in a C# verbatim string literal.<br/><br/>Default: 2</html>"
 Enabled=false
 EditorType=numeric
 CallName="warn_level_tabs_found_in_verbatim_string_literals="
@@ -7293,7 +7293,7 @@ ValueDefault=2
 
 [Debug Max Number Of Loops]
 Category=13
-Description="<html>(818)Limit the number of loops.<br/>Used by uncrustify.cpp to exit from infinite loop.<br/>0: no limit.</html>"
+Description="<html>Limit the number of loops.<br/>Used by uncrustify.cpp to exit from infinite loop.<br/>0: no limit.</html>"
 Enabled=false
 EditorType=numeric
 CallName="debug_max_number_of_loops="
@@ -7303,7 +7303,7 @@ ValueDefault=0
 
 [Debug Line Number To Protocol]
 Category=13
-Description="<html>(819)Set the number of the line to protocol;<br/>Used in the function prot_the_line if the 2. parameter is zero.<br/>0: nothing protocol.</html>"
+Description="<html>Set the number of the line to protocol;<br/>Used in the function prot_the_line if the 2. parameter is zero.<br/>0: nothing protocol.</html>"
 Enabled=false
 EditorType=numeric
 CallName="debug_line_number_to_protocol="
@@ -7313,7 +7313,7 @@ ValueDefault=0
 
 [Debug Timeout]
 Category=13
-Description="<html>(820)Set the number of second(s) before terminating formatting the current file,<br/>0: no timeout.<br/>only for linux</html>"
+Description="<html>Set the number of second(s) before terminating formatting the current file,<br/>0: no timeout.<br/>only for linux</html>"
 Enabled=false
 EditorType=numeric
 CallName="debug_timeout="
@@ -7323,7 +7323,7 @@ ValueDefault=0
 
 [Debug Truncate]
 Category=13
-Description="<html>(821)Set the number of characters to be printed if the text is too long,<br/>0: do not truncate.</html>"
+Description="<html>Set the number of characters to be printed if the text is too long,<br/>0: do not truncate.</html>"
 Enabled=false
 EditorType=numeric
 CallName="debug_truncate="
@@ -7333,7 +7333,7 @@ ValueDefault=0
 
 [Debug Sort The Tracks]
 Category=13
-Description="<html>(822)sort (or not) the tracking info.<br/><br/>Default: true</html>"
+Description="<html>sort (or not) the tracking info.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=debug_sort_the_tracks=true|debug_sort_the_tracks=false
@@ -7341,7 +7341,7 @@ ValueDefault=true
 
 [Set Numbering For Html Output]
 Category=13
-Description="<html>(823)insert the number of the line at the beginning of each line</html>"
+Description="<html>insert the number of the line at the beginning of each line</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=set_numbering_for_html_output=true|set_numbering_for_html_output=false


### PR DESCRIPTION
Per PR #3801, this resets the version string in all the option-related documents to
be the last release string + "-dev". It also removes all the option numbering in
uigui_uncrustify.ini, since that is only supposed to be there for debug builds.