### PR TITLE
Fix issue #4122

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1854,10 +1854,22 @@ static Chunk *output_comment_c(Chunk *first)
       cmt.cont_text = options::cmt_star_cont() ? " * " : "   ";
       LOG_CONTTEXT();
 
-      log_rule_B("cmt_trailing_single_line_c_to_cpp");
+      bool replace_comment = (options::cmt_trailing_single_line_c_to_cpp() && first->IsLastChunkOnLine());
 
-      if (options::cmt_trailing_single_line_c_to_cpp() && first->IsLastChunkOnLine())
+      if (  replace_comment
+         && first->TestFlags(PCF_IN_PREPROC))
       {
+         // Do not replace a single line comment if we are inside a #define line
+         if (first->GetPpStart()->GetParentType() == CT_PP_DEFINE)
+         {
+            replace_comment = false;
+         }
+      }
+
+      if (replace_comment)
+      {
+         log_rule_B("cmt_trailing_single_line_c_to_cpp");
+
          add_text("//");
 
          UncText tmp;

--- a/tests/c.test
+++ b/tests/c.test
@@ -146,6 +146,7 @@
 00305  c/ben_081.cfg                              c/one-liner-define.c
 
 00310  common/empty.cfg                           c/sp_embed_comment.c
+00311  c/comment_conversion.cfg                   c/comment_conversion.c
 
 00320  c/rdan.cfg                                 c/indent_first_bool_expr.c
 

--- a/tests/config/c/comment_conversion.cfg
+++ b/tests/config/c/comment_conversion.cfg
@@ -1,0 +1,1 @@
+cmt_trailing_single_line_c_to_cpp = true

--- a/tests/expected/c/00311-comment_conversion.c
+++ b/tests/expected/c/00311-comment_conversion.c
@@ -1,0 +1,24 @@
+#define HDROFF_TYPE(b)      sizeof(ElfPreHeader)             /* ElfXX_Half  e_type; */
+
+typedef struct _libr_file
+{
+	unsigned int version;
+} libr_file;
+
+#define HDROFF_TYPE(b)      sizeof(    /* ElfXX_Half  e_type; */    \
+		ElfPreHeader /* ElfXX_Half  e_type; */ \
+		) /* Repeat ElfXX_Half  e_type; */
+
+// ElfXX_Half  e_shstrndx;
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS  // TEST
+
+// Do something
+void foo()
+{
+	// comment
+	int i = 0;
+}
+
+#endif
+

--- a/tests/input/c/comment_conversion.c
+++ b/tests/input/c/comment_conversion.c
@@ -1,0 +1,24 @@
+#define HDROFF_TYPE(b)      sizeof(ElfPreHeader)             /* ElfXX_Half  e_type; */
+
+typedef struct _libr_file
+{
+  unsigned int  version;
+} libr_file;
+
+#define HDROFF_TYPE(b)      sizeof(    /* ElfXX_Half  e_type; */    \
+		ElfPreHeader /* ElfXX_Half  e_type; */ \
+		) /* Repeat ElfXX_Half  e_type; */
+
+/* ElfXX_Half  e_shstrndx; */
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS  /* TEST */
+
+/* Do something */
+void foo()
+{
+	/* comment */
+	int i = 0;
+}
+
+#endif
+


### PR DESCRIPTION
Single line trailing comments in #define will no longer be converted, to avoid possible FTBFS in the resulting code.