### PR TITLE
Replace Chunk's SetType and SetParentType macros with real methods

### DIFF
--- a/documentation/htdocs/options_Align.html
+++ b/documentation/htdocs/options_Align.html
@@ -3,10 +3,6 @@
 align_pp_define_gap
 The minimum space between label and value of a preprocessor define
 
-#define SetType(tt)      do { \
-      LOG_FUNC_CALL(); \
-      SetTypeReal((tt)); \
-} while (false)
 align_nl_cont                 = true
 
 #define LOG_STR(sev, str, len)                           \

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -558,7 +558,7 @@ void Chunk::SetResetFlags(PcfFlags resetBits, PcfFlags setBits)
 }
 
 
-void Chunk::SetTypeReal(const E_Token token, const char *func, const int line)
+void Chunk::SetType(const E_Token token)
 {
    LOG_FUNC_ENTRY();
 
@@ -568,7 +568,7 @@ void Chunk::SetTypeReal(const E_Token token, const char *func, const int line)
       return;
    }
    LOG_FMT(LSETTYP, "%s(%d): orig line is %zu, orig col is %zu, Text() is ",
-           func, line, m_origLine, m_origCol);
+           __func__, __LINE__, m_origLine, m_origCol);
 
    if (token == CT_NEWLINE)
    {
@@ -584,7 +584,7 @@ void Chunk::SetTypeReal(const E_Token token, const char *func, const int line)
 }
 
 
