### PR TITLE
Add option 'pp_indent_with_tabs'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 A source code beautifier for C, C++, C#, Objective-C, D, Java, Pawn and Vala.
 
 ## Features
-* Highly configurable - 824 configurable options as of version 0.75.0
+* Highly configurable - 825 configurable options as of version 0.75.0
 - <details><summary>add/remove spaces</summary>
 
   - `sp_before_sparen`: _Add or remove space before '(' of 'if', 'for', 'switch', 'while', etc._

--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -3293,6 +3293,16 @@ mod_sort_oc_property_nullability_weight = 0        # number
 # Preprocessor options
 #
 
+# How to use tabs when indenting preprocessor code.
+#
+# -1: Use 'indent_with_tabs' setting (default)
+#  0: Spaces only
+#  1: Indent with tabs to brace level, align with spaces
+#  2: Indent and align with tabs, using spaces when not on a tabstop
+#
+# Default: -1
+pp_indent_with_tabs             = -1       # number
+
 # Add or remove indentation of preprocessor directives inside #if blocks
 # at brace level 0 (file-level).
 pp_indent                       = ignore   # ignore/add/remove/force/not_defined

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -3293,6 +3293,16 @@ mod_sort_oc_property_nullability_weight = 0        # number
 # Preprocessor options
 #
 
+# How to use tabs when indenting preprocessor code.
+#
+# -1: Use 'indent_with_tabs' setting (default)
+#  0: Spaces only
+#  1: Indent with tabs to brace level, align with spaces
+#  2: Indent and align with tabs, using spaces when not on a tabstop
+#
+# Default: -1
+pp_indent_with_tabs             = -1       # number
+
 # Add or remove indentation of preprocessor directives inside #if blocks
 # at brace level 0 (file-level).
 pp_indent                       = ignore   # ignore/add/remove/force/not_defined

--- a/documentation/htdocs/index.html
+++ b/documentation/htdocs/index.html
@@ -54,7 +54,7 @@ Create a highly configurable, easily modifiable source code beautifier.</p>
    <li>Add or remove parens on return statements</li>
    <li>Add or remove braces on single-statement if/do/while/for statements</li>
    <li>Supports embedded SQL 'EXEC SQL' stuff</li>
-   <li>Highly configurable - 824 configurable options as of version 0.75.0</li>
+   <li>Highly configurable - 825 configurable options as of version 0.75.0</li>
 </ul>
 
 <p>

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -3293,6 +3293,16 @@ mod_sort_oc_property_nullability_weight = 0        # number
 # Preprocessor options
 #
 
+# How to use tabs when indenting preprocessor code.
+#
+# -1: Use 'indent_with_tabs' setting (default)
+#  0: Spaces only
+#  1: Indent with tabs to brace level, align with spaces
+#  2: Indent and align with tabs, using spaces when not on a tabstop
+#
+# Default: -1
+pp_indent_with_tabs             = -1       # number
+
 # Add or remove indentation of preprocessor directives inside #if blocks
 # at brace level 0 (file-level).
 pp_indent                       = ignore   # ignore/add/remove/force/not_defined

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -7045,6 +7045,16 @@ MinVal=
 MaxVal=
 ValueDefault=0
 
+[Pp Indent With Tabs]
+Category=10
+Description="<html>How to use tabs when indenting preprocessor code.<br/><br/>-1: Use 'indent_with_tabs' setting (default)<br/> 0: Spaces only<br/> 1: Indent with tabs to brace level, align with spaces<br/> 2: Indent and align with tabs, using spaces when not on a tabstop<br/><br/>Default: -1</html>"
+Enabled=false
+EditorType=numeric
+CallName="pp_indent_with_tabs="
+MinVal=-1
+MaxVal=2
+ValueDefault=-1
+
 [Pp Indent]
 Category=10
 Description="<html>Add or remove indentation of preprocessor directives inside #if blocks<br/>at brace level 0 (file-level).</html>"

--- a/src/options.h
+++ b/src/options.h
@@ -4023,6 +4023,15 @@ mod_sort_oc_property_nullability_weight;
 ///////////////////////////////////////////////////////////////////////////////
 //BEGIN Preprocessor options
 
+// How to use tabs when indenting preprocessor code.
+//
+// -1: Use 'indent_with_tabs' setting (default)
+//  0: Spaces only
+//  1: Indent with tabs to brace level, align with spaces
+//  2: Indent and align with tabs, using spaces when not on a tabstop
+extern BoundedOption<signed, -1, 2>
+pp_indent_with_tabs; // = -1
+
 // Add or remove indentation of preprocessor directives inside #if blocks
 // at brace level 0 (file-level).
 extern Option<iarf_e>

--- a/tests/c.test
+++ b/tests/c.test
@@ -387,6 +387,13 @@
 
 02510  c/ben_093.cfg                              c/asm.c
 
+02520  c/pp_indent_with_tabs_0.cfg                c/pp_indent_with_tabs.c
+02521  c/pp_indent_with_tabs_1.cfg                c/pp_indent_with_tabs.c
+02522  c/pp_indent_with_tabs_2.cfg                c/pp_indent_with_tabs.c
+02523  c/pp_indent_with_tabs_-1_0.cfg             c/pp_indent_with_tabs.c
+02524  c/pp_indent_with_tabs_-1_1.cfg             c/pp_indent_with_tabs.c
+02525  c/pp_indent_with_tabs_-1_2.cfg             c/pp_indent_with_tabs.c
+
 07630  c/indent-vbrace.cfg                        c/indent-vbrace.c
 
 08399  c/ben_095.cfg                              c/gh399.c

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -7045,6 +7045,16 @@ MinVal=
 MaxVal=
 ValueDefault=0
 
