### PR TITLE
Rename object names to improve parsing frame code

### DIFF
--- a/src/ParseFrame.cpp
+++ b/src/ParseFrame.cpp
@@ -1,7 +1,7 @@
 /**
- * @file ParseFrame.cpp
+ * @file ParsingFrame.cpp
  *
- * Container that holds data needed for indenting and brace parsing
+ * Holds data needed for indenting and brace parsing
  *
  * @author  Daniel Chumak
  * @license GPL v2+
@@ -19,17 +19,14 @@ using std::string;
 using std::to_string;
 using std::invalid_argument;
 
-using ContainerType = paren_stack_entry_t;
-using Container     = std::vector<ContainerType>;
-
 
 //! amount of elements for which memory is going to be pre-initialized
 static constexpr const int CONTAINER_INIT_SIZE = 16;
 
 
-static ContainerType genDummy()
+static ParsingFrameEntry genDummy()
 {
-   ContainerType tmp_dummy{};
+   ParsingFrameEntry tmp_dummy{};
 
    tmp_dummy.indent     = 1;
    tmp_dummy.indent_tmp = 1;
@@ -42,11 +39,11 @@ static ContainerType genDummy()
 }
 
 
-void ParseFrame::clear()
+void ParsingFrame::clear()
 {
    last_poped = genDummy();
 
-   pse = Container{};
+   pse = std::vector<ParsingFrameEntry>();
    pse.reserve(CONTAINER_INIT_SIZE);
    pse.push_back(genDummy());
 
@@ -62,13 +59,13 @@ void ParseFrame::clear()
 }
 
 
-ParseFrame::ParseFrame()
+ParsingFrame::ParsingFrame()
 {
-   ParseFrame::clear();
+   ParsingFrame::clear();
 }
 
 
-bool ParseFrame::empty() const
+bool ParsingFrame::empty() const
 {
    // always at least one (dummy) element inside pse guaranteed
    return(false);
@@ -76,19 +73,19 @@ bool ParseFrame::empty() const
 }
 
 
-ContainerType &ParseFrame::at(size_t idx)
+ParsingFrameEntry &ParsingFrame::at(size_t idx)
 {
    return(pse.at(idx));
 }
 
 
-const ContainerType &ParseFrame::at(size_t idx) const
+const ParsingFrameEntry &ParsingFrame::at(size_t idx) const
 {
    return(pse.at(idx));
 }
 
 
-ContainerType &ParseFrame::prev(size_t idx)
+ParsingFrameEntry &ParsingFrame::prev(size_t idx)
 {
    LOG_FUNC_ENTRY();
 
@@ -109,7 +106,7 @@ ContainerType &ParseFrame::prev(size_t idx)
 }
 
 
-const ContainerType &ParseFrame::prev(size_t idx) const
+const ParsingFrameEntry &ParsingFrame::prev(size_t idx) const
 {
    LOG_FUNC_ENTRY();
 
@@ -123,7 +120,7 @@ const ContainerType &ParseFrame::prev(size_t idx) const
 }
 
 
-ContainerType &ParseFrame::top()
+ParsingFrameEntry &ParsingFrame::top()
 {
    // always at least one (dummy) element inside pse guaranteed
 //   if (pse.empty())
@@ -135,7 +132,7 @@ ContainerType &ParseFrame::top()
 }
 
 
-const ContainerType &ParseFrame::top() const
+const ParsingFrameEntry &ParsingFrame::top() const
 {
    // always at least one (dummy) element inside pse guaranteed
 //   if (pse.empty())
@@ -147,7 +144,7 @@ const ContainerType &ParseFrame::top() const
 }
 
 
-void ParseFrame::push(std::nullptr_t, brace_stage_e stage)
+void ParsingFrame::push(std::nullptr_t, E_BraceStage stage)
 {
    static Chunk dummy;
 
@@ -156,11 +153,11 @@ void ParseFrame::push(std::nullptr_t, brace_stage_e stage)
 }
 
 
-void ParseFrame::push(Chunk *pc, const char *func, int line, brace_stage_e stage)
+void ParsingFrame::push(Chunk *pc, const char *func, int line, E_BraceStage stage)
 {
    LOG_FUNC_ENTRY();
 
-   ContainerType new_entry = {};
+   ParsingFrameEntry new_entry = {};
 
    new_entry.type      = pc->GetType();
    new_entry.level     = pc->GetLevel();
@@ -182,13 +179,13 @@ void ParseFrame::push(Chunk *pc, const char *func, int line, brace_stage_e stage
 // uncomment the line below to get the address of the pse
 // #define DEBUG_PUSH_POP
 #ifdef DEBUG_PUSH_POP
-   LOG_FMT(LINDPSE, "ParseFrame::push(%s:%d) Add is %4zu: orig line is %4zu, orig col is %4zu, type is %12s, "
+   LOG_FMT(LINDPSE, "ParsingFrame::push(%s:%d) Add is %4zu: orig line is %4zu, orig col is %4zu, type is %12s, "
            "brace level is %2zu, level is %2zu, pse_tos: %2zu -> %2zu\n",
            func, line, (size_t)this, pc->GetOrigLine(), pc->GetOrigCol(),
            get_token_name(pc->GetType()), pc->GetBraceLevel(), pc->GetLevel(),
            (pse.size() - 2), (pse.size() - 1));
 #else /* DEBUG_PUSH_POP */
