### PR TITLE
Rename SkipToMatch methods

### DIFF
--- a/src/EnumStructUnionParser.cpp
+++ b/src/EnumStructUnionParser.cpp
@@ -58,7 +58,7 @@ static bool adj_tokens_match_qualified_identifier_pattern(Chunk *prev, Chunk *ne
           * templated type, just check to see if there's a matching closing
           * angle
           */
-         return(prev->SkipToMatch(E_Scope::PREPROC)->IsNotNullChunk());
+         return(prev->GetClosingParen(E_Scope::PREPROC)->IsNotNullChunk());
 
       case CT_DC_MEMBER:
          /**
@@ -128,7 +128,7 @@ static bool adj_tokens_match_var_def_pattern(Chunk *prev, Chunk *next)
           * templated type, just check to see if there's a matching closing
           * angle
           */
-         return(prev->SkipToMatch(E_Scope::PREPROC)->IsNotNullChunk());
+         return(prev->GetClosingParen(E_Scope::PREPROC)->IsNotNullChunk());
 
       case CT_BRACE_CLOSE:
          /**
@@ -151,7 +151,7 @@ static bool adj_tokens_match_var_def_pattern(Chunk *prev, Chunk *next)
           * start of a braced initializer list - skip ahead to find a matching
           * closing brace
           */
-         return(prev->SkipToMatch(E_Scope::PREPROC)->IsNotNullChunk());
+         return(prev->GetClosingParen(E_Scope::PREPROC)->IsNotNullChunk());
 
       case CT_BYREF:
          /**
@@ -201,7 +201,7 @@ static bool adj_tokens_match_var_def_pattern(Chunk *prev, Chunk *next)
           * start of a constructor call parameter list - skip ahead to find a
           * matching closing paren
           */
-         next = prev->SkipToMatch(E_Scope::PREPROC);
+         next = prev->GetClosingParen(E_Scope::PREPROC);
 
          if (next->IsNotNullChunk())
          {
@@ -247,7 +247,7 @@ static bool adj_tokens_match_var_def_pattern(Chunk *prev, Chunk *next)
           * if the previous token is an opening bracket, it may indicate an
           * array declaration - skip ahead to find a matching closing bracket
           */
-         return(prev->SkipToMatch(E_Scope::PREPROC)->IsNotNullChunk());
+         return(prev->GetClosingParen(E_Scope::PREPROC)->IsNotNullChunk());
 
       case CT_STAR:
          /**
@@ -578,7 +578,7 @@ static std::pair<Chunk *, Chunk *> match_variable_end(Chunk *pc, std::size_t lev
          || pc->IsParenOpen()
          || pc->Is(CT_SQUARE_OPEN))
       {
-         pc = pc->SkipToMatch(E_Scope::PREPROC);
+         pc = pc->GetClosingParen(E_Scope::PREPROC);
       }
       /**
        * call a separate function to validate adjacent tokens as potentially
@@ -690,7 +690,7 @@ static std::pair<Chunk *, Chunk *> match_variable_start(Chunk *pc, std::size_t l
          || pc->IsParenClose()
          || pc->Is(CT_SQUARE_CLOSE))
       {
-         pc = pc->SkipToMatchRev(E_Scope::PREPROC);
+         pc = pc->GetOpeningParen(E_Scope::PREPROC);
       }
       /**
        * call a separate function to validate adjacent tokens as potentially
@@ -769,7 +769,7 @@ static Chunk *skip_scope_resolution_and_nested_name_specifiers(Chunk *pc)
           */
          if (pc->Is(CT_ANGLE_OPEN))
          {
-            pc = pc->SkipToMatch(E_Scope::PREPROC);
+            pc = pc->GetClosingParen(E_Scope::PREPROC);
          }
          Chunk *next = pc->GetNextNcNnl();
 
@@ -815,7 +815,7 @@ static Chunk *skip_scope_resolution_and_nested_name_specifiers_rev(Chunk *pc)
           */
          if (pc->Is(CT_ANGLE_CLOSE))
          {
-            pc = pc->SkipToMatchRev(E_Scope::PREPROC);
+            pc = pc->GetOpeningParen(E_Scope::PREPROC);
          }
          Chunk *prev = pc->GetPrevNcNnlNi();
 
@@ -1568,7 +1568,7 @@ void EnumStructUnionParser::mark_braces(Chunk *brace_open)
    }
    brace_open->SetParentType(m_start->GetType());
 
-   auto *brace_close = brace_open->SkipToMatch(E_Scope::PREPROC);
+   auto *brace_close = brace_open->GetClosingParen(E_Scope::PREPROC);
 
    if (brace_close->IsNotNullChunk())
    {
@@ -1788,7 +1788,7 @@ void EnumStructUnionParser::mark_nested_name_specifiers(Chunk *pc)
              * the template may have already been previously marked elsewhere...
              */
             auto *angle_open  = next;
-            auto *angle_close = angle_open->SkipToMatch(E_Scope::PREPROC);
+            auto *angle_close = angle_open->GetClosingParen(E_Scope::PREPROC);
 
             if (angle_close->IsNullChunk())
             {
@@ -1857,7 +1857,7 @@ void EnumStructUnionParser::mark_template(Chunk *start) const
    }
    start->SetParentType(CT_TEMPLATE);
 
-   auto *end = start->SkipToMatch(E_Scope::PREPROC);
+   auto *end = start->GetClosingParen(E_Scope::PREPROC);
 
    if (end->IsNotNullChunk())
    {
@@ -2100,7 +2100,7 @@ void EnumStructUnionParser::parse(Chunk *pc)
          {
             mark_template(next);
          }
-         next = next->SkipToMatch(E_Scope::PREPROC);
+         next = next->GetClosingParen(E_Scope::PREPROC);
       }
       else if (  next->Is(CT_QUALIFIER)
               && language_is_set(LANG_JAVA)
@@ -2159,7 +2159,7 @@ Chunk *EnumStructUnionParser::parse_angles(Chunk *angle_open)
       /**
        * check to see if there's a matching closing angle bracket
        */
-      auto *angle_close = angle_open->SkipToMatch(E_Scope::PREPROC);
+      auto *angle_close = angle_open->GetClosingParen(E_Scope::PREPROC);
 
       if (angle_close->IsNullChunk())
       {
@@ -2231,7 +2231,7 @@ Chunk *EnumStructUnionParser::parse_braces(Chunk *brace_open)
     */
 
    auto *pc          = brace_open;
-   auto *brace_close = pc->SkipToMatch(E_Scope::PREPROC);
+   auto *brace_close = pc->GetClosingParen(E_Scope::PREPROC);
 
    if (brace_close->IsNotNullChunk())
    {
@@ -2280,7 +2280,7 @@ Chunk *EnumStructUnionParser::parse_braces(Chunk *brace_open)
          auto *paren_close = prev;
 
          // skip in reverse to the matching open paren
-         auto *paren_open = paren_close->SkipToMatchRev();
+         auto *paren_open = paren_close->GetOpeningParen();
 
          if (paren_open->IsNotNullChunk())
          {
@@ -2706,7 +2706,7 @@ void EnumStructUnionParser::try_post_identify_macro_calls()
             if (pc->IsParenOpen())
             {
                auto *paren_open  = pc;
-               auto *paren_close = paren_open->SkipToMatch(E_Scope::PREPROC);
+               auto *paren_close = paren_open->GetClosingParen(E_Scope::PREPROC);
 
                if (paren_close->IsNotNullChunk())
                {
@@ -2897,7 +2897,7 @@ bool EnumStructUnionParser::try_pre_identify_type()
             if (  next->IsSquareBracket()                       // Issue #3601
                || next->IsParenOpen())
             {
-               prev = next->SkipToMatch(E_Scope::PREPROC);
+               prev = next->GetClosingParen(E_Scope::PREPROC);
                next = prev->GetNextNcNnl(E_Scope::PREPROC);
             }
 
@@ -2930,7 +2930,7 @@ bool EnumStructUnionParser::try_pre_identify_type()
       if (  language_is_set(LANG_D)
          && pc->IsParenClose())
       {
-         pc = pc->SkipToMatchRev();
+         pc = pc->GetOpeningParen();
          pc = pc->GetPrevNcNnlNi();
       }
 

--- a/src/align_assign.cpp
+++ b/src/align_assign.cpp
@@ -108,7 +108,7 @@ Chunk *align_assign(Chunk *first, size_t span, size_t thresh, size_t *p_nl_count
          LOG_FMT(LALASS, "%s(%d): Don't check inside SPAREN, PAREN or SQUARE groups, type is %s\n",
                  __func__, __LINE__, get_token_name(pc->GetType()));
          tmp = pc->GetOrigLine();
-         pc  = pc->SkipToMatch();
+         pc  = pc->GetClosingParen();
 
          if (pc->IsNotNullChunk())
          {

--- a/src/align_braced_init_list.cpp
+++ b/src/align_braced_init_list.cpp
@@ -59,7 +59,7 @@ Chunk *align_braced_init_list(Chunk *first, size_t span, size_t thresh, size_t *
          LOG_FMT(LALASS, "%s(%d)OK: Don't check inside SPAREN, PAREN or SQUARE groups, type is %s\n",
                  __func__, __LINE__, get_token_name(pc->GetType()));
          tmp = pc->GetOrigLine();
-         pc  = pc->SkipToMatch();
+         pc  = pc->GetClosingParen();
 
          if (pc->IsNotNullChunk())
          {

--- a/src/align_tools.cpp
+++ b/src/align_tools.cpp
@@ -17,7 +17,7 @@ Chunk *skip_c99_array(Chunk *sq_open)
 {
    if (sq_open->Is(CT_SQUARE_OPEN))
    {
-      Chunk *tmp = sq_open->SkipToMatch()->GetNextNc();
+      Chunk *tmp = sq_open->GetClosingParen()->GetNextNc();
 
       if (tmp->Is(CT_ASSIGN))
       {

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -1261,7 +1261,7 @@ static void mark_namespace(Chunk *pns)
       log_rule_B("indent_namespace_limit");
 
       if (  (options::indent_namespace_limit() > 0)
-         && ((br_close = pc->SkipToMatch())->IsNotNullChunk()))
+         && ((br_close = pc->GetClosingParen())->IsNotNullChunk()))
       {
          // br_close->GetOrigLine() is always >= pc->GetOrigLine();
          size_t numberOfLines = br_close->GetOrigLine() - pc->GetOrigLine() - 1;                 // Issue #2345

--- a/src/braces.cpp
+++ b/src/braces.cpp
@@ -132,7 +132,7 @@ static bool paren_multiline_before_brace(Chunk *brace)
 
    // find parenthesis pair of the if/for/while/...
    auto paren_close = brace->GetPrevType(paren_t, brace->GetLevel(), E_Scope::ALL);
-   auto paren_open  = paren_close->SkipToMatchRev();
+   auto paren_open  = paren_close->GetOpeningParen();
 
    if (  paren_close->IsNullChunk()
       || paren_open->IsNullChunk()
@@ -818,7 +818,7 @@ static void convert_brace(Chunk *br)
          }
          else if (br->Is(CT_VBRACE_CLOSE))
          {
-            brace = br->SkipToMatchRev();
+            brace = br->GetOpeningParen();
 
             if (brace->IsNullChunk())
             {
@@ -1387,7 +1387,7 @@ static Chunk *mod_case_brace_add(Chunk *cl_colon)
    // look for the opening brace of the switch
    Chunk *open = swit->GetNextType(CT_BRACE_OPEN, swit->GetLevel());
    // look for the closing brace of the switch
-   Chunk *clos = open->SkipToMatch();
+   Chunk *clos = open->GetClosingParen();
 
    // find the end of the case-block
    pc = pc->GetNextNcNnl(E_Scope::PREPROC);
@@ -1566,7 +1566,7 @@ static void process_if_chain(Chunk *br_start)
          must_have_braces = true;
       }
       braces.push_back(pc);
-      Chunk *br_close = pc->SkipToMatch(E_Scope::PREPROC);
+      Chunk *br_close = pc->GetClosingParen(E_Scope::PREPROC);
 
       if (br_close->IsNullChunk())
       {

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -662,7 +662,7 @@ Chunk *Chunk::GetNextNbsb() const
    {
       if (pc->Is(CT_SQUARE_OPEN))
       {
-         pc = pc->SkipToMatch();
+         pc = pc->GetClosingParen();
       }
       pc = pc->GetNextNcNnl();
    }
@@ -679,7 +679,7 @@ Chunk *Chunk::GetPrevNbsb() const
    {
       if (pc->Is(CT_SQUARE_CLOSE))
       {
-         pc = pc->SkipToMatchRev();
+         pc = pc->GetOpeningParen();
       }
       pc = pc->GetPrevNcNnl();
    }
@@ -782,7 +782,7 @@ bool Chunk::IsStringAndLevel(const char *cStr, const size_t len,
 }
 
 
-Chunk *Chunk::SkipToMatch(E_Scope scope) const
+Chunk *Chunk::GetClosingParen(E_Scope scope) const
 {
    if (  Is(CT_PAREN_OPEN)
       || Is(CT_SPAREN_OPEN)
@@ -799,7 +799,7 @@ Chunk *Chunk::SkipToMatch(E_Scope scope) const
 }
 
 
-Chunk *Chunk::SkipToMatchRev(E_Scope scope) const
+Chunk *Chunk::GetOpeningParen(E_Scope scope) const
 {
    if (  Is(CT_PAREN_CLOSE)
       || Is(CT_SPAREN_CLOSE)

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -660,18 +660,18 @@ public:
    Chunk *SearchStringLevel(const char *cStr, const size_t len, const int level, const E_Scope scope = E_Scope::ALL, const E_Direction dir = E_Direction::FORWARD) const;
 
    /**
-    * @brief skip to the closing match for the current paren/brace/square.
+    * @brief returns the closing match for the current paren/brace/square.
     * @param scope chunk section to consider
     * @return pointer to the next matching chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *SkipToMatch(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetClosingParen(E_Scope scope = E_Scope::ALL) const;
 
    /**
-    * @brief skip to the opening match for the current paren/brace/square.
+    * @brief returns the opening match for the current paren/brace/square.
     * @param scope chunk section to consider
     * @return pointer to the prev matching chunk or Chunk::NullChunkPtr if no chunk was found
     */
-   Chunk *SkipToMatchRev(E_Scope scope = E_Scope::ALL) const;
+   Chunk *GetOpeningParen(E_Scope scope = E_Scope::ALL) const;
 
 
    // --------- Is* functions

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -262,7 +262,7 @@ static void flag_asm(Chunk *pc)
    {
       return;
    }
-   Chunk *end = po->SkipToMatch(E_Scope::PREPROC);
+   Chunk *end = po->GetClosingParen(E_Scope::PREPROC);
 
    if (end->IsNullChunk())
    {
@@ -1882,7 +1882,7 @@ static void check_double_brace_init(Chunk *bo1)
       if (bo2->Is(CT_BRACE_OPEN))
       {
          // found a potential double brace
-         Chunk *bc2 = bo2->SkipToMatch();
+         Chunk *bc2 = bo2->GetClosingParen();
 
          if (bc2->IsNullChunk())
          {
@@ -2517,7 +2517,7 @@ static void handle_cpp_lambda(Chunk *sq_o)
    if (sq_o->Is(CT_SQUARE_OPEN))
    {
       // make sure there is a ']'
-      sq_c = sq_o->SkipToMatch();
+      sq_c = sq_o->GetClosingParen();
 
       if (sq_c->IsNullChunk())
       {
@@ -2546,7 +2546,7 @@ static void handle_cpp_lambda(Chunk *sq_o)
    if (pa_o->Is(CT_PAREN_OPEN))
    {
       // and now find the ')'
-      pa_c = pa_o->SkipToMatch();
+      pa_c = pa_o->GetClosingParen();
 
       if (pa_c->IsNullChunk())
       {
@@ -2594,7 +2594,7 @@ static void handle_cpp_lambda(Chunk *sq_o)
       return;
    }
    // and now find the '}'
-   Chunk *br_c = br_o->SkipToMatch();
+   Chunk *br_c = br_o->GetClosingParen();
 
    if (br_c->IsNullChunk())
    {
@@ -2665,7 +2665,7 @@ static void handle_cpp_lambda(Chunk *sq_o)
 
    if (call_pa_o->Is(CT_PAREN_OPEN))
    {
-      Chunk *call_pa_c = call_pa_o->SkipToMatch();
+      Chunk *call_pa_c = call_pa_o->GetClosingParen();
 
       if (call_pa_c->IsNotNullChunk())
       {
@@ -3019,7 +3019,7 @@ static void handle_oc_block_literal(Chunk *pc)
    }
 
    // make sure we have braces
-   bbc = bbo->SkipToMatch();
+   bbc = bbo->GetClosingParen();
 
    if (  bbo->IsNullChunk()
       || bbc->IsNullChunk())
@@ -3038,7 +3038,7 @@ static void handle_oc_block_literal(Chunk *pc)
 
    if (apo->IsNotNullChunk())
    {
-      Chunk *apc = apo->SkipToMatch();  // arg parenthesis close
+      Chunk *apc = apo->GetClosingParen();  // arg parenthesis close
 
       if (apc->IsParenClose())
       {
@@ -3099,10 +3099,10 @@ static void handle_oc_block_type(Chunk *pc)
        * block type: 'RTYPE (^LABEL)(ARGS)'
        * LABEL is optional.
        */
-      Chunk *tpc = tpo->SkipToMatch();    // type close paren (after '^')
-      Chunk *nam = tpc->GetPrevNcNnlNi(); // name (if any) or '^'   Issue #2279
-      Chunk *apo = tpc->GetNextNcNnl();   // arg open paren
-      Chunk *apc = apo->SkipToMatch();    // arg close paren
+      Chunk *tpc = tpo->GetClosingParen(); // type close paren (after '^')
+      Chunk *nam = tpc->GetPrevNcNnlNi();  // name (if any) or '^'   Issue #2279
+      Chunk *apo = tpc->GetNextNcNnl();    // arg open paren
+      Chunk *apc = apo->GetClosingParen(); // arg close paren
 
       /*
        * If this is a block literal instead of a block type, 'nam'
@@ -3165,7 +3165,7 @@ static Chunk *handle_oc_md_type(Chunk *paren_open, E_Token ptype, T_PcfFlags fla
    Chunk *paren_close;
 
    if (  !paren_open->IsParenOpen()
-      || ((paren_close = paren_open->SkipToMatch())->IsNullChunk()))
+      || ((paren_close = paren_open->GetClosingParen())->IsNullChunk()))
    {
       did_it = false;
       return(paren_open);
@@ -3309,7 +3309,7 @@ static void handle_oc_message_decl(Chunk *pc)
    if (pc->Is(CT_BRACE_OPEN))
    {
       pc->SetParentType(pt);
-      pc = pc->SkipToMatch();
+      pc = pc->GetClosingParen();
 
       if (pc->IsNotNullChunk())
       {
@@ -3386,7 +3386,7 @@ static void handle_oc_message_send(Chunk *os)
             return;
          }
       }
-      tmp = tmp->SkipToMatch();
+      tmp = tmp->GetClosingParen();
    }
    else if (  tmp->IsNot(CT_WORD)
            && tmp->IsNot(CT_TYPE)
@@ -3501,7 +3501,7 @@ static void handle_oc_message_send(Chunk *os)
    // [(self.foo.bar) method]
    if (tmp->IsParenOpen())
    {
-      tmp = tmp->SkipToMatch()->GetNextNcNnl();
+      tmp = tmp->GetClosingParen()->GetNextNcNnl();
    }
 
    if (  tmp->Is(CT_WORD)
@@ -3808,7 +3808,7 @@ static void handle_oc_property_decl(Chunk *os)
 
    if (tmp->IsParenOpen())
    {
-      tmp = tmp->SkipToMatch()->GetNextNcNnl();
+      tmp = tmp->GetClosingParen()->GetNextNcNnl();
    }
    fix_variable_definition(tmp);
 } // handle_oc_property_decl
@@ -3985,7 +3985,7 @@ static void handle_proto_wrap(Chunk *pc)
    Chunk *opp  = pc->GetNextNcNnl();
    Chunk *name = opp->GetNextNcNnl();
    Chunk *tmp  = name->GetNextNcNnl()->GetNextNcNnl();
-   Chunk *clp  = opp->SkipToMatch();
+   Chunk *clp  = opp->GetClosingParen();
    Chunk *cma  = clp->GetNextNcNnl();
 
    if (  opp->IsNullChunk()
@@ -4028,7 +4028,7 @@ static void handle_proto_wrap(Chunk *pc)
       fix_fcn_def_params(opp);
       name->SetType(CT_WORD);
    }
-   tmp = tmp->SkipToMatch();
+   tmp = tmp->GetClosingParen();
 
    if (tmp->IsNotNullChunk())
    {

--- a/src/combine_fix_mark.cpp
+++ b/src/combine_fix_mark.cpp
@@ -509,7 +509,7 @@ void fix_typedef(Chunk *start)
 
       if (the_type->IsParenClose())
       {
-         open_paren = the_type->SkipToMatchRev();
+         open_paren = the_type->GetOpeningParen();
          mark_function_type(the_type);
          the_type = the_type->GetPrevNcNnlNi(E_Scope::PREPROC);   // Issue #2279
 
@@ -1072,7 +1072,7 @@ void mark_function_return_type(Chunk *fname, Chunk *start, E_Token parent_type)
       if (  pc->Is(CT_PAREN_CLOSE)
          && !pc->TestFlags(PCF_IN_PREPROC))
       {
-         first           = pc->SkipToMatchRev();
+         first           = pc->GetOpeningParen();
          is_return_tuple = true;
       }
       pc = first;
@@ -1368,7 +1368,7 @@ void mark_function(Chunk *pc)
       // Issue #3852
       while (tmp3->IsString("("))
       {
-         tmp3 = tmp3->SkipToMatch();
+         tmp3 = tmp3->GetClosingParen();
          tmp3 = tmp3->GetNextNcNnl();
       }
 
@@ -1604,7 +1604,7 @@ void mark_function(Chunk *pc)
 
          if (prev->GetParentType() == CT_DECLSPEC)  // Issue 1289
          {
-            prev = prev->SkipToMatchRev();
+            prev = prev->GetOpeningParen();
 
             if (prev->IsNotNullChunk())
             {
@@ -1796,7 +1796,7 @@ void mark_function(Chunk *pc)
          && prev->Is(CT_PAREN_CLOSE)
          && prev->GetNextNcNnl() == pc)
       {
-         tmp = prev->SkipToMatchRev();
+         tmp = prev->GetOpeningParen();
 
          while (  tmp->IsNotNullChunk() // Issue #2315
                && tmp != prev)
@@ -2093,7 +2093,7 @@ void mark_function(Chunk *pc)
          LOG_FMT(LFCN, "%s(%d): (14) SET TO CT_FUNC_DEF: orig line is %zu, orig col is %zu, Text() '%s'\n",
                  __func__, __LINE__, tmp->GetOrigLine(), tmp->GetOrigCol(), tmp->Text());
          tmp->SetParentType(CT_FUNC_DEF);
-         tmp = tmp->SkipToMatch();
+         tmp = tmp->GetClosingParen();
 
          if (tmp->IsNotNullChunk())
          {
@@ -2152,11 +2152,11 @@ bool mark_function_type(Chunk *pc)
    {
       return(false);
    }
-   apc = apo->SkipToMatch();
+   apc = apo->GetClosingParen();
 
    if (  apc->IsNotNullChunk()
       && (  !apo->IsParenOpen()
-         || ((apc = apo->SkipToMatch())->IsNullChunk())))
+         || ((apc = apo->GetClosingParen())->IsNullChunk())))
    {
       LOG_FMT(LFTYPE, "%s(%d): not followed by parens\n", __func__, __LINE__);
       goto nogo_exit;

--- a/src/combine_skip.cpp
+++ b/src/combine_skip.cpp
@@ -222,7 +222,7 @@ Chunk *skip_declspec(Chunk *pc)
 
       if (pc->Is(CT_PAREN_OPEN))
       {
-         pc = pc->SkipToMatch();
+         pc = pc->GetClosingParen();
       }
    }
    return(pc);

--- a/src/combine_tools.cpp
+++ b/src/combine_tools.cpp
@@ -97,7 +97,7 @@ bool can_be_full_param(Chunk *start, Chunk *end)
               && pc->Is(CT_PAREN_OPEN))
       {
          // Check for old-school func proto param '(type)'
-         Chunk *tmp1 = pc->SkipToMatch(E_Scope::PREPROC);
+         Chunk *tmp1 = pc->GetClosingParen(E_Scope::PREPROC);
 
          if (tmp1->IsNullChunk())
          {
@@ -191,7 +191,7 @@ bool can_be_full_param(Chunk *start, Chunk *end)
 
          if (tmp1->IsString("("))
          {
-            tmp3 = tmp1->SkipToMatch(E_Scope::PREPROC);
+            tmp3 = tmp1->GetClosingParen(E_Scope::PREPROC);
          }
          pc = tmp3;
          LOG_FMT(LFPARAM, "%s(%d): pc->Text() is '%s', type is %s\n",
@@ -209,7 +209,7 @@ bool can_be_full_param(Chunk *start, Chunk *end)
               && pc->Is(CT_SQUARE_OPEN))
       {
          // skip over any array stuff
-         pc = pc->SkipToMatch(E_Scope::PREPROC);
+         pc = pc->GetClosingParen(E_Scope::PREPROC);
          LOG_FMT(LFPARAM, "%s(%d): pc->Text() is '%s', type is %s\n",
                  __func__, __LINE__, pc->Text(), get_token_name(pc->GetType()));
       }
@@ -217,7 +217,7 @@ bool can_be_full_param(Chunk *start, Chunk *end)
               && pc->Is(CT_SQUARE_OPEN))
       {
          // Bug #671: is it such as: bool foo[FOO_MAX]
-         pc = pc->SkipToMatch(E_Scope::PREPROC);
+         pc = pc->GetClosingParen(E_Scope::PREPROC);
          LOG_FMT(LFPARAM, "%s(%d): pc->Text() is '%s', type is %s\n",
                  __func__, __LINE__, pc->Text(), get_token_name(pc->GetType()));
       }
@@ -562,7 +562,7 @@ Chunk *set_paren_parent(Chunk *start, E_Token parent_type)
    LOG_FUNC_ENTRY();
    Chunk *end;
 
-   end = start->SkipToMatch(E_Scope::PREPROC);
+   end = start->GetClosingParen(E_Scope::PREPROC);
 
    if (end->IsNotNullChunk())
    {

--- a/src/flag_braced_init_list.cpp
+++ b/src/flag_braced_init_list.cpp
@@ -60,7 +60,7 @@ bool detect_cpp_braced_init_list(Chunk *pc, Chunk *next)
             || brace_open->GetParentType() == CT_BRACED_INIT_LIST))
       {
          log_pcf_flags(LFCNR, brace_open->GetFlags());
-         auto brace_close = next->SkipToMatch();
+         auto brace_close = next->GetClosingParen();
 
          if (brace_close->Is(CT_BRACE_CLOSE))
          {
@@ -75,7 +75,7 @@ bool detect_cpp_braced_init_list(Chunk *pc, Chunk *next)
 void flag_cpp_braced_init_list(Chunk *pc, Chunk *next)
 {
    Chunk *brace_open  = pc->GetNextNcNnl();
-   Chunk *brace_close = next->SkipToMatch();
+   Chunk *brace_close = next->GetClosingParen();
 
    brace_open->SetParentType(CT_BRACED_INIT_LIST);
    brace_close->SetParentType(CT_BRACED_INIT_LIST);
@@ -89,7 +89,7 @@ void flag_cpp_braced_init_list(Chunk *pc, Chunk *next)
       // Flag call operator
       if (tmp->Is(CT_PAREN_OPEN))
       {
-         Chunk *c = tmp->SkipToMatch();
+         Chunk *c = tmp->GetClosingParen();
 
          if (c->IsNotNullChunk())
          {

--- a/src/flag_parens.cpp
+++ b/src/flag_parens.cpp
@@ -15,7 +15,7 @@ Chunk *flag_parens(Chunk *po, T_PcfFlags flags, E_Token opentype, E_Token parent
    LOG_FUNC_ENTRY();
    Chunk *paren_close;
 
-   paren_close = po->SkipToMatch(E_Scope::PREPROC);
+   paren_close = po->GetClosingParen(E_Scope::PREPROC);
 
    if (paren_close->IsNullChunk())
    {

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -506,7 +506,7 @@ static Chunk *oc_msg_block_indent(Chunk *pc, bool from_brace,
    // Skip to open paren in ':^TYPE *(ARGS) {'
    if (tmp->IsParenClose())
    {
-      tmp = tmp->SkipToMatchRev()->GetPrevNc();
+      tmp = tmp->GetOpeningParen()->GetPrevNc();
    }
 
    // // Check for star in ':^TYPE *(ARGS) {'. Issue 2477
@@ -1655,7 +1655,7 @@ void indent_text()
             Chunk *tail     = Chunk::NullChunkPtr;
             Chunk *frm_prev = frm.prev().pc;
             bool  enclosure = (  frm_prev->GetParentType() != CT_FUNC_DEF           // Issue #3407
-                              && frm_prev != frm_prev->SkipToMatch());
+                              && frm_prev != frm_prev->GetClosingParen());
             bool  linematch = true;
 
             for (auto it = frm.rbegin(); it != frm.rend() && tail->IsNullChunk(); ++it)
@@ -1664,7 +1664,7 @@ void indent_text()
                {
                   linematch &= it->pc->IsOnSameLine(head);
                }
-               Chunk *match = it->pc->SkipToMatch();
+               Chunk *match = it->pc->GetClosingParen();
 
                if (match->IsNullChunk())
                {
@@ -1712,7 +1712,7 @@ void indent_text()
             // 2a. If it's an assignment, check that both sides of the assignment operator are on the same line
             // 2b. If it's inside some closure, check that all the frames are on the same line,
             //     and it is in the top level closure, and indent_continue is non-zero
-            bool sameLine = frm.top().pc->SkipToMatch()->IsOnSameLine(tail);
+            bool sameLine = frm.top().pc->GetClosingParen()->IsOnSameLine(tail);
 
             bool isAssignSameLine =
                !enclosure
@@ -1726,7 +1726,7 @@ void indent_text()
                && enclosure
                && linematch
                && toplevel
-               && frm.top().pc->SkipToMatch()->IsOnSameLine(frm.top().pc);
+               && frm.top().pc->GetClosingParen()->IsOnSameLine(frm.top().pc);
 
             if (sameLine && ((isAssignSameLine) || (closureSameLineTopLevel)))
             {
@@ -1916,7 +1916,7 @@ void indent_text()
 
                   if (options::indent_oc_block_msg_xcode_style())
                   {
-                     Chunk *bbc           = pc->SkipToMatch(); // block brace close '}'
+                     Chunk *bbc           = pc->GetClosingParen(); // block brace close '}'
                      Chunk *bbc_next_ncnl = bbc->GetNextNcNnl();
 
                      if (  bbc_next_ncnl->GetType() == CT_OC_MSG_NAME
@@ -2568,7 +2568,7 @@ void indent_text()
               && options::indent_ignore_asm_block())
       {
          log_rule_B("indent_ignore_asm_block");
-         Chunk *tmp = pc->SkipToMatch();
+         Chunk *tmp = pc->GetClosingParen();
 
          int   move = 0;
 
@@ -3789,7 +3789,7 @@ void indent_text()
                            || searchNext->GetType() == CT_NEWLINE)
                         {
                            LOG_FMT(LINDLINE, "%s(%d):\n", __func__, __LINE__);
-                           search = search->SkipToMatchRev();
+                           search = search->GetOpeningParen();
 
                            if (  options::indent_oc_inside_msg_sel()
                               && search->GetPrevNcNnl()->Is(CT_OC_COLON)

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -1367,7 +1367,7 @@ static void newlines_func_pre_blank_lines(Chunk *start, E_Token start_type)
       {
          LOG_FMT(LNLFUNCT, "%s(%d):\n", __func__, __LINE__);
          // skip template stuff to add newlines before it
-         pc = pc->SkipToMatchRev();
+         pc = pc->GetOpeningParen();
 
          if (pc->IsNotNullChunk())
          {
@@ -1959,7 +1959,7 @@ static bool is_var_def(Chunk *pc, Chunk *next)
       && next->Is(CT_PAREN_OPEN))
    {
       // If current token starts a decltype expression, skip it
-      next = next->SkipToMatch();
+      next = next->GetClosingParen();
       next = next->GetNextNcNnl();
    }
    else if (!pc->IsTypeDefinition())
@@ -1975,7 +1975,7 @@ static bool is_var_def(Chunk *pc, Chunk *next)
    else if (next->Is(CT_ANGLE_OPEN))
    {
       // If we have a template type, skip it
-      next = next->SkipToMatch();
+      next = next->GetClosingParen();
       next = next->GetNextNcNnl();
    }
    bool is = (  (  next->IsTypeDefinition()
@@ -2027,7 +2027,7 @@ static Chunk *newline_var_def_blk(Chunk *start)
          && prev->IsNotNullChunk()
          && prev->Is(CT_ASSIGN))
       {
-         Chunk *tmp = start->SkipToMatch();
+         Chunk *tmp = start->GetClosingParen();
          return(tmp->GetNextNcNnl());
       }
       // check if we're at the top of a function definition, or function call with a
@@ -2324,7 +2324,7 @@ static void newlines_brace_pair(Chunk *br_open)
       && (br_open->GetParentType() == CT_NAMESPACE)
       && br_open->GetPrev()->IsNewline())
    {
-      Chunk *chunk_brace_close = br_open->SkipToMatch();
+      Chunk *chunk_brace_close = br_open->GetClosingParen();
 
       if (chunk_brace_close->IsNotNullChunk())
       {
@@ -2353,7 +2353,7 @@ static void newlines_brace_pair(Chunk *br_open)
       && options::nl_create_func_def_one_liner()
       && !br_open->TestFlags(PCF_NOT_POSSIBLE))          // Issue #2795
    {
-      Chunk *br_close = br_open->SkipToMatch();
+      Chunk *br_close = br_open->GetClosingParen();
       Chunk *tmp      = br_open->GetPrevNcNnlNi(); // Issue #2279
 
       if (  br_close->IsNotNullChunk()             // Issue #2594
@@ -2591,7 +2591,7 @@ static void newlines_brace_pair(Chunk *br_open)
 
    if (br_open->Is(CT_BRACE_OPEN))
    {
-      Chunk *chunk_closing_brace = br_open->SkipToMatch();
+      Chunk *chunk_closing_brace = br_open->GetClosingParen();
 
       if (chunk_closing_brace->IsNotNullChunk())
       {
@@ -3277,7 +3277,7 @@ static void newline_func_def_or_call(Chunk *start)
 
          if (tmp_next->IsNot(CT_FUNC_CLASS_DEF))
          {
-            Chunk  *closing = tmp->SkipToMatch();
+            Chunk  *closing = tmp->GetClosingParen();
             Chunk  *brace   = closing->GetNextNcNnl();
             iarf_e a;                                            // Issue #2561
 
@@ -3477,7 +3477,7 @@ static void newline_oc_msg(Chunk *start)
 {
    LOG_FUNC_ENTRY();
 
-   Chunk *sq_c = start->SkipToMatch();
+   Chunk *sq_c = start->GetClosingParen();
 
    if (sq_c->IsNullChunk())
    {
@@ -5442,8 +5442,8 @@ void newlines_squeeze_paren_close()
          && next->IsParenClose()
          && prev->IsParenClose())
       {
-         Chunk *prev_op = prev->SkipToMatchRev();
-         Chunk *next_op = next->SkipToMatchRev();
+         Chunk *prev_op = prev->GetOpeningParen();
+         Chunk *next_op = next->GetOpeningParen();
          bool  flag     = true;
 
          Chunk *tmp = prev;
@@ -6782,7 +6782,7 @@ void annotations_newlines()
       if (next->IsParenOpen())
       {
          // TODO: control newline between annotation and '(' ?
-         ae = next->SkipToMatch();
+         ae = next->GetClosingParen();
       }
       else
       {

--- a/src/parens.cpp
+++ b/src/parens.cpp
@@ -323,7 +323,7 @@ static void check_bool_parens(Chunk *popen, Chunk *pclose, int nest)
       }
       else if (pc->IsParenOpen())
       {
-         Chunk *next = pc->SkipToMatch();
+         Chunk *next = pc->GetClosingParen();
 
          if (next->IsNotNullChunk())
          {
@@ -336,7 +336,7 @@ static void check_bool_parens(Chunk *popen, Chunk *pclose, int nest)
               || pc->Is(CT_ANGLE_OPEN))
       {
          // Skip [], {}, and <>
-         pc = pc->SkipToMatch();
+         pc = pc->GetClosingParen();
       }
    }
 

--- a/src/rewrite_infinite_loops.cpp
+++ b/src/rewrite_infinite_loops.cpp
@@ -253,7 +253,7 @@ void rewrite_infinite_loops()
       if (pc->Is(CT_DO))
       {
          Chunk *start_brace   = find_start_brace(pc);
-         Chunk *end_brace     = start_brace->SkipToMatch();
+         Chunk *end_brace     = start_brace->GetClosingParen();
          Chunk *while_keyword = end_brace->GetNextNcNnl();
 
          if (  !while_keyword->Is(CT_WHILE_OF_DO)
@@ -299,7 +299,7 @@ void rewrite_infinite_loops()
                  && for_needs_rewrite(pc, desired_type)))
       {
          Chunk *start_brace = find_start_brace(pc);
-         Chunk *end_brace   = start_brace->SkipToMatch();
+         Chunk *end_brace   = start_brace->GetClosingParen();
 
          if (desired_type == CT_WHILE_OF_DO)
          {

--- a/src/semicolons.cpp
+++ b/src/semicolons.cpp
@@ -77,7 +77,7 @@ void remove_extra_semicolons()
             if (  closing_brace != nullptr
                && closing_brace->IsNotNullChunk())
             {
-               Chunk *opening_brace = closing_brace->SkipToMatchRev();
+               Chunk *opening_brace = closing_brace->GetOpeningParen();
 
                if (  opening_brace != nullptr
                   && opening_brace->IsNotNullChunk())

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1749,7 +1749,7 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
          || second->GetParentType() == CT_UNION)
       {
          // Fix for issue #1240  adding space in struct initializers
-         Chunk *tmp = second->SkipToMatchRev()->GetPrevNcNnl();
+         Chunk *tmp = second->GetOpeningParen()->GetPrevNcNnl();
 
          if (tmp->Is(CT_ASSIGN))
          {
@@ -2837,7 +2837,7 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
 
       if (second->Is(CT_WORD))
       {
-         Chunk *open_paren = first->SkipToMatchRev();
+         Chunk *open_paren = first->GetOpeningParen();
          Chunk *type       = open_paren->GetPrev()->GetPrev();
 
          if (type->Is(CT_TYPE))

--- a/src/tokenize_cleanup.cpp
+++ b/src/tokenize_cleanup.cpp
@@ -1408,7 +1408,7 @@ static void check_template(Chunk *start, bool in_type_cast)
          if (pc->Is(CT_BRACE_OPEN))                     // Issue #2886
          {
             // look for the closing brace
-            Chunk *A = pc->SkipToMatch();
+            Chunk *A = pc->GetClosingParen();
             LOG_FMT(LTEMPL, "%s(%d): A orig line is %zu, orig col is %zu, type is %s\n",
                     __func__, __LINE__, A->GetOrigLine(), A->GetOrigCol(), get_token_name(A->GetType()));
             pc = A->GetNext();
@@ -1472,7 +1472,7 @@ static void check_template(Chunk *start, bool in_type_cast)
                break;
             }
             auto brace_open  = pc->GetNextNcNnl();
-            auto brace_close = brace_open->SkipToMatch();
+            auto brace_close = brace_open->GetClosingParen();
 
             brace_open->SetParentType(CT_BRACED_INIT_LIST);
             brace_close->SetParentType(CT_BRACED_INIT_LIST);


### PR DESCRIPTION
Rename Chunk::SkipToMatch to Chunk::GetClosingParen and Chunk::SkipToMatchRev to Chunk::GetOpeningParen.
The original names were misleading because the two methods are returning a different chunk, they don't move the current one