+[Pp Indent With Tabs]
+Category=10
+Description="<html>How to use tabs when indenting preprocessor code.<br/><br/>-1: Use 'indent_with_tabs' setting (default)<br/> 0: Spaces only<br/> 1: Indent with tabs to brace level, align with spaces<br/> 2: Indent and align with tabs, using spaces when not on a tabstop<br/><br/>Default: -1</html>"
+Enabled=false
+EditorType=numeric
+CallName="pp_indent_with_tabs="
+MinVal=-1
+MaxVal=2
+ValueDefault=-1
+
 [Pp Indent]
 Category=10
 Description="<html>Add or remove indentation of preprocessor directives inside #if blocks<br/>at brace level 0 (file-level).</html>"

--- a/tests/config/c/pp_indent_with_tabs_-1_0.cfg
+++ b/tests/config/c/pp_indent_with_tabs_-1_0.cfg
@@ -1,0 +1,5 @@
+output_tab_size = 2
+indent_columns = 2
+indent_with_tabs = 0
+pp_indent = force
+pp_indent_with_tabs = -1

--- a/tests/config/c/pp_indent_with_tabs_-1_1.cfg
+++ b/tests/config/c/pp_indent_with_tabs_-1_1.cfg
@@ -1,0 +1,5 @@
+output_tab_size = 2
+indent_columns = 2
+indent_with_tabs = 1
+pp_indent = force
+pp_indent_with_tabs = -1

--- a/tests/config/c/pp_indent_with_tabs_-1_2.cfg
+++ b/tests/config/c/pp_indent_with_tabs_-1_2.cfg
@@ -1,0 +1,5 @@
+output_tab_size = 2
+indent_columns = 2
+indent_with_tabs = 2
+pp_indent = force
+pp_indent_with_tabs = -1

--- a/tests/config/c/pp_indent_with_tabs_0.cfg
+++ b/tests/config/c/pp_indent_with_tabs_0.cfg
@@ -1,0 +1,4 @@
+output_tab_size = 2
+indent_columns = 2
+pp_indent = force
+pp_indent_with_tabs = 0

--- a/tests/config/c/pp_indent_with_tabs_1.cfg
+++ b/tests/config/c/pp_indent_with_tabs_1.cfg
@@ -1,0 +1,4 @@
+output_tab_size = 2
+indent_columns = 2
+pp_indent = force
+pp_indent_with_tabs = 1

--- a/tests/config/c/pp_indent_with_tabs_2.cfg
+++ b/tests/config/c/pp_indent_with_tabs_2.cfg
@@ -1,0 +1,4 @@
+output_tab_size = 2
+indent_columns = 2
+pp_indent = force
+pp_indent_with_tabs = 2

--- a/tests/config/cpp/class-colon-pos-eol-add.cfg
+++ b/tests/config/cpp/class-colon-pos-eol-add.cfg
@@ -9,3 +9,4 @@ nl_constr_colon                 = add
 pos_class_comma                 = trail
 pos_constr_comma                = trail
 pos_constr_colon                = trail
+pp_indent_with_tabs             = 0

--- a/tests/config/cpp/class-colon-pos-eol.cfg
+++ b/tests/config/cpp/class-colon-pos-eol.cfg
@@ -5,3 +5,4 @@ indent_columns                  = 3
 indent_class_colon              = true
 indent_constr_colon             = true
 pos_constr_colon                = trail
+pp_indent_with_tabs             = 0

--- a/tests/config/cpp/class-colon-pos-sol-add.cfg
+++ b/tests/config/cpp/class-colon-pos-sol-add.cfg
@@ -15,3 +15,4 @@ pos_class_comma                 = trail
 pos_constr_comma                = trail
 pos_class_colon                 = lead
 pos_constr_colon                = lead
+pp_indent_with_tabs             = 0

--- a/tests/config/cpp/class-colon-pos-sol.cfg
+++ b/tests/config/cpp/class-colon-pos-sol.cfg
@@ -5,3 +5,4 @@ indent_class_colon              = true
 indent_constr_colon             = true
 pos_class_colon                 = lead
 pos_constr_colon                = lead
+pp_indent_with_tabs             = 0

--- a/tests/config/cpp/class-on-colon-indent.cfg
+++ b/tests/config/cpp/class-on-colon-indent.cfg
@@ -14,3 +14,4 @@ nl_constr_colon                 = add
 pos_class_comma                 = lead
 pos_constr_comma                = lead
 pos_constr_colon                = lead_force
+pp_indent_with_tabs             = 0

--- a/tests/config/oc/U24-Cpp.cfg
+++ b/tests/config/oc/U24-Cpp.cfg
@@ -1,3 +1,4 @@
 input_tab_size                  = 4
 indent_columns                  = 4
 pp_ignore_define_body           = true
+pp_indent_with_tabs             = 0

--- a/tests/expected/c/00094-Issue_3457.c
+++ b/tests/expected/c/00094-Issue_3457.c
@@ -1,12 +1,12 @@
 #define IS_UNSIGNED(t) \
 	_Generic((t), \
-	         uint8_t: true, \
-	         uint16_t: true, \
-	         uint32_t: true, \
-	         uint64_t: true, \
-	         unsigned long long: true, \
-	         int8_t: false, \
-	         int16_t: false, \
-	         int32_t: false, \
-	         int64_t: false, \
-	         signed long long: false)
+		 uint8_t: true, \
+		 uint16_t: true, \
+		 uint32_t: true, \
+		 uint64_t: true, \
+		 unsigned long long: true, \
+		 int8_t: false, \
+		 int16_t: false, \
+		 int32_t: false, \
+		 int64_t: false, \
+		 signed long long: false)

