### PR TITLE
CI: use python3 interpreter

### DIFF
--- a/scripts/run_ctest.py
+++ b/scripts/run_ctest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import math


### PR DESCRIPTION
Modern Linux distributions install neither python2 nor symlink for python3. Hence, `run_ctest.py` will fail.