### PR TITLE
Make uncrustify respect the -q flag.

### DIFF
--- a/src/uncrustify.h
+++ b/src/uncrustify.h
@@ -16,7 +16,7 @@
 int load_header_files();
 
 
-void uncrustify_file(const file_mem &fm, FILE *pfout, const char *parsed_file, const char *dump_filename, bool defer_uncrustify_end = false);
+void uncrustify_file(const file_mem &fm, FILE *pfout, const char *parsed_file, const char *dump_filename, bool is_quiet, bool defer_uncrustify_end = false);
 
 
 void uncrustify_end();


### PR DESCRIPTION
The -q flag is supposed make uncrustify quiet, yet uncrustify still
prints "PASS: grid.c (32140 bytes)". This PR fixes that so uncrustify is
silent if the check passes, but not if it fails as it's likely the
wanted behavior.
