### PR TITLE
First step in improving parsing frame code: renaming of the object names

### DIFF
--- a/src/ParseFrame.h
+++ b/src/ParseFrame.h
@@ -1,7 +1,7 @@
 /**
  * @file ParseFrame.h
  *
- * Container that holds data needed for indenting and brace parsing
+ * Holds data needed for indenting and brace parsing
  *
  * @author  Daniel Chumak
  * @license GPL v2+
@@ -15,21 +15,22 @@
 #include <memory>
 
 
-//! Structure for counting nested level
-struct paren_stack_entry_t
+//! Structure describing a parsing frame and its information
+class ParsingFrame
 {
-   E_Token         type;         //! the type that opened the entry
-   size_t          level;        //! Level of opening type
+public:
+   E_Token         type;         //! the type that opened the frame
+   size_t          level;        //! level of opening type
    size_t          open_line;    //! line that open symbol is on, only for logging purposes
    size_t          open_colu;    //! column that open symbol is on, only for logging purposes
-   Chunk           *pc;          //! Chunk that opened the level, TODO: make const
+   Chunk           *pc;          //! chunk that opened the level, TODO: make const
    size_t          brace_indent; //! indent for braces - may not relate to indent
    size_t          indent;       //! indent level (depends on use)
    size_t          indent_tmp;   //! temporary indent level (depends on use)
    size_t          indent_tab;   //! the 'tab' indent (always <= real column)
    bool            indent_cont;  //! indent_continue was applied
    E_Token         parent;       //! if, for, function, etc
-   brace_stage_e   stage;        //! used to check progression of complex statements.
+   E_BraceStage    stage;        //! used to check progression of complex statements.
    bool            in_preproc;   //! whether this was created in a preprocessor
    size_t          ns_cnt;       //! Number of consecutive namespace levels
    bool            non_vardef;   //! Hit a non-vardef line
@@ -37,11 +38,11 @@ struct paren_stack_entry_t
    Chunk           *pop_pc;
 };
 
-class ParseFrame
+class ParsingFrameStack
 {
 private:
-   std::vector<paren_stack_entry_t> pse;
-   paren_stack_entry_t              last_poped;
+   std::vector<ParsingFrame> pse;
+   ParsingFrame              last_poped;
 
    void clear();
 
@@ -57,41 +58,41 @@ public:
    size_t  expr_count;
 
 
-   ParseFrame();
-   virtual ~ParseFrame() = default;
+   ParsingFrameStack();
+   virtual ~ParsingFrameStack() = default;
 
    bool empty() const;
 
-   paren_stack_entry_t &at(size_t idx);
-   const paren_stack_entry_t &at(size_t idx) const;
+   ParsingFrame &at(size_t idx);
+   const ParsingFrame &at(size_t idx) const;
 
-   paren_stack_entry_t &prev(size_t idx = 1);
-   const paren_stack_entry_t &prev(size_t idx = 1) const;
+   ParsingFrame &prev(size_t idx = 1);
+   const ParsingFrame &prev(size_t idx = 1) const;
 
-   paren_stack_entry_t &top();
-   const paren_stack_entry_t &top() const;
+   ParsingFrame &top();
+   const ParsingFrame &top() const;
 
-   const paren_stack_entry_t &poped() const;
+   const ParsingFrame &poped() const;
 
-   void push(Chunk *pc, const char *func, int line, brace_stage_e stage = brace_stage_e::NONE);
-   void push(std::nullptr_t, brace_stage_e stage = brace_stage_e::NONE);
+   void push(Chunk *pc, const char *func, int line, E_BraceStage stage = E_BraceStage::NONE);
+   void push(std::nullptr_t, E_BraceStage stage = E_BraceStage::NONE);
    void pop(const char *func, int line, Chunk *pc);
 
    size_t size() const;
 
-   using iterator = std::vector<paren_stack_entry_t>::iterator;
+   using iterator = std::vector<ParsingFrame>::iterator;
    iterator begin();
    iterator end();
 
-   using const_iterator = std::vector<paren_stack_entry_t>::const_iterator;
+   using const_iterator = std::vector<ParsingFrame>::const_iterator;
    const_iterator begin() const;
    const_iterator end() const;
 
-   using reverse_iterator = std::vector<paren_stack_entry_t>::reverse_iterator;
+   using reverse_iterator = std::vector<ParsingFrame>::reverse_iterator;
    reverse_iterator rbegin();
    reverse_iterator rend();
 
-   using const_reverse_iterator = std::vector<paren_stack_entry_t>::const_reverse_iterator;
+   using const_reverse_iterator = std::vector<ParsingFrame>::const_reverse_iterator;
    const_reverse_iterator rbegin() const;
    const_reverse_iterator rend() const;
 };

--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -38,10 +38,10 @@ using std::stringstream;
 
 struct BraceState
 {
-   std::vector<ParseFrame> frames     = {};
-   E_Token                 in_preproc = CT_NONE;
-   int                     pp_level   = 0;
-   bool                    consumed   = false;
+   std::vector<ParsingFrameStack> frames     = {};
+   E_Token                        in_preproc = CT_NONE;
+   int                            pp_level   = 0;
+   bool                           consumed   = false;
 };
 
 /**
@@ -54,13 +54,13 @@ struct BraceState
  * @retval true   done with this chunk
  * @retval false  keep processing
  */
