### PR TITLE
correct the float constant test

### DIFF
--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -15,6 +15,7 @@
 30003  cpp/ben_004.cfg                                      cpp/strings.cpp
 30004  cpp/Issue_4036.cfg                                   cpp/Issue_4036.cpp
 30005  common/empty.cfg                                     cpp/Issue_4042.cpp
+30006  common/empty.cfg                                     cpp/Issue_4027.cpp
 
 30010  cpp/ben_005.cfg                                      cpp/class.h
 30011  cpp/ben_006.cfg                                      cpp/misc.cpp

--- a/tests/expected/cpp/30006-Issue_4027.cpp
+++ b/tests/expected/cpp/30006-Issue_4027.cpp
@@ -1,0 +1,1 @@
+#define KK2 27F30

--- a/tests/input/cpp/Issue_4027.cpp
+++ b/tests/input/cpp/Issue_4027.cpp
@@ -1,0 +1,1 @@
+#define KK2 27F30


### PR DESCRIPTION
The character **F** was consider the condition to have a float constant.
It is not enought. A **dot** must appear before the **F**.
The proposed string _2F300000_ is a constant string.
Fixes #4027