--- a/tests/expected/c/02455-macro-returns.c
+++ b/tests/expected/c/02455-macro-returns.c
@@ -1,14 +1,14 @@
 #define foo1 return(x + \
-	            y)
+		    y)
 
 #define foo2 return (x + \
-	             y)
+		     y)
 
 #define foo3 return \
-	        (0)
+		(0)
 
 #define foo4 return \
-	        (0)
+		(0)
 
 #define foo5 return /* empty */
 

--- a/tests/expected/c/02456-macro-returns.c
+++ b/tests/expected/c/02456-macro-returns.c
@@ -5,10 +5,10 @@
 	       y
 
 #define foo3 return \
-	        0
+		0
 
 #define foo4 return \
-	        0
+		0
 
 #define foo5 return /* empty */
 

--- a/tests/expected/c/02520-pp_indent_with_tabs.c
+++ b/tests/expected/c/02520-pp_indent_with_tabs.c
@@ -1,0 +1,167 @@
+#ifndef _XTRANSINT_H_
+#define _XTRANSINT_H_
+
+int main()
+{
+	if (true)
+	{
+		if (true)
+		{
+			if (true)
+			{
+				if (true)
+				{
+					if (true)
+					{
+						int i = 0;
+					}
+				}
+			}
+		}
+	}
+}
+
+#ifndef OPEN_MAX
+ #ifdef SVR4
+  #define OPEN_MAX 256
+ #else
+  #include <sys/param.h>
+  #ifndef OPEN_MAX
+   #if defined(__OSF1__) || defined(__osf__)
+    #define OPEN_MAX 256
+   #else
+    #ifdef NOFILE
+     #define OPEN_MAX NOFILE
+    #else
+     #if !defined(__EMX__) && !defined(__QNX__)
+      #define OPEN_MAX NOFILES_MAX
+     #else
+      #define OPEN_MAX 256
+      #ifdef NOFILE
+       #define OPEN_MAX NOFILE
+      #else
+       #define OPEN_MAX 256
+       #ifdef NOFILE
+        #define OPEN_MAX NOFILE
+       #endif
+      #endif
+     #endif
+    #endif
+   #endif
+  #endif
+ #endif
+#endif
+
+#ifndef __EMX__
+ #define XTRANSDEBUG 1
+#else
+ #define XTRANSDEBUG 1
+#endif
+
+#ifdef _WIN32
+ #define _WILLWINSOCK_
+#endif
+
+#include "Xtrans.h"
+
+#ifdef XTRANSDEBUG
+ #include <stdio.h>
+#endif /* XTRANSDEBUG */
+
+#include <errno.h>
+#ifdef X_NOT_STDC_ENV
+extern int errno;               /* Internal system error number. */
+#endif
+
+#ifndef _WIN32
+ #ifndef MINIX
+  #ifndef Lynx
+   #include <sys/socket.h>
+  #else
+   #include <socket.h>
+  #endif
+  #include <netinet/in.h>
+  #include <arpa/inet.h>
+ #endif
+ #ifdef __EMX__
+  #include <sys/ioctl.h>
+ #endif
+
+ #if (defined(_POSIX_SOURCE) && !defined(AIXV3) && !defined(__QNX__)) || defined(hpux) || defined(USG) || defined(SVR4) || defined(SCO)
+  #ifndef NEED_UTSNAME
+   #define NEED_UTSNAME
+  #endif
+  #include <sys/utsname.h>
+ #endif
+
+ #ifndef TRANS_OPEN_MAX
+
+  #ifndef X_NOT_POSIX
+   #ifdef _POSIX_SOURCE
+    #include <limits.h>
+   #else
+    #define _POSIX_SOURCE
+    #include <limits.h>
+    #undef _POSIX_SOURCE
+   #endif
+  #endif
+  #ifndef OPEN_MAX
+   #ifdef __GNU__
+    #define OPEN_MAX (sysconf(_SC_OPEN_MAX))
+   #endif
+   #ifdef SVR4
+    #define OPEN_MAX 256
+   #else
+    #include <sys/param.h>
+    #ifndef OPEN_MAX
+     #if defined(__OSF1__) || defined(__osf__)
+      #define OPEN_MAX 256
+     #else
+      #ifdef NOFILE
+       #define OPEN_MAX NOFILE
+      #else
+       #if !defined(__EMX__) && !defined(__QNX__)
+        #define OPEN_MAX NOFILES_MAX
+       #else
+        #define OPEN_MAX 256
+       #endif
+      #endif
+     #endif
+    #endif
+   #endif
+  #endif
+  #ifdef __GNU__
+   #define TRANS_OPEN_MAX OPEN_MAX
+  #elif OPEN_MAX > 256
+   #define TRANS_OPEN_MAX 256
+  #else
+   #define TRANS_OPEN_MAX OPEN_MAX
+  #endif /*__GNU__*/
+
+ #endif /* TRANS_OPEN_MAX */
+
+ #ifdef __EMX__
+  #define ESET(val)
+ #else
+  #define ESET(val) errno = val
+ #endif
+ #define EGET() errno
+
+#else /* _WIN32 */
+
+ #include <limits.h>    /* for USHRT_MAX */
+
+ #define ESET(val) WSASetLastError(val)
+ #define EGET() WSAGetLastError()
+
+#endif /* _WIN32 */
+
+#ifndef NULL
+ #define NULL 0
+#endif
+
+#ifdef X11_t
+ #define X_TCP_PORT      6000
+#endif
+
+#endif

