### PR TITLE
a macro may not stop align_var_def_brace

### DIFF
--- a/src/align_var_def_brace.cpp
+++ b/src/align_var_def_brace.cpp
@@ -134,25 +134,6 @@ Chunk *align_var_def_brace(Chunk *start, size_t span, size_t *p_nl_count)
                  __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol(), pc->Text(), get_token_name(pc->GetType()), pc->IsPreproc() ? "true" : "false");
       }
 
-      //if (  pc->level >= start->level
-      //   || pc->level == 0)
-      //{
-      //   // go on
-      //}
-      //else
-      //{
-      //   //
-      //   if (pc->IsPreproc())
-      //   {
-      //      // go on
-      //   }
-      //   else
-      //   {
-      //      LOG_FMT(LAVDB, "%s(%d): orig line is %zu, orig col is %zu, Text() '%s', type is %s, PRE is %s\n",
-      //              __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol(), pc->Text(), get_token_name(pc->GetType()), pc->IsPreproc() ? "true" : "false");
-      //      break;
-      //   }
-      //}
       if (  pc->level < start->level
          && pc->level != 0
          && !pc->IsPreproc())

--- a/src/align_var_def_brace.cpp
+++ b/src/align_var_def_brace.cpp
@@ -113,20 +113,45 @@ Chunk *align_var_def_brace(Chunk *start, size_t span, size_t *p_nl_count)
    log_rule_B("align_mix_var_proto");
    bool  fp_active = options::align_mix_var_proto();
    Chunk *pc       = start->GetNext();
+   LOG_FMT(LAVDB, "%s(%d): start->Text() is '%s', level is %zu, brace_level is %zu\n",
+           __func__, __LINE__, start->IsNewline() ? "Newline" : start->Text(), start->level, start->brace_level);
 
-   while (  pc->IsNotNullChunk()
-         && (  pc->level >= start->level
-            || pc->level == 0))
+   while (pc->IsNotNullChunk())
    {
-      if (pc->IsNewline())
+      if (pc->Is(CT_NEWLINE))
       {
-         LOG_FMT(LAVDB, "%s(%d): orig line is %zu, orig col is %zu, <Newline>\n",
-                 __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol());
+         LOG_FMT(LAVDB, "%s(%d): orig line is %zu, orig col is %zu, <Newline>, PRE is %s\n",
+                 __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol(), pc->IsPreproc() ? "true" : "false");
+      }
+      else if (pc->Is(CT_NL_CONT))
+      {
+         LOG_FMT(LAVDB, "%s(%d): orig line is %zu, orig col is %zu, Text() '%s', type is %s, PRE is %s\n",
+                 __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol(), pc->Text(), get_token_name(pc->GetType()), pc->IsPreproc() ? "true" : "false");
       }
       else
       {
-         LOG_FMT(LAVDB, "%s(%d): orig line is %zu, orig col is %zu, Text() '%s', type is %s\n",
-                 __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol(), pc->Text(), get_token_name(pc->GetType()));
+         LOG_FMT(LAVDB, "%s(%d): orig line is %zu, orig col is %zu, Text() '%s', type is %s, PRE is %s\n",
+                 __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol(), pc->Text(), get_token_name(pc->GetType()), pc->IsPreproc() ? "true" : "false");
+      }
+
+      if (  pc->level >= start->level
+         || pc->level == 0)
+      {
+         // go on
+      }
+      else
+      {
+         //
+         if (pc->IsPreproc())
+         {
+            // go on
+         }
+         else
+         {
+            LOG_FMT(LAVDB, "%s(%d): orig line is %zu, orig col is %zu, Text() '%s', type is %s, PRE is %s\n",
+                    __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol(), pc->Text(), get_token_name(pc->GetType()), pc->IsPreproc() ? "true" : "false");
+            break;
+         }
       }
 
       if (pc->IsComment())
@@ -139,6 +164,8 @@ Chunk *align_var_def_brace(Chunk *start, size_t span, size_t *p_nl_count)
             as_br.NewLines(pc->nl_count);
          }
          pc = pc->GetNext();
+         LOG_FMT(LAVDB, "%s(%d): pc->Text() is '%s', level is %zu, pc->brace_level is %zu\n",
+                 __func__, __LINE__, pc->IsNewline() ? "Newline" : pc->Text(), pc->level, pc->brace_level);
          continue;
       }
 
@@ -210,6 +237,8 @@ Chunk *align_var_def_brace(Chunk *start, size_t span, size_t *p_nl_count)
       if (pc->Is(CT_BRACE_CLOSE))
       {
          pc = pc->GetNext();
+         LOG_FMT(LAVDB, "%s(%d): pc->Text() is '%s', level is %zu, pc->brace_level is %zu\n",
+                 __func__, __LINE__, pc->IsNewline() ? "Newline" : pc->Text(), pc->level, pc->brace_level);
          break;
       }
 
@@ -246,6 +275,8 @@ Chunk *align_var_def_brace(Chunk *start, size_t span, size_t *p_nl_count)
       if (pc->level > pc->brace_level)
       {
          pc = pc->GetNext();
+         LOG_FMT(LAVDB, "%s(%d): pc->Text() is '%s', level is %zu, pc->brace_level is %zu\n",
+                 __func__, __LINE__, pc->IsNewline() ? "Newline" : pc->Text(), pc->level, pc->brace_level);
          continue;
       }
 
@@ -280,6 +311,8 @@ Chunk *align_var_def_brace(Chunk *start, size_t span, size_t *p_nl_count)
                   prev_local = prev_local->GetPrev();
                }
                pc = prev_local->GetNext();