-void Chunk::SetParentTypeReal(const E_Token token, const char *func, const int line)
+void Chunk::SetParentType(const E_Token token)
 {
    LOG_FUNC_ENTRY();
 
@@ -594,7 +594,7 @@ void Chunk::SetParentTypeReal(const E_Token token, const char *func, const int l
       return;
    }
    LOG_FMT(LSETPAR, "%s(%d): orig line is %zu, orig col is %zu, Text() is ",
-           func, line, m_origLine, m_origCol);
+           __func__, __LINE__, m_origLine, m_origCol);
 
    if (token == CT_NEWLINE)
    {

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -77,10 +77,8 @@ public:
    /**
     * @brief Sets the chunk type
     * @param token the type to set
-    * @param func the name of the function from where this method is called (for log purposes)
-    * @param line the line number from where this method is called (for log purposes)
     */
-   void SetTypeReal(const E_Token token, const char *func, const int line);
+   void SetType(const E_Token token);
 
    /**
     * @brief Returns the parent type of the chunk
@@ -90,10 +88,8 @@ public:
    /**
     * @brief Sets the type of the parent chunk
     * @param token the type to set
-    * @param func the name of the function from where this method is called (for log purposes)
-    * @param line the line number from where this method is called (for log purposes)
     */
-   void SetParentTypeReal(const E_Token token, const char *func, const int line);
+   void SetParentType(const E_Token token);
 
    /**
     * @brief Returns the parent of the chunk
@@ -1791,12 +1787,6 @@ inline Chunk *Chunk::CopyAndAddBefore(Chunk *ref) const
 {
    return(CopyAndAdd(ref, E_Direction::BACKWARD));
 }
-
-
-#define SetType(tt)          SetTypeReal((tt), __unqualified_func__, __LINE__)
-
-
-#define SetParentType(tt)    SetParentTypeReal((tt), __unqualified_func__, __LINE__)
 
 
 #endif /* CHUNK_LIST_H_INCLUDED */

--- a/src/log_levels.h
+++ b/src/log_levels.h
@@ -119,8 +119,8 @@ enum log_sev_t
    LINDENTAG = 88,  //! indent again
    LNFD      = 89,  //! newline-function-def
    LJDBI     = 90,  //! Java Double Brace Init
-   LSETPAR   = 91,  //! Chunk::SetParentTypeReal()
-   LSETTYP   = 92,  //! Chunk::SetTypeReal()
+   LSETPAR   = 91,  //! Chunk::SetParentType()
+   LSETTYP   = 92,  //! Chunk::SetType()
    LSETFLG   = 93,  //! set_chunk_flags()
    LNLFUNCT  = 94,  //! newlines before function
    LCHUNK    = 95,  //! Add or delete chunk

--- a/tests/cli/output/92.txt
+++ b/tests/cli/output/92.txt
@@ -1,196 +1,196 @@
-parse_word : orig line is 1, orig col is 1, Text() is 'struct'
+SetType : orig line is 1, orig col is 1, Text() is 'struct'
    type is NONE, parent type is NONE => new type is WORD
-parse_word : orig line is 1, orig col is 1, Text() is 'struct'
+SetType : orig line is 1, orig col is 1, Text() is 'struct'
    type is WORD, parent type is NONE => new type is STRUCT
-parse_whitespace : orig line is 1, orig col is 7, Text() is ''
+SetType : orig line is 1, orig col is 7, Text() is ''
    type is NONE, parent type is NONE => new type is WHITESPACE
-parse_word : orig line is 1, orig col is 8, Text() is 'TelegramIndex'
+SetType : orig line is 1, orig col is 8, Text() is 'TelegramIndex'
    type is NONE, parent type is NONE => new type is WORD
-parse_whitespace : orig line is 1, orig col is 21, Text() is <Newline>
+SetType : orig line is 1, orig col is 21, Text() is <Newline>
    type is NONE, parent type is NONE => new type is NEWLINE
-parse_next : orig line is 2, orig col is 1, Text() is '{'
+SetType : orig line is 2, orig col is 1, Text() is '{'
    type is NONE, parent type is NONE => new type is BRACE_OPEN
-parse_whitespace : orig line is 2, orig col is 2, Text() is <Newline>
+SetType : orig line is 2, orig col is 2, Text() is <Newline>
    type is NONE, parent type is NONE => new type is NEWLINE
-parse_word : orig line is 3, orig col is 1, Text() is 'TelegramIndex'
+SetType : orig line is 3, orig col is 1, Text() is 'TelegramIndex'
    type is NONE, parent type is NONE => new type is WORD
-parse_next : orig line is 3, orig col is 14, Text() is '('
+SetType : orig line is 3, orig col is 14, Text() is '('
    type is NONE, parent type is NONE => new type is PAREN_OPEN
-parse_word : orig line is 3, orig col is 15, Text() is 'const'
+SetType : orig line is 3, orig col is 15, Text() is 'const'
    type is NONE, parent type is NONE => new type is WORD
-parse_word : orig line is 3, orig col is 15, Text() is 'const'
+SetType : orig line is 3, orig col is 15, Text() is 'const'
    type is WORD, parent type is NONE => new type is QUALIFIER
-parse_whitespace : orig line is 3, orig col is 20, Text() is ''
+SetType : orig line is 3, orig col is 20, Text() is ''
    type is NONE, parent type is NONE => new type is WHITESPACE
-parse_word : orig line is 3, orig col is 21, Text() is 'char'
+SetType : orig line is 3, orig col is 21, Text() is 'char'
    type is NONE, parent type is NONE => new type is WORD
-parse_word : orig line is 3, orig col is 21, Text() is 'char'
+SetType : orig line is 3, orig col is 21, Text() is 'char'
    type is WORD, parent type is NONE => new type is TYPE
-parse_next : orig line is 3, orig col is 25, Text() is '*'
+SetType : orig line is 3, orig col is 25, Text() is '*'
    type is NONE, parent type is NONE => new type is STAR
-parse_whitespace : orig line is 3, orig col is 26, Text() is ''
+SetType : orig line is 3, orig col is 26, Text() is ''
    type is NONE, parent type is NONE => new type is WHITESPACE
-parse_word : orig line is 3, orig col is 27, Text() is 'pN'
+SetType : orig line is 3, orig col is 27, Text() is 'pN'
    type is NONE, parent type is NONE => new type is WORD
-parse_next : orig line is 3, orig col is 29, Text() is ','
+SetType : orig line is 3, orig col is 29, Text() is ','
    type is NONE, parent type is NONE => new type is COMMA
-parse_whitespace : orig line is 3, orig col is 30, Text() is ''
+SetType : orig line is 3, orig col is 30, Text() is ''
    type is NONE, parent type is NONE => new type is WHITESPACE
-parse_word : orig line is 3, orig col is 31, Text() is 'unsigned'
+SetType : orig line is 3, orig col is 31, Text() is 'unsigned'
    type is NONE, parent type is NONE => new type is WORD
-parse_word : orig line is 3, orig col is 31, Text() is 'unsigned'
+SetType : orig line is 3, orig col is 31, Text() is 'unsigned'
    type is WORD, parent type is NONE => new type is TYPE
-parse_whitespace : orig line is 3, orig col is 39, Text() is ''
+SetType : orig line is 3, orig col is 39, Text() is ''
    type is NONE, parent type is NONE => new type is WHITESPACE
-parse_word : orig line is 3, orig col is 40, Text() is 'long'
+SetType : orig line is 3, orig col is 40, Text() is 'long'
    type is NONE, parent type is NONE => new type is WORD
-parse_word : orig line is 3, orig col is 40, Text() is 'long'
+SetType : orig line is 3, orig col is 40, Text() is 'long'
    type is WORD, parent type is NONE => new type is TYPE
-parse_whitespace : orig line is 3, orig col is 44, Text() is ''
+SetType : orig line is 3, orig col is 44, Text() is ''
    type is NONE, parent type is NONE => new type is WHITESPACE
-parse_word : orig line is 3, orig col is 45, Text() is 'nI'
+SetType : orig line is 3, orig col is 45, Text() is 'nI'
    type is NONE, parent type is NONE => new type is WORD
-parse_next : orig line is 3, orig col is 47, Text() is ')'
+SetType : orig line is 3, orig col is 47, Text() is ')'
    type is NONE, parent type is NONE => new type is PAREN_CLOSE
-parse_whitespace : orig line is 3, orig col is 48, Text() is ''
+SetType : orig line is 3, orig col is 48, Text() is ''
    type is NONE, parent type is NONE => new type is WHITESPACE
-parse_next : orig line is 3, orig col is 49, Text() is ':'
+SetType : orig line is 3, orig col is 49, Text() is ':'
    type is NONE, parent type is NONE => new type is COLON
-parse_whitespace : orig line is 3, orig col is 50, Text() is <Newline>
+SetType : orig line is 3, orig col is 50, Text() is <Newline>
    type is NONE, parent type is NONE => new type is NEWLINE
-parse_word : orig line is 4, orig col is 1, Text() is 'pTelName'
+SetType : orig line is 4, orig col is 1, Text() is 'pTelName'
    type is NONE, parent type is NONE => new type is WORD
-parse_next : orig line is 4, orig col is 9, Text() is '('
+SetType : orig line is 4, orig col is 9, Text() is '('
    type is NONE, parent type is NONE => new type is PAREN_OPEN
-parse_word : orig line is 4, orig col is 10, Text() is 'pN'
+SetType : orig line is 4, orig col is 10, Text() is 'pN'
    type is NONE, parent type is NONE => new type is WORD
-parse_next : orig line is 4, orig col is 12, Text() is ')'
+SetType : orig line is 4, orig col is 12, Text() is ')'
    type is NONE, parent type is NONE => new type is PAREN_CLOSE
-parse_next : orig line is 4, orig col is 13, Text() is ','
+SetType : orig line is 4, orig col is 13, Text() is ','
    type is NONE, parent type is NONE => new type is COMMA
-parse_whitespace : orig line is 4, orig col is 14, Text() is <Newline>
+SetType : orig line is 4, orig col is 14, Text() is <Newline>
    type is NONE, parent type is NONE => new type is NEWLINE
-parse_word : orig line is 5, orig col is 1, Text() is 'nTelIndex'
+SetType : orig line is 5, orig col is 1, Text() is 'nTelIndex'
    type is NONE, parent type is NONE => new type is WORD
-parse_next : orig line is 5, orig col is 10, Text() is '('
+SetType : orig line is 5, orig col is 10, Text() is '('
    type is NONE, parent type is NONE => new type is PAREN_OPEN
-parse_word : orig line is 5, orig col is 11, Text() is 'n'
+SetType : orig line is 5, orig col is 11, Text() is 'n'
    type is NONE, parent type is NONE => new type is WORD
-parse_next : orig line is 5, orig col is 12, Text() is ')'
+SetType : orig line is 5, orig col is 12, Text() is ')'
    type is NONE, parent type is NONE => new type is PAREN_CLOSE
-parse_whitespace : orig line is 5, orig col is 13, Text() is <Newline>
+SetType : orig line is 5, orig col is 13, Text() is <Newline>
    type is NONE, parent type is NONE => new type is NEWLINE
-parse_next : orig line is 6, orig col is 1, Text() is '{'
+SetType : orig line is 6, orig col is 1, Text() is '{'
    type is NONE, parent type is NONE => new type is BRACE_OPEN
-parse_whitespace : orig line is 6, orig col is 2, Text() is <Newline>
+SetType : orig line is 6, orig col is 2, Text() is <Newline>
    type is NONE, parent type is NONE => new type is NEWLINE
-parse_next : orig line is 7, orig col is 1, Text() is '}'
+SetType : orig line is 7, orig col is 1, Text() is '}'
    type is NONE, parent type is NONE => new type is BRACE_CLOSE
-parse_whitespace : orig line is 7, orig col is 2, Text() is <Newline>
+SetType : orig line is 7, orig col is 2, Text() is <Newline>
    type is NONE, parent type is NONE => new type is NEWLINE
-parse_next : orig line is 9, orig col is 1, Text() is '~'
+SetType : orig line is 9, orig col is 1, Text() is '~'
    type is NONE, parent type is NONE => new type is INV
-parse_word : orig line is 9, orig col is 2, Text() is 'TelegramIndex'
+SetType : orig line is 9, orig col is 2, Text() is 'TelegramIndex'
    type is NONE, parent type is NONE => new type is WORD
-parse_next : orig line is 9, orig col is 15, Text() is '('
+SetType : orig line is 9, orig col is 15, Text() is '('
    type is NONE, parent type is NONE => new type is PAREN_OPEN
-parse_next : orig line is 9, orig col is 16, Text() is ')'
+SetType : orig line is 9, orig col is 16, Text() is ')'
    type is NONE, parent type is NONE => new type is PAREN_CLOSE
-parse_whitespace : orig line is 9, orig col is 17, Text() is <Newline>
+SetType : orig line is 9, orig col is 17, Text() is <Newline>
    type is NONE, parent type is NONE => new type is NEWLINE
-parse_next : orig line is 10, orig col is 1, Text() is '{'
+SetType : orig line is 10, orig col is 1, Text() is '{'
    type is NONE, parent type is NONE => new type is BRACE_OPEN
-parse_whitespace : orig line is 10, orig col is 2, Text() is <Newline>
+SetType : orig line is 10, orig col is 2, Text() is <Newline>
    type is NONE, parent type is NONE => new type is NEWLINE
-parse_next : orig line is 11, orig col is 1, Text() is '}'
+SetType : orig line is 11, orig col is 1, Text() is '}'
    type is NONE, parent type is NONE => new type is BRACE_CLOSE
-parse_whitespace : orig line is 11, orig col is 2, Text() is <Newline>
+SetType : orig line is 11, orig col is 2, Text() is <Newline>
    type is NONE, parent type is NONE => new type is NEWLINE
-parse_word : orig line is 13, orig col is 1, Text() is 'const'
+SetType : orig line is 13, orig col is 1, Text() is 'const'
    type is NONE, parent type is NONE => new type is WORD
-parse_word : orig line is 13, orig col is 1, Text() is 'const'
+SetType : orig line is 13, orig col is 1, Text() is 'const'
    type is WORD, parent type is NONE => new type is QUALIFIER
-parse_whitespace : orig line is 13, orig col is 6, Text() is ''
+SetType : orig line is 13, orig col is 6, Text() is ''
    type is NONE, parent type is NONE => new type is WHITESPACE
-parse_word : orig line is 13, orig col is 7, Text() is 'char'
+SetType : orig line is 13, orig col is 7, Text() is 'char'
    type is NONE, parent type is NONE => new type is WORD
-parse_word : orig line is 13, orig col is 7, Text() is 'char'
+SetType : orig line is 13, orig col is 7, Text() is 'char'
    type is WORD, parent type is NONE => new type is TYPE
-parse_next : orig line is 13, orig col is 11, Text() is '*'
+SetType : orig line is 13, orig col is 11, Text() is '*'
    type is NONE, parent type is NONE => new type is STAR
-parse_whitespace : orig line is 13, orig col is 12, Text() is ''
+SetType : orig line is 13, orig col is 12, Text() is ''
    type is NONE, parent type is NONE => new type is WHITESPACE
-parse_word : orig line is 13, orig col is 13, Text() is 'const'
+SetType : orig line is 13, orig col is 13, Text() is 'const'
    type is NONE, parent type is NONE => new type is WORD
-parse_word : orig line is 13, orig col is 13, Text() is 'const'
+SetType : orig line is 13, orig col is 13, Text() is 'const'
    type is WORD, parent type is NONE => new type is QUALIFIER
-parse_whitespace : orig line is 13, orig col is 18, Text() is ''
+SetType : orig line is 13, orig col is 18, Text() is ''
    type is NONE, parent type is NONE => new type is WHITESPACE
-parse_word : orig line is 13, orig col is 19, Text() is 'pTelName'
+SetType : orig line is 13, orig col is 19, Text() is 'pTelName'
    type is NONE, parent type is NONE => new type is WORD
-parse_next : orig line is 13, orig col is 27, Text() is ';'
+SetType : orig line is 13, orig col is 27, Text() is ';'
    type is NONE, parent type is NONE => new type is SEMICOLON
-parse_whitespace : orig line is 13, orig col is 28, Text() is <Newline>
+SetType : orig line is 13, orig col is 28, Text() is <Newline>
    type is NONE, parent type is NONE => new type is NEWLINE
-parse_word : orig line is 14, orig col is 1, Text() is 'unsigned'
+SetType : orig line is 14, orig col is 1, Text() is 'unsigned'
    type is NONE, parent type is NONE => new type is WORD
-parse_word : orig line is 14, orig col is 1, Text() is 'unsigned'
+SetType : orig line is 14, orig col is 1, Text() is 'unsigned'
    type is WORD, parent type is NONE => new type is TYPE
-parse_whitespace : orig line is 14, orig col is 9, Text() is ''
+SetType : orig line is 14, orig col is 9, Text() is ''
    type is NONE, parent type is NONE => new type is WHITESPACE
-parse_word : orig line is 14, orig col is 10, Text() is 'long'
+SetType : orig line is 14, orig col is 10, Text() is 'long'
    type is NONE, parent type is NONE => new type is WORD
-parse_word : orig line is 14, orig col is 10, Text() is 'long'
+SetType : orig line is 14, orig col is 10, Text() is 'long'
    type is WORD, parent type is NONE => new type is TYPE
-parse_whitespace : orig line is 14, orig col is 14, Text() is ''
+SetType : orig line is 14, orig col is 14, Text() is ''
    type is NONE, parent type is NONE => new type is WHITESPACE
-parse_word : orig line is 14, orig col is 15, Text() is 'nTelIndex'
+SetType : orig line is 14, orig col is 15, Text() is 'nTelIndex'
    type is NONE, parent type is NONE => new type is WORD
-parse_next : orig line is 14, orig col is 24, Text() is ';'
+SetType : orig line is 14, orig col is 24, Text() is ';'
    type is NONE, parent type is NONE => new type is SEMICOLON
-parse_whitespace : orig line is 14, orig col is 25, Text() is <Newline>
+SetType : orig line is 14, orig col is 25, Text() is <Newline>
    type is NONE, parent type is NONE => new type is NEWLINE
-parse_next : orig line is 15, orig col is 1, Text() is '}'
+SetType : orig line is 15, orig col is 1, Text() is '}'
    type is NONE, parent type is NONE => new type is BRACE_CLOSE
-parse_next : orig line is 15, orig col is 2, Text() is ';'
+SetType : orig line is 15, orig col is 2, Text() is ';'
    type is NONE, parent type is NONE => new type is SEMICOLON
-parse_whitespace : orig line is 15, orig col is 3, Text() is <Newline>
+SetType : orig line is 15, orig col is 3, Text() is <Newline>
    type is NONE, parent type is NONE => new type is NEWLINE
-tokenize_cleanup : orig line is 1, orig col is 8, Text() is 'TelegramIndex'
+SetType : orig line is 1, orig col is 8, Text() is 'TelegramIndex'
    type is WORD, parent type is NONE => new type is TYPE
-tokenize_cleanup : orig line is 3, orig col is 25, Text() is '*'
+SetType : orig line is 3, orig col is 25, Text() is '*'
    type is STAR, parent type is NONE => new type is PTR_TYPE
-tokenize_cleanup : orig line is 13, orig col is 11, Text() is '*'
+SetType : orig line is 13, orig col is 11, Text() is '*'
    type is STAR, parent type is NONE => new type is PTR_TYPE
-try_find_end_chunk : orig line is 1, orig col is 8, Text() is 'TelegramIndex'
+SetType : orig line is 1, orig col is 8, Text() is 'TelegramIndex'
    type is TYPE, parent type is NONE => new type is WORD
-make_type : orig line is 1, orig col is 8, Text() is 'TelegramIndex'
+SetType : orig line is 1, orig col is 8, Text() is 'TelegramIndex'
    type is WORD, parent type is NONE => new type is TYPE
-mark_constructors : orig line is 3, orig col is 1, Text() is 'TelegramIndex'
+SetType : orig line is 3, orig col is 1, Text() is 'TelegramIndex'
    type is WORD, parent type is NONE => new type is FUNC_CLASS_DEF
-flag_parens : orig line is 3, orig col is 14, Text() is '('
+SetType : orig line is 3, orig col is 14, Text() is '('
    type is PAREN_OPEN, parent type is NONE => new type is FPAREN_OPEN
-flag_parens : orig line is 3, orig col is 47, Text() is ')'
+SetType : orig line is 3, orig col is 47, Text() is ')'
    type is PAREN_CLOSE, parent type is NONE => new type is FPAREN_CLOSE
-mark_cpp_constructor : orig line is 3, orig col is 49, Text() is ':'
+SetType : orig line is 3, orig col is 49, Text() is ':'
    type is COLON, parent type is NONE => new type is CONSTR_COLON
-mark_cpp_constructor : orig line is 4, orig col is 1, Text() is 'pTelName'
+SetType : orig line is 4, orig col is 1, Text() is 'pTelName'
    type is WORD, parent type is NONE => new type is FUNC_CTOR_VAR
-flag_parens : orig line is 4, orig col is 9, Text() is '('
+SetType : orig line is 4, orig col is 9, Text() is '('
    type is PAREN_OPEN, parent type is NONE => new type is FPAREN_OPEN
-flag_parens : orig line is 4, orig col is 12, Text() is ')'
+SetType : orig line is 4, orig col is 12, Text() is ')'
    type is PAREN_CLOSE, parent type is NONE => new type is FPAREN_CLOSE
-mark_cpp_constructor : orig line is 5, orig col is 1, Text() is 'nTelIndex'
+SetType : orig line is 5, orig col is 1, Text() is 'nTelIndex'
    type is WORD, parent type is NONE => new type is FUNC_CTOR_VAR
-flag_parens : orig line is 5, orig col is 10, Text() is '('
+SetType : orig line is 5, orig col is 10, Text() is '('
    type is PAREN_OPEN, parent type is NONE => new type is FPAREN_OPEN
-flag_parens : orig line is 5, orig col is 12, Text() is ')'
+SetType : orig line is 5, orig col is 12, Text() is ')'
    type is PAREN_CLOSE, parent type is NONE => new type is FPAREN_CLOSE
-mark_constructors : orig line is 9, orig col is 2, Text() is 'TelegramIndex'
+SetType : orig line is 9, orig col is 2, Text() is 'TelegramIndex'
    type is WORD, parent type is NONE => new type is FUNC_CLASS_DEF
-mark_cpp_constructor : orig line is 9, orig col is 1, Text() is '~'
+SetType : orig line is 9, orig col is 1, Text() is '~'
    type is INV, parent type is NONE => new type is DESTRUCTOR
-flag_parens : orig line is 9, orig col is 15, Text() is '('
+SetType : orig line is 9, orig col is 15, Text() is '('
    type is PAREN_OPEN, parent type is NONE => new type is FPAREN_OPEN
-flag_parens : orig line is 9, orig col is 16, Text() is ')'
+SetType : orig line is 9, orig col is 16, Text() is ')'
    type is PAREN_CLOSE, parent type is NONE => new type is FPAREN_CLOSE

--- a/tests/cli/test_cli_options.py
+++ b/tests/cli/test_cli_options.py
@@ -787,7 +787,8 @@ def main(args):
                                   reg_replace(r'   \[0[xX][0-9a-fA-F]+:[_|,|1|A-Z]*\]', '   []'),
                                   reg_replace(r'^[ \t]*[_A-Za-z][_A-Za-z0-9]*::', ''),
                                   reg_replace(RE_CALLSTACK, '[CallStack]'),
-                                  reg_replace(RE_DO_SPACE, '')]
+                                  reg_replace(RE_DO_SPACE, ''),
+                                  reg_replace(r'Chunk::', '')]
             ):
             return_flag = False
 