--- a/tests/expected/c/02521-pp_indent_with_tabs.c
+++ b/tests/expected/c/02521-pp_indent_with_tabs.c
@@ -1,0 +1,167 @@
+#ifndef _XTRANSINT_H_
+#define _XTRANSINT_H_
+
+int main()
+{
+	if (true)
+	{
+		if (true)
+		{
+			if (true)
+			{
+				if (true)
+				{
+					if (true)
+					{
+						int i = 0;
+					}
+				}
+			}
+		}
+	}
+}
+
+#ifndef OPEN_MAX
+ #ifdef SVR4
+	#define OPEN_MAX 256
+ #else
+	#include <sys/param.h>
+	#ifndef OPEN_MAX
+	 #if defined(__OSF1__) || defined(__osf__)
+		#define OPEN_MAX 256
+	 #else
+		#ifdef NOFILE
+		 #define OPEN_MAX NOFILE
+		#else
+		 #if !defined(__EMX__) && !defined(__QNX__)
+			#define OPEN_MAX NOFILES_MAX
+		 #else
+			#define OPEN_MAX 256
+			#ifdef NOFILE
+			 #define OPEN_MAX NOFILE
+			#else
+			 #define OPEN_MAX 256
+			 #ifdef NOFILE
+				#define OPEN_MAX NOFILE
+			 #endif
+			#endif
+		 #endif
+		#endif
+	 #endif
+	#endif
+ #endif
+#endif
+
+#ifndef __EMX__
+ #define XTRANSDEBUG 1
+#else
+ #define XTRANSDEBUG 1
+#endif
+
+#ifdef _WIN32
+ #define _WILLWINSOCK_
+#endif
+
+#include "Xtrans.h"
+
+#ifdef XTRANSDEBUG
+ #include <stdio.h>
+#endif /* XTRANSDEBUG */
+
+#include <errno.h>
+#ifdef X_NOT_STDC_ENV
+extern int errno;               /* Internal system error number. */
+#endif
+
+#ifndef _WIN32
+ #ifndef MINIX
+	#ifndef Lynx
+	 #include <sys/socket.h>
+	#else
+	 #include <socket.h>
+	#endif
+	#include <netinet/in.h>
+	#include <arpa/inet.h>
+ #endif
+ #ifdef __EMX__
+	#include <sys/ioctl.h>
+ #endif
+
+ #if (defined(_POSIX_SOURCE) && !defined(AIXV3) && !defined(__QNX__)) || defined(hpux) || defined(USG) || defined(SVR4) || defined(SCO)
+	#ifndef NEED_UTSNAME
+	 #define NEED_UTSNAME
+	#endif
+	#include <sys/utsname.h>
+ #endif
+
+ #ifndef TRANS_OPEN_MAX
+
+	#ifndef X_NOT_POSIX
+	 #ifdef _POSIX_SOURCE
+		#include <limits.h>
+	 #else
+		#define _POSIX_SOURCE
+		#include <limits.h>
+		#undef _POSIX_SOURCE
+	 #endif
+	#endif
+	#ifndef OPEN_MAX
+	 #ifdef __GNU__
+		#define OPEN_MAX (sysconf(_SC_OPEN_MAX))
+	 #endif
+	 #ifdef SVR4
+		#define OPEN_MAX 256
+	 #else
+		#include <sys/param.h>
+		#ifndef OPEN_MAX
+		 #if defined(__OSF1__) || defined(__osf__)
+			#define OPEN_MAX 256
+		 #else
+			#ifdef NOFILE
+			 #define OPEN_MAX NOFILE
+			#else
+			 #if !defined(__EMX__) && !defined(__QNX__)
+				#define OPEN_MAX NOFILES_MAX
+			 #else
+				#define OPEN_MAX 256
+			 #endif
+			#endif
+		 #endif
+		#endif
+	 #endif
+	#endif
+	#ifdef __GNU__
+	 #define TRANS_OPEN_MAX OPEN_MAX
+	#elif OPEN_MAX > 256
+	 #define TRANS_OPEN_MAX 256
+	#else
+	 #define TRANS_OPEN_MAX OPEN_MAX
+	#endif /*__GNU__*/
+
+ #endif /* TRANS_OPEN_MAX */
+
+ #ifdef __EMX__
+	#define ESET(val)
+ #else
+	#define ESET(val) errno = val
+ #endif
+ #define EGET() errno
+
+#else /* _WIN32 */
+
+ #include <limits.h>    /* for USHRT_MAX */
+
+ #define ESET(val) WSASetLastError(val)
+ #define EGET() WSAGetLastError()
+
+#endif /* _WIN32 */
+
+#ifndef NULL
+ #define NULL 0
+#endif
+
+#ifdef X11_t
+ #define X_TCP_PORT      6000
+#endif
+
+#endif

