### PR TITLE
Fix issue #4026

### DIFF
--- a/src/parsing_frame.cpp
+++ b/src/parsing_frame.cpp
@@ -154,55 +154,57 @@ void ParsingFrame::pop(const char *func, int line, Chunk *pc)
 {
    LOG_FUNC_ENTRY();
 
-   if (  pc->GetType() == CT_PAREN_CLOSE
-      || pc->GetType() == CT_BRACE_CLOSE
-      || pc->GetType() == CT_VBRACE_CLOSE
-      || pc->GetType() == CT_FPAREN_CLOSE
-      || pc->GetType() == CT_LPAREN_CLOSE
-      || pc->GetType() == CT_RPAREN_CLOSE                      // Issue #3914
-      || pc->GetType() == CT_SPAREN_CLOSE
-      || pc->GetType() == CT_TPAREN_CLOSE
-      || pc->GetType() == CT_CLASS_COLON
+   if (  pc->GetType() == CT_ACCESS
       || pc->GetType() == CT_ANGLE_CLOSE
+      || pc->GetType() == CT_ANGLE_OPEN
+      || pc->GetType() == CT_ARITH                    // Issue #3965
+      || pc->GetType() == CT_ASSIGN
+      || pc->GetType() == CT_BRACE_CLOSE
+      || pc->GetType() == CT_BRACE_OPEN
+      || pc->GetType() == CT_BOOL
+      || pc->GetType() == CT_CASE
+      || pc->GetType() == CT_CLASS_COLON
+      || pc->GetType() == CT_COMMA
+      || pc->GetType() == CT_COMMENT
+      || pc->GetType() == CT_COMMENT_CPP
+      || pc->GetType() == CT_COMMENT_MULTI
+      || pc->GetType() == CT_COMPARE                  // Issue #3915
+      || pc->GetType() == CT_COND_COLON
+      || pc->GetType() == CT_FPAREN_CLOSE
+      || pc->GetType() == CT_FPAREN_OPEN
+      || pc->GetType() == CT_INCDEC_AFTER             // Issue #4026
+      || pc->GetType() == CT_LPAREN_CLOSE
+      || pc->GetType() == CT_LPAREN_OPEN
+      || pc->GetType() == CT_MACRO_CLOSE
+      || pc->GetType() == CT_MACRO_OPEN
+      || pc->GetType() == CT_MEMBER                   // Issue #3996
+      || pc->GetType() == CT_NEWLINE
+      || pc->GetType() == CT_NONE
+      || pc->GetType() == CT_OC_END
+      || pc->GetType() == CT_OC_MSG_NAME
+      || pc->GetType() == CT_OC_PROPERTY
+      || pc->GetType() == CT_OC_SCOPE
+      || pc->GetType() == CT_PAREN_CLOSE
+      || pc->GetType() == CT_PAREN_OPEN
+      || pc->GetType() == CT_PREPROC
+      || pc->GetType() == CT_QUESTION                 // Issue #4023
+      || pc->GetType() == CT_RPAREN_CLOSE             // Issue #3914
+      || pc->GetType() == CT_RPAREN_OPEN
+      || pc->GetType() == CT_SBOOL                    // Issue #3965
       || pc->GetType() == CT_SEMICOLON
-      || pc->GetType() == CT_SQUARE_CLOSE)
-   {
-      LOG_FMT(LINDPSE, "ParsingFrame::pop (%s:%d): orig line is %4zu, orig col is %4zu, type is %12s, pushed with\n",
-              func, line, pc->GetOrigLine(), pc->GetOrigCol(), get_token_name(pc->GetType()));
-   }
-   else if (  pc->GetType() == CT_ACCESS
-           || pc->GetType() == CT_ARITH                    // Issue #3965
-           || pc->GetType() == CT_ASSIGN
-           || pc->GetType() == CT_BRACE_OPEN
-           || pc->GetType() == CT_BOOL
-           || pc->GetType() == CT_CASE
-           || pc->GetType() == CT_COMMA
-           || pc->GetType() == CT_COMMENT
-           || pc->GetType() == CT_COMMENT_CPP
-           || pc->GetType() == CT_COMMENT_MULTI
-           || pc->GetType() == CT_COMPARE                  // Issue #3915
-           || pc->GetType() == CT_COND_COLON
-           || pc->GetType() == CT_FPAREN_OPEN
-           || pc->GetType() == CT_PAREN_OPEN
-           || pc->GetType() == CT_TPAREN_OPEN
-           || pc->GetType() == CT_MACRO_CLOSE
-           || pc->GetType() == CT_MACRO_OPEN
-           || pc->GetType() == CT_MEMBER                   // Issue 3996
-           || pc->GetType() == CT_NEWLINE
-           || pc->GetType() == CT_NONE
-           || pc->GetType() == CT_OC_END
-           || pc->GetType() == CT_OC_MSG_NAME
-           || pc->GetType() == CT_OC_SCOPE
-           || pc->GetType() == CT_OC_PROPERTY
-           || pc->GetType() == CT_PREPROC
-           || pc->GetType() == CT_QUESTION                 // Issue #4023
-           || pc->GetType() == CT_SBOOL                    // Issue #3965
-           || pc->GetType() == CT_SHIFT                    // Issue #3983
-           || pc->GetType() == CT_SQUARE_OPEN
-           || pc->GetType() == CT_SQL_END
-           || pc->GetType() == CT_TYPEDEF
-           || pc->GetType() == CT_VSEMICOLON
-           || pc->GetType() == CT_WORD)
+      || pc->GetType() == CT_SHIFT                    // Issue #3983
+      || pc->GetType() == CT_SPAREN_CLOSE
+      || pc->GetType() == CT_SPAREN_OPEN
+      || pc->GetType() == CT_SQL_END
+      || pc->GetType() == CT_SQUARE_CLOSE
+      || pc->GetType() == CT_SQUARE_OPEN
+      || pc->GetType() == CT_TPAREN_CLOSE
+      || pc->GetType() == CT_TPAREN_OPEN
+      || pc->GetType() == CT_TYPEDEF
+      || pc->GetType() == CT_VBRACE_CLOSE
+      || pc->GetType() == CT_VBRACE_OPEN
+      || pc->GetType() == CT_VSEMICOLON
+      || pc->GetType() == CT_WORD)
    {
       LOG_FMT(LINDPSE, "ParsingFrame::pop (%s:%d): orig line is %4zu, orig col is %4zu, type is %12s\n",
               func, line, pc->GetOrigLine(), pc->GetOrigCol(), get_token_name(pc->GetType()));

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -172,6 +172,7 @@
 30150  cpp/Issue_3983.cfg                                   cpp/Issue_3983.cpp
 30151  cpp/Issue_3983.cfg                                   cpp/Issue_3996.cpp
 30152  cpp/Issue_3983.cfg                                   cpp/Issue_4023.cpp
+30153  cpp/Issue_3983.cfg                                   cpp/Issue_4026.cpp
 
 30160  common/empty.cfg                                     cpp/Issue_3980.cpp
 30161  cpp/Discussion_3987.cfg                              cpp/Discussion_3987.cpp

--- a/tests/expected/cpp/30153-Issue_4026.cpp
+++ b/tests/expected/cpp/30153-Issue_4026.cpp
@@ -1,0 +1,17 @@
+class foo {
+public:
+int var;
+
+foo(int x) {
+	var = x;
+}
+};
+
+int main()
+{
+	int a = 2;
+	a++;
+
+	foo f(3);
+	f.var++;
+}

--- a/tests/input/cpp/Issue_4026.cpp
+++ b/tests/input/cpp/Issue_4026.cpp
@@ -1,0 +1,15 @@
+class foo {
+public:
+    int var;
+ 
+    foo(int x) { var = x; }
+};
+
+int main() 
+{
+    int a = 2;
+    a++;
+
+    foo f(3);
+    f.var++;
+}


### PR DESCRIPTION
@guy-maurel 
I have reworked the two big `if` blocks into one only. The difference was only the message that was printed (the first one having a `pushed with` added at the end). Having one big `if` makes it easy to see the CT_* in the test.
Let me know if it is ok for you, then I will merge