--- a/tests/expected/cpp/33110-enum.cpp
+++ b/tests/expected/cpp/33110-enum.cpp
@@ -148,8 +148,8 @@ enum log_sev_t
    LINDENTAG = 88, /* indent again */
    LNFD      = 89, /* newline-function-def */
    LJDBI     = 90, /* Java Double Brace Init */
-   LSETPAR   = 91, /* Chunk::SetParentTypeReal() */
-   LSETTYP   = 92, /* Chunk::SetTypeReal() */
+   LSETPAR   = 91, /* Chunk::SetParentType() */
+   LSETTYP   = 92, /* Chunk::SetType() */
    LSETFLG   = 93, /* set_chunk_flags() */
    LNLFUNCT  = 94, /* newlines before function */
    LCHUNK    = 95, /* Add or del chunk */

--- a/tests/input/cpp/enum.cpp
+++ b/tests/input/cpp/enum.cpp
@@ -151,8 +151,8 @@ enum log_sev_t
    LINDENTAG = 88, /* indent again */
    LNFD      = 89, /* newline-function-def */
    LJDBI     = 90, /* Java Double Brace Init */
-   LSETPAR   = 91, /* Chunk::SetParentTypeReal() */
-   LSETTYP   = 92, /* Chunk::SetTypeReal() */
+   LSETPAR   = 91, /* Chunk::SetParentType() */
+   LSETTYP   = 92, /* Chunk::SetType() */
    LSETFLG   = 93, /* set_chunk_flags() */
    LNLFUNCT  = 94, /* newlines before function */
    LCHUNK    = 95, /* Add or del chunk */


### PR DESCRIPTION
@guy-maurel 
As discussed by email, macros have been replaced with real methods. This allows to define "SetType()" methods on other classes without any clash.

Please check before I merge it.