### PR TITLE
Suppress clang warning with -Wno-deprecated-declarations.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
   endif()
   unset(gcc_warning_flags)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-deprecated-declarations")
 endif()
 
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
This will prevent warnings such as:
"warning: 'sprintf' is deprecated: This function is provided for
compatibility reasons only.  Due to security concerns inherent in the
design of sprintf(3), it is highly recommended that you use snprintf(3)
instead. [-Wdeprecated-declarations]"
