### PR TITLE
Regression fix sp arth and refs

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1584,7 +1584,8 @@ void do_symbol_check(Chunk *prev, Chunk *pc, Chunk *next)
          }
          else if (  pc->TestFlags(PCF_IN_PREPROC) // Issue #3559
                  && pc->Is(CT_AMP)
-                 && next->Is(CT_WORD))
+                 && next->Is(CT_WORD)
+                 && !pc->TestFlags(PCF_IN_SPAREN))
          {
             //LOG_FMT(LGUY, " ++++++++++ pc->GetFlags(): ");
             //log_pcf_flags(LGUY, pc->GetFlags());

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1616,7 +1616,23 @@ void do_symbol_check(Chunk *prev, Chunk *pc, Chunk *next)
                   }
                   else if (tmp->Is(CT_DC_MEMBER))
                   {
-                     prev->SetType(CT_TYPE);
+                     // Issue #2103 & Issue #3865: partial fix
+                     // No easy way to tell between an enum and a type with
+                     // a namespace qualifier. Compromise: if we're in a
+                     // function def or call, assume it's a ref.
+                     Chunk *nextNext = next->GetNext();
+
+                     if (  nextNext->IsNot(CT_DC_MEMBER)
+                        && (  pc->TestFlags(PCF_IN_FCN_CALL)
+                           || pc->TestFlags(PCF_IN_FCN_CTOR)
+                           || pc->TestFlags(PCF_IN_FCN_DEF)))
+                     {
+                        pc->SetType(CT_BYREF);
+                     }
+                     else
+                     {
+                        prev->SetType(CT_TYPE);
+                     }
                   }
                }
             }

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1538,12 +1538,15 @@ void do_symbol_check(Chunk *prev, Chunk *pc, Chunk *next)
 
    if (pc->Is(CT_AMP))
    {
+      Chunk *prevNext = prev->GetNext();
+
       if (prev->Is(CT_DELETE))
       {
          pc->SetType(CT_ADDR);
       }
       else if (  prev->Is(CT_TYPE)
-              || prev->Is(CT_QUALIFIER))
+              || prev->Is(CT_QUALIFIER)
+              || prevNext->Is(CT_QUALIFIER))
       {
          pc->SetType(CT_BYREF);
       }

--- a/tests/config/cpp/Issue_3865.cfg
+++ b/tests/config/cpp/Issue_3865.cfg
@@ -1,0 +1,1 @@
+sp_arith = add

--- a/tests/config/cpp/Issue_3865_2.cfg
+++ b/tests/config/cpp/Issue_3865_2.cfg
@@ -1,0 +1,2 @@
+sp_arith        = add
+sp_before_byref = remove

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -1132,3 +1132,5 @@
 60089  cpp/Issue_3863.cfg                                   cpp/Issue_3863.cpp
 60090  cpp/Issue_3863.cfg                                   cpp/Issue_3863_2.cpp
 60091  cpp/Issue_3863.cfg                                   cpp/Issue_3863_3.cpp
+60092  cpp/Issue_3865.cfg                                   cpp/Issue_3865.cpp
+60093  cpp/Issue_3865_2.cfg                                 cpp/Issue_3865.cpp

--- a/tests/expected/cpp/60092-Issue_3865.cpp
+++ b/tests/expected/cpp/60092-Issue_3865.cpp
@@ -30,3 +30,5 @@ MyThing* MyClass::my_function()
 
 // Shouldn't change
 EXPECT_EQ(static_cast<int>(MyEnumm::Last & MyEnumm::MyValue));
+#define SOME_MACRO(type, sss) if(n & type) { if(!k.doofer()) { k += "| "; } k += sss; }
+#define SOME_OTHER_MACRO(ttt, sss) (&ttt, &sss)

--- a/tests/expected/cpp/60092-Issue_3865.cpp
+++ b/tests/expected/cpp/60092-Issue_3865.cpp
@@ -1,0 +1,8 @@
+MOCK_METHOD(bool, isThat, (const std::string& name), (override));
+MOCK_METHOD(bool, isThat, (std::string& name), (override));
+MOCK_METHOD(bool, isThat, std::string& name, (override));
+MOCK_METHOD(bool, isThat, const std::string& name, (override));
+MyFunction(const std::string& some_value);
+
+// Shouldn't change
+EXPECT_EQ(static_cast<int>(MyEnumm::Last & MyEnumm::MyValue));

--- a/tests/expected/cpp/60092-Issue_3865.cpp
+++ b/tests/expected/cpp/60092-Issue_3865.cpp
@@ -3,6 +3,30 @@ MOCK_METHOD(bool, isThat, (std::string& name), (override));
 MOCK_METHOD(bool, isThat, std::string& name, (override));
 MOCK_METHOD(bool, isThat, const std::string& name, (override));
 MyFunction(const std::string& some_value);
