### PR TITLE
Fixed #3658 lambda indentation regression with namespaces

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1700,44 +1700,6 @@ void indent_text()
                }
             }
 
-            // Issues: #1813, #3409, #3428
-            // if enclosure is set, the namespace is already accounted for
-            // so don't apply the correction twice.
-            // And for some reason, it's also accounted for when
-            // indent_namespace_single_indent is set
-            if (!enclosure && !options::indent_namespace_single_indent())
-            {
-               size_t namespace_indent_to_ignore = 0;
-               log_rule_B("indent_namespace");
-
-               for (auto i = frm.rbegin(); i != frm.rend(); ++i)
-               {
-                  if (i->ns_cnt)
-                  {
-                     const auto foo = i->ns_cnt;
-                     namespace_indent_to_ignore = indent_size * foo;
-                     break;
-                  }
-               }
-
-               if (namespace_indent_to_ignore && options::indent_namespace())
-               {
-                  // I honestly don't know what's going on, so this is an
-                  // empirical fix. For some reason lambdas don't have
-                  // their indent calculated properly when indent_namespace
-                  // is true. But only if they are not in enclosures.
-                  namespace_indent_to_ignore = indent_size;
-               }
-
-               if (namespace_indent_to_ignore <= frm.top().brace_indent)
-               {
-                  frm.top().brace_indent -= namespace_indent_to_ignore;
-               }
-               else
-               {
-                  frm.top().brace_indent = 1;
-               }
-            }
             // A few things to check:
             // 1. The matching brace is on the same line as the ending semicolon
             // 2a. If it's an assignment, check that both sides of the assignment operator are on the same line

--- a/tests/config/cpp/Issue_3409.cfg
+++ b/tests/config/cpp/Issue_3409.cfg
@@ -1,6 +1,6 @@
 indent_cpp_lambda_body = true
 indent_cpp_lambda_only_once = true
+indent_align_assign = false
 indent_columns = 4
 indent_with_tabs = 0
-indent_continue = 4
 indent_paren_close = 2

--- a/tests/config/cpp/Issue_3428.cfg
+++ b/tests/config/cpp/Issue_3428.cfg
@@ -1,7 +1,7 @@
 indent_cpp_lambda_body         = true
 indent_cpp_lambda_only_once    = true
+indent_align_assign            = false
 
 indent_columns = 4
 indent_with_tabs = 0
-indent_continue = 4
 indent_paren_close = 2

--- a/tests/config/cpp/Issue_3428_2.cfg
+++ b/tests/config/cpp/Issue_3428_2.cfg
@@ -1,8 +1,8 @@
 indent_cpp_lambda_body         = true
 indent_cpp_lambda_only_once    = true
 indent_namespace               = true
+indent_align_assign            = false
 
 indent_columns = 4
 indent_with_tabs = 0
-indent_continue = 4
 indent_paren_close = 2

--- a/tests/config/cpp/Issue_3428_3.cfg
+++ b/tests/config/cpp/Issue_3428_3.cfg
@@ -2,8 +2,8 @@ indent_cpp_lambda_body         = true
 indent_cpp_lambda_only_once    = true
 indent_namespace               = true
 indent_namespace_single_indent = true
+indent_align_assign            = false
 
 indent_columns = 4
 indent_with_tabs = 0
-indent_continue = 4
 indent_paren_close = 2

--- a/tests/config/cpp/Issue_3428_4.cfg
+++ b/tests/config/cpp/Issue_3428_4.cfg
@@ -1,7 +1,7 @@
 indent_cpp_lambda_body         = true
 indent_cpp_lambda_only_once    = false
+indent_align_assign            = false
 
 indent_columns = 4
 indent_with_tabs = 0
-indent_continue = 4
 indent_paren_close = 2

--- a/tests/config/cpp/Issue_3428_5.cfg
+++ b/tests/config/cpp/Issue_3428_5.cfg
@@ -1,8 +1,8 @@
 indent_cpp_lambda_body         = true
 indent_cpp_lambda_only_once    = false
 indent_namespace               = true
+indent_align_assign            = false
 
 indent_columns = 4
 indent_with_tabs = 0
-indent_continue = 4
 indent_paren_close = 2

--- a/tests/config/cpp/Issue_3428_6.cfg
+++ b/tests/config/cpp/Issue_3428_6.cfg
@@ -2,8 +2,8 @@ indent_cpp_lambda_body         = true
 indent_cpp_lambda_only_once    = false
 indent_namespace               = true
 indent_namespace_single_indent = true
+indent_align_assign            = false
 
 indent_columns = 4
 indent_with_tabs = 0
-indent_continue = 4
 indent_paren_close = 2


### PR DESCRIPTION
Removed namespace indent code introduced by my patch fix for issue #1813
The code has matured so that that fix is no longer needed, and actually
breaks things.

Secondly, due to misunderstanding of the indent_align_assign and
indent_continue settings, tests for issue #4328 were malformed. Updated
the configuration for those tests so that they are valid.