### PR TITLE
Re-Type C++ Access Modifiers in ObjC Message Send

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -3505,6 +3505,7 @@ static void handle_oc_message_send(Chunk *os)
    }
 
    if (  tmp->Is(CT_WORD)
+      || tmp->Is(CT_ACCESS)
       || tmp->Is(CT_TYPE))
    {
       tmp->SetType(CT_OC_MSG_FUNC);
@@ -3517,11 +3518,13 @@ static void handle_oc_message_send(Chunk *os)
 
       if (tmp->level == cs->level + 1)
       {
-         if (tmp->Is(CT_COLON))
+         if (  tmp->Is(CT_COLON)
+            || tmp->Is(CT_ACCESS_COLON))
          {
             tmp->SetType(CT_OC_COLON);
 
             if (  prev->Is(CT_WORD)
+               || prev->Is(CT_ACCESS)
                || prev->Is(CT_TYPE))
             {
                // Might be a named param, check previous block

--- a/tests/expected/oc/50633-ocpp_msg_access.mm
+++ b/tests/expected/oc/50633-ocpp_msg_access.mm
@@ -1,0 +1,4 @@
+NSValue *result = [anObject
+     public:value1
+   argument:arg
+    signals:value2];

--- a/tests/input/oc/ocpp_msg_access.mm
+++ b/tests/input/oc/ocpp_msg_access.mm
@@ -1,0 +1,4 @@
+NSValue *result = [anObject
+                   public:value1
+                   argument:arg
+                   signals:value2];

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -144,6 +144,8 @@
 50631  oc/nl_oc_msg_args_min_params.cfg         oc/nl_oc_msg_args_min_params.m
 50632  oc/nl_oc_msg_args_max_code_width.cfg     oc/nl_oc_msg_args_max_code_width.m
 
+50633  common/aet.cfg                           oc/ocpp_msg_access.mm
+
 50700  common/cmt_insert-0.cfg                  oc/cmt_insert.m
 50701  common/cmt_insert-0.cfg                  oc/cmt_insert2.m
 


### PR DESCRIPTION
Tokens inside an Objective-C message send are parsed differently than in other contexts. Parameter names that are spelled the same as C++ access modifiers (e.g. `private:` or Qt's `signals:`) were previously formatted as access modifiers where the parameter name and colon were formatted on their own line with access modifier indentation (e.g. -2) and the argument value on the following line.

This change extends the re-typing logic in `handle_oc_message_send()` to also check for tokens typed as access modifier related.