### PR TITLE
Fix issue #4048

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1134,7 +1134,8 @@ void do_symbol_check(Chunk *prev, Chunk *pc, Chunk *next)
       && !is_oc_block(pc)
       && pc->GetParentType() != CT_OC_MSG_DECL
       && pc->GetParentType() != CT_OC_MSG_SPEC
-      && pc->IsString(")")
+      && (  pc->IsString(")")
+         || pc->Is(CT_FUNC_TYPE))
       && next->IsString("("))
    {
       if (language_is_set(LANG_D))
@@ -1997,7 +1998,7 @@ void fix_symbols()
          pc = pc->GetNextNcNnl();
          continue;
       }
-      LOG_FMT(LFCNR, "%s(%d): pc orig line       is %zu, orig col is %zu, Text() is '%s', type is %s\n",
+      LOG_FMT(LFCNR, "%s(%d): pc orig line %zu, orig col %zu, text '%s', type %s\n",
               __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol(), pc->Text(), get_token_name(pc->GetType()));
       Chunk *prev = pc->GetPrevNcNnlNi(E_Scope::PREPROC);   // Issue #2279
 
@@ -2008,27 +2009,27 @@ void fix_symbols()
 
       if (prev->IsNullChunk())
       {
-         LOG_FMT(LFCNR, "%s(%d): WARNING: prev is NOT defined\n", __func__, __LINE__);
+         LOG_FMT(LFCNR, "%s(%d): prev is NOT defined\n", __func__, __LINE__);
       }
       else
       {
          // Issue #2279
-         LOG_FMT(LFCNR, "%s(%d): prev(ni) orig line is %zu, orig col is %zu, Text() is '%s', type is %s\n",
+         LOG_FMT(LFCNR, "%s(%d): prev(ni) orig line %zu, orig col %zu, text '%s', type %s\n",
                  __func__, __LINE__, prev->GetOrigLine(), prev->GetOrigCol(), prev->Text(), get_token_name(prev->GetType()));
       }
       Chunk *next = pc->GetNextNcNnl(E_Scope::PREPROC);
 
       if (next->IsNullChunk())
       {
-         LOG_FMT(LFCNR, "%s(%d): WARNING: next is NOT defined\n", __func__, __LINE__);
+         LOG_FMT(LFCNR, "%s(%d): next is NOT defined\n", __func__, __LINE__);
       }
       else
       {
          // Issue #2279
-         LOG_FMT(LFCNR, "%s(%d): next orig line     is %zu, orig col is %zu, Text() is '%s', type is %s\n",
+         LOG_FMT(LFCNR, "%s(%d): next orig line %zu, orig col %zu, text '%s', type %s\n",
                  __func__, __LINE__, next->GetOrigLine(), next->GetOrigCol(), next->Text(), get_token_name(next->GetType()));
       }
-      LOG_FMT(LFCNR, "%s(%d): do_symbol_check(%s, %s, %s)\n",
+      LOG_FMT(LFCNR, "%s(%d): do_symbol_check for '%s, %s, %s'\n",
               __func__, __LINE__, prev->Text(), pc->Text(), next->Text());
       do_symbol_check(prev, pc, next);
       pc = pc->GetNextNcNnl();

--- a/src/combine_tools.cpp
+++ b/src/combine_tools.cpp
@@ -312,18 +312,16 @@ bool can_be_full_param(Chunk *start, Chunk *end)
 bool chunk_ends_type(Chunk *start)
 {
    LOG_FUNC_ENTRY();
+
+   if (start->TestFlags(PCF_IN_FCN_CTOR))
+   {
+      return(false);
+   }
    Chunk  *pc       = start;
    bool   ret       = false;
    size_t cnt       = 0;
    bool   last_expr = false;
    bool   last_lval = false;
-
-   bool   a = pc->TestFlags(PCF_IN_FCN_CTOR);
-
-   if (a)
-   {
-      return(false);
-   }
 
    for ( ; pc->IsNotNullChunk(); pc = pc->GetPrevNcNnlNi()) // Issue #2279
    {

--- a/src/pcf_flags.cpp
+++ b/src/pcf_flags.cpp
@@ -68,11 +68,7 @@ std::string pcf_flags_str(PcfFlags flags)
    char buffer[64];
 
    // Generate hex representation first
-#ifdef WIN32
-   snprintf(buffer, 63, "[");
-#else // not WIN32
    snprintf(buffer, 63, "[0x%llx:", (long long unsigned int)(flags));
-#endif // ifdef WIN32
 
    // Add human-readable names
    auto out   = std::string{ buffer };
@@ -105,5 +101,5 @@ void log_pcf_flags(log_sev_t sev, PcfFlags flags)
    {
       return;
    }
-   log_fmt(sev, "%s\n", pcf_flags_str(flags).c_str());
+   log_fmt(sev, "   chunk flags: %s\n", pcf_flags_str(flags).c_str());
 }

--- a/tests/cli/input/in_fcn_def.cpp
+++ b/tests/cli/input/in_fcn_def.cpp
@@ -1,0 +1,5 @@
+void (*fnPtr)(int i, double d);
+void function(int i, double d);
+typedef	void (*fnPtr)(int i, double d);
+typedef	void function(int i, double d);
+

--- a/tests/cli/output/28.txt
+++ b/tests/cli/output/28.txt
@@ -70,13 +70,13 @@ log_rule(parse_next : rule is 'disable_processing_nl_cont'
 log_rule(tokenize : rule is 'newlines'
 brace_cleanup : orig line is 1, orig col is 1, Text() 'struct', type is STRUCT, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 1, orig col is 1, type is STRUCT, tos is 0, TOS.type is EOF, TOS.stage is NONE, []
+parse_cleanup : orig line is 1, orig col is 1, type is STRUCT, tos is 0, TOS.type is EOF, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 1, type is STRUCT, Text() is 'struct'
 parse_cleanup : frame statement count is 0, expression count is 0
 parse_cleanup : frame statement count is 1, expression count is 1
 brace_cleanup : orig line is 1, orig col is 8, Text() 'TelegramIndex', type is TYPE, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 1, orig col is 8, type is TYPE, tos is 0, TOS.type is EOF, TOS.stage is NONE, []
+parse_cleanup : orig line is 1, orig col is 8, type is TYPE, tos is 0, TOS.type is EOF, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 1, type is TYPE, Text() is 'TelegramIndex'
 parse_cleanup : frame statement count is 1, expression count is 1
 parse_cleanup : frame statement count is 2, expression count is 2
@@ -84,7 +84,7 @@ brace_cleanup : orig line is 1, orig col is 21, <Newline>, PRE is false
 brace_cleanup : pp level is 0
 brace_cleanup : orig line is 2, orig col is 1, Text() '{', type is BRACE_OPEN, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 2, orig col is 1, type is BRACE_OPEN, tos is 0, TOS.type is EOF, TOS.stage is NONE, []
+parse_cleanup : orig line is 2, orig col is 1, type is BRACE_OPEN, tos is 0, TOS.type is EOF, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 2, type is BRACE_OPEN, Text() is '{'
 parse_cleanup : frame statement count is 2, expression count is 2
 parse_cleanup : frame statement count is 3, expression count is 3
@@ -93,73 +93,73 @@ brace_cleanup : orig line is 2, orig col is 2, <Newline>, PRE is false
 brace_cleanup : pp level is 0
 brace_cleanup : orig line is 3, orig col is 1, Text() 'TelegramIndex', type is WORD, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 3, orig col is 1, type is WORD, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 3, orig col is 1, type is WORD, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 3, type is WORD, Text() is 'TelegramIndex'
 parse_cleanup : frame statement count is 0, expression count is 0
 parse_cleanup : frame statement count is 1, expression count is 1
 brace_cleanup : orig line is 3, orig col is 14, Text() '(', type is PAREN_OPEN, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 3, orig col is 14, type is PAREN_OPEN, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 3, orig col is 14, type is PAREN_OPEN, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 3, type is PAREN_OPEN, Text() is '('
 parse_cleanup : frame statement count is 1, expression count is 1
 parse_cleanup : frame statement count is 2, expression count is 2
 brace_cleanup : orig line is 3, orig col is 15, Text() 'const', type is QUALIFIER, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 3, orig col is 15, type is QUALIFIER, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 3, orig col is 15, type is QUALIFIER, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 3, type is QUALIFIER, Text() is 'const'
 parse_cleanup : frame statement count is 2, expression count is 0
 parse_cleanup : frame statement count is 3, expression count is 1
 brace_cleanup : orig line is 3, orig col is 21, Text() 'char', type is TYPE, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 3, orig col is 21, type is TYPE, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 3, orig col is 21, type is TYPE, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 3, type is TYPE, Text() is 'char'
 parse_cleanup : frame statement count is 3, expression count is 1
 parse_cleanup : frame statement count is 4, expression count is 2
 brace_cleanup : orig line is 3, orig col is 25, Text() '*', type is PTR_TYPE, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 3, orig col is 25, type is PTR_TYPE, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 3, orig col is 25, type is PTR_TYPE, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 3, type is PTR_TYPE, Text() is '*'
 parse_cleanup : frame statement count is 4, expression count is 2
 parse_cleanup : frame statement count is 5, expression count is 3
 brace_cleanup : orig line is 3, orig col is 27, Text() 'pN', type is WORD, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 3, orig col is 27, type is WORD, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 3, orig col is 27, type is WORD, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 3, type is WORD, Text() is 'pN'
 parse_cleanup : frame statement count is 5, expression count is 3
 parse_cleanup : frame statement count is 6, expression count is 4
 brace_cleanup : orig line is 3, orig col is 29, Text() ',', type is COMMA, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 3, orig col is 29, type is COMMA, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 3, orig col is 29, type is COMMA, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 3, type is COMMA, Text() is ','
 parse_cleanup : frame statement count is 6, expression count is 4
 parse_cleanup : frame statement count is 7, expression count is 5
 brace_cleanup : orig line is 3, orig col is 31, Text() 'unsigned', type is TYPE, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 3, orig col is 31, type is TYPE, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 3, orig col is 31, type is TYPE, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 3, type is TYPE, Text() is 'unsigned'
 parse_cleanup : frame statement count is 7, expression count is 0
 parse_cleanup : frame statement count is 8, expression count is 1
 brace_cleanup : orig line is 3, orig col is 40, Text() 'long', type is TYPE, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 3, orig col is 40, type is TYPE, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 3, orig col is 40, type is TYPE, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 3, type is TYPE, Text() is 'long'
 parse_cleanup : frame statement count is 8, expression count is 1
 parse_cleanup : frame statement count is 9, expression count is 2
 brace_cleanup : orig line is 3, orig col is 45, Text() 'nI', type is WORD, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 3, orig col is 45, type is WORD, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 3, orig col is 45, type is WORD, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 3, type is WORD, Text() is 'nI'
 parse_cleanup : frame statement count is 9, expression count is 2
 parse_cleanup : frame statement count is 10, expression count is 3
 brace_cleanup : orig line is 3, orig col is 47, Text() ')', type is PAREN_CLOSE, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 3, orig col is 47, type is PAREN_CLOSE, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 3, orig col is 47, type is PAREN_CLOSE, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 3, type is PAREN_CLOSE, Text() is ')'
 parse_cleanup : frame statement count is 10, expression count is 3
 parse_cleanup : frame statement count is 11, expression count is 4
 brace_cleanup : orig line is 3, orig col is 49, Text() ':', type is COLON, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 3, orig col is 49, type is COLON, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 3, orig col is 49, type is COLON, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 3, type is COLON, Text() is ':'
 parse_cleanup : frame statement count is 11, expression count is 4
 parse_cleanup : frame statement count is 12, expression count is 5
@@ -168,31 +168,31 @@ brace_cleanup : orig line is 3, orig col is 50, <Newline>, PRE is false
 brace_cleanup : pp level is 0
 brace_cleanup : orig line is 4, orig col is 1, Text() 'pTelName', type is WORD, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 4, orig col is 1, type is WORD, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 4, orig col is 1, type is WORD, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 4, type is WORD, Text() is 'pTelName'
 parse_cleanup : frame statement count is 0, expression count is 0
 parse_cleanup : frame statement count is 1, expression count is 1
 brace_cleanup : orig line is 4, orig col is 9, Text() '(', type is PAREN_OPEN, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 4, orig col is 9, type is PAREN_OPEN, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 4, orig col is 9, type is PAREN_OPEN, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 4, type is PAREN_OPEN, Text() is '('
 parse_cleanup : frame statement count is 1, expression count is 1
 parse_cleanup : frame statement count is 2, expression count is 2
 brace_cleanup : orig line is 4, orig col is 10, Text() 'pN', type is WORD, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 4, orig col is 10, type is WORD, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 4, orig col is 10, type is WORD, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 4, type is WORD, Text() is 'pN'
 parse_cleanup : frame statement count is 2, expression count is 0
 parse_cleanup : frame statement count is 3, expression count is 1
 brace_cleanup : orig line is 4, orig col is 12, Text() ')', type is PAREN_CLOSE, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 4, orig col is 12, type is PAREN_CLOSE, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 4, orig col is 12, type is PAREN_CLOSE, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 4, type is PAREN_CLOSE, Text() is ')'
 parse_cleanup : frame statement count is 3, expression count is 1
 parse_cleanup : frame statement count is 4, expression count is 2
 brace_cleanup : orig line is 4, orig col is 13, Text() ',', type is COMMA, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 4, orig col is 13, type is COMMA, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 4, orig col is 13, type is COMMA, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 4, type is COMMA, Text() is ','
 parse_cleanup : frame statement count is 4, expression count is 2
 parse_cleanup : frame statement count is 5, expression count is 3
@@ -200,25 +200,25 @@ brace_cleanup : orig line is 4, orig col is 14, <Newline>, PRE is false
 brace_cleanup : pp level is 0
 brace_cleanup : orig line is 5, orig col is 1, Text() 'nTelIndex', type is WORD, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 5, orig col is 1, type is WORD, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 5, orig col is 1, type is WORD, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 5, type is WORD, Text() is 'nTelIndex'
 parse_cleanup : frame statement count is 5, expression count is 0
 parse_cleanup : frame statement count is 6, expression count is 1
 brace_cleanup : orig line is 5, orig col is 10, Text() '(', type is PAREN_OPEN, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 5, orig col is 10, type is PAREN_OPEN, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 5, orig col is 10, type is PAREN_OPEN, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 5, type is PAREN_OPEN, Text() is '('
 parse_cleanup : frame statement count is 6, expression count is 1
 parse_cleanup : frame statement count is 7, expression count is 2
 brace_cleanup : orig line is 5, orig col is 11, Text() 'n', type is WORD, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 5, orig col is 11, type is WORD, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 5, orig col is 11, type is WORD, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 5, type is WORD, Text() is 'n'
 parse_cleanup : frame statement count is 7, expression count is 0
 parse_cleanup : frame statement count is 8, expression count is 1
 brace_cleanup : orig line is 5, orig col is 12, Text() ')', type is PAREN_CLOSE, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 5, orig col is 12, type is PAREN_CLOSE, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 5, orig col is 12, type is PAREN_CLOSE, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 5, type is PAREN_CLOSE, Text() is ')'
 parse_cleanup : frame statement count is 8, expression count is 1
 parse_cleanup : frame statement count is 9, expression count is 2
@@ -226,7 +226,7 @@ brace_cleanup : orig line is 5, orig col is 13, <Newline>, PRE is false
 brace_cleanup : pp level is 0
 brace_cleanup : orig line is 6, orig col is 1, Text() '{', type is BRACE_OPEN, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 6, orig col is 1, type is BRACE_OPEN, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 6, orig col is 1, type is BRACE_OPEN, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 6, type is BRACE_OPEN, Text() is '{'
 parse_cleanup : frame statement count is 9, expression count is 2
 parse_cleanup : frame statement count is 10, expression count is 3
@@ -235,7 +235,7 @@ brace_cleanup : orig line is 6, orig col is 2, <Newline>, PRE is false
 brace_cleanup : pp level is 0
 brace_cleanup : orig line is 7, orig col is 1, Text() '}', type is BRACE_CLOSE, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 7, orig col is 1, type is BRACE_CLOSE, tos is 2, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 7, orig col is 1, type is BRACE_CLOSE, tos is 2, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 7, type is BRACE_CLOSE, Text() is '}'
 parse_cleanup : frame statement count is 0, expression count is 0
 parse_cleanup : frame statement count is 1, expression count is 1
@@ -244,25 +244,25 @@ brace_cleanup : orig line is 7, orig col is 2, <Newline>, PRE is false
 brace_cleanup : pp level is 0
 brace_cleanup : orig line is 9, orig col is 1, Text() '~', type is INV, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 9, orig col is 1, type is INV, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 9, orig col is 1, type is INV, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 9, type is INV, Text() is '~'
 parse_cleanup : frame statement count is 0, expression count is 0
 parse_cleanup : frame statement count is 1, expression count is 1
 brace_cleanup : orig line is 9, orig col is 2, Text() 'TelegramIndex', type is WORD, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 9, orig col is 2, type is WORD, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 9, orig col is 2, type is WORD, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 9, type is WORD, Text() is 'TelegramIndex'
 parse_cleanup : frame statement count is 1, expression count is 0
 parse_cleanup : frame statement count is 2, expression count is 1
 brace_cleanup : orig line is 9, orig col is 15, Text() '(', type is PAREN_OPEN, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 9, orig col is 15, type is PAREN_OPEN, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 9, orig col is 15, type is PAREN_OPEN, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 9, type is PAREN_OPEN, Text() is '('
 parse_cleanup : frame statement count is 2, expression count is 1
 parse_cleanup : frame statement count is 3, expression count is 2
 brace_cleanup : orig line is 9, orig col is 16, Text() ')', type is PAREN_CLOSE, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 9, orig col is 16, type is PAREN_CLOSE, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 9, orig col is 16, type is PAREN_CLOSE, tos is 2, TOS.type is PAREN_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 9, type is PAREN_CLOSE, Text() is ')'
 parse_cleanup : frame statement count is 3, expression count is 0
 parse_cleanup : frame statement count is 4, expression count is 1
@@ -270,7 +270,7 @@ brace_cleanup : orig line is 9, orig col is 17, <Newline>, PRE is false
 brace_cleanup : pp level is 0
 brace_cleanup : orig line is 10, orig col is 1, Text() '{', type is BRACE_OPEN, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 10, orig col is 1, type is BRACE_OPEN, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 10, orig col is 1, type is BRACE_OPEN, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 10, type is BRACE_OPEN, Text() is '{'
 parse_cleanup : frame statement count is 4, expression count is 1
 parse_cleanup : frame statement count is 5, expression count is 2
@@ -279,7 +279,7 @@ brace_cleanup : orig line is 10, orig col is 2, <Newline>, PRE is false
 brace_cleanup : pp level is 0
 brace_cleanup : orig line is 11, orig col is 1, Text() '}', type is BRACE_CLOSE, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 11, orig col is 1, type is BRACE_CLOSE, tos is 2, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 11, orig col is 1, type is BRACE_CLOSE, tos is 2, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 11, type is BRACE_CLOSE, Text() is '}'
 parse_cleanup : frame statement count is 0, expression count is 0
 parse_cleanup : frame statement count is 1, expression count is 1
@@ -288,37 +288,37 @@ brace_cleanup : orig line is 11, orig col is 2, <Newline>, PRE is false
 brace_cleanup : pp level is 0
 brace_cleanup : orig line is 13, orig col is 1, Text() 'const', type is QUALIFIER, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 13, orig col is 1, type is QUALIFIER, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 13, orig col is 1, type is QUALIFIER, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 13, type is QUALIFIER, Text() is 'const'
 parse_cleanup : frame statement count is 0, expression count is 0
 parse_cleanup : frame statement count is 1, expression count is 1
 brace_cleanup : orig line is 13, orig col is 7, Text() 'char', type is TYPE, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 13, orig col is 7, type is TYPE, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 13, orig col is 7, type is TYPE, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 13, type is TYPE, Text() is 'char'
 parse_cleanup : frame statement count is 1, expression count is 1
 parse_cleanup : frame statement count is 2, expression count is 2
 brace_cleanup : orig line is 13, orig col is 11, Text() '*', type is PTR_TYPE, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 13, orig col is 11, type is PTR_TYPE, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 13, orig col is 11, type is PTR_TYPE, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 13, type is PTR_TYPE, Text() is '*'
 parse_cleanup : frame statement count is 2, expression count is 2
 parse_cleanup : frame statement count is 3, expression count is 3
 brace_cleanup : orig line is 13, orig col is 13, Text() 'const', type is QUALIFIER, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 13, orig col is 13, type is QUALIFIER, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 13, orig col is 13, type is QUALIFIER, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 13, type is QUALIFIER, Text() is 'const'
 parse_cleanup : frame statement count is 3, expression count is 3
 parse_cleanup : frame statement count is 4, expression count is 4
 brace_cleanup : orig line is 13, orig col is 19, Text() 'pTelName', type is WORD, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 13, orig col is 19, type is WORD, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 13, orig col is 19, type is WORD, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 13, type is WORD, Text() is 'pTelName'
 parse_cleanup : frame statement count is 4, expression count is 4
 parse_cleanup : frame statement count is 5, expression count is 5
 brace_cleanup : orig line is 13, orig col is 27, Text() ';', type is SEMICOLON, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 13, orig col is 27, type is SEMICOLON, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 13, orig col is 27, type is SEMICOLON, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 13, type is SEMICOLON, Text() is ';'
 parse_cleanup : frame statement count is 5, expression count is 5
 parse_cleanup : frame statement count is 6, expression count is 6
@@ -327,25 +327,25 @@ brace_cleanup : orig line is 13, orig col is 28, <Newline>, PRE is false
 brace_cleanup : pp level is 0
 brace_cleanup : orig line is 14, orig col is 1, Text() 'unsigned', type is TYPE, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 14, orig col is 1, type is TYPE, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 14, orig col is 1, type is TYPE, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 14, type is TYPE, Text() is 'unsigned'
 parse_cleanup : frame statement count is 0, expression count is 0
 parse_cleanup : frame statement count is 1, expression count is 1
 brace_cleanup : orig line is 14, orig col is 10, Text() 'long', type is TYPE, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 14, orig col is 10, type is TYPE, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 14, orig col is 10, type is TYPE, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 14, type is TYPE, Text() is 'long'
 parse_cleanup : frame statement count is 1, expression count is 1
 parse_cleanup : frame statement count is 2, expression count is 2
 brace_cleanup : orig line is 14, orig col is 15, Text() 'nTelIndex', type is WORD, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 14, orig col is 15, type is WORD, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 14, orig col is 15, type is WORD, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x0:]
 parse_cleanup : orig line is 14, type is WORD, Text() is 'nTelIndex'
 parse_cleanup : frame statement count is 2, expression count is 2
 parse_cleanup : frame statement count is 3, expression count is 3
 brace_cleanup : orig line is 14, orig col is 24, Text() ';', type is SEMICOLON, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 14, orig col is 24, type is SEMICOLON, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 14, orig col is 24, type is SEMICOLON, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 14, type is SEMICOLON, Text() is ';'
 parse_cleanup : frame statement count is 3, expression count is 3
 parse_cleanup : frame statement count is 4, expression count is 4
@@ -354,14 +354,14 @@ brace_cleanup : orig line is 14, orig col is 25, <Newline>, PRE is false
 brace_cleanup : pp level is 0
 brace_cleanup : orig line is 15, orig col is 1, Text() '}', type is BRACE_CLOSE, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 15, orig col is 1, type is BRACE_CLOSE, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE, []
+parse_cleanup : orig line is 15, orig col is 1, type is BRACE_CLOSE, tos is 1, TOS.type is BRACE_OPEN, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 15, type is BRACE_CLOSE, Text() is '}'
 parse_cleanup : frame statement count is 0, expression count is 0
 parse_cleanup : frame statement count is 1, expression count is 1
 parse_cleanup : frame statement count is 0, expression count is 0
 brace_cleanup : orig line is 15, orig col is 2, Text() ';', type is SEMICOLON, PRE is false
 brace_cleanup : pp level is 0
-parse_cleanup : orig line is 15, orig col is 2, type is SEMICOLON, tos is 0, TOS.type is EOF, TOS.stage is NONE, []
+parse_cleanup : orig line is 15, orig col is 2, type is SEMICOLON, tos is 0, TOS.type is EOF, TOS.stage is NONE,    chunk flags: [0x200000000:PUNCTUATOR]
 parse_cleanup : orig line is 15, type is SEMICOLON, Text() is ';'
 parse_cleanup : frame statement count is 0, expression count is 0
 parse_cleanup : frame statement count is 1, expression count is 1

--- a/tests/cli/output/31.txt
+++ b/tests/cli/output/31.txt
@@ -1,6 +1,6 @@
 indent_text : orig line is 1, orig col is 1, Text() 'struct', type is STRUCT, PRE is false
 indent_text : orig line is 1, orig col is 1, column is 1, for 'struct'
-   []
+      chunk flags: [0xe0000:FORCE_SPACE,STMT_START,EXPR_START]
 indent_text : frm.pse_tos is 0, ...indent_tmp is 1
 indent_text :     pc orig line is 1, orig col is 1, Text() is 'struct', type is STRUCT
 indent_text : frm.pse_tos is 0, ...indent_tmp is 1
@@ -9,7 +9,7 @@ reindent_line : orig line is 1, orig col is 1, on 'struct' [STRUCT/NONE] => 1
 indent_text : pc orig line is 1, orig col is 8, Text() is 'TelegramIndex', type is TYPE
 indent_text : orig line is 1, orig col is 8, Text() 'TelegramIndex', type is TYPE, PRE is false
 indent_text : orig line is 1, orig col is 8, column is 8, for 'TelegramIndex'
-   []
+      chunk flags: [0x0:]
 indent_text : frm.pse_tos is 0, ...indent_tmp is 1
 indent_text :     pc orig line is 1, orig col is 8, Text() is 'TelegramIndex', type is TYPE
 indent_text : frm.pse_tos is 0, ...indent_tmp is 1
@@ -24,7 +24,7 @@ indent_text : frm.pse_tos is 0, ...indent_tmp is 1
 indent_text : pc orig line is 2, orig col is 1, Text() is '{', type is BRACE_OPEN
 indent_text : orig line is 2, orig col is 1, Text() '{', type is BRACE_OPEN, PRE is false
 indent_text : orig line is 2, orig col is 1, column is 1, for '{'
-   []
+      chunk flags: [0x200000400:IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 0, ...indent_tmp is 1
 indent_text :     pc orig line is 2, orig col is 1, Text() is '{', type is BRACE_OPEN
 indent_text : frm.pse_tos is 0, ...indent_tmp is 1
@@ -43,7 +43,7 @@ indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 3, orig col is 1, Text() is 'TelegramIndex', type is FUNC_CLASS_DEF
 indent_text : orig line is 3, orig col is 1, Text() 'TelegramIndex', type is FUNC_CLASS_DEF, PRE is false
 indent_text : orig line is 3, orig col is 1, column is 1, for 'TelegramIndex'
-   []
+      chunk flags: [0xc0402:IN_STRUCT,IN_CLASS,STMT_START,EXPR_START]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 reindent_line : orig line is 3, orig col is 1, on 'TelegramIndex' [FUNC_CLASS_DEF/NONE] => 9
@@ -51,7 +51,7 @@ reindent_line : orig line is 3, orig col is 1, on 'TelegramIndex' [FUNC_CLASS_DE
 indent_text : pc orig line is 3, orig col is 14, Text() is '(', type is FPAREN_OPEN
 indent_text : orig line is 3, orig col is 14, Text() '(', type is FPAREN_OPEN, PRE is false
 indent_text : orig line is 3, orig col is 14, column is 22, for '('
-   []
+      chunk flags: [0x200000502:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 2, ...indent is 23
@@ -60,55 +60,55 @@ indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : pc orig line is 3, orig col is 15, Text() is 'const', type is QUALIFIER
 indent_text : orig line is 3, orig col is 15, Text() 'const', type is QUALIFIER, PRE is false
 indent_text : orig line is 3, orig col is 15, column is 23, for 'const'
-   []
+      chunk flags: [0xa0512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,FORCE_SPACE,EXPR_START]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : pc orig line is 3, orig col is 21, Text() is 'char', type is TYPE
 indent_text : orig line is 3, orig col is 21, Text() 'char', type is TYPE, PRE is false
 indent_text : orig line is 3, orig col is 21, column is 29, for 'char'
-   []
+      chunk flags: [0x800512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,VAR_TYPE]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : pc orig line is 3, orig col is 25, Text() is '*', type is PTR_TYPE
 indent_text : orig line is 3, orig col is 25, Text() '*', type is PTR_TYPE, PRE is false
 indent_text : orig line is 3, orig col is 25, column is 33, for '*'
-   []
+      chunk flags: [0x200000512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : pc orig line is 3, orig col is 27, Text() is 'pN', type is WORD
 indent_text : orig line is 3, orig col is 27, Text() 'pN', type is WORD, PRE is false
 indent_text : orig line is 3, orig col is 27, column is 35, for 'pN'
-   []
+      chunk flags: [0x1000512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,VAR_DEF]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : pc orig line is 3, orig col is 29, Text() is ',', type is COMMA
 indent_text : orig line is 3, orig col is 29, Text() ',', type is COMMA, PRE is false
 indent_text : orig line is 3, orig col is 29, column is 37, for ','
-   []
+      chunk flags: [0x200000512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : pc orig line is 3, orig col is 31, Text() is 'unsigned', type is TYPE
 indent_text : orig line is 3, orig col is 31, Text() 'unsigned', type is TYPE, PRE is false
 indent_text : orig line is 3, orig col is 31, column is 39, for 'unsigned'
-   []
+      chunk flags: [0x8a0512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,FORCE_SPACE,EXPR_START,VAR_TYPE]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : pc orig line is 3, orig col is 40, Text() is 'long', type is TYPE
 indent_text : orig line is 3, orig col is 40, Text() 'long', type is TYPE, PRE is false
 indent_text : orig line is 3, orig col is 40, column is 48, for 'long'
-   []
+      chunk flags: [0x820512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,FORCE_SPACE,VAR_TYPE]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : pc orig line is 3, orig col is 45, Text() is 'nI', type is WORD
 indent_text : orig line is 3, orig col is 45, Text() 'nI', type is WORD, PRE is false
 indent_text : orig line is 3, orig col is 45, column is 53, for 'nI'
-   []
+      chunk flags: [0x1000512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,VAR_DEF]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : pc orig line is 3, orig col is 47, Text() is ')', type is FPAREN_CLOSE
 indent_text : orig line is 3, orig col is 47, Text() ')', type is FPAREN_CLOSE, PRE is false
 indent_text : orig line is 3, orig col is 47, column is 55, for ')'
-   []
+      chunk flags: [0x200000512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text :     pc orig line is 3, orig col is 47, Text() is ')', type is FPAREN_CLOSE
 indent_text : pc orig line is 3, orig col is 47, Text() is ')', type is FPAREN_CLOSE
@@ -116,7 +116,7 @@ indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 3, orig col is 49, Text() is ':', type is CONSTR_COLON
 indent_text : orig line is 3, orig col is 49, Text() ':', type is CONSTR_COLON, PRE is false
 indent_text : orig line is 3, orig col is 49, column is 57, for ':'
-   []
+      chunk flags: [0x200000502:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 2, ...indent is 17
@@ -132,7 +132,7 @@ indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text : pc orig line is 4, orig col is 1, Text() is 'pTelName', type is FUNC_CTOR_VAR
 indent_text : orig line is 4, orig col is 1, Text() 'pTelName', type is FUNC_CTOR_VAR, PRE is false
 indent_text : orig line is 4, orig col is 1, column is 1, for 'pTelName'
-   []
+      chunk flags: [0xc0502:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,STMT_START,EXPR_START]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text :     pc orig line is 4, orig col is 1, Text() is 'pTelName', type is FUNC_CTOR_VAR
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
@@ -141,7 +141,7 @@ reindent_line : orig line is 4, orig col is 1, on 'pTelName' [FUNC_CTOR_VAR/NONE
 indent_text : pc orig line is 4, orig col is 9, Text() is '(', type is FPAREN_OPEN
 indent_text : orig line is 4, orig col is 9, Text() '(', type is FPAREN_OPEN, PRE is false
 indent_text : orig line is 4, orig col is 9, column is 25, for '('
-   []
+      chunk flags: [0x200000502:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text :     pc orig line is 4, orig col is 9, Text() is '(', type is FPAREN_OPEN
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
@@ -151,13 +151,13 @@ indent_text : frm.pse_tos is 3, ...indent_tmp is 26
 indent_text : pc orig line is 4, orig col is 10, Text() is 'pN', type is WORD
 indent_text : orig line is 4, orig col is 10, Text() 'pN', type is WORD, PRE is false
 indent_text : orig line is 4, orig col is 10, column is 26, for 'pN'
-   []
+      chunk flags: [0x80512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,EXPR_START]
 indent_text : frm.pse_tos is 3, ...indent_tmp is 26
 indent_text : frm.pse_tos is 3, ...indent_tmp is 26
 indent_text : pc orig line is 4, orig col is 12, Text() is ')', type is FPAREN_CLOSE
 indent_text : orig line is 4, orig col is 12, Text() ')', type is FPAREN_CLOSE, PRE is false
 indent_text : orig line is 4, orig col is 12, column is 28, for ')'
-   []
+      chunk flags: [0x200000512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 3, ...indent_tmp is 26
 indent_text :     pc orig line is 4, orig col is 12, Text() is ')', type is FPAREN_CLOSE
 indent_text : pc orig line is 4, orig col is 12, Text() is ')', type is FPAREN_CLOSE
@@ -166,7 +166,7 @@ indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text : pc orig line is 4, orig col is 13, Text() is ',', type is COMMA
 indent_text : orig line is 4, orig col is 13, Text() ',', type is COMMA, PRE is false
 indent_text : orig line is 4, orig col is 13, column is 29, for ','
-   []
+      chunk flags: [0x200000502:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text :     pc orig line is 4, orig col is 13, Text() is ',', type is COMMA
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
@@ -181,7 +181,7 @@ indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text : pc orig line is 5, orig col is 1, Text() is 'nTelIndex', type is FUNC_CTOR_VAR
 indent_text : orig line is 5, orig col is 1, Text() 'nTelIndex', type is FUNC_CTOR_VAR, PRE is false
 indent_text : orig line is 5, orig col is 1, column is 1, for 'nTelIndex'
-   []
+      chunk flags: [0x80502:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,EXPR_START]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text :     pc orig line is 5, orig col is 1, Text() is 'nTelIndex', type is FUNC_CTOR_VAR
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
@@ -190,7 +190,7 @@ reindent_line : orig line is 5, orig col is 1, on 'nTelIndex' [FUNC_CTOR_VAR/NON
 indent_text : pc orig line is 5, orig col is 10, Text() is '(', type is FPAREN_OPEN
 indent_text : orig line is 5, orig col is 10, Text() '(', type is FPAREN_OPEN, PRE is false
 indent_text : orig line is 5, orig col is 10, column is 26, for '('
-   []
+      chunk flags: [0x200000502:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text :     pc orig line is 5, orig col is 10, Text() is '(', type is FPAREN_OPEN
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
@@ -200,13 +200,13 @@ indent_text : frm.pse_tos is 3, ...indent_tmp is 27
 indent_text : pc orig line is 5, orig col is 11, Text() is 'n', type is WORD
 indent_text : orig line is 5, orig col is 11, Text() 'n', type is WORD, PRE is false
 indent_text : orig line is 5, orig col is 11, column is 27, for 'n'
-   []
+      chunk flags: [0x80512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,EXPR_START]
 indent_text : frm.pse_tos is 3, ...indent_tmp is 27
 indent_text : frm.pse_tos is 3, ...indent_tmp is 27
 indent_text : pc orig line is 5, orig col is 12, Text() is ')', type is FPAREN_CLOSE
 indent_text : orig line is 5, orig col is 12, Text() ')', type is FPAREN_CLOSE, PRE is false
 indent_text : orig line is 5, orig col is 12, column is 28, for ')'
-   []
+      chunk flags: [0x200000512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 3, ...indent_tmp is 27
 indent_text :     pc orig line is 5, orig col is 12, Text() is ')', type is FPAREN_CLOSE
 indent_text : pc orig line is 5, orig col is 12, Text() is ')', type is FPAREN_CLOSE
@@ -223,7 +223,7 @@ indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text : pc orig line is 6, orig col is 1, Text() is '{', type is BRACE_OPEN
 indent_text : orig line is 6, orig col is 1, Text() '{', type is BRACE_OPEN, PRE is false
 indent_text : orig line is 6, orig col is 1, column is 1, for '{'
-   []
+      chunk flags: [0x280000402:IN_STRUCT,IN_CLASS,EMPTY_BODY,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text : pc orig line is 6, orig col is 1, Text() is '{', type is BRACE_OPEN
 indent_text :     pc orig line is 6, orig col is 1, Text() is '{', type is BRACE_OPEN
@@ -243,7 +243,7 @@ indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text : pc orig line is 7, orig col is 1, Text() is '}', type is BRACE_CLOSE
 indent_text : orig line is 7, orig col is 1, Text() '}', type is BRACE_CLOSE, PRE is false
 indent_text : orig line is 7, orig col is 1, column is 1, for '}'
-   []
+      chunk flags: [0x280000402:IN_STRUCT,IN_CLASS,EMPTY_BODY,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text :     pc orig line is 7, orig col is 1, Text() is '}', type is BRACE_CLOSE
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
@@ -260,7 +260,7 @@ indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 9, orig col is 1, Text() is '~', type is DESTRUCTOR
 indent_text : orig line is 9, orig col is 1, Text() '~', type is DESTRUCTOR, PRE is false
 indent_text : orig line is 9, orig col is 1, column is 1, for '~'
-   []
+      chunk flags: [0x2000c0402:IN_STRUCT,IN_CLASS,STMT_START,EXPR_START,PUNCTUATOR]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 reindent_line : orig line is 9, orig col is 1, on '~' [DESTRUCTOR/FUNC_CLASS_DEF] => 9
@@ -268,13 +268,13 @@ reindent_line : orig line is 9, orig col is 1, on '~' [DESTRUCTOR/FUNC_CLASS_DEF
 indent_text : pc orig line is 9, orig col is 2, Text() is 'TelegramIndex', type is FUNC_CLASS_DEF
 indent_text : orig line is 9, orig col is 2, Text() 'TelegramIndex', type is FUNC_CLASS_DEF, PRE is false
 indent_text : orig line is 9, orig col is 2, column is 10, for 'TelegramIndex'
-   []
+      chunk flags: [0x80402:IN_STRUCT,IN_CLASS,EXPR_START]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 9, orig col is 15, Text() is '(', type is FPAREN_OPEN
 indent_text : orig line is 9, orig col is 15, Text() '(', type is FPAREN_OPEN, PRE is false
 indent_text : orig line is 9, orig col is 15, column is 23, for '('
-   []
+      chunk flags: [0x200000502:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 2, ...indent is 24
@@ -283,7 +283,7 @@ indent_text : frm.pse_tos is 2, ...indent_tmp is 24
 indent_text : pc orig line is 9, orig col is 16, Text() is ')', type is FPAREN_CLOSE
 indent_text : orig line is 9, orig col is 16, Text() ')', type is FPAREN_CLOSE, PRE is false
 indent_text : orig line is 9, orig col is 16, column is 24, for ')'
-   []
+      chunk flags: [0x200000512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 24
 indent_text :     pc orig line is 9, orig col is 16, Text() is ')', type is FPAREN_CLOSE
 indent_text : pc orig line is 9, orig col is 16, Text() is ')', type is FPAREN_CLOSE
@@ -298,7 +298,7 @@ indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 10, orig col is 1, Text() is '{', type is BRACE_OPEN
 indent_text : orig line is 10, orig col is 1, Text() '{', type is BRACE_OPEN, PRE is false
 indent_text : orig line is 10, orig col is 1, column is 1, for '{'
-   []
+      chunk flags: [0x280000402:IN_STRUCT,IN_CLASS,EMPTY_BODY,PUNCTUATOR]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 2, ... indent is 17
@@ -316,7 +316,7 @@ indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text : pc orig line is 11, orig col is 1, Text() is '}', type is BRACE_CLOSE
 indent_text : orig line is 11, orig col is 1, Text() '}', type is BRACE_CLOSE, PRE is false
 indent_text : orig line is 11, orig col is 1, column is 1, for '}'
-   []
+      chunk flags: [0x280000402:IN_STRUCT,IN_CLASS,EMPTY_BODY,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text :     pc orig line is 11, orig col is 1, Text() is '}', type is BRACE_CLOSE
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
@@ -333,7 +333,7 @@ indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 13, orig col is 1, Text() is 'const', type is QUALIFIER
 indent_text : orig line is 13, orig col is 1, Text() 'const', type is QUALIFIER, PRE is false
 indent_text : orig line is 13, orig col is 1, column is 1, for 'const'
-   []
+      chunk flags: [0x8e0402:IN_STRUCT,IN_CLASS,FORCE_SPACE,STMT_START,EXPR_START,VAR_TYPE]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 reindent_line : orig line is 13, orig col is 1, on 'const' [QUALIFIER/NONE] => 9
@@ -341,31 +341,31 @@ reindent_line : orig line is 13, orig col is 1, on 'const' [QUALIFIER/NONE] => 9
 indent_text : pc orig line is 13, orig col is 7, Text() is 'char', type is TYPE
 indent_text : orig line is 13, orig col is 7, Text() 'char', type is TYPE, PRE is false
 indent_text : orig line is 13, orig col is 7, column is 15, for 'char'
-   []
+      chunk flags: [0x800402:IN_STRUCT,IN_CLASS,VAR_TYPE]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 13, orig col is 11, Text() is '*', type is PTR_TYPE
 indent_text : orig line is 13, orig col is 11, Text() '*', type is PTR_TYPE, PRE is false
 indent_text : orig line is 13, orig col is 11, column is 19, for '*'
-   []
+      chunk flags: [0x200800402:IN_STRUCT,IN_CLASS,VAR_TYPE,PUNCTUATOR]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 13, orig col is 13, Text() is 'const', type is QUALIFIER
 indent_text : orig line is 13, orig col is 13, Text() 'const', type is QUALIFIER, PRE is false
 indent_text : orig line is 13, orig col is 13, column is 21, for 'const'
-   []
+      chunk flags: [0x820402:IN_STRUCT,IN_CLASS,FORCE_SPACE,VAR_TYPE]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 13, orig col is 19, Text() is 'pTelName', type is WORD
 indent_text : orig line is 13, orig col is 19, Text() 'pTelName', type is WORD, PRE is false
 indent_text : orig line is 13, orig col is 19, column is 27, for 'pTelName'
-   []
+      chunk flags: [0x3000402:IN_STRUCT,IN_CLASS,VAR_DEF,VAR_1ST]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 13, orig col is 27, Text() is ';', type is SEMICOLON
 indent_text : orig line is 13, orig col is 27, Text() ';', type is SEMICOLON, PRE is false
 indent_text : orig line is 13, orig col is 27, column is 35, for ';'
-   []
+      chunk flags: [0x200000402:IN_STRUCT,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 13, orig col is 28, Text() is '', type is NEWLINE
@@ -378,7 +378,7 @@ indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 14, orig col is 1, Text() is 'unsigned', type is TYPE
 indent_text : orig line is 14, orig col is 1, Text() 'unsigned', type is TYPE, PRE is false
 indent_text : orig line is 14, orig col is 1, column is 1, for 'unsigned'
-   []
+      chunk flags: [0x8e0402:IN_STRUCT,IN_CLASS,FORCE_SPACE,STMT_START,EXPR_START,VAR_TYPE]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 reindent_line : orig line is 14, orig col is 1, on 'unsigned' [TYPE/NONE] => 9
@@ -386,19 +386,19 @@ reindent_line : orig line is 14, orig col is 1, on 'unsigned' [TYPE/NONE] => 9
 indent_text : pc orig line is 14, orig col is 10, Text() is 'long', type is TYPE
 indent_text : orig line is 14, orig col is 10, Text() 'long', type is TYPE, PRE is false
 indent_text : orig line is 14, orig col is 10, column is 18, for 'long'
-   []
+      chunk flags: [0x820402:IN_STRUCT,IN_CLASS,FORCE_SPACE,VAR_TYPE]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 14, orig col is 15, Text() is 'nTelIndex', type is WORD
 indent_text : orig line is 14, orig col is 15, Text() 'nTelIndex', type is WORD, PRE is false
 indent_text : orig line is 14, orig col is 15, column is 23, for 'nTelIndex'
-   []
+      chunk flags: [0x3000402:IN_STRUCT,IN_CLASS,VAR_DEF,VAR_1ST]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 14, orig col is 24, Text() is ';', type is SEMICOLON
 indent_text : orig line is 14, orig col is 24, Text() ';', type is SEMICOLON, PRE is false
 indent_text : orig line is 14, orig col is 24, column is 32, for ';'
-   []
+      chunk flags: [0x200000402:IN_STRUCT,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 14, orig col is 25, Text() is '', type is NEWLINE
@@ -411,7 +411,7 @@ indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 15, orig col is 1, Text() is '}', type is BRACE_CLOSE
 indent_text : orig line is 15, orig col is 1, Text() '}', type is BRACE_CLOSE, PRE is false
 indent_text : orig line is 15, orig col is 1, column is 1, for '}'
-   []
+      chunk flags: [0x200000402:IN_STRUCT,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text :     pc orig line is 15, orig col is 1, Text() is '}', type is BRACE_CLOSE
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
@@ -421,7 +421,7 @@ reindent_line : orig line is 15, orig col is 1, on '}' [BRACE_CLOSE/STRUCT] => 1
 indent_text : pc orig line is 15, orig col is 2, Text() is ';', type is SEMICOLON
 indent_text : orig line is 15, orig col is 2, Text() ';', type is SEMICOLON, PRE is false
 indent_text : orig line is 15, orig col is 2, column is 2, for ';'
-   []
+      chunk flags: [0x200000000:PUNCTUATOR]
 indent_text : frm.pse_tos is 0, ...indent_tmp is 1
 indent_text :     pc orig line is 15, orig col is 2, Text() is ';', type is SEMICOLON
 indent_text : frm.pse_tos is 0, ...indent_tmp is 1
@@ -462,7 +462,7 @@ reindent_line : orig line is 15, orig col is 1, on '}' [BRACE_CLOSE/STRUCT] => 1
 indent_text : after quick_align_again
 indent_text : orig line is 1, orig col is 1, Text() 'struct', type is STRUCT, PRE is false
 indent_text : orig line is 1, orig col is 1, column is 1, for 'struct'
-   []
+      chunk flags: [0xe0000:FORCE_SPACE,STMT_START,EXPR_START]
 indent_text : frm.pse_tos is 0, ...indent_tmp is 1
 indent_text :     pc orig line is 1, orig col is 1, Text() is 'struct', type is STRUCT
 indent_text : frm.pse_tos is 0, ...indent_tmp is 1
@@ -471,7 +471,7 @@ reindent_line : orig line is 1, orig col is 1, on 'struct' [STRUCT/NONE] => 1
 indent_text : pc orig line is 1, orig col is 8, Text() is 'TelegramIndex', type is TYPE
 indent_text : orig line is 1, orig col is 8, Text() 'TelegramIndex', type is TYPE, PRE is false
 indent_text : orig line is 1, orig col is 8, column is 8, for 'TelegramIndex'
-   []
+      chunk flags: [0x0:]
 indent_text : frm.pse_tos is 0, ...indent_tmp is 1
 indent_text :     pc orig line is 1, orig col is 8, Text() is 'TelegramIndex', type is TYPE
 indent_text : frm.pse_tos is 0, ...indent_tmp is 1
@@ -486,7 +486,7 @@ indent_text : frm.pse_tos is 0, ...indent_tmp is 1
 indent_text : pc orig line is 2, orig col is 1, Text() is '{', type is BRACE_OPEN
 indent_text : orig line is 2, orig col is 1, Text() '{', type is BRACE_OPEN, PRE is false
 indent_text : orig line is 2, orig col is 1, column is 1, for '{'
-   []
+      chunk flags: [0x200000400:IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 0, ...indent_tmp is 1
 indent_text :     pc orig line is 2, orig col is 1, Text() is '{', type is BRACE_OPEN
 indent_text : frm.pse_tos is 0, ...indent_tmp is 1
@@ -505,7 +505,7 @@ indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 3, orig col is 1, Text() is 'TelegramIndex', type is FUNC_CLASS_DEF
 indent_text : orig line is 3, orig col is 1, Text() 'TelegramIndex', type is FUNC_CLASS_DEF, PRE is false
 indent_text : orig line is 3, orig col is 1, column is 9, for 'TelegramIndex'
-   []
+      chunk flags: [0xc0402:IN_STRUCT,IN_CLASS,STMT_START,EXPR_START]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 reindent_line : orig line is 3, orig col is 1, on 'TelegramIndex' [FUNC_CLASS_DEF/NONE] => 9
@@ -513,7 +513,7 @@ reindent_line : orig line is 3, orig col is 1, on 'TelegramIndex' [FUNC_CLASS_DE
 indent_text : pc orig line is 3, orig col is 14, Text() is '(', type is FPAREN_OPEN
 indent_text : orig line is 3, orig col is 14, Text() '(', type is FPAREN_OPEN, PRE is false
 indent_text : orig line is 3, orig col is 14, column is 22, for '('
-   []
+      chunk flags: [0x200000502:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 2, ...indent is 23
@@ -522,55 +522,55 @@ indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : pc orig line is 3, orig col is 15, Text() is 'const', type is QUALIFIER
 indent_text : orig line is 3, orig col is 15, Text() 'const', type is QUALIFIER, PRE is false
 indent_text : orig line is 3, orig col is 15, column is 23, for 'const'
-   []
+      chunk flags: [0xa0512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,FORCE_SPACE,EXPR_START]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : pc orig line is 3, orig col is 21, Text() is 'char', type is TYPE
 indent_text : orig line is 3, orig col is 21, Text() 'char', type is TYPE, PRE is false
 indent_text : orig line is 3, orig col is 21, column is 29, for 'char'
-   []
+      chunk flags: [0x800512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,VAR_TYPE]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : pc orig line is 3, orig col is 25, Text() is '*', type is PTR_TYPE
 indent_text : orig line is 3, orig col is 25, Text() '*', type is PTR_TYPE, PRE is false
 indent_text : orig line is 3, orig col is 25, column is 33, for '*'
-   []
+      chunk flags: [0x200000512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : pc orig line is 3, orig col is 27, Text() is 'pN', type is WORD
 indent_text : orig line is 3, orig col is 27, Text() 'pN', type is WORD, PRE is false
 indent_text : orig line is 3, orig col is 27, column is 35, for 'pN'
-   []
+      chunk flags: [0x1000512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,VAR_DEF]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : pc orig line is 3, orig col is 29, Text() is ',', type is COMMA
 indent_text : orig line is 3, orig col is 29, Text() ',', type is COMMA, PRE is false
 indent_text : orig line is 3, orig col is 29, column is 37, for ','
-   []
+      chunk flags: [0x200000512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : pc orig line is 3, orig col is 31, Text() is 'unsigned', type is TYPE
 indent_text : orig line is 3, orig col is 31, Text() 'unsigned', type is TYPE, PRE is false
 indent_text : orig line is 3, orig col is 31, column is 39, for 'unsigned'
-   []
+      chunk flags: [0x8a0512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,FORCE_SPACE,EXPR_START,VAR_TYPE]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : pc orig line is 3, orig col is 40, Text() is 'long', type is TYPE
 indent_text : orig line is 3, orig col is 40, Text() 'long', type is TYPE, PRE is false
 indent_text : orig line is 3, orig col is 40, column is 48, for 'long'
-   []
+      chunk flags: [0x820512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,FORCE_SPACE,VAR_TYPE]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : pc orig line is 3, orig col is 45, Text() is 'nI', type is WORD
 indent_text : orig line is 3, orig col is 45, Text() 'nI', type is WORD, PRE is false
 indent_text : orig line is 3, orig col is 45, column is 53, for 'nI'
-   []
+      chunk flags: [0x1000512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,VAR_DEF]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text : pc orig line is 3, orig col is 47, Text() is ')', type is FPAREN_CLOSE
 indent_text : orig line is 3, orig col is 47, Text() ')', type is FPAREN_CLOSE, PRE is false
 indent_text : orig line is 3, orig col is 47, column is 55, for ')'
-   []
+      chunk flags: [0x200000512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 23
 indent_text :     pc orig line is 3, orig col is 47, Text() is ')', type is FPAREN_CLOSE
 indent_text : pc orig line is 3, orig col is 47, Text() is ')', type is FPAREN_CLOSE
@@ -578,7 +578,7 @@ indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 3, orig col is 49, Text() is ':', type is CONSTR_COLON
 indent_text : orig line is 3, orig col is 49, Text() ':', type is CONSTR_COLON, PRE is false
 indent_text : orig line is 3, orig col is 49, column is 57, for ':'
-   []
+      chunk flags: [0x200000502:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 2, ...indent is 17
@@ -594,7 +594,7 @@ indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text : pc orig line is 4, orig col is 1, Text() is 'pTelName', type is FUNC_CTOR_VAR
 indent_text : orig line is 4, orig col is 1, Text() 'pTelName', type is FUNC_CTOR_VAR, PRE is false
 indent_text : orig line is 4, orig col is 1, column is 17, for 'pTelName'
-   []
+      chunk flags: [0xc0502:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,STMT_START,EXPR_START]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text :     pc orig line is 4, orig col is 1, Text() is 'pTelName', type is FUNC_CTOR_VAR
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
@@ -603,7 +603,7 @@ reindent_line : orig line is 4, orig col is 1, on 'pTelName' [FUNC_CTOR_VAR/NONE
 indent_text : pc orig line is 4, orig col is 9, Text() is '(', type is FPAREN_OPEN
 indent_text : orig line is 4, orig col is 9, Text() '(', type is FPAREN_OPEN, PRE is false
 indent_text : orig line is 4, orig col is 9, column is 25, for '('
-   []
+      chunk flags: [0x200000502:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text :     pc orig line is 4, orig col is 9, Text() is '(', type is FPAREN_OPEN
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
@@ -613,13 +613,13 @@ indent_text : frm.pse_tos is 3, ...indent_tmp is 26
 indent_text : pc orig line is 4, orig col is 10, Text() is 'pN', type is WORD
 indent_text : orig line is 4, orig col is 10, Text() 'pN', type is WORD, PRE is false
 indent_text : orig line is 4, orig col is 10, column is 26, for 'pN'
-   []
+      chunk flags: [0x80512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,EXPR_START]
 indent_text : frm.pse_tos is 3, ...indent_tmp is 26
 indent_text : frm.pse_tos is 3, ...indent_tmp is 26
 indent_text : pc orig line is 4, orig col is 12, Text() is ')', type is FPAREN_CLOSE
 indent_text : orig line is 4, orig col is 12, Text() ')', type is FPAREN_CLOSE, PRE is false
 indent_text : orig line is 4, orig col is 12, column is 28, for ')'
-   []
+      chunk flags: [0x200000512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 3, ...indent_tmp is 26
 indent_text :     pc orig line is 4, orig col is 12, Text() is ')', type is FPAREN_CLOSE
 indent_text : pc orig line is 4, orig col is 12, Text() is ')', type is FPAREN_CLOSE
@@ -628,7 +628,7 @@ indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text : pc orig line is 4, orig col is 13, Text() is ',', type is COMMA
 indent_text : orig line is 4, orig col is 13, Text() ',', type is COMMA, PRE is false
 indent_text : orig line is 4, orig col is 13, column is 29, for ','
-   []
+      chunk flags: [0x200000502:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text :     pc orig line is 4, orig col is 13, Text() is ',', type is COMMA
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
@@ -643,7 +643,7 @@ indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text : pc orig line is 5, orig col is 1, Text() is 'nTelIndex', type is FUNC_CTOR_VAR
 indent_text : orig line is 5, orig col is 1, Text() 'nTelIndex', type is FUNC_CTOR_VAR, PRE is false
 indent_text : orig line is 5, orig col is 1, column is 17, for 'nTelIndex'
-   []
+      chunk flags: [0x80502:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,EXPR_START]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text :     pc orig line is 5, orig col is 1, Text() is 'nTelIndex', type is FUNC_CTOR_VAR
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
@@ -652,7 +652,7 @@ reindent_line : orig line is 5, orig col is 1, on 'nTelIndex' [FUNC_CTOR_VAR/NON
 indent_text : pc orig line is 5, orig col is 10, Text() is '(', type is FPAREN_OPEN
 indent_text : orig line is 5, orig col is 10, Text() '(', type is FPAREN_OPEN, PRE is false
 indent_text : orig line is 5, orig col is 10, column is 26, for '('
-   []
+      chunk flags: [0x200000502:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text :     pc orig line is 5, orig col is 10, Text() is '(', type is FPAREN_OPEN
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
@@ -662,13 +662,13 @@ indent_text : frm.pse_tos is 3, ...indent_tmp is 27
 indent_text : pc orig line is 5, orig col is 11, Text() is 'n', type is WORD
 indent_text : orig line is 5, orig col is 11, Text() 'n', type is WORD, PRE is false
 indent_text : orig line is 5, orig col is 11, column is 27, for 'n'
-   []
+      chunk flags: [0x80512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,EXPR_START]
 indent_text : frm.pse_tos is 3, ...indent_tmp is 27
 indent_text : frm.pse_tos is 3, ...indent_tmp is 27
 indent_text : pc orig line is 5, orig col is 12, Text() is ')', type is FPAREN_CLOSE
 indent_text : orig line is 5, orig col is 12, Text() ')', type is FPAREN_CLOSE, PRE is false
 indent_text : orig line is 5, orig col is 12, column is 28, for ')'
-   []
+      chunk flags: [0x200000512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 3, ...indent_tmp is 27
 indent_text :     pc orig line is 5, orig col is 12, Text() is ')', type is FPAREN_CLOSE
 indent_text : pc orig line is 5, orig col is 12, Text() is ')', type is FPAREN_CLOSE
@@ -685,7 +685,7 @@ indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text : pc orig line is 6, orig col is 1, Text() is '{', type is BRACE_OPEN
 indent_text : orig line is 6, orig col is 1, Text() '{', type is BRACE_OPEN, PRE is false
 indent_text : orig line is 6, orig col is 1, column is 9, for '{'
-   []
+      chunk flags: [0x280000402:IN_STRUCT,IN_CLASS,EMPTY_BODY,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text : pc orig line is 6, orig col is 1, Text() is '{', type is BRACE_OPEN
 indent_text :     pc orig line is 6, orig col is 1, Text() is '{', type is BRACE_OPEN
@@ -705,7 +705,7 @@ indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text : pc orig line is 7, orig col is 1, Text() is '}', type is BRACE_CLOSE
 indent_text : orig line is 7, orig col is 1, Text() '}', type is BRACE_CLOSE, PRE is false
 indent_text : orig line is 7, orig col is 1, column is 9, for '}'
-   []
+      chunk flags: [0x280000402:IN_STRUCT,IN_CLASS,EMPTY_BODY,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text :     pc orig line is 7, orig col is 1, Text() is '}', type is BRACE_CLOSE
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
@@ -722,7 +722,7 @@ indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 9, orig col is 1, Text() is '~', type is DESTRUCTOR
 indent_text : orig line is 9, orig col is 1, Text() '~', type is DESTRUCTOR, PRE is false
 indent_text : orig line is 9, orig col is 1, column is 9, for '~'
-   []
+      chunk flags: [0x2000c0402:IN_STRUCT,IN_CLASS,STMT_START,EXPR_START,PUNCTUATOR]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 reindent_line : orig line is 9, orig col is 1, on '~' [DESTRUCTOR/FUNC_CLASS_DEF] => 9
@@ -730,13 +730,13 @@ reindent_line : orig line is 9, orig col is 1, on '~' [DESTRUCTOR/FUNC_CLASS_DEF
 indent_text : pc orig line is 9, orig col is 2, Text() is 'TelegramIndex', type is FUNC_CLASS_DEF
 indent_text : orig line is 9, orig col is 2, Text() 'TelegramIndex', type is FUNC_CLASS_DEF, PRE is false
 indent_text : orig line is 9, orig col is 2, column is 10, for 'TelegramIndex'
-   []
+      chunk flags: [0x80402:IN_STRUCT,IN_CLASS,EXPR_START]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 9, orig col is 15, Text() is '(', type is FPAREN_OPEN
 indent_text : orig line is 9, orig col is 15, Text() '(', type is FPAREN_OPEN, PRE is false
 indent_text : orig line is 9, orig col is 15, column is 23, for '('
-   []
+      chunk flags: [0x200000502:IN_STRUCT,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 2, ...indent is 24
@@ -745,7 +745,7 @@ indent_text : frm.pse_tos is 2, ...indent_tmp is 24
 indent_text : pc orig line is 9, orig col is 16, Text() is ')', type is FPAREN_CLOSE
 indent_text : orig line is 9, orig col is 16, Text() ')', type is FPAREN_CLOSE, PRE is false
 indent_text : orig line is 9, orig col is 16, column is 24, for ')'
-   []
+      chunk flags: [0x200000512:IN_STRUCT,IN_FCN_CALL,IN_CONST_ARGS,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 24
 indent_text :     pc orig line is 9, orig col is 16, Text() is ')', type is FPAREN_CLOSE
 indent_text : pc orig line is 9, orig col is 16, Text() is ')', type is FPAREN_CLOSE
@@ -760,7 +760,7 @@ indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 10, orig col is 1, Text() is '{', type is BRACE_OPEN
 indent_text : orig line is 10, orig col is 1, Text() '{', type is BRACE_OPEN, PRE is false
 indent_text : orig line is 10, orig col is 1, column is 9, for '{'
-   []
+      chunk flags: [0x280000402:IN_STRUCT,IN_CLASS,EMPTY_BODY,PUNCTUATOR]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 2, ... indent is 17
@@ -778,7 +778,7 @@ indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text : pc orig line is 11, orig col is 1, Text() is '}', type is BRACE_CLOSE
 indent_text : orig line is 11, orig col is 1, Text() '}', type is BRACE_CLOSE, PRE is false
 indent_text : orig line is 11, orig col is 1, column is 9, for '}'
-   []
+      chunk flags: [0x280000402:IN_STRUCT,IN_CLASS,EMPTY_BODY,PUNCTUATOR]
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
 indent_text :     pc orig line is 11, orig col is 1, Text() is '}', type is BRACE_CLOSE
 indent_text : frm.pse_tos is 2, ...indent_tmp is 17
@@ -795,7 +795,7 @@ indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 13, orig col is 1, Text() is 'const', type is QUALIFIER
 indent_text : orig line is 13, orig col is 1, Text() 'const', type is QUALIFIER, PRE is false
 indent_text : orig line is 13, orig col is 1, column is 9, for 'const'
-   []
+      chunk flags: [0x8e0402:IN_STRUCT,IN_CLASS,FORCE_SPACE,STMT_START,EXPR_START,VAR_TYPE]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 reindent_line : orig line is 13, orig col is 1, on 'const' [QUALIFIER/NONE] => 9
@@ -803,31 +803,31 @@ reindent_line : orig line is 13, orig col is 1, on 'const' [QUALIFIER/NONE] => 9
 indent_text : pc orig line is 13, orig col is 7, Text() is 'char', type is TYPE
 indent_text : orig line is 13, orig col is 7, Text() 'char', type is TYPE, PRE is false
 indent_text : orig line is 13, orig col is 7, column is 15, for 'char'
-   []
+      chunk flags: [0x800402:IN_STRUCT,IN_CLASS,VAR_TYPE]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 13, orig col is 11, Text() is '*', type is PTR_TYPE
 indent_text : orig line is 13, orig col is 11, Text() '*', type is PTR_TYPE, PRE is false
 indent_text : orig line is 13, orig col is 11, column is 19, for '*'
-   []
+      chunk flags: [0x200800402:IN_STRUCT,IN_CLASS,VAR_TYPE,PUNCTUATOR]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 13, orig col is 13, Text() is 'const', type is QUALIFIER
 indent_text : orig line is 13, orig col is 13, Text() 'const', type is QUALIFIER, PRE is false
 indent_text : orig line is 13, orig col is 13, column is 21, for 'const'
-   []
+      chunk flags: [0x820402:IN_STRUCT,IN_CLASS,FORCE_SPACE,VAR_TYPE]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 13, orig col is 19, Text() is 'pTelName', type is WORD
 indent_text : orig line is 13, orig col is 19, Text() 'pTelName', type is WORD, PRE is false
 indent_text : orig line is 13, orig col is 19, column is 27, for 'pTelName'
-   []
+      chunk flags: [0x3000402:IN_STRUCT,IN_CLASS,VAR_DEF,VAR_1ST]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 13, orig col is 27, Text() is ';', type is SEMICOLON
 indent_text : orig line is 13, orig col is 27, Text() ';', type is SEMICOLON, PRE is false
 indent_text : orig line is 13, orig col is 27, column is 35, for ';'
-   []
+      chunk flags: [0x200000402:IN_STRUCT,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 13, orig col is 28, Text() is '', type is NEWLINE
@@ -840,7 +840,7 @@ indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 14, orig col is 1, Text() is 'unsigned', type is TYPE
 indent_text : orig line is 14, orig col is 1, Text() 'unsigned', type is TYPE, PRE is false
 indent_text : orig line is 14, orig col is 1, column is 9, for 'unsigned'
-   []
+      chunk flags: [0x8e0402:IN_STRUCT,IN_CLASS,FORCE_SPACE,STMT_START,EXPR_START,VAR_TYPE]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 reindent_line : orig line is 14, orig col is 1, on 'unsigned' [TYPE/NONE] => 9
@@ -848,19 +848,19 @@ reindent_line : orig line is 14, orig col is 1, on 'unsigned' [TYPE/NONE] => 9
 indent_text : pc orig line is 14, orig col is 10, Text() is 'long', type is TYPE
 indent_text : orig line is 14, orig col is 10, Text() 'long', type is TYPE, PRE is false
 indent_text : orig line is 14, orig col is 10, column is 18, for 'long'
-   []
+      chunk flags: [0x820402:IN_STRUCT,IN_CLASS,FORCE_SPACE,VAR_TYPE]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 14, orig col is 15, Text() is 'nTelIndex', type is WORD
 indent_text : orig line is 14, orig col is 15, Text() 'nTelIndex', type is WORD, PRE is false
 indent_text : orig line is 14, orig col is 15, column is 23, for 'nTelIndex'
-   []
+      chunk flags: [0x3000402:IN_STRUCT,IN_CLASS,VAR_DEF,VAR_1ST]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 14, orig col is 24, Text() is ';', type is SEMICOLON
 indent_text : orig line is 14, orig col is 24, Text() ';', type is SEMICOLON, PRE is false
 indent_text : orig line is 14, orig col is 24, column is 32, for ';'
-   []
+      chunk flags: [0x200000402:IN_STRUCT,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 14, orig col is 25, Text() is '', type is NEWLINE
@@ -873,7 +873,7 @@ indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text : pc orig line is 15, orig col is 1, Text() is '}', type is BRACE_CLOSE
 indent_text : orig line is 15, orig col is 1, Text() '}', type is BRACE_CLOSE, PRE is false
 indent_text : orig line is 15, orig col is 1, column is 1, for '}'
-   []
+      chunk flags: [0x200000402:IN_STRUCT,IN_CLASS,PUNCTUATOR]
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
 indent_text :     pc orig line is 15, orig col is 1, Text() is '}', type is BRACE_CLOSE
 indent_text : frm.pse_tos is 1, ...indent_tmp is 9
@@ -883,7 +883,7 @@ reindent_line : orig line is 15, orig col is 1, on '}' [BRACE_CLOSE/STRUCT] => 1
 indent_text : pc orig line is 15, orig col is 2, Text() is ';', type is SEMICOLON
 indent_text : orig line is 15, orig col is 2, Text() ';', type is SEMICOLON, PRE is false
 indent_text : orig line is 15, orig col is 2, column is 2, for ';'
-   []
+      chunk flags: [0x200000000:PUNCTUATOR]
 indent_text : frm.pse_tos is 0, ...indent_tmp is 1
 indent_text :     pc orig line is 15, orig col is 2, Text() is ';', type is SEMICOLON
 indent_text : frm.pse_tos is 0, ...indent_tmp is 1

--- a/tests/cli/output/in_fcn_def.txt
+++ b/tests/cli/output/in_fcn_def.txt
@@ -1,0 +1,62 @@
+
+# option(s) with 'not default' value: 0
+#
+# -=====-
+# number of loops               = 0
+# -=====-
+# language                      = CPP
+# -=====-
+# Line                Tag         Parent_type  Type of the parent         Columns Br/Lvl/pp             Flags   Nl  Text
+#   1>               TYPE|           FUNC_VAR|     PARENT_NOT_SET[  1/  1/  5/  0][0/0/0][             c 0000][0-0] void
+#   1>        TPAREN_OPEN|           FUNC_VAR|     PARENT_NOT_SET[  6/  6/  7/  1][0/0/0][        2 0300 0000][0-0]      (
+#   1>           PTR_TYPE|               NONE|     PARENT_NOT_SET[  7/  7/  8/  0][0/1/0][        2 0008 0000][0-0]       *
+#   1>           FUNC_VAR|               NONE|     PARENT_NOT_SET[  8/  8/ 13/  0][0/1/0][           308 0000][0-0]        fnPtr
+#   1>       TPAREN_CLOSE|           FUNC_VAR|     PARENT_NOT_SET[ 13/ 13/ 14/  0][0/0/0][        2 0000 0000][0-0]             )
+#   1>        FPAREN_OPEN|         FUNC_PROTO|     PARENT_NOT_SET[ 14/ 14/ 15/  0][0/0/0][        2 0000 0000][0-0]              (
+#   1>               TYPE|               NONE|     PARENT_NOT_SET[ 15/ 15/ 18/  0][0/1/0][            8a 0008][0-0]               int
+#   1>               WORD|               NONE|     PARENT_NOT_SET[ 19/ 19/ 20/  1][0/1/0][           100 0008][0-0]                   i
+#   1>              COMMA|               NONE|     PARENT_NOT_SET[ 20/ 20/ 21/  0][0/1/0][        2 0000 0008][0-0]                    ,
+#   1>               TYPE|               NONE|     PARENT_NOT_SET[ 22/ 22/ 28/  1][0/1/0][            8a 0008][0-0]                      double
+#   1>               WORD|               NONE|     PARENT_NOT_SET[ 29/ 29/ 30/  1][0/1/0][           100 0008][0-0]                             d
+#   1>       FPAREN_CLOSE|         FUNC_PROTO|     PARENT_NOT_SET[ 30/ 30/ 31/  0][0/0/0][        2 0000 0008][0-0]                              )
+#   1>          SEMICOLON|           FUNC_VAR|     PARENT_NOT_SET[ 31/ 31/ 32/  0][0/0/0][        2 0000 0000][0-0]                               ;
+#   1>            NEWLINE|               NONE|     PARENT_NOT_SET[ 32/ 32/  1/  0][0/0/0][                  0][1-0]
+#   2>               TYPE|         FUNC_PROTO|     PARENT_NOT_SET[  1/  1/  5/  0][0/0/0][             e 0000][0-0] void
+#   2>         FUNC_PROTO|               NONE|     PARENT_NOT_SET[  6/  6/ 14/  1][0/0/0][                  0][0-0]      function
+#   2>        FPAREN_OPEN|         FUNC_PROTO|     PARENT_NOT_SET[ 14/ 14/ 15/  0][0/0/0][        2 0000 0000][0-0]              (
+#   2>               TYPE|               NONE|     PARENT_NOT_SET[ 15/ 15/ 18/  0][0/1/0][            8a 0008][0-0]               int
+#   2>               WORD|               NONE|     PARENT_NOT_SET[ 19/ 19/ 20/  1][0/1/0][           100 0008][0-0]                   i
+#   2>              COMMA|               NONE|     PARENT_NOT_SET[ 20/ 20/ 21/  0][0/1/0][        2 0000 0008][0-0]                    ,
+#   2>               TYPE|               NONE|     PARENT_NOT_SET[ 22/ 22/ 28/  1][0/1/0][            8a 0008][0-0]                      double
+#   2>               WORD|               NONE|     PARENT_NOT_SET[ 29/ 29/ 30/  1][0/1/0][           100 0008][0-0]                             d
+#   2>       FPAREN_CLOSE|         FUNC_PROTO|     PARENT_NOT_SET[ 30/ 30/ 31/  0][0/0/0][        2 0000 0008][0-0]                              )
+#   2>          SEMICOLON|         FUNC_PROTO|     PARENT_NOT_SET[ 31/ 31/ 32/  0][0/0/0][        2 0000 0000][0-0]                               ;
+#   2>            NEWLINE|               NONE|     PARENT_NOT_SET[ 32/ 32/  1/  0][0/0/0][                  0][1-0]
+#   3>            TYPEDEF|               NONE|     PARENT_NOT_SET[  1/  1/  8/  0][0/0/0][             e 0000][0-0] typedef
+#   3>               TYPE|          FUNC_TYPE|     PARENT_NOT_SET[  9/  9/ 13/  1][0/0/0][                 80][0-1]         void
+#   3>        TPAREN_OPEN|          FUNC_TYPE|     PARENT_NOT_SET[ 14/ 14/ 15/  1][0/0/0][        2 0000 0080][0-0]              (
+#   3>           PTR_TYPE|               NONE|     PARENT_NOT_SET[ 15/ 15/ 16/  0][0/1/0][        2 0008 0080][0-0]               *
+#   3>          FUNC_TYPE|            TYPEDEF|     PARENT_NOT_SET[ 16/ 16/ 21/  0][0/1/0][             8 0080][0-0]                fnPtr
+#   3>       TPAREN_CLOSE|          FUNC_TYPE|     PARENT_NOT_SET[ 21/ 21/ 22/  0][0/0/0][        2 0000 0080][0-0]                     )
+#   3>        FPAREN_OPEN|         FUNC_PROTO|     PARENT_NOT_SET[ 22/ 22/ 23/  0][0/0/0][        2 0000 0080][0-0]                      (
+#   3>               TYPE|               NONE|     PARENT_NOT_SET[ 23/ 23/ 26/  0][0/1/0][            8a 0088][0-0]                       int
+#   3>               WORD|               NONE|     PARENT_NOT_SET[ 27/ 27/ 28/  1][0/1/0][           100 0088][0-0]                           i
+#   3>              COMMA|               NONE|     PARENT_NOT_SET[ 28/ 28/ 29/  0][0/1/0][        2 0000 0088][0-0]                            ,
+#   3>               TYPE|               NONE|     PARENT_NOT_SET[ 30/ 30/ 36/  1][0/1/0][            8a 0088][0-0]                              double
+#   3>               WORD|               NONE|     PARENT_NOT_SET[ 37/ 37/ 38/  1][0/1/0][           100 0088][0-0]                                     d
+#   3>       FPAREN_CLOSE|         FUNC_PROTO|     PARENT_NOT_SET[ 38/ 38/ 39/  0][0/0/0][        2 0000 0088][0-0]                                      )
+#   3>          SEMICOLON|            TYPEDEF|     PARENT_NOT_SET[ 39/ 39/ 40/  0][0/0/0][        2 0000 0080][0-0]                                       ;
+#   3>            NEWLINE|               NONE|     PARENT_NOT_SET[ 40/ 40/  1/  0][0/0/0][                  0][1-0]
+#   4>            TYPEDEF|               NONE|     PARENT_NOT_SET[  1/  1/  8/  0][0/0/0][             e 0000][0-0] typedef
+#   4>               TYPE|               NONE|     PARENT_NOT_SET[  9/  9/ 13/  1][0/0/0][             2 0080][0-1]         void
+#   4>          FUNC_TYPE|            TYPEDEF|     PARENT_NOT_SET[ 14/ 14/ 22/  1][0/0/0][                 80][0-0]              function
+#   4>        FPAREN_OPEN|          FUNC_CALL|     PARENT_NOT_SET[ 22/ 22/ 23/  0][0/0/0][        2 0000 0080][0-0]                      (
+#   4>               TYPE|               NONE|     PARENT_NOT_SET[ 23/ 23/ 26/  0][0/1/0][            8a 0088][0-0]                       int
+#   4>               WORD|               NONE|     PARENT_NOT_SET[ 27/ 27/ 28/  1][0/1/0][           100 0088][0-0]                           i
+#   4>              COMMA|               NONE|     PARENT_NOT_SET[ 28/ 28/ 29/  0][0/1/0][        2 0000 0088][0-0]                            ,
+#   4>               TYPE|               NONE|     PARENT_NOT_SET[ 30/ 30/ 36/  1][0/1/0][            8a 0088][0-0]                              double
+#   4>               WORD|               NONE|     PARENT_NOT_SET[ 37/ 37/ 38/  1][0/1/0][           100 0088][0-0]                                     d
+#   4>       FPAREN_CLOSE|          FUNC_CALL|     PARENT_NOT_SET[ 38/ 38/ 39/  0][0/0/0][        2 0000 0088][0-0]                                      )
+#   4>          SEMICOLON|            TYPEDEF|     PARENT_NOT_SET[ 39/ 39/ 40/  0][0/0/0][        2 0000 0080][0-0]                                       ;
+#   4>            NEWLINE|               NONE|     PARENT_NOT_SET[ 40/ 40/  1/  0][0/0/0][                  0][2-0]
+# -=====-

--- a/tests/cli/test_cli_options.py
+++ b/tests/cli/test_cli_options.py
@@ -678,6 +678,17 @@ def main(args):
                 ):
             return_flag = False
 
+        if not check_uncrustify_output(
+                uncr_bin,
+                parsed_args,
+                args_arr=['-f', s_path_join(script_dir, 'input/in_fcn_def.cpp'),
+                          '-p', s_path_join(test_dir, 'results/in_fcn_def.txt')],
+                gen_expected_path=s_path_join(script_dir, 'output/in_fcn_def.txt'),
+                gen_result_path=s_path_join(test_dir, 'results/in_fcn_def.txt'),
+                gen_result_manip=reg_replace(r'\# Uncrustify.+[^\n\r]', '')
+                ):
+            return_flag = False
+
     if os_name == 'nt' or check_uncrustify_output(
             uncr_bin,
             parsed_args,

--- a/tests/expected/c/00901-code_width.c
+++ b/tests/expected/c/00901-code_width.c
@@ -38,10 +38,9 @@ typedef
     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     yyyyyyyyyyyyyyyyyyyyyy;
 
-typedef some_return_value (*some_function_type)(another_type
-                                                parameter1,
-                                                another_type
-                                                parameter2);
+typedef some_return_value (*some_function_type)(
+    another_type parameter1,
+    another_type parameter2);
 
 typedef struct
     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/tests/expected/c/00902-code_width.c
+++ b/tests/expected/c/00902-code_width.c
@@ -31,10 +31,8 @@ typedef
     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     yyyyyyyyyyyyyyyyyyyyyy;
 
-typedef some_return_value (*some_function_type)(another_type
-                                                parameter1,
-                                                another_type
-                                                parameter2);
+typedef some_return_value (*some_function_type)(
+    another_type parameter1, another_type parameter2);
 
 typedef struct
     xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx


### PR DESCRIPTION
Arguments of functions, function pointers or related typedef are now marked with PCF_IN_FCN_DEF. This will help having more consistent indentation across the various types.
Two tests were doing the wrong thing and this PR fixes them too.