### PR TITLE
Reintroduce 'optiondocs' code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,10 @@ There are lots of ways to contribute to Uncrustify:
       Changes without tests should explain why tests are not present.
       (Changes that are non-functional, such as documentation changes,
       can usually omit tests without justification.)
+    - Any updates to `src/options.h`, including option descriptions, should be
+      accompanied by an update of the option documentation. This can be done by
+      building uncrustify and then running:
+      `./scripts/release_tool.py optiondocs path_to_uncrustify_binary`
 
 * Prepare a Pull Request (PR):
     - To reduce the likelihood of conflicts and test failures,

--- a/scripts/release_tool.py
+++ b/scripts/release_tool.py
@@ -82,13 +82,26 @@ def generate(repo, version, path, *args):
     import subprocess
 
     p = os.path.join(repo.working_tree_dir, path)
+
+    if version is None:
+        with open(p, 'r') as f:
+            content = f.read()
+            version = re.search(r'Uncrustify([a-z_]*)?-([0-9]+(\.[0-9]+)+(-[0-9]+)?)?(-?[0-9a-f]{6,})?', content)
+            if version:
+                version = version.group()
+            else:
+                version = 'Uncrustify'
+            version += "-dev"
+    else:
+        version = 'Uncrustify-{}'.format(version)
+
     with open(p, 'w') as f:
         c = subprocess.check_call(args, stdout=f)
     print('Created: {}'.format(path))
 
     alter(repo, path,
-          r'Uncrustify-[0-9.]+(-[0-9]+-[0-9a-f]+(-dirty)?)?',
-          r'Uncrustify-{}'.format(version))
+           r'Uncrustify([a-z_]*)?-([0-9]+(\.[0-9]+)+(-[0-9]+)?)?(-?[0-9a-f]{6,})?(-?dirty)?(-dev)?',
+           r'{}'.format(version))
 
 
 # -----------------------------------------------------------------------------
@@ -119,21 +132,33 @@ def cmd_init(repo, args):
 
 # -----------------------------------------------------------------------------
 def cmd_update(repo, args):
-    v = get_version_str(repo)
+    if args.keepversion:
+        print('Not updating version info in docs')
+        v = None
+    else:
+        v = get_version_str(repo)
     c = get_option_count(args.executable)
 
-    alter(repo, 'CMakeLists.txt',
-          r'(set *[(] *UNCRUSTIFY_VERSION +")[0-9.]+',
-          r'\g<1>{}'.format(v))
-    alter(repo, 'package.json',
-          r'("version" *): *"[0-9.]+"',
-          r'\g<1>: "{}"'.format(v))
-    alter(repo, 'README.md',
-          r'[0-9]+ configurable options as of version [0-9.]+',
-          r'{} configurable options as of version {}'.format(c, v))
-    alter(repo, 'documentation/htdocs/index.html',
-          r'[0-9]+ configurable options as of version [0-9.]+',
-          r'{} configurable options as of version {}'.format(c, v))
+    if not args.keepversion:
+        alter(repo, 'CMakeLists.txt',
+              r'(set *[(] *UNCRUSTIFY_VERSION +")[0-9.]+',
+              r'\g<1>{}'.format(v))
+        alter(repo, 'package.json',
+              r'("version" *): *"[0-9.]+"',
+              r'\g<1>: "{}"'.format(v))
+        alter(repo, 'README.md',
+              r'[0-9]+ configurable options as of version [0-9.]+',
+              r'{} configurable options as of version {}'.format(c, v))
+        alter(repo, 'documentation/htdocs/index.html',
+              r'[0-9]+ configurable options as of version [0-9.]+',
+              r'{} configurable options as of version {}'.format(c, v))
+    else:
+        alter(repo, 'README.md',
+              r'[0-9]+ configurable options as of version ',
+              r'{} configurable options as of version '.format(c))
+        alter(repo, 'documentation/htdocs/index.html',
+              r'[0-9]+ configurable options as of version ',
+              r'{} configurable options as of version '.format(c))
 
     generate(repo, v, 'etc/defaults.cfg',
              args.executable, '--show-config')
@@ -144,6 +169,15 @@ def cmd_update(repo, args):
     generate(repo, v, 'etc/uigui_uncrustify.ini',
              args.executable, '--universalindent')
 
+    # For 'optiondocs' command, update universalindent.cfg also, since
+    # unit tests verify it.
+    if args.keepversion:
+        # Needs to be kept in sync with test_cli_options.py
+        generate(repo, v, 'tests/cli/output/universalindent.cfg',
+                 args.executable, '--universalindent')
+        alter(repo, 'tests/cli/output/universalindent.cfg',
+              r'(version=U.+)|(\(\d+\))|(\r)',
+              r'');
 
 # -----------------------------------------------------------------------------
 def cmd_commit(repo, args):
@@ -232,8 +266,14 @@ def main():
                              help='version number for release')
 
     parser_update = subparsers.add_parser(
+        'optiondocs', help='update documentation from options')
+    parser_update.set_defaults(func=cmd_update, keepversion=True)
+    parser_update.add_argument('executable',
+                               help='path to uncrustify executable')
+
+    parser_update = subparsers.add_parser(
         'update', help='update version information')
-    parser_update.set_defaults(func=cmd_update, keepversion=False)
+    parser_update.set_defaults(func=cmd_update)
     parser_update.add_argument('executable',
                                help='path to uncrustify executable')
 


### PR DESCRIPTION
This was initially added in commit 3ec19877 and mistakenly removed in commit cdf5de39