--- a/tests/expected/c/02522-pp_indent_with_tabs.c
+++ b/tests/expected/c/02522-pp_indent_with_tabs.c
@@ -1,0 +1,167 @@
+#ifndef _XTRANSINT_H_
+#define _XTRANSINT_H_
+
+int main()
+{
+	if (true)
+	{
+		if (true)
+		{
+			if (true)
+			{
+				if (true)
+				{
+					if (true)
+					{
+						int i = 0;
+					}
+				}
+			}
+		}
+	}
+}
+
+#ifndef OPEN_MAX
+ #ifdef SVR4
+	#define OPEN_MAX 256
+ #else
+	#include <sys/param.h>
+	#ifndef OPEN_MAX
+	 #if defined(__OSF1__) || defined(__osf__)
+		#define OPEN_MAX 256
+	 #else
+		#ifdef NOFILE
+		 #define OPEN_MAX NOFILE
+		#else
+		 #if !defined(__EMX__) && !defined(__QNX__)
+			#define OPEN_MAX NOFILES_MAX
+		 #else
+			#define OPEN_MAX 256
+			#ifdef NOFILE
+			 #define OPEN_MAX NOFILE
+			#else
+			 #define OPEN_MAX 256
+			 #ifdef NOFILE
+				#define OPEN_MAX NOFILE
+			 #endif
+			#endif
+		 #endif
+		#endif
+	 #endif
+	#endif
+ #endif
+#endif
+
+#ifndef __EMX__
+ #define XTRANSDEBUG 1
+#else
+ #define XTRANSDEBUG 1
+#endif
+
+#ifdef _WIN32
+ #define _WILLWINSOCK_
+#endif
+
+#include "Xtrans.h"
+
+#ifdef XTRANSDEBUG
+ #include <stdio.h>
+#endif /* XTRANSDEBUG */
+
+#include <errno.h>
+#ifdef X_NOT_STDC_ENV
+extern int errno;               /* Internal system error number. */
+#endif
+
+#ifndef _WIN32
+ #ifndef MINIX
+	#ifndef Lynx
+	 #include <sys/socket.h>
+	#else
+	 #include <socket.h>
+	#endif
+	#include <netinet/in.h>
+	#include <arpa/inet.h>
+ #endif
+ #ifdef __EMX__
+	#include <sys/ioctl.h>
+ #endif
+
+ #if (defined(_POSIX_SOURCE) && !defined(AIXV3) && !defined(__QNX__)) || defined(hpux) || defined(USG) || defined(SVR4) || defined(SCO)
+	#ifndef NEED_UTSNAME
+	 #define NEED_UTSNAME
+	#endif
+	#include <sys/utsname.h>
+ #endif
+
+ #ifndef TRANS_OPEN_MAX
+
+	#ifndef X_NOT_POSIX
+	 #ifdef _POSIX_SOURCE
+		#include <limits.h>
+	 #else
+		#define _POSIX_SOURCE
+		#include <limits.h>
+		#undef _POSIX_SOURCE
+	 #endif
+	#endif
+	#ifndef OPEN_MAX
+	 #ifdef __GNU__
+		#define OPEN_MAX (sysconf(_SC_OPEN_MAX))
+	 #endif
+	 #ifdef SVR4
+		#define OPEN_MAX 256
+	 #else
+		#include <sys/param.h>
+		#ifndef OPEN_MAX
+		 #if defined(__OSF1__) || defined(__osf__)
+			#define OPEN_MAX 256
+		 #else
+			#ifdef NOFILE
+			 #define OPEN_MAX NOFILE
+			#else
+			 #if !defined(__EMX__) && !defined(__QNX__)
+				#define OPEN_MAX NOFILES_MAX
+			 #else
+				#define OPEN_MAX 256
+			 #endif
+			#endif
+		 #endif
+		#endif
+	 #endif
+	#endif
+	#ifdef __GNU__
+	 #define TRANS_OPEN_MAX OPEN_MAX
+	#elif OPEN_MAX > 256
+	 #define TRANS_OPEN_MAX 256
+	#else
+	 #define TRANS_OPEN_MAX OPEN_MAX
+	#endif /*__GNU__*/
+
+ #endif /* TRANS_OPEN_MAX */
+
+ #ifdef __EMX__
+	#define ESET(val)
+ #else
+	#define ESET(val) errno = val
+ #endif
+ #define EGET() errno
+
+#else /* _WIN32 */
+
+ #include <limits.h>    /* for USHRT_MAX */
+
+ #define ESET(val) WSASetLastError(val)
+ #define EGET() WSAGetLastError()
+
+#endif /* _WIN32 */
+
+#ifndef NULL
+ #define NULL 0
+#endif
+
+#ifdef X11_t
+ #define X_TCP_PORT      6000
+#endif
+
+#endif