+MOCK_METHOD(void, isThat, (Callback const&), (override));
+
+class MyClass
+{
+constexpr explicit MyClass(MyClass*& a) noexcept;
+};
+
+SomeClass::SomeClass(unsigned& counter, MyOtherType& lock)
+	: thisThing(counter)
+	, thatThing(lock)
+{
+}
+
+template<typename T = unsigned>
+struct TemplatedClass
+{
+	TemplatedClass(T& thing) {
+	}
+};
+
+MyThing* MyClass::my_function()
+{
+	return &_theirThing;
+}
 
 // Shouldn't change
 EXPECT_EQ(static_cast<int>(MyEnumm::Last & MyEnumm::MyValue));

--- a/tests/expected/cpp/60093-Issue_3865.cpp
+++ b/tests/expected/cpp/60093-Issue_3865.cpp
@@ -30,3 +30,5 @@ MyThing* MyClass::my_function()
 
 // Shouldn't change
 EXPECT_EQ(static_cast<int>(MyEnumm::Last & MyEnumm::MyValue));
+#define SOME_MACRO(type, sss) if(n & type) { if(!k.doofer()) { k += "| "; } k += sss; }
+#define SOME_OTHER_MACRO(ttt, sss) (&ttt, &sss)

--- a/tests/expected/cpp/60093-Issue_3865.cpp
+++ b/tests/expected/cpp/60093-Issue_3865.cpp
@@ -1,0 +1,8 @@
+MOCK_METHOD(bool, isThat, (const std::string& name), (override));
+MOCK_METHOD(bool, isThat, (std::string& name), (override));
+MOCK_METHOD(bool, isThat, std::string& name, (override));
+MOCK_METHOD(bool, isThat, const std::string& name, (override));
+MyFunction(const std::string& some_value);
+
+// Shouldn't change
+EXPECT_EQ(static_cast<int>(MyEnumm::Last & MyEnumm::MyValue));

--- a/tests/expected/cpp/60093-Issue_3865.cpp
+++ b/tests/expected/cpp/60093-Issue_3865.cpp
@@ -3,6 +3,30 @@ MOCK_METHOD(bool, isThat, (std::string& name), (override));
 MOCK_METHOD(bool, isThat, std::string& name, (override));
 MOCK_METHOD(bool, isThat, const std::string& name, (override));
 MyFunction(const std::string& some_value);
+MOCK_METHOD(void, isThat, (Callback const&), (override));
+
+class MyClass
+{
+constexpr explicit MyClass(MyClass*& a) noexcept;
+};
+
+SomeClass::SomeClass(unsigned& counter, MyOtherType& lock)
+	: thisThing(counter)
+	, thatThing(lock)
+{
+}
+
+template<typename T = unsigned>
+struct TemplatedClass
+{
+	TemplatedClass(T& thing) {
+	}
+};
+
+MyThing* MyClass::my_function()
+{
+	return &_theirThing;
+}
 
 // Shouldn't change
 EXPECT_EQ(static_cast<int>(MyEnumm::Last & MyEnumm::MyValue));

--- a/tests/input/cpp/Issue_3865.cpp
+++ b/tests/input/cpp/Issue_3865.cpp
@@ -3,6 +3,29 @@ MOCK_METHOD(bool, isThat, (std::string& name), (override));
 MOCK_METHOD(bool, isThat, std::string& name, (override));
 MOCK_METHOD(bool, isThat, const std::string& name, (override));
 MyFunction(const std::string& some_value);
+MOCK_METHOD(void, isThat, (Callback const&), (override));
+
+class MyClass
+{
+	constexpr explicit MyClass(MyClass*& a) noexcept;
+};
+
+SomeClass::SomeClass(unsigned& counter, MyOtherType& lock)
+    : thisThing(counter)
+    , thatThing(lock)
+{
+}
+
+template<typename T = unsigned>
+struct TemplatedClass
+{
+    TemplatedClass(T& thing) {}
+};
+
+MyThing* MyClass::my_function()
+{
+    return &_theirThing;
+}
 
 // Shouldn't change
 EXPECT_EQ(static_cast<int>(MyEnumm::Last & MyEnumm::MyValue));

--- a/tests/input/cpp/Issue_3865.cpp
+++ b/tests/input/cpp/Issue_3865.cpp
@@ -29,3 +29,5 @@ MyThing* MyClass::my_function()
 
 // Shouldn't change
 EXPECT_EQ(static_cast<int>(MyEnumm::Last & MyEnumm::MyValue));
+#define SOME_MACRO(type, sss) if(n & type) { if(!k.doofer()) { k += "| "; } k += sss; }
+#define SOME_OTHER_MACRO(ttt, sss) (&ttt, &sss)

--- a/tests/input/cpp/Issue_3865.cpp
+++ b/tests/input/cpp/Issue_3865.cpp
@@ -1,0 +1,8 @@
+MOCK_METHOD(bool, isThat, (const std::string& name), (override));
+MOCK_METHOD(bool, isThat, (std::string& name), (override));
+MOCK_METHOD(bool, isThat, std::string& name, (override));
+MOCK_METHOD(bool, isThat, const std::string& name, (override));
+MyFunction(const std::string& some_value);
+
+// Shouldn't change
+EXPECT_EQ(static_cast<int>(MyEnumm::Last & MyEnumm::MyValue));


### PR DESCRIPTION
Three c++ 0.73 regression fixes here regarding `&`