### PR TITLE
Don't create uninstall target if used as subproject.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -549,7 +549,10 @@ endif()
 #
 # Uninstall
 #
-add_custom_target(uninstall "${CMAKE_COMMAND}" -P "${PROJECT_SOURCE_DIR}/cmake/uninstall.cmake")
+get_directory_property(hasParent PARENT_DIRECTORY)
+if(NOT hasParent)
+  add_custom_target(uninstall "${CMAKE_COMMAND}" -P "${PROJECT_SOURCE_DIR}/cmake/uninstall.cmake")
+endif()
 
 #
 # add to build the compile_commands.json file, to be used by clang-tidy


### PR DESCRIPTION
This allows other projects to use uncrustify while still having their
own "uninstall" target.
