### PR TITLE
Fix space before unnamed reference

### DIFF
--- a/src/space.cpp
+++ b/src/space.cpp
@@ -23,6 +23,7 @@
 #include "log_rules.h"
 #include "options_for_QT.h"
 #include "punctuators.h"
+#include "token_enum.h"
 
 #ifdef WIN32
 #include <algorithm>                   // to get max
@@ -1417,7 +1418,8 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
          && (  next->Is(CT_COMMA)
             || next->Is(CT_PAREN_CLOSE)                            // Issue #3691
             || next->Is(CT_FPAREN_CLOSE)
-            || next->Is(CT_SEMICOLON)))
+            || next->Is(CT_SEMICOLON)
+            || next->Is(CT_ANGLE_CLOSE)))                          // Issue #4064
       {
          if (options::sp_before_unnamed_byref() != IARF_IGNORE)    // Issue #3691
          {


### PR DESCRIPTION
For unnamed references, next token is examined before 'sp_before_unnamed_byref' option can be effective. Closing angle bracket (>) was missing from this check, hense cases like <int &> were not corrected.
Resolved by adding 'CT_ANGLE_CLOSE' to next token checklist.