--- a/tests/expected/c/02523-pp_indent_with_tabs.c
+++ b/tests/expected/c/02523-pp_indent_with_tabs.c
@@ -1,0 +1,167 @@
+#ifndef _XTRANSINT_H_
+#define _XTRANSINT_H_
+
+int main()
+{
+  if (true)
+  {
+    if (true)
+    {
+      if (true)
+      {
+        if (true)
+        {
+          if (true)
+          {
+            int i = 0;
+          }
+        }
+      }
+    }
+  }
+}
+
+#ifndef OPEN_MAX
+ #ifdef SVR4
+  #define OPEN_MAX 256
+ #else
+  #include <sys/param.h>
+  #ifndef OPEN_MAX
+   #if defined(__OSF1__) || defined(__osf__)
+    #define OPEN_MAX 256
+   #else
+    #ifdef NOFILE
+     #define OPEN_MAX NOFILE
+    #else
+     #if !defined(__EMX__) && !defined(__QNX__)
+      #define OPEN_MAX NOFILES_MAX
+     #else
+      #define OPEN_MAX 256
+      #ifdef NOFILE
+       #define OPEN_MAX NOFILE
+      #else
+       #define OPEN_MAX 256
+       #ifdef NOFILE
+        #define OPEN_MAX NOFILE
+       #endif
+      #endif
+     #endif
+    #endif
+   #endif
+  #endif
+ #endif
+#endif
+
+#ifndef __EMX__
+ #define XTRANSDEBUG 1
+#else
+ #define XTRANSDEBUG 1
+#endif
+
+#ifdef _WIN32
+ #define _WILLWINSOCK_
+#endif
+
+#include "Xtrans.h"
+
+#ifdef XTRANSDEBUG
+ #include <stdio.h>
+#endif /* XTRANSDEBUG */
+
+#include <errno.h>
+#ifdef X_NOT_STDC_ENV
+extern int errno;               /* Internal system error number. */
+#endif
+
+#ifndef _WIN32
+ #ifndef MINIX
+  #ifndef Lynx
+   #include <sys/socket.h>
+  #else
+   #include <socket.h>
+  #endif
+  #include <netinet/in.h>
+  #include <arpa/inet.h>
+ #endif
+ #ifdef __EMX__
+  #include <sys/ioctl.h>
+ #endif
+
+ #if (defined(_POSIX_SOURCE) && !defined(AIXV3) && !defined(__QNX__)) || defined(hpux) || defined(USG) || defined(SVR4) || defined(SCO)
+  #ifndef NEED_UTSNAME
+   #define NEED_UTSNAME
+  #endif
+  #include <sys/utsname.h>
+ #endif
+
+ #ifndef TRANS_OPEN_MAX
+
+  #ifndef X_NOT_POSIX
+   #ifdef _POSIX_SOURCE
+    #include <limits.h>
+   #else
+    #define _POSIX_SOURCE
+    #include <limits.h>
+    #undef _POSIX_SOURCE
+   #endif
+  #endif
+  #ifndef OPEN_MAX
+   #ifdef __GNU__
+    #define OPEN_MAX (sysconf(_SC_OPEN_MAX))
+   #endif
+   #ifdef SVR4
+    #define OPEN_MAX 256
+   #else
+    #include <sys/param.h>
+    #ifndef OPEN_MAX
+     #if defined(__OSF1__) || defined(__osf__)
+      #define OPEN_MAX 256
+     #else
+      #ifdef NOFILE
+       #define OPEN_MAX NOFILE
+      #else
+       #if !defined(__EMX__) && !defined(__QNX__)
+        #define OPEN_MAX NOFILES_MAX
+       #else
+        #define OPEN_MAX 256
+       #endif
+      #endif
+     #endif
+    #endif
+   #endif
+  #endif
+  #ifdef __GNU__
+   #define TRANS_OPEN_MAX OPEN_MAX
+  #elif OPEN_MAX > 256
+   #define TRANS_OPEN_MAX 256
+  #else
+   #define TRANS_OPEN_MAX OPEN_MAX
+  #endif /*__GNU__*/
+
+ #endif /* TRANS_OPEN_MAX */
+
+ #ifdef __EMX__
+  #define ESET(val)
+ #else
+  #define ESET(val) errno = val
+ #endif
+ #define EGET() errno
+
+#else /* _WIN32 */
+
+ #include <limits.h>    /* for USHRT_MAX */
+
+ #define ESET(val) WSASetLastError(val)
+ #define EGET() WSAGetLastError()
+
+#endif /* _WIN32 */
+
+#ifndef NULL
+ #define NULL 0
+#endif
+
+#ifdef X11_t
+ #define X_TCP_PORT      6000
+#endif
+
+#endif

--- a/tests/expected/c/02524-pp_indent_with_tabs.c
+++ b/tests/expected/c/02524-pp_indent_with_tabs.c
@@ -1,0 +1,167 @@
+#ifndef _XTRANSINT_H_
+#define _XTRANSINT_H_
+
+int main()
+{
+	if (true)
+	{
+		if (true)
+		{
+			if (true)
+			{
+				if (true)
+				{
+					if (true)
+					{
+						int i = 0;
+					}
+				}
+			}
+		}
+	}
+}
+
+#ifndef OPEN_MAX
+ #ifdef SVR4
+	#define OPEN_MAX 256
+ #else
+	#include <sys/param.h>
+	#ifndef OPEN_MAX
+	 #if defined(__OSF1__) || defined(__osf__)
+		#define OPEN_MAX 256
+	 #else
+		#ifdef NOFILE
+		 #define OPEN_MAX NOFILE
+		#else
+		 #if !defined(__EMX__) && !defined(__QNX__)
+			#define OPEN_MAX NOFILES_MAX
+		 #else
+			#define OPEN_MAX 256
+			#ifdef NOFILE
+			 #define OPEN_MAX NOFILE
+			#else
+			 #define OPEN_MAX 256
+			 #ifdef NOFILE
+				#define OPEN_MAX NOFILE
+			 #endif
+			#endif
+		 #endif
+		#endif
+	 #endif
+	#endif
+ #endif
+#endif
+
+#ifndef __EMX__
+ #define XTRANSDEBUG 1
+#else
+ #define XTRANSDEBUG 1
+#endif
+
+#ifdef _WIN32
+ #define _WILLWINSOCK_
+#endif
+
+#include "Xtrans.h"
+
+#ifdef XTRANSDEBUG
+ #include <stdio.h>
+#endif /* XTRANSDEBUG */
+
+#include <errno.h>
+#ifdef X_NOT_STDC_ENV
+extern int errno;               /* Internal system error number. */
+#endif
+
+#ifndef _WIN32
+ #ifndef MINIX
+	#ifndef Lynx
+	 #include <sys/socket.h>
+	#else
+	 #include <socket.h>
+	#endif
+	#include <netinet/in.h>
+	#include <arpa/inet.h>
+ #endif
+ #ifdef __EMX__
+	#include <sys/ioctl.h>
+ #endif
+
+ #if (defined(_POSIX_SOURCE) && !defined(AIXV3) && !defined(__QNX__)) || defined(hpux) || defined(USG) || defined(SVR4) || defined(SCO)
+	#ifndef NEED_UTSNAME
+	 #define NEED_UTSNAME
+	#endif
+	#include <sys/utsname.h>
+ #endif
+
+ #ifndef TRANS_OPEN_MAX
+
+	#ifndef X_NOT_POSIX
+	 #ifdef _POSIX_SOURCE
+		#include <limits.h>
+	 #else
+		#define _POSIX_SOURCE
+		#include <limits.h>
+		#undef _POSIX_SOURCE
+	 #endif
+	#endif
+	#ifndef OPEN_MAX
+	 #ifdef __GNU__
+		#define OPEN_MAX (sysconf(_SC_OPEN_MAX))
+	 #endif
+	 #ifdef SVR4
+		#define OPEN_MAX 256
+	 #else
+		#include <sys/param.h>
+		#ifndef OPEN_MAX
+		 #if defined(__OSF1__) || defined(__osf__)
+			#define OPEN_MAX 256
+		 #else
+			#ifdef NOFILE
+			 #define OPEN_MAX NOFILE
+			#else
+			 #if !defined(__EMX__) && !defined(__QNX__)
+				#define OPEN_MAX NOFILES_MAX
+			 #else
+				#define OPEN_MAX 256
+			 #endif
+			#endif
+		 #endif
+		#endif
+	 #endif
+	#endif
+	#ifdef __GNU__
+	 #define TRANS_OPEN_MAX OPEN_MAX
+	#elif OPEN_MAX > 256
+	 #define TRANS_OPEN_MAX 256
+	#else
+	 #define TRANS_OPEN_MAX OPEN_MAX
+	#endif /*__GNU__*/
+
+ #endif /* TRANS_OPEN_MAX */
+
+ #ifdef __EMX__
+	#define ESET(val)
+ #else
+	#define ESET(val) errno = val
+ #endif
+ #define EGET() errno
+
+#else /* _WIN32 */
+
+ #include <limits.h>    /* for USHRT_MAX */
+
+ #define ESET(val) WSASetLastError(val)
+ #define EGET() WSAGetLastError()
+
+#endif /* _WIN32 */
+
+#ifndef NULL
+ #define NULL 0
+#endif
+
+#ifdef X11_t
+ #define X_TCP_PORT      6000
+#endif
+
+#endif

