### PR TITLE
Fix indent_cpp_lambda_only_once documentation

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -3445,10 +3445,10 @@ use_indent_continue_only_once   = false    # true/false
 
 # The indentation can be:
 # - after the assignment, at the '[' character
-# - at the begin of the lambda body
+# - at the beginning of the lambda body
 #
-# true:  indentation will be after the assignment
-# false: indentation will be at the begin of the lambda body (default)
+# true:  indentation will be at the beginning of the lambda body
+# false: indentation will be after the assignment (default)
 indent_cpp_lambda_only_once     = false    # true/false
 
 # Whether sp_after_angle takes precedence over sp_inside_fparen. This was the

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -3445,10 +3445,10 @@ use_indent_continue_only_once   = false    # true/false
 
 # The indentation can be:
 # - after the assignment, at the '[' character
-# - at the begin of the lambda body
+# - at the beginning of the lambda body
 #
-# true:  indentation will be after the assignment
-# false: indentation will be at the begin of the lambda body (default)
+# true:  indentation will be at the beginning of the lambda body
+# false: indentation will be after the assignment (default)
 indent_cpp_lambda_only_once     = false    # true/false
 
 # Whether sp_after_angle takes precedence over sp_inside_fparen. This was the

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -3445,10 +3445,10 @@ use_indent_continue_only_once   = false    # true/false
 
 # The indentation can be:
 # - after the assignment, at the '[' character
-# - at the begin of the lambda body
+# - at the beginning of the lambda body
 #
-# true:  indentation will be after the assignment
-# false: indentation will be at the begin of the lambda body (default)
+# true:  indentation will be at the beginning of the lambda body
+# false: indentation will be after the assignment (default)
 indent_cpp_lambda_only_once     = false    # true/false
 
 # Whether sp_after_angle takes precedence over sp_inside_fparen. This was the

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -7251,7 +7251,7 @@ ValueDefault=false
 
 [Indent Cpp Lambda Only Once]
 Category=12
-Description="<html>The indentation can be:<br/>- after the assignment, at the '[' character<br/>- at the begin of the lambda body<br/><br/>true:  indentation will be after the assignment<br/>false: indentation will be at the begin of the lambda body (default)</html>"
+Description="<html>The indentation can be:<br/>- after the assignment, at the '[' character<br/>- at the beginning of the lambda body<br/><br/>true:  indentation will be at the beginning of the lambda body<br/>false: indentation will be after the assignment (default)</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_cpp_lambda_only_once=true|indent_cpp_lambda_only_once=false

--- a/src/options.h
+++ b/src/options.h
@@ -4194,10 +4194,10 @@ use_indent_continue_only_once;
 
 // The indentation can be:
 // - after the assignment, at the '[' character
-// - at the begin of the lambda body
+// - at the beginning of the lambda body
 //
-// true:  indentation will be after the assignment
-// false: indentation will be at the begin of the lambda body (default)
+// true:  indentation will be at the beginning of the lambda body
+// false: indentation will be after the assignment (default)
 extern Option<bool>
 indent_cpp_lambda_only_once;
 

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -7251,7 +7251,7 @@ ValueDefault=false
 
 [Indent Cpp Lambda Only Once]
 Category=12
-Description="<html>The indentation can be:<br/>- after the assignment, at the '[' character<br/>- at the begin of the lambda body<br/><br/>true:  indentation will be after the assignment<br/>false: indentation will be at the begin of the lambda body (default)</html>"
+Description="<html>The indentation can be:<br/>- after the assignment, at the '[' character<br/>- at the beginning of the lambda body<br/><br/>true:  indentation will be at the beginning of the lambda body<br/>false: indentation will be after the assignment (default)</html>"
 Enabled=false
 EditorType=boolean
 TrueFalse=indent_cpp_lambda_only_once=true|indent_cpp_lambda_only_once=false


### PR DESCRIPTION
With ``uncrustify -c tests/config/common/empty.cfg -f test.cpp`` you will get:
```
auto x = [] {
                 return 0;
         };
```

Adding ``indent_cpp_lambda_only_once = true`` to ``empty.cfg``, instead:
```
auto x = [] {
        return 0;
};
```