-static bool close_statement(ParseFrame &frm, Chunk *pc, const BraceState &braceState);
+static bool close_statement(ParsingFrameStack &frm, Chunk *pc, const BraceState &braceState);
 
 
-static size_t preproc_start(BraceState &braceState, ParseFrame &frm, Chunk *pc);
+static size_t preproc_start(BraceState &braceState, ParsingFrameStack &frm, Chunk *pc);
 
 
-static void print_stack(log_sev_t logsev, const char *str, const ParseFrame &frm);
+static void print_stack(log_sev_t logsev, const char *str, const ParsingFrameStack &frm);
 
 
 /**
@@ -74,12 +74,12 @@ static bool maybe_while_of_do(Chunk *pc);
  * @param after  determines: true  - insert_vbrace_close_after(pc, frm)
  *                           false - insert_vbrace_open_before(pc, frm)
  */
-static Chunk *insert_vbrace(Chunk *pc, bool after, const ParseFrame &frm);
+static Chunk *insert_vbrace(Chunk *pc, bool after, const ParsingFrameStack &frm);
 
 #define insert_vbrace_close_after(pc, frm)    insert_vbrace(pc, true, frm)
 #define insert_vbrace_open_before(pc, frm)    insert_vbrace(pc, false, frm)
 
-static void parse_cleanup(BraceState &braceState, ParseFrame &frm, Chunk *pc);
+static void parse_cleanup(BraceState &braceState, ParsingFrameStack &frm, Chunk *pc);
 
 
 /**
@@ -95,7 +95,7 @@ static void parse_cleanup(BraceState &braceState, ParseFrame &frm, Chunk *pc);
  *
  * @return true - done with this chunk, false - keep processing
  */
-static bool check_complex_statements(ParseFrame &frm, Chunk *pc, const BraceState &braceState);
+static bool check_complex_statements(ParsingFrameStack &frm, Chunk *pc, const BraceState &braceState);
 
 
 /**
@@ -107,14 +107,14 @@ static bool check_complex_statements(ParseFrame &frm, Chunk *pc, const BraceStat
  *
  * @return true - done with this chunk, false - keep processing
  */
-static bool handle_complex_close(ParseFrame &frm, Chunk *pc, const BraceState &braceState);
+static bool handle_complex_close(ParsingFrameStack &frm, Chunk *pc, const BraceState &braceState);
 
 
 //! We're on a 'namespace' skip the word and then set the parent of the braces.
 static void mark_namespace(Chunk *pns);
 
 