+               LOG_FMT(LAVDB, "%s(%d): pc->Text() is '%s', level is %zu, pc->brace_level is %zu\n",
+                       __func__, __LINE__, pc->IsNewline() ? "Newline" : pc->Text(), pc->level, pc->brace_level);
             }
             // we must look after the previous token
             Chunk *prev_local = pc->GetPrev();
@@ -296,6 +329,8 @@ Chunk *align_var_def_brace(Chunk *start, size_t span, size_t *p_nl_count)
             if (options::align_var_def_colon())
             {
                next = pc->GetNextNc();
+               LOG_FMT(LAVDB, "%s(%d): pc->Text() is '%s', level is %zu, pc->brace_level is %zu\n",
+                       __func__, __LINE__, pc->IsNewline() ? "Newline" : pc->Text(), pc->level, pc->brace_level);
 
                if (next->Is(CT_BIT_COLON))
                {
@@ -340,6 +375,8 @@ Chunk *align_var_def_brace(Chunk *start, size_t span, size_t *p_nl_count)
                  __func__, __LINE__, did_this_line ? "TRUE" : "FALSE");
       }
       pc = pc->GetNext();
+      LOG_FMT(LAVDB, "%s(%d): pc->Text() is '%s', level is %zu, pc->brace_level is %zu\n",
+              __func__, __LINE__, pc->IsNewline() ? "Newline" : pc->Text(), pc->level, pc->brace_level);
    }
    as.End();
    as_bc.End();

--- a/src/align_var_def_brace.cpp
+++ b/src/align_var_def_brace.cpp
@@ -134,24 +134,32 @@ Chunk *align_var_def_brace(Chunk *start, size_t span, size_t *p_nl_count)
                  __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol(), pc->Text(), get_token_name(pc->GetType()), pc->IsPreproc() ? "true" : "false");
       }
 
-      if (  pc->level >= start->level
-         || pc->level == 0)
+      //if (  pc->level >= start->level
+      //   || pc->level == 0)
+      //{
+      //   // go on
+      //}
+      //else
+      //{
+      //   //
+      //   if (pc->IsPreproc())
+      //   {
+      //      // go on
+      //   }
+      //   else
+      //   {
+      //      LOG_FMT(LAVDB, "%s(%d): orig line is %zu, orig col is %zu, Text() '%s', type is %s, PRE is %s\n",
+      //              __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol(), pc->Text(), get_token_name(pc->GetType()), pc->IsPreproc() ? "true" : "false");
+      //      break;
+      //   }
+      //}
+      if (  pc->level < start->level
+         && pc->level != 0
+         && !pc->IsPreproc())
       {
-         // go on
-      }
-      else
-      {
-         //
-         if (pc->IsPreproc())
-         {
-            // go on
-         }
-         else
-         {
-            LOG_FMT(LAVDB, "%s(%d): orig line is %zu, orig col is %zu, Text() '%s', type is %s, PRE is %s\n",
-                    __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol(), pc->Text(), get_token_name(pc->GetType()), pc->IsPreproc() ? "true" : "false");
-            break;
-         }
+         LOG_FMT(LAVDB, "%s(%d): orig line is %zu, orig col is %zu, Text() '%s', type is %s, PRE is %s\n",
+                 __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol(), pc->Text(), get_token_name(pc->GetType()), pc->IsPreproc() ? "true" : "false");
+         break;
       }
 
       if (pc->IsComment())

--- a/tests/config/cpp/Issue_3785.cfg
+++ b/tests/config/cpp/Issue_3785.cfg
@@ -1,0 +1,4 @@
+indent_columns           = 3
+indent_with_tabs         = 0
+align_var_def_span       = 2
+align_var_def_star_style = 1

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -159,6 +159,8 @@
 30138  cpp/Issue_3513.cfg                                   cpp/Issue_3513-1.cpp
 30139  cpp/Issue_3604.cfg                                   cpp/Issue_3604.cpp
 
+30140  cpp/Issue_3785.cfg                                   cpp/Issue_3785.cpp
+
 30200  cpp/bug_1862.cfg                                     cpp/bug_1862.cpp
 30201  cpp/cmt_indent-1.cfg                                 cpp/cmt_indent.cpp
 30202  cpp/cmt_indent-2.cfg                                 cpp/cmt_indent.cpp

--- a/tests/expected/cpp/30140-Issue_3785.cpp
+++ b/tests/expected/cpp/30140-Issue_3785.cpp
@@ -1,0 +1,24 @@
+void output_text(FILE *pfile)
+{
+   for (pc = Chunk::GetHead(); pc->IsNotNullChunk(); pc = pc->GetNext())
+   {
+      if (pc->tracking != nullptr)
+      {
+         if (many > 1)
+         {
+         }
+#define \
+        EXTRA_LOG_2
+         char *old_one = nullptr;
+      }
+   }
+} // output_text
+
+
+void dump_step(const char *filename, const char *step_description)
+{
+   static int file_num = 0;
+   char       buffer[256];
+   FILE       *dump_file;
+   fclose(dump_file);
+} // dump_step

--- a/tests/input/cpp/Issue_3785.cpp
+++ b/tests/input/cpp/Issue_3785.cpp
@@ -1,0 +1,24 @@
+void output_text(FILE *pfile)
+{
+   for (pc = Chunk::GetHead(); pc->IsNotNullChunk(); pc = pc->GetNext())
+   {
+      if (pc->tracking != nullptr)
+      {
+         if (many > 1)
+         {
+         }
+#define \
+   EXTRA_LOG_2
+         char *old_one = nullptr;
+      }
+   }
+} // output_text
+
+
+void dump_step(const char *filename, const char *step_description)
+{
+   static     int     file_num = 0;
+     char         buffer[256];
+       FILE             *dump_file;
+   fclose(dump_file);
+} // dump_step


### PR DESCRIPTION
the  level of a macro may not be compare with the level of other tokens
fixes #3785