### PR TITLE
correct token_is_within_trailing_return

### DIFF
--- a/src/space.cpp
+++ b/src/space.cpp
@@ -70,7 +70,8 @@ bool token_is_within_trailing_return(Chunk *pc)
          return(true);
       }
       else if (  prev->Is(CT_FPAREN_CLOSE)
-              || prev->Is(CT_FPAREN_OPEN))
+              || prev->Is(CT_FPAREN_OPEN)
+              || prev->Is(CT_SEMICOLON))                     // Issue #4080
       {
          return(false);
       }

--- a/tests/config/cpp/Issue_3220-ir.cfg
+++ b/tests/config/cpp/Issue_3220-ir.cfg
@@ -9,3 +9,4 @@ sp_before_ptr_star_trailing = ignore
 sp_before_unnamed_ptr_star  = ignore
 sp_between_ptr_star         = ignore
 sp_ptr_star_paren           = ignore
+sp_before_ptr_star          = ignore

--- a/tests/config/cpp/Issue_4080.cfg
+++ b/tests/config/cpp/Issue_4080.cfg
@@ -1,0 +1,1 @@
+sp_before_ptr_star = add

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -16,6 +16,7 @@
 30004  cpp/Issue_4036.cfg                                   cpp/Issue_4036.cpp
 30005  common/empty.cfg                                     cpp/Issue_4042.cpp
 30006  common/empty.cfg                                     cpp/Issue_4027.cpp
+30007  cpp/Issue_4080.cfg                                   cpp/Issue_4080.cpp
 
 30010  cpp/ben_005.cfg                                      cpp/class.h
 30011  cpp/ben_006.cfg                                      cpp/misc.cpp

--- a/tests/expected/cpp/30007-Issue_4080.cpp
+++ b/tests/expected/cpp/30007-Issue_4080.cpp
@@ -1,0 +1,6 @@
+auto foo() -> char;
+int *x;
+int *y;
+int reset();
+int *X;
+int *Y;

--- a/tests/expected/cpp/34508-Issue_3220.cpp
+++ b/tests/expected/cpp/34508-Issue_3220.cpp
@@ -1,6 +1,6 @@
-int*   b;
-auto Func2(Model*      model) -> Color                  *  *    const;
-auto Func2(Model*   model) -> Color   *   *        const {
+int *   b;
+auto Func2(Model    *      model) -> Color                  *  *    const;
+auto Func2(Model   *   model) -> Color   *   *        const {
         return nullptr;
 }
-int    *    Funcf(Model*   model, int*  *);
+int    *    Funcf(Model   *   model, int   *  *);

--- a/tests/input/cpp/Issue_4080.cpp
+++ b/tests/input/cpp/Issue_4080.cpp
@@ -1,0 +1,6 @@
+auto foo() -> char;
+int*x;
+int*y;
+int reset();
+int*X;
+int*Y;


### PR DESCRIPTION
take care of the semicolon.
Fixes #4080