-static size_t preproc_start(BraceState &braceState, ParseFrame &frm, Chunk *pc)
+static size_t preproc_start(BraceState &braceState, ParsingFrameStack &frm, Chunk *pc)
 {
    LOG_FUNC_ENTRY();
    const size_t pp_level = braceState.pp_level;
@@ -151,7 +151,7 @@ static size_t preproc_start(BraceState &braceState, ParseFrame &frm, Chunk *pc)
 
 
 static void print_stack(log_sev_t logsev, const char *str,
-                        const ParseFrame &frm)
+                        const ParsingFrameStack &frm)
 {
    LOG_FUNC_ENTRY();
 
@@ -163,7 +163,7 @@ static void print_stack(log_sev_t logsev, const char *str,
 
    for (size_t idx = 1; idx < frm.size(); idx++)
    {
-      if (frm.at(idx).stage != brace_stage_e::NONE)
+      if (frm.at(idx).stage != E_BraceStage::NONE)
       {
          LOG_FMT(logsev, " [%s - %u]", get_token_name(frm.at(idx).type),
                  (unsigned int)frm.at(idx).stage);
@@ -183,9 +183,9 @@ void brace_cleanup()
 {
    LOG_FUNC_ENTRY();
 
-   BraceState braceState;
-   ParseFrame frm{};
-   Chunk      *pc = Chunk::GetHead();
+   BraceState        braceState;
+   ParsingFrameStack frm{};
+   Chunk             *pc = Chunk::GetHead();
 
    while (pc->IsNotNullChunk())
    {
@@ -349,7 +349,7 @@ static bool maybe_while_of_do(Chunk *pc)
  * When a #define is entered, the current frame is pushed and cleared.
  * When a #define is exited, the frame is popped.
  */
-static void parse_cleanup(BraceState &braceState, ParseFrame &frm, Chunk *pc)
+static void parse_cleanup(BraceState &braceState, ParsingFrameStack &frm, Chunk *pc)
 {
    LOG_FUNC_ENTRY();
 
@@ -408,7 +408,7 @@ static void parse_cleanup(BraceState &braceState, ParseFrame &frm, Chunk *pc)
    }
 
    // Check the progression of complex statements
-   if (  frm.top().stage != brace_stage_e::NONE
+   if (  frm.top().stage != E_BraceStage::NONE
       && !pc->Is(CT_AUTORELEASEPOOL)
       && check_complex_statements(frm, pc, braceState))
    {
@@ -474,7 +474,7 @@ static void parse_cleanup(BraceState &braceState, ParseFrame &frm, Chunk *pc)
          {
             LOG_FMT(LWARN, "%s(%d): pc orig line is %zu, orig col is %zu, Text() is '%s', type is %s\n",
                     __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol(), pc->Text(), get_token_name(pc->GetType()));
-            paren_stack_entry_t AA = frm.top();                // Issue #3055
+            ParsingFrame AA = frm.top();                // Issue #3055
 
             if (AA.type != CT_EOF)
             {
@@ -520,7 +520,7 @@ static void parse_cleanup(BraceState &braceState, ParseFrame &frm, Chunk *pc)
          frm.pop(__func__, __LINE__, pc);
          print_stack(LBCSPOP, "-Close  ", frm);
 
-         if (  frm.top().stage == brace_stage_e::NONE
+         if (  frm.top().stage == E_BraceStage::NONE
             && (  pc->Is(CT_VBRACE_CLOSE)
                || pc->Is(CT_BRACE_CLOSE)
                || pc->Is(CT_SEMICOLON))
@@ -530,11 +530,11 @@ static void parse_cleanup(BraceState &braceState, ParseFrame &frm, Chunk *pc)
             // this here is a hackish solution to close a vbrace of a block that
             // contains the function
             frm.push(nullptr); // <- dummy frame for the function
-            frm.top().stage = brace_stage_e::BRACE2;
+            frm.top().stage = E_BraceStage::BRACE2;
          }
 
          // See if we are in a complex statement
-         if (frm.top().stage != brace_stage_e::NONE)
+         if (frm.top().stage != E_BraceStage::NONE)
          {
             handle_complex_close(frm, pc, braceState);
          }
@@ -546,7 +546,7 @@ static void parse_cleanup(BraceState &braceState, ParseFrame &frm, Chunk *pc)
     * sparen, so we need to check braceState.consumed to see if the close sparen
     * was already handled.
     */
-   if (frm.top().stage == brace_stage_e::WOD_SEMI)
+   if (frm.top().stage == E_BraceStage::WOD_SEMI)
    {
       if (braceState.consumed)
       {
@@ -641,7 +641,7 @@ static void parse_cleanup(BraceState &braceState, ParseFrame &frm, Chunk *pc)
          else  // must be CT_BRACE_OPEN
          {
             // Set the parent for open braces
-            if (frm.top().stage != brace_stage_e::NONE)
+            if (frm.top().stage != E_BraceStage::NONE)
             {
                parentType = frm.top().type;
             }
@@ -796,31 +796,31 @@ static void parse_cleanup(BraceState &braceState, ParseFrame &frm, Chunk *pc)
     */
    if (patcls == pattern_class_e::BRACED)
    {
-      frm.push(pc, __func__, __LINE__, (pc->Is(CT_DO) ? brace_stage_e::BRACE_DO
-                    : brace_stage_e::BRACE2));
+      frm.push(pc, __func__, __LINE__, (pc->Is(CT_DO) ? E_BraceStage::BRACE_DO
+                    : E_BraceStage::BRACE2));
       // "+ComplexBraced"
    }
    else if (patcls == pattern_class_e::PBRACED)
    {
-      brace_stage_e bs = brace_stage_e::PAREN1;
+      E_BraceStage bs = E_BraceStage::PAREN1;
 
       if (  pc->Is(CT_WHILE)
          && maybe_while_of_do(pc))
       {
          pc->SetType(CT_WHILE_OF_DO);
-         bs = brace_stage_e::WOD_PAREN;
+         bs = E_BraceStage::WOD_PAREN;
       }
       frm.push(pc, __func__, __LINE__, bs);
       // "+ComplexParenBraced"
    }
    else if (patcls == pattern_class_e::OPBRACED)
    {
-      frm.push(pc, __func__, __LINE__, brace_stage_e::OP_PAREN1);
+      frm.push(pc, __func__, __LINE__, E_BraceStage::OP_PAREN1);
       // "+ComplexOpParenBraced");
    }
    else if (patcls == pattern_class_e::ELSE)
    {
-      frm.push(pc, __func__, __LINE__, brace_stage_e::ELSEIF);
+      frm.push(pc, __func__, __LINE__, E_BraceStage::ELSEIF);
       // "+ComplexElse");
    }
 
@@ -892,33 +892,33 @@ static void parse_cleanup(BraceState &braceState, ParseFrame &frm, Chunk *pc)
 } // parse_cleanup
 
 
-static bool check_complex_statements(ParseFrame &frm, Chunk *pc, const BraceState &braceState)
+static bool check_complex_statements(ParsingFrameStack &frm, Chunk *pc, const BraceState &braceState)
 {
    LOG_FUNC_ENTRY();
 
-   brace_stage_e atest = frm.top().stage;
+   E_BraceStage atest = frm.top().stage;
 
    LOG_FMT(LBCSPOP, "%s(%d): atest is %s\n",
            __func__, __LINE__, get_brace_stage_name(atest));
 
    // Turn an optional parenthesis into either a real parenthesis or a brace
-   if (frm.top().stage == brace_stage_e::OP_PAREN1)
+   if (frm.top().stage == E_BraceStage::OP_PAREN1)
    {
       frm.top().stage = (pc->IsNot(CT_PAREN_OPEN))
-                        ? brace_stage_e::BRACE2
-                        : brace_stage_e::PAREN1;
+                        ? E_BraceStage::BRACE2
+                        : E_BraceStage::PAREN1;
       LOG_FMT(LBCSPOP, "%s(%d): frm.top().stage is now %s\n",
               __func__, __LINE__, get_brace_stage_name(frm.top().stage));
    }
 
    // Check for CT_ELSE after CT_IF
-   while (frm.top().stage == brace_stage_e::ELSE)
+   while (frm.top().stage == E_BraceStage::ELSE)
    {
       if (pc->Is(CT_ELSE))
       {
          // Replace CT_IF with CT_ELSE on the stack & we are done
          frm.top().type  = CT_ELSE;
-         frm.top().stage = brace_stage_e::ELSEIF;
+         frm.top().stage = E_BraceStage::ELSEIF;
          print_stack(LBCSSWAP, "=Swap   ", frm);
 
          return(true);
@@ -936,7 +936,7 @@ static bool check_complex_statements(ParseFrame &frm, Chunk *pc, const BraceStat
    }
 
    // Check for CT_IF after CT_ELSE
-   if (frm.top().stage == brace_stage_e::ELSEIF)
+   if (frm.top().stage == E_BraceStage::ELSEIF)
    {
       log_rule_B("indent_else_if");
 
@@ -947,15 +947,15 @@ static bool check_complex_statements(ParseFrame &frm, Chunk *pc, const BraceStat
          // Replace CT_ELSE with CT_IF
          pc->SetType(CT_ELSEIF);
          frm.top().type  = CT_ELSEIF;
-         frm.top().stage = brace_stage_e::PAREN1;
+         frm.top().stage = E_BraceStage::PAREN1;
          return(true);
       }
       // Jump to the 'expecting brace' stage
-      frm.top().stage = brace_stage_e::BRACE2;
+      frm.top().stage = E_BraceStage::BRACE2;
    }
 
    // Check for CT_CATCH or CT_FINALLY after CT_TRY or CT_CATCH
-   while (frm.top().stage == brace_stage_e::CATCH)
+   while (frm.top().stage == E_BraceStage::CATCH)
    {
       if (  pc->Is(CT_CATCH)
          || pc->Is(CT_FINALLY))
@@ -965,14 +965,14 @@ static bool check_complex_statements(ParseFrame &frm, Chunk *pc, const BraceStat
 
          if (language_is_set(LANG_CS))
          {
-            frm.top().stage = (pc->Is(CT_CATCH)) ? brace_stage_e::CATCH_WHEN : brace_stage_e::BRACE2;
+            frm.top().stage = (pc->Is(CT_CATCH)) ? E_BraceStage::CATCH_WHEN : E_BraceStage::BRACE2;
          }
          else
          {
             // historically this used OP_PAREN1; however, to my knowledge the expression after a catch clause
             // is only optional for C# which has been handled above; therefore, this should now always expect
             // a parenthetical expression after the catch keyword and brace after the finally keyword
-            frm.top().stage = (pc->Is(CT_CATCH)) ? brace_stage_e::PAREN1 : brace_stage_e::BRACE2;
+            frm.top().stage = (pc->Is(CT_CATCH)) ? E_BraceStage::PAREN1 : E_BraceStage::BRACE2;
          }
          print_stack(LBCSSWAP, "=Swap   ", frm);
 
@@ -991,14 +991,14 @@ static bool check_complex_statements(ParseFrame &frm, Chunk *pc, const BraceStat
    }
 
    // Check for optional parenthesis and optional CT_WHEN after CT_CATCH
-   if (frm.top().stage == brace_stage_e::CATCH_WHEN)
+   if (frm.top().stage == E_BraceStage::CATCH_WHEN)
    {
       if (pc->Is(CT_PAREN_OPEN)) // this is for the paren after "catch"
       {
          // Replace CT_PAREN_OPEN with CT_SPAREN_OPEN
          pc->SetType(CT_SPAREN_OPEN);
          frm.top().type  = pc->GetType();
-         frm.top().stage = brace_stage_e::PAREN1;
+         frm.top().stage = E_BraceStage::PAREN1;
 
          return(false);
       }
@@ -1006,27 +1006,27 @@ static bool check_complex_statements(ParseFrame &frm, Chunk *pc, const BraceStat
       if (pc->Is(CT_WHEN))
       {
          frm.top().type  = pc->GetType();
-         frm.top().stage = brace_stage_e::OP_PAREN1;
+         frm.top().stage = E_BraceStage::OP_PAREN1;
 
          return(true);
       }
 
       if (pc->Is(CT_BRACE_OPEN))
       {
-         frm.top().stage = brace_stage_e::BRACE2;
+         frm.top().stage = E_BraceStage::BRACE2;
 
          return(false);
       }
    }
 
    // Check for CT_WHILE after the CT_DO
-   if (frm.top().stage == brace_stage_e::WHILE)
+   if (frm.top().stage == E_BraceStage::WHILE)
    {
       if (pc->Is(CT_WHILE))
       {
          pc->SetType(CT_WHILE_OF_DO);
          frm.top().type  = CT_WHILE_OF_DO; //CT_WHILE;
-         frm.top().stage = brace_stage_e::WOD_PAREN;
+         frm.top().stage = E_BraceStage::WOD_PAREN;
 
          return(true);
       }
@@ -1045,8 +1045,8 @@ static bool check_complex_statements(ParseFrame &frm, Chunk *pc, const BraceStat
 
    if (  pc->IsNot(CT_BRACE_OPEN)
       && !pc->TestFlags(PCF_IN_PREPROC)
-      && (  (frm.top().stage == brace_stage_e::BRACE2)
-         || (frm.top().stage == brace_stage_e::BRACE_DO)))
+      && (  (frm.top().stage == E_BraceStage::BRACE2)
+         || (frm.top().stage == E_BraceStage::BRACE_DO)))
    {
       log_rule_B("indent_using_block");
 
@@ -1069,7 +1069,7 @@ static bool check_complex_statements(ParseFrame &frm, Chunk *pc, const BraceStat
                  __func__, __LINE__, frm.brace_level);
          log_pcf_flags(LBCSPOP, pc->GetFlags());
 
-         frm.push(vbrace, __func__, __LINE__, brace_stage_e::NONE);
+         frm.push(vbrace, __func__, __LINE__, E_BraceStage::NONE);
          // "+VBrace");
 
          frm.top().parent = parentType;
@@ -1092,7 +1092,7 @@ static bool check_complex_statements(ParseFrame &frm, Chunk *pc, const BraceStat
    }
 
    // Check for "constexpr" after CT_IF or CT_ELSEIF
-   if (  frm.top().stage == brace_stage_e::PAREN1
+   if (  frm.top().stage == E_BraceStage::PAREN1
       && (  frm.top().type == CT_IF
          || frm.top().type == CT_ELSEIF)
       && pc->Is(CT_CONSTEXPR))
@@ -1102,8 +1102,8 @@ static bool check_complex_statements(ParseFrame &frm, Chunk *pc, const BraceStat
 
    // Verify open parenthesis in complex statement
    if (  pc->IsNot(CT_PAREN_OPEN)
-      && (  (frm.top().stage == brace_stage_e::PAREN1)
-         || (frm.top().stage == brace_stage_e::WOD_PAREN)))
+      && (  (frm.top().stage == E_BraceStage::PAREN1)
+         || (frm.top().stage == E_BraceStage::WOD_PAREN)))
    {
       LOG_FMT(LWARN, "%s(%d): %s, orig line is %zu, Error: Expected '(', got '%s' for '%s'\n",
               __func__, __LINE__, cpd.filename.c_str(), pc->GetOrigLine(), pc->Text(),
@@ -1120,29 +1120,29 @@ static bool check_complex_statements(ParseFrame &frm, Chunk *pc, const BraceStat
 } // check_complex_statements
 
 
-static bool handle_complex_close(ParseFrame &frm, Chunk *pc, const BraceState &braceState)
+static bool handle_complex_close(ParsingFrameStack &frm, Chunk *pc, const BraceState &braceState)
 {
    LOG_FUNC_ENTRY();
 
-   if (frm.top().stage == brace_stage_e::PAREN1)
+   if (frm.top().stage == E_BraceStage::PAREN1)
    {
       if (pc->GetNext()->GetType() == CT_WHEN)
       {
          frm.top().type  = pc->GetType();
-         frm.top().stage = brace_stage_e::CATCH_WHEN;
+         frm.top().stage = E_BraceStage::CATCH_WHEN;
 
          return(true);
       }
       // PAREN1 always => BRACE2
-      frm.top().stage = brace_stage_e::BRACE2;
+      frm.top().stage = E_BraceStage::BRACE2;
    }
-   else if (frm.top().stage == brace_stage_e::BRACE2)
+   else if (frm.top().stage == E_BraceStage::BRACE2)
    {
       // BRACE2: IF => ELSE, anything else => close
       if (  (frm.top().type == CT_IF)
          || (frm.top().type == CT_ELSEIF))
       {
-         frm.top().stage = brace_stage_e::ELSE;
+         frm.top().stage = E_BraceStage::ELSE;
 
          // If the next chunk isn't CT_ELSE, close the statement
          Chunk *next = pc->GetNextNcNnl();
@@ -1161,7 +1161,7 @@ static bool handle_complex_close(ParseFrame &frm, Chunk *pc, const BraceState &b
       else if (  (frm.top().type == CT_TRY)
               || (frm.top().type == CT_CATCH))
       {
-         frm.top().stage = brace_stage_e::CATCH;
+         frm.top().stage = E_BraceStage::CATCH;
 
          // If the next chunk isn't CT_CATCH or CT_FINALLY, close the statement
          Chunk *next = pc->GetNextNcNnl();
@@ -1179,7 +1179,7 @@ static bool handle_complex_close(ParseFrame &frm, Chunk *pc, const BraceState &b
       }
       else
       {
-         LOG_FMT(LNOTE, "%s(%d): close_statement on %s brace_stage_e::BRACE2\n",
+         LOG_FMT(LNOTE, "%s(%d): close_statement on %s E_BraceStage::BRACE2\n",
                  __func__, __LINE__, get_token_name(frm.top().type));
          LOG_FMT(LBCSPOP, "%s(%d): pc orig line is %zu, orig col is %zu, Text() is '%s', type is %s\n",
                  __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol(), pc->Text(), get_token_name(pc->GetType()));
@@ -1189,20 +1189,20 @@ static bool handle_complex_close(ParseFrame &frm, Chunk *pc, const BraceState &b
          return(close_statement(frm, pc, braceState));
       }
    }
-   else if (frm.top().stage == brace_stage_e::BRACE_DO)
+   else if (frm.top().stage == E_BraceStage::BRACE_DO)
    {
-      frm.top().stage = brace_stage_e::WHILE;
+      frm.top().stage = E_BraceStage::WHILE;
    }
-   else if (frm.top().stage == brace_stage_e::WOD_PAREN)
+   else if (frm.top().stage == E_BraceStage::WOD_PAREN)
    {
-      LOG_FMT(LNOTE, "%s(%d): close_statement on %s brace_stage_e::WOD_PAREN\n",
+      LOG_FMT(LNOTE, "%s(%d): close_statement on %s E_BraceStage::WOD_PAREN\n",
               __func__, __LINE__, get_token_name(frm.top().type));
-      frm.top().stage = brace_stage_e::WOD_SEMI;
+      frm.top().stage = E_BraceStage::WOD_SEMI;
       print_stack(LBCSPOP, "-HCC WoDP ", frm);
    }
-   else if (frm.top().stage == brace_stage_e::WOD_SEMI)
+   else if (frm.top().stage == E_BraceStage::WOD_SEMI)
    {
-      LOG_FMT(LNOTE, "%s(%d): close_statement on %s brace_stage_e::WOD_SEMI\n",
+      LOG_FMT(LNOTE, "%s(%d): close_statement on %s E_BraceStage::WOD_SEMI\n",
               __func__, __LINE__, get_token_name(frm.top().type));
       LOG_FMT(LBCSPOP, "%s(%d): pc orig line is %zu, orig col is %zu, Text() is '%s', type is %s\n",
               __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol(), pc->Text(), get_token_name(pc->GetType()));
@@ -1284,7 +1284,7 @@ static void mark_namespace(Chunk *pns)
 } // mark_namespace
 
 
-static Chunk *insert_vbrace(Chunk *pc, bool after, const ParseFrame &frm)
+static Chunk *insert_vbrace(Chunk *pc, bool after, const ParsingFrameStack &frm)
 {
    LOG_FUNC_ENTRY();
 
@@ -1371,7 +1371,7 @@ static Chunk *insert_vbrace(Chunk *pc, bool after, const ParseFrame &frm)
 } // insert_vbrace
 
 
-bool close_statement(ParseFrame &frm, Chunk *pc, const BraceState &braceState)
+bool close_statement(ParsingFrameStack &frm, Chunk *pc, const BraceState &braceState)
 {
    LOG_FUNC_ENTRY();
 
@@ -1436,7 +1436,7 @@ bool close_statement(ParseFrame &frm, Chunk *pc, const BraceState &braceState)
    }
 
    // See if we are done with a complex statement
-   if (frm.top().stage != brace_stage_e::NONE)
+   if (frm.top().stage != E_BraceStage::NONE)
    {
       if (handle_complex_close(frm, vbc, braceState))
       {

--- a/src/frame_list.cpp
+++ b/src/frame_list.cpp
@@ -14,38 +14,38 @@
 namespace
 {
 
-void fl_log_frms(log_sev_t logsev, const char *txt, const ParseFrame &frm, const std::vector<ParseFrame> &frames);
+void fl_log_frms(log_sev_t logsev, const char *txt, const ParsingFrameStack &frm, const std::vector<ParsingFrameStack> &frames);
 
 
 //! Logs the entire parse frame stack
-void fl_log_all(log_sev_t logsev, const std::vector<ParseFrame> &frames);
+void fl_log_all(log_sev_t logsev, const std::vector<ParsingFrameStack> &frames);
 
 
 /**
- * Copy the top element of the frame list into the ParseFrame.
+ * Copy the top element of the frame list into the ParsingFrameStack.
  *
  * If the frame list is empty nothing happens.
  *
  * This is called on #else and #elif.
  */
-void fl_copy_tos(ParseFrame &pf, const std::vector<ParseFrame> &frames);
+void fl_copy_tos(ParsingFrameStack &pf, const std::vector<ParsingFrameStack> &frames);
 
 
 /**
- * Copy the 2nd top element off the list into the ParseFrame.
+ * Copy the 2nd top element off the list into the ParsingFrameStack.
  * This is called on #else and #elif.
  * The stack contains [...] [base] [if] at this point.
  * We want to copy [base].
  */
-void fl_copy_2nd_tos(ParseFrame &pf, const std::vector<ParseFrame> &frames);
+void fl_copy_2nd_tos(ParsingFrameStack &pf, const std::vector<ParsingFrameStack> &frames);
 
 
 //! Deletes the top element from the list.
-void fl_trash_tos(std::vector<ParseFrame> &frames);
+void fl_trash_tos(std::vector<ParsingFrameStack> &frames);
 
 
 //! Logs one parse frame
-void fl_log(log_sev_t logsev, const ParseFrame &frm)
+void fl_log(log_sev_t logsev, const ParsingFrameStack &frm)
 {
    LOG_FMT(logsev, "[%s] BrLevel=%zu Level=%zu PseTos=%zu\n",
            get_token_name(frm.in_ifdef), frm.brace_level, frm.level, frm.size() - 1);
@@ -62,10 +62,10 @@ void fl_log(log_sev_t logsev, const ParseFrame &frm)
 }
 
 
-void fl_log_frms(log_sev_t                     logsev,
-                 const char                    *txt,
-                 const ParseFrame              &frm,
-                 const std::vector<ParseFrame> &frames)
+void fl_log_frms(log_sev_t                            logsev,
+                 const char                           *txt,
+                 const ParsingFrameStack              &frm,
+                 const std::vector<ParsingFrameStack> &frames)
 {
    LOG_FMT(logsev, "%s Parse Frames(%zu):", txt, frames.size());
 
@@ -79,7 +79,7 @@ void fl_log_frms(log_sev_t                     logsev,
 }
 
 
-void fl_log_all(log_sev_t logsev, const std::vector<ParseFrame> &frames)
+void fl_log_all(log_sev_t logsev, const std::vector<ParsingFrameStack> &frames)
 {
    LOG_FMT(logsev, "##=- Parse Frame : %zu entries\n", frames.size());
 
@@ -94,7 +94,7 @@ void fl_log_all(log_sev_t logsev, const std::vector<ParseFrame> &frames)
 }
 
 
-void fl_copy_tos(ParseFrame &pf, const std::vector<ParseFrame> &frames)
+void fl_copy_tos(ParsingFrameStack &pf, const std::vector<ParsingFrameStack> &frames)
 {
    if (!frames.empty())
    {
@@ -104,7 +104,7 @@ void fl_copy_tos(ParseFrame &pf, const std::vector<ParseFrame> &frames)
 }
 
 
-void fl_copy_2nd_tos(ParseFrame &pf, const std::vector<ParseFrame> &frames)
+void fl_copy_2nd_tos(ParsingFrameStack &pf, const std::vector<ParsingFrameStack> &frames)
 {
    if (frames.size() > 1)
    {
@@ -114,7 +114,7 @@ void fl_copy_2nd_tos(ParseFrame &pf, const std::vector<ParseFrame> &frames)
 }
 
 
-void fl_trash_tos(std::vector<ParseFrame> &frames)
+void fl_trash_tos(std::vector<ParsingFrameStack> &frames)
 {
    if (!frames.empty())
    {
@@ -126,7 +126,7 @@ void fl_trash_tos(std::vector<ParseFrame> &frames)
 } // namespace
 
 
-void fl_push(std::vector<ParseFrame> &frames, ParseFrame &frm)
+void fl_push(std::vector<ParsingFrameStack> &frames, ParsingFrameStack &frm)
 {
    static int ref_no = 1;
 
@@ -137,7 +137,7 @@ void fl_push(std::vector<ParseFrame> &frames, ParseFrame &frm)
 }
 
 
-void fl_pop(std::vector<ParseFrame> &frames, ParseFrame &pf)
+void fl_pop(std::vector<ParsingFrameStack> &frames, ParsingFrameStack &pf)
 {
    if (frames.empty())
    {
@@ -148,7 +148,7 @@ void fl_pop(std::vector<ParseFrame> &frames, ParseFrame &pf)
 }
 
 
-int fl_check(std::vector<ParseFrame> &frames, ParseFrame &frm, int &pp_level, Chunk *pc)
+int fl_check(std::vector<ParsingFrameStack> &frames, ParsingFrameStack &frm, int &pp_level, Chunk *pc)
 {
    if (pc->IsNot(CT_PREPROC))
    {

--- a/src/frame_list.h
+++ b/src/frame_list.h
@@ -14,27 +14,27 @@
 
 
 /**
- * Push a copy of a ParseFrame onto the frames list.
+ * Push a copy of a ParsingFrameStack onto the frames list.
  * This is called on #if and #ifdef.
  */
-void fl_push(std::vector<ParseFrame> &frames, ParseFrame &frm);
+void fl_push(std::vector<ParsingFrameStack> &frames, ParsingFrameStack &frm);
 
 
 /**
- * Pop the top element off the frame list and copy it into the ParseFrame.
+ * Pop the top element off the frame list and copy it into the ParsingFrameStack.
  *
  * Does nothing if the frame list is empty.
  *
  * This is called on #endif
  */
-void fl_pop(std::vector<ParseFrame> &frames, ParseFrame &pf);
+void fl_pop(std::vector<ParsingFrameStack> &frames, ParsingFrameStack &pf);
 
 
 // TODO: this name is dumb:
 // - what is it checking?
 // - why does is much more than simple checks, it allters kinds of stuff
 //! Returns the pp_indent to use for this line
-int fl_check(std::vector<ParseFrame> &frames, ParseFrame &frm, int &pp_level, Chunk *pc);
+int fl_check(std::vector<ParsingFrameStack> &frames, ParsingFrameStack &frm, int &pp_level, Chunk *pc);
 
 
 #endif /* PARSE_FRAME_H_INCLUDED */

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -168,7 +168,7 @@ static void indent_comment(Chunk *pc, size_t col);
 static size_t token_indent(E_Token type);
 
 
-static size_t calc_indent_continue(const ParseFrame &frm, size_t pse_tos);
+static size_t calc_indent_continue(const ParsingFrameStack &frm, size_t pse_tos);
 
 /**
  * Get candidate chunk first on line to which OC blocks can be indented against.
@@ -193,7 +193,7 @@ static bool single_line_comment_indent_rule_applies(Chunk *start, bool forward);
  * returns true if semicolon on the same level ends any assign operations
  * false if next thing hit is not the end of an assign operation
  */
-static bool is_end_of_assignment(Chunk *pc, const ParseFrame &frm);
+static bool is_end_of_assignment(Chunk *pc, const ParsingFrameStack &frm);
 
 
 void indent_to_column(Chunk *pc, size_t column)
@@ -447,7 +447,7 @@ static size_t get_indent_first_continue(Chunk *pc)
 }
 
 
-static size_t calc_indent_continue(const ParseFrame &frm, size_t pse_tos)
+static size_t calc_indent_continue(const ParsingFrameStack &frm, size_t pse_tos)
 {
    log_rule_B("indent_continue");
    const int ic = options::indent_continue();
@@ -461,7 +461,7 @@ static size_t calc_indent_continue(const ParseFrame &frm, size_t pse_tos)
 }
 
 
-static size_t calc_indent_continue(const ParseFrame &frm)
+static size_t calc_indent_continue(const ParsingFrameStack &frm)
 {
    return(calc_indent_continue(frm, frm.size() - 1));
 }
@@ -582,7 +582,7 @@ static Chunk *oc_msg_block_indent(Chunk *pc, bool from_brace,
    } while (false)
 
 
-static void _log_indent(const char *func, const uint32_t line, const ParseFrame &frm)
+static void _log_indent(const char *func, const uint32_t line, const ParsingFrameStack &frm)
 {
    LOG_FMT(LINDLINE, "%s(%d): frm.pse_tos is %zu, ...indent is %zu\n",
            func, line, frm.size() - 1, frm.top().indent);
@@ -594,7 +594,7 @@ static void _log_indent(const char *func, const uint32_t line, const ParseFrame 
    } while (false)
 
 
-static void _log_prev_indent(const char *func, const uint32_t line, const ParseFrame &frm)
+static void _log_prev_indent(const char *func, const uint32_t line, const ParsingFrameStack &frm)
 {
    LOG_FMT(LINDLINE, "%s(%d): frm.pse_tos is %zu, prev....indent is %zu\n",
            func, line, frm.size() - 1, frm.prev().indent);
@@ -606,7 +606,7 @@ static void _log_prev_indent(const char *func, const uint32_t line, const ParseF
    } while (false)
 
 
-static void _log_indent_tmp(const char *func, const uint32_t line, const ParseFrame &frm)
+static void _log_indent_tmp(const char *func, const uint32_t line, const ParsingFrameStack &frm)
 {
    LOG_FMT(LINDLINE, "%s(%d): frm.pse_tos is %zu, ...indent_tmp is %zu\n",
            func, line, frm.size() - 1, frm.top().indent_tmp);
@@ -655,8 +655,8 @@ void indent_text()
    bool         in_func_def   = false;
 
 
-   std::vector<ParseFrame> frames;
-   ParseFrame              frm{};
+   std::vector<ParsingFrameStack> frames;
+   ParsingFrameStack              frm{};
 
 
    Chunk *pc        = Chunk::GetHead();
@@ -787,7 +787,7 @@ void indent_text()
                     __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol(), pc->Text(), get_token_name(pc->GetType()));
             frm.pop(__func__, __LINE__, pc);
          }
-         ParseFrame frmbkup = frm;
+         ParsingFrameStack frmbkup = frm;
          fl_check(frames, frm, cpd.pp_level, pc);
 
          // Indent the body of a #region here
@@ -4395,7 +4395,7 @@ static bool single_line_comment_indent_rule_applies(Chunk *start, bool forward)
 } // single_line_comment_indent_rule_applies
 
 
-static bool is_end_of_assignment(Chunk *pc, const ParseFrame &frm)
+static bool is_end_of_assignment(Chunk *pc, const ParsingFrameStack &frm)
 {
    return(  (  frm.top().type == CT_ASSIGN_NL
             || frm.top().type == CT_MEMBER

--- a/src/uncrustify_types.cpp
+++ b/src/uncrustify_types.cpp
@@ -9,44 +9,44 @@
 #include "uncrustify_types.h"
 
 
-const char *get_brace_stage_name(brace_stage_e brace_stage)
+const char *get_brace_stage_name(E_BraceStage brace_stage)
 {
    switch (brace_stage)
    {
-   case brace_stage_e::NONE:
+   case E_BraceStage::NONE:
       return("NONE");
 
-   case brace_stage_e::PAREN1:
+   case E_BraceStage::PAREN1:
       return("PAREN1");
 
-   case brace_stage_e::OP_PAREN1:
+   case E_BraceStage::OP_PAREN1:
       return("OP_PAREN1");
 
-   case brace_stage_e::WOD_PAREN:
+   case E_BraceStage::WOD_PAREN:
       return("WOD_PAREN");
 
-   case brace_stage_e::WOD_SEMI:
+   case E_BraceStage::WOD_SEMI:
       return("WOD_SEMI");
 
-   case brace_stage_e::BRACE_DO:
+   case E_BraceStage::BRACE_DO:
       return("BRACE_DO");
 
-   case brace_stage_e::BRACE2:
+   case E_BraceStage::BRACE2:
       return("BRACE2");
 
-   case brace_stage_e::ELSE:
+   case E_BraceStage::ELSE:
       return("ELSE");
 
-   case brace_stage_e::ELSEIF:
+   case E_BraceStage::ELSEIF:
       return("ELSEIF");
 
-   case brace_stage_e::WHILE:
+   case E_BraceStage::WHILE:
       return("WHILE");
 
-   case brace_stage_e::CATCH:
+   case E_BraceStage::CATCH:
       return("CATCH");
 
-   case brace_stage_e::CATCH_WHEN:
+   case E_BraceStage::CATCH_WHEN:
       return("CATCH_WHEN");
    }
    return("?????");

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -49,7 +49,7 @@ class ParseFrame;
 
 
 //! Brace stage enum used in brace_cleanup
-enum class brace_stage_e : unsigned int
+enum class E_BraceStage : unsigned int
 {
    NONE,
    PAREN1,      //! expected paren after if/catch (C++)/for/switch/synchronized/while
@@ -274,7 +274,7 @@ struct cp_data_t
 
 extern cp_data_t cpd;  // TODO: can we avoid this external variable?
 
-const char *get_brace_stage_name(brace_stage_e brace_stage);
+const char *get_brace_stage_name(E_BraceStage brace_stage);
 
 const char *get_unc_stage_name(unc_stage_e unc_stage);
 


### PR DESCRIPTION
This commit is intended as a first step to improve the code related to the parsing frame stack. It renames some of the classes/enums to provide more meaningful names. More improvements will come in future commits.

@guy-maurel: before I merge, please let me know if you are ok with the new names.