### PR TITLE
Introduce option 'align_func_proto_span_ignore_cont_lines'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 A source code beautifier for C, C++, C#, Objective-C, D, Java, Pawn and Vala.
 
 ## Features
-* Highly configurable - 849 configurable options as of version 0.77.1
+* Highly configurable - 850 configurable options as of version 0.77.1
 - <details><summary>add/remove spaces</summary>
 
   - `sp_before_sparen`: _Add or remove space before '(' of 'if', 'for', 'switch', 'while', etc._

--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -2868,6 +2868,13 @@ align_right_cmt_at_col          = 0        # unsigned number
 # 0: Don't align (default).
 align_func_proto_span           = 0        # unsigned number
 
+# Whether to ignore continuation lines when evaluating the number of
+# new lines for the function prototype alignment's span.
+#
+# false: continuation lines are part of the newlines count
+# true:  continuation lines are not counted
+align_func_proto_span_ignore_cont_lines = false    # true/false
+
 # How to consider (or treat) the '*' in the alignment of function prototypes.
 #
 # 0: Part of the type     'void *   foo();' (default)

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -2868,6 +2868,13 @@ align_right_cmt_at_col          = 0        # unsigned number
 # 0: Don't align (default).
 align_func_proto_span           = 0        # unsigned number
 
+# Whether to ignore continuation lines when evaluating the number of
+# new lines for the function prototype alignment's span.
+#
+# false: continuation lines are part of the newlines count
+# true:  continuation lines are not counted
+align_func_proto_span_ignore_cont_lines = false    # true/false
+
 # How to consider (or treat) the '*' in the alignment of function prototypes.
 #
 # 0: Part of the type     'void *   foo();' (default)

--- a/documentation/htdocs/index.html
+++ b/documentation/htdocs/index.html
@@ -54,7 +54,7 @@ Create a highly configurable, easily modifiable source code beautifier.</p>
    <li>Add or remove parens on return statements</li>
    <li>Add or remove braces on single-statement if/do/while/for statements</li>
    <li>Supports embedded SQL 'EXEC SQL' stuff</li>
-   <li>Highly configurable - 849 configurable options as of version 0.77.1</li>
+   <li>Highly configurable - 850 configurable options as of version 0.77.1</li>
 </ul>
 
 <p>

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -2868,6 +2868,13 @@ align_right_cmt_at_col          = 0        # unsigned number
 # 0: Don't align (default).
 align_func_proto_span           = 0        # unsigned number
 
+# Whether to ignore continuation lines when evaluating the number of
+# new lines for the function prototype alignment's span.
+#
+# false: continuation lines are part of the newlines count
+# true:  continuation lines are not counted
+align_func_proto_span_ignore_cont_lines = false    # true/false
+
 # How to consider (or treat) the '*' in the alignment of function prototypes.
 #
 # 0: Part of the type     'void *   foo();' (default)

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -6289,6 +6289,14 @@ MinVal=0
 MaxVal=5000
 ValueDefault=0
 
+[Align Func Proto Span Ignore Cont Lines]
+Category=7
+Description="<html>Whether to ignore continuation lines when evaluating the number of<br/>new lines for the function prototype alignment's span.<br/><br/>false: continuation lines are part of the newlines count<br/>true:  continuation lines are not counted</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=align_func_proto_span_ignore_cont_lines=true|align_func_proto_span_ignore_cont_lines=false
+ValueDefault=false
+
 [Align Func Proto Star Style]
 Category=7
 Description="<html>How to consider (or treat) the '*' in the alignment of function prototypes.<br/><br/>0: Part of the type     'void *   foo();' (default)<br/>1: Part of the function 'void     *foo();'<br/>2: Dangling             'void    *foo();'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"

