### PR TITLE
Fix #3865: space added BEFORE reference & for a varible with a namesp…

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1616,7 +1616,20 @@ void do_symbol_check(Chunk *prev, Chunk *pc, Chunk *next)
                   }
                   else if (tmp->Is(CT_DC_MEMBER))
                   {
-                     prev->SetType(CT_TYPE);
+                     // Issue #2103 & Issue #3865: partial fix
+                     // No easy way to tell between an enum and a type with
+                     // a namespace qualifier. Compromise: if we're in a
+                     // function def or call, assume it's a ref.
+                     if (  pc->TestFlags(PCF_IN_FCN_CALL)
+                        || pc->TestFlags(PCF_IN_FCN_CTOR)
+                        || pc->TestFlags(PCF_IN_FCN_DEF))
+                     {
+                        pc->SetType(CT_BYREF);
+                     }
+                     else
+                     {
+                        prev->SetType(CT_TYPE);
+                     }
                   }
                }
             }

--- a/tests/config/cpp/Issue_3865.cfg
+++ b/tests/config/cpp/Issue_3865.cfg
@@ -1,0 +1,1 @@
+sp_arith = add

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -1131,3 +1131,4 @@
 60089  cpp/Issue_3863.cfg                                   cpp/Issue_3863.cpp
 60090  cpp/Issue_3863.cfg                                   cpp/Issue_3863_2.cpp
 60091  cpp/Issue_3863.cfg                                   cpp/Issue_3863_3.cpp
+60092  cpp/Issue_3865.cfg                                   cpp/Issue_3865.cpp

--- a/tests/expected/cpp/60092-Issue_3865.cpp
+++ b/tests/expected/cpp/60092-Issue_3865.cpp
@@ -1,0 +1,5 @@
+MOCK_METHOD(bool, isThat, (const std::string& name), (override));
+MOCK_METHOD(bool, isThat, (std::string& name), (override));
+MOCK_METHOD(bool, isThat, std::string& name, (override));
+MOCK_METHOD(bool, isThat, const std::string& name, (override));
+MyFunction(const std::string& some_value);

--- a/tests/input/cpp/Issue_3865.cpp
+++ b/tests/input/cpp/Issue_3865.cpp
@@ -1,0 +1,5 @@
+MOCK_METHOD(bool, isThat, (const std::string& name), (override));
+MOCK_METHOD(bool, isThat, (std::string& name), (override));
+MOCK_METHOD(bool, isThat, std::string& name, (override));
+MOCK_METHOD(bool, isThat, const std::string& name, (override));
+MyFunction(const std::string& some_value);


### PR DESCRIPTION
…ace qualifier when sp_arith = true