-   LOG_FMT(LINDPSE, "ParseFrame::push(%s:%d): orig line is %4zu, orig col is %4zu, type is %12s, "
+   LOG_FMT(LINDPSE, "ParsingFrame::push(%s:%d): orig line is %4zu, orig col is %4zu, type is %12s, "
            "brace level is %2zu, level is %2zu, pse_tos: %2zu -> %2zu\n",
            func, line, pc->GetOrigLine(), pc->GetOrigCol(),
            get_token_name(pc->GetType()), pc->GetBraceLevel(), pc->GetLevel(),
@@ -197,7 +194,7 @@ void ParseFrame::push(Chunk *pc, const char *func, int line, brace_stage_e stage
 }
 
 
-void ParseFrame::pop(const char *func, int line, Chunk *pc)
+void ParsingFrame::pop(const char *func, int line, Chunk *pc)
 {
    LOG_FUNC_ENTRY();
 
@@ -220,7 +217,7 @@ void ParseFrame::pop(const char *func, int line, Chunk *pc)
       || pc->GetType() == CT_SEMICOLON
       || pc->GetType() == CT_SQUARE_CLOSE)
    {
-      LOG_FMT(LINDPSE, "ParseFrame::pop (%s:%d): orig line is %4zu, orig col is %4zu, type is %12s, pushed with\n",
+      LOG_FMT(LINDPSE, "ParsingFrame::pop (%s:%d): orig line is %4zu, orig col is %4zu, type is %12s, pushed with\n",
               func, line, pc->GetOrigLine(), pc->GetOrigCol(), get_token_name(pc->GetType()));
    }
    else if (  pc->GetType() == CT_ACCESS
@@ -251,26 +248,26 @@ void ParseFrame::pop(const char *func, int line, Chunk *pc)
            || pc->GetType() == CT_VSEMICOLON
            || pc->GetType() == CT_WORD)
    {
-      LOG_FMT(LINDPSE, "ParseFrame::pop (%s:%d): orig line is %4zu, orig col is %4zu, type is %12s\n",
+      LOG_FMT(LINDPSE, "ParsingFrame::pop (%s:%d): orig line is %4zu, orig col is %4zu, type is %12s\n",
               func, line, pc->GetOrigLine(), pc->GetOrigCol(), get_token_name(pc->GetType()));
    }
    else
    {
-      LOG_FMT(LINDPSE, "ParseFrame::pop (%s:%d): orig line is %4zu, orig col is %4zu, type is %12s,\n",
+      LOG_FMT(LINDPSE, "ParsingFrame::pop (%s:%d): orig line is %4zu, orig col is %4zu, type is %12s,\n",
               func, line, pc->GetOrigLine(), pc->GetOrigCol(), get_token_name(pc->GetType()));
-      LOG_FMT(LINDPSE, "ParseFrame::pop (%s:%d): the type is %s, is not coded. Please make a call.\n",
+      LOG_FMT(LINDPSE, "ParsingFrame::pop (%s:%d): the type is %s, is not coded. Please make a call.\n",
               func, line, get_token_name(pc->GetType()));
       log_flush(true);
       exit(EX_SOFTWARE);
    }
 #ifdef DEBUG_PUSH_POP
-   LOG_FMT(LINDPSE, "ParseFrame::pop (%s:%d) Add is %4zu: open_line is %4zu, clos_col is %4zu, type is %12s, "
+   LOG_FMT(LINDPSE, "ParsingFrame::pop (%s:%d) Add is %4zu: open_line is %4zu, clos_col is %4zu, type is %12s, "
            "cpd.level   is %2d, level is %2zu, pse_tos: %2zu -> %2zu\n",
            func, line, (size_t)this, pse.back().open_line, pse.back().open_colu,
            get_token_name(pse.back().type), cpd.pp_level, pse.back().level,
            (pse.size() - 1), (pse.size() - 2));
 #else /* DEBUG_PUSH_POP */
-   LOG_FMT(LINDPSE, "ParseFrame::pop (%s:%d): open_line is %4zu, clos_col is %4zu, type is %12s, "
+   LOG_FMT(LINDPSE, "ParsingFrame::pop (%s:%d): open_line is %4zu, clos_col is %4zu, type is %12s, "
            "cpd.level   is %2d, level is %2zu, pse_tos: %2zu -> %2zu\n",
            func, line, pse.back().open_line, pse.back().open_colu,
            get_token_name(pse.back().type), cpd.pp_level, pse.back().level,
@@ -287,66 +284,66 @@ void ParseFrame::pop(const char *func, int line, Chunk *pc)
    {
       pse.pop_back();
    }
-} // ParseFrame::pop
+} // ParsingFrame::pop
 
 
-size_t ParseFrame::size() const
+size_t ParsingFrame::size() const
 {
    // always at least one (dummy) element inside pse guaranteed
    return(pse.size());
 }
 
 
-const paren_stack_entry_t &ParseFrame::poped() const
+const ParsingFrameEntry &ParsingFrame::poped() const
 {
    return(last_poped);
 }
 
 
 // TODO C++14: see abstract versions: std::rend, std::cend, std::crend ...
-ParseFrame::iterator ParseFrame::begin()
+ParsingFrame::iterator ParsingFrame::begin()
 {
    return(std::begin(pse));
 }
 
 
-ParseFrame::const_iterator ParseFrame::begin() const
+ParsingFrame::const_iterator ParsingFrame::begin() const
 {
    return(std::begin(pse));
 }
 
 
-ParseFrame::reverse_iterator ParseFrame::rbegin()
+ParsingFrame::reverse_iterator ParsingFrame::rbegin()
 {
    return(pse.rbegin());
 }
 
 
-ParseFrame::const_reverse_iterator ParseFrame::rbegin() const
+ParsingFrame::const_reverse_iterator ParsingFrame::rbegin() const
 {
    return(pse.rbegin());
 }
 
 
-ParseFrame::iterator ParseFrame::end()
+ParsingFrame::iterator ParsingFrame::end()
 {
    return(std::end(pse));
 }
 
 
-ParseFrame::const_iterator ParseFrame::end() const
+ParsingFrame::const_iterator ParsingFrame::end() const
 {
    return(std::end(pse));
 }
 
 
-ParseFrame::reverse_iterator ParseFrame::rend()
+ParsingFrame::reverse_iterator ParsingFrame::rend()
 {
    return(pse.rend());
 }
 
 
-ParseFrame::const_reverse_iterator ParseFrame::rend() const
+ParsingFrame::const_reverse_iterator ParsingFrame::rend() const
 {
    return(pse.rend());
 }

--- a/src/ParseFrame.h
+++ b/src/ParseFrame.h
@@ -1,7 +1,7 @@
 /**
  * @file ParseFrame.h
  *
- * Container that holds data needed for indenting and brace parsing
+ * Holds data needed for indenting and brace parsing
  *
  * @author  Daniel Chumak
  * @license GPL v2+
@@ -13,23 +13,25 @@
 #include "uncrustify_types.h"
 
 #include <memory>
+#include <vector>
 
 
-//! Structure for counting nested level
-struct paren_stack_entry_t
+//! Structure describing a parsing frame and its information
+class ParsingFrameEntry
 {
-   E_Token         type;         //! the type that opened the entry
-   size_t          level;        //! Level of opening type
+public:
+   E_Token         type;         //! the type that opened the frame
+   size_t          level;        //! level of opening type
    size_t          open_line;    //! line that open symbol is on, only for logging purposes
    size_t          open_colu;    //! column that open symbol is on, only for logging purposes
-   Chunk           *pc;          //! Chunk that opened the level, TODO: make const
+   Chunk           *pc;          //! chunk that opened the level, TODO: make const
    size_t          brace_indent; //! indent for braces - may not relate to indent
    size_t          indent;       //! indent level (depends on use)
    size_t          indent_tmp;   //! temporary indent level (depends on use)
    size_t          indent_tab;   //! the 'tab' indent (always <= real column)
    bool            indent_cont;  //! indent_continue was applied
    E_Token         parent;       //! if, for, function, etc
-   brace_stage_e   stage;        //! used to check progression of complex statements.
+   E_BraceStage    stage;        //! used to check progression of complex statements.
    bool            in_preproc;   //! whether this was created in a preprocessor
    size_t          ns_cnt;       //! Number of consecutive namespace levels
    bool            non_vardef;   //! Hit a non-vardef line
@@ -37,11 +39,11 @@ struct paren_stack_entry_t
    Chunk           *pop_pc;
 };
 
-class ParseFrame
+class ParsingFrame
 {
 private:
-   std::vector<paren_stack_entry_t> pse;
-   paren_stack_entry_t              last_poped;
+   std::vector<ParsingFrameEntry> pse;
+   ParsingFrameEntry              last_poped;
 
    void clear();
 
@@ -57,43 +59,45 @@ public:
    size_t  expr_count;
 
 
-   ParseFrame();
-   virtual ~ParseFrame() = default;
+   ParsingFrame();
+   virtual ~ParsingFrame() = default;
 
    bool empty() const;
 
-   paren_stack_entry_t &at(size_t idx);
-   const paren_stack_entry_t &at(size_t idx) const;
+   ParsingFrameEntry &at(size_t idx);
+   const ParsingFrameEntry &at(size_t idx) const;
 
-   paren_stack_entry_t &prev(size_t idx = 1);
-   const paren_stack_entry_t &prev(size_t idx = 1) const;
+   ParsingFrameEntry &prev(size_t idx = 1);
+   const ParsingFrameEntry &prev(size_t idx = 1) const;
 
-   paren_stack_entry_t &top();
-   const paren_stack_entry_t &top() const;
+   ParsingFrameEntry &top();
+   const ParsingFrameEntry &top() const;
 
-   const paren_stack_entry_t &poped() const;
+   const ParsingFrameEntry &poped() const;
 
-   void push(Chunk *pc, const char *func, int line, brace_stage_e stage = brace_stage_e::NONE);
-   void push(std::nullptr_t, brace_stage_e stage = brace_stage_e::NONE);
+   void push(Chunk *pc, const char *func, int line, E_BraceStage stage = E_BraceStage::NONE);
+   void push(std::nullptr_t, E_BraceStage stage = E_BraceStage::NONE);
    void pop(const char *func, int line, Chunk *pc);
 
    size_t size() const;
 
-   using iterator = std::vector<paren_stack_entry_t>::iterator;
+   using iterator = std::vector<ParsingFrameEntry>::iterator;
    iterator begin();
    iterator end();
 
-   using const_iterator = std::vector<paren_stack_entry_t>::const_iterator;
+   using const_iterator = std::vector<ParsingFrameEntry>::const_iterator;
    const_iterator begin() const;
    const_iterator end() const;
 
-   using reverse_iterator = std::vector<paren_stack_entry_t>::reverse_iterator;
+   using reverse_iterator = std::vector<ParsingFrameEntry>::reverse_iterator;
    reverse_iterator rbegin();
    reverse_iterator rend();
 
-   using const_reverse_iterator = std::vector<paren_stack_entry_t>::const_reverse_iterator;
+   using const_reverse_iterator = std::vector<ParsingFrameEntry>::const_reverse_iterator;
    const_reverse_iterator rbegin() const;
    const_reverse_iterator rend() const;
 };
+
+typedef std::vector<ParsingFrame> ParsingFrameStack;
 
 #endif /* SRC_PARSEFRAME_H_ */

--- a/src/frame_list.cpp
+++ b/src/frame_list.cpp
@@ -14,38 +14,38 @@
 namespace
 {
 
-void fl_log_frms(log_sev_t logsev, const char *txt, const ParseFrame &frm, const std::vector<ParseFrame> &frames);
+void fl_log_frms(log_sev_t logsev, const char *txt, const ParsingFrame &frm, const ParsingFrameStack &frames);
 
 
 //! Logs the entire parse frame stack
-void fl_log_all(log_sev_t logsev, const std::vector<ParseFrame> &frames);
+void fl_log_all(log_sev_t logsev, const ParsingFrameStack &frames);
 
 
 /**
- * Copy the top element of the frame list into the ParseFrame.
+ * Copy the top element of the frame list into the ParsingFrame.
  *
  * If the frame list is empty nothing happens.
  *
  * This is called on #else and #elif.
  */
-void fl_copy_tos(ParseFrame &pf, const std::vector<ParseFrame> &frames);
+void fl_copy_tos(ParsingFrame &pf, const ParsingFrameStack &frames);
 
 
 /**
- * Copy the 2nd top element off the list into the ParseFrame.
+ * Copy the 2nd top element off the list into the ParsingFrame.
  * This is called on #else and #elif.
  * The stack contains [...] [base] [if] at this point.
  * We want to copy [base].
  */
-void fl_copy_2nd_tos(ParseFrame &pf, const std::vector<ParseFrame> &frames);
+void fl_copy_2nd_tos(ParsingFrame &pf, const ParsingFrameStack &frames);
 
 
 //! Deletes the top element from the list.
-void fl_trash_tos(std::vector<ParseFrame> &frames);
+void fl_trash_tos(ParsingFrameStack &frames);
 
 
 //! Logs one parse frame
-void fl_log(log_sev_t logsev, const ParseFrame &frm)
+void fl_log(log_sev_t logsev, const ParsingFrame &frm)
 {
    LOG_FMT(logsev, "[%s] BrLevel=%zu Level=%zu PseTos=%zu\n",
            get_token_name(frm.in_ifdef), frm.brace_level, frm.level, frm.size() - 1);
@@ -62,10 +62,10 @@ void fl_log(log_sev_t logsev, const ParseFrame &frm)
 }
 
 
-void fl_log_frms(log_sev_t                     logsev,
-                 const char                    *txt,
-                 const ParseFrame              &frm,
-                 const std::vector<ParseFrame> &frames)
+void fl_log_frms(log_sev_t               logsev,
+                 const char              *txt,
+                 const ParsingFrame      &frm,
+                 const ParsingFrameStack &frames)
 {
    LOG_FMT(logsev, "%s Parse Frames(%zu):", txt, frames.size());
 
@@ -79,7 +79,7 @@ void fl_log_frms(log_sev_t                     logsev,
 }
 
 
-void fl_log_all(log_sev_t logsev, const std::vector<ParseFrame> &frames)
+void fl_log_all(log_sev_t logsev, const ParsingFrameStack &frames)
 {
    LOG_FMT(logsev, "##=- Parse Frame : %zu entries\n", frames.size());
 
@@ -94,7 +94,7 @@ void fl_log_all(log_sev_t logsev, const std::vector<ParseFrame> &frames)
 }
 
 
-void fl_copy_tos(ParseFrame &pf, const std::vector<ParseFrame> &frames)
+void fl_copy_tos(ParsingFrame &pf, const ParsingFrameStack &frames)
 {
    if (!frames.empty())
    {
@@ -104,7 +104,7 @@ void fl_copy_tos(ParseFrame &pf, const std::vector<ParseFrame> &frames)
 }
 
 
-void fl_copy_2nd_tos(ParseFrame &pf, const std::vector<ParseFrame> &frames)
+void fl_copy_2nd_tos(ParsingFrame &pf, const ParsingFrameStack &frames)
 {
    if (frames.size() > 1)
    {
@@ -114,7 +114,7 @@ void fl_copy_2nd_tos(ParseFrame &pf, const std::vector<ParseFrame> &frames)
 }
 
 
-void fl_trash_tos(std::vector<ParseFrame> &frames)
+void fl_trash_tos(ParsingFrameStack &frames)
 {
    if (!frames.empty())
    {
@@ -126,7 +126,7 @@ void fl_trash_tos(std::vector<ParseFrame> &frames)
 } // namespace
 
 
-void fl_push(std::vector<ParseFrame> &frames, ParseFrame &frm)
+void fl_push(ParsingFrameStack &frames, ParsingFrame &frm)
 {
    static int ref_no = 1;
 
@@ -137,7 +137,7 @@ void fl_push(std::vector<ParseFrame> &frames, ParseFrame &frm)
 }
 
 
-void fl_pop(std::vector<ParseFrame> &frames, ParseFrame &pf)
+void fl_pop(ParsingFrameStack &frames, ParsingFrame &pf)
 {
    if (frames.empty())
    {
@@ -148,7 +148,7 @@ void fl_pop(std::vector<ParseFrame> &frames, ParseFrame &pf)
 }
 
 
-int fl_check(std::vector<ParseFrame> &frames, ParseFrame &frm, int &pp_level, Chunk *pc)
+int fl_check(ParsingFrameStack &frames, ParsingFrame &frm, int &pp_level, Chunk *pc)
 {
    if (pc->IsNot(CT_PREPROC))
    {

--- a/src/frame_list.h
+++ b/src/frame_list.h
@@ -14,27 +14,27 @@
 
 
 /**
- * Push a copy of a ParseFrame onto the frames list.
+ * Push a copy of a ParsingFrame onto the frames list.
  * This is called on #if and #ifdef.
  */
-void fl_push(std::vector<ParseFrame> &frames, ParseFrame &frm);
+void fl_push(ParsingFrameStack &frames, ParsingFrame &frm);
 
 
 /**
- * Pop the top element off the frame list and copy it into the ParseFrame.
+ * Pop the top element off the frame list and copy it into the ParsingFrame.
  *
  * Does nothing if the frame list is empty.
  *
  * This is called on #endif
  */
-void fl_pop(std::vector<ParseFrame> &frames, ParseFrame &pf);
+void fl_pop(ParsingFrameStack &frames, ParsingFrame &pf);
 
 
 // TODO: this name is dumb:
 // - what is it checking?
 // - why does is much more than simple checks, it allters kinds of stuff
 //! Returns the pp_indent to use for this line
-int fl_check(std::vector<ParseFrame> &frames, ParseFrame &frm, int &pp_level, Chunk *pc);
+int fl_check(ParsingFrameStack &frames, ParsingFrame &frm, int &pp_level, Chunk *pc);
 
 
 #endif /* PARSE_FRAME_H_INCLUDED */

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -168,7 +168,7 @@ static void indent_comment(Chunk *pc, size_t col);
 static size_t token_indent(E_Token type);
 
 
-static size_t calc_indent_continue(const ParseFrame &frm, size_t pse_tos);
+static size_t calc_indent_continue(const ParsingFrame &frm, size_t pse_tos);
 
 /**
  * Get candidate chunk first on line to which OC blocks can be indented against.
@@ -193,7 +193,7 @@ static bool single_line_comment_indent_rule_applies(Chunk *start, bool forward);
  * returns true if semicolon on the same level ends any assign operations
  * false if next thing hit is not the end of an assign operation
  */
-static bool is_end_of_assignment(Chunk *pc, const ParseFrame &frm);
+static bool is_end_of_assignment(Chunk *pc, const ParsingFrame &frm);
 
 
 void indent_to_column(Chunk *pc, size_t column)
@@ -447,7 +447,7 @@ static size_t get_indent_first_continue(Chunk *pc)
 }
 
 
-static size_t calc_indent_continue(const ParseFrame &frm, size_t pse_tos)
+static size_t calc_indent_continue(const ParsingFrame &frm, size_t pse_tos)
 {
    log_rule_B("indent_continue");
    const int ic = options::indent_continue();
@@ -461,7 +461,7 @@ static size_t calc_indent_continue(const ParseFrame &frm, size_t pse_tos)
 }
 
 
-static size_t calc_indent_continue(const ParseFrame &frm)
+static size_t calc_indent_continue(const ParsingFrame &frm)
 {
    return(calc_indent_continue(frm, frm.size() - 1));
 }
@@ -582,7 +582,7 @@ static Chunk *oc_msg_block_indent(Chunk *pc, bool from_brace,
    } while (false)
 
 
-static void _log_indent(const char *func, const uint32_t line, const ParseFrame &frm)
+static void _log_indent(const char *func, const uint32_t line, const ParsingFrame &frm)
 {
    LOG_FMT(LINDLINE, "%s(%d): frm.pse_tos is %zu, ...indent is %zu\n",
            func, line, frm.size() - 1, frm.top().indent);
@@ -594,7 +594,7 @@ static void _log_indent(const char *func, const uint32_t line, const ParseFrame 
    } while (false)
 
 
-static void _log_prev_indent(const char *func, const uint32_t line, const ParseFrame &frm)
+static void _log_prev_indent(const char *func, const uint32_t line, const ParsingFrame &frm)
 {
    LOG_FMT(LINDLINE, "%s(%d): frm.pse_tos is %zu, prev....indent is %zu\n",
            func, line, frm.size() - 1, frm.prev().indent);
@@ -606,7 +606,7 @@ static void _log_prev_indent(const char *func, const uint32_t line, const ParseF
    } while (false)
 
 
-static void _log_indent_tmp(const char *func, const uint32_t line, const ParseFrame &frm)
+static void _log_indent_tmp(const char *func, const uint32_t line, const ParsingFrame &frm)
 {
    LOG_FMT(LINDLINE, "%s(%d): frm.pse_tos is %zu, ...indent_tmp is %zu\n",
            func, line, frm.size() - 1, frm.top().indent_tmp);
@@ -655,8 +655,8 @@ void indent_text()
    bool         in_func_def   = false;
 
 
-   std::vector<ParseFrame> frames;
-   ParseFrame              frm{};
+   ParsingFrameStack frames;
+   ParsingFrame      frm{};
 
 
    Chunk *pc        = Chunk::GetHead();
@@ -787,7 +787,7 @@ void indent_text()
                     __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol(), pc->Text(), get_token_name(pc->GetType()));
             frm.pop(__func__, __LINE__, pc);
          }
-         ParseFrame frmbkup = frm;
+         ParsingFrame frmbkup = frm;
          fl_check(frames, frm, cpd.pp_level, pc);
 
          // Indent the body of a #region here
@@ -4395,7 +4395,7 @@ static bool single_line_comment_indent_rule_applies(Chunk *start, bool forward)
 } // single_line_comment_indent_rule_applies
 
 
-static bool is_end_of_assignment(Chunk *pc, const ParseFrame &frm)
+static bool is_end_of_assignment(Chunk *pc, const ParsingFrame &frm)
 {
    return(  (  frm.top().type == CT_ASSIGN_NL
             || frm.top().type == CT_MEMBER

--- a/src/uncrustify_types.cpp
+++ b/src/uncrustify_types.cpp
@@ -9,44 +9,44 @@
 #include "uncrustify_types.h"
 
 
-const char *get_brace_stage_name(brace_stage_e brace_stage)
+const char *get_brace_stage_name(E_BraceStage brace_stage)
 {
    switch (brace_stage)
    {
-   case brace_stage_e::NONE:
+   case E_BraceStage::NONE:
       return("NONE");
 
-   case brace_stage_e::PAREN1:
+   case E_BraceStage::PAREN1:
       return("PAREN1");
 
-   case brace_stage_e::OP_PAREN1:
+   case E_BraceStage::OP_PAREN1:
       return("OP_PAREN1");
 
-   case brace_stage_e::WOD_PAREN:
+   case E_BraceStage::WOD_PAREN:
       return("WOD_PAREN");
 
-   case brace_stage_e::WOD_SEMI:
+   case E_BraceStage::WOD_SEMI:
       return("WOD_SEMI");
 
-   case brace_stage_e::BRACE_DO:
+   case E_BraceStage::BRACE_DO:
       return("BRACE_DO");
 
-   case brace_stage_e::BRACE2:
+   case E_BraceStage::BRACE2:
       return("BRACE2");
 
-   case brace_stage_e::ELSE:
+   case E_BraceStage::ELSE:
       return("ELSE");
 
-   case brace_stage_e::ELSEIF:
+   case E_BraceStage::ELSEIF:
       return("ELSEIF");
 
-   case brace_stage_e::WHILE:
+   case E_BraceStage::WHILE:
       return("WHILE");
 
-   case brace_stage_e::CATCH:
+   case E_BraceStage::CATCH:
       return("CATCH");
 
-   case brace_stage_e::CATCH_WHEN:
+   case E_BraceStage::CATCH_WHEN:
       return("CATCH_WHEN");
    }
    return("?????");

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -49,7 +49,7 @@ class ParseFrame;
 
 
 //! Brace stage enum used in brace_cleanup
-enum class brace_stage_e : unsigned int
+enum class E_BraceStage : unsigned int
 {
    NONE,
    PAREN1,      //! expected paren after if/catch (C++)/for/switch/synchronized/while
@@ -274,7 +274,7 @@ struct cp_data_t
 
 extern cp_data_t cpd;  // TODO: can we avoid this external variable?
 
-const char *get_brace_stage_name(brace_stage_e brace_stage);
+const char *get_brace_stage_name(E_BraceStage brace_stage);
 
 const char *get_unc_stage_name(unc_stage_e unc_stage);
 


### PR DESCRIPTION
This commit is intended as a first step to improve the code related to the parsing frame stack. It renames some of the classes/enums to provide more meaningful names. More improvements will come in future commits.

@guy-maurel: before I merge, please let me know if you are ok with the new names.