--- a/src/align_tools.cpp
+++ b/src/align_tools.cpp
@@ -180,15 +180,10 @@ void ib_shift_out(size_t idx, size_t num)
 
 Chunk *step_back_over_member(Chunk *pc)
 {
-   if (pc->IsNullChunk())
-   {
-      pc = Chunk::NullChunkPtr;
-   }
    Chunk *tmp = pc->GetPrevNcNnl();
 
    // Skip over any class stuff: bool CFoo::bar()
-   while (  tmp->IsNotNullChunk()
-         && tmp->Is(CT_DC_MEMBER))
+   while (tmp->Is(CT_DC_MEMBER))
    {
       pc  = tmp->GetPrevNcNnl();
       tmp = pc->GetPrevNcNnl();

--- a/src/options.h
+++ b/src/options.h
@@ -3512,6 +3512,14 @@ align_right_cmt_at_col;
 extern BoundedOption<unsigned, 0, 5000>
 align_func_proto_span;
 
+// Whether to ignore continuation lines when evaluating the number of
+// new lines for the function prototype alignment's span.
+//
+// false: continuation lines are part of the newlines count
+// true:  continuation lines are not counted
+extern Option<bool>
+align_func_proto_span_ignore_cont_lines; // = false
+
 // How to consider (or treat) the '*' in the alignment of function prototypes.
 //
 // 0: Part of the type     'void *   foo();' (default)

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -33,17 +33,6 @@ using namespace uncrustify;
 
 
 /**
- * Decides how to change inter-chunk spacing.
- * Note that the order of the if statements is VERY important.
- *
- * @param first   The first chunk
- * @param second  The second chunk
- *
- * @return IARF_IGNORE, IARF_ADD, IARF_REMOVE or IARF_FORCE
- */
-static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp);
-
-/**
  * Ensure to force the space between the \a first and the \a second chunks
  * if the PCF_FORCE_SPACE flag is set in the \a first.
  *
@@ -84,15 +73,23 @@ bool token_is_within_trailing_return(Chunk *pc)
 } // token_is_within_trailing_return
 
 
-/*
- * this function is called for every chunk in the input file.
- * Thus it is important to keep this function efficient
+/**
+ * Decides how to change inter-chunk spacing.
+ * Note that the order of the if statements is VERY important.
+ *
+ * @param first   The first chunk
+ * @param second  The second chunk
+ *
+ * @return IARF_IGNORE, IARF_ADD, IARF_REMOVE or IARF_FORCE
+ *
+ * This function is called for every chunk in the input file,
+ * thus it is important to keep this function efficient
  */
 static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
 {
    LOG_FUNC_ENTRY();
 
-   LOG_FMT(LSPACE, "%s(%d): orig line is %zu, orig col is %zu, first Text() '%s', type is %s\n",
+   LOG_FMT(LSPACE, "%s(%d): orig line %zu, orig col %zu, first text '%s', type %s\n",
            __func__, __LINE__, first->GetOrigLine(), first->GetOrigCol(), first->Text(), get_token_name(first->GetType()));
 
    min_sp = 1;
@@ -3472,7 +3469,7 @@ static iarf_e ensure_force_space(Chunk *first, Chunk *second, iarf_e av)
 {
    if (first->TestFlags(PCF_FORCE_SPACE))
    {
-      LOG_FMT(LSPACE, "%s(%d): <force between '%s' and '%s'>\n",
+      LOG_FMT(LSPACE, "%s(%d): force between '%s' and '%s'\n",
               __func__, __LINE__, first->Text(), second->Text());
       return(av | IARF_ADD);
    }
@@ -3482,9 +3479,7 @@ static iarf_e ensure_force_space(Chunk *first, Chunk *second, iarf_e av)
 
 static iarf_e do_space_ensured(Chunk *first, Chunk *second, int &min_sp)
 {
-   iarf_e aa = ensure_force_space(first, second, do_space(first, second, min_sp));
-
-   return(aa);
+   return(ensure_force_space(first, second, do_space(first, second, min_sp)));
 }
 
 
@@ -3892,11 +3887,11 @@ size_t space_col_align(Chunk *first, Chunk *second)
 {
    LOG_FUNC_ENTRY();
 
-   LOG_FMT(LSPACE, "%s(%d): first orig line is %zu, orig col is %zu, [%s/%s], Text() '%s' <==>\n",
+   LOG_FMT(LSPACE, "%s(%d): 1st orig line %zu, orig col %zu, [%s/%s], text '%s' <==>\n",
            __func__, __LINE__, first->GetOrigLine(), first->GetOrigCol(),
            get_token_name(first->GetType()), get_token_name(first->GetParentType()),
            first->Text());
-   LOG_FMT(LSPACE, "%s(%d): second orig line is %zu, orig col is %zu [%s/%s], Text() '%s',",
+   LOG_FMT(LSPACE, "%s(%d): 2nd orig line %zu, orig col %zu, [%s/%s], text '%s'\n",
            __func__, __LINE__, second->GetOrigLine(), second->GetOrigCol(),
            get_token_name(second->GetType()), get_token_name(second->GetParentType()),
            second->Text());
@@ -3908,14 +3903,15 @@ size_t space_col_align(Chunk *first, Chunk *second)
    LOG_FMT(LSPACE, "%s(%d): av is %s\n", __func__, __LINE__, to_string(av));
    size_t coldiff;
 
-   if (first->GetNlCount())
+   if (first->GetNlCount() > 0)
    {
-      LOG_FMT(LSPACE, "%s(%d):    new line count is %zu, orig col end is %zu\n", __func__, __LINE__, first->GetNlCount(), first->GetOrigColEnd());
+      LOG_FMT(LSPACE, "%s(%d):    new line count %zu, orig col end %zu\n",
+              __func__, __LINE__, first->GetNlCount(), first->GetOrigColEnd());
       coldiff = first->GetOrigColEnd() - 1;
    }
    else
    {
-      LOG_FMT(LSPACE, "%s(%d):    Len is %zu\n", __func__, __LINE__, first->Len());
+      LOG_FMT(LSPACE, "%s(%d):    '1st' len is %zu\n", __func__, __LINE__, first->Len());
       coldiff = first->Len();
    }
    LOG_FMT(LSPACE, "%s(%d):    => coldiff is %zu\n", __func__, __LINE__, coldiff);
@@ -3938,11 +3934,11 @@ size_t space_col_align(Chunk *first, Chunk *second)
    case IARF_IGNORE:                // Issue #2064
       LOG_FMT(LSPACE, "%s(%d):    => first orig line  is %zu\n", __func__, __LINE__, first->GetOrigLine());
       LOG_FMT(LSPACE, "%s(%d):    => second orig line is %zu\n", __func__, __LINE__, second->GetOrigLine());
-      LOG_FMT(LSPACE, "%s(%d):    => first Text()     is '%s'\n", __func__, __LINE__, first->Text());
-      LOG_FMT(LSPACE, "%s(%d):    => second Text()    is '%s'\n", __func__, __LINE__, second->Text());
+      LOG_FMT(LSPACE, "%s(%d):    => first text       is '%s'\n", __func__, __LINE__, first->Text());
+      LOG_FMT(LSPACE, "%s(%d):    => second text      is '%s'\n", __func__, __LINE__, second->Text());
       LOG_FMT(LSPACE, "%s(%d):    => first orig col   is %zu\n", __func__, __LINE__, first->GetOrigCol());
       LOG_FMT(LSPACE, "%s(%d):    => second orig col  is %zu\n", __func__, __LINE__, second->GetOrigCol());
-      LOG_FMT(LSPACE, "%s(%d):    => first Len()      is %zu\n", __func__, __LINE__, first->Len());
+      LOG_FMT(LSPACE, "%s(%d):    => first len        is %zu\n", __func__, __LINE__, first->Len());
 
       if (  first->GetOrigLine() == second->GetOrigLine()
          && second->GetOrigCol() > (first->GetOrigCol() + first->Len()))

--- a/tests/c.test
+++ b/tests/c.test
@@ -54,6 +54,7 @@
 00072  common/star_pos-0.cfg                      c/align-proto.c
 00073  common/empty.cfg                           c/nl_proto_endif.c
 00074  c/clang-has_include.cfg                    c/clang-has_include.h
+00075  common/tde.cfg                             c/function_prototypes_alignment.c
 00076  c/1225.cfg                                 c/1225.c
 
 00081  c/else-if-1.cfg                            c/else-if.c

--- a/tests/cli/output/66.txt
+++ b/tests/cli/output/66.txt
@@ -1,34 +1,34 @@
 space_text : orig line is 1, orig col is 1, 'struct' type is STRUCT
 space_text : back-to-back words need a space: pc->Text() 'struct', next->Text() 'TelegramIndex'
 space_text : orig line is 1, orig col is 1, pc-Text() 'struct', type is STRUCT
-do_space : orig line is 1, orig col is 1, first Text() 'struct', type is STRUCT
+do_space : orig line 1, orig col 1, first text 'struct', type STRUCT
 do_space : first orig line is 1, orig col is 1, Text() is 'struct', [STRUCT/NONE] <===>
            second orig line is 1, orig col is 8, Text() is 'TelegramIndex', [TYPE/STRUCT] : rule ADD from add_space_table @ 236.[ ]
-ensure_force_space : <force between 'struct' and 'TelegramIndex'>
+ensure_force_space : force between 'struct' and 'TelegramIndex'
 space_text : orig line is 1, orig col is 1, pc-Text() 'struct', type is STRUCT
 space_text :    rule = ADD @ 1 => 8
 space_text : orig line is 1, orig col is 8, 'TelegramIndex' type is TYPE
 space_text : orig line is 1, orig col is 8, pc-Text() 'TelegramIndex', type is TYPE
-do_space : orig line is 1, orig col is 8, first Text() 'TelegramIndex', type is TYPE
+do_space : orig line 1, orig col 8, first text 'TelegramIndex', type TYPE
 space_text : orig line is 1, orig col is 8, pc-Text() 'TelegramIndex', type is TYPE
 space_text :    rule = REMOVE @ 0 => 21
 space_text : orig line is 1, orig col is 21, <Newline>, nl is 1
 space_text : orig line is 2, orig col is 1, '{' type is BRACE_OPEN
 space_text : orig line is 2, orig col is 1, pc-Text() '{', type is BRACE_OPEN
-do_space : orig line is 2, orig col is 1, first Text() '{', type is BRACE_OPEN
+do_space : orig line 2, orig col 1, first text '{', type BRACE_OPEN
 space_text : orig line is 2, orig col is 1, pc-Text() '{', type is BRACE_OPEN
 space_text :    rule = REMOVE @ 0 => 2
 space_text : orig line is 2, orig col is 2, <Newline>, nl is 1
 space_text : orig line is 3, orig col is 1, 'TelegramIndex' type is FUNC_CLASS_DEF
 space_text : orig line is 3, orig col is 1, pc-Text() 'TelegramIndex', type is FUNC_CLASS_DEF
-do_space : orig line is 3, orig col is 1, first Text() 'TelegramIndex', type is FUNC_CLASS_DEF
+do_space : orig line 3, orig col 1, first text 'TelegramIndex', type FUNC_CLASS_DEF
 do_space : first orig line is 3, orig col is 1, Text() is 'TelegramIndex', [FUNC_CLASS_DEF/NONE] <===>
            second orig line is 3, orig col is 14, Text() is '(', [FPAREN_OPEN/FUNC_CLASS_DEF] : rule sp_func_class_paren[ ]
 space_text : orig line is 3, orig col is 1, pc-Text() 'TelegramIndex', type is FUNC_CLASS_DEF
 space_text :    rule = IGNORE @ 0 => 14
 space_text : orig line is 3, orig col is 14, '(' type is FPAREN_OPEN
 space_text : orig line is 3, orig col is 14, pc-Text() '(', type is FPAREN_OPEN
-do_space : orig line is 3, orig col is 14, first Text() '(', type is FPAREN_OPEN
+do_space : orig line 3, orig col 14, first text '(', type FPAREN_OPEN
 do_space : first orig line is 3, orig col is 14, Text() is '(', [FPAREN_OPEN/FUNC_CLASS_DEF] <===>
            second orig line is 3, orig col is 15, Text() is 'const', [QUALIFIER/NONE] : rule sp_inside_fparen[ ]
 space_text : orig line is 3, orig col is 14, pc-Text() '(', type is FPAREN_OPEN
@@ -36,36 +36,36 @@ space_text :    rule = IGNORE @ 0 => 15
 space_text : orig line is 3, orig col is 15, 'const' type is QUALIFIER
 space_text : back-to-back words need a space: pc->Text() 'const', next->Text() 'char'
 space_text : orig line is 3, orig col is 15, pc-Text() 'const', type is QUALIFIER
-do_space : orig line is 3, orig col is 15, first Text() 'const', type is QUALIFIER
+do_space : orig line 3, orig col 15, first text 'const', type QUALIFIER
 do_space : first orig line is 3, orig col is 15, Text() is 'const', [QUALIFIER/NONE] <===>
            second orig line is 3, orig col is 21, Text() is 'char', [TYPE/NONE] : rule sp_after_type[ ]
-ensure_force_space : <force between 'const' and 'char'>
+ensure_force_space : force between 'const' and 'char'
 space_text : orig line is 3, orig col is 15, pc-Text() 'const', type is QUALIFIER
 space_text :    rule = FORCE @ 1 => 21
 space_text : orig line is 3, orig col is 21, 'char' type is TYPE
 space_text : orig line is 3, orig col is 21, pc-Text() 'char', type is TYPE
-do_space : orig line is 3, orig col is 21, first Text() 'char', type is TYPE
+do_space : orig line 3, orig col 21, first text 'char', type TYPE
 do_space : first orig line is 3, orig col is 21, Text() is 'char', [TYPE/NONE] <===>
            second orig line is 3, orig col is 25, Text() is '*', [PTR_TYPE/NONE] : rule IGNORE[ ]
 space_text : orig line is 3, orig col is 21, pc-Text() 'char', type is TYPE
 space_text :    rule = IGNORE @ 0 => 25
 space_text : orig line is 3, orig col is 25, '*' type is PTR_TYPE
 space_text : orig line is 3, orig col is 25, pc-Text() '*', type is PTR_TYPE
-do_space : orig line is 3, orig col is 25, first Text() '*', type is PTR_TYPE
+do_space : orig line 3, orig col 25, first text '*', type PTR_TYPE
 do_space : first orig line is 3, orig col is 25, Text() is '*', [PTR_TYPE/NONE] <===>
            second orig line is 3, orig col is 27, Text() is 'pN', [WORD/NONE] : rule sp_after_ptr_star[ ]
 space_text : orig line is 3, orig col is 25, pc-Text() '*', type is PTR_TYPE
 space_text :    rule = IGNORE @ 1 => 27
 space_text : orig line is 3, orig col is 27, 'pN' type is WORD
 space_text : orig line is 3, orig col is 27, pc-Text() 'pN', type is WORD
-do_space : orig line is 3, orig col is 27, first Text() 'pN', type is WORD
+do_space : orig line 3, orig col 27, first text 'pN', type WORD
 do_space : first orig line is 3, orig col is 27, Text() is 'pN', [WORD/NONE] <===>
            second orig line is 3, orig col is 29, Text() is ',', [COMMA/NONE] : rule sp_before_comma[ ]
 space_text : orig line is 3, orig col is 27, pc-Text() 'pN', type is WORD
 space_text :    rule = REMOVE @ 0 => 29
 space_text : orig line is 3, orig col is 29, ',' type is COMMA
 space_text : orig line is 3, orig col is 29, pc-Text() ',', type is COMMA
-do_space : orig line is 3, orig col is 29, first Text() ',', type is COMMA
+do_space : orig line 3, orig col 29, first text ',', type COMMA
 do_space : first orig line is 3, orig col is 29, Text() is ',', [COMMA/NONE] <===>
            second orig line is 3, orig col is 31, Text() is 'unsigned', [TYPE/NONE] : rule sp_after_comma[ ]
 space_text : orig line is 3, orig col is 29, pc-Text() ',', type is COMMA
@@ -73,172 +73,172 @@ space_text :    rule = IGNORE @ 1 => 31
 space_text : orig line is 3, orig col is 31, 'unsigned' type is TYPE
 space_text : back-to-back words need a space: pc->Text() 'unsigned', next->Text() 'long'
 space_text : orig line is 3, orig col is 31, pc-Text() 'unsigned', type is TYPE
-do_space : orig line is 3, orig col is 31, first Text() 'unsigned', type is TYPE
+do_space : orig line 3, orig col 31, first text 'unsigned', type TYPE
 do_space : first orig line is 3, orig col is 31, Text() is 'unsigned', [TYPE/NONE] <===>
            second orig line is 3, orig col is 40, Text() is 'long', [TYPE/NONE] : rule sp_after_type[ ]
-ensure_force_space : <force between 'unsigned' and 'long'>
+ensure_force_space : force between 'unsigned' and 'long'
 space_text : orig line is 3, orig col is 31, pc-Text() 'unsigned', type is TYPE
 space_text :    rule = FORCE @ 1 => 40
 space_text : orig line is 3, orig col is 40, 'long' type is TYPE
 space_text : back-to-back words need a space: pc->Text() 'long', next->Text() 'nI'
 space_text : orig line is 3, orig col is 40, pc-Text() 'long', type is TYPE
-do_space : orig line is 3, orig col is 40, first Text() 'long', type is TYPE
+do_space : orig line 3, orig col 40, first text 'long', type TYPE
 do_space : first orig line is 3, orig col is 40, Text() is 'long', [TYPE/NONE] <===>
            second orig line is 3, orig col is 45, Text() is 'nI', [WORD/NONE] : rule sp_after_type[ ]
-ensure_force_space : <force between 'long' and 'nI'>
+ensure_force_space : force between 'long' and 'nI'
 space_text : orig line is 3, orig col is 40, pc-Text() 'long', type is TYPE
 space_text :    rule = FORCE @ 1 => 45
 space_text : orig line is 3, orig col is 45, 'nI' type is WORD
 space_text : orig line is 3, orig col is 45, pc-Text() 'nI', type is WORD
-do_space : orig line is 3, orig col is 45, first Text() 'nI', type is WORD
+do_space : orig line 3, orig col 45, first text 'nI', type WORD
 do_space : first orig line is 3, orig col is 45, Text() is 'nI', [WORD/NONE] <===>
            second orig line is 3, orig col is 47, Text() is ')', [FPAREN_CLOSE/FUNC_CLASS_DEF] : rule sp_inside_fparen[ ]
 space_text : orig line is 3, orig col is 45, pc-Text() 'nI', type is WORD
 space_text :    rule = IGNORE @ 0 => 47
 space_text : orig line is 3, orig col is 47, ')' type is FPAREN_CLOSE
 space_text : orig line is 3, orig col is 47, pc-Text() ')', type is FPAREN_CLOSE
-do_space : orig line is 3, orig col is 47, first Text() ')', type is FPAREN_CLOSE
+do_space : orig line 3, orig col 47, first text ')', type FPAREN_CLOSE
 do_space : first orig line is 3, orig col is 47, Text() is ')', [FPAREN_CLOSE/FUNC_CLASS_DEF] <===>
            second orig line is 3, orig col is 49, Text() is ':', [CONSTR_COLON/NONE] : rule sp_before_constr_colon[ ]
 space_text : orig line is 3, orig col is 47, pc-Text() ')', type is FPAREN_CLOSE
 space_text :    rule = ADD @ 1 => 49
 space_text : orig line is 3, orig col is 49, ':' type is CONSTR_COLON
 space_text : orig line is 3, orig col is 49, pc-Text() ':', type is CONSTR_COLON
-do_space : orig line is 3, orig col is 49, first Text() ':', type is CONSTR_COLON
+do_space : orig line 3, orig col 49, first text ':', type CONSTR_COLON
 space_text : orig line is 3, orig col is 49, pc-Text() ':', type is CONSTR_COLON
 space_text :    rule = REMOVE @ 0 => 50
 space_text : orig line is 3, orig col is 50, <Newline>, nl is 1
 space_text : orig line is 4, orig col is 1, 'pTelName' type is FUNC_CTOR_VAR
 space_text : orig line is 4, orig col is 1, pc-Text() 'pTelName', type is FUNC_CTOR_VAR
-do_space : orig line is 4, orig col is 1, first Text() 'pTelName', type is FUNC_CTOR_VAR
+do_space : orig line 4, orig col 1, first text 'pTelName', type FUNC_CTOR_VAR
 do_space : first orig line is 4, orig col is 1, Text() is 'pTelName', [FUNC_CTOR_VAR/NONE] <===>
            second orig line is 4, orig col is 9, Text() is '(', [FPAREN_OPEN/FUNC_CTOR_VAR] : rule sp_func_call_paren[ ]
 space_text : orig line is 4, orig col is 1, pc-Text() 'pTelName', type is FUNC_CTOR_VAR
 space_text :    rule = IGNORE @ 0 => 9
 space_text : orig line is 4, orig col is 9, '(' type is FPAREN_OPEN
 space_text : orig line is 4, orig col is 9, pc-Text() '(', type is FPAREN_OPEN
-do_space : orig line is 4, orig col is 9, first Text() '(', type is FPAREN_OPEN
+do_space : orig line 4, orig col 9, first text '(', type FPAREN_OPEN
 do_space : first orig line is 4, orig col is 9, Text() is '(', [FPAREN_OPEN/FUNC_CTOR_VAR] <===>
            second orig line is 4, orig col is 10, Text() is 'pN', [WORD/NONE] : rule sp_inside_fparen[ ]
 space_text : orig line is 4, orig col is 9, pc-Text() '(', type is FPAREN_OPEN
 space_text :    rule = IGNORE @ 0 => 10
 space_text : orig line is 4, orig col is 10, 'pN' type is WORD
 space_text : orig line is 4, orig col is 10, pc-Text() 'pN', type is WORD
-do_space : orig line is 4, orig col is 10, first Text() 'pN', type is WORD
+do_space : orig line 4, orig col 10, first text 'pN', type WORD
 do_space : first orig line is 4, orig col is 10, Text() is 'pN', [WORD/NONE] <===>
            second orig line is 4, orig col is 12, Text() is ')', [FPAREN_CLOSE/FUNC_CTOR_VAR] : rule sp_inside_fparen[ ]
 space_text : orig line is 4, orig col is 10, pc-Text() 'pN', type is WORD
 space_text :    rule = IGNORE @ 0 => 12
 space_text : orig line is 4, orig col is 12, ')' type is FPAREN_CLOSE
 space_text : orig line is 4, orig col is 12, pc-Text() ')', type is FPAREN_CLOSE
-do_space : orig line is 4, orig col is 12, first Text() ')', type is FPAREN_CLOSE
+do_space : orig line 4, orig col 12, first text ')', type FPAREN_CLOSE
 do_space : first orig line is 4, orig col is 12, Text() is ')', [FPAREN_CLOSE/FUNC_CTOR_VAR] <===>
            second orig line is 4, orig col is 13, Text() is ',', [COMMA/NONE] : rule sp_before_comma[ ]
 space_text : orig line is 4, orig col is 12, pc-Text() ')', type is FPAREN_CLOSE
 space_text :    rule = REMOVE @ 0 => 13
 space_text : orig line is 4, orig col is 13, ',' type is COMMA
 space_text : orig line is 4, orig col is 13, pc-Text() ',', type is COMMA
-do_space : orig line is 4, orig col is 13, first Text() ',', type is COMMA
+do_space : orig line 4, orig col 13, first text ',', type COMMA
 space_text : orig line is 4, orig col is 13, pc-Text() ',', type is COMMA
 space_text :    rule = REMOVE @ 0 => 14
 space_text : orig line is 4, orig col is 14, <Newline>, nl is 1
 space_text : orig line is 5, orig col is 1, 'nTelIndex' type is FUNC_CTOR_VAR
 space_text : orig line is 5, orig col is 1, pc-Text() 'nTelIndex', type is FUNC_CTOR_VAR
-do_space : orig line is 5, orig col is 1, first Text() 'nTelIndex', type is FUNC_CTOR_VAR
+do_space : orig line 5, orig col 1, first text 'nTelIndex', type FUNC_CTOR_VAR
 do_space : first orig line is 5, orig col is 1, Text() is 'nTelIndex', [FUNC_CTOR_VAR/NONE] <===>
            second orig line is 5, orig col is 10, Text() is '(', [FPAREN_OPEN/FUNC_CTOR_VAR] : rule sp_func_call_paren[ ]
 space_text : orig line is 5, orig col is 1, pc-Text() 'nTelIndex', type is FUNC_CTOR_VAR
 space_text :    rule = IGNORE @ 0 => 10
 space_text : orig line is 5, orig col is 10, '(' type is FPAREN_OPEN
 space_text : orig line is 5, orig col is 10, pc-Text() '(', type is FPAREN_OPEN
-do_space : orig line is 5, orig col is 10, first Text() '(', type is FPAREN_OPEN
+do_space : orig line 5, orig col 10, first text '(', type FPAREN_OPEN
 do_space : first orig line is 5, orig col is 10, Text() is '(', [FPAREN_OPEN/FUNC_CTOR_VAR] <===>
            second orig line is 5, orig col is 11, Text() is 'n', [WORD/NONE] : rule sp_inside_fparen[ ]
 space_text : orig line is 5, orig col is 10, pc-Text() '(', type is FPAREN_OPEN
 space_text :    rule = IGNORE @ 0 => 11
 space_text : orig line is 5, orig col is 11, 'n' type is WORD
 space_text : orig line is 5, orig col is 11, pc-Text() 'n', type is WORD
-do_space : orig line is 5, orig col is 11, first Text() 'n', type is WORD
+do_space : orig line 5, orig col 11, first text 'n', type WORD
 do_space : first orig line is 5, orig col is 11, Text() is 'n', [WORD/NONE] <===>
            second orig line is 5, orig col is 12, Text() is ')', [FPAREN_CLOSE/FUNC_CTOR_VAR] : rule sp_inside_fparen[ ]
 space_text : orig line is 5, orig col is 11, pc-Text() 'n', type is WORD
 space_text :    rule = IGNORE @ 0 => 12
 space_text : orig line is 5, orig col is 12, ')' type is FPAREN_CLOSE
 space_text : orig line is 5, orig col is 12, pc-Text() ')', type is FPAREN_CLOSE
-do_space : orig line is 5, orig col is 12, first Text() ')', type is FPAREN_CLOSE
+do_space : orig line 5, orig col 12, first text ')', type FPAREN_CLOSE
 space_text : orig line is 5, orig col is 12, pc-Text() ')', type is FPAREN_CLOSE
 space_text :    rule = REMOVE @ 0 => 13
 space_text : orig line is 5, orig col is 13, <Newline>, nl is 1
 space_text : orig line is 6, orig col is 1, '{' type is BRACE_OPEN
 space_text : orig line is 6, orig col is 1, pc-Text() '{', type is BRACE_OPEN
-do_space : orig line is 6, orig col is 1, first Text() '{', type is BRACE_OPEN
+do_space : orig line 6, orig col 1, first text '{', type BRACE_OPEN
 space_text : orig line is 6, orig col is 1, pc-Text() '{', type is BRACE_OPEN
 space_text :    rule = REMOVE @ 0 => 2
 space_text : orig line is 6, orig col is 2, <Newline>, nl is 1
 space_text : orig line is 7, orig col is 1, '}' type is BRACE_CLOSE
 space_text : orig line is 7, orig col is 1, pc-Text() '}', type is BRACE_CLOSE
-do_space : orig line is 7, orig col is 1, first Text() '}', type is BRACE_CLOSE
+do_space : orig line 7, orig col 1, first text '}', type BRACE_CLOSE
 space_text : orig line is 7, orig col is 1, pc-Text() '}', type is BRACE_CLOSE
 space_text :    rule = REMOVE @ 0 => 2
 space_text : orig line is 7, orig col is 2, <Newline>, nl is 2
 space_text : orig line is 9, orig col is 1, '~' type is DESTRUCTOR
 space_text : orig line is 9, orig col is 1, pc-Text() '~', type is DESTRUCTOR
-do_space : orig line is 9, orig col is 1, first Text() '~', type is DESTRUCTOR
+do_space : orig line 9, orig col 1, first text '~', type DESTRUCTOR
 do_space : first orig line is 9, orig col is 1, Text() is '~', [DESTRUCTOR/FUNC_CLASS_DEF] <===>
            second orig line is 9, orig col is 2, Text() is 'TelegramIndex', [FUNC_CLASS_DEF/DESTRUCTOR] : rule REMOVE[ ]
 space_text : orig line is 9, orig col is 1, pc-Text() '~', type is DESTRUCTOR
 space_text :    rule = REMOVE @ 0 => 2
 space_text : orig line is 9, orig col is 2, 'TelegramIndex' type is FUNC_CLASS_DEF
 space_text : orig line is 9, orig col is 2, pc-Text() 'TelegramIndex', type is FUNC_CLASS_DEF
-do_space : orig line is 9, orig col is 2, first Text() 'TelegramIndex', type is FUNC_CLASS_DEF
+do_space : orig line 9, orig col 2, first text 'TelegramIndex', type FUNC_CLASS_DEF
 do_space : first orig line is 9, orig col is 2, Text() is 'TelegramIndex', [FUNC_CLASS_DEF/DESTRUCTOR] <===>
            second orig line is 9, orig col is 15, Text() is '(', [FPAREN_OPEN/FUNC_CLASS_DEF] : rule sp_func_class_paren[ ]
 space_text : orig line is 9, orig col is 2, pc-Text() 'TelegramIndex', type is FUNC_CLASS_DEF
 space_text :    rule = IGNORE @ 0 => 15
 space_text : orig line is 9, orig col is 15, '(' type is FPAREN_OPEN
 space_text : orig line is 9, orig col is 15, pc-Text() '(', type is FPAREN_OPEN
-do_space : orig line is 9, orig col is 15, first Text() '(', type is FPAREN_OPEN
+do_space : orig line 9, orig col 15, first text '(', type FPAREN_OPEN
 do_space : first orig line is 9, orig col is 15, Text() is '(', [FPAREN_OPEN/FUNC_CLASS_DEF] <===>
            second orig line is 9, orig col is 16, Text() is ')', [FPAREN_CLOSE/FUNC_CLASS_DEF] : rule sp_inside_fparens[ ]
 space_text : orig line is 9, orig col is 15, pc-Text() '(', type is FPAREN_OPEN
 space_text :    rule = IGNORE @ 0 => 16
 space_text : orig line is 9, orig col is 16, ')' type is FPAREN_CLOSE
 space_text : orig line is 9, orig col is 16, pc-Text() ')', type is FPAREN_CLOSE
-do_space : orig line is 9, orig col is 16, first Text() ')', type is FPAREN_CLOSE
+do_space : orig line 9, orig col 16, first text ')', type FPAREN_CLOSE
 space_text : orig line is 9, orig col is 16, pc-Text() ')', type is FPAREN_CLOSE
 space_text :    rule = REMOVE @ 0 => 17
 space_text : orig line is 9, orig col is 17, <Newline>, nl is 1
 space_text : orig line is 10, orig col is 1, '{' type is BRACE_OPEN
 space_text : orig line is 10, orig col is 1, pc-Text() '{', type is BRACE_OPEN
-do_space : orig line is 10, orig col is 1, first Text() '{', type is BRACE_OPEN
+do_space : orig line 10, orig col 1, first text '{', type BRACE_OPEN
 space_text : orig line is 10, orig col is 1, pc-Text() '{', type is BRACE_OPEN
 space_text :    rule = REMOVE @ 0 => 2
 space_text : orig line is 10, orig col is 2, <Newline>, nl is 1
 space_text : orig line is 11, orig col is 1, '}' type is BRACE_CLOSE
 space_text : orig line is 11, orig col is 1, pc-Text() '}', type is BRACE_CLOSE
-do_space : orig line is 11, orig col is 1, first Text() '}', type is BRACE_CLOSE
+do_space : orig line 11, orig col 1, first text '}', type BRACE_CLOSE
 space_text : orig line is 11, orig col is 1, pc-Text() '}', type is BRACE_CLOSE
 space_text :    rule = REMOVE @ 0 => 2
 space_text : orig line is 11, orig col is 2, <Newline>, nl is 2
 space_text : orig line is 13, orig col is 1, 'const' type is QUALIFIER
 space_text : back-to-back words need a space: pc->Text() 'const', next->Text() 'char'
 space_text : orig line is 13, orig col is 1, pc-Text() 'const', type is QUALIFIER
-do_space : orig line is 13, orig col is 1, first Text() 'const', type is QUALIFIER
+do_space : orig line 13, orig col 1, first text 'const', type QUALIFIER
 do_space : first orig line is 13, orig col is 1, Text() is 'const', [QUALIFIER/NONE] <===>
            second orig line is 13, orig col is 7, Text() is 'char', [TYPE/NONE] : rule sp_after_type[ ]
-ensure_force_space : <force between 'const' and 'char'>
+ensure_force_space : force between 'const' and 'char'
 space_text : orig line is 13, orig col is 1, pc-Text() 'const', type is QUALIFIER
 space_text :    rule = FORCE @ 1 => 7
 space_text : orig line is 13, orig col is 7, 'char' type is TYPE
 space_text : orig line is 13, orig col is 7, pc-Text() 'char', type is TYPE
-do_space : orig line is 13, orig col is 7, first Text() 'char', type is TYPE
+do_space : orig line 13, orig col 7, first text 'char', type TYPE
 do_space : first orig line is 13, orig col is 7, Text() is 'char', [TYPE/NONE] <===>
            second orig line is 13, orig col is 11, Text() is '*', [PTR_TYPE/NONE] : rule IGNORE[ ]
 space_text : orig line is 13, orig col is 7, pc-Text() 'char', type is TYPE
 space_text :    rule = IGNORE @ 0 => 11
 space_text : orig line is 13, orig col is 11, '*' type is PTR_TYPE
 space_text : orig line is 13, orig col is 11, pc-Text() '*', type is PTR_TYPE
-do_space : orig line is 13, orig col is 11, first Text() '*', type is PTR_TYPE
+do_space : orig line 13, orig col 11, first text '*', type PTR_TYPE
 do_space : first orig line is 13, orig col is 11, Text() is '*', [PTR_TYPE/NONE] <===>
            second orig line is 13, orig col is 13, Text() is 'const', [QUALIFIER/NONE] : rule sp_after_ptr_star_qualifier[ ]
 space_text : orig line is 13, orig col is 11, pc-Text() '*', type is PTR_TYPE
@@ -246,555 +246,594 @@ space_text :    rule = IGNORE @ 1 => 13
 space_text : orig line is 13, orig col is 13, 'const' type is QUALIFIER
 space_text : back-to-back words need a space: pc->Text() 'const', next->Text() 'pTelName'
 space_text : orig line is 13, orig col is 13, pc-Text() 'const', type is QUALIFIER
-do_space : orig line is 13, orig col is 13, first Text() 'const', type is QUALIFIER
+do_space : orig line 13, orig col 13, first text 'const', type QUALIFIER
 do_space : first orig line is 13, orig col is 13, Text() is 'const', [QUALIFIER/NONE] <===>
            second orig line is 13, orig col is 19, Text() is 'pTelName', [WORD/NONE] : rule sp_after_type[ ]
-ensure_force_space : <force between 'const' and 'pTelName'>
+ensure_force_space : force between 'const' and 'pTelName'
 space_text : orig line is 13, orig col is 13, pc-Text() 'const', type is QUALIFIER
 space_text :    rule = FORCE @ 1 => 19
 space_text : orig line is 13, orig col is 19, 'pTelName' type is WORD
 space_text : orig line is 13, orig col is 19, pc-Text() 'pTelName', type is WORD
-do_space : orig line is 13, orig col is 19, first Text() 'pTelName', type is WORD
+do_space : orig line 13, orig col 19, first text 'pTelName', type WORD
 do_space : first orig line is 13, orig col is 19, Text() is 'pTelName', [WORD/NONE] <===>
            second orig line is 13, orig col is 27, Text() is ';', [SEMICOLON/NONE] : rule sp_before_semi[ ]
 space_text : orig line is 13, orig col is 19, pc-Text() 'pTelName', type is WORD
 space_text :    rule = REMOVE @ 0 => 27
 space_text : orig line is 13, orig col is 27, ';' type is SEMICOLON
 space_text : orig line is 13, orig col is 27, pc-Text() ';', type is SEMICOLON
-do_space : orig line is 13, orig col is 27, first Text() ';', type is SEMICOLON
+do_space : orig line 13, orig col 27, first text ';', type SEMICOLON
 space_text : orig line is 13, orig col is 27, pc-Text() ';', type is SEMICOLON
 space_text :    rule = REMOVE @ 0 => 28
 space_text : orig line is 13, orig col is 28, <Newline>, nl is 1
 space_text : orig line is 14, orig col is 1, 'unsigned' type is TYPE
 space_text : back-to-back words need a space: pc->Text() 'unsigned', next->Text() 'long'
 space_text : orig line is 14, orig col is 1, pc-Text() 'unsigned', type is TYPE
-do_space : orig line is 14, orig col is 1, first Text() 'unsigned', type is TYPE
+do_space : orig line 14, orig col 1, first text 'unsigned', type TYPE
 do_space : first orig line is 14, orig col is 1, Text() is 'unsigned', [TYPE/NONE] <===>
            second orig line is 14, orig col is 10, Text() is 'long', [TYPE/NONE] : rule sp_after_type[ ]
-ensure_force_space : <force between 'unsigned' and 'long'>
+ensure_force_space : force between 'unsigned' and 'long'
 space_text : orig line is 14, orig col is 1, pc-Text() 'unsigned', type is TYPE
 space_text :    rule = FORCE @ 1 => 10
 space_text : orig line is 14, orig col is 10, 'long' type is TYPE
 space_text : back-to-back words need a space: pc->Text() 'long', next->Text() 'nTelIndex'
 space_text : orig line is 14, orig col is 10, pc-Text() 'long', type is TYPE
-do_space : orig line is 14, orig col is 10, first Text() 'long', type is TYPE
+do_space : orig line 14, orig col 10, first text 'long', type TYPE
 do_space : first orig line is 14, orig col is 10, Text() is 'long', [TYPE/NONE] <===>
            second orig line is 14, orig col is 15, Text() is 'nTelIndex', [WORD/NONE] : rule sp_after_type[ ]
-ensure_force_space : <force between 'long' and 'nTelIndex'>
+ensure_force_space : force between 'long' and 'nTelIndex'
 space_text : orig line is 14, orig col is 10, pc-Text() 'long', type is TYPE
 space_text :    rule = FORCE @ 1 => 15
 space_text : orig line is 14, orig col is 15, 'nTelIndex' type is WORD
 space_text : orig line is 14, orig col is 15, pc-Text() 'nTelIndex', type is WORD
-do_space : orig line is 14, orig col is 15, first Text() 'nTelIndex', type is WORD
+do_space : orig line 14, orig col 15, first text 'nTelIndex', type WORD
 do_space : first orig line is 14, orig col is 15, Text() is 'nTelIndex', [WORD/NONE] <===>
            second orig line is 14, orig col is 24, Text() is ';', [SEMICOLON/NONE] : rule sp_before_semi[ ]
 space_text : orig line is 14, orig col is 15, pc-Text() 'nTelIndex', type is WORD
 space_text :    rule = REMOVE @ 0 => 24
 space_text : orig line is 14, orig col is 24, ';' type is SEMICOLON
 space_text : orig line is 14, orig col is 24, pc-Text() ';', type is SEMICOLON
-do_space : orig line is 14, orig col is 24, first Text() ';', type is SEMICOLON
+do_space : orig line 14, orig col 24, first text ';', type SEMICOLON
 space_text : orig line is 14, orig col is 24, pc-Text() ';', type is SEMICOLON
 space_text :    rule = REMOVE @ 0 => 25
 space_text : orig line is 14, orig col is 25, <Newline>, nl is 1
 space_text : orig line is 15, orig col is 1, '}' type is BRACE_CLOSE
 space_text : orig line is 15, orig col is 1, pc-Text() '}', type is BRACE_CLOSE
-do_space : orig line is 15, orig col is 1, first Text() '}', type is BRACE_CLOSE
+do_space : orig line 15, orig col 1, first text '}', type BRACE_CLOSE
 do_space : first orig line is 15, orig col is 1, Text() is '}', [BRACE_CLOSE/STRUCT] <===>
            second orig line is 15, orig col is 2, Text() is ';', [SEMICOLON/STRUCT] : rule sp_before_semi[ ]
 space_text : orig line is 15, orig col is 1, pc-Text() '}', type is BRACE_CLOSE
 space_text :    rule = REMOVE @ 0 => 2
 space_text : orig line is 15, orig col is 2, ';' type is SEMICOLON
 space_text : orig line is 15, orig col is 2, pc-Text() ';', type is SEMICOLON
-do_space : orig line is 15, orig col is 2, first Text() ';', type is SEMICOLON
+do_space : orig line 15, orig col 2, first text ';', type SEMICOLON
 space_text : orig line is 15, orig col is 2, pc-Text() ';', type is SEMICOLON
 space_text :    rule = REMOVE @ 0 => 3
 space_text : orig line is 15, orig col is 3, <Newline>, nl is 2
-space_col_align : first orig line is 3, orig col is 1, [FUNC_CLASS_DEF/NONE], Text() 'TelegramIndex' <==>
-space_col_align : second orig line is 3, orig col is 14 [FPAREN_OPEN/FUNC_CLASS_DEF], Text() '(', [CallStack]
-do_space : orig line is 3, orig col is 1, first Text() 'TelegramIndex', type is FUNC_CLASS_DEF
+space_col_align : 1st orig line 3, orig col 1, [FUNC_CLASS_DEF/NONE], text 'TelegramIndex' <==>
+space_col_align : 2nd orig line 3, orig col 14, [FPAREN_OPEN/FUNC_CLASS_DEF], text '('
+ [CallStack]
+do_space : orig line 3, orig col 1, first text 'TelegramIndex', type FUNC_CLASS_DEF
 do_space : first orig line is 3, orig col is 1, Text() is 'TelegramIndex', [FUNC_CLASS_DEF/NONE] <===>
            second orig line is 3, orig col is 14, Text() is '(', [FPAREN_OPEN/FUNC_CLASS_DEF] : rule sp_func_class_paren[ ]
 space_col_align : av is ignore
-space_col_align :    Len is 13
+space_col_align :    '1st' len is 13
 space_col_align :    => coldiff is 13
 space_col_align :    => av is IGNORE
 space_col_align :    => first orig line  is 3
 space_col_align :    => second orig line is 3
-space_col_align :    => first Text()     is 'TelegramIndex'
-space_col_align :    => second Text()    is '('
+space_col_align :    => first text       is 'TelegramIndex'
+space_col_align :    => second text      is '('
 space_col_align :    => first orig col   is 1
 space_col_align :    => second orig col  is 14
-space_col_align :    => first Len()      is 13
+space_col_align :    => first len        is 13
 space_col_align :    => coldiff is 13
-space_col_align : first orig line is 3, orig col is 14, [FPAREN_OPEN/FUNC_CLASS_DEF], Text() '(' <==>
-space_col_align : second orig line is 3, orig col is 15 [QUALIFIER/NONE], Text() 'const', [CallStack]
-do_space : orig line is 3, orig col is 14, first Text() '(', type is FPAREN_OPEN
+space_col_align : 1st orig line 3, orig col 14, [FPAREN_OPEN/FUNC_CLASS_DEF], text '(' <==>
+space_col_align : 2nd orig line 3, orig col 15, [QUALIFIER/NONE], text 'const'
+ [CallStack]
+do_space : orig line 3, orig col 14, first text '(', type FPAREN_OPEN
 do_space : first orig line is 3, orig col is 14, Text() is '(', [FPAREN_OPEN/FUNC_CLASS_DEF] <===>
            second orig line is 3, orig col is 15, Text() is 'const', [QUALIFIER/NONE] : rule sp_inside_fparen[ ]
 space_col_align : av is ignore
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is IGNORE
 space_col_align :    => first orig line  is 3
 space_col_align :    => second orig line is 3
-space_col_align :    => first Text()     is '('
-space_col_align :    => second Text()    is 'const'
+space_col_align :    => first text       is '('
+space_col_align :    => second text      is 'const'
 space_col_align :    => first orig col   is 14
 space_col_align :    => second orig col  is 15
-space_col_align :    => first Len()      is 1
+space_col_align :    => first len        is 1
 space_col_align :    => coldiff is 1
-space_col_align : first orig line is 3, orig col is 15, [QUALIFIER/NONE], Text() 'const' <==>
-space_col_align : second orig line is 3, orig col is 21 [TYPE/NONE], Text() 'char', [CallStack]
-do_space : orig line is 3, orig col is 15, first Text() 'const', type is QUALIFIER
+space_col_align : 1st orig line 3, orig col 15, [QUALIFIER/NONE], text 'const' <==>
+space_col_align : 2nd orig line 3, orig col 21, [TYPE/NONE], text 'char'
+ [CallStack]
+do_space : orig line 3, orig col 15, first text 'const', type QUALIFIER
 do_space : first orig line is 3, orig col is 15, Text() is 'const', [QUALIFIER/NONE] <===>
            second orig line is 3, orig col is 21, Text() is 'char', [TYPE/NONE] : rule sp_after_type[ ]
-ensure_force_space : <force between 'const' and 'char'>
+ensure_force_space : force between 'const' and 'char'
 space_col_align : av is force
-space_col_align :    Len is 5
+space_col_align :    '1st' len is 5
 space_col_align :    => coldiff is 5
 space_col_align :    => av is FORCE
 space_col_align :    => coldiff is 6
-space_col_align : first orig line is 3, orig col is 21, [TYPE/NONE], Text() 'char' <==>
-space_col_align : second orig line is 3, orig col is 25 [PTR_TYPE/NONE], Text() '*', [CallStack]
-do_space : orig line is 3, orig col is 21, first Text() 'char', type is TYPE
+space_col_align : 1st orig line 3, orig col 21, [TYPE/NONE], text 'char' <==>
+space_col_align : 2nd orig line 3, orig col 25, [PTR_TYPE/NONE], text '*'
+ [CallStack]
+do_space : orig line 3, orig col 21, first text 'char', type TYPE
 do_space : first orig line is 3, orig col is 21, Text() is 'char', [TYPE/NONE] <===>
            second orig line is 3, orig col is 25, Text() is '*', [PTR_TYPE/NONE] : rule IGNORE[ ]
 space_col_align : av is ignore
-space_col_align :    Len is 4
+space_col_align :    '1st' len is 4
 space_col_align :    => coldiff is 4
 space_col_align :    => av is IGNORE
 space_col_align :    => first orig line  is 3
 space_col_align :    => second orig line is 3
-space_col_align :    => first Text()     is 'char'
-space_col_align :    => second Text()    is '*'
+space_col_align :    => first text       is 'char'
+space_col_align :    => second text      is '*'
 space_col_align :    => first orig col   is 21
 space_col_align :    => second orig col  is 25
-space_col_align :    => first Len()      is 4
+space_col_align :    => first len        is 4
 space_col_align :    => coldiff is 4
-space_col_align : first orig line is 3, orig col is 25, [PTR_TYPE/NONE], Text() '*' <==>
-space_col_align : second orig line is 3, orig col is 27 [WORD/NONE], Text() 'pN', [CallStack]
-do_space : orig line is 3, orig col is 25, first Text() '*', type is PTR_TYPE
+space_col_align : 1st orig line 3, orig col 25, [PTR_TYPE/NONE], text '*' <==>
+space_col_align : 2nd orig line 3, orig col 27, [WORD/NONE], text 'pN'
+ [CallStack]
+do_space : orig line 3, orig col 25, first text '*', type PTR_TYPE
 do_space : first orig line is 3, orig col is 25, Text() is '*', [PTR_TYPE/NONE] <===>
            second orig line is 3, orig col is 27, Text() is 'pN', [WORD/NONE] : rule sp_after_ptr_star[ ]
 space_col_align : av is ignore
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is IGNORE
 space_col_align :    => first orig line  is 3
 space_col_align :    => second orig line is 3
-space_col_align :    => first Text()     is '*'
-space_col_align :    => second Text()    is 'pN'
+space_col_align :    => first text       is '*'
+space_col_align :    => second text      is 'pN'
 space_col_align :    => first orig col   is 25
 space_col_align :    => second orig col  is 27
-space_col_align :    => first Len()      is 1
+space_col_align :    => first len        is 1
 space_col_align :    => coldiff is 2
-space_col_align : first orig line is 3, orig col is 27, [WORD/NONE], Text() 'pN' <==>
-space_col_align : second orig line is 3, orig col is 29 [COMMA/NONE], Text() ',', [CallStack]
-do_space : orig line is 3, orig col is 27, first Text() 'pN', type is WORD
+space_col_align : 1st orig line 3, orig col 27, [WORD/NONE], text 'pN' <==>
+space_col_align : 2nd orig line 3, orig col 29, [COMMA/NONE], text ','
+ [CallStack]
+do_space : orig line 3, orig col 27, first text 'pN', type WORD
 do_space : first orig line is 3, orig col is 27, Text() is 'pN', [WORD/NONE] <===>
            second orig line is 3, orig col is 29, Text() is ',', [COMMA/NONE] : rule sp_before_comma[ ]
 space_col_align : av is remove
-space_col_align :    Len is 2
+space_col_align :    '1st' len is 2
 space_col_align :    => coldiff is 2
 space_col_align :    => av is REMOVE
 space_col_align :    => coldiff is 2
-space_col_align : first orig line is 3, orig col is 29, [COMMA/NONE], Text() ',' <==>
-space_col_align : second orig line is 3, orig col is 31 [TYPE/NONE], Text() 'unsigned', [CallStack]
-do_space : orig line is 3, orig col is 29, first Text() ',', type is COMMA
+space_col_align : 1st orig line 3, orig col 29, [COMMA/NONE], text ',' <==>
+space_col_align : 2nd orig line 3, orig col 31, [TYPE/NONE], text 'unsigned'
+ [CallStack]
+do_space : orig line 3, orig col 29, first text ',', type COMMA
 do_space : first orig line is 3, orig col is 29, Text() is ',', [COMMA/NONE] <===>
            second orig line is 3, orig col is 31, Text() is 'unsigned', [TYPE/NONE] : rule sp_after_comma[ ]
 space_col_align : av is ignore
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is IGNORE
 space_col_align :    => first orig line  is 3
 space_col_align :    => second orig line is 3
-space_col_align :    => first Text()     is ','
-space_col_align :    => second Text()    is 'unsigned'
+space_col_align :    => first text       is ','
+space_col_align :    => second text      is 'unsigned'
 space_col_align :    => first orig col   is 29
 space_col_align :    => second orig col  is 31
-space_col_align :    => first Len()      is 1
+space_col_align :    => first len        is 1
 space_col_align :    => coldiff is 2
-space_col_align : first orig line is 3, orig col is 31, [TYPE/NONE], Text() 'unsigned' <==>
-space_col_align : second orig line is 3, orig col is 40 [TYPE/NONE], Text() 'long', [CallStack]
-do_space : orig line is 3, orig col is 31, first Text() 'unsigned', type is TYPE
+space_col_align : 1st orig line 3, orig col 31, [TYPE/NONE], text 'unsigned' <==>
+space_col_align : 2nd orig line 3, orig col 40, [TYPE/NONE], text 'long'
+ [CallStack]
+do_space : orig line 3, orig col 31, first text 'unsigned', type TYPE
 do_space : first orig line is 3, orig col is 31, Text() is 'unsigned', [TYPE/NONE] <===>
            second orig line is 3, orig col is 40, Text() is 'long', [TYPE/NONE] : rule sp_after_type[ ]
-ensure_force_space : <force between 'unsigned' and 'long'>
+ensure_force_space : force between 'unsigned' and 'long'
 space_col_align : av is force
-space_col_align :    Len is 8
+space_col_align :    '1st' len is 8
 space_col_align :    => coldiff is 8
 space_col_align :    => av is FORCE
 space_col_align :    => coldiff is 9
-space_col_align : first orig line is 3, orig col is 40, [TYPE/NONE], Text() 'long' <==>
-space_col_align : second orig line is 3, orig col is 45 [WORD/NONE], Text() 'nI', [CallStack]
-do_space : orig line is 3, orig col is 40, first Text() 'long', type is TYPE
+space_col_align : 1st orig line 3, orig col 40, [TYPE/NONE], text 'long' <==>
+space_col_align : 2nd orig line 3, orig col 45, [WORD/NONE], text 'nI'
+ [CallStack]
+do_space : orig line 3, orig col 40, first text 'long', type TYPE
 do_space : first orig line is 3, orig col is 40, Text() is 'long', [TYPE/NONE] <===>
            second orig line is 3, orig col is 45, Text() is 'nI', [WORD/NONE] : rule sp_after_type[ ]
-ensure_force_space : <force between 'long' and 'nI'>
+ensure_force_space : force between 'long' and 'nI'
 space_col_align : av is force
-space_col_align :    Len is 4
+space_col_align :    '1st' len is 4
 space_col_align :    => coldiff is 4
 space_col_align :    => av is FORCE
 space_col_align :    => coldiff is 5
-space_col_align : first orig line is 3, orig col is 45, [WORD/NONE], Text() 'nI' <==>
-space_col_align : second orig line is 3, orig col is 47 [FPAREN_CLOSE/FUNC_CLASS_DEF], Text() ')', [CallStack]
-do_space : orig line is 3, orig col is 45, first Text() 'nI', type is WORD
+space_col_align : 1st orig line 3, orig col 45, [WORD/NONE], text 'nI' <==>
+space_col_align : 2nd orig line 3, orig col 47, [FPAREN_CLOSE/FUNC_CLASS_DEF], text ')'
+ [CallStack]
+do_space : orig line 3, orig col 45, first text 'nI', type WORD
 do_space : first orig line is 3, orig col is 45, Text() is 'nI', [WORD/NONE] <===>
            second orig line is 3, orig col is 47, Text() is ')', [FPAREN_CLOSE/FUNC_CLASS_DEF] : rule sp_inside_fparen[ ]
 space_col_align : av is ignore
-space_col_align :    Len is 2
+space_col_align :    '1st' len is 2
 space_col_align :    => coldiff is 2
 space_col_align :    => av is IGNORE
 space_col_align :    => first orig line  is 3
 space_col_align :    => second orig line is 3
-space_col_align :    => first Text()     is 'nI'
-space_col_align :    => second Text()    is ')'
+space_col_align :    => first text       is 'nI'
+space_col_align :    => second text      is ')'
 space_col_align :    => first orig col   is 45
 space_col_align :    => second orig col  is 47
-space_col_align :    => first Len()      is 2
+space_col_align :    => first len        is 2
 space_col_align :    => coldiff is 2
-space_col_align : first orig line is 3, orig col is 47, [FPAREN_CLOSE/FUNC_CLASS_DEF], Text() ')' <==>
-space_col_align : second orig line is 3, orig col is 49 [CONSTR_COLON/NONE], Text() ':', [CallStack]
-do_space : orig line is 3, orig col is 47, first Text() ')', type is FPAREN_CLOSE
+space_col_align : 1st orig line 3, orig col 47, [FPAREN_CLOSE/FUNC_CLASS_DEF], text ')' <==>
+space_col_align : 2nd orig line 3, orig col 49, [CONSTR_COLON/NONE], text ':'
+ [CallStack]
+do_space : orig line 3, orig col 47, first text ')', type FPAREN_CLOSE
 do_space : first orig line is 3, orig col is 47, Text() is ')', [FPAREN_CLOSE/FUNC_CLASS_DEF] <===>
            second orig line is 3, orig col is 49, Text() is ':', [CONSTR_COLON/NONE] : rule sp_before_constr_colon[ ]
 space_col_align : av is add
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is ADD
 space_col_align :    => coldiff is 2
-space_col_align : first orig line is 3, orig col is 49, [CONSTR_COLON/NONE], Text() ':' <==>
-space_col_align : second orig line is 3, orig col is 50 [NEWLINE/NONE], Text() '', [CallStack]
-do_space : orig line is 3, orig col is 49, first Text() ':', type is CONSTR_COLON
+space_col_align : 1st orig line 3, orig col 49, [CONSTR_COLON/NONE], text ':' <==>
+space_col_align : 2nd orig line 3, orig col 50, [NEWLINE/NONE], text ''
+ [CallStack]
+do_space : orig line 3, orig col 49, first text ':', type CONSTR_COLON
 space_col_align : av is remove
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is REMOVE
 space_col_align :    => coldiff is 1
-space_col_align : first orig line is 4, orig col is 1, [FUNC_CTOR_VAR/NONE], Text() 'pTelName' <==>
-space_col_align : second orig line is 4, orig col is 9 [FPAREN_OPEN/FUNC_CTOR_VAR], Text() '(', [CallStack]
-do_space : orig line is 4, orig col is 1, first Text() 'pTelName', type is FUNC_CTOR_VAR
+space_col_align : 1st orig line 4, orig col 1, [FUNC_CTOR_VAR/NONE], text 'pTelName' <==>
+space_col_align : 2nd orig line 4, orig col 9, [FPAREN_OPEN/FUNC_CTOR_VAR], text '('
+ [CallStack]
+do_space : orig line 4, orig col 1, first text 'pTelName', type FUNC_CTOR_VAR
 do_space : first orig line is 4, orig col is 1, Text() is 'pTelName', [FUNC_CTOR_VAR/NONE] <===>
            second orig line is 4, orig col is 9, Text() is '(', [FPAREN_OPEN/FUNC_CTOR_VAR] : rule sp_func_call_paren[ ]
 space_col_align : av is ignore
-space_col_align :    Len is 8
+space_col_align :    '1st' len is 8
 space_col_align :    => coldiff is 8
 space_col_align :    => av is IGNORE
 space_col_align :    => first orig line  is 4
 space_col_align :    => second orig line is 4
-space_col_align :    => first Text()     is 'pTelName'
-space_col_align :    => second Text()    is '('
+space_col_align :    => first text       is 'pTelName'
+space_col_align :    => second text      is '('
 space_col_align :    => first orig col   is 1
 space_col_align :    => second orig col  is 9
-space_col_align :    => first Len()      is 8
+space_col_align :    => first len        is 8
 space_col_align :    => coldiff is 8
-space_col_align : first orig line is 4, orig col is 9, [FPAREN_OPEN/FUNC_CTOR_VAR], Text() '(' <==>
-space_col_align : second orig line is 4, orig col is 10 [WORD/NONE], Text() 'pN', [CallStack]
-do_space : orig line is 4, orig col is 9, first Text() '(', type is FPAREN_OPEN
+space_col_align : 1st orig line 4, orig col 9, [FPAREN_OPEN/FUNC_CTOR_VAR], text '(' <==>
+space_col_align : 2nd orig line 4, orig col 10, [WORD/NONE], text 'pN'
+ [CallStack]
+do_space : orig line 4, orig col 9, first text '(', type FPAREN_OPEN
 do_space : first orig line is 4, orig col is 9, Text() is '(', [FPAREN_OPEN/FUNC_CTOR_VAR] <===>
            second orig line is 4, orig col is 10, Text() is 'pN', [WORD/NONE] : rule sp_inside_fparen[ ]
 space_col_align : av is ignore
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is IGNORE
 space_col_align :    => first orig line  is 4
 space_col_align :    => second orig line is 4
-space_col_align :    => first Text()     is '('
-space_col_align :    => second Text()    is 'pN'
+space_col_align :    => first text       is '('
+space_col_align :    => second text      is 'pN'
 space_col_align :    => first orig col   is 9
 space_col_align :    => second orig col  is 10
-space_col_align :    => first Len()      is 1
+space_col_align :    => first len        is 1
 space_col_align :    => coldiff is 1
-space_col_align : first orig line is 4, orig col is 10, [WORD/NONE], Text() 'pN' <==>
-space_col_align : second orig line is 4, orig col is 12 [FPAREN_CLOSE/FUNC_CTOR_VAR], Text() ')', [CallStack]
-do_space : orig line is 4, orig col is 10, first Text() 'pN', type is WORD
+space_col_align : 1st orig line 4, orig col 10, [WORD/NONE], text 'pN' <==>
+space_col_align : 2nd orig line 4, orig col 12, [FPAREN_CLOSE/FUNC_CTOR_VAR], text ')'
+ [CallStack]
+do_space : orig line 4, orig col 10, first text 'pN', type WORD
 do_space : first orig line is 4, orig col is 10, Text() is 'pN', [WORD/NONE] <===>
            second orig line is 4, orig col is 12, Text() is ')', [FPAREN_CLOSE/FUNC_CTOR_VAR] : rule sp_inside_fparen[ ]
 space_col_align : av is ignore
-space_col_align :    Len is 2
+space_col_align :    '1st' len is 2
 space_col_align :    => coldiff is 2
 space_col_align :    => av is IGNORE
 space_col_align :    => first orig line  is 4
 space_col_align :    => second orig line is 4
-space_col_align :    => first Text()     is 'pN'
-space_col_align :    => second Text()    is ')'
+space_col_align :    => first text       is 'pN'
+space_col_align :    => second text      is ')'
 space_col_align :    => first orig col   is 10
 space_col_align :    => second orig col  is 12
-space_col_align :    => first Len()      is 2
+space_col_align :    => first len        is 2
 space_col_align :    => coldiff is 2
-space_col_align : first orig line is 4, orig col is 12, [FPAREN_CLOSE/FUNC_CTOR_VAR], Text() ')' <==>
-space_col_align : second orig line is 4, orig col is 13 [COMMA/NONE], Text() ',', [CallStack]
-do_space : orig line is 4, orig col is 12, first Text() ')', type is FPAREN_CLOSE
+space_col_align : 1st orig line 4, orig col 12, [FPAREN_CLOSE/FUNC_CTOR_VAR], text ')' <==>
+space_col_align : 2nd orig line 4, orig col 13, [COMMA/NONE], text ','
+ [CallStack]
+do_space : orig line 4, orig col 12, first text ')', type FPAREN_CLOSE
 do_space : first orig line is 4, orig col is 12, Text() is ')', [FPAREN_CLOSE/FUNC_CTOR_VAR] <===>
            second orig line is 4, orig col is 13, Text() is ',', [COMMA/NONE] : rule sp_before_comma[ ]
 space_col_align : av is remove
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is REMOVE
 space_col_align :    => coldiff is 1
-space_col_align : first orig line is 4, orig col is 13, [COMMA/NONE], Text() ',' <==>
-space_col_align : second orig line is 4, orig col is 14 [NEWLINE/NONE], Text() '', [CallStack]
-do_space : orig line is 4, orig col is 13, first Text() ',', type is COMMA
+space_col_align : 1st orig line 4, orig col 13, [COMMA/NONE], text ',' <==>
+space_col_align : 2nd orig line 4, orig col 14, [NEWLINE/NONE], text ''
+ [CallStack]
+do_space : orig line 4, orig col 13, first text ',', type COMMA
 space_col_align : av is remove
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is REMOVE
 space_col_align :    => coldiff is 1
-space_col_align : first orig line is 5, orig col is 1, [FUNC_CTOR_VAR/NONE], Text() 'nTelIndex' <==>
-space_col_align : second orig line is 5, orig col is 10 [FPAREN_OPEN/FUNC_CTOR_VAR], Text() '(', [CallStack]
-do_space : orig line is 5, orig col is 1, first Text() 'nTelIndex', type is FUNC_CTOR_VAR
+space_col_align : 1st orig line 5, orig col 1, [FUNC_CTOR_VAR/NONE], text 'nTelIndex' <==>
+space_col_align : 2nd orig line 5, orig col 10, [FPAREN_OPEN/FUNC_CTOR_VAR], text '('
+ [CallStack]
+do_space : orig line 5, orig col 1, first text 'nTelIndex', type FUNC_CTOR_VAR
 do_space : first orig line is 5, orig col is 1, Text() is 'nTelIndex', [FUNC_CTOR_VAR/NONE] <===>
            second orig line is 5, orig col is 10, Text() is '(', [FPAREN_OPEN/FUNC_CTOR_VAR] : rule sp_func_call_paren[ ]
 space_col_align : av is ignore
-space_col_align :    Len is 9
+space_col_align :    '1st' len is 9
 space_col_align :    => coldiff is 9
 space_col_align :    => av is IGNORE
 space_col_align :    => first orig line  is 5
 space_col_align :    => second orig line is 5
-space_col_align :    => first Text()     is 'nTelIndex'
-space_col_align :    => second Text()    is '('
+space_col_align :    => first text       is 'nTelIndex'
+space_col_align :    => second text      is '('
 space_col_align :    => first orig col   is 1
 space_col_align :    => second orig col  is 10
-space_col_align :    => first Len()      is 9
+space_col_align :    => first len        is 9
 space_col_align :    => coldiff is 9
-space_col_align : first orig line is 5, orig col is 10, [FPAREN_OPEN/FUNC_CTOR_VAR], Text() '(' <==>
-space_col_align : second orig line is 5, orig col is 11 [WORD/NONE], Text() 'n', [CallStack]
-do_space : orig line is 5, orig col is 10, first Text() '(', type is FPAREN_OPEN
+space_col_align : 1st orig line 5, orig col 10, [FPAREN_OPEN/FUNC_CTOR_VAR], text '(' <==>
+space_col_align : 2nd orig line 5, orig col 11, [WORD/NONE], text 'n'
+ [CallStack]
+do_space : orig line 5, orig col 10, first text '(', type FPAREN_OPEN
 do_space : first orig line is 5, orig col is 10, Text() is '(', [FPAREN_OPEN/FUNC_CTOR_VAR] <===>
            second orig line is 5, orig col is 11, Text() is 'n', [WORD/NONE] : rule sp_inside_fparen[ ]
 space_col_align : av is ignore
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is IGNORE
 space_col_align :    => first orig line  is 5
 space_col_align :    => second orig line is 5
-space_col_align :    => first Text()     is '('
-space_col_align :    => second Text()    is 'n'
+space_col_align :    => first text       is '('
+space_col_align :    => second text      is 'n'
 space_col_align :    => first orig col   is 10
 space_col_align :    => second orig col  is 11
-space_col_align :    => first Len()      is 1
+space_col_align :    => first len        is 1
 space_col_align :    => coldiff is 1
-space_col_align : first orig line is 5, orig col is 11, [WORD/NONE], Text() 'n' <==>
-space_col_align : second orig line is 5, orig col is 12 [FPAREN_CLOSE/FUNC_CTOR_VAR], Text() ')', [CallStack]
-do_space : orig line is 5, orig col is 11, first Text() 'n', type is WORD
+space_col_align : 1st orig line 5, orig col 11, [WORD/NONE], text 'n' <==>
+space_col_align : 2nd orig line 5, orig col 12, [FPAREN_CLOSE/FUNC_CTOR_VAR], text ')'
+ [CallStack]
+do_space : orig line 5, orig col 11, first text 'n', type WORD
 do_space : first orig line is 5, orig col is 11, Text() is 'n', [WORD/NONE] <===>
            second orig line is 5, orig col is 12, Text() is ')', [FPAREN_CLOSE/FUNC_CTOR_VAR] : rule sp_inside_fparen[ ]
 space_col_align : av is ignore
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is IGNORE
 space_col_align :    => first orig line  is 5
 space_col_align :    => second orig line is 5
-space_col_align :    => first Text()     is 'n'
-space_col_align :    => second Text()    is ')'
+space_col_align :    => first text       is 'n'
+space_col_align :    => second text      is ')'
 space_col_align :    => first orig col   is 11
 space_col_align :    => second orig col  is 12
-space_col_align :    => first Len()      is 1
+space_col_align :    => first len        is 1
 space_col_align :    => coldiff is 1
-space_col_align : first orig line is 5, orig col is 12, [FPAREN_CLOSE/FUNC_CTOR_VAR], Text() ')' <==>
-space_col_align : second orig line is 5, orig col is 13 [NEWLINE/NONE], Text() '', [CallStack]
-do_space : orig line is 5, orig col is 12, first Text() ')', type is FPAREN_CLOSE
+space_col_align : 1st orig line 5, orig col 12, [FPAREN_CLOSE/FUNC_CTOR_VAR], text ')' <==>
+space_col_align : 2nd orig line 5, orig col 13, [NEWLINE/NONE], text ''
+ [CallStack]
+do_space : orig line 5, orig col 12, first text ')', type FPAREN_CLOSE
 space_col_align : av is remove
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is REMOVE
 space_col_align :    => coldiff is 1
-space_col_align : first orig line is 6, orig col is 1, [BRACE_OPEN/FUNC_CLASS_DEF], Text() '{' <==>
-space_col_align : second orig line is 6, orig col is 2 [NEWLINE/NONE], Text() '', [CallStack]
-do_space : orig line is 6, orig col is 1, first Text() '{', type is BRACE_OPEN
+space_col_align : 1st orig line 6, orig col 1, [BRACE_OPEN/FUNC_CLASS_DEF], text '{' <==>
+space_col_align : 2nd orig line 6, orig col 2, [NEWLINE/NONE], text ''
+ [CallStack]
+do_space : orig line 6, orig col 1, first text '{', type BRACE_OPEN
 space_col_align : av is remove
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is REMOVE
 space_col_align :    => coldiff is 1
-space_col_align : first orig line is 7, orig col is 1, [BRACE_CLOSE/FUNC_CLASS_DEF], Text() '}' <==>
-space_col_align : second orig line is 7, orig col is 2 [NEWLINE/NONE], Text() '', [CallStack]
-do_space : orig line is 7, orig col is 1, first Text() '}', type is BRACE_CLOSE
+space_col_align : 1st orig line 7, orig col 1, [BRACE_CLOSE/FUNC_CLASS_DEF], text '}' <==>
+space_col_align : 2nd orig line 7, orig col 2, [NEWLINE/NONE], text ''
+ [CallStack]
+do_space : orig line 7, orig col 1, first text '}', type BRACE_CLOSE
 space_col_align : av is remove
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is REMOVE
 space_col_align :    => coldiff is 1
-space_col_align : first orig line is 9, orig col is 1, [DESTRUCTOR/FUNC_CLASS_DEF], Text() '~' <==>
-space_col_align : second orig line is 9, orig col is 2 [FUNC_CLASS_DEF/DESTRUCTOR], Text() 'TelegramIndex', [CallStack]
-do_space : orig line is 9, orig col is 1, first Text() '~', type is DESTRUCTOR
+space_col_align : 1st orig line 9, orig col 1, [DESTRUCTOR/FUNC_CLASS_DEF], text '~' <==>
+space_col_align : 2nd orig line 9, orig col 2, [FUNC_CLASS_DEF/DESTRUCTOR], text 'TelegramIndex'
+ [CallStack]
+do_space : orig line 9, orig col 1, first text '~', type DESTRUCTOR
 do_space : first orig line is 9, orig col is 1, Text() is '~', [DESTRUCTOR/FUNC_CLASS_DEF] <===>
            second orig line is 9, orig col is 2, Text() is 'TelegramIndex', [FUNC_CLASS_DEF/DESTRUCTOR] : rule REMOVE[ ]
 space_col_align : av is remove
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is REMOVE
 space_col_align :    => coldiff is 1
-space_col_align : first orig line is 9, orig col is 2, [FUNC_CLASS_DEF/DESTRUCTOR], Text() 'TelegramIndex' <==>
-space_col_align : second orig line is 9, orig col is 15 [FPAREN_OPEN/FUNC_CLASS_DEF], Text() '(', [CallStack]
-do_space : orig line is 9, orig col is 2, first Text() 'TelegramIndex', type is FUNC_CLASS_DEF
+space_col_align : 1st orig line 9, orig col 2, [FUNC_CLASS_DEF/DESTRUCTOR], text 'TelegramIndex' <==>
+space_col_align : 2nd orig line 9, orig col 15, [FPAREN_OPEN/FUNC_CLASS_DEF], text '('
+ [CallStack]
+do_space : orig line 9, orig col 2, first text 'TelegramIndex', type FUNC_CLASS_DEF
 do_space : first orig line is 9, orig col is 2, Text() is 'TelegramIndex', [FUNC_CLASS_DEF/DESTRUCTOR] <===>
            second orig line is 9, orig col is 15, Text() is '(', [FPAREN_OPEN/FUNC_CLASS_DEF] : rule sp_func_class_paren[ ]
 space_col_align : av is ignore
-space_col_align :    Len is 13
+space_col_align :    '1st' len is 13
 space_col_align :    => coldiff is 13
 space_col_align :    => av is IGNORE
 space_col_align :    => first orig line  is 9
 space_col_align :    => second orig line is 9
-space_col_align :    => first Text()     is 'TelegramIndex'
-space_col_align :    => second Text()    is '('
+space_col_align :    => first text       is 'TelegramIndex'
+space_col_align :    => second text      is '('
 space_col_align :    => first orig col   is 2
 space_col_align :    => second orig col  is 15
-space_col_align :    => first Len()      is 13
+space_col_align :    => first len        is 13
 space_col_align :    => coldiff is 13
-space_col_align : first orig line is 9, orig col is 15, [FPAREN_OPEN/FUNC_CLASS_DEF], Text() '(' <==>
-space_col_align : second orig line is 9, orig col is 16 [FPAREN_CLOSE/FUNC_CLASS_DEF], Text() ')', [CallStack]
-do_space : orig line is 9, orig col is 15, first Text() '(', type is FPAREN_OPEN
+space_col_align : 1st orig line 9, orig col 15, [FPAREN_OPEN/FUNC_CLASS_DEF], text '(' <==>
+space_col_align : 2nd orig line 9, orig col 16, [FPAREN_CLOSE/FUNC_CLASS_DEF], text ')'
+ [CallStack]
+do_space : orig line 9, orig col 15, first text '(', type FPAREN_OPEN
 do_space : first orig line is 9, orig col is 15, Text() is '(', [FPAREN_OPEN/FUNC_CLASS_DEF] <===>
            second orig line is 9, orig col is 16, Text() is ')', [FPAREN_CLOSE/FUNC_CLASS_DEF] : rule sp_inside_fparens[ ]
 space_col_align : av is ignore
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is IGNORE
 space_col_align :    => first orig line  is 9
 space_col_align :    => second orig line is 9
-space_col_align :    => first Text()     is '('
-space_col_align :    => second Text()    is ')'
+space_col_align :    => first text       is '('
+space_col_align :    => second text      is ')'
 space_col_align :    => first orig col   is 15
 space_col_align :    => second orig col  is 16
-space_col_align :    => first Len()      is 1
+space_col_align :    => first len        is 1
 space_col_align :    => coldiff is 1
-space_col_align : first orig line is 9, orig col is 16, [FPAREN_CLOSE/FUNC_CLASS_DEF], Text() ')' <==>
-space_col_align : second orig line is 9, orig col is 17 [NEWLINE/NONE], Text() '', [CallStack]
-do_space : orig line is 9, orig col is 16, first Text() ')', type is FPAREN_CLOSE
+space_col_align : 1st orig line 9, orig col 16, [FPAREN_CLOSE/FUNC_CLASS_DEF], text ')' <==>
+space_col_align : 2nd orig line 9, orig col 17, [NEWLINE/NONE], text ''
+ [CallStack]
+do_space : orig line 9, orig col 16, first text ')', type FPAREN_CLOSE
 space_col_align : av is remove
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is REMOVE
 space_col_align :    => coldiff is 1
-space_col_align : first orig line is 10, orig col is 1, [BRACE_OPEN/FUNC_CLASS_DEF], Text() '{' <==>
-space_col_align : second orig line is 10, orig col is 2 [NEWLINE/NONE], Text() '', [CallStack]
-do_space : orig line is 10, orig col is 1, first Text() '{', type is BRACE_OPEN
+space_col_align : 1st orig line 10, orig col 1, [BRACE_OPEN/FUNC_CLASS_DEF], text '{' <==>
+space_col_align : 2nd orig line 10, orig col 2, [NEWLINE/NONE], text ''
+ [CallStack]
+do_space : orig line 10, orig col 1, first text '{', type BRACE_OPEN
 space_col_align : av is remove
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is REMOVE
 space_col_align :    => coldiff is 1
-space_col_align : first orig line is 11, orig col is 1, [BRACE_CLOSE/FUNC_CLASS_DEF], Text() '}' <==>
-space_col_align : second orig line is 11, orig col is 2 [NEWLINE/NONE], Text() '', [CallStack]
-do_space : orig line is 11, orig col is 1, first Text() '}', type is BRACE_CLOSE
+space_col_align : 1st orig line 11, orig col 1, [BRACE_CLOSE/FUNC_CLASS_DEF], text '}' <==>
+space_col_align : 2nd orig line 11, orig col 2, [NEWLINE/NONE], text ''
+ [CallStack]
+do_space : orig line 11, orig col 1, first text '}', type BRACE_CLOSE
 space_col_align : av is remove
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is REMOVE
 space_col_align :    => coldiff is 1
-space_col_align : first orig line is 13, orig col is 1, [QUALIFIER/NONE], Text() 'const' <==>
-space_col_align : second orig line is 13, orig col is 7 [TYPE/NONE], Text() 'char', [CallStack]
-do_space : orig line is 13, orig col is 1, first Text() 'const', type is QUALIFIER
+space_col_align : 1st orig line 13, orig col 1, [QUALIFIER/NONE], text 'const' <==>
+space_col_align : 2nd orig line 13, orig col 7, [TYPE/NONE], text 'char'
+ [CallStack]
+do_space : orig line 13, orig col 1, first text 'const', type QUALIFIER
 do_space : first orig line is 13, orig col is 1, Text() is 'const', [QUALIFIER/NONE] <===>
            second orig line is 13, orig col is 7, Text() is 'char', [TYPE/NONE] : rule sp_after_type[ ]
-ensure_force_space : <force between 'const' and 'char'>
+ensure_force_space : force between 'const' and 'char'
 space_col_align : av is force
-space_col_align :    Len is 5
+space_col_align :    '1st' len is 5
 space_col_align :    => coldiff is 5
 space_col_align :    => av is FORCE
 space_col_align :    => coldiff is 6
-space_col_align : first orig line is 13, orig col is 7, [TYPE/NONE], Text() 'char' <==>
-space_col_align : second orig line is 13, orig col is 11 [PTR_TYPE/NONE], Text() '*', [CallStack]
-do_space : orig line is 13, orig col is 7, first Text() 'char', type is TYPE
+space_col_align : 1st orig line 13, orig col 7, [TYPE/NONE], text 'char' <==>
+space_col_align : 2nd orig line 13, orig col 11, [PTR_TYPE/NONE], text '*'
+ [CallStack]
+do_space : orig line 13, orig col 7, first text 'char', type TYPE
 do_space : first orig line is 13, orig col is 7, Text() is 'char', [TYPE/NONE] <===>
            second orig line is 13, orig col is 11, Text() is '*', [PTR_TYPE/NONE] : rule IGNORE[ ]
 space_col_align : av is ignore
-space_col_align :    Len is 4
+space_col_align :    '1st' len is 4
 space_col_align :    => coldiff is 4
 space_col_align :    => av is IGNORE
 space_col_align :    => first orig line  is 13
 space_col_align :    => second orig line is 13
-space_col_align :    => first Text()     is 'char'
-space_col_align :    => second Text()    is '*'
+space_col_align :    => first text       is 'char'
+space_col_align :    => second text      is '*'
 space_col_align :    => first orig col   is 7
 space_col_align :    => second orig col  is 11
-space_col_align :    => first Len()      is 4
+space_col_align :    => first len        is 4
 space_col_align :    => coldiff is 4
-space_col_align : first orig line is 13, orig col is 11, [PTR_TYPE/NONE], Text() '*' <==>
-space_col_align : second orig line is 13, orig col is 13 [QUALIFIER/NONE], Text() 'const', [CallStack]
-do_space : orig line is 13, orig col is 11, first Text() '*', type is PTR_TYPE
+space_col_align : 1st orig line 13, orig col 11, [PTR_TYPE/NONE], text '*' <==>
+space_col_align : 2nd orig line 13, orig col 13, [QUALIFIER/NONE], text 'const'
+ [CallStack]
+do_space : orig line 13, orig col 11, first text '*', type PTR_TYPE
 do_space : first orig line is 13, orig col is 11, Text() is '*', [PTR_TYPE/NONE] <===>
            second orig line is 13, orig col is 13, Text() is 'const', [QUALIFIER/NONE] : rule sp_after_ptr_star_qualifier[ ]
 space_col_align : av is ignore
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is IGNORE
 space_col_align :    => first orig line  is 13
 space_col_align :    => second orig line is 13
-space_col_align :    => first Text()     is '*'
-space_col_align :    => second Text()    is 'const'
+space_col_align :    => first text       is '*'
+space_col_align :    => second text      is 'const'
 space_col_align :    => first orig col   is 11
 space_col_align :    => second orig col  is 13
-space_col_align :    => first Len()      is 1
+space_col_align :    => first len        is 1
 space_col_align :    => coldiff is 2
-space_col_align : first orig line is 13, orig col is 13, [QUALIFIER/NONE], Text() 'const' <==>
-space_col_align : second orig line is 13, orig col is 19 [WORD/NONE], Text() 'pTelName', [CallStack]
-do_space : orig line is 13, orig col is 13, first Text() 'const', type is QUALIFIER
+space_col_align : 1st orig line 13, orig col 13, [QUALIFIER/NONE], text 'const' <==>
+space_col_align : 2nd orig line 13, orig col 19, [WORD/NONE], text 'pTelName'
+ [CallStack]
+do_space : orig line 13, orig col 13, first text 'const', type QUALIFIER
 do_space : first orig line is 13, orig col is 13, Text() is 'const', [QUALIFIER/NONE] <===>
            second orig line is 13, orig col is 19, Text() is 'pTelName', [WORD/NONE] : rule sp_after_type[ ]
-ensure_force_space : <force between 'const' and 'pTelName'>
+ensure_force_space : force between 'const' and 'pTelName'
 space_col_align : av is force
-space_col_align :    Len is 5
+space_col_align :    '1st' len is 5
 space_col_align :    => coldiff is 5
 space_col_align :    => av is FORCE
 space_col_align :    => coldiff is 6
-space_col_align : first orig line is 13, orig col is 19, [WORD/NONE], Text() 'pTelName' <==>
-space_col_align : second orig line is 13, orig col is 27 [SEMICOLON/NONE], Text() ';', [CallStack]
-do_space : orig line is 13, orig col is 19, first Text() 'pTelName', type is WORD
+space_col_align : 1st orig line 13, orig col 19, [WORD/NONE], text 'pTelName' <==>
+space_col_align : 2nd orig line 13, orig col 27, [SEMICOLON/NONE], text ';'
+ [CallStack]
+do_space : orig line 13, orig col 19, first text 'pTelName', type WORD
 do_space : first orig line is 13, orig col is 19, Text() is 'pTelName', [WORD/NONE] <===>
            second orig line is 13, orig col is 27, Text() is ';', [SEMICOLON/NONE] : rule sp_before_semi[ ]
 space_col_align : av is remove
-space_col_align :    Len is 8
+space_col_align :    '1st' len is 8
 space_col_align :    => coldiff is 8
 space_col_align :    => av is REMOVE
 space_col_align :    => coldiff is 8
-space_col_align : first orig line is 13, orig col is 27, [SEMICOLON/NONE], Text() ';' <==>
-space_col_align : second orig line is 13, orig col is 28 [NEWLINE/NONE], Text() '', [CallStack]
-do_space : orig line is 13, orig col is 27, first Text() ';', type is SEMICOLON
+space_col_align : 1st orig line 13, orig col 27, [SEMICOLON/NONE], text ';' <==>
+space_col_align : 2nd orig line 13, orig col 28, [NEWLINE/NONE], text ''
+ [CallStack]
+do_space : orig line 13, orig col 27, first text ';', type SEMICOLON
 space_col_align : av is remove
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is REMOVE
 space_col_align :    => coldiff is 1
-space_col_align : first orig line is 14, orig col is 1, [TYPE/NONE], Text() 'unsigned' <==>
-space_col_align : second orig line is 14, orig col is 10 [TYPE/NONE], Text() 'long', [CallStack]
-do_space : orig line is 14, orig col is 1, first Text() 'unsigned', type is TYPE
+space_col_align : 1st orig line 14, orig col 1, [TYPE/NONE], text 'unsigned' <==>
+space_col_align : 2nd orig line 14, orig col 10, [TYPE/NONE], text 'long'
+ [CallStack]
+do_space : orig line 14, orig col 1, first text 'unsigned', type TYPE
 do_space : first orig line is 14, orig col is 1, Text() is 'unsigned', [TYPE/NONE] <===>
            second orig line is 14, orig col is 10, Text() is 'long', [TYPE/NONE] : rule sp_after_type[ ]
-ensure_force_space : <force between 'unsigned' and 'long'>
+ensure_force_space : force between 'unsigned' and 'long'
 space_col_align : av is force
-space_col_align :    Len is 8
+space_col_align :    '1st' len is 8
 space_col_align :    => coldiff is 8
 space_col_align :    => av is FORCE
 space_col_align :    => coldiff is 9
-space_col_align : first orig line is 14, orig col is 10, [TYPE/NONE], Text() 'long' <==>
-space_col_align : second orig line is 14, orig col is 15 [WORD/NONE], Text() 'nTelIndex', [CallStack]
-do_space : orig line is 14, orig col is 10, first Text() 'long', type is TYPE
+space_col_align : 1st orig line 14, orig col 10, [TYPE/NONE], text 'long' <==>
+space_col_align : 2nd orig line 14, orig col 15, [WORD/NONE], text 'nTelIndex'
+ [CallStack]
+do_space : orig line 14, orig col 10, first text 'long', type TYPE
 do_space : first orig line is 14, orig col is 10, Text() is 'long', [TYPE/NONE] <===>
            second orig line is 14, orig col is 15, Text() is 'nTelIndex', [WORD/NONE] : rule sp_after_type[ ]
-ensure_force_space : <force between 'long' and 'nTelIndex'>
+ensure_force_space : force between 'long' and 'nTelIndex'
 space_col_align : av is force
-space_col_align :    Len is 4
+space_col_align :    '1st' len is 4
 space_col_align :    => coldiff is 4
 space_col_align :    => av is FORCE
 space_col_align :    => coldiff is 5
-space_col_align : first orig line is 14, orig col is 15, [WORD/NONE], Text() 'nTelIndex' <==>
-space_col_align : second orig line is 14, orig col is 24 [SEMICOLON/NONE], Text() ';', [CallStack]
-do_space : orig line is 14, orig col is 15, first Text() 'nTelIndex', type is WORD
+space_col_align : 1st orig line 14, orig col 15, [WORD/NONE], text 'nTelIndex' <==>
+space_col_align : 2nd orig line 14, orig col 24, [SEMICOLON/NONE], text ';'
+ [CallStack]
+do_space : orig line 14, orig col 15, first text 'nTelIndex', type WORD
 do_space : first orig line is 14, orig col is 15, Text() is 'nTelIndex', [WORD/NONE] <===>
            second orig line is 14, orig col is 24, Text() is ';', [SEMICOLON/NONE] : rule sp_before_semi[ ]
 space_col_align : av is remove
-space_col_align :    Len is 9
+space_col_align :    '1st' len is 9
 space_col_align :    => coldiff is 9
 space_col_align :    => av is REMOVE
 space_col_align :    => coldiff is 9
-space_col_align : first orig line is 14, orig col is 24, [SEMICOLON/NONE], Text() ';' <==>
-space_col_align : second orig line is 14, orig col is 25 [NEWLINE/NONE], Text() '', [CallStack]
-do_space : orig line is 14, orig col is 24, first Text() ';', type is SEMICOLON
+space_col_align : 1st orig line 14, orig col 24, [SEMICOLON/NONE], text ';' <==>
+space_col_align : 2nd orig line 14, orig col 25, [NEWLINE/NONE], text ''
+ [CallStack]
+do_space : orig line 14, orig col 24, first text ';', type SEMICOLON
 space_col_align : av is remove
-space_col_align :    Len is 1
+space_col_align :    '1st' len is 1
 space_col_align :    => coldiff is 1
 space_col_align :    => av is REMOVE
 space_col_align :    => coldiff is 1

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -6289,6 +6289,14 @@ MinVal=0
 MaxVal=5000
 ValueDefault=0
 
+[Align Func Proto Span Ignore Cont Lines]
+Category=7
+Description="<html>Whether to ignore continuation lines when evaluating the number of<br/>new lines for the function prototype alignment's span.<br/><br/>false: continuation lines are part of the newlines count<br/>true:  continuation lines are not counted</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=align_func_proto_span_ignore_cont_lines=true|align_func_proto_span_ignore_cont_lines=false
+ValueDefault=false
+
 [Align Func Proto Star Style]
 Category=7
 Description="<html>How to consider (or treat) the '*' in the alignment of function prototypes.<br/><br/>0: Part of the type     'void *   foo();' (default)<br/>1: Part of the function 'void     *foo();'<br/>2: Dangling             'void    *foo();'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"

--- a/tests/config/common/tde.cfg
+++ b/tests/config/common/tde.cfg
@@ -698,6 +698,7 @@ align_right_cmt_mix             = false    # true/false
 align_right_cmt_same_level      = false    # true/false
 align_right_cmt_at_col          = 0        # unsigned number
 align_func_proto_span           = 1        # unsigned number
+align_func_proto_span_ignore_cont_lines = true # true/false
 align_func_proto_star_style     = 0        # unsigned number
 align_func_proto_amp_style      = 0        # unsigned number
 align_func_proto_thresh         = 0        # number

--- a/tests/expected/c/00075-function_prototypes_alignment.c
+++ b/tests/expected/c/00075-function_prototypes_alignment.c
@@ -1,0 +1,21 @@
+libr_intstatus set_data1(libr_file *file_handle, libr_section *scn, libr_data *data, off_t offset,
+        char *buffer, size_t size);
+void           write_output1(libr_file *file_handle);
+libr_intstatus open_handles1(libr_file *file_handle, char *filename, libr_access_t access);
+
+libr_intstatus set_data2(libr_file *file_handle, libr_section *scn, libr_data *data, off_t offset,
+        char *buffer, size_t size);
+libr_intstatus open_handles2(libr_file *file_handle, char *filename, libr_access_t access);
+void           write_output2(libr_file *file_handle);
+
+INTERNAL_FN libr_intstatus set_data1(libr_file *file_handle, libr_section *scn, libr_data *data,
+        off_t offset, char *buffer, size_t size);
+INTERNAL_FN void           write_output1(libr_file *file_handle);
+INTERNAL_FN libr_intstatus open_handles1(libr_file *file_handle, char *filename,
+        libr_access_t access);
+
+INTERNAL_FN libr_intstatus set_data2(libr_file *file_handle, libr_section *scn, libr_data *data,
+        off_t offset, char *buffer, size_t size);
+INTERNAL_FN libr_intstatus open_handles2(libr_file *file_handle, char *filename,
+        libr_access_t access);
+INTERNAL_FN void           write_output2(libr_file *file_handle);

--- a/tests/input/c/function_prototypes_alignment.c
+++ b/tests/input/c/function_prototypes_alignment.c
@@ -1,0 +1,15 @@
+libr_intstatus set_data1(libr_file *file_handle, libr_section *scn, libr_data *data, off_t offset, char *buffer, size_t size);
+void write_output1(libr_file *file_handle);
+libr_intstatus open_handles1(libr_file *file_handle, char *filename, libr_access_t access);
+
+libr_intstatus set_data2(libr_file *file_handle, libr_section *scn, libr_data *data, off_t offset, char *buffer, size_t size);
+libr_intstatus open_handles2(libr_file *file_handle, char *filename, libr_access_t access);
+void write_output2(libr_file *file_handle);
+
+INTERNAL_FN libr_intstatus set_data1(libr_file *file_handle, libr_section *scn, libr_data *data, off_t offset, char *buffer, size_t size);
+INTERNAL_FN void write_output1(libr_file *file_handle);
+INTERNAL_FN libr_intstatus open_handles1(libr_file *file_handle, char *filename, libr_access_t access);
+
+INTERNAL_FN libr_intstatus set_data2(libr_file *file_handle, libr_section *scn, libr_data *data, off_t offset, char *buffer, size_t size);
+INTERNAL_FN libr_intstatus open_handles2(libr_file *file_handle, char *filename, libr_access_t access);
+INTERNAL_FN void write_output2(libr_file *file_handle);


### PR DESCRIPTION
This resolves issue #4131.
When the option is `true`, continuation lines are not counted when evaluation the number of new lines for the function prototype alignment span.