--- a/tests/expected/c/02525-pp_indent_with_tabs.c
+++ b/tests/expected/c/02525-pp_indent_with_tabs.c
@@ -1,0 +1,167 @@
+#ifndef _XTRANSINT_H_
+#define _XTRANSINT_H_
+
+int main()
+{
+	if (true)
+	{
+		if (true)
+		{
+			if (true)
+			{
+				if (true)
+				{
+					if (true)
+					{
+						int i = 0;
+					}
+				}
+			}
+		}
+	}
+}
+
+#ifndef OPEN_MAX
+ #ifdef SVR4
+	#define OPEN_MAX 256
+ #else
+	#include <sys/param.h>
+	#ifndef OPEN_MAX
+	 #if defined(__OSF1__) || defined(__osf__)
+		#define OPEN_MAX 256
+	 #else
+		#ifdef NOFILE
+		 #define OPEN_MAX NOFILE
+		#else
+		 #if !defined(__EMX__) && !defined(__QNX__)
+			#define OPEN_MAX NOFILES_MAX
+		 #else
+			#define OPEN_MAX 256
+			#ifdef NOFILE
+			 #define OPEN_MAX NOFILE
+			#else
+			 #define OPEN_MAX 256
+			 #ifdef NOFILE
+				#define OPEN_MAX NOFILE
+			 #endif
+			#endif
+		 #endif
+		#endif
+	 #endif
+	#endif
+ #endif
+#endif
+
+#ifndef __EMX__
+ #define XTRANSDEBUG 1
+#else
+ #define XTRANSDEBUG 1
+#endif
+
+#ifdef _WIN32
+ #define _WILLWINSOCK_
+#endif
+
+#include "Xtrans.h"
+
+#ifdef XTRANSDEBUG
+ #include <stdio.h>
+#endif /* XTRANSDEBUG */
+
+#include <errno.h>
+#ifdef X_NOT_STDC_ENV
+extern int errno;               /* Internal system error number. */
+#endif
+
+#ifndef _WIN32
+ #ifndef MINIX
+	#ifndef Lynx
+	 #include <sys/socket.h>
+	#else
+	 #include <socket.h>
+	#endif
+	#include <netinet/in.h>
+	#include <arpa/inet.h>
+ #endif
+ #ifdef __EMX__
+	#include <sys/ioctl.h>
+ #endif
+
+ #if (defined(_POSIX_SOURCE) && !defined(AIXV3) && !defined(__QNX__)) || defined(hpux) || defined(USG) || defined(SVR4) || defined(SCO)
+	#ifndef NEED_UTSNAME
+	 #define NEED_UTSNAME
+	#endif
+	#include <sys/utsname.h>
+ #endif
+
+ #ifndef TRANS_OPEN_MAX
+
+	#ifndef X_NOT_POSIX
+	 #ifdef _POSIX_SOURCE
+		#include <limits.h>
+	 #else
+		#define _POSIX_SOURCE
+		#include <limits.h>
+		#undef _POSIX_SOURCE
+	 #endif
+	#endif
+	#ifndef OPEN_MAX
+	 #ifdef __GNU__
+		#define OPEN_MAX (sysconf(_SC_OPEN_MAX))
+	 #endif
+	 #ifdef SVR4
+		#define OPEN_MAX 256
+	 #else
+		#include <sys/param.h>
+		#ifndef OPEN_MAX
+		 #if defined(__OSF1__) || defined(__osf__)
+			#define OPEN_MAX 256
+		 #else
+			#ifdef NOFILE
+			 #define OPEN_MAX NOFILE
+			#else
+			 #if !defined(__EMX__) && !defined(__QNX__)
+				#define OPEN_MAX NOFILES_MAX
+			 #else
+				#define OPEN_MAX 256
+			 #endif
+			#endif
+		 #endif
+		#endif
+	 #endif
+	#endif
+	#ifdef __GNU__
+	 #define TRANS_OPEN_MAX OPEN_MAX
+	#elif OPEN_MAX > 256
+	 #define TRANS_OPEN_MAX 256
+	#else
+	 #define TRANS_OPEN_MAX OPEN_MAX
+	#endif /*__GNU__*/
+
+ #endif /* TRANS_OPEN_MAX */
+
+ #ifdef __EMX__
+	#define ESET(val)
+ #else
+	#define ESET(val) errno = val
+ #endif
+ #define EGET() errno
+
+#else /* _WIN32 */
+
+ #include <limits.h>    /* for USHRT_MAX */
+
+ #define ESET(val) WSASetLastError(val)
+ #define EGET() WSAGetLastError()
+
+#endif /* _WIN32 */
+
+#ifndef NULL
+ #define NULL 0
+#endif
+
+#ifdef X11_t
+ #define X_TCP_PORT      6000
+#endif
+
+#endif

