### PR TITLE
Vala: add .vapi file extension detection

### DIFF
--- a/src/language_names.cpp
+++ b/src/language_names.cpp
@@ -56,6 +56,7 @@ struct lang_ext_t language_exts[] =
    { ".sqc",  "C"        },  // embedded SQL
    { ".sql",  "SQL"      },
    { ".vala", "VALA"     },
+   { ".vapi", "VALA"     },
 };
 
 

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2,7 +2,7 @@
 categories=General options|Spacing options|Indenting options|Newline adding and removing options|Blank line options|Positioning options|Line splitting options|Code alignment options (not left column spaces/tabs)|Comment modification options|Code modifying options (non-whitespace)|Preprocessor options|Sort includes options|Use or Do not Use options|Warn levels - 1: error, 2: warning (default), 3: note
 cfgFileParameterEnding=cr
 configFilename=uncrustify.cfg
-fileTypes=*.c|*.c++|*.cc|*.cp|*.cpp|*.cs|*.cxx|*.d|*.di|*.es|*.h|*.h++|*.hh|*.hp|*.hpp|*.hxx|*.inc|*.inl|*.java|*.js|*.m|*.mm|*.p|*.pawn|*.sma|*.sqc|*.sql|*.vala
+fileTypes=*.c|*.c++|*.cc|*.cp|*.cpp|*.cs|*.cxx|*.d|*.di|*.es|*.h|*.h++|*.hh|*.hp|*.hpp|*.hxx|*.inc|*.inl|*.java|*.js|*.m|*.mm|*.p|*.pawn|*.sma|*.sqc|*.sql|*.vala|*.vapi
 indenterFileName=uncrustify
 indenterName=Uncrustify (C, C++, C#, ObjectiveC, D, Java, Pawn, VALA)
 inputFileName=indentinput


### PR DESCRIPTION
Vala uses .vapi files for bindings: https://en.wikipedia.org/wiki/Vala_(programming_language)#Bindings