### PR TITLE
Adjust place for log rules and comments in main align block

### DIFF
--- a/src/align.cpp
+++ b/src/align.cpp
@@ -118,49 +118,47 @@ void align_all()
 {
    LOG_FUNC_ENTRY();
 
-   log_rule_B("align_typedef_span");
-
    if (options::align_typedef_span() > 0)
    {
+      log_rule_B("align_typedef_span");
       align_typedefs(options::align_typedef_span());
    }
-   log_rule_B("align_left_shift");
 
    if (options::align_left_shift())
    {
+      log_rule_B("align_left_shift");
       align_left_shift();
    }
-   log_rule_B("align_eigen_comma_init");
 
    if (options::align_eigen_comma_init())
    {
+      log_rule_B("align_eigen_comma_init");
       align_eigen_comma_init();
    }
-   log_rule_B("align_oc_msg_colon_span");
 
    if (options::align_oc_msg_colon_span() > 0)
    {
+      log_rule_B("align_oc_msg_colon_span");
       align_oc_msg_colons();
    }
-   // Align variable definitions
-   log_rule_B("align_var_def_span");
-   log_rule_B("align_var_struct_span");
-   log_rule_B("align_var_class_span");
 
    if (  (options::align_var_def_span() > 0)
       || (options::align_var_struct_span() > 0)
       || (options::align_var_class_span() > 0))
    {
+      // Align variable definitions
+      log_rule_B("align_var_def_span");
+      log_rule_B("align_var_struct_span");
+      log_rule_B("align_var_class_span");
       align_var_def_brace(Chunk::GetHead(), options::align_var_def_span(), nullptr);
    }
-   // Align assignments
-   log_rule_B("align_enum_equ_span");
-   log_rule_B("align_assign_span");
-   log_rule_B("align_assign_thresh");
 
    if (  (options::align_enum_equ_span() > 0)
       || (options::align_assign_span() > 0))
    {
+      // Align assignments
+      log_rule_B("align_enum_equ_span");
+      log_rule_B("align_assign_span");
       align_assign(Chunk::GetHead(),
                    options::align_assign_span(),
                    options::align_assign_thresh(),
@@ -170,60 +168,63 @@ void align_all()
    if (  (options::align_braced_init_list_span() > 0)                   // Issue #750
       || (options::align_braced_init_list_thresh() > 0))
    {
+      // Align braced initializers lists
       align_braced_init_list(Chunk::GetHead(),
                              options::align_braced_init_list_span(),
                              options::align_braced_init_list_thresh(),
                              nullptr);
    }
-   // Align structure initializers
-   log_rule_B("align_struct_init_span");
 
    if (options::align_struct_init_span() > 0)
    {
+      // Align structure initializers
+      log_rule_B("align_struct_init_span");
       align_struct_initializers();
    }
-   // Align function prototypes
-   log_rule_B("align_func_proto_span");
-   log_rule_B("align_mix_var_proto");
 
    if (  (options::align_func_proto_span() > 0)
       && !options::align_mix_var_proto())
    {
+      // Align function prototypes
+      log_rule_B("align_func_proto_span");
+      log_rule_B("align_mix_var_proto");
       align_func_proto(options::align_func_proto_span());
    }
-   // Align function prototypes
-   log_rule_B("align_oc_msg_spec_span");
 
    if (options::align_oc_msg_spec_span() > 0)
    {
+      // Align OC message spec
+      log_rule_B("align_oc_msg_spec_span");
       align_oc_msg_spec(options::align_oc_msg_spec_span());
    }
-   // Align OC colons
-   log_rule_B("align_oc_decl_colon");
 
    if (options::align_oc_decl_colon())
    {
+      // Align OC colons
+      log_rule_B("align_oc_decl_colon");
       align_oc_decl_colon();
    }
-   log_rule_B("align_asm_colon");
 
    if (options::align_asm_colon())
    {
+      // Align ASM colons
+      log_rule_B("align_asm_colon");
       align_asm_colon();
    }
-   // Align variable definitions in function prototypes
-   log_rule_B("align_func_params");
-   log_rule_B("align_func_params_span");
 
    if (  options::align_func_params()
       || options::align_func_params_span() > 0)
    {
+      // Align variable definitions in function prototypes
+      log_rule_B("align_func_params");
+      log_rule_B("align_func_params_span");
       align_func_params();
    }
-   log_rule_B("align_same_func_call_params");
 
    if (options::align_same_func_call_params())
    {
+      // Align parameters in function call
+      log_rule_B("align_same_func_call_params");
       align_same_func_call_params();
    }
    // Just in case something was aligned out of order... do it again


### PR DESCRIPTION
Make comments more consistent and provide more meaningful logs. Minor commit.
