### PR TITLE
Fixes for building with GCC13 and MinGW-w64

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -16,6 +16,7 @@
 #include "prototypes.h"
 #include "quick_align_again.h"
 #include "space.h"
+#include <cstdint>
 
 #ifdef WIN32
 #include <algorithm>                   // to get max

--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include <cstdint>
 
 
 using namespace std;

--- a/src/unc_tools.cpp
+++ b/src/unc_tools.cpp
@@ -516,7 +516,7 @@ void dump_keyword_for_lang(size_t language_count, chunk_tag_t *keyword_for_lang)
       LOG_FMT(LDYNKW, "%s: %3zu: %18s, %14s, %12ld, %16s, %s\n",
               __func__, ii,
               keyword_for_lang[ii].tag, get_token_name(keyword_for_lang[ii].type),
-              keyword_for_lang[ii].lang_flags,
+              (long)keyword_for_lang[ii].lang_flags,
               g_a.data(),
               language_name_from_flags(keyword_for_lang[ii].lang_flags));
    }


### PR DESCRIPTION
- Add `#include <cstdint>` in `src/indent.cpp` and `src/unc_text.cpp` to fix undefined types `uint32_t` and `int_fast8_t`.
- Fix format issue in `src/unc_tools.cpp` for MinGW-w64 where `size_t` is a different size than `long`