--- a/tests/input/c/pp_indent_with_tabs.c
+++ b/tests/input/c/pp_indent_with_tabs.c
@@ -1,0 +1,167 @@
+#ifndef _XTRANSINT_H_
+#define _XTRANSINT_H_
+
+int main()
+{
+	if (true)
+	{
+		if (true)
+		{
+			if (true)
+			{
+				if (true)
+				{
+					if (true)
+					{
+						int i = 0;
+					}
+				}
+			}
+		}
+	}
+}
+
+#ifndef OPEN_MAX
+#ifdef SVR4
+#define OPEN_MAX 256
+#else
+#include <sys/param.h>
+#ifndef OPEN_MAX
+#if defined(__OSF1__) || defined(__osf__)
+#define OPEN_MAX 256
+#else
+#ifdef NOFILE
+#define OPEN_MAX NOFILE
+#else
+#if !defined(__EMX__) && !defined(__QNX__)
+#define OPEN_MAX NOFILES_MAX
+#else
+#define OPEN_MAX 256
+#ifdef NOFILE
+#define OPEN_MAX NOFILE
+#else
+#define OPEN_MAX 256
+#ifdef NOFILE
+#define OPEN_MAX NOFILE
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+
+#ifndef __EMX__
+#define XTRANSDEBUG 1
+#else
+#define XTRANSDEBUG 1
+#endif
+
+#ifdef _WIN32
+#define _WILLWINSOCK_
+#endif
+
+#include "Xtrans.h"
+
+#ifdef XTRANSDEBUG
+#include <stdio.h>
+#endif /* XTRANSDEBUG */
+
+#include <errno.h>
+#ifdef X_NOT_STDC_ENV
+extern int  errno;		/* Internal system error number. */
+#endif
+
+#ifndef _WIN32
+#ifndef MINIX
+#ifndef Lynx
+#include <sys/socket.h>
+#else
+#include <socket.h>
+#endif
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#endif
+#ifdef __EMX__
+#include <sys/ioctl.h>
+#endif
+
+#if (defined(_POSIX_SOURCE) && !defined(AIXV3) && !defined(__QNX__)) || defined(hpux) || defined(USG) || defined(SVR4) || defined(SCO)
+#ifndef NEED_UTSNAME
+#define NEED_UTSNAME
+#endif
+#include <sys/utsname.h>
+#endif
+
+#ifndef TRANS_OPEN_MAX
+
+#ifndef X_NOT_POSIX
+#ifdef _POSIX_SOURCE
+#include <limits.h>
+#else
+#define _POSIX_SOURCE
+#include <limits.h>
+#undef _POSIX_SOURCE
+#endif
+#endif
+#ifndef OPEN_MAX
+#ifdef __GNU__
+#define OPEN_MAX (sysconf(_SC_OPEN_MAX))
+#endif
+#ifdef SVR4
+#define OPEN_MAX 256
+#else
+#include <sys/param.h>
+#ifndef OPEN_MAX
+#if defined(__OSF1__) || defined(__osf__)
+#define OPEN_MAX 256
+#else
+#ifdef NOFILE
+#define OPEN_MAX NOFILE
+#else
+#if !defined(__EMX__) && !defined(__QNX__)
+#define OPEN_MAX NOFILES_MAX
+#else
+#define OPEN_MAX 256
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#ifdef __GNU__
+#define TRANS_OPEN_MAX OPEN_MAX
+#elif OPEN_MAX > 256
+#define TRANS_OPEN_MAX 256
+#else
+#define TRANS_OPEN_MAX OPEN_MAX
+#endif /*__GNU__*/
+
+#endif /* TRANS_OPEN_MAX */
+
+#ifdef __EMX__
+#define ESET(val)
+#else
+#define ESET(val) errno = val
+#endif
+#define EGET() errno
+
+#else /* _WIN32 */
+
+#include <limits.h>	/* for USHRT_MAX */
+
+#define ESET(val) WSASetLastError(val)
+#define EGET() WSAGetLastError()
+
+#endif /* _WIN32 */
+
+#ifndef NULL
+#define NULL 0
+#endif
+
+#ifdef X11_t
+#define X_TCP_PORT	6000
+#endif
+
+#endif


### PR DESCRIPTION
This allows finer control on how preprocessor code is indented.
By default the value of 'indent_with_tabs' is used, to preserve
previous behavior.
