### PR TITLE
Add support for regex in etc/uigui_uncrustify.ini

### DIFF
--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -15,6 +15,7 @@ parameterOrder=ipo
 showHelpParameter=-h
 stringparaminquotes=false
 useCfgFileParameter="-c "
+useRegex=true
 version=Uncrustify_d-0.76.0-148-ce753d9e9-dev
 
 [Newlines]
@@ -22,7 +23,7 @@ Category=0
 Description="<html>The type of line endings.<br/><br/>Default: auto</html>"
 Enabled=false
 EditorType=multiple
-Choices=newlines=lf|newlines=crlf|newlines=cr|newlines=auto
+Choices=newlines\s*=\s*lf|newlines\s*=\s*crlf|newlines\s*=\s*cr|newlines\s*=\s*auto
 ChoicesReadable="Newlines Unix|Newlines Win|Newlines Mac|Newlines Auto"
 ValueDefault=auto
 
@@ -31,7 +32,7 @@ Category=0
 Description="<html>The original size of tabs in the input.<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
-CallName="input_tab_size="
+CallName="input_tab_size\s*=\s*"
 MinVal=1
 MaxVal=32
 ValueDefault=8
@@ -41,7 +42,7 @@ Category=0
 Description="<html>The size of tabs in the output (only used if align_with_tabs=true).<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
-CallName="output_tab_size="
+CallName="output_tab_size\s*=\s*"
 MinVal=1
 MaxVal=32
 ValueDefault=8
@@ -51,7 +52,7 @@ Category=0
 Description="<html>The ASCII value of the string escape char, usually 92 (\) or (Pawn) 94 (^).<br/><br/>Default: 92</html>"
 Enabled=false
 EditorType=numeric
-CallName="string_escape_char="
+CallName="string_escape_char\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=92
@@ -61,7 +62,7 @@ Category=0
 Description="<html>Alternate string escape char (usually only used for Pawn).<br/>Only works right before the quote char.</html>"
 Enabled=false
 EditorType=numeric
-CallName="string_escape_char2="
+CallName="string_escape_char2\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -71,7 +72,7 @@ Category=0
 Description="<html>Replace tab characters found in string literals with the escape sequence \t<br/>instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=string_replace_tab_chars=true|string_replace_tab_chars=false
+TrueFalse=string_replace_tab_chars\s*=\s*true|string_replace_tab_chars\s*=\s*false
 ValueDefault=false
 
 [Tok Split Gte]
@@ -79,7 +80,7 @@ Category=0
 Description="<html>Allow interpreting '&gt;=' and '&gt;&gt;=' as part of a template in code like<br/>'void f(list&lt;list&lt;B&gt;&gt;=val);'. If true, 'assert(x&lt;0 &amp;&amp; y&gt;=3)' will be broken.<br/>Improvements to template detection may make this option obsolete.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=tok_split_gte=true|tok_split_gte=false
+TrueFalse=tok_split_gte\s*=\s*true|tok_split_gte\s*=\s*false
 ValueDefault=false
 
 [Disable Processing Nl Cont]
@@ -87,14 +88,14 @@ Category=0
 Description="<html>Disable formatting of NL_CONT ('\\n') ended lines (e.g. multi-line macros).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=disable_processing_nl_cont=true|disable_processing_nl_cont=false
+TrueFalse=disable_processing_nl_cont\s*=\s*true|disable_processing_nl_cont\s*=\s*false
 ValueDefault=false
 
 [Disable Processing Cmt]
 Category=0
 Description="<html>Specify the marker used in comments to disable processing of part of the<br/>file.<br/><br/>Default:  *INDENT-OFF*</html>"
 Enabled=false
-CallName=disable_processing_cmt=
+CallName=disable_processing_cmt\s*=\s*
 EditorType=string
 ValueDefault= *INDENT-OFF*
 
@@ -102,7 +103,7 @@ ValueDefault= *INDENT-OFF*
 Category=0
 Description="<html>Specify the marker used in comments to (re)enable processing in a file.<br/><br/>Default:  *INDENT-ON*</html>"
 Enabled=false
-CallName=enable_processing_cmt=
+CallName=enable_processing_cmt\s*=\s*
 EditorType=string
 ValueDefault= *INDENT-ON*
 
@@ -111,7 +112,7 @@ Category=0
 Description="<html>Enable parsing of digraphs.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=enable_digraphs=true|enable_digraphs=false
+TrueFalse=enable_digraphs\s*=\s*true|enable_digraphs\s*=\s*false
 ValueDefault=false
 
 [Processing Cmt As Regex]
@@ -119,7 +120,7 @@ Category=0
 Description="<html>Option to allow both disable_processing_cmt and enable_processing_cmt<br/>strings, if specified, to be interpreted as ECMAScript regular expressions.<br/>If true, a regex search will be performed within comments according to the<br/>specified patterns in order to disable/enable processing.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=processing_cmt_as_regex=true|processing_cmt_as_regex=false
+TrueFalse=processing_cmt_as_regex\s*=\s*true|processing_cmt_as_regex\s*=\s*false
 ValueDefault=false
 
 [Utf8 Bom]
@@ -127,7 +128,7 @@ Category=0
 Description="<html>Add or remove the UTF-8 BOM (recommend 'remove').</html>"
 Enabled=false
 EditorType=multiple
-Choices=utf8_bom=ignore|utf8_bom=add|utf8_bom=remove|utf8_bom=force|utf8_bom=not_defined
+Choices=utf8_bom\s*=\s*ignore|utf8_bom\s*=\s*add|utf8_bom\s*=\s*remove|utf8_bom\s*=\s*force|utf8_bom\s*=\s*not_defined
 ChoicesReadable="Ignore Utf8 Bom|Add Utf8 Bom|Remove Utf8 Bom|Force Utf8 Bom"
 ValueDefault=ignore
 
@@ -136,7 +137,7 @@ Category=0
 Description="<html>If the file contains bytes with values between 128 and 255, but is not<br/>UTF-8, then output as UTF-8.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=utf8_byte=true|utf8_byte=false
+TrueFalse=utf8_byte\s*=\s*true|utf8_byte\s*=\s*false
 ValueDefault=false
 
 [Utf8 Force]
@@ -144,7 +145,7 @@ Category=0
 Description="<html>Force the output encoding to UTF-8.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=utf8_force=true|utf8_force=false
+TrueFalse=utf8_force\s*=\s*true|utf8_force\s*=\s*false
 ValueDefault=false
 
 [Sp Arith]
@@ -152,7 +153,7 @@ Category=1
 Description="<html>Add or remove space around non-assignment symbolic operators ('+', '/', '%',<br/>'&lt;&lt;', and so forth).</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_arith=ignore|sp_arith=add|sp_arith=remove|sp_arith=force|sp_arith=not_defined
+Choices=sp_arith\s*=\s*ignore|sp_arith\s*=\s*add|sp_arith\s*=\s*remove|sp_arith\s*=\s*force|sp_arith\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Arith|Add Sp Arith|Remove Sp Arith|Force Sp Arith"
 ValueDefault=ignore
 
@@ -161,7 +162,7 @@ Category=1
 Description="<html>Add or remove space around arithmetic operators '+' and '-'.<br/><br/>Overrides sp_arith.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_arith_additive=ignore|sp_arith_additive=add|sp_arith_additive=remove|sp_arith_additive=force|sp_arith_additive=not_defined
+Choices=sp_arith_additive\s*=\s*ignore|sp_arith_additive\s*=\s*add|sp_arith_additive\s*=\s*remove|sp_arith_additive\s*=\s*force|sp_arith_additive\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Arith Additive|Add Sp Arith Additive|Remove Sp Arith Additive|Force Sp Arith Additive"
 ValueDefault=ignore
 
@@ -170,7 +171,7 @@ Category=1
 Description="<html>Add or remove space around assignment operator '=', '+=', etc.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_assign=ignore|sp_assign=add|sp_assign=remove|sp_assign=force|sp_assign=not_defined
+Choices=sp_assign\s*=\s*ignore|sp_assign\s*=\s*add|sp_assign\s*=\s*remove|sp_assign\s*=\s*force|sp_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Assign|Add Sp Assign|Remove Sp Assign|Force Sp Assign"
 ValueDefault=ignore
 
@@ -179,7 +180,7 @@ Category=1
 Description="<html>Add or remove space around '=' in C++11 lambda capture specifications.<br/><br/>Overrides sp_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_assign=ignore|sp_cpp_lambda_assign=add|sp_cpp_lambda_assign=remove|sp_cpp_lambda_assign=force|sp_cpp_lambda_assign=not_defined
+Choices=sp_cpp_lambda_assign\s*=\s*ignore|sp_cpp_lambda_assign\s*=\s*add|sp_cpp_lambda_assign\s*=\s*remove|sp_cpp_lambda_assign\s*=\s*force|sp_cpp_lambda_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Assign|Add Sp Cpp Lambda Assign|Remove Sp Cpp Lambda Assign|Force Sp Cpp Lambda Assign"
 ValueDefault=ignore
 
@@ -188,7 +189,7 @@ Category=1
 Description="<html>Add or remove space after the capture specification of a C++11 lambda when<br/>an argument list is present, as in '[] &lt;here&gt; (int x){ ... }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_square_paren=ignore|sp_cpp_lambda_square_paren=add|sp_cpp_lambda_square_paren=remove|sp_cpp_lambda_square_paren=force|sp_cpp_lambda_square_paren=not_defined
+Choices=sp_cpp_lambda_square_paren\s*=\s*ignore|sp_cpp_lambda_square_paren\s*=\s*add|sp_cpp_lambda_square_paren\s*=\s*remove|sp_cpp_lambda_square_paren\s*=\s*force|sp_cpp_lambda_square_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Square Paren|Add Sp Cpp Lambda Square Paren|Remove Sp Cpp Lambda Square Paren|Force Sp Cpp Lambda Square Paren"
 ValueDefault=ignore
 
@@ -197,7 +198,7 @@ Category=1
 Description="<html>Add or remove space after the capture specification of a C++11 lambda with<br/>no argument list is present, as in '[] &lt;here&gt; { ... }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_square_brace=ignore|sp_cpp_lambda_square_brace=add|sp_cpp_lambda_square_brace=remove|sp_cpp_lambda_square_brace=force|sp_cpp_lambda_square_brace=not_defined
+Choices=sp_cpp_lambda_square_brace\s*=\s*ignore|sp_cpp_lambda_square_brace\s*=\s*add|sp_cpp_lambda_square_brace\s*=\s*remove|sp_cpp_lambda_square_brace\s*=\s*force|sp_cpp_lambda_square_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Square Brace|Add Sp Cpp Lambda Square Brace|Remove Sp Cpp Lambda Square Brace|Force Sp Cpp Lambda Square Brace"
 ValueDefault=ignore
 
@@ -206,7 +207,7 @@ Category=1
 Description="<html>Add or remove space after the opening parenthesis and before the closing<br/>parenthesis of a argument list of a C++11 lambda, as in<br/>'[]( &lt;here&gt; ){ ... }'<br/>with an empty list.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_argument_list_empty=ignore|sp_cpp_lambda_argument_list_empty=add|sp_cpp_lambda_argument_list_empty=remove|sp_cpp_lambda_argument_list_empty=force|sp_cpp_lambda_argument_list_empty=not_defined
+Choices=sp_cpp_lambda_argument_list_empty\s*=\s*ignore|sp_cpp_lambda_argument_list_empty\s*=\s*add|sp_cpp_lambda_argument_list_empty\s*=\s*remove|sp_cpp_lambda_argument_list_empty\s*=\s*force|sp_cpp_lambda_argument_list_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Argument List Empty|Add Sp Cpp Lambda Argument List Empty|Remove Sp Cpp Lambda Argument List Empty|Force Sp Cpp Lambda Argument List Empty"
 ValueDefault=ignore
 
@@ -215,7 +216,7 @@ Category=1
 Description="<html>Add or remove space after the opening parenthesis and before the closing<br/>parenthesis of a argument list of a C++11 lambda, as in<br/>'[]( &lt;here&gt; int x &lt;here&gt; ){ ... }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_argument_list=ignore|sp_cpp_lambda_argument_list=add|sp_cpp_lambda_argument_list=remove|sp_cpp_lambda_argument_list=force|sp_cpp_lambda_argument_list=not_defined
+Choices=sp_cpp_lambda_argument_list\s*=\s*ignore|sp_cpp_lambda_argument_list\s*=\s*add|sp_cpp_lambda_argument_list\s*=\s*remove|sp_cpp_lambda_argument_list\s*=\s*force|sp_cpp_lambda_argument_list\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Argument List|Add Sp Cpp Lambda Argument List|Remove Sp Cpp Lambda Argument List|Force Sp Cpp Lambda Argument List"
 ValueDefault=ignore
 
@@ -224,7 +225,7 @@ Category=1
 Description="<html>Add or remove space after the argument list of a C++11 lambda, as in<br/>'[](int x) &lt;here&gt; { ... }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_paren_brace=ignore|sp_cpp_lambda_paren_brace=add|sp_cpp_lambda_paren_brace=remove|sp_cpp_lambda_paren_brace=force|sp_cpp_lambda_paren_brace=not_defined
+Choices=sp_cpp_lambda_paren_brace\s*=\s*ignore|sp_cpp_lambda_paren_brace\s*=\s*add|sp_cpp_lambda_paren_brace\s*=\s*remove|sp_cpp_lambda_paren_brace\s*=\s*force|sp_cpp_lambda_paren_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Paren Brace|Add Sp Cpp Lambda Paren Brace|Remove Sp Cpp Lambda Paren Brace|Force Sp Cpp Lambda Paren Brace"
 ValueDefault=ignore
 
@@ -233,7 +234,7 @@ Category=1
 Description="<html>Add or remove space between a lambda body and its call operator of an<br/>immediately invoked lambda, as in '[]( ... ){ ... } &lt;here&gt; ( ... )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_fparen=ignore|sp_cpp_lambda_fparen=add|sp_cpp_lambda_fparen=remove|sp_cpp_lambda_fparen=force|sp_cpp_lambda_fparen=not_defined
+Choices=sp_cpp_lambda_fparen\s*=\s*ignore|sp_cpp_lambda_fparen\s*=\s*add|sp_cpp_lambda_fparen\s*=\s*remove|sp_cpp_lambda_fparen\s*=\s*force|sp_cpp_lambda_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Fparen|Add Sp Cpp Lambda Fparen|Remove Sp Cpp Lambda Fparen|Force Sp Cpp Lambda Fparen"
 ValueDefault=ignore
 
@@ -242,7 +243,7 @@ Category=1
 Description="<html>Add or remove space around assignment operator '=' in a prototype.<br/><br/>If set to ignore, use sp_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_assign_default=ignore|sp_assign_default=add|sp_assign_default=remove|sp_assign_default=force|sp_assign_default=not_defined
+Choices=sp_assign_default\s*=\s*ignore|sp_assign_default\s*=\s*add|sp_assign_default\s*=\s*remove|sp_assign_default\s*=\s*force|sp_assign_default\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Assign Default|Add Sp Assign Default|Remove Sp Assign Default|Force Sp Assign Default"
 ValueDefault=ignore
 
@@ -251,7 +252,7 @@ Category=1
 Description="<html>Add or remove space before assignment operator '=', '+=', etc.<br/><br/>Overrides sp_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_assign=ignore|sp_before_assign=add|sp_before_assign=remove|sp_before_assign=force|sp_before_assign=not_defined
+Choices=sp_before_assign\s*=\s*ignore|sp_before_assign\s*=\s*add|sp_before_assign\s*=\s*remove|sp_before_assign\s*=\s*force|sp_before_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Assign|Add Sp Before Assign|Remove Sp Before Assign|Force Sp Before Assign"
 ValueDefault=ignore
 
@@ -260,7 +261,7 @@ Category=1
 Description="<html>Add or remove space after assignment operator '=', '+=', etc.<br/><br/>Overrides sp_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_assign=ignore|sp_after_assign=add|sp_after_assign=remove|sp_after_assign=force|sp_after_assign=not_defined
+Choices=sp_after_assign\s*=\s*ignore|sp_after_assign\s*=\s*add|sp_after_assign\s*=\s*remove|sp_after_assign\s*=\s*force|sp_after_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Assign|Add Sp After Assign|Remove Sp After Assign|Force Sp After Assign"
 ValueDefault=ignore
 
@@ -269,7 +270,7 @@ Category=1
 Description="<html>Add or remove space in 'enum {'.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_brace=ignore|sp_enum_brace=add|sp_enum_brace=remove|sp_enum_brace=force|sp_enum_brace=not_defined
+Choices=sp_enum_brace\s*=\s*ignore|sp_enum_brace\s*=\s*add|sp_enum_brace\s*=\s*remove|sp_enum_brace\s*=\s*force|sp_enum_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Brace|Add Sp Enum Brace|Remove Sp Enum Brace|Force Sp Enum Brace"
 ValueDefault=add
 
@@ -278,7 +279,7 @@ Category=1
 Description="<html>Add or remove space in 'NS_ENUM ('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_paren=ignore|sp_enum_paren=add|sp_enum_paren=remove|sp_enum_paren=force|sp_enum_paren=not_defined
+Choices=sp_enum_paren\s*=\s*ignore|sp_enum_paren\s*=\s*add|sp_enum_paren\s*=\s*remove|sp_enum_paren\s*=\s*force|sp_enum_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Paren|Add Sp Enum Paren|Remove Sp Enum Paren|Force Sp Enum Paren"
 ValueDefault=ignore
 
@@ -287,7 +288,7 @@ Category=1
 Description="<html>Add or remove space around assignment '=' in enum.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_assign=ignore|sp_enum_assign=add|sp_enum_assign=remove|sp_enum_assign=force|sp_enum_assign=not_defined
+Choices=sp_enum_assign\s*=\s*ignore|sp_enum_assign\s*=\s*add|sp_enum_assign\s*=\s*remove|sp_enum_assign\s*=\s*force|sp_enum_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Assign|Add Sp Enum Assign|Remove Sp Enum Assign|Force Sp Enum Assign"
 ValueDefault=ignore
 
@@ -296,7 +297,7 @@ Category=1
 Description="<html>Add or remove space before assignment '=' in enum.<br/><br/>Overrides sp_enum_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_before_assign=ignore|sp_enum_before_assign=add|sp_enum_before_assign=remove|sp_enum_before_assign=force|sp_enum_before_assign=not_defined
+Choices=sp_enum_before_assign\s*=\s*ignore|sp_enum_before_assign\s*=\s*add|sp_enum_before_assign\s*=\s*remove|sp_enum_before_assign\s*=\s*force|sp_enum_before_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Before Assign|Add Sp Enum Before Assign|Remove Sp Enum Before Assign|Force Sp Enum Before Assign"
 ValueDefault=ignore
 
@@ -305,7 +306,7 @@ Category=1
 Description="<html>Add or remove space after assignment '=' in enum.<br/><br/>Overrides sp_enum_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_after_assign=ignore|sp_enum_after_assign=add|sp_enum_after_assign=remove|sp_enum_after_assign=force|sp_enum_after_assign=not_defined
+Choices=sp_enum_after_assign\s*=\s*ignore|sp_enum_after_assign\s*=\s*add|sp_enum_after_assign\s*=\s*remove|sp_enum_after_assign\s*=\s*force|sp_enum_after_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum After Assign|Add Sp Enum After Assign|Remove Sp Enum After Assign|Force Sp Enum After Assign"
 ValueDefault=ignore
 
@@ -314,7 +315,7 @@ Category=1
 Description="<html>Add or remove space around assignment ':' in enum.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_colon=ignore|sp_enum_colon=add|sp_enum_colon=remove|sp_enum_colon=force|sp_enum_colon=not_defined
+Choices=sp_enum_colon\s*=\s*ignore|sp_enum_colon\s*=\s*add|sp_enum_colon\s*=\s*remove|sp_enum_colon\s*=\s*force|sp_enum_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Colon|Add Sp Enum Colon|Remove Sp Enum Colon|Force Sp Enum Colon"
 ValueDefault=ignore
 
@@ -323,7 +324,7 @@ Category=1
 Description="<html>Add or remove space around preprocessor '##' concatenation operator.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_pp_concat=ignore|sp_pp_concat=add|sp_pp_concat=remove|sp_pp_concat=force|sp_pp_concat=not_defined
+Choices=sp_pp_concat\s*=\s*ignore|sp_pp_concat\s*=\s*add|sp_pp_concat\s*=\s*remove|sp_pp_concat\s*=\s*force|sp_pp_concat\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Pp Concat|Add Sp Pp Concat|Remove Sp Pp Concat|Force Sp Pp Concat"
 ValueDefault=add
 
@@ -332,7 +333,7 @@ Category=1
 Description="<html>Add or remove space after preprocessor '#' stringify operator.<br/>Also affects the '#@' charizing operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_pp_stringify=ignore|sp_pp_stringify=add|sp_pp_stringify=remove|sp_pp_stringify=force|sp_pp_stringify=not_defined
+Choices=sp_pp_stringify\s*=\s*ignore|sp_pp_stringify\s*=\s*add|sp_pp_stringify\s*=\s*remove|sp_pp_stringify\s*=\s*force|sp_pp_stringify\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Pp Stringify|Add Sp Pp Stringify|Remove Sp Pp Stringify|Force Sp Pp Stringify"
 ValueDefault=ignore
 
@@ -341,7 +342,7 @@ Category=1
 Description="<html>Add or remove space before preprocessor '#' stringify operator<br/>as in '#define x(y) L#y'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_pp_stringify=ignore|sp_before_pp_stringify=add|sp_before_pp_stringify=remove|sp_before_pp_stringify=force|sp_before_pp_stringify=not_defined
+Choices=sp_before_pp_stringify\s*=\s*ignore|sp_before_pp_stringify\s*=\s*add|sp_before_pp_stringify\s*=\s*remove|sp_before_pp_stringify\s*=\s*force|sp_before_pp_stringify\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Pp Stringify|Add Sp Before Pp Stringify|Remove Sp Before Pp Stringify|Force Sp Before Pp Stringify"
 ValueDefault=ignore
 
@@ -350,7 +351,7 @@ Category=1
 Description="<html>Add or remove space around boolean operators '&amp;&amp;' and '||'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_bool=ignore|sp_bool=add|sp_bool=remove|sp_bool=force|sp_bool=not_defined
+Choices=sp_bool\s*=\s*ignore|sp_bool\s*=\s*add|sp_bool\s*=\s*remove|sp_bool\s*=\s*force|sp_bool\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Bool|Add Sp Bool|Remove Sp Bool|Force Sp Bool"
 ValueDefault=ignore
 
@@ -359,7 +360,7 @@ Category=1
 Description="<html>Add or remove space around compare operator '&lt;', '&gt;', '==', etc.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_compare=ignore|sp_compare=add|sp_compare=remove|sp_compare=force|sp_compare=not_defined
+Choices=sp_compare\s*=\s*ignore|sp_compare\s*=\s*add|sp_compare\s*=\s*remove|sp_compare\s*=\s*force|sp_compare\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Compare|Add Sp Compare|Remove Sp Compare|Force Sp Compare"
 ValueDefault=ignore
 
@@ -368,7 +369,7 @@ Category=1
 Description="<html>Add or remove space inside '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_paren=ignore|sp_inside_paren=add|sp_inside_paren=remove|sp_inside_paren=force|sp_inside_paren=not_defined
+Choices=sp_inside_paren\s*=\s*ignore|sp_inside_paren\s*=\s*add|sp_inside_paren\s*=\s*remove|sp_inside_paren\s*=\s*force|sp_inside_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Paren|Add Sp Inside Paren|Remove Sp Inside Paren|Force Sp Inside Paren"
 ValueDefault=ignore
 
@@ -377,7 +378,7 @@ Category=1
 Description="<html>Add or remove space between nested parentheses, i.e. '((' vs. ') )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_paren=ignore|sp_paren_paren=add|sp_paren_paren=remove|sp_paren_paren=force|sp_paren_paren=not_defined
+Choices=sp_paren_paren\s*=\s*ignore|sp_paren_paren\s*=\s*add|sp_paren_paren\s*=\s*remove|sp_paren_paren\s*=\s*force|sp_paren_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Paren|Add Sp Paren Paren|Remove Sp Paren Paren|Force Sp Paren Paren"
 ValueDefault=ignore
 
@@ -386,7 +387,7 @@ Category=1
 Description="<html>Add or remove space between back-to-back parentheses, i.e. ')(' vs. ') ('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cparen_oparen=ignore|sp_cparen_oparen=add|sp_cparen_oparen=remove|sp_cparen_oparen=force|sp_cparen_oparen=not_defined
+Choices=sp_cparen_oparen\s*=\s*ignore|sp_cparen_oparen\s*=\s*add|sp_cparen_oparen\s*=\s*remove|sp_cparen_oparen\s*=\s*force|sp_cparen_oparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cparen Oparen|Add Sp Cparen Oparen|Remove Sp Cparen Oparen|Force Sp Cparen Oparen"
 ValueDefault=ignore
 
@@ -395,7 +396,7 @@ Category=1
 Description="<html>Whether to balance spaces inside nested parentheses.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_balance_nested_parens=true|sp_balance_nested_parens=false
+TrueFalse=sp_balance_nested_parens\s*=\s*true|sp_balance_nested_parens\s*=\s*false
 ValueDefault=false
 
 [Sp Paren Brace]
@@ -403,7 +404,7 @@ Category=1
 Description="<html>Add or remove space between ')' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_brace=ignore|sp_paren_brace=add|sp_paren_brace=remove|sp_paren_brace=force|sp_paren_brace=not_defined
+Choices=sp_paren_brace\s*=\s*ignore|sp_paren_brace\s*=\s*add|sp_paren_brace\s*=\s*remove|sp_paren_brace\s*=\s*force|sp_paren_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Brace|Add Sp Paren Brace|Remove Sp Paren Brace|Force Sp Paren Brace"
 ValueDefault=ignore
 
@@ -412,7 +413,7 @@ Category=1
 Description="<html>Add or remove space between nested braces, i.e. '{{' vs. '{ {'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_brace=ignore|sp_brace_brace=add|sp_brace_brace=remove|sp_brace_brace=force|sp_brace_brace=not_defined
+Choices=sp_brace_brace\s*=\s*ignore|sp_brace_brace\s*=\s*add|sp_brace_brace\s*=\s*remove|sp_brace_brace\s*=\s*force|sp_brace_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Brace|Add Sp Brace Brace|Remove Sp Brace Brace|Force Sp Brace Brace"
 ValueDefault=ignore
 
@@ -421,7 +422,7 @@ Category=1
 Description="<html>Add or remove space before pointer star '*'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_ptr_star=ignore|sp_before_ptr_star=add|sp_before_ptr_star=remove|sp_before_ptr_star=force|sp_before_ptr_star=not_defined
+Choices=sp_before_ptr_star\s*=\s*ignore|sp_before_ptr_star\s*=\s*add|sp_before_ptr_star\s*=\s*remove|sp_before_ptr_star\s*=\s*force|sp_before_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Ptr Star|Add Sp Before Ptr Star|Remove Sp Before Ptr Star|Force Sp Before Ptr Star"
 ValueDefault=ignore
 
@@ -430,7 +431,7 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that isn't followed by a<br/>variable name. If set to ignore, sp_before_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_unnamed_ptr_star=ignore|sp_before_unnamed_ptr_star=add|sp_before_unnamed_ptr_star=remove|sp_before_unnamed_ptr_star=force|sp_before_unnamed_ptr_star=not_defined
+Choices=sp_before_unnamed_ptr_star\s*=\s*ignore|sp_before_unnamed_ptr_star\s*=\s*add|sp_before_unnamed_ptr_star\s*=\s*remove|sp_before_unnamed_ptr_star\s*=\s*force|sp_before_unnamed_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Unnamed Ptr Star|Add Sp Before Unnamed Ptr Star|Remove Sp Before Unnamed Ptr Star|Force Sp Before Unnamed Ptr Star"
 ValueDefault=ignore
 
@@ -439,7 +440,7 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that is followed by a qualifier.<br/>If set to ignore, sp_before_unnamed_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_qualifier_ptr_star=ignore|sp_before_qualifier_ptr_star=add|sp_before_qualifier_ptr_star=remove|sp_before_qualifier_ptr_star=force|sp_before_qualifier_ptr_star=not_defined
+Choices=sp_before_qualifier_ptr_star\s*=\s*ignore|sp_before_qualifier_ptr_star\s*=\s*add|sp_before_qualifier_ptr_star\s*=\s*remove|sp_before_qualifier_ptr_star\s*=\s*force|sp_before_qualifier_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Qualifier Ptr Star|Add Sp Before Qualifier Ptr Star|Remove Sp Before Qualifier Ptr Star|Force Sp Before Qualifier Ptr Star"
 ValueDefault=ignore
 
@@ -448,7 +449,7 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that is followed by 'operator' keyword.<br/>If set to ignore, sp_before_unnamed_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_operator_ptr_star=ignore|sp_before_operator_ptr_star=add|sp_before_operator_ptr_star=remove|sp_before_operator_ptr_star=force|sp_before_operator_ptr_star=not_defined
+Choices=sp_before_operator_ptr_star\s*=\s*ignore|sp_before_operator_ptr_star\s*=\s*add|sp_before_operator_ptr_star\s*=\s*remove|sp_before_operator_ptr_star\s*=\s*force|sp_before_operator_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Operator Ptr Star|Add Sp Before Operator Ptr Star|Remove Sp Before Operator Ptr Star|Force Sp Before Operator Ptr Star"
 ValueDefault=ignore
 
@@ -457,7 +458,7 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that is followed by<br/>a class scope (as in 'int *MyClass::method()') or namespace scope<br/>(as in 'int *my_ns::func()').<br/>If set to ignore, sp_before_unnamed_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_scope_ptr_star=ignore|sp_before_scope_ptr_star=add|sp_before_scope_ptr_star=remove|sp_before_scope_ptr_star=force|sp_before_scope_ptr_star=not_defined
+Choices=sp_before_scope_ptr_star\s*=\s*ignore|sp_before_scope_ptr_star\s*=\s*add|sp_before_scope_ptr_star\s*=\s*remove|sp_before_scope_ptr_star\s*=\s*force|sp_before_scope_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Scope Ptr Star|Add Sp Before Scope Ptr Star|Remove Sp Before Scope Ptr Star|Force Sp Before Scope Ptr Star"
 ValueDefault=ignore
 
@@ -466,7 +467,7 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that is followed by '::',<br/>as in 'int *::func()'.<br/>If set to ignore, sp_before_unnamed_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_global_scope_ptr_star=ignore|sp_before_global_scope_ptr_star=add|sp_before_global_scope_ptr_star=remove|sp_before_global_scope_ptr_star=force|sp_before_global_scope_ptr_star=not_defined
+Choices=sp_before_global_scope_ptr_star\s*=\s*ignore|sp_before_global_scope_ptr_star\s*=\s*add|sp_before_global_scope_ptr_star\s*=\s*remove|sp_before_global_scope_ptr_star\s*=\s*force|sp_before_global_scope_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Global Scope Ptr Star|Add Sp Before Global Scope Ptr Star|Remove Sp Before Global Scope Ptr Star|Force Sp Before Global Scope Ptr Star"
 ValueDefault=ignore
 
@@ -475,7 +476,7 @@ Category=1
 Description="<html>Add or remove space between a qualifier and a pointer star '*' that isn't<br/>followed by a variable name, as in '(char const *)'. If set to ignore,<br/>sp_before_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_qualifier_unnamed_ptr_star=ignore|sp_qualifier_unnamed_ptr_star=add|sp_qualifier_unnamed_ptr_star=remove|sp_qualifier_unnamed_ptr_star=force|sp_qualifier_unnamed_ptr_star=not_defined
+Choices=sp_qualifier_unnamed_ptr_star\s*=\s*ignore|sp_qualifier_unnamed_ptr_star\s*=\s*add|sp_qualifier_unnamed_ptr_star\s*=\s*remove|sp_qualifier_unnamed_ptr_star\s*=\s*force|sp_qualifier_unnamed_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Qualifier Unnamed Ptr Star|Add Sp Qualifier Unnamed Ptr Star|Remove Sp Qualifier Unnamed Ptr Star|Force Sp Qualifier Unnamed Ptr Star"
 ValueDefault=ignore
 
@@ -484,7 +485,7 @@ Category=1
 Description="<html>Add or remove space between pointer stars '*', as in 'int ***a;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_ptr_star=ignore|sp_between_ptr_star=add|sp_between_ptr_star=remove|sp_between_ptr_star=force|sp_between_ptr_star=not_defined
+Choices=sp_between_ptr_star\s*=\s*ignore|sp_between_ptr_star\s*=\s*add|sp_between_ptr_star\s*=\s*remove|sp_between_ptr_star\s*=\s*force|sp_between_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between Ptr Star|Add Sp Between Ptr Star|Remove Sp Between Ptr Star|Force Sp Between Ptr Star"
 ValueDefault=ignore
 
@@ -493,7 +494,7 @@ Category=1
 Description="<html>Add or remove space between pointer star '*' and reference '&amp;', as in 'int *&amp; a;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_ptr_ref=ignore|sp_between_ptr_ref=add|sp_between_ptr_ref=remove|sp_between_ptr_ref=force|sp_between_ptr_ref=not_defined
+Choices=sp_between_ptr_ref\s*=\s*ignore|sp_between_ptr_ref\s*=\s*add|sp_between_ptr_ref\s*=\s*remove|sp_between_ptr_ref\s*=\s*force|sp_between_ptr_ref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between Ptr Ref|Add Sp Between Ptr Ref|Remove Sp Between Ptr Ref|Force Sp Between Ptr Ref"
 ValueDefault=ignore
 
@@ -502,7 +503,7 @@ Category=1
 Description="<html>Add or remove space after pointer star '*', if followed by a word.<br/><br/>Overrides sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_star=ignore|sp_after_ptr_star=add|sp_after_ptr_star=remove|sp_after_ptr_star=force|sp_after_ptr_star=not_defined
+Choices=sp_after_ptr_star\s*=\s*ignore|sp_after_ptr_star\s*=\s*add|sp_after_ptr_star\s*=\s*remove|sp_after_ptr_star\s*=\s*force|sp_after_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Star|Add Sp After Ptr Star|Remove Sp After Ptr Star|Force Sp After Ptr Star"
 ValueDefault=ignore
 
@@ -511,7 +512,7 @@ Category=1
 Description="<html>Add or remove space after pointer caret '^', if followed by a word.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_block_caret=ignore|sp_after_ptr_block_caret=add|sp_after_ptr_block_caret=remove|sp_after_ptr_block_caret=force|sp_after_ptr_block_caret=not_defined
+Choices=sp_after_ptr_block_caret\s*=\s*ignore|sp_after_ptr_block_caret\s*=\s*add|sp_after_ptr_block_caret\s*=\s*remove|sp_after_ptr_block_caret\s*=\s*force|sp_after_ptr_block_caret\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Block Caret|Add Sp After Ptr Block Caret|Remove Sp After Ptr Block Caret|Force Sp After Ptr Block Caret"
 ValueDefault=ignore
 
@@ -520,7 +521,7 @@ Category=1
 Description="<html>Add or remove space after pointer star '*', if followed by a qualifier.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_star_qualifier=ignore|sp_after_ptr_star_qualifier=add|sp_after_ptr_star_qualifier=remove|sp_after_ptr_star_qualifier=force|sp_after_ptr_star_qualifier=not_defined
+Choices=sp_after_ptr_star_qualifier\s*=\s*ignore|sp_after_ptr_star_qualifier\s*=\s*add|sp_after_ptr_star_qualifier\s*=\s*remove|sp_after_ptr_star_qualifier\s*=\s*force|sp_after_ptr_star_qualifier\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Star Qualifier|Add Sp After Ptr Star Qualifier|Remove Sp After Ptr Star Qualifier|Force Sp After Ptr Star Qualifier"
 ValueDefault=ignore
 
@@ -529,7 +530,7 @@ Category=1
 Description="<html>Add or remove space after a pointer star '*', if followed by a function<br/>prototype or function definition.<br/><br/>Overrides sp_after_ptr_star and sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_star_func=ignore|sp_after_ptr_star_func=add|sp_after_ptr_star_func=remove|sp_after_ptr_star_func=force|sp_after_ptr_star_func=not_defined
+Choices=sp_after_ptr_star_func\s*=\s*ignore|sp_after_ptr_star_func\s*=\s*add|sp_after_ptr_star_func\s*=\s*remove|sp_after_ptr_star_func\s*=\s*force|sp_after_ptr_star_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Star Func|Add Sp After Ptr Star Func|Remove Sp After Ptr Star Func|Force Sp After Ptr Star Func"
 ValueDefault=ignore
 
@@ -538,7 +539,7 @@ Category=1
 Description="<html>Add or remove space after a pointer star '*' in the trailing return of a<br/>function prototype or function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_star_trailing=ignore|sp_after_ptr_star_trailing=add|sp_after_ptr_star_trailing=remove|sp_after_ptr_star_trailing=force|sp_after_ptr_star_trailing=not_defined
+Choices=sp_after_ptr_star_trailing\s*=\s*ignore|sp_after_ptr_star_trailing\s*=\s*add|sp_after_ptr_star_trailing\s*=\s*remove|sp_after_ptr_star_trailing\s*=\s*force|sp_after_ptr_star_trailing\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Star Trailing|Add Sp After Ptr Star Trailing|Remove Sp After Ptr Star Trailing|Force Sp After Ptr Star Trailing"
 ValueDefault=ignore
 
@@ -547,7 +548,7 @@ Category=1
 Description="<html>Add or remove space between the pointer star '*' and the name of the variable<br/>in a function pointer definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ptr_star_func_var=ignore|sp_ptr_star_func_var=add|sp_ptr_star_func_var=remove|sp_ptr_star_func_var=force|sp_ptr_star_func_var=not_defined
+Choices=sp_ptr_star_func_var\s*=\s*ignore|sp_ptr_star_func_var\s*=\s*add|sp_ptr_star_func_var\s*=\s*remove|sp_ptr_star_func_var\s*=\s*force|sp_ptr_star_func_var\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ptr Star Func Var|Add Sp Ptr Star Func Var|Remove Sp Ptr Star Func Var|Force Sp Ptr Star Func Var"
 ValueDefault=ignore
 
@@ -556,7 +557,7 @@ Category=1
 Description="<html>Add or remove space between the pointer star '*' and the name of the type<br/>in a function pointer type definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ptr_star_func_type=ignore|sp_ptr_star_func_type=add|sp_ptr_star_func_type=remove|sp_ptr_star_func_type=force|sp_ptr_star_func_type=not_defined
+Choices=sp_ptr_star_func_type\s*=\s*ignore|sp_ptr_star_func_type\s*=\s*add|sp_ptr_star_func_type\s*=\s*remove|sp_ptr_star_func_type\s*=\s*force|sp_ptr_star_func_type\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ptr Star Func Type|Add Sp Ptr Star Func Type|Remove Sp Ptr Star Func Type|Force Sp Ptr Star Func Type"
 ValueDefault=ignore
 
@@ -565,7 +566,7 @@ Category=1
 Description="<html>Add or remove space after a pointer star '*', if followed by an open<br/>parenthesis, as in 'void* (*)()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ptr_star_paren=ignore|sp_ptr_star_paren=add|sp_ptr_star_paren=remove|sp_ptr_star_paren=force|sp_ptr_star_paren=not_defined
+Choices=sp_ptr_star_paren\s*=\s*ignore|sp_ptr_star_paren\s*=\s*add|sp_ptr_star_paren\s*=\s*remove|sp_ptr_star_paren\s*=\s*force|sp_ptr_star_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ptr Star Paren|Add Sp Ptr Star Paren|Remove Sp Ptr Star Paren|Force Sp Ptr Star Paren"
 ValueDefault=ignore
 
@@ -574,7 +575,7 @@ Category=1
 Description="<html>Add or remove space before a pointer star '*', if followed by a function<br/>prototype or function definition. If set to ignore, sp_before_ptr_star is<br/>used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_ptr_star_func=ignore|sp_before_ptr_star_func=add|sp_before_ptr_star_func=remove|sp_before_ptr_star_func=force|sp_before_ptr_star_func=not_defined
+Choices=sp_before_ptr_star_func\s*=\s*ignore|sp_before_ptr_star_func\s*=\s*add|sp_before_ptr_star_func\s*=\s*remove|sp_before_ptr_star_func\s*=\s*force|sp_before_ptr_star_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Ptr Star Func|Add Sp Before Ptr Star Func|Remove Sp Before Ptr Star Func|Force Sp Before Ptr Star Func"
 ValueDefault=ignore
 
@@ -583,7 +584,7 @@ Category=1
 Description="<html>Add or remove space between a qualifier and a pointer star '*' followed by<br/>the name of the function in a function prototype or definition, as in<br/>'char const *foo()`. If set to ignore, sp_before_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_qualifier_ptr_star_func=ignore|sp_qualifier_ptr_star_func=add|sp_qualifier_ptr_star_func=remove|sp_qualifier_ptr_star_func=force|sp_qualifier_ptr_star_func=not_defined
+Choices=sp_qualifier_ptr_star_func\s*=\s*ignore|sp_qualifier_ptr_star_func\s*=\s*add|sp_qualifier_ptr_star_func\s*=\s*remove|sp_qualifier_ptr_star_func\s*=\s*force|sp_qualifier_ptr_star_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Qualifier Ptr Star Func|Add Sp Qualifier Ptr Star Func|Remove Sp Qualifier Ptr Star Func|Force Sp Qualifier Ptr Star Func"
 ValueDefault=ignore
 
@@ -592,7 +593,7 @@ Category=1
 Description="<html>Add or remove space before a pointer star '*' in the trailing return of a<br/>function prototype or function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_ptr_star_trailing=ignore|sp_before_ptr_star_trailing=add|sp_before_ptr_star_trailing=remove|sp_before_ptr_star_trailing=force|sp_before_ptr_star_trailing=not_defined
+Choices=sp_before_ptr_star_trailing\s*=\s*ignore|sp_before_ptr_star_trailing\s*=\s*add|sp_before_ptr_star_trailing\s*=\s*remove|sp_before_ptr_star_trailing\s*=\s*force|sp_before_ptr_star_trailing\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Ptr Star Trailing|Add Sp Before Ptr Star Trailing|Remove Sp Before Ptr Star Trailing|Force Sp Before Ptr Star Trailing"
 ValueDefault=ignore
 
@@ -601,7 +602,7 @@ Category=1
 Description="<html>Add or remove space between a qualifier and a pointer star '*' in the<br/>trailing return of a function prototype or function definition, as in<br/>'auto foo() -&gt; char const *'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_qualifier_ptr_star_trailing=ignore|sp_qualifier_ptr_star_trailing=add|sp_qualifier_ptr_star_trailing=remove|sp_qualifier_ptr_star_trailing=force|sp_qualifier_ptr_star_trailing=not_defined
+Choices=sp_qualifier_ptr_star_trailing\s*=\s*ignore|sp_qualifier_ptr_star_trailing\s*=\s*add|sp_qualifier_ptr_star_trailing\s*=\s*remove|sp_qualifier_ptr_star_trailing\s*=\s*force|sp_qualifier_ptr_star_trailing\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Qualifier Ptr Star Trailing|Add Sp Qualifier Ptr Star Trailing|Remove Sp Qualifier Ptr Star Trailing|Force Sp Qualifier Ptr Star Trailing"
 ValueDefault=ignore
 
@@ -610,7 +611,7 @@ Category=1
 Description="<html>Add or remove space before a reference sign '&amp;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_byref=ignore|sp_before_byref=add|sp_before_byref=remove|sp_before_byref=force|sp_before_byref=not_defined
+Choices=sp_before_byref\s*=\s*ignore|sp_before_byref\s*=\s*add|sp_before_byref\s*=\s*remove|sp_before_byref\s*=\s*force|sp_before_byref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Byref|Add Sp Before Byref|Remove Sp Before Byref|Force Sp Before Byref"
 ValueDefault=ignore
 
@@ -619,7 +620,7 @@ Category=1
 Description="<html>Add or remove space before a reference sign '&amp;' that isn't followed by a<br/>variable name. If set to ignore, sp_before_byref is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_unnamed_byref=ignore|sp_before_unnamed_byref=add|sp_before_unnamed_byref=remove|sp_before_unnamed_byref=force|sp_before_unnamed_byref=not_defined
+Choices=sp_before_unnamed_byref\s*=\s*ignore|sp_before_unnamed_byref\s*=\s*add|sp_before_unnamed_byref\s*=\s*remove|sp_before_unnamed_byref\s*=\s*force|sp_before_unnamed_byref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Unnamed Byref|Add Sp Before Unnamed Byref|Remove Sp Before Unnamed Byref|Force Sp Before Unnamed Byref"
 ValueDefault=ignore
 
@@ -628,7 +629,7 @@ Category=1
 Description="<html>Add or remove space after reference sign '&amp;', if followed by a word.<br/><br/>Overrides sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_byref=ignore|sp_after_byref=add|sp_after_byref=remove|sp_after_byref=force|sp_after_byref=not_defined
+Choices=sp_after_byref\s*=\s*ignore|sp_after_byref\s*=\s*add|sp_after_byref\s*=\s*remove|sp_after_byref\s*=\s*force|sp_after_byref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Byref|Add Sp After Byref|Remove Sp After Byref|Force Sp After Byref"
 ValueDefault=ignore
 
@@ -637,7 +638,7 @@ Category=1
 Description="<html>Add or remove space after a reference sign '&amp;', if followed by a function<br/>prototype or function definition.<br/><br/>Overrides sp_after_byref and sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_byref_func=ignore|sp_after_byref_func=add|sp_after_byref_func=remove|sp_after_byref_func=force|sp_after_byref_func=not_defined
+Choices=sp_after_byref_func\s*=\s*ignore|sp_after_byref_func\s*=\s*add|sp_after_byref_func\s*=\s*remove|sp_after_byref_func\s*=\s*force|sp_after_byref_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Byref Func|Add Sp After Byref Func|Remove Sp After Byref Func|Force Sp After Byref Func"
 ValueDefault=ignore
 
@@ -646,7 +647,7 @@ Category=1
 Description="<html>Add or remove space before a reference sign '&amp;', if followed by a function<br/>prototype or function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_byref_func=ignore|sp_before_byref_func=add|sp_before_byref_func=remove|sp_before_byref_func=force|sp_before_byref_func=not_defined
+Choices=sp_before_byref_func\s*=\s*ignore|sp_before_byref_func\s*=\s*add|sp_before_byref_func\s*=\s*remove|sp_before_byref_func\s*=\s*force|sp_before_byref_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Byref Func|Add Sp Before Byref Func|Remove Sp Before Byref Func|Force Sp Before Byref Func"
 ValueDefault=ignore
 
@@ -655,7 +656,7 @@ Category=1
 Description="<html>Add or remove space after a reference sign '&amp;', if followed by an open<br/>parenthesis, as in 'char&amp; (*)()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_byref_paren=ignore|sp_byref_paren=add|sp_byref_paren=remove|sp_byref_paren=force|sp_byref_paren=not_defined
+Choices=sp_byref_paren\s*=\s*ignore|sp_byref_paren\s*=\s*add|sp_byref_paren\s*=\s*remove|sp_byref_paren\s*=\s*force|sp_byref_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Byref Paren|Add Sp Byref Paren|Remove Sp Byref Paren|Force Sp Byref Paren"
 ValueDefault=ignore
 
@@ -664,7 +665,7 @@ Category=1
 Description="<html>Add or remove space between type and word. In cases where total removal of<br/>whitespace would be a syntax error, a value of 'remove' is treated the same<br/>as 'force'.<br/><br/>This also affects some other instances of space following a type that are<br/>not covered by other options; for example, between the return type and<br/>parenthesis of a function type template argument, between the type and<br/>parenthesis of an array parameter, or between 'decltype(...)' and the<br/>following word.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_type=ignore|sp_after_type=add|sp_after_type=remove|sp_after_type=force|sp_after_type=not_defined
+Choices=sp_after_type\s*=\s*ignore|sp_after_type\s*=\s*add|sp_after_type\s*=\s*remove|sp_after_type\s*=\s*force|sp_after_type\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Type|Add Sp After Type|Remove Sp After Type|Force Sp After Type"
 ValueDefault=force
 
@@ -673,7 +674,7 @@ Category=1
 Description="<html>Add or remove space between 'decltype(...)' and word,<br/>brace or function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_decltype=ignore|sp_after_decltype=add|sp_after_decltype=remove|sp_after_decltype=force|sp_after_decltype=not_defined
+Choices=sp_after_decltype\s*=\s*ignore|sp_after_decltype\s*=\s*add|sp_after_decltype\s*=\s*remove|sp_after_decltype\s*=\s*force|sp_after_decltype\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Decltype|Add Sp After Decltype|Remove Sp After Decltype|Force Sp After Decltype"
 ValueDefault=ignore
 
@@ -682,7 +683,7 @@ Category=1
 Description="<html>(D) Add or remove space before the parenthesis in the D constructs<br/>'template Foo(' and 'class Foo('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_template_paren=ignore|sp_before_template_paren=add|sp_before_template_paren=remove|sp_before_template_paren=force|sp_before_template_paren=not_defined
+Choices=sp_before_template_paren\s*=\s*ignore|sp_before_template_paren\s*=\s*add|sp_before_template_paren\s*=\s*remove|sp_before_template_paren\s*=\s*force|sp_before_template_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Template Paren|Add Sp Before Template Paren|Remove Sp Before Template Paren|Force Sp Before Template Paren"
 ValueDefault=ignore
 
@@ -691,7 +692,7 @@ Category=1
 Description="<html>Add or remove space between 'template' and '&lt;'.<br/>If set to ignore, sp_before_angle is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_template_angle=ignore|sp_template_angle=add|sp_template_angle=remove|sp_template_angle=force|sp_template_angle=not_defined
+Choices=sp_template_angle\s*=\s*ignore|sp_template_angle\s*=\s*add|sp_template_angle\s*=\s*remove|sp_template_angle\s*=\s*force|sp_template_angle\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Template Angle|Add Sp Template Angle|Remove Sp Template Angle|Force Sp Template Angle"
 ValueDefault=ignore
 
@@ -700,7 +701,7 @@ Category=1
 Description="<html>Add or remove space before '&lt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_angle=ignore|sp_before_angle=add|sp_before_angle=remove|sp_before_angle=force|sp_before_angle=not_defined
+Choices=sp_before_angle\s*=\s*ignore|sp_before_angle\s*=\s*add|sp_before_angle\s*=\s*remove|sp_before_angle\s*=\s*force|sp_before_angle\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Angle|Add Sp Before Angle|Remove Sp Before Angle|Force Sp Before Angle"
 ValueDefault=ignore
 
@@ -709,7 +710,7 @@ Category=1
 Description="<html>Add or remove space inside '&lt;' and '&gt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_angle=ignore|sp_inside_angle=add|sp_inside_angle=remove|sp_inside_angle=force|sp_inside_angle=not_defined
+Choices=sp_inside_angle\s*=\s*ignore|sp_inside_angle\s*=\s*add|sp_inside_angle\s*=\s*remove|sp_inside_angle\s*=\s*force|sp_inside_angle\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Angle|Add Sp Inside Angle|Remove Sp Inside Angle|Force Sp Inside Angle"
 ValueDefault=ignore
 
@@ -718,7 +719,7 @@ Category=1
 Description="<html>Add or remove space inside '&lt;&gt;'.<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_angle_empty=ignore|sp_inside_angle_empty=add|sp_inside_angle_empty=remove|sp_inside_angle_empty=force|sp_inside_angle_empty=not_defined
+Choices=sp_inside_angle_empty\s*=\s*ignore|sp_inside_angle_empty\s*=\s*add|sp_inside_angle_empty\s*=\s*remove|sp_inside_angle_empty\s*=\s*force|sp_inside_angle_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Angle Empty|Add Sp Inside Angle Empty|Remove Sp Inside Angle Empty|Force Sp Inside Angle Empty"
 ValueDefault=ignore
 
@@ -727,7 +728,7 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_colon=ignore|sp_angle_colon=add|sp_angle_colon=remove|sp_angle_colon=force|sp_angle_colon=not_defined
+Choices=sp_angle_colon\s*=\s*ignore|sp_angle_colon\s*=\s*add|sp_angle_colon\s*=\s*remove|sp_angle_colon\s*=\s*force|sp_angle_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Colon|Add Sp Angle Colon|Remove Sp Angle Colon|Force Sp Angle Colon"
 ValueDefault=ignore
 
@@ -736,7 +737,7 @@ Category=1
 Description="<html>Add or remove space after '&gt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_angle=ignore|sp_after_angle=add|sp_after_angle=remove|sp_after_angle=force|sp_after_angle=not_defined
+Choices=sp_after_angle\s*=\s*ignore|sp_after_angle\s*=\s*add|sp_after_angle\s*=\s*remove|sp_after_angle\s*=\s*force|sp_after_angle\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Angle|Add Sp After Angle|Remove Sp After Angle|Force Sp After Angle"
 ValueDefault=ignore
 
@@ -745,7 +746,7 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and '(' as found in 'new List&lt;byte&gt;(foo);'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_paren=ignore|sp_angle_paren=add|sp_angle_paren=remove|sp_angle_paren=force|sp_angle_paren=not_defined
+Choices=sp_angle_paren\s*=\s*ignore|sp_angle_paren\s*=\s*add|sp_angle_paren\s*=\s*remove|sp_angle_paren\s*=\s*force|sp_angle_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Paren|Add Sp Angle Paren|Remove Sp Angle Paren|Force Sp Angle Paren"
 ValueDefault=ignore
 
@@ -754,7 +755,7 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and '()' as found in 'new List&lt;byte&gt;();'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_paren_empty=ignore|sp_angle_paren_empty=add|sp_angle_paren_empty=remove|sp_angle_paren_empty=force|sp_angle_paren_empty=not_defined
+Choices=sp_angle_paren_empty\s*=\s*ignore|sp_angle_paren_empty\s*=\s*add|sp_angle_paren_empty\s*=\s*remove|sp_angle_paren_empty\s*=\s*force|sp_angle_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Paren Empty|Add Sp Angle Paren Empty|Remove Sp Angle Paren Empty|Force Sp Angle Paren Empty"
 ValueDefault=ignore
 
@@ -763,7 +764,7 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and a word as in 'List&lt;byte&gt; m;' or<br/>'template &lt;typename T&gt; static ...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_word=ignore|sp_angle_word=add|sp_angle_word=remove|sp_angle_word=force|sp_angle_word=not_defined
+Choices=sp_angle_word\s*=\s*ignore|sp_angle_word\s*=\s*add|sp_angle_word\s*=\s*remove|sp_angle_word\s*=\s*force|sp_angle_word\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Word|Add Sp Angle Word|Remove Sp Angle Word|Force Sp Angle Word"
 ValueDefault=ignore
 
@@ -772,7 +773,7 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and '&gt;' in '&gt;&gt;' (template stuff).<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_shift=ignore|sp_angle_shift=add|sp_angle_shift=remove|sp_angle_shift=force|sp_angle_shift=not_defined
+Choices=sp_angle_shift\s*=\s*ignore|sp_angle_shift\s*=\s*add|sp_angle_shift\s*=\s*remove|sp_angle_shift\s*=\s*force|sp_angle_shift\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Shift|Add Sp Angle Shift|Remove Sp Angle Shift|Force Sp Angle Shift"
 ValueDefault=add
 
@@ -781,7 +782,7 @@ Category=1
 Description="<html>(C++11) Permit removal of the space between '&gt;&gt;' in 'foo&lt;bar&lt;int&gt; &gt;'. Note<br/>that sp_angle_shift cannot remove the space without this option.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_permit_cpp11_shift=true|sp_permit_cpp11_shift=false
+TrueFalse=sp_permit_cpp11_shift\s*=\s*true|sp_permit_cpp11_shift\s*=\s*false
 ValueDefault=false
 
 [Sp Before Sparen]
@@ -789,7 +790,7 @@ Category=1
 Description="<html>Add or remove space before '(' of control statements ('if', 'for', 'switch',<br/>'while', etc.).</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_sparen=ignore|sp_before_sparen=add|sp_before_sparen=remove|sp_before_sparen=force|sp_before_sparen=not_defined
+Choices=sp_before_sparen\s*=\s*ignore|sp_before_sparen\s*=\s*add|sp_before_sparen\s*=\s*remove|sp_before_sparen\s*=\s*force|sp_before_sparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Sparen|Add Sp Before Sparen|Remove Sp Before Sparen|Force Sp Before Sparen"
 ValueDefault=ignore
 
@@ -798,7 +799,7 @@ Category=1
 Description="<html>Add or remove space inside '(' and ')' of control statements other than<br/>'for'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_sparen=ignore|sp_inside_sparen=add|sp_inside_sparen=remove|sp_inside_sparen=force|sp_inside_sparen=not_defined
+Choices=sp_inside_sparen\s*=\s*ignore|sp_inside_sparen\s*=\s*add|sp_inside_sparen\s*=\s*remove|sp_inside_sparen\s*=\s*force|sp_inside_sparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Sparen|Add Sp Inside Sparen|Remove Sp Inside Sparen|Force Sp Inside Sparen"
 ValueDefault=ignore
 
@@ -807,7 +808,7 @@ Category=1
 Description="<html>Add or remove space after '(' of control statements other than 'for'.<br/><br/>Overrides sp_inside_sparen.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_sparen_open=ignore|sp_inside_sparen_open=add|sp_inside_sparen_open=remove|sp_inside_sparen_open=force|sp_inside_sparen_open=not_defined
+Choices=sp_inside_sparen_open\s*=\s*ignore|sp_inside_sparen_open\s*=\s*add|sp_inside_sparen_open\s*=\s*remove|sp_inside_sparen_open\s*=\s*force|sp_inside_sparen_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Sparen Open|Add Sp Inside Sparen Open|Remove Sp Inside Sparen Open|Force Sp Inside Sparen Open"
 ValueDefault=ignore
 
@@ -816,7 +817,7 @@ Category=1
 Description="<html>Add or remove space before ')' of control statements other than 'for'.<br/><br/>Overrides sp_inside_sparen.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_sparen_close=ignore|sp_inside_sparen_close=add|sp_inside_sparen_close=remove|sp_inside_sparen_close=force|sp_inside_sparen_close=not_defined
+Choices=sp_inside_sparen_close\s*=\s*ignore|sp_inside_sparen_close\s*=\s*add|sp_inside_sparen_close\s*=\s*remove|sp_inside_sparen_close\s*=\s*force|sp_inside_sparen_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Sparen Close|Add Sp Inside Sparen Close|Remove Sp Inside Sparen Close|Force Sp Inside Sparen Close"
 ValueDefault=ignore
 
@@ -825,7 +826,7 @@ Category=1
 Description="<html>Add or remove space inside '(' and ')' of 'for' statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_for=ignore|sp_inside_for=add|sp_inside_for=remove|sp_inside_for=force|sp_inside_for=not_defined
+Choices=sp_inside_for\s*=\s*ignore|sp_inside_for\s*=\s*add|sp_inside_for\s*=\s*remove|sp_inside_for\s*=\s*force|sp_inside_for\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside For|Add Sp Inside For|Remove Sp Inside For|Force Sp Inside For"
 ValueDefault=ignore
 
@@ -834,7 +835,7 @@ Category=1
 Description="<html>Add or remove space after '(' of 'for' statements.<br/><br/>Overrides sp_inside_for.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_for_open=ignore|sp_inside_for_open=add|sp_inside_for_open=remove|sp_inside_for_open=force|sp_inside_for_open=not_defined
+Choices=sp_inside_for_open\s*=\s*ignore|sp_inside_for_open\s*=\s*add|sp_inside_for_open\s*=\s*remove|sp_inside_for_open\s*=\s*force|sp_inside_for_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside For Open|Add Sp Inside For Open|Remove Sp Inside For Open|Force Sp Inside For Open"
 ValueDefault=ignore
 
@@ -843,7 +844,7 @@ Category=1
 Description="<html>Add or remove space before ')' of 'for' statements.<br/><br/>Overrides sp_inside_for.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_for_close=ignore|sp_inside_for_close=add|sp_inside_for_close=remove|sp_inside_for_close=force|sp_inside_for_close=not_defined
+Choices=sp_inside_for_close\s*=\s*ignore|sp_inside_for_close\s*=\s*add|sp_inside_for_close\s*=\s*remove|sp_inside_for_close\s*=\s*force|sp_inside_for_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside For Close|Add Sp Inside For Close|Remove Sp Inside For Close|Force Sp Inside For Close"
 ValueDefault=ignore
 
@@ -852,7 +853,7 @@ Category=1
 Description="<html>Add or remove space between '((' or '))' of control statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sparen_paren=ignore|sp_sparen_paren=add|sp_sparen_paren=remove|sp_sparen_paren=force|sp_sparen_paren=not_defined
+Choices=sp_sparen_paren\s*=\s*ignore|sp_sparen_paren\s*=\s*add|sp_sparen_paren\s*=\s*remove|sp_sparen_paren\s*=\s*force|sp_sparen_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sparen Paren|Add Sp Sparen Paren|Remove Sp Sparen Paren|Force Sp Sparen Paren"
 ValueDefault=ignore
 
@@ -861,7 +862,7 @@ Category=1
 Description="<html>Add or remove space after ')' of control statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_sparen=ignore|sp_after_sparen=add|sp_after_sparen=remove|sp_after_sparen=force|sp_after_sparen=not_defined
+Choices=sp_after_sparen\s*=\s*ignore|sp_after_sparen\s*=\s*add|sp_after_sparen\s*=\s*remove|sp_after_sparen\s*=\s*force|sp_after_sparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Sparen|Add Sp After Sparen|Remove Sp After Sparen|Force Sp After Sparen"
 ValueDefault=ignore
 
@@ -870,7 +871,7 @@ Category=1
 Description="<html>Add or remove space between ')' and '{' of control statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sparen_brace=ignore|sp_sparen_brace=add|sp_sparen_brace=remove|sp_sparen_brace=force|sp_sparen_brace=not_defined
+Choices=sp_sparen_brace\s*=\s*ignore|sp_sparen_brace\s*=\s*add|sp_sparen_brace\s*=\s*remove|sp_sparen_brace\s*=\s*force|sp_sparen_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sparen Brace|Add Sp Sparen Brace|Remove Sp Sparen Brace|Force Sp Sparen Brace"
 ValueDefault=ignore
 
@@ -879,7 +880,7 @@ Category=1
 Description="<html>Add or remove space between 'do' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_do_brace_open=ignore|sp_do_brace_open=add|sp_do_brace_open=remove|sp_do_brace_open=force|sp_do_brace_open=not_defined
+Choices=sp_do_brace_open\s*=\s*ignore|sp_do_brace_open\s*=\s*add|sp_do_brace_open\s*=\s*remove|sp_do_brace_open\s*=\s*force|sp_do_brace_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Do Brace Open|Add Sp Do Brace Open|Remove Sp Do Brace Open|Force Sp Do Brace Open"
 ValueDefault=ignore
 
@@ -888,7 +889,7 @@ Category=1
 Description="<html>Add or remove space between '}' and 'while'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_close_while=ignore|sp_brace_close_while=add|sp_brace_close_while=remove|sp_brace_close_while=force|sp_brace_close_while=not_defined
+Choices=sp_brace_close_while\s*=\s*ignore|sp_brace_close_while\s*=\s*add|sp_brace_close_while\s*=\s*remove|sp_brace_close_while\s*=\s*force|sp_brace_close_while\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Close While|Add Sp Brace Close While|Remove Sp Brace Close While|Force Sp Brace Close While"
 ValueDefault=ignore
 
@@ -897,7 +898,7 @@ Category=1
 Description="<html>Add or remove space between 'while' and '('. Overrides sp_before_sparen.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_while_paren_open=ignore|sp_while_paren_open=add|sp_while_paren_open=remove|sp_while_paren_open=force|sp_while_paren_open=not_defined
+Choices=sp_while_paren_open\s*=\s*ignore|sp_while_paren_open\s*=\s*add|sp_while_paren_open\s*=\s*remove|sp_while_paren_open\s*=\s*force|sp_while_paren_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp While Paren Open|Add Sp While Paren Open|Remove Sp While Paren Open|Force Sp While Paren Open"
 ValueDefault=ignore
 
@@ -906,7 +907,7 @@ Category=1
 Description="<html>(D) Add or remove space between 'invariant' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_invariant_paren=ignore|sp_invariant_paren=add|sp_invariant_paren=remove|sp_invariant_paren=force|sp_invariant_paren=not_defined
+Choices=sp_invariant_paren\s*=\s*ignore|sp_invariant_paren\s*=\s*add|sp_invariant_paren\s*=\s*remove|sp_invariant_paren\s*=\s*force|sp_invariant_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Invariant Paren|Add Sp Invariant Paren|Remove Sp Invariant Paren|Force Sp Invariant Paren"
 ValueDefault=ignore
 
@@ -915,7 +916,7 @@ Category=1
 Description="<html>(D) Add or remove space after the ')' in 'invariant (C) c'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_invariant_paren=ignore|sp_after_invariant_paren=add|sp_after_invariant_paren=remove|sp_after_invariant_paren=force|sp_after_invariant_paren=not_defined
+Choices=sp_after_invariant_paren\s*=\s*ignore|sp_after_invariant_paren\s*=\s*add|sp_after_invariant_paren\s*=\s*remove|sp_after_invariant_paren\s*=\s*force|sp_after_invariant_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Invariant Paren|Add Sp After Invariant Paren|Remove Sp After Invariant Paren|Force Sp After Invariant Paren"
 ValueDefault=ignore
 
@@ -924,7 +925,7 @@ Category=1
 Description="<html>Add or remove space before empty statement ';' on 'if', 'for' and 'while'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_special_semi=ignore|sp_special_semi=add|sp_special_semi=remove|sp_special_semi=force|sp_special_semi=not_defined
+Choices=sp_special_semi\s*=\s*ignore|sp_special_semi\s*=\s*add|sp_special_semi\s*=\s*remove|sp_special_semi\s*=\s*force|sp_special_semi\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Special Semi|Add Sp Special Semi|Remove Sp Special Semi|Force Sp Special Semi"
 ValueDefault=ignore
 
@@ -933,7 +934,7 @@ Category=1
 Description="<html>Add or remove space before ';'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_semi=ignore|sp_before_semi=add|sp_before_semi=remove|sp_before_semi=force|sp_before_semi=not_defined
+Choices=sp_before_semi\s*=\s*ignore|sp_before_semi\s*=\s*add|sp_before_semi\s*=\s*remove|sp_before_semi\s*=\s*force|sp_before_semi\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Semi|Add Sp Before Semi|Remove Sp Before Semi|Force Sp Before Semi"
 ValueDefault=remove
 
@@ -942,7 +943,7 @@ Category=1
 Description="<html>Add or remove space before ';' in non-empty 'for' statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_semi_for=ignore|sp_before_semi_for=add|sp_before_semi_for=remove|sp_before_semi_for=force|sp_before_semi_for=not_defined
+Choices=sp_before_semi_for\s*=\s*ignore|sp_before_semi_for\s*=\s*add|sp_before_semi_for\s*=\s*remove|sp_before_semi_for\s*=\s*force|sp_before_semi_for\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Semi For|Add Sp Before Semi For|Remove Sp Before Semi For|Force Sp Before Semi For"
 ValueDefault=ignore
 
@@ -951,7 +952,7 @@ Category=1
 Description="<html>Add or remove space before a semicolon of an empty left part of a for<br/>statement, as in 'for ( &lt;here&gt; ; ; )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_semi_for_empty=ignore|sp_before_semi_for_empty=add|sp_before_semi_for_empty=remove|sp_before_semi_for_empty=force|sp_before_semi_for_empty=not_defined
+Choices=sp_before_semi_for_empty\s*=\s*ignore|sp_before_semi_for_empty\s*=\s*add|sp_before_semi_for_empty\s*=\s*remove|sp_before_semi_for_empty\s*=\s*force|sp_before_semi_for_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Semi For Empty|Add Sp Before Semi For Empty|Remove Sp Before Semi For Empty|Force Sp Before Semi For Empty"
 ValueDefault=ignore
 
@@ -960,7 +961,7 @@ Category=1
 Description="<html>Add or remove space between the semicolons of an empty middle part of a for<br/>statement, as in 'for ( ; &lt;here&gt; ; )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_semi_for_empty=ignore|sp_between_semi_for_empty=add|sp_between_semi_for_empty=remove|sp_between_semi_for_empty=force|sp_between_semi_for_empty=not_defined
+Choices=sp_between_semi_for_empty\s*=\s*ignore|sp_between_semi_for_empty\s*=\s*add|sp_between_semi_for_empty\s*=\s*remove|sp_between_semi_for_empty\s*=\s*force|sp_between_semi_for_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between Semi For Empty|Add Sp Between Semi For Empty|Remove Sp Between Semi For Empty|Force Sp Between Semi For Empty"
 ValueDefault=ignore
 
@@ -969,7 +970,7 @@ Category=1
 Description="<html>Add or remove space after ';', except when followed by a comment.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_semi=ignore|sp_after_semi=add|sp_after_semi=remove|sp_after_semi=force|sp_after_semi=not_defined
+Choices=sp_after_semi\s*=\s*ignore|sp_after_semi\s*=\s*add|sp_after_semi\s*=\s*remove|sp_after_semi\s*=\s*force|sp_after_semi\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Semi|Add Sp After Semi|Remove Sp After Semi|Force Sp After Semi"
 ValueDefault=add
 
@@ -978,7 +979,7 @@ Category=1
 Description="<html>Add or remove space after ';' in non-empty 'for' statements.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_semi_for=ignore|sp_after_semi_for=add|sp_after_semi_for=remove|sp_after_semi_for=force|sp_after_semi_for=not_defined
+Choices=sp_after_semi_for\s*=\s*ignore|sp_after_semi_for\s*=\s*add|sp_after_semi_for\s*=\s*remove|sp_after_semi_for\s*=\s*force|sp_after_semi_for\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Semi For|Add Sp After Semi For|Remove Sp After Semi For|Force Sp After Semi For"
 ValueDefault=force
 
@@ -987,7 +988,7 @@ Category=1
 Description="<html>Add or remove space after the final semicolon of an empty part of a for<br/>statement, as in 'for ( ; ; &lt;here&gt; )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_semi_for_empty=ignore|sp_after_semi_for_empty=add|sp_after_semi_for_empty=remove|sp_after_semi_for_empty=force|sp_after_semi_for_empty=not_defined
+Choices=sp_after_semi_for_empty\s*=\s*ignore|sp_after_semi_for_empty\s*=\s*add|sp_after_semi_for_empty\s*=\s*remove|sp_after_semi_for_empty\s*=\s*force|sp_after_semi_for_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Semi For Empty|Add Sp After Semi For Empty|Remove Sp After Semi For Empty|Force Sp After Semi For Empty"
 ValueDefault=ignore
 
@@ -996,7 +997,7 @@ Category=1
 Description="<html>Add or remove space before '[' (except '[]').</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_square=ignore|sp_before_square=add|sp_before_square=remove|sp_before_square=force|sp_before_square=not_defined
+Choices=sp_before_square\s*=\s*ignore|sp_before_square\s*=\s*add|sp_before_square\s*=\s*remove|sp_before_square\s*=\s*force|sp_before_square\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Square|Add Sp Before Square|Remove Sp Before Square|Force Sp Before Square"
 ValueDefault=ignore
 
@@ -1005,7 +1006,7 @@ Category=1
 Description="<html>Add or remove space before '[' for a variable definition.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_vardef_square=ignore|sp_before_vardef_square=add|sp_before_vardef_square=remove|sp_before_vardef_square=force|sp_before_vardef_square=not_defined
+Choices=sp_before_vardef_square\s*=\s*ignore|sp_before_vardef_square\s*=\s*add|sp_before_vardef_square\s*=\s*remove|sp_before_vardef_square\s*=\s*force|sp_before_vardef_square\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Vardef Square|Add Sp Before Vardef Square|Remove Sp Before Vardef Square|Force Sp Before Vardef Square"
 ValueDefault=remove
 
@@ -1014,7 +1015,7 @@ Category=1
 Description="<html>Add or remove space before '[' for asm block.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_square_asm_block=ignore|sp_before_square_asm_block=add|sp_before_square_asm_block=remove|sp_before_square_asm_block=force|sp_before_square_asm_block=not_defined
+Choices=sp_before_square_asm_block\s*=\s*ignore|sp_before_square_asm_block\s*=\s*add|sp_before_square_asm_block\s*=\s*remove|sp_before_square_asm_block\s*=\s*force|sp_before_square_asm_block\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Square Asm Block|Add Sp Before Square Asm Block|Remove Sp Before Square Asm Block|Force Sp Before Square Asm Block"
 ValueDefault=ignore
 
@@ -1023,7 +1024,7 @@ Category=1
 Description="<html>Add or remove space before '[]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_squares=ignore|sp_before_squares=add|sp_before_squares=remove|sp_before_squares=force|sp_before_squares=not_defined
+Choices=sp_before_squares\s*=\s*ignore|sp_before_squares\s*=\s*add|sp_before_squares\s*=\s*remove|sp_before_squares\s*=\s*force|sp_before_squares\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Squares|Add Sp Before Squares|Remove Sp Before Squares|Force Sp Before Squares"
 ValueDefault=ignore
 
@@ -1032,7 +1033,7 @@ Category=1
 Description="<html>Add or remove space before C++17 structured bindings.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_before_struct_binding=ignore|sp_cpp_before_struct_binding=add|sp_cpp_before_struct_binding=remove|sp_cpp_before_struct_binding=force|sp_cpp_before_struct_binding=not_defined
+Choices=sp_cpp_before_struct_binding\s*=\s*ignore|sp_cpp_before_struct_binding\s*=\s*add|sp_cpp_before_struct_binding\s*=\s*remove|sp_cpp_before_struct_binding\s*=\s*force|sp_cpp_before_struct_binding\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Before Struct Binding|Add Sp Cpp Before Struct Binding|Remove Sp Cpp Before Struct Binding|Force Sp Cpp Before Struct Binding"
 ValueDefault=ignore
 
@@ -1041,7 +1042,7 @@ Category=1
 Description="<html>Add or remove space inside a non-empty '[' and ']'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_square=ignore|sp_inside_square=add|sp_inside_square=remove|sp_inside_square=force|sp_inside_square=not_defined
+Choices=sp_inside_square\s*=\s*ignore|sp_inside_square\s*=\s*add|sp_inside_square\s*=\s*remove|sp_inside_square\s*=\s*force|sp_inside_square\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Square|Add Sp Inside Square|Remove Sp Inside Square|Force Sp Inside Square"
 ValueDefault=ignore
 
@@ -1050,7 +1051,7 @@ Category=1
 Description="<html>Add or remove space inside '[]'.<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_square_empty=ignore|sp_inside_square_empty=add|sp_inside_square_empty=remove|sp_inside_square_empty=force|sp_inside_square_empty=not_defined
+Choices=sp_inside_square_empty\s*=\s*ignore|sp_inside_square_empty\s*=\s*add|sp_inside_square_empty\s*=\s*remove|sp_inside_square_empty\s*=\s*force|sp_inside_square_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Square Empty|Add Sp Inside Square Empty|Remove Sp Inside Square Empty|Force Sp Inside Square Empty"
 ValueDefault=ignore
 
@@ -1059,7 +1060,7 @@ Category=1
 Description="<html>(OC) Add or remove space inside a non-empty Objective-C boxed array '@[' and<br/>']'. If set to ignore, sp_inside_square is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_square_oc_array=ignore|sp_inside_square_oc_array=add|sp_inside_square_oc_array=remove|sp_inside_square_oc_array=force|sp_inside_square_oc_array=not_defined
+Choices=sp_inside_square_oc_array\s*=\s*ignore|sp_inside_square_oc_array\s*=\s*add|sp_inside_square_oc_array\s*=\s*remove|sp_inside_square_oc_array\s*=\s*force|sp_inside_square_oc_array\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Square Oc Array|Add Sp Inside Square Oc Array|Remove Sp Inside Square Oc Array|Force Sp Inside Square Oc Array"
 ValueDefault=ignore
 
@@ -1068,7 +1069,7 @@ Category=1
 Description="<html>Add or remove space after ',', i.e. 'a,b' vs. 'a, b'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_comma=ignore|sp_after_comma=add|sp_after_comma=remove|sp_after_comma=force|sp_after_comma=not_defined
+Choices=sp_after_comma\s*=\s*ignore|sp_after_comma\s*=\s*add|sp_after_comma\s*=\s*remove|sp_after_comma\s*=\s*force|sp_after_comma\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Comma|Add Sp After Comma|Remove Sp After Comma|Force Sp After Comma"
 ValueDefault=ignore
 
@@ -1077,7 +1078,7 @@ Category=1
 Description="<html>Add or remove space before ',', i.e. 'a,b' vs. 'a ,b'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_comma=ignore|sp_before_comma=add|sp_before_comma=remove|sp_before_comma=force|sp_before_comma=not_defined
+Choices=sp_before_comma\s*=\s*ignore|sp_before_comma\s*=\s*add|sp_before_comma\s*=\s*remove|sp_before_comma\s*=\s*force|sp_before_comma\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Comma|Add Sp Before Comma|Remove Sp Before Comma|Force Sp Before Comma"
 ValueDefault=remove
 
@@ -1086,7 +1087,7 @@ Category=1
 Description="<html>(C#, Vala) Add or remove space between ',' and ']' in multidimensional array type<br/>like 'int[,,]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_mdatype_commas=ignore|sp_after_mdatype_commas=add|sp_after_mdatype_commas=remove|sp_after_mdatype_commas=force|sp_after_mdatype_commas=not_defined
+Choices=sp_after_mdatype_commas\s*=\s*ignore|sp_after_mdatype_commas\s*=\s*add|sp_after_mdatype_commas\s*=\s*remove|sp_after_mdatype_commas\s*=\s*force|sp_after_mdatype_commas\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Mdatype Commas|Add Sp After Mdatype Commas|Remove Sp After Mdatype Commas|Force Sp After Mdatype Commas"
 ValueDefault=ignore
 
@@ -1095,7 +1096,7 @@ Category=1
 Description="<html>(C#, Vala) Add or remove space between '[' and ',' in multidimensional array type<br/>like 'int[,,]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_mdatype_commas=ignore|sp_before_mdatype_commas=add|sp_before_mdatype_commas=remove|sp_before_mdatype_commas=force|sp_before_mdatype_commas=not_defined
+Choices=sp_before_mdatype_commas\s*=\s*ignore|sp_before_mdatype_commas\s*=\s*add|sp_before_mdatype_commas\s*=\s*remove|sp_before_mdatype_commas\s*=\s*force|sp_before_mdatype_commas\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Mdatype Commas|Add Sp Before Mdatype Commas|Remove Sp Before Mdatype Commas|Force Sp Before Mdatype Commas"
 ValueDefault=ignore
 
@@ -1104,7 +1105,7 @@ Category=1
 Description="<html>(C#, Vala) Add or remove space between ',' in multidimensional array type<br/>like 'int[,,]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_mdatype_commas=ignore|sp_between_mdatype_commas=add|sp_between_mdatype_commas=remove|sp_between_mdatype_commas=force|sp_between_mdatype_commas=not_defined
+Choices=sp_between_mdatype_commas\s*=\s*ignore|sp_between_mdatype_commas\s*=\s*add|sp_between_mdatype_commas\s*=\s*remove|sp_between_mdatype_commas\s*=\s*force|sp_between_mdatype_commas\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between Mdatype Commas|Add Sp Between Mdatype Commas|Remove Sp Between Mdatype Commas|Force Sp Between Mdatype Commas"
 ValueDefault=ignore
 
@@ -1113,7 +1114,7 @@ Category=1
 Description="<html>Add or remove space between an open parenthesis and comma,<br/>i.e. '(,' vs. '( ,'.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_comma=ignore|sp_paren_comma=add|sp_paren_comma=remove|sp_paren_comma=force|sp_paren_comma=not_defined
+Choices=sp_paren_comma\s*=\s*ignore|sp_paren_comma\s*=\s*add|sp_paren_comma\s*=\s*remove|sp_paren_comma\s*=\s*force|sp_paren_comma\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Comma|Add Sp Paren Comma|Remove Sp Paren Comma|Force Sp Paren Comma"
 ValueDefault=force
 
@@ -1122,7 +1123,7 @@ Category=1
 Description="<html>Add or remove space between a type and ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_type_colon=ignore|sp_type_colon=add|sp_type_colon=remove|sp_type_colon=force|sp_type_colon=not_defined
+Choices=sp_type_colon\s*=\s*ignore|sp_type_colon\s*=\s*add|sp_type_colon\s*=\s*remove|sp_type_colon\s*=\s*force|sp_type_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Type Colon|Add Sp Type Colon|Remove Sp Type Colon|Force Sp Type Colon"
 ValueDefault=ignore
 
@@ -1131,7 +1132,7 @@ Category=1
 Description="<html>Add or remove space after the variadic '...' when preceded by a<br/>non-punctuator.<br/>The value REMOVE will be overridden with FORCE</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ellipsis=ignore|sp_after_ellipsis=add|sp_after_ellipsis=remove|sp_after_ellipsis=force|sp_after_ellipsis=not_defined
+Choices=sp_after_ellipsis\s*=\s*ignore|sp_after_ellipsis\s*=\s*add|sp_after_ellipsis\s*=\s*remove|sp_after_ellipsis\s*=\s*force|sp_after_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ellipsis|Add Sp After Ellipsis|Remove Sp After Ellipsis|Force Sp After Ellipsis"
 ValueDefault=ignore
 
@@ -1140,7 +1141,7 @@ Category=1
 Description="<html>Add or remove space before the variadic '...' when preceded by a<br/>non-punctuator.<br/>The value REMOVE will be overridden with FORCE</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_ellipsis=ignore|sp_before_ellipsis=add|sp_before_ellipsis=remove|sp_before_ellipsis=force|sp_before_ellipsis=not_defined
+Choices=sp_before_ellipsis\s*=\s*ignore|sp_before_ellipsis\s*=\s*add|sp_before_ellipsis\s*=\s*remove|sp_before_ellipsis\s*=\s*force|sp_before_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Ellipsis|Add Sp Before Ellipsis|Remove Sp Before Ellipsis|Force Sp Before Ellipsis"
 ValueDefault=ignore
 
@@ -1149,7 +1150,7 @@ Category=1
 Description="<html>Add or remove space between a type and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_type_ellipsis=ignore|sp_type_ellipsis=add|sp_type_ellipsis=remove|sp_type_ellipsis=force|sp_type_ellipsis=not_defined
+Choices=sp_type_ellipsis\s*=\s*ignore|sp_type_ellipsis\s*=\s*add|sp_type_ellipsis\s*=\s*remove|sp_type_ellipsis\s*=\s*force|sp_type_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Type Ellipsis|Add Sp Type Ellipsis|Remove Sp Type Ellipsis|Force Sp Type Ellipsis"
 ValueDefault=ignore
 
@@ -1158,7 +1159,7 @@ Category=1
 Description="<html>Add or remove space between a '*' and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ptr_type_ellipsis=ignore|sp_ptr_type_ellipsis=add|sp_ptr_type_ellipsis=remove|sp_ptr_type_ellipsis=force|sp_ptr_type_ellipsis=not_defined
+Choices=sp_ptr_type_ellipsis\s*=\s*ignore|sp_ptr_type_ellipsis\s*=\s*add|sp_ptr_type_ellipsis\s*=\s*remove|sp_ptr_type_ellipsis\s*=\s*force|sp_ptr_type_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ptr Type Ellipsis|Add Sp Ptr Type Ellipsis|Remove Sp Ptr Type Ellipsis|Force Sp Ptr Type Ellipsis"
 ValueDefault=ignore
 
@@ -1167,7 +1168,7 @@ Category=1
 Description="<html>Add or remove space between ')' and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_ellipsis=ignore|sp_paren_ellipsis=add|sp_paren_ellipsis=remove|sp_paren_ellipsis=force|sp_paren_ellipsis=not_defined
+Choices=sp_paren_ellipsis\s*=\s*ignore|sp_paren_ellipsis\s*=\s*add|sp_paren_ellipsis\s*=\s*remove|sp_paren_ellipsis\s*=\s*force|sp_paren_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Ellipsis|Add Sp Paren Ellipsis|Remove Sp Paren Ellipsis|Force Sp Paren Ellipsis"
 ValueDefault=ignore
 
@@ -1176,7 +1177,7 @@ Category=1
 Description="<html>Add or remove space between '&amp;&amp;' and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_byref_ellipsis=ignore|sp_byref_ellipsis=add|sp_byref_ellipsis=remove|sp_byref_ellipsis=force|sp_byref_ellipsis=not_defined
+Choices=sp_byref_ellipsis\s*=\s*ignore|sp_byref_ellipsis\s*=\s*add|sp_byref_ellipsis\s*=\s*remove|sp_byref_ellipsis\s*=\s*force|sp_byref_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Byref Ellipsis|Add Sp Byref Ellipsis|Remove Sp Byref Ellipsis|Force Sp Byref Ellipsis"
 ValueDefault=ignore
 
@@ -1185,7 +1186,7 @@ Category=1
 Description="<html>Add or remove space between ')' and a qualifier such as 'const'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_qualifier=ignore|sp_paren_qualifier=add|sp_paren_qualifier=remove|sp_paren_qualifier=force|sp_paren_qualifier=not_defined
+Choices=sp_paren_qualifier\s*=\s*ignore|sp_paren_qualifier\s*=\s*add|sp_paren_qualifier\s*=\s*remove|sp_paren_qualifier\s*=\s*force|sp_paren_qualifier\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Qualifier|Add Sp Paren Qualifier|Remove Sp Paren Qualifier|Force Sp Paren Qualifier"
 ValueDefault=ignore
 
@@ -1194,7 +1195,7 @@ Category=1
 Description="<html>Add or remove space between ')' and 'noexcept'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_noexcept=ignore|sp_paren_noexcept=add|sp_paren_noexcept=remove|sp_paren_noexcept=force|sp_paren_noexcept=not_defined
+Choices=sp_paren_noexcept\s*=\s*ignore|sp_paren_noexcept\s*=\s*add|sp_paren_noexcept\s*=\s*remove|sp_paren_noexcept\s*=\s*force|sp_paren_noexcept\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Noexcept|Add Sp Paren Noexcept|Remove Sp Paren Noexcept|Force Sp Paren Noexcept"
 ValueDefault=ignore
 
@@ -1203,7 +1204,7 @@ Category=1
 Description="<html>Add or remove space after class ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_class_colon=ignore|sp_after_class_colon=add|sp_after_class_colon=remove|sp_after_class_colon=force|sp_after_class_colon=not_defined
+Choices=sp_after_class_colon\s*=\s*ignore|sp_after_class_colon\s*=\s*add|sp_after_class_colon\s*=\s*remove|sp_after_class_colon\s*=\s*force|sp_after_class_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Class Colon|Add Sp After Class Colon|Remove Sp After Class Colon|Force Sp After Class Colon"
 ValueDefault=ignore
 
@@ -1212,7 +1213,7 @@ Category=1
 Description="<html>Add or remove space before class ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_class_colon=ignore|sp_before_class_colon=add|sp_before_class_colon=remove|sp_before_class_colon=force|sp_before_class_colon=not_defined
+Choices=sp_before_class_colon\s*=\s*ignore|sp_before_class_colon\s*=\s*add|sp_before_class_colon\s*=\s*remove|sp_before_class_colon\s*=\s*force|sp_before_class_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Class Colon|Add Sp Before Class Colon|Remove Sp Before Class Colon|Force Sp Before Class Colon"
 ValueDefault=ignore
 
@@ -1221,7 +1222,7 @@ Category=1
 Description="<html>Add or remove space after class constructor ':'.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_constr_colon=ignore|sp_after_constr_colon=add|sp_after_constr_colon=remove|sp_after_constr_colon=force|sp_after_constr_colon=not_defined
+Choices=sp_after_constr_colon\s*=\s*ignore|sp_after_constr_colon\s*=\s*add|sp_after_constr_colon\s*=\s*remove|sp_after_constr_colon\s*=\s*force|sp_after_constr_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Constr Colon|Add Sp After Constr Colon|Remove Sp After Constr Colon|Force Sp After Constr Colon"
 ValueDefault=add
 
@@ -1230,7 +1231,7 @@ Category=1
 Description="<html>Add or remove space before class constructor ':'.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_constr_colon=ignore|sp_before_constr_colon=add|sp_before_constr_colon=remove|sp_before_constr_colon=force|sp_before_constr_colon=not_defined
+Choices=sp_before_constr_colon\s*=\s*ignore|sp_before_constr_colon\s*=\s*add|sp_before_constr_colon\s*=\s*remove|sp_before_constr_colon\s*=\s*force|sp_before_constr_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Constr Colon|Add Sp Before Constr Colon|Remove Sp Before Constr Colon|Force Sp Before Constr Colon"
 ValueDefault=add
 
@@ -1239,7 +1240,7 @@ Category=1
 Description="<html>Add or remove space before case ':'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_case_colon=ignore|sp_before_case_colon=add|sp_before_case_colon=remove|sp_before_case_colon=force|sp_before_case_colon=not_defined
+Choices=sp_before_case_colon\s*=\s*ignore|sp_before_case_colon\s*=\s*add|sp_before_case_colon\s*=\s*remove|sp_before_case_colon\s*=\s*force|sp_before_case_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Case Colon|Add Sp Before Case Colon|Remove Sp Before Case Colon|Force Sp Before Case Colon"
 ValueDefault=remove
 
@@ -1248,7 +1249,7 @@ Category=1
 Description="<html>Add or remove space between 'operator' and operator sign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_operator=ignore|sp_after_operator=add|sp_after_operator=remove|sp_after_operator=force|sp_after_operator=not_defined
+Choices=sp_after_operator\s*=\s*ignore|sp_after_operator\s*=\s*add|sp_after_operator\s*=\s*remove|sp_after_operator\s*=\s*force|sp_after_operator\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Operator|Add Sp After Operator|Remove Sp After Operator|Force Sp After Operator"
 ValueDefault=ignore
 
@@ -1257,7 +1258,7 @@ Category=1
 Description="<html>Add or remove space between the operator symbol and the open parenthesis, as<br/>in 'operator ++('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_operator_sym=ignore|sp_after_operator_sym=add|sp_after_operator_sym=remove|sp_after_operator_sym=force|sp_after_operator_sym=not_defined
+Choices=sp_after_operator_sym\s*=\s*ignore|sp_after_operator_sym\s*=\s*add|sp_after_operator_sym\s*=\s*remove|sp_after_operator_sym\s*=\s*force|sp_after_operator_sym\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Operator Sym|Add Sp After Operator Sym|Remove Sp After Operator Sym|Force Sp After Operator Sym"
 ValueDefault=ignore
 
@@ -1266,7 +1267,7 @@ Category=1
 Description="<html>Overrides sp_after_operator_sym when the operator has no arguments, as in<br/>'operator *()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_operator_sym_empty=ignore|sp_after_operator_sym_empty=add|sp_after_operator_sym_empty=remove|sp_after_operator_sym_empty=force|sp_after_operator_sym_empty=not_defined
+Choices=sp_after_operator_sym_empty\s*=\s*ignore|sp_after_operator_sym_empty\s*=\s*add|sp_after_operator_sym_empty\s*=\s*remove|sp_after_operator_sym_empty\s*=\s*force|sp_after_operator_sym_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Operator Sym Empty|Add Sp After Operator Sym Empty|Remove Sp After Operator Sym Empty|Force Sp After Operator Sym Empty"
 ValueDefault=ignore
 
@@ -1275,7 +1276,7 @@ Category=1
 Description="<html>Add or remove space after C/D cast, i.e. 'cast(int)a' vs. 'cast(int) a' or<br/>'(int)a' vs. '(int) a'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_cast=ignore|sp_after_cast=add|sp_after_cast=remove|sp_after_cast=force|sp_after_cast=not_defined
+Choices=sp_after_cast\s*=\s*ignore|sp_after_cast\s*=\s*add|sp_after_cast\s*=\s*remove|sp_after_cast\s*=\s*force|sp_after_cast\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Cast|Add Sp After Cast|Remove Sp After Cast|Force Sp After Cast"
 ValueDefault=ignore
 
@@ -1284,7 +1285,7 @@ Category=1
 Description="<html>Add or remove spaces inside cast parentheses.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_paren_cast=ignore|sp_inside_paren_cast=add|sp_inside_paren_cast=remove|sp_inside_paren_cast=force|sp_inside_paren_cast=not_defined
+Choices=sp_inside_paren_cast\s*=\s*ignore|sp_inside_paren_cast\s*=\s*add|sp_inside_paren_cast\s*=\s*remove|sp_inside_paren_cast\s*=\s*force|sp_inside_paren_cast\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Paren Cast|Add Sp Inside Paren Cast|Remove Sp Inside Paren Cast|Force Sp Inside Paren Cast"
 ValueDefault=ignore
 
@@ -1293,7 +1294,7 @@ Category=1
 Description="<html>Add or remove space between the type and open parenthesis in a C++ cast,<br/>i.e. 'int(exp)' vs. 'int (exp)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_cast_paren=ignore|sp_cpp_cast_paren=add|sp_cpp_cast_paren=remove|sp_cpp_cast_paren=force|sp_cpp_cast_paren=not_defined
+Choices=sp_cpp_cast_paren\s*=\s*ignore|sp_cpp_cast_paren\s*=\s*add|sp_cpp_cast_paren\s*=\s*remove|sp_cpp_cast_paren\s*=\s*force|sp_cpp_cast_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Cast Paren|Add Sp Cpp Cast Paren|Remove Sp Cpp Cast Paren|Force Sp Cpp Cast Paren"
 ValueDefault=ignore
 
@@ -1302,7 +1303,7 @@ Category=1
 Description="<html>Add or remove space between 'sizeof' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sizeof_paren=ignore|sp_sizeof_paren=add|sp_sizeof_paren=remove|sp_sizeof_paren=force|sp_sizeof_paren=not_defined
+Choices=sp_sizeof_paren\s*=\s*ignore|sp_sizeof_paren\s*=\s*add|sp_sizeof_paren\s*=\s*remove|sp_sizeof_paren\s*=\s*force|sp_sizeof_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sizeof Paren|Add Sp Sizeof Paren|Remove Sp Sizeof Paren|Force Sp Sizeof Paren"
 ValueDefault=ignore
 
@@ -1311,7 +1312,7 @@ Category=1
 Description="<html>Add or remove space between 'sizeof' and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sizeof_ellipsis=ignore|sp_sizeof_ellipsis=add|sp_sizeof_ellipsis=remove|sp_sizeof_ellipsis=force|sp_sizeof_ellipsis=not_defined
+Choices=sp_sizeof_ellipsis\s*=\s*ignore|sp_sizeof_ellipsis\s*=\s*add|sp_sizeof_ellipsis\s*=\s*remove|sp_sizeof_ellipsis\s*=\s*force|sp_sizeof_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sizeof Ellipsis|Add Sp Sizeof Ellipsis|Remove Sp Sizeof Ellipsis|Force Sp Sizeof Ellipsis"
 ValueDefault=ignore
 
@@ -1320,7 +1321,7 @@ Category=1
 Description="<html>Add or remove space between 'sizeof...' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sizeof_ellipsis_paren=ignore|sp_sizeof_ellipsis_paren=add|sp_sizeof_ellipsis_paren=remove|sp_sizeof_ellipsis_paren=force|sp_sizeof_ellipsis_paren=not_defined
+Choices=sp_sizeof_ellipsis_paren\s*=\s*ignore|sp_sizeof_ellipsis_paren\s*=\s*add|sp_sizeof_ellipsis_paren\s*=\s*remove|sp_sizeof_ellipsis_paren\s*=\s*force|sp_sizeof_ellipsis_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sizeof Ellipsis Paren|Add Sp Sizeof Ellipsis Paren|Remove Sp Sizeof Ellipsis Paren|Force Sp Sizeof Ellipsis Paren"
 ValueDefault=ignore
 
@@ -1329,7 +1330,7 @@ Category=1
 Description="<html>Add or remove space between '...' and a parameter pack.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ellipsis_parameter_pack=ignore|sp_ellipsis_parameter_pack=add|sp_ellipsis_parameter_pack=remove|sp_ellipsis_parameter_pack=force|sp_ellipsis_parameter_pack=not_defined
+Choices=sp_ellipsis_parameter_pack\s*=\s*ignore|sp_ellipsis_parameter_pack\s*=\s*add|sp_ellipsis_parameter_pack\s*=\s*remove|sp_ellipsis_parameter_pack\s*=\s*force|sp_ellipsis_parameter_pack\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ellipsis Parameter Pack|Add Sp Ellipsis Parameter Pack|Remove Sp Ellipsis Parameter Pack|Force Sp Ellipsis Parameter Pack"
 ValueDefault=ignore
 
@@ -1338,7 +1339,7 @@ Category=1
 Description="<html>Add or remove space between a parameter pack and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_parameter_pack_ellipsis=ignore|sp_parameter_pack_ellipsis=add|sp_parameter_pack_ellipsis=remove|sp_parameter_pack_ellipsis=force|sp_parameter_pack_ellipsis=not_defined
+Choices=sp_parameter_pack_ellipsis\s*=\s*ignore|sp_parameter_pack_ellipsis\s*=\s*add|sp_parameter_pack_ellipsis\s*=\s*remove|sp_parameter_pack_ellipsis\s*=\s*force|sp_parameter_pack_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Parameter Pack Ellipsis|Add Sp Parameter Pack Ellipsis|Remove Sp Parameter Pack Ellipsis|Force Sp Parameter Pack Ellipsis"
 ValueDefault=ignore
 
@@ -1347,7 +1348,7 @@ Category=1
 Description="<html>Add or remove space between 'decltype' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_decltype_paren=ignore|sp_decltype_paren=add|sp_decltype_paren=remove|sp_decltype_paren=force|sp_decltype_paren=not_defined
+Choices=sp_decltype_paren\s*=\s*ignore|sp_decltype_paren\s*=\s*add|sp_decltype_paren\s*=\s*remove|sp_decltype_paren\s*=\s*force|sp_decltype_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Decltype Paren|Add Sp Decltype Paren|Remove Sp Decltype Paren|Force Sp Decltype Paren"
 ValueDefault=ignore
 
@@ -1356,7 +1357,7 @@ Category=1
 Description="<html>(Pawn) Add or remove space after the tag keyword.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_tag=ignore|sp_after_tag=add|sp_after_tag=remove|sp_after_tag=force|sp_after_tag=not_defined
+Choices=sp_after_tag\s*=\s*ignore|sp_after_tag\s*=\s*add|sp_after_tag\s*=\s*remove|sp_after_tag\s*=\s*force|sp_after_tag\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Tag|Add Sp After Tag|Remove Sp After Tag|Force Sp After Tag"
 ValueDefault=ignore
 
@@ -1365,7 +1366,7 @@ Category=1
 Description="<html>Add or remove space inside enum '{' and '}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces_enum=ignore|sp_inside_braces_enum=add|sp_inside_braces_enum=remove|sp_inside_braces_enum=force|sp_inside_braces_enum=not_defined
+Choices=sp_inside_braces_enum\s*=\s*ignore|sp_inside_braces_enum\s*=\s*add|sp_inside_braces_enum\s*=\s*remove|sp_inside_braces_enum\s*=\s*force|sp_inside_braces_enum\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces Enum|Add Sp Inside Braces Enum|Remove Sp Inside Braces Enum|Force Sp Inside Braces Enum"
 ValueDefault=ignore
 
@@ -1374,7 +1375,7 @@ Category=1
 Description="<html>Add or remove space inside struct/union '{' and '}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces_struct=ignore|sp_inside_braces_struct=add|sp_inside_braces_struct=remove|sp_inside_braces_struct=force|sp_inside_braces_struct=not_defined
+Choices=sp_inside_braces_struct\s*=\s*ignore|sp_inside_braces_struct\s*=\s*add|sp_inside_braces_struct\s*=\s*remove|sp_inside_braces_struct\s*=\s*force|sp_inside_braces_struct\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces Struct|Add Sp Inside Braces Struct|Remove Sp Inside Braces Struct|Force Sp Inside Braces Struct"
 ValueDefault=ignore
 
@@ -1383,7 +1384,7 @@ Category=1
 Description="<html>(OC) Add or remove space inside Objective-C boxed dictionary '{' and '}'</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces_oc_dict=ignore|sp_inside_braces_oc_dict=add|sp_inside_braces_oc_dict=remove|sp_inside_braces_oc_dict=force|sp_inside_braces_oc_dict=not_defined
+Choices=sp_inside_braces_oc_dict\s*=\s*ignore|sp_inside_braces_oc_dict\s*=\s*add|sp_inside_braces_oc_dict\s*=\s*remove|sp_inside_braces_oc_dict\s*=\s*force|sp_inside_braces_oc_dict\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces Oc Dict|Add Sp Inside Braces Oc Dict|Remove Sp Inside Braces Oc Dict|Force Sp Inside Braces Oc Dict"
 ValueDefault=ignore
 
@@ -1392,7 +1393,7 @@ Category=1
 Description="<html>Add or remove space after open brace in an unnamed temporary<br/>direct-list-initialization<br/>if statement is a brace_init_lst<br/>works only if sp_brace_brace is set to ignore.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_type_brace_init_lst_open=ignore|sp_after_type_brace_init_lst_open=add|sp_after_type_brace_init_lst_open=remove|sp_after_type_brace_init_lst_open=force|sp_after_type_brace_init_lst_open=not_defined
+Choices=sp_after_type_brace_init_lst_open\s*=\s*ignore|sp_after_type_brace_init_lst_open\s*=\s*add|sp_after_type_brace_init_lst_open\s*=\s*remove|sp_after_type_brace_init_lst_open\s*=\s*force|sp_after_type_brace_init_lst_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Type Brace Init Lst Open|Add Sp After Type Brace Init Lst Open|Remove Sp After Type Brace Init Lst Open|Force Sp After Type Brace Init Lst Open"
 ValueDefault=ignore
 
@@ -1401,7 +1402,7 @@ Category=1
 Description="<html>Add or remove space before close brace in an unnamed temporary<br/>direct-list-initialization<br/>if statement is a brace_init_lst<br/>works only if sp_brace_brace is set to ignore.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_type_brace_init_lst_close=ignore|sp_before_type_brace_init_lst_close=add|sp_before_type_brace_init_lst_close=remove|sp_before_type_brace_init_lst_close=force|sp_before_type_brace_init_lst_close=not_defined
+Choices=sp_before_type_brace_init_lst_close\s*=\s*ignore|sp_before_type_brace_init_lst_close\s*=\s*add|sp_before_type_brace_init_lst_close\s*=\s*remove|sp_before_type_brace_init_lst_close\s*=\s*force|sp_before_type_brace_init_lst_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Type Brace Init Lst Close|Add Sp Before Type Brace Init Lst Close|Remove Sp Before Type Brace Init Lst Close|Force Sp Before Type Brace Init Lst Close"
 ValueDefault=ignore
 
@@ -1410,7 +1411,7 @@ Category=1
 Description="<html>Add or remove space inside an unnamed temporary direct-list-initialization<br/>if statement is a brace_init_lst<br/>works only if sp_brace_brace is set to ignore<br/>works only if sp_before_type_brace_init_lst_close is set to ignore.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_type_brace_init_lst=ignore|sp_inside_type_brace_init_lst=add|sp_inside_type_brace_init_lst=remove|sp_inside_type_brace_init_lst=force|sp_inside_type_brace_init_lst=not_defined
+Choices=sp_inside_type_brace_init_lst\s*=\s*ignore|sp_inside_type_brace_init_lst\s*=\s*add|sp_inside_type_brace_init_lst\s*=\s*remove|sp_inside_type_brace_init_lst\s*=\s*force|sp_inside_type_brace_init_lst\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Type Brace Init Lst|Add Sp Inside Type Brace Init Lst|Remove Sp Inside Type Brace Init Lst|Force Sp Inside Type Brace Init Lst"
 ValueDefault=ignore
 
@@ -1419,7 +1420,7 @@ Category=1
 Description="<html>Add or remove space inside '{' and '}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces=ignore|sp_inside_braces=add|sp_inside_braces=remove|sp_inside_braces=force|sp_inside_braces=not_defined
+Choices=sp_inside_braces\s*=\s*ignore|sp_inside_braces\s*=\s*add|sp_inside_braces\s*=\s*remove|sp_inside_braces\s*=\s*force|sp_inside_braces\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces|Add Sp Inside Braces|Remove Sp Inside Braces|Force Sp Inside Braces"
 ValueDefault=ignore
 
@@ -1428,7 +1429,7 @@ Category=1
 Description="<html>Add or remove space inside '{}'.<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces_empty=ignore|sp_inside_braces_empty=add|sp_inside_braces_empty=remove|sp_inside_braces_empty=force|sp_inside_braces_empty=not_defined
+Choices=sp_inside_braces_empty\s*=\s*ignore|sp_inside_braces_empty\s*=\s*add|sp_inside_braces_empty\s*=\s*remove|sp_inside_braces_empty\s*=\s*force|sp_inside_braces_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces Empty|Add Sp Inside Braces Empty|Remove Sp Inside Braces Empty|Force Sp Inside Braces Empty"
 ValueDefault=ignore
 
@@ -1437,7 +1438,7 @@ Category=1
 Description="<html>Add or remove space around trailing return operator '-&gt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_trailing_return=ignore|sp_trailing_return=add|sp_trailing_return=remove|sp_trailing_return=force|sp_trailing_return=not_defined
+Choices=sp_trailing_return\s*=\s*ignore|sp_trailing_return\s*=\s*add|sp_trailing_return\s*=\s*remove|sp_trailing_return\s*=\s*force|sp_trailing_return\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Trailing Return|Add Sp Trailing Return|Remove Sp Trailing Return|Force Sp Trailing Return"
 ValueDefault=ignore
 
@@ -1446,7 +1447,7 @@ Category=1
 Description="<html>Add or remove space between return type and function name. A minimum of 1<br/>is forced except for pointer return types.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_type_func=ignore|sp_type_func=add|sp_type_func=remove|sp_type_func=force|sp_type_func=not_defined
+Choices=sp_type_func\s*=\s*ignore|sp_type_func\s*=\s*add|sp_type_func\s*=\s*remove|sp_type_func\s*=\s*force|sp_type_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Type Func|Add Sp Type Func|Remove Sp Type Func|Force Sp Type Func"
 ValueDefault=ignore
 
@@ -1455,7 +1456,7 @@ Category=1
 Description="<html>Add or remove space between type and open brace of an unnamed temporary<br/>direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_type_brace_init_lst=ignore|sp_type_brace_init_lst=add|sp_type_brace_init_lst=remove|sp_type_brace_init_lst=force|sp_type_brace_init_lst=not_defined
+Choices=sp_type_brace_init_lst\s*=\s*ignore|sp_type_brace_init_lst\s*=\s*add|sp_type_brace_init_lst\s*=\s*remove|sp_type_brace_init_lst\s*=\s*force|sp_type_brace_init_lst\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Type Brace Init Lst|Add Sp Type Brace Init Lst|Remove Sp Type Brace Init Lst|Force Sp Type Brace Init Lst"
 ValueDefault=ignore
 
@@ -1464,7 +1465,7 @@ Category=1
 Description="<html>Add or remove space between function name and '(' on function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_proto_paren=ignore|sp_func_proto_paren=add|sp_func_proto_paren=remove|sp_func_proto_paren=force|sp_func_proto_paren=not_defined
+Choices=sp_func_proto_paren\s*=\s*ignore|sp_func_proto_paren\s*=\s*add|sp_func_proto_paren\s*=\s*remove|sp_func_proto_paren\s*=\s*force|sp_func_proto_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Proto Paren|Add Sp Func Proto Paren|Remove Sp Func Proto Paren|Force Sp Func Proto Paren"
 ValueDefault=ignore
 
@@ -1473,7 +1474,7 @@ Category=1
 Description="<html>Add or remove space between function name and '()' on function declaration<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_proto_paren_empty=ignore|sp_func_proto_paren_empty=add|sp_func_proto_paren_empty=remove|sp_func_proto_paren_empty=force|sp_func_proto_paren_empty=not_defined
+Choices=sp_func_proto_paren_empty\s*=\s*ignore|sp_func_proto_paren_empty\s*=\s*add|sp_func_proto_paren_empty\s*=\s*remove|sp_func_proto_paren_empty\s*=\s*force|sp_func_proto_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Proto Paren Empty|Add Sp Func Proto Paren Empty|Remove Sp Func Proto Paren Empty|Force Sp Func Proto Paren Empty"
 ValueDefault=ignore
 
@@ -1482,7 +1483,7 @@ Category=1
 Description="<html>Add or remove space between function name and '(' with a typedef specifier.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_type_paren=ignore|sp_func_type_paren=add|sp_func_type_paren=remove|sp_func_type_paren=force|sp_func_type_paren=not_defined
+Choices=sp_func_type_paren\s*=\s*ignore|sp_func_type_paren\s*=\s*add|sp_func_type_paren\s*=\s*remove|sp_func_type_paren\s*=\s*force|sp_func_type_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Type Paren|Add Sp Func Type Paren|Remove Sp Func Type Paren|Force Sp Func Type Paren"
 ValueDefault=ignore
 
@@ -1491,7 +1492,7 @@ Category=1
 Description="<html>Add or remove space between alias name and '(' of a non-pointer function type typedef.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_def_paren=ignore|sp_func_def_paren=add|sp_func_def_paren=remove|sp_func_def_paren=force|sp_func_def_paren=not_defined
+Choices=sp_func_def_paren\s*=\s*ignore|sp_func_def_paren\s*=\s*add|sp_func_def_paren\s*=\s*remove|sp_func_def_paren\s*=\s*force|sp_func_def_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Def Paren|Add Sp Func Def Paren|Remove Sp Func Def Paren|Force Sp Func Def Paren"
 ValueDefault=ignore
 
@@ -1500,7 +1501,7 @@ Category=1
 Description="<html>Add or remove space between function name and '()' on function definition<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_def_paren_empty=ignore|sp_func_def_paren_empty=add|sp_func_def_paren_empty=remove|sp_func_def_paren_empty=force|sp_func_def_paren_empty=not_defined
+Choices=sp_func_def_paren_empty\s*=\s*ignore|sp_func_def_paren_empty\s*=\s*add|sp_func_def_paren_empty\s*=\s*remove|sp_func_def_paren_empty\s*=\s*force|sp_func_def_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Def Paren Empty|Add Sp Func Def Paren Empty|Remove Sp Func Def Paren Empty|Force Sp Func Def Paren Empty"
 ValueDefault=ignore
 
@@ -1509,7 +1510,7 @@ Category=1
 Description="<html>Add or remove space inside empty function '()'.<br/>Overrides sp_after_angle unless use_sp_after_angle_always is set to true.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_fparens=ignore|sp_inside_fparens=add|sp_inside_fparens=remove|sp_inside_fparens=force|sp_inside_fparens=not_defined
+Choices=sp_inside_fparens\s*=\s*ignore|sp_inside_fparens\s*=\s*add|sp_inside_fparens\s*=\s*remove|sp_inside_fparens\s*=\s*force|sp_inside_fparens\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Fparens|Add Sp Inside Fparens|Remove Sp Inside Fparens|Force Sp Inside Fparens"
 ValueDefault=ignore
 
@@ -1518,7 +1519,7 @@ Category=1
 Description="<html>Add or remove space inside function '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_fparen=ignore|sp_inside_fparen=add|sp_inside_fparen=remove|sp_inside_fparen=force|sp_inside_fparen=not_defined
+Choices=sp_inside_fparen\s*=\s*ignore|sp_inside_fparen\s*=\s*add|sp_inside_fparen\s*=\s*remove|sp_inside_fparen\s*=\s*force|sp_inside_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Fparen|Add Sp Inside Fparen|Remove Sp Inside Fparen|Force Sp Inside Fparen"
 ValueDefault=ignore
 
@@ -1527,7 +1528,7 @@ Category=1
 Description="<html>Add or remove space inside user functor '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_user_inside_rparen=ignore|sp_func_call_user_inside_rparen=add|sp_func_call_user_inside_rparen=remove|sp_func_call_user_inside_rparen=force|sp_func_call_user_inside_rparen=not_defined
+Choices=sp_func_call_user_inside_rparen\s*=\s*ignore|sp_func_call_user_inside_rparen\s*=\s*add|sp_func_call_user_inside_rparen\s*=\s*remove|sp_func_call_user_inside_rparen\s*=\s*force|sp_func_call_user_inside_rparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call User Inside Rparen|Add Sp Func Call User Inside Rparen|Remove Sp Func Call User Inside Rparen|Force Sp Func Call User Inside Rparen"
 ValueDefault=ignore
 
@@ -1536,7 +1537,7 @@ Category=1
 Description="<html>Add or remove space inside empty functor '()'.<br/>Overrides sp_after_angle unless use_sp_after_angle_always is set to true.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_rparens=ignore|sp_inside_rparens=add|sp_inside_rparens=remove|sp_inside_rparens=force|sp_inside_rparens=not_defined
+Choices=sp_inside_rparens\s*=\s*ignore|sp_inside_rparens\s*=\s*add|sp_inside_rparens\s*=\s*remove|sp_inside_rparens\s*=\s*force|sp_inside_rparens\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Rparens|Add Sp Inside Rparens|Remove Sp Inside Rparens|Force Sp Inside Rparens"
 ValueDefault=ignore
 
@@ -1545,7 +1546,7 @@ Category=1
 Description="<html>Add or remove space inside functor '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_rparen=ignore|sp_inside_rparen=add|sp_inside_rparen=remove|sp_inside_rparen=force|sp_inside_rparen=not_defined
+Choices=sp_inside_rparen\s*=\s*ignore|sp_inside_rparen\s*=\s*add|sp_inside_rparen\s*=\s*remove|sp_inside_rparen\s*=\s*force|sp_inside_rparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Rparen|Add Sp Inside Rparen|Remove Sp Inside Rparen|Force Sp Inside Rparen"
 ValueDefault=ignore
 
@@ -1554,7 +1555,7 @@ Category=1
 Description="<html>Add or remove space inside the first parentheses in a function type, as in<br/>'void (*x)(...)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_tparen=ignore|sp_inside_tparen=add|sp_inside_tparen=remove|sp_inside_tparen=force|sp_inside_tparen=not_defined
+Choices=sp_inside_tparen\s*=\s*ignore|sp_inside_tparen\s*=\s*add|sp_inside_tparen\s*=\s*remove|sp_inside_tparen\s*=\s*force|sp_inside_tparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Tparen|Add Sp Inside Tparen|Remove Sp Inside Tparen|Force Sp Inside Tparen"
 ValueDefault=ignore
 
@@ -1563,7 +1564,7 @@ Category=1
 Description="<html>Add or remove space between the ')' and '(' in a function type, as in<br/>'void (*x)(...)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_tparen_close=ignore|sp_after_tparen_close=add|sp_after_tparen_close=remove|sp_after_tparen_close=force|sp_after_tparen_close=not_defined
+Choices=sp_after_tparen_close\s*=\s*ignore|sp_after_tparen_close\s*=\s*add|sp_after_tparen_close\s*=\s*remove|sp_after_tparen_close\s*=\s*force|sp_after_tparen_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Tparen Close|Add Sp After Tparen Close|Remove Sp After Tparen Close|Force Sp After Tparen Close"
 ValueDefault=ignore
 
@@ -1572,7 +1573,7 @@ Category=1
 Description="<html>Add or remove space between ']' and '(' when part of a function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_square_fparen=ignore|sp_square_fparen=add|sp_square_fparen=remove|sp_square_fparen=force|sp_square_fparen=not_defined
+Choices=sp_square_fparen\s*=\s*ignore|sp_square_fparen\s*=\s*add|sp_square_fparen\s*=\s*remove|sp_square_fparen\s*=\s*force|sp_square_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Square Fparen|Add Sp Square Fparen|Remove Sp Square Fparen|Force Sp Square Fparen"
 ValueDefault=ignore
 
@@ -1581,7 +1582,7 @@ Category=1
 Description="<html>Add or remove space between ')' and '{' of function.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_fparen_brace=ignore|sp_fparen_brace=add|sp_fparen_brace=remove|sp_fparen_brace=force|sp_fparen_brace=not_defined
+Choices=sp_fparen_brace\s*=\s*ignore|sp_fparen_brace\s*=\s*add|sp_fparen_brace\s*=\s*remove|sp_fparen_brace\s*=\s*force|sp_fparen_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Fparen Brace|Add Sp Fparen Brace|Remove Sp Fparen Brace|Force Sp Fparen Brace"
 ValueDefault=ignore
 
@@ -1590,7 +1591,7 @@ Category=1
 Description="<html>Add or remove space between ')' and '{' of a function call in object<br/>initialization.<br/><br/>Overrides sp_fparen_brace.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_fparen_brace_initializer=ignore|sp_fparen_brace_initializer=add|sp_fparen_brace_initializer=remove|sp_fparen_brace_initializer=force|sp_fparen_brace_initializer=not_defined
+Choices=sp_fparen_brace_initializer\s*=\s*ignore|sp_fparen_brace_initializer\s*=\s*add|sp_fparen_brace_initializer\s*=\s*remove|sp_fparen_brace_initializer\s*=\s*force|sp_fparen_brace_initializer\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Fparen Brace Initializer|Add Sp Fparen Brace Initializer|Remove Sp Fparen Brace Initializer|Force Sp Fparen Brace Initializer"
 ValueDefault=ignore
 
@@ -1599,7 +1600,7 @@ Category=1
 Description="<html>(Java) Add or remove space between ')' and '{{' of double brace initializer.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_fparen_dbrace=ignore|sp_fparen_dbrace=add|sp_fparen_dbrace=remove|sp_fparen_dbrace=force|sp_fparen_dbrace=not_defined
+Choices=sp_fparen_dbrace\s*=\s*ignore|sp_fparen_dbrace\s*=\s*add|sp_fparen_dbrace\s*=\s*remove|sp_fparen_dbrace\s*=\s*force|sp_fparen_dbrace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Fparen Dbrace|Add Sp Fparen Dbrace|Remove Sp Fparen Dbrace|Force Sp Fparen Dbrace"
 ValueDefault=ignore
 
@@ -1608,7 +1609,7 @@ Category=1
 Description="<html>Add or remove space between function name and '(' on function calls.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_paren=ignore|sp_func_call_paren=add|sp_func_call_paren=remove|sp_func_call_paren=force|sp_func_call_paren=not_defined
+Choices=sp_func_call_paren\s*=\s*ignore|sp_func_call_paren\s*=\s*add|sp_func_call_paren\s*=\s*remove|sp_func_call_paren\s*=\s*force|sp_func_call_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call Paren|Add Sp Func Call Paren|Remove Sp Func Call Paren|Force Sp Func Call Paren"
 ValueDefault=ignore
 
@@ -1617,7 +1618,7 @@ Category=1
 Description="<html>Add or remove space between function name and '()' on function calls without<br/>parameters. If set to ignore (the default), sp_func_call_paren is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_paren_empty=ignore|sp_func_call_paren_empty=add|sp_func_call_paren_empty=remove|sp_func_call_paren_empty=force|sp_func_call_paren_empty=not_defined
+Choices=sp_func_call_paren_empty\s*=\s*ignore|sp_func_call_paren_empty\s*=\s*add|sp_func_call_paren_empty\s*=\s*remove|sp_func_call_paren_empty\s*=\s*force|sp_func_call_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call Paren Empty|Add Sp Func Call Paren Empty|Remove Sp Func Call Paren Empty|Force Sp Func Call Paren Empty"
 ValueDefault=ignore
 
@@ -1626,7 +1627,7 @@ Category=1
 Description="<html>Add or remove space between the user function name and '(' on function<br/>calls. You need to set a keyword to be a user function in the config file,<br/>like:<br/>  set func_call_user tr _ i18n</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_user_paren=ignore|sp_func_call_user_paren=add|sp_func_call_user_paren=remove|sp_func_call_user_paren=force|sp_func_call_user_paren=not_defined
+Choices=sp_func_call_user_paren\s*=\s*ignore|sp_func_call_user_paren\s*=\s*add|sp_func_call_user_paren\s*=\s*remove|sp_func_call_user_paren\s*=\s*force|sp_func_call_user_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call User Paren|Add Sp Func Call User Paren|Remove Sp Func Call User Paren|Force Sp Func Call User Paren"
 ValueDefault=ignore
 
@@ -1635,7 +1636,7 @@ Category=1
 Description="<html>Add or remove space inside user function '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_user_inside_fparen=ignore|sp_func_call_user_inside_fparen=add|sp_func_call_user_inside_fparen=remove|sp_func_call_user_inside_fparen=force|sp_func_call_user_inside_fparen=not_defined
+Choices=sp_func_call_user_inside_fparen\s*=\s*ignore|sp_func_call_user_inside_fparen\s*=\s*add|sp_func_call_user_inside_fparen\s*=\s*remove|sp_func_call_user_inside_fparen\s*=\s*force|sp_func_call_user_inside_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call User Inside Fparen|Add Sp Func Call User Inside Fparen|Remove Sp Func Call User Inside Fparen|Force Sp Func Call User Inside Fparen"
 ValueDefault=ignore
 
@@ -1644,7 +1645,7 @@ Category=1
 Description="<html>Add or remove space between nested parentheses with user functions,<br/>i.e. '((' vs. '( ('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_user_paren_paren=ignore|sp_func_call_user_paren_paren=add|sp_func_call_user_paren_paren=remove|sp_func_call_user_paren_paren=force|sp_func_call_user_paren_paren=not_defined
+Choices=sp_func_call_user_paren_paren\s*=\s*ignore|sp_func_call_user_paren_paren\s*=\s*add|sp_func_call_user_paren_paren\s*=\s*remove|sp_func_call_user_paren_paren\s*=\s*force|sp_func_call_user_paren_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call User Paren Paren|Add Sp Func Call User Paren Paren|Remove Sp Func Call User Paren Paren|Force Sp Func Call User Paren Paren"
 ValueDefault=ignore
 
@@ -1653,7 +1654,7 @@ Category=1
 Description="<html>Add or remove space between a constructor/destructor and the open<br/>parenthesis.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_class_paren=ignore|sp_func_class_paren=add|sp_func_class_paren=remove|sp_func_class_paren=force|sp_func_class_paren=not_defined
+Choices=sp_func_class_paren\s*=\s*ignore|sp_func_class_paren\s*=\s*add|sp_func_class_paren\s*=\s*remove|sp_func_class_paren\s*=\s*force|sp_func_class_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Class Paren|Add Sp Func Class Paren|Remove Sp Func Class Paren|Force Sp Func Class Paren"
 ValueDefault=ignore
 
@@ -1662,7 +1663,7 @@ Category=1
 Description="<html>Add or remove space between a constructor without parameters or destructor<br/>and '()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_class_paren_empty=ignore|sp_func_class_paren_empty=add|sp_func_class_paren_empty=remove|sp_func_class_paren_empty=force|sp_func_class_paren_empty=not_defined
+Choices=sp_func_class_paren_empty\s*=\s*ignore|sp_func_class_paren_empty\s*=\s*add|sp_func_class_paren_empty\s*=\s*remove|sp_func_class_paren_empty\s*=\s*force|sp_func_class_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Class Paren Empty|Add Sp Func Class Paren Empty|Remove Sp Func Class Paren Empty|Force Sp Func Class Paren Empty"
 ValueDefault=ignore
 
@@ -1671,7 +1672,7 @@ Category=1
 Description="<html>Add or remove space after 'return'.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_return=ignore|sp_return=add|sp_return=remove|sp_return=force|sp_return=not_defined
+Choices=sp_return\s*=\s*ignore|sp_return\s*=\s*add|sp_return\s*=\s*remove|sp_return\s*=\s*force|sp_return\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Return|Add Sp Return|Remove Sp Return|Force Sp Return"
 ValueDefault=force
 
@@ -1680,7 +1681,7 @@ Category=1
 Description="<html>Add or remove space between 'return' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_return_paren=ignore|sp_return_paren=add|sp_return_paren=remove|sp_return_paren=force|sp_return_paren=not_defined
+Choices=sp_return_paren\s*=\s*ignore|sp_return_paren\s*=\s*add|sp_return_paren\s*=\s*remove|sp_return_paren\s*=\s*force|sp_return_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Return Paren|Add Sp Return Paren|Remove Sp Return Paren|Force Sp Return Paren"
 ValueDefault=ignore
 
@@ -1689,7 +1690,7 @@ Category=1
 Description="<html>Add or remove space between 'return' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_return_brace=ignore|sp_return_brace=add|sp_return_brace=remove|sp_return_brace=force|sp_return_brace=not_defined
+Choices=sp_return_brace\s*=\s*ignore|sp_return_brace\s*=\s*add|sp_return_brace\s*=\s*remove|sp_return_brace\s*=\s*force|sp_return_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Return Brace|Add Sp Return Brace|Remove Sp Return Brace|Force Sp Return Brace"
 ValueDefault=ignore
 
@@ -1698,7 +1699,7 @@ Category=1
 Description="<html>Add or remove space between '__attribute__' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_attribute_paren=ignore|sp_attribute_paren=add|sp_attribute_paren=remove|sp_attribute_paren=force|sp_attribute_paren=not_defined
+Choices=sp_attribute_paren\s*=\s*ignore|sp_attribute_paren\s*=\s*add|sp_attribute_paren\s*=\s*remove|sp_attribute_paren\s*=\s*force|sp_attribute_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Attribute Paren|Add Sp Attribute Paren|Remove Sp Attribute Paren|Force Sp Attribute Paren"
 ValueDefault=ignore
 
@@ -1707,7 +1708,7 @@ Category=1
 Description="<html>Add or remove space between 'defined' and '(' in '#if defined (FOO)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_defined_paren=ignore|sp_defined_paren=add|sp_defined_paren=remove|sp_defined_paren=force|sp_defined_paren=not_defined
+Choices=sp_defined_paren\s*=\s*ignore|sp_defined_paren\s*=\s*add|sp_defined_paren\s*=\s*remove|sp_defined_paren\s*=\s*force|sp_defined_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Defined Paren|Add Sp Defined Paren|Remove Sp Defined Paren|Force Sp Defined Paren"
 ValueDefault=ignore
 
@@ -1716,7 +1717,7 @@ Category=1
 Description="<html>Add or remove space between 'throw' and '(' in 'throw (something)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_throw_paren=ignore|sp_throw_paren=add|sp_throw_paren=remove|sp_throw_paren=force|sp_throw_paren=not_defined
+Choices=sp_throw_paren\s*=\s*ignore|sp_throw_paren\s*=\s*add|sp_throw_paren\s*=\s*remove|sp_throw_paren\s*=\s*force|sp_throw_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Throw Paren|Add Sp Throw Paren|Remove Sp Throw Paren|Force Sp Throw Paren"
 ValueDefault=ignore
 
@@ -1725,7 +1726,7 @@ Category=1
 Description="<html>Add or remove space between 'throw' and anything other than '(' as in<br/>'@throw [...];'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_throw=ignore|sp_after_throw=add|sp_after_throw=remove|sp_after_throw=force|sp_after_throw=not_defined
+Choices=sp_after_throw\s*=\s*ignore|sp_after_throw\s*=\s*add|sp_after_throw\s*=\s*remove|sp_after_throw\s*=\s*force|sp_after_throw\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Throw|Add Sp After Throw|Remove Sp After Throw|Force Sp After Throw"
 ValueDefault=ignore
 
@@ -1734,7 +1735,7 @@ Category=1
 Description="<html>Add or remove space between 'catch' and '(' in 'catch (something) { }'.<br/>If set to ignore, sp_before_sparen is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_catch_paren=ignore|sp_catch_paren=add|sp_catch_paren=remove|sp_catch_paren=force|sp_catch_paren=not_defined
+Choices=sp_catch_paren\s*=\s*ignore|sp_catch_paren\s*=\s*add|sp_catch_paren\s*=\s*remove|sp_catch_paren\s*=\s*force|sp_catch_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Catch Paren|Add Sp Catch Paren|Remove Sp Catch Paren|Force Sp Catch Paren"
 ValueDefault=ignore
 
@@ -1743,7 +1744,7 @@ Category=1
 Description="<html>(OC) Add or remove space between '@catch' and '('<br/>in '@catch (something) { }'. If set to ignore, sp_catch_paren is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_oc_catch_paren=ignore|sp_oc_catch_paren=add|sp_oc_catch_paren=remove|sp_oc_catch_paren=force|sp_oc_catch_paren=not_defined
+Choices=sp_oc_catch_paren\s*=\s*ignore|sp_oc_catch_paren\s*=\s*add|sp_oc_catch_paren\s*=\s*remove|sp_oc_catch_paren\s*=\s*force|sp_oc_catch_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Oc Catch Paren|Add Sp Oc Catch Paren|Remove Sp Oc Catch Paren|Force Sp Oc Catch Paren"
 ValueDefault=ignore
 
@@ -1752,7 +1753,7 @@ Category=1
 Description="<html>(OC) Add or remove space before Objective-C protocol list<br/>as in '@protocol Protocol&lt;here&gt;&lt;Protocol_A&gt;' or '@interface MyClass : NSObject&lt;here&gt;&lt;MyProtocol&gt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_oc_proto_list=ignore|sp_before_oc_proto_list=add|sp_before_oc_proto_list=remove|sp_before_oc_proto_list=force|sp_before_oc_proto_list=not_defined
+Choices=sp_before_oc_proto_list\s*=\s*ignore|sp_before_oc_proto_list\s*=\s*add|sp_before_oc_proto_list\s*=\s*remove|sp_before_oc_proto_list\s*=\s*force|sp_before_oc_proto_list\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Oc Proto List|Add Sp Before Oc Proto List|Remove Sp Before Oc Proto List|Force Sp Before Oc Proto List"
 ValueDefault=ignore
 
@@ -1761,7 +1762,7 @@ Category=1
 Description="<html>(OC) Add or remove space between class name and '('<br/>in '@interface className(categoryName)&lt;ProtocolName&gt;:BaseClass'</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_oc_classname_paren=ignore|sp_oc_classname_paren=add|sp_oc_classname_paren=remove|sp_oc_classname_paren=force|sp_oc_classname_paren=not_defined
+Choices=sp_oc_classname_paren\s*=\s*ignore|sp_oc_classname_paren\s*=\s*add|sp_oc_classname_paren\s*=\s*remove|sp_oc_classname_paren\s*=\s*force|sp_oc_classname_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Oc Classname Paren|Add Sp Oc Classname Paren|Remove Sp Oc Classname Paren|Force Sp Oc Classname Paren"
 ValueDefault=ignore
 
@@ -1770,7 +1771,7 @@ Category=1
 Description="<html>(D) Add or remove space between 'version' and '('<br/>in 'version (something) { }'. If set to ignore, sp_before_sparen is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_version_paren=ignore|sp_version_paren=add|sp_version_paren=remove|sp_version_paren=force|sp_version_paren=not_defined
+Choices=sp_version_paren\s*=\s*ignore|sp_version_paren\s*=\s*add|sp_version_paren\s*=\s*remove|sp_version_paren\s*=\s*force|sp_version_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Version Paren|Add Sp Version Paren|Remove Sp Version Paren|Force Sp Version Paren"
 ValueDefault=ignore
 
@@ -1779,7 +1780,7 @@ Category=1
 Description="<html>(D) Add or remove space between 'scope' and '('<br/>in 'scope (something) { }'. If set to ignore, sp_before_sparen is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_scope_paren=ignore|sp_scope_paren=add|sp_scope_paren=remove|sp_scope_paren=force|sp_scope_paren=not_defined
+Choices=sp_scope_paren\s*=\s*ignore|sp_scope_paren\s*=\s*add|sp_scope_paren\s*=\s*remove|sp_scope_paren\s*=\s*force|sp_scope_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Scope Paren|Add Sp Scope Paren|Remove Sp Scope Paren|Force Sp Scope Paren"
 ValueDefault=ignore
 
@@ -1788,7 +1789,7 @@ Category=1
 Description="<html>Add or remove space between 'super' and '(' in 'super (something)'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_super_paren=ignore|sp_super_paren=add|sp_super_paren=remove|sp_super_paren=force|sp_super_paren=not_defined
+Choices=sp_super_paren\s*=\s*ignore|sp_super_paren\s*=\s*add|sp_super_paren\s*=\s*remove|sp_super_paren\s*=\s*force|sp_super_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Super Paren|Add Sp Super Paren|Remove Sp Super Paren|Force Sp Super Paren"
 ValueDefault=remove
 
@@ -1797,7 +1798,7 @@ Category=1
 Description="<html>Add or remove space between 'this' and '(' in 'this (something)'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_this_paren=ignore|sp_this_paren=add|sp_this_paren=remove|sp_this_paren=force|sp_this_paren=not_defined
+Choices=sp_this_paren\s*=\s*ignore|sp_this_paren\s*=\s*add|sp_this_paren\s*=\s*remove|sp_this_paren\s*=\s*force|sp_this_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp This Paren|Add Sp This Paren|Remove Sp This Paren|Force Sp This Paren"
 ValueDefault=remove
 
@@ -1806,7 +1807,7 @@ Category=1
 Description="<html>Add or remove space between a macro name and its definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_macro=ignore|sp_macro=add|sp_macro=remove|sp_macro=force|sp_macro=not_defined
+Choices=sp_macro\s*=\s*ignore|sp_macro\s*=\s*add|sp_macro\s*=\s*remove|sp_macro\s*=\s*force|sp_macro\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Macro|Add Sp Macro|Remove Sp Macro|Force Sp Macro"
 ValueDefault=ignore
 
@@ -1815,7 +1816,7 @@ Category=1
 Description="<html>Add or remove space between a macro function ')' and its definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_macro_func=ignore|sp_macro_func=add|sp_macro_func=remove|sp_macro_func=force|sp_macro_func=not_defined
+Choices=sp_macro_func\s*=\s*ignore|sp_macro_func\s*=\s*add|sp_macro_func\s*=\s*remove|sp_macro_func\s*=\s*force|sp_macro_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Macro Func|Add Sp Macro Func|Remove Sp Macro Func|Force Sp Macro Func"
 ValueDefault=ignore
 
@@ -1824,7 +1825,7 @@ Category=1
 Description="<html>Add or remove space between 'else' and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_else_brace=ignore|sp_else_brace=add|sp_else_brace=remove|sp_else_brace=force|sp_else_brace=not_defined
+Choices=sp_else_brace\s*=\s*ignore|sp_else_brace\s*=\s*add|sp_else_brace\s*=\s*remove|sp_else_brace\s*=\s*force|sp_else_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Else Brace|Add Sp Else Brace|Remove Sp Else Brace|Force Sp Else Brace"
 ValueDefault=ignore
 
@@ -1833,7 +1834,7 @@ Category=1
 Description="<html>Add or remove space between '}' and 'else' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_else=ignore|sp_brace_else=add|sp_brace_else=remove|sp_brace_else=force|sp_brace_else=not_defined
+Choices=sp_brace_else\s*=\s*ignore|sp_brace_else\s*=\s*add|sp_brace_else\s*=\s*remove|sp_brace_else\s*=\s*force|sp_brace_else\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Else|Add Sp Brace Else|Remove Sp Brace Else|Force Sp Brace Else"
 ValueDefault=ignore
 
@@ -1842,7 +1843,7 @@ Category=1
 Description="<html>Add or remove space between '}' and the name of a typedef on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_typedef=ignore|sp_brace_typedef=add|sp_brace_typedef=remove|sp_brace_typedef=force|sp_brace_typedef=not_defined
+Choices=sp_brace_typedef\s*=\s*ignore|sp_brace_typedef\s*=\s*add|sp_brace_typedef\s*=\s*remove|sp_brace_typedef\s*=\s*force|sp_brace_typedef\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Typedef|Add Sp Brace Typedef|Remove Sp Brace Typedef|Force Sp Brace Typedef"
 ValueDefault=ignore
 
@@ -1851,7 +1852,7 @@ Category=1
 Description="<html>Add or remove space before the '{' of a 'catch' statement, if the '{' and<br/>'catch' are on the same line, as in 'catch (decl) &lt;here&gt; {'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_catch_brace=ignore|sp_catch_brace=add|sp_catch_brace=remove|sp_catch_brace=force|sp_catch_brace=not_defined
+Choices=sp_catch_brace\s*=\s*ignore|sp_catch_brace\s*=\s*add|sp_catch_brace\s*=\s*remove|sp_catch_brace\s*=\s*force|sp_catch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Catch Brace|Add Sp Catch Brace|Remove Sp Catch Brace|Force Sp Catch Brace"
 ValueDefault=ignore
 
@@ -1860,7 +1861,7 @@ Category=1
 Description="<html>(OC) Add or remove space before the '{' of a '@catch' statement, if the '{'<br/>and '@catch' are on the same line, as in '@catch (decl) &lt;here&gt; {'.<br/>If set to ignore, sp_catch_brace is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_oc_catch_brace=ignore|sp_oc_catch_brace=add|sp_oc_catch_brace=remove|sp_oc_catch_brace=force|sp_oc_catch_brace=not_defined
+Choices=sp_oc_catch_brace\s*=\s*ignore|sp_oc_catch_brace\s*=\s*add|sp_oc_catch_brace\s*=\s*remove|sp_oc_catch_brace\s*=\s*force|sp_oc_catch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Oc Catch Brace|Add Sp Oc Catch Brace|Remove Sp Oc Catch Brace|Force Sp Oc Catch Brace"
 ValueDefault=ignore
 
@@ -1869,7 +1870,7 @@ Category=1
 Description="<html>Add or remove space between '}' and 'catch' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_catch=ignore|sp_brace_catch=add|sp_brace_catch=remove|sp_brace_catch=force|sp_brace_catch=not_defined
+Choices=sp_brace_catch\s*=\s*ignore|sp_brace_catch\s*=\s*add|sp_brace_catch\s*=\s*remove|sp_brace_catch\s*=\s*force|sp_brace_catch\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Catch|Add Sp Brace Catch|Remove Sp Brace Catch|Force Sp Brace Catch"
 ValueDefault=ignore
 
@@ -1878,7 +1879,7 @@ Category=1
 Description="<html>(OC) Add or remove space between '}' and '@catch' if on the same line.<br/>If set to ignore, sp_brace_catch is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_oc_brace_catch=ignore|sp_oc_brace_catch=add|sp_oc_brace_catch=remove|sp_oc_brace_catch=force|sp_oc_brace_catch=not_defined
+Choices=sp_oc_brace_catch\s*=\s*ignore|sp_oc_brace_catch\s*=\s*add|sp_oc_brace_catch\s*=\s*remove|sp_oc_brace_catch\s*=\s*force|sp_oc_brace_catch\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Oc Brace Catch|Add Sp Oc Brace Catch|Remove Sp Oc Brace Catch|Force Sp Oc Brace Catch"
 ValueDefault=ignore
 
@@ -1887,7 +1888,7 @@ Category=1
 Description="<html>Add or remove space between 'finally' and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_finally_brace=ignore|sp_finally_brace=add|sp_finally_brace=remove|sp_finally_brace=force|sp_finally_brace=not_defined
+Choices=sp_finally_brace\s*=\s*ignore|sp_finally_brace\s*=\s*add|sp_finally_brace\s*=\s*remove|sp_finally_brace\s*=\s*force|sp_finally_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Finally Brace|Add Sp Finally Brace|Remove Sp Finally Brace|Force Sp Finally Brace"
 ValueDefault=ignore
 
@@ -1896,7 +1897,7 @@ Category=1
 Description="<html>Add or remove space between '}' and 'finally' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_finally=ignore|sp_brace_finally=add|sp_brace_finally=remove|sp_brace_finally=force|sp_brace_finally=not_defined
+Choices=sp_brace_finally\s*=\s*ignore|sp_brace_finally\s*=\s*add|sp_brace_finally\s*=\s*remove|sp_brace_finally\s*=\s*force|sp_brace_finally\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Finally|Add Sp Brace Finally|Remove Sp Brace Finally|Force Sp Brace Finally"
 ValueDefault=ignore
 
@@ -1905,7 +1906,7 @@ Category=1
 Description="<html>Add or remove space between 'try' and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_try_brace=ignore|sp_try_brace=add|sp_try_brace=remove|sp_try_brace=force|sp_try_brace=not_defined
+Choices=sp_try_brace\s*=\s*ignore|sp_try_brace\s*=\s*add|sp_try_brace\s*=\s*remove|sp_try_brace\s*=\s*force|sp_try_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Try Brace|Add Sp Try Brace|Remove Sp Try Brace|Force Sp Try Brace"
 ValueDefault=ignore
 
@@ -1914,7 +1915,7 @@ Category=1
 Description="<html>Add or remove space between get/set and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_getset_brace=ignore|sp_getset_brace=add|sp_getset_brace=remove|sp_getset_brace=force|sp_getset_brace=not_defined
+Choices=sp_getset_brace\s*=\s*ignore|sp_getset_brace\s*=\s*add|sp_getset_brace\s*=\s*remove|sp_getset_brace\s*=\s*force|sp_getset_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Getset Brace|Add Sp Getset Brace|Remove Sp Getset Brace|Force Sp Getset Brace"
 ValueDefault=ignore
 
@@ -1923,7 +1924,7 @@ Category=1
 Description="<html>Add or remove space between a variable and '{' for C++ uniform<br/>initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_word_brace_init_lst=ignore|sp_word_brace_init_lst=add|sp_word_brace_init_lst=remove|sp_word_brace_init_lst=force|sp_word_brace_init_lst=not_defined
+Choices=sp_word_brace_init_lst\s*=\s*ignore|sp_word_brace_init_lst\s*=\s*add|sp_word_brace_init_lst\s*=\s*remove|sp_word_brace_init_lst\s*=\s*force|sp_word_brace_init_lst\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Word Brace Init Lst|Add Sp Word Brace Init Lst|Remove Sp Word Brace Init Lst|Force Sp Word Brace Init Lst"
 ValueDefault=ignore
 
@@ -1932,7 +1933,7 @@ Category=1
 Description="<html>Add or remove space between a variable and '{' for a namespace.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_word_brace_ns=ignore|sp_word_brace_ns=add|sp_word_brace_ns=remove|sp_word_brace_ns=force|sp_word_brace_ns=not_defined
+Choices=sp_word_brace_ns\s*=\s*ignore|sp_word_brace_ns\s*=\s*add|sp_word_brace_ns\s*=\s*remove|sp_word_brace_ns\s*=\s*force|sp_word_brace_ns\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Word Brace Ns|Add Sp Word Brace Ns|Remove Sp Word Brace Ns|Force Sp Word Brace Ns"
 ValueDefault=add
 
@@ -1941,7 +1942,7 @@ Category=1
 Description="<html>Add or remove space before the '::' operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_dc=ignore|sp_before_dc=add|sp_before_dc=remove|sp_before_dc=force|sp_before_dc=not_defined
+Choices=sp_before_dc\s*=\s*ignore|sp_before_dc\s*=\s*add|sp_before_dc\s*=\s*remove|sp_before_dc\s*=\s*force|sp_before_dc\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Dc|Add Sp Before Dc|Remove Sp Before Dc|Force Sp Before Dc"
 ValueDefault=ignore
 
@@ -1950,7 +1951,7 @@ Category=1
 Description="<html>Add or remove space after the '::' operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_dc=ignore|sp_after_dc=add|sp_after_dc=remove|sp_after_dc=force|sp_after_dc=not_defined
+Choices=sp_after_dc\s*=\s*ignore|sp_after_dc\s*=\s*add|sp_after_dc\s*=\s*remove|sp_after_dc\s*=\s*force|sp_after_dc\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Dc|Add Sp After Dc|Remove Sp After Dc|Force Sp After Dc"
 ValueDefault=ignore
 
@@ -1959,7 +1960,7 @@ Category=1
 Description="<html>(D) Add or remove around the D named array initializer ':' operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_d_array_colon=ignore|sp_d_array_colon=add|sp_d_array_colon=remove|sp_d_array_colon=force|sp_d_array_colon=not_defined
+Choices=sp_d_array_colon\s*=\s*ignore|sp_d_array_colon\s*=\s*add|sp_d_array_colon\s*=\s*remove|sp_d_array_colon\s*=\s*force|sp_d_array_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp D Array Colon|Add Sp D Array Colon|Remove Sp D Array Colon|Force Sp D Array Colon"
 ValueDefault=ignore
 
@@ -1968,7 +1969,7 @@ Category=1
 Description="<html>Add or remove space after the '!' (not) unary operator.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_not=ignore|sp_not=add|sp_not=remove|sp_not=force|sp_not=not_defined
+Choices=sp_not\s*=\s*ignore|sp_not\s*=\s*add|sp_not\s*=\s*remove|sp_not\s*=\s*force|sp_not\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Not|Add Sp Not|Remove Sp Not|Force Sp Not"
 ValueDefault=remove
 
@@ -1977,7 +1978,7 @@ Category=1
 Description="<html>Add or remove space between two '!' (not) unary operators.<br/>If set to ignore, sp_not will be used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_not_not=ignore|sp_not_not=add|sp_not_not=remove|sp_not_not=force|sp_not_not=not_defined
+Choices=sp_not_not\s*=\s*ignore|sp_not_not\s*=\s*add|sp_not_not\s*=\s*remove|sp_not_not\s*=\s*force|sp_not_not\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Not Not|Add Sp Not Not|Remove Sp Not Not|Force Sp Not Not"
 ValueDefault=ignore
 
@@ -1986,7 +1987,7 @@ Category=1
 Description="<html>Add or remove space after the '~' (invert) unary operator.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inv=ignore|sp_inv=add|sp_inv=remove|sp_inv=force|sp_inv=not_defined
+Choices=sp_inv\s*=\s*ignore|sp_inv\s*=\s*add|sp_inv\s*=\s*remove|sp_inv\s*=\s*force|sp_inv\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inv|Add Sp Inv|Remove Sp Inv|Force Sp Inv"
 ValueDefault=remove
 
@@ -1995,7 +1996,7 @@ Category=1
 Description="<html>Add or remove space after the '&amp;' (address-of) unary operator. This does not<br/>affect the spacing after a '&amp;' that is part of a type.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_addr=ignore|sp_addr=add|sp_addr=remove|sp_addr=force|sp_addr=not_defined
+Choices=sp_addr\s*=\s*ignore|sp_addr\s*=\s*add|sp_addr\s*=\s*remove|sp_addr\s*=\s*force|sp_addr\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Addr|Add Sp Addr|Remove Sp Addr|Force Sp Addr"
 ValueDefault=remove
 
@@ -2004,7 +2005,7 @@ Category=1
 Description="<html>Add or remove space around the '.' or '-&gt;' operators.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_member=ignore|sp_member=add|sp_member=remove|sp_member=force|sp_member=not_defined
+Choices=sp_member\s*=\s*ignore|sp_member\s*=\s*add|sp_member\s*=\s*remove|sp_member\s*=\s*force|sp_member\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Member|Add Sp Member|Remove Sp Member|Force Sp Member"
 ValueDefault=remove
 
@@ -2013,7 +2014,7 @@ Category=1
 Description="<html>Add or remove space after the '*' (dereference) unary operator. This does<br/>not affect the spacing after a '*' that is part of a type.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_deref=ignore|sp_deref=add|sp_deref=remove|sp_deref=force|sp_deref=not_defined
+Choices=sp_deref\s*=\s*ignore|sp_deref\s*=\s*add|sp_deref\s*=\s*remove|sp_deref\s*=\s*force|sp_deref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Deref|Add Sp Deref|Remove Sp Deref|Force Sp Deref"
 ValueDefault=remove
 
@@ -2022,7 +2023,7 @@ Category=1
 Description="<html>Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sign=ignore|sp_sign=add|sp_sign=remove|sp_sign=force|sp_sign=not_defined
+Choices=sp_sign\s*=\s*ignore|sp_sign\s*=\s*add|sp_sign\s*=\s*remove|sp_sign\s*=\s*force|sp_sign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sign|Add Sp Sign|Remove Sp Sign|Force Sp Sign"
 ValueDefault=remove
 
@@ -2031,7 +2032,7 @@ Category=1
 Description="<html>Add or remove space between '++' and '--' the word to which it is being<br/>applied, as in '(--x)' or 'y++;'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_incdec=ignore|sp_incdec=add|sp_incdec=remove|sp_incdec=force|sp_incdec=not_defined
+Choices=sp_incdec\s*=\s*ignore|sp_incdec\s*=\s*add|sp_incdec\s*=\s*remove|sp_incdec\s*=\s*force|sp_incdec\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Incdec|Add Sp Incdec|Remove Sp Incdec|Force Sp Incdec"
 ValueDefault=remove
 
@@ -2040,7 +2041,7 @@ Category=1
 Description="<html>Add or remove space before a backslash-newline at the end of a line.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_nl_cont=ignore|sp_before_nl_cont=add|sp_before_nl_cont=remove|sp_before_nl_cont=force|sp_before_nl_cont=not_defined
+Choices=sp_before_nl_cont\s*=\s*ignore|sp_before_nl_cont\s*=\s*add|sp_before_nl_cont\s*=\s*remove|sp_before_nl_cont\s*=\s*force|sp_before_nl_cont\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Nl Cont|Add Sp Before Nl Cont|Remove Sp Before Nl Cont|Force Sp Before Nl Cont"
 ValueDefault=add
 
@@ -2049,7 +2050,7 @@ Category=1
 Description="<html>(OC) Add or remove space after the scope '+' or '-', as in '-(void) foo;'<br/>or '+(int) bar;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_scope=ignore|sp_after_oc_scope=add|sp_after_oc_scope=remove|sp_after_oc_scope=force|sp_after_oc_scope=not_defined
+Choices=sp_after_oc_scope\s*=\s*ignore|sp_after_oc_scope\s*=\s*add|sp_after_oc_scope\s*=\s*remove|sp_after_oc_scope\s*=\s*force|sp_after_oc_scope\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Scope|Add Sp After Oc Scope|Remove Sp After Oc Scope|Force Sp After Oc Scope"
 ValueDefault=ignore
 
@@ -2058,7 +2059,7 @@ Category=1
 Description="<html>(OC) Add or remove space after the colon in message specs,<br/>i.e. '-(int) f:(int) x;' vs. '-(int) f: (int) x;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_colon=ignore|sp_after_oc_colon=add|sp_after_oc_colon=remove|sp_after_oc_colon=force|sp_after_oc_colon=not_defined
+Choices=sp_after_oc_colon\s*=\s*ignore|sp_after_oc_colon\s*=\s*add|sp_after_oc_colon\s*=\s*remove|sp_after_oc_colon\s*=\s*force|sp_after_oc_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Colon|Add Sp After Oc Colon|Remove Sp After Oc Colon|Force Sp After Oc Colon"
 ValueDefault=ignore
 
@@ -2067,7 +2068,7 @@ Category=1
 Description="<html>(OC) Add or remove space before the colon in message specs,<br/>i.e. '-(int) f: (int) x;' vs. '-(int) f : (int) x;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_oc_colon=ignore|sp_before_oc_colon=add|sp_before_oc_colon=remove|sp_before_oc_colon=force|sp_before_oc_colon=not_defined
+Choices=sp_before_oc_colon\s*=\s*ignore|sp_before_oc_colon\s*=\s*add|sp_before_oc_colon\s*=\s*remove|sp_before_oc_colon\s*=\s*force|sp_before_oc_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Oc Colon|Add Sp Before Oc Colon|Remove Sp Before Oc Colon|Force Sp Before Oc Colon"
 ValueDefault=ignore
 
@@ -2076,7 +2077,7 @@ Category=1
 Description="<html>(OC) Add or remove space after the colon in immutable dictionary expression<br/>'NSDictionary *test = @{@"foo" :@"bar"};'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_dict_colon=ignore|sp_after_oc_dict_colon=add|sp_after_oc_dict_colon=remove|sp_after_oc_dict_colon=force|sp_after_oc_dict_colon=not_defined
+Choices=sp_after_oc_dict_colon\s*=\s*ignore|sp_after_oc_dict_colon\s*=\s*add|sp_after_oc_dict_colon\s*=\s*remove|sp_after_oc_dict_colon\s*=\s*force|sp_after_oc_dict_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Dict Colon|Add Sp After Oc Dict Colon|Remove Sp After Oc Dict Colon|Force Sp After Oc Dict Colon"
 ValueDefault=ignore
 
@@ -2085,7 +2086,7 @@ Category=1
 Description="<html>(OC) Add or remove space before the colon in immutable dictionary expression<br/>'NSDictionary *test = @{@"foo" :@"bar"};'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_oc_dict_colon=ignore|sp_before_oc_dict_colon=add|sp_before_oc_dict_colon=remove|sp_before_oc_dict_colon=force|sp_before_oc_dict_colon=not_defined
+Choices=sp_before_oc_dict_colon\s*=\s*ignore|sp_before_oc_dict_colon\s*=\s*add|sp_before_oc_dict_colon\s*=\s*remove|sp_before_oc_dict_colon\s*=\s*force|sp_before_oc_dict_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Oc Dict Colon|Add Sp Before Oc Dict Colon|Remove Sp Before Oc Dict Colon|Force Sp Before Oc Dict Colon"
 ValueDefault=ignore
 
@@ -2094,7 +2095,7 @@ Category=1
 Description="<html>(OC) Add or remove space after the colon in message specs,<br/>i.e. '[object setValue:1];' vs. '[object setValue: 1];'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_send_oc_colon=ignore|sp_after_send_oc_colon=add|sp_after_send_oc_colon=remove|sp_after_send_oc_colon=force|sp_after_send_oc_colon=not_defined
+Choices=sp_after_send_oc_colon\s*=\s*ignore|sp_after_send_oc_colon\s*=\s*add|sp_after_send_oc_colon\s*=\s*remove|sp_after_send_oc_colon\s*=\s*force|sp_after_send_oc_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Send Oc Colon|Add Sp After Send Oc Colon|Remove Sp After Send Oc Colon|Force Sp After Send Oc Colon"
 ValueDefault=ignore
 
@@ -2103,7 +2104,7 @@ Category=1
 Description="<html>(OC) Add or remove space before the colon in message specs,<br/>i.e. '[object setValue:1];' vs. '[object setValue :1];'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_send_oc_colon=ignore|sp_before_send_oc_colon=add|sp_before_send_oc_colon=remove|sp_before_send_oc_colon=force|sp_before_send_oc_colon=not_defined
+Choices=sp_before_send_oc_colon\s*=\s*ignore|sp_before_send_oc_colon\s*=\s*add|sp_before_send_oc_colon\s*=\s*remove|sp_before_send_oc_colon\s*=\s*force|sp_before_send_oc_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Send Oc Colon|Add Sp Before Send Oc Colon|Remove Sp Before Send Oc Colon|Force Sp Before Send Oc Colon"
 ValueDefault=ignore
 
@@ -2112,7 +2113,7 @@ Category=1
 Description="<html>(OC) Add or remove space after the (type) in message specs,<br/>i.e. '-(int)f: (int) x;' vs. '-(int)f: (int)x;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_type=ignore|sp_after_oc_type=add|sp_after_oc_type=remove|sp_after_oc_type=force|sp_after_oc_type=not_defined
+Choices=sp_after_oc_type\s*=\s*ignore|sp_after_oc_type\s*=\s*add|sp_after_oc_type\s*=\s*remove|sp_after_oc_type\s*=\s*force|sp_after_oc_type\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Type|Add Sp After Oc Type|Remove Sp After Oc Type|Force Sp After Oc Type"
 ValueDefault=ignore
 
@@ -2121,7 +2122,7 @@ Category=1
 Description="<html>(OC) Add or remove space after the first (type) in message specs,<br/>i.e. '-(int) f:(int)x;' vs. '-(int)f:(int)x;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_return_type=ignore|sp_after_oc_return_type=add|sp_after_oc_return_type=remove|sp_after_oc_return_type=force|sp_after_oc_return_type=not_defined
+Choices=sp_after_oc_return_type\s*=\s*ignore|sp_after_oc_return_type\s*=\s*add|sp_after_oc_return_type\s*=\s*remove|sp_after_oc_return_type\s*=\s*force|sp_after_oc_return_type\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Return Type|Add Sp After Oc Return Type|Remove Sp After Oc Return Type|Force Sp After Oc Return Type"
 ValueDefault=ignore
 
@@ -2130,7 +2131,7 @@ Category=1
 Description="<html>(OC) Add or remove space between '@selector' and '(',<br/>i.e. '@selector(msgName)' vs. '@selector (msgName)'.<br/>Also applies to '@protocol()' constructs.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_at_sel=ignore|sp_after_oc_at_sel=add|sp_after_oc_at_sel=remove|sp_after_oc_at_sel=force|sp_after_oc_at_sel=not_defined
+Choices=sp_after_oc_at_sel\s*=\s*ignore|sp_after_oc_at_sel\s*=\s*add|sp_after_oc_at_sel\s*=\s*remove|sp_after_oc_at_sel\s*=\s*force|sp_after_oc_at_sel\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc At Sel|Add Sp After Oc At Sel|Remove Sp After Oc At Sel|Force Sp After Oc At Sel"
 ValueDefault=ignore
 
@@ -2139,7 +2140,7 @@ Category=1
 Description="<html>(OC) Add or remove space between '@selector(x)' and the following word,<br/>i.e. '@selector(foo) a:' vs. '@selector(foo)a:'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_at_sel_parens=ignore|sp_after_oc_at_sel_parens=add|sp_after_oc_at_sel_parens=remove|sp_after_oc_at_sel_parens=force|sp_after_oc_at_sel_parens=not_defined
+Choices=sp_after_oc_at_sel_parens\s*=\s*ignore|sp_after_oc_at_sel_parens\s*=\s*add|sp_after_oc_at_sel_parens\s*=\s*remove|sp_after_oc_at_sel_parens\s*=\s*force|sp_after_oc_at_sel_parens\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc At Sel Parens|Add Sp After Oc At Sel Parens|Remove Sp After Oc At Sel Parens|Force Sp After Oc At Sel Parens"
 ValueDefault=ignore
 
@@ -2148,7 +2149,7 @@ Category=1
 Description="<html>(OC) Add or remove space inside '@selector' parentheses,<br/>i.e. '@selector(foo)' vs. '@selector( foo )'.<br/>Also applies to '@protocol()' constructs.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_oc_at_sel_parens=ignore|sp_inside_oc_at_sel_parens=add|sp_inside_oc_at_sel_parens=remove|sp_inside_oc_at_sel_parens=force|sp_inside_oc_at_sel_parens=not_defined
+Choices=sp_inside_oc_at_sel_parens\s*=\s*ignore|sp_inside_oc_at_sel_parens\s*=\s*add|sp_inside_oc_at_sel_parens\s*=\s*remove|sp_inside_oc_at_sel_parens\s*=\s*force|sp_inside_oc_at_sel_parens\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Oc At Sel Parens|Add Sp Inside Oc At Sel Parens|Remove Sp Inside Oc At Sel Parens|Force Sp Inside Oc At Sel Parens"
 ValueDefault=ignore
 
@@ -2157,7 +2158,7 @@ Category=1
 Description="<html>(OC) Add or remove space before a block pointer caret,<br/>i.e. '^int (int arg){...}' vs. ' ^int (int arg){...}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_oc_block_caret=ignore|sp_before_oc_block_caret=add|sp_before_oc_block_caret=remove|sp_before_oc_block_caret=force|sp_before_oc_block_caret=not_defined
+Choices=sp_before_oc_block_caret\s*=\s*ignore|sp_before_oc_block_caret\s*=\s*add|sp_before_oc_block_caret\s*=\s*remove|sp_before_oc_block_caret\s*=\s*force|sp_before_oc_block_caret\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Oc Block Caret|Add Sp Before Oc Block Caret|Remove Sp Before Oc Block Caret|Force Sp Before Oc Block Caret"
 ValueDefault=ignore
 
@@ -2166,7 +2167,7 @@ Category=1
 Description="<html>(OC) Add or remove space after a block pointer caret,<br/>i.e. '^int (int arg){...}' vs. '^ int (int arg){...}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_block_caret=ignore|sp_after_oc_block_caret=add|sp_after_oc_block_caret=remove|sp_after_oc_block_caret=force|sp_after_oc_block_caret=not_defined
+Choices=sp_after_oc_block_caret\s*=\s*ignore|sp_after_oc_block_caret\s*=\s*add|sp_after_oc_block_caret\s*=\s*remove|sp_after_oc_block_caret\s*=\s*force|sp_after_oc_block_caret\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Block Caret|Add Sp After Oc Block Caret|Remove Sp After Oc Block Caret|Force Sp After Oc Block Caret"
 ValueDefault=ignore
 
@@ -2175,7 +2176,7 @@ Category=1
 Description="<html>(OC) Add or remove space between the receiver and selector in a message,<br/>as in '[receiver selector ...]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_msg_receiver=ignore|sp_after_oc_msg_receiver=add|sp_after_oc_msg_receiver=remove|sp_after_oc_msg_receiver=force|sp_after_oc_msg_receiver=not_defined
+Choices=sp_after_oc_msg_receiver\s*=\s*ignore|sp_after_oc_msg_receiver\s*=\s*add|sp_after_oc_msg_receiver\s*=\s*remove|sp_after_oc_msg_receiver\s*=\s*force|sp_after_oc_msg_receiver\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Msg Receiver|Add Sp After Oc Msg Receiver|Remove Sp After Oc Msg Receiver|Force Sp After Oc Msg Receiver"
 ValueDefault=ignore
 
@@ -2184,7 +2185,7 @@ Category=1
 Description="<html>(OC) Add or remove space after '@property'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_property=ignore|sp_after_oc_property=add|sp_after_oc_property=remove|sp_after_oc_property=force|sp_after_oc_property=not_defined
+Choices=sp_after_oc_property\s*=\s*ignore|sp_after_oc_property\s*=\s*add|sp_after_oc_property\s*=\s*remove|sp_after_oc_property\s*=\s*force|sp_after_oc_property\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Property|Add Sp After Oc Property|Remove Sp After Oc Property|Force Sp After Oc Property"
 ValueDefault=ignore
 
@@ -2193,7 +2194,7 @@ Category=1
 Description="<html>(OC) Add or remove space between '@synchronized' and the open parenthesis,<br/>i.e. '@synchronized(foo)' vs. '@synchronized (foo)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_synchronized=ignore|sp_after_oc_synchronized=add|sp_after_oc_synchronized=remove|sp_after_oc_synchronized=force|sp_after_oc_synchronized=not_defined
+Choices=sp_after_oc_synchronized\s*=\s*ignore|sp_after_oc_synchronized\s*=\s*add|sp_after_oc_synchronized\s*=\s*remove|sp_after_oc_synchronized\s*=\s*force|sp_after_oc_synchronized\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Synchronized|Add Sp After Oc Synchronized|Remove Sp After Oc Synchronized|Force Sp After Oc Synchronized"
 ValueDefault=ignore
 
@@ -2202,7 +2203,7 @@ Category=1
 Description="<html>Add or remove space around the ':' in 'b ? t : f'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_colon=ignore|sp_cond_colon=add|sp_cond_colon=remove|sp_cond_colon=force|sp_cond_colon=not_defined
+Choices=sp_cond_colon\s*=\s*ignore|sp_cond_colon\s*=\s*add|sp_cond_colon\s*=\s*remove|sp_cond_colon\s*=\s*force|sp_cond_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Colon|Add Sp Cond Colon|Remove Sp Cond Colon|Force Sp Cond Colon"
 ValueDefault=ignore
 
@@ -2211,7 +2212,7 @@ Category=1
 Description="<html>Add or remove space before the ':' in 'b ? t : f'.<br/><br/>Overrides sp_cond_colon.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_colon_before=ignore|sp_cond_colon_before=add|sp_cond_colon_before=remove|sp_cond_colon_before=force|sp_cond_colon_before=not_defined
+Choices=sp_cond_colon_before\s*=\s*ignore|sp_cond_colon_before\s*=\s*add|sp_cond_colon_before\s*=\s*remove|sp_cond_colon_before\s*=\s*force|sp_cond_colon_before\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Colon Before|Add Sp Cond Colon Before|Remove Sp Cond Colon Before|Force Sp Cond Colon Before"
 ValueDefault=ignore
 
@@ -2220,7 +2221,7 @@ Category=1
 Description="<html>Add or remove space after the ':' in 'b ? t : f'.<br/><br/>Overrides sp_cond_colon.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_colon_after=ignore|sp_cond_colon_after=add|sp_cond_colon_after=remove|sp_cond_colon_after=force|sp_cond_colon_after=not_defined
+Choices=sp_cond_colon_after\s*=\s*ignore|sp_cond_colon_after\s*=\s*add|sp_cond_colon_after\s*=\s*remove|sp_cond_colon_after\s*=\s*force|sp_cond_colon_after\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Colon After|Add Sp Cond Colon After|Remove Sp Cond Colon After|Force Sp Cond Colon After"
 ValueDefault=ignore
 
@@ -2229,7 +2230,7 @@ Category=1
 Description="<html>Add or remove space around the '?' in 'b ? t : f'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_question=ignore|sp_cond_question=add|sp_cond_question=remove|sp_cond_question=force|sp_cond_question=not_defined
+Choices=sp_cond_question\s*=\s*ignore|sp_cond_question\s*=\s*add|sp_cond_question\s*=\s*remove|sp_cond_question\s*=\s*force|sp_cond_question\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Question|Add Sp Cond Question|Remove Sp Cond Question|Force Sp Cond Question"
 ValueDefault=ignore
 
@@ -2238,7 +2239,7 @@ Category=1
 Description="<html>Add or remove space before the '?' in 'b ? t : f'.<br/><br/>Overrides sp_cond_question.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_question_before=ignore|sp_cond_question_before=add|sp_cond_question_before=remove|sp_cond_question_before=force|sp_cond_question_before=not_defined
+Choices=sp_cond_question_before\s*=\s*ignore|sp_cond_question_before\s*=\s*add|sp_cond_question_before\s*=\s*remove|sp_cond_question_before\s*=\s*force|sp_cond_question_before\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Question Before|Add Sp Cond Question Before|Remove Sp Cond Question Before|Force Sp Cond Question Before"
 ValueDefault=ignore
 
@@ -2247,7 +2248,7 @@ Category=1
 Description="<html>Add or remove space after the '?' in 'b ? t : f'.<br/><br/>Overrides sp_cond_question.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_question_after=ignore|sp_cond_question_after=add|sp_cond_question_after=remove|sp_cond_question_after=force|sp_cond_question_after=not_defined
+Choices=sp_cond_question_after\s*=\s*ignore|sp_cond_question_after\s*=\s*add|sp_cond_question_after\s*=\s*remove|sp_cond_question_after\s*=\s*force|sp_cond_question_after\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Question After|Add Sp Cond Question After|Remove Sp Cond Question After|Force Sp Cond Question After"
 ValueDefault=ignore
 
@@ -2256,7 +2257,7 @@ Category=1
 Description="<html>In the abbreviated ternary form '(a ?: b)', add or remove space between '?'<br/>and ':'.<br/><br/>Overrides all other sp_cond_* options.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_ternary_short=ignore|sp_cond_ternary_short=add|sp_cond_ternary_short=remove|sp_cond_ternary_short=force|sp_cond_ternary_short=not_defined
+Choices=sp_cond_ternary_short\s*=\s*ignore|sp_cond_ternary_short\s*=\s*add|sp_cond_ternary_short\s*=\s*remove|sp_cond_ternary_short\s*=\s*force|sp_cond_ternary_short\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Ternary Short|Add Sp Cond Ternary Short|Remove Sp Cond Ternary Short|Force Sp Cond Ternary Short"
 ValueDefault=ignore
 
@@ -2265,7 +2266,7 @@ Category=1
 Description="<html>Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make<br/>sense here.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_case_label=ignore|sp_case_label=add|sp_case_label=remove|sp_case_label=force|sp_case_label=not_defined
+Choices=sp_case_label\s*=\s*ignore|sp_case_label\s*=\s*add|sp_case_label\s*=\s*remove|sp_case_label\s*=\s*force|sp_case_label\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Case Label|Add Sp Case Label|Remove Sp Case Label|Force Sp Case Label"
 ValueDefault=ignore
 
@@ -2274,7 +2275,7 @@ Category=1
 Description="<html>(D) Add or remove space around the D '..' operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_range=ignore|sp_range=add|sp_range=remove|sp_range=force|sp_range=not_defined
+Choices=sp_range\s*=\s*ignore|sp_range\s*=\s*add|sp_range\s*=\s*remove|sp_range\s*=\s*force|sp_range\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Range|Add Sp Range|Remove Sp Range|Force Sp Range"
 ValueDefault=ignore
 
@@ -2283,7 +2284,7 @@ Category=1
 Description="<html>Add or remove space after ':' in a Java/C++11 range-based 'for',<br/>as in 'for (Type var : &lt;here&gt; expr)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_for_colon=ignore|sp_after_for_colon=add|sp_after_for_colon=remove|sp_after_for_colon=force|sp_after_for_colon=not_defined
+Choices=sp_after_for_colon\s*=\s*ignore|sp_after_for_colon\s*=\s*add|sp_after_for_colon\s*=\s*remove|sp_after_for_colon\s*=\s*force|sp_after_for_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After For Colon|Add Sp After For Colon|Remove Sp After For Colon|Force Sp After For Colon"
 ValueDefault=ignore
 
@@ -2292,7 +2293,7 @@ Category=1
 Description="<html>Add or remove space before ':' in a Java/C++11 range-based 'for',<br/>as in 'for (Type var &lt;here&gt; : expr)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_for_colon=ignore|sp_before_for_colon=add|sp_before_for_colon=remove|sp_before_for_colon=force|sp_before_for_colon=not_defined
+Choices=sp_before_for_colon\s*=\s*ignore|sp_before_for_colon\s*=\s*add|sp_before_for_colon\s*=\s*remove|sp_before_for_colon\s*=\s*force|sp_before_for_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before For Colon|Add Sp Before For Colon|Remove Sp Before For Colon|Force Sp Before For Colon"
 ValueDefault=ignore
 
@@ -2301,7 +2302,7 @@ Category=1
 Description="<html>(D) Add or remove space between 'extern' and '(' as in 'extern &lt;here&gt; (C)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_extern_paren=ignore|sp_extern_paren=add|sp_extern_paren=remove|sp_extern_paren=force|sp_extern_paren=not_defined
+Choices=sp_extern_paren\s*=\s*ignore|sp_extern_paren\s*=\s*add|sp_extern_paren\s*=\s*remove|sp_extern_paren\s*=\s*force|sp_extern_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Extern Paren|Add Sp Extern Paren|Remove Sp Extern Paren|Force Sp Extern Paren"
 ValueDefault=ignore
 
@@ -2310,7 +2311,7 @@ Category=1
 Description="<html>Add or remove space after the opening of a C++ comment, as in '// &lt;here&gt; A'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cmt_cpp_start=ignore|sp_cmt_cpp_start=add|sp_cmt_cpp_start=remove|sp_cmt_cpp_start=force|sp_cmt_cpp_start=not_defined
+Choices=sp_cmt_cpp_start\s*=\s*ignore|sp_cmt_cpp_start\s*=\s*add|sp_cmt_cpp_start\s*=\s*remove|sp_cmt_cpp_start\s*=\s*force|sp_cmt_cpp_start\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cmt Cpp Start|Add Sp Cmt Cpp Start|Remove Sp Cmt Cpp Start|Force Sp Cmt Cpp Start"
 ValueDefault=ignore
 
@@ -2319,7 +2320,7 @@ Category=1
 Description="<html>remove space after the '//' and the pvs command '-V1234',<br/>only works with sp_cmt_cpp_start set to add or force.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_cmt_cpp_pvs=true|sp_cmt_cpp_pvs=false
+TrueFalse=sp_cmt_cpp_pvs\s*=\s*true|sp_cmt_cpp_pvs\s*=\s*false
 ValueDefault=false
 
 [Sp Cmt Cpp Lint]
@@ -2327,7 +2328,7 @@ Category=1
 Description="<html>remove space after the '//' and the command 'lint',<br/>only works with sp_cmt_cpp_start set to add or force.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_cmt_cpp_lint=true|sp_cmt_cpp_lint=false
+TrueFalse=sp_cmt_cpp_lint\s*=\s*true|sp_cmt_cpp_lint\s*=\s*false
 ValueDefault=false
 
 [Sp Cmt Cpp Region]
@@ -2335,7 +2336,7 @@ Category=1
 Description="<html>Add or remove space in a C++ region marker comment, as in '// &lt;here&gt; BEGIN'.<br/>A region marker is defined as a comment which is not preceded by other text<br/>(i.e. the comment is the first non-whitespace on the line), and which starts<br/>with either 'BEGIN' or 'END'.<br/><br/>Overrides sp_cmt_cpp_start.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cmt_cpp_region=ignore|sp_cmt_cpp_region=add|sp_cmt_cpp_region=remove|sp_cmt_cpp_region=force|sp_cmt_cpp_region=not_defined
+Choices=sp_cmt_cpp_region\s*=\s*ignore|sp_cmt_cpp_region\s*=\s*add|sp_cmt_cpp_region\s*=\s*remove|sp_cmt_cpp_region\s*=\s*force|sp_cmt_cpp_region\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cmt Cpp Region|Add Sp Cmt Cpp Region|Remove Sp Cmt Cpp Region|Force Sp Cmt Cpp Region"
 ValueDefault=ignore
 
@@ -2344,7 +2345,7 @@ Category=1
 Description="<html>If true, space added with sp_cmt_cpp_start will be added after Doxygen<br/>sequences like '///', '///&lt;', '//!' and '//!&lt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_cmt_cpp_doxygen=true|sp_cmt_cpp_doxygen=false
+TrueFalse=sp_cmt_cpp_doxygen\s*=\s*true|sp_cmt_cpp_doxygen\s*=\s*false
 ValueDefault=false
 
 [Sp Cmt Cpp Qttr]
@@ -2352,7 +2353,7 @@ Category=1
 Description="<html>If true, space added with sp_cmt_cpp_start will be added after Qt translator<br/>or meta-data comments like '//:', '//=', and '//~'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_cmt_cpp_qttr=true|sp_cmt_cpp_qttr=false
+TrueFalse=sp_cmt_cpp_qttr\s*=\s*true|sp_cmt_cpp_qttr\s*=\s*false
 ValueDefault=false
 
 [Sp Endif Cmt]
@@ -2360,7 +2361,7 @@ Category=1
 Description="<html>Add or remove space between #else or #endif and a trailing comment.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_endif_cmt=ignore|sp_endif_cmt=add|sp_endif_cmt=remove|sp_endif_cmt=force|sp_endif_cmt=not_defined
+Choices=sp_endif_cmt\s*=\s*ignore|sp_endif_cmt\s*=\s*add|sp_endif_cmt\s*=\s*remove|sp_endif_cmt\s*=\s*force|sp_endif_cmt\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Endif Cmt|Add Sp Endif Cmt|Remove Sp Endif Cmt|Force Sp Endif Cmt"
 ValueDefault=ignore
 
@@ -2369,7 +2370,7 @@ Category=1
 Description="<html>Add or remove space after 'new', 'delete' and 'delete[]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_new=ignore|sp_after_new=add|sp_after_new=remove|sp_after_new=force|sp_after_new=not_defined
+Choices=sp_after_new\s*=\s*ignore|sp_after_new\s*=\s*add|sp_after_new\s*=\s*remove|sp_after_new\s*=\s*force|sp_after_new\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After New|Add Sp After New|Remove Sp After New|Force Sp After New"
 ValueDefault=ignore
 
@@ -2378,7 +2379,7 @@ Category=1
 Description="<html>Add or remove space between 'new' and '(' in 'new()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_new_paren=ignore|sp_between_new_paren=add|sp_between_new_paren=remove|sp_between_new_paren=force|sp_between_new_paren=not_defined
+Choices=sp_between_new_paren\s*=\s*ignore|sp_between_new_paren\s*=\s*add|sp_between_new_paren\s*=\s*remove|sp_between_new_paren\s*=\s*force|sp_between_new_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between New Paren|Add Sp Between New Paren|Remove Sp Between New Paren|Force Sp Between New Paren"
 ValueDefault=ignore
 
@@ -2387,7 +2388,7 @@ Category=1
 Description="<html>Add or remove space between ')' and type in 'new(foo) BAR'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_newop_paren=ignore|sp_after_newop_paren=add|sp_after_newop_paren=remove|sp_after_newop_paren=force|sp_after_newop_paren=not_defined
+Choices=sp_after_newop_paren\s*=\s*ignore|sp_after_newop_paren\s*=\s*add|sp_after_newop_paren\s*=\s*remove|sp_after_newop_paren\s*=\s*force|sp_after_newop_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Newop Paren|Add Sp After Newop Paren|Remove Sp After Newop Paren|Force Sp After Newop Paren"
 ValueDefault=ignore
 
@@ -2396,7 +2397,7 @@ Category=1
 Description="<html>Add or remove space inside parentheses of the new operator<br/>as in 'new(foo) BAR'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_newop_paren=ignore|sp_inside_newop_paren=add|sp_inside_newop_paren=remove|sp_inside_newop_paren=force|sp_inside_newop_paren=not_defined
+Choices=sp_inside_newop_paren\s*=\s*ignore|sp_inside_newop_paren\s*=\s*add|sp_inside_newop_paren\s*=\s*remove|sp_inside_newop_paren\s*=\s*force|sp_inside_newop_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Newop Paren|Add Sp Inside Newop Paren|Remove Sp Inside Newop Paren|Force Sp Inside Newop Paren"
 ValueDefault=ignore
 
@@ -2405,7 +2406,7 @@ Category=1
 Description="<html>Add or remove space after the open parenthesis of the new operator,<br/>as in 'new(foo) BAR'.<br/><br/>Overrides sp_inside_newop_paren.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_newop_paren_open=ignore|sp_inside_newop_paren_open=add|sp_inside_newop_paren_open=remove|sp_inside_newop_paren_open=force|sp_inside_newop_paren_open=not_defined
+Choices=sp_inside_newop_paren_open\s*=\s*ignore|sp_inside_newop_paren_open\s*=\s*add|sp_inside_newop_paren_open\s*=\s*remove|sp_inside_newop_paren_open\s*=\s*force|sp_inside_newop_paren_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Newop Paren Open|Add Sp Inside Newop Paren Open|Remove Sp Inside Newop Paren Open|Force Sp Inside Newop Paren Open"
 ValueDefault=ignore
 
@@ -2414,7 +2415,7 @@ Category=1
 Description="<html>Add or remove space before the close parenthesis of the new operator,<br/>as in 'new(foo) BAR'.<br/><br/>Overrides sp_inside_newop_paren.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_newop_paren_close=ignore|sp_inside_newop_paren_close=add|sp_inside_newop_paren_close=remove|sp_inside_newop_paren_close=force|sp_inside_newop_paren_close=not_defined
+Choices=sp_inside_newop_paren_close\s*=\s*ignore|sp_inside_newop_paren_close\s*=\s*add|sp_inside_newop_paren_close\s*=\s*remove|sp_inside_newop_paren_close\s*=\s*force|sp_inside_newop_paren_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Newop Paren Close|Add Sp Inside Newop Paren Close|Remove Sp Inside Newop Paren Close|Force Sp Inside Newop Paren Close"
 ValueDefault=ignore
 
@@ -2423,7 +2424,7 @@ Category=1
 Description="<html>Add or remove space before a trailing comment.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_tr_cmt=ignore|sp_before_tr_cmt=add|sp_before_tr_cmt=remove|sp_before_tr_cmt=force|sp_before_tr_cmt=not_defined
+Choices=sp_before_tr_cmt\s*=\s*ignore|sp_before_tr_cmt\s*=\s*add|sp_before_tr_cmt\s*=\s*remove|sp_before_tr_cmt\s*=\s*force|sp_before_tr_cmt\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Tr Cmt|Add Sp Before Tr Cmt|Remove Sp Before Tr Cmt|Force Sp Before Tr Cmt"
 ValueDefault=ignore
 
@@ -2432,7 +2433,7 @@ Category=1
 Description="<html>Number of spaces before a trailing comment.</html>"
 Enabled=false
 EditorType=numeric
-CallName="sp_num_before_tr_cmt="
+CallName="sp_num_before_tr_cmt\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2442,7 +2443,7 @@ Category=1
 Description="<html>Add or remove space before an embedded comment.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_emb_cmt=ignore|sp_before_emb_cmt=add|sp_before_emb_cmt=remove|sp_before_emb_cmt=force|sp_before_emb_cmt=not_defined
+Choices=sp_before_emb_cmt\s*=\s*ignore|sp_before_emb_cmt\s*=\s*add|sp_before_emb_cmt\s*=\s*remove|sp_before_emb_cmt\s*=\s*force|sp_before_emb_cmt\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Emb Cmt|Add Sp Before Emb Cmt|Remove Sp Before Emb Cmt|Force Sp Before Emb Cmt"
 ValueDefault=force
 
@@ -2451,7 +2452,7 @@ Category=1
 Description="<html>Number of spaces before an embedded comment.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="sp_num_before_emb_cmt="
+CallName="sp_num_before_emb_cmt\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -2461,7 +2462,7 @@ Category=1
 Description="<html>Add or remove space after an embedded comment.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_emb_cmt=ignore|sp_after_emb_cmt=add|sp_after_emb_cmt=remove|sp_after_emb_cmt=force|sp_after_emb_cmt=not_defined
+Choices=sp_after_emb_cmt\s*=\s*ignore|sp_after_emb_cmt\s*=\s*add|sp_after_emb_cmt\s*=\s*remove|sp_after_emb_cmt\s*=\s*force|sp_after_emb_cmt\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Emb Cmt|Add Sp After Emb Cmt|Remove Sp After Emb Cmt|Force Sp After Emb Cmt"
 ValueDefault=force
 
@@ -2470,7 +2471,7 @@ Category=1
 Description="<html>Number of spaces after an embedded comment.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="sp_num_after_emb_cmt="
+CallName="sp_num_after_emb_cmt\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -2480,7 +2481,7 @@ Category=1
 Description="<html>(Java) Add or remove space between an annotation and the open parenthesis.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_annotation_paren=ignore|sp_annotation_paren=add|sp_annotation_paren=remove|sp_annotation_paren=force|sp_annotation_paren=not_defined
+Choices=sp_annotation_paren\s*=\s*ignore|sp_annotation_paren\s*=\s*add|sp_annotation_paren\s*=\s*remove|sp_annotation_paren\s*=\s*force|sp_annotation_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Annotation Paren|Add Sp Annotation Paren|Remove Sp Annotation Paren|Force Sp Annotation Paren"
 ValueDefault=ignore
 
@@ -2489,7 +2490,7 @@ Category=1
 Description="<html>If true, vbrace tokens are dropped to the previous token and skipped.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_skip_vbrace_tokens=true|sp_skip_vbrace_tokens=false
+TrueFalse=sp_skip_vbrace_tokens\s*=\s*true|sp_skip_vbrace_tokens\s*=\s*false
 ValueDefault=false
 
 [Sp After Noexcept]
@@ -2497,7 +2498,7 @@ Category=1
 Description="<html>Add or remove space after 'noexcept'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_noexcept=ignore|sp_after_noexcept=add|sp_after_noexcept=remove|sp_after_noexcept=force|sp_after_noexcept=not_defined
+Choices=sp_after_noexcept\s*=\s*ignore|sp_after_noexcept\s*=\s*add|sp_after_noexcept\s*=\s*remove|sp_after_noexcept\s*=\s*force|sp_after_noexcept\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Noexcept|Add Sp After Noexcept|Remove Sp After Noexcept|Force Sp After Noexcept"
 ValueDefault=ignore
 
@@ -2506,7 +2507,7 @@ Category=1
 Description="<html>Add or remove space after '_'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_vala_after_translation=ignore|sp_vala_after_translation=add|sp_vala_after_translation=remove|sp_vala_after_translation=force|sp_vala_after_translation=not_defined
+Choices=sp_vala_after_translation\s*=\s*ignore|sp_vala_after_translation\s*=\s*add|sp_vala_after_translation\s*=\s*remove|sp_vala_after_translation\s*=\s*force|sp_vala_after_translation\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Vala After Translation|Add Sp Vala After Translation|Remove Sp Vala After Translation|Force Sp Vala After Translation"
 ValueDefault=ignore
 
@@ -2515,7 +2516,7 @@ Category=1
 Description="<html>Add or remove space before a bit colon ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_bit_colon=ignore|sp_before_bit_colon=add|sp_before_bit_colon=remove|sp_before_bit_colon=force|sp_before_bit_colon=not_defined
+Choices=sp_before_bit_colon\s*=\s*ignore|sp_before_bit_colon\s*=\s*add|sp_before_bit_colon\s*=\s*remove|sp_before_bit_colon\s*=\s*force|sp_before_bit_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Bit Colon|Add Sp Before Bit Colon|Remove Sp Before Bit Colon|Force Sp Before Bit Colon"
 ValueDefault=ignore
 
@@ -2524,7 +2525,7 @@ Category=1
 Description="<html>Add or remove space after a bit colon ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_bit_colon=ignore|sp_after_bit_colon=add|sp_after_bit_colon=remove|sp_after_bit_colon=force|sp_after_bit_colon=not_defined
+Choices=sp_after_bit_colon\s*=\s*ignore|sp_after_bit_colon\s*=\s*add|sp_after_bit_colon\s*=\s*remove|sp_after_bit_colon\s*=\s*force|sp_after_bit_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Bit Colon|Add Sp After Bit Colon|Remove Sp After Bit Colon|Force Sp After Bit Colon"
 ValueDefault=ignore
 
@@ -2533,7 +2534,7 @@ Category=1
 Description="<html>If true, a &lt;TAB&gt; is inserted after #define.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=force_tab_after_define=true|force_tab_after_define=false
+TrueFalse=force_tab_after_define\s*=\s*true|force_tab_after_define\s*=\s*false
 ValueDefault=false
 
 [Indent Columns]
@@ -2541,7 +2542,7 @@ Category=2
 Description="<html>The number of columns to indent per level. Usually 2, 3, 4, or 8.<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_columns="
+CallName="indent_columns\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=8
@@ -2551,7 +2552,7 @@ Category=2
 Description="<html>Whether to ignore indent for the first continuation line. Subsequent<br/>continuation lines will still be indented to match the first.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_first_continue=true|indent_ignore_first_continue=false
+TrueFalse=indent_ignore_first_continue\s*=\s*true|indent_ignore_first_continue\s*=\s*false
 ValueDefault=false
 
 [Indent Continue]
@@ -2559,7 +2560,7 @@ Category=2
 Description="<html>The continuation indent. If non-zero, this overrides the indent of '(', '['<br/>and '=' continuation indents. Negative values are OK; negative value is<br/>absolute and not increased for each '(' or '[' level.<br/><br/>For FreeBSD, this is set to 4.<br/>Requires indent_ignore_first_continue=false.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_continue="
+CallName="indent_continue\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -2569,7 +2570,7 @@ Category=2
 Description="<html>The continuation indent, only for class header line(s). If non-zero, this<br/>overrides the indent of 'class' continuation indents.<br/>Requires indent_ignore_first_continue=false.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_continue_class_head="
+CallName="indent_continue_class_head\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2579,7 +2580,7 @@ Category=2
 Description="<html>Whether to indent empty lines (i.e. lines which contain only spaces before<br/>the newline character).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_single_newlines=true|indent_single_newlines=false
+TrueFalse=indent_single_newlines\s*=\s*true|indent_single_newlines\s*=\s*false
 ValueDefault=false
 
 [Indent Param]
@@ -2587,7 +2588,7 @@ Category=2
 Description="<html>The continuation indent for func_*_param if they are true. If non-zero, this<br/>overrides the indent.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_param="
+CallName="indent_param\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2597,7 +2598,7 @@ Category=2
 Description="<html>How to use tabs when indenting code.<br/><br/>0: Spaces only<br/>1: Indent with tabs to brace level, align with spaces (default)<br/>2: Indent and align with tabs, using spaces when not on a tabstop<br/><br/>Default: 1</html>"
 Enabled=true
 EditorType=multiple
-Choices="indent_with_tabs=0|indent_with_tabs=1|indent_with_tabs=2"
+Choices="indent_with_tabs\s*=\s*0|indent_with_tabs\s*=\s*1|indent_with_tabs\s*=\s*2"
 ChoicesReadable="Spaces only|Indent with tabs, align with spaces|Indent and align with tabs"
 ValueDefault=1
 
@@ -2606,7 +2607,7 @@ Category=2
 Description="<html>Whether to indent comments that are not at a brace level with tabs on a<br/>tabstop. Requires indent_with_tabs=2. If false, will use spaces.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cmt_with_tabs=true|indent_cmt_with_tabs=false
+TrueFalse=indent_cmt_with_tabs\s*=\s*true|indent_cmt_with_tabs\s*=\s*false
 ValueDefault=false
 
 [Indent Align String]
@@ -2614,7 +2615,7 @@ Category=2
 Description="<html>Whether to indent strings broken by '\' so that they line up.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_align_string=true|indent_align_string=false
+TrueFalse=indent_align_string\s*=\s*true|indent_align_string\s*=\s*false
 ValueDefault=false
 
 [Indent Xml String]
@@ -2622,7 +2623,7 @@ Category=2
 Description="<html>The number of spaces to indent multi-line XML strings.<br/>Requires indent_align_string=true.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_xml_string="
+CallName="indent_xml_string\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2632,7 +2633,7 @@ Category=2
 Description="<html>Spaces to indent '{' from level.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_brace="
+CallName="indent_brace\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2642,7 +2643,7 @@ Category=2
 Description="<html>Whether braces are indented to the body level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_braces=true|indent_braces=false
+TrueFalse=indent_braces\s*=\s*true|indent_braces\s*=\s*false
 ValueDefault=false
 
 [Indent Braces No Func]
@@ -2650,7 +2651,7 @@ Category=2
 Description="<html>Whether to disable indenting function braces if indent_braces=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_braces_no_func=true|indent_braces_no_func=false
+TrueFalse=indent_braces_no_func\s*=\s*true|indent_braces_no_func\s*=\s*false
 ValueDefault=false
 
 [Indent Braces No Class]
@@ -2658,7 +2659,7 @@ Category=2
 Description="<html>Whether to disable indenting class braces if indent_braces=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_braces_no_class=true|indent_braces_no_class=false
+TrueFalse=indent_braces_no_class\s*=\s*true|indent_braces_no_class\s*=\s*false
 ValueDefault=false
 
 [Indent Braces No Struct]
@@ -2666,7 +2667,7 @@ Category=2
 Description="<html>Whether to disable indenting struct braces if indent_braces=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_braces_no_struct=true|indent_braces_no_struct=false
+TrueFalse=indent_braces_no_struct\s*=\s*true|indent_braces_no_struct\s*=\s*false
 ValueDefault=false
 
 [Indent Brace Parent]
@@ -2674,7 +2675,7 @@ Category=2
 Description="<html>Whether to indent based on the size of the brace parent,<br/>i.e. 'if' =&gt; 3 spaces, 'for' =&gt; 4 spaces, etc.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_brace_parent=true|indent_brace_parent=false
+TrueFalse=indent_brace_parent\s*=\s*true|indent_brace_parent\s*=\s*false
 ValueDefault=false
 
 [Indent Paren Open Brace]
@@ -2682,7 +2683,7 @@ Category=2
 Description="<html>Whether to indent based on the open parenthesis instead of the open brace<br/>in '({\n'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_open_brace=true|indent_paren_open_brace=false
+TrueFalse=indent_paren_open_brace\s*=\s*true|indent_paren_open_brace\s*=\s*false
 ValueDefault=false
 
 [Indent Cs Delegate Brace]
@@ -2690,7 +2691,7 @@ Category=2
 Description="<html>(C#) Whether to indent the brace of a C# delegate by another level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cs_delegate_brace=true|indent_cs_delegate_brace=false
+TrueFalse=indent_cs_delegate_brace\s*=\s*true|indent_cs_delegate_brace\s*=\s*false
 ValueDefault=false
 
 [Indent Cs Delegate Body]
@@ -2698,7 +2699,7 @@ Category=2
 Description="<html>(C#) Whether to indent a C# delegate (to handle delegates with no brace) by<br/>another level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cs_delegate_body=true|indent_cs_delegate_body=false
+TrueFalse=indent_cs_delegate_body\s*=\s*true|indent_cs_delegate_body\s*=\s*false
 ValueDefault=false
 
 [Indent Namespace]
@@ -2706,7 +2707,7 @@ Category=2
 Description="<html>Whether to indent the body of a 'namespace'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_namespace=true|indent_namespace=false
+TrueFalse=indent_namespace\s*=\s*true|indent_namespace\s*=\s*false
 ValueDefault=false
 
 [Indent Namespace Single Indent]
@@ -2714,7 +2715,7 @@ Category=2
 Description="<html>Whether to indent only the first namespace, and not any nested namespaces.<br/>Requires indent_namespace=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_namespace_single_indent=true|indent_namespace_single_indent=false
+TrueFalse=indent_namespace_single_indent\s*=\s*true|indent_namespace_single_indent\s*=\s*false
 ValueDefault=false
 
 [Indent Namespace Level]
@@ -2722,7 +2723,7 @@ Category=2
 Description="<html>The number of spaces to indent a namespace block.<br/>If set to zero, use the value indent_columns</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_namespace_level="
+CallName="indent_namespace_level\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2732,7 +2733,7 @@ Category=2
 Description="<html>If the body of the namespace is longer than this number, it won't be<br/>indented. Requires indent_namespace=true. 0 means no limit.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_namespace_limit="
+CallName="indent_namespace_limit\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -2742,7 +2743,7 @@ Category=2
 Description="<html>Whether to indent only in inner namespaces (nested in other namespaces).<br/>Requires indent_namespace=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_namespace_inner_only=true|indent_namespace_inner_only=false
+TrueFalse=indent_namespace_inner_only\s*=\s*true|indent_namespace_inner_only\s*=\s*false
 ValueDefault=false
 
 [Indent Extern]
@@ -2750,7 +2751,7 @@ Category=2
 Description="<html>Whether the 'extern "C"' body is indented.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_extern=true|indent_extern=false
+TrueFalse=indent_extern\s*=\s*true|indent_extern\s*=\s*false
 ValueDefault=false
 
 [Indent Class]
@@ -2758,7 +2759,7 @@ Category=2
 Description="<html>Whether the 'class' body is indented.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_class=true|indent_class=false
+TrueFalse=indent_class\s*=\s*true|indent_class\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Before Class Colon]
@@ -2766,7 +2767,7 @@ Category=2
 Description="<html>Whether to ignore indent for the leading base class colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_before_class_colon=true|indent_ignore_before_class_colon=false
+TrueFalse=indent_ignore_before_class_colon\s*=\s*true|indent_ignore_before_class_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Before Class Colon]
@@ -2774,7 +2775,7 @@ Category=2
 Description="<html>Additional indent before the leading base class colon.<br/>Negative values decrease indent down to the first column.<br/>Requires indent_ignore_before_class_colon=false and a newline break before<br/>the colon (see pos_class_colon and nl_class_colon)</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_before_class_colon="
+CallName="indent_before_class_colon\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -2784,7 +2785,7 @@ Category=2
 Description="<html>Whether to indent the stuff after a leading base class colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_class_colon=true|indent_class_colon=false
+TrueFalse=indent_class_colon\s*=\s*true|indent_class_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Class On Colon]
@@ -2792,7 +2793,7 @@ Category=2
 Description="<html>Whether to indent based on a class colon instead of the stuff after the<br/>colon. Requires indent_class_colon=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_class_on_colon=true|indent_class_on_colon=false
+TrueFalse=indent_class_on_colon\s*=\s*true|indent_class_on_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Before Constr Colon]
@@ -2800,7 +2801,7 @@ Category=2
 Description="<html>Whether to ignore indent for a leading class initializer colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_before_constr_colon=true|indent_ignore_before_constr_colon=false
+TrueFalse=indent_ignore_before_constr_colon\s*=\s*true|indent_ignore_before_constr_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Constr Colon]
@@ -2808,7 +2809,7 @@ Category=2
 Description="<html>Whether to indent the stuff after a leading class initializer colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_constr_colon=true|indent_constr_colon=false
+TrueFalse=indent_constr_colon\s*=\s*true|indent_constr_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Ctor Init Leading]
@@ -2816,7 +2817,7 @@ Category=2
 Description="<html>Virtual indent from the ':' for leading member initializers.<br/><br/>Default: 2</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_ctor_init_leading="
+CallName="indent_ctor_init_leading\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=2
@@ -2826,7 +2827,7 @@ Category=2
 Description="<html>Virtual indent from the ':' for following member initializers.<br/><br/>Default: 2</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_ctor_init_following="
+CallName="indent_ctor_init_following\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=2
@@ -2836,7 +2837,7 @@ Category=2
 Description="<html>Additional indent for constructor initializer list.<br/>Negative values decrease indent down to the first column.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_ctor_init="
+CallName="indent_ctor_init\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -2846,7 +2847,7 @@ Category=2
 Description="<html>Whether to indent 'if' following 'else' as a new block under the 'else'.<br/>If false, 'else\nif' is treated as 'else if' for indenting purposes.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_else_if=true|indent_else_if=false
+TrueFalse=indent_else_if\s*=\s*true|indent_else_if\s*=\s*false
 ValueDefault=false
 
 [Indent Var Def Blk]
@@ -2854,7 +2855,7 @@ Category=2
 Description="<html>Amount to indent variable declarations after a open brace.<br/><br/> &lt;0: Relative<br/>&gt;=0: Absolute</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_var_def_blk="
+CallName="indent_var_def_blk\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -2864,7 +2865,7 @@ Category=2
 Description="<html>Whether to indent continued variable declarations instead of aligning.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_var_def_cont=true|indent_var_def_cont=false
+TrueFalse=indent_var_def_cont\s*=\s*true|indent_var_def_cont\s*=\s*false
 ValueDefault=false
 
 [Indent Shift]
@@ -2872,7 +2873,7 @@ Category=2
 Description="<html>How to indent continued shift expressions ('&lt;&lt;' and '&gt;&gt;').<br/>Set align_left_shift=false when using this.<br/> 0: Align shift operators instead of indenting them (default)<br/> 1: Indent by one level<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_shift="
+CallName="indent_shift\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=0
@@ -2882,7 +2883,7 @@ Category=2
 Description="<html>Whether to force indentation of function definitions to start in column 1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_def_force_col1=true|indent_func_def_force_col1=false
+TrueFalse=indent_func_def_force_col1\s*=\s*true|indent_func_def_force_col1\s*=\s*false
 ValueDefault=false
 
 [Indent Func Call Param]
@@ -2890,7 +2891,7 @@ Category=2
 Description="<html>Whether to indent continued function call parameters one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_call_param=true|indent_func_call_param=false
+TrueFalse=indent_func_call_param\s*=\s*true|indent_func_call_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Def Param]
@@ -2898,7 +2899,7 @@ Category=2
 Description="<html>Whether to indent continued function definition parameters one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_def_param=true|indent_func_def_param=false
+TrueFalse=indent_func_def_param\s*=\s*true|indent_func_def_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Def Param Paren Pos Threshold]
@@ -2906,7 +2907,7 @@ Category=2
 Description="<html>for function definitions, only if indent_func_def_param is false<br/>Allows to align params when appropriate and indent them when not<br/>behave as if it was true if paren position is more than this value<br/>if paren position is more than the option value</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_func_def_param_paren_pos_threshold="
+CallName="indent_func_def_param_paren_pos_threshold\s*=\s*"
 MinVal=0
 MaxVal=160
 ValueDefault=0
@@ -2916,7 +2917,7 @@ Category=2
 Description="<html>Whether to indent continued function call prototype one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_proto_param=true|indent_func_proto_param=false
+TrueFalse=indent_func_proto_param\s*=\s*true|indent_func_proto_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Class Param]
@@ -2924,7 +2925,7 @@ Category=2
 Description="<html>Whether to indent continued function call declaration one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_class_param=true|indent_func_class_param=false
+TrueFalse=indent_func_class_param\s*=\s*true|indent_func_class_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Ctor Var Param]
@@ -2932,7 +2933,7 @@ Category=2
 Description="<html>Whether to indent continued class variable constructors one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_ctor_var_param=true|indent_func_ctor_var_param=false
+TrueFalse=indent_func_ctor_var_param\s*=\s*true|indent_func_ctor_var_param\s*=\s*false
 ValueDefault=false
 
 [Indent Template Param]
@@ -2940,7 +2941,7 @@ Category=2
 Description="<html>Whether to indent continued template parameter list one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_template_param=true|indent_template_param=false
+TrueFalse=indent_template_param\s*=\s*true|indent_template_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Param Double]
@@ -2948,7 +2949,7 @@ Category=2
 Description="<html>Double the indent for indent_func_xxx_param options.<br/>Use both values of the options indent_columns and indent_param.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_param_double=true|indent_func_param_double=false
+TrueFalse=indent_func_param_double\s*=\s*true|indent_func_param_double\s*=\s*false
 ValueDefault=false
 
 [Indent Func Const]
@@ -2956,7 +2957,7 @@ Category=2
 Description="<html>Indentation column for standalone 'const' qualifier on a function<br/>prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_func_const="
+CallName="indent_func_const\s*=\s*"
 MinVal=0
 MaxVal=69
 ValueDefault=0
@@ -2966,7 +2967,7 @@ Category=2
 Description="<html>Indentation column for standalone 'throw' qualifier on a function<br/>prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_func_throw="
+CallName="indent_func_throw\s*=\s*"
 MinVal=0
 MaxVal=41
 ValueDefault=0
@@ -2976,7 +2977,7 @@ Category=2
 Description="<html>How to indent within a macro followed by a brace on the same line<br/>This allows reducing the indent in macros that have (for example)<br/>`do { ... } while (0)` blocks bracketing them.<br/><br/>true:  add an indent for the brace on the same line as the macro<br/>false: do not add an indent for the brace on the same line as the macro<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_macro_brace=true|indent_macro_brace=false
+TrueFalse=indent_macro_brace\s*=\s*true|indent_macro_brace\s*=\s*false
 ValueDefault=true
 
 [Indent Member]
@@ -2984,7 +2985,7 @@ Category=2
 Description="<html>The number of spaces to indent a continued '-&gt;' or '.'.<br/>Usually set to 0, 1, or indent_columns.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_member="
+CallName="indent_member\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2994,7 +2995,7 @@ Category=2
 Description="<html>Whether lines broken at '.' or '-&gt;' should be indented by a single indent.<br/>The indent_member option will not be effective if this is set to true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_member_single=true|indent_member_single=false
+TrueFalse=indent_member_single\s*=\s*true|indent_member_single\s*=\s*false
 ValueDefault=false
 
 [Indent Single Line Comments Before]
@@ -3002,7 +3003,7 @@ Category=2
 Description="<html>Spaces to indent single line ('//') comments on lines before code.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_single_line_comments_before="
+CallName="indent_single_line_comments_before\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3012,7 +3013,7 @@ Category=2
 Description="<html>Spaces to indent single line ('//') comments on lines after code.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_single_line_comments_after="
+CallName="indent_single_line_comments_after\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3022,7 +3023,7 @@ Category=2
 Description="<html>When opening a paren for a control statement (if, for, while, etc), increase<br/>the indent level by this value. Negative values decrease the indent level.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_sparen_extra="
+CallName="indent_sparen_extra\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -3032,7 +3033,7 @@ Category=2
 Description="<html>Whether to indent trailing single line ('//') comments relative to the code<br/>instead of trying to keep the same absolute column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_relative_single_line_comments=true|indent_relative_single_line_comments=false
+TrueFalse=indent_relative_single_line_comments\s*=\s*true|indent_relative_single_line_comments\s*=\s*false
 ValueDefault=false
 
 [Indent Switch Case]
@@ -3040,7 +3041,7 @@ Category=2
 Description="<html>Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.<br/>It might be wise to choose the same value for the option indent_case_brace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_switch_case="
+CallName="indent_switch_case\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3050,7 +3051,7 @@ Category=2
 Description="<html>Spaces to indent the body of a 'switch' before any 'case'.<br/>Usually the same as indent_columns or indent_switch_case.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_switch_body="
+CallName="indent_switch_body\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3060,7 +3061,7 @@ Category=2
 Description="<html>Whether to ignore indent for '{' following 'case'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_case_brace=true|indent_ignore_case_brace=false
+TrueFalse=indent_ignore_case_brace\s*=\s*true|indent_ignore_case_brace\s*=\s*false
 ValueDefault=false
 
 [Indent Case Brace]
@@ -3068,7 +3069,7 @@ Category=2
 Description="<html>Spaces to indent '{' from 'case'. By default, the brace will appear under<br/>the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.<br/>It might be wise to choose the same value for the option indent_switch_case.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_case_brace="
+CallName="indent_case_brace\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -3078,7 +3079,7 @@ Category=2
 Description="<html>indent 'break' with 'case' from 'switch'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_switch_break_with_case=true|indent_switch_break_with_case=false
+TrueFalse=indent_switch_break_with_case\s*=\s*true|indent_switch_break_with_case\s*=\s*false
 ValueDefault=false
 
 [Indent Switch Pp]
@@ -3086,7 +3087,7 @@ Category=2
 Description="<html>Whether to indent preprocessor statements inside of switch statements.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_switch_pp=true|indent_switch_pp=false
+TrueFalse=indent_switch_pp\s*=\s*true|indent_switch_pp\s*=\s*false
 ValueDefault=true
 
 [Indent Case Shift]
@@ -3094,7 +3095,7 @@ Category=2
 Description="<html>Spaces to shift the 'case' line, without affecting any other lines.<br/>Usually 0.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_case_shift="
+CallName="indent_case_shift\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3104,7 +3105,7 @@ Category=2
 Description="<html>Whether to align comments before 'case' with the 'case'.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_case_comment=true|indent_case_comment=false
+TrueFalse=indent_case_comment\s*=\s*true|indent_case_comment\s*=\s*false
 ValueDefault=true
 
 [Indent Comment]
@@ -3112,7 +3113,7 @@ Category=2
 Description="<html>Whether to indent comments not found in first column.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_comment=true|indent_comment=false
+TrueFalse=indent_comment\s*=\s*true|indent_comment\s*=\s*false
 ValueDefault=true
 
 [Indent Col1 Comment]
@@ -3120,7 +3121,7 @@ Category=2
 Description="<html>Whether to indent comments found in first column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_col1_comment=true|indent_col1_comment=false
+TrueFalse=indent_col1_comment\s*=\s*true|indent_col1_comment\s*=\s*false
 ValueDefault=false
 
 [Indent Col1 Multi String Literal]
@@ -3128,7 +3129,7 @@ Category=2
 Description="<html>Whether to indent multi string literal in first column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_col1_multi_string_literal=true|indent_col1_multi_string_literal=false
+TrueFalse=indent_col1_multi_string_literal\s*=\s*true|indent_col1_multi_string_literal\s*=\s*false
 ValueDefault=false
 
 [Indent Comment Align Thresh]
@@ -3136,7 +3137,7 @@ Category=2
 Description="<html>Align comments on adjacent lines that are this many columns apart or less.<br/><br/>Default: 3</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_comment_align_thresh="
+CallName="indent_comment_align_thresh\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=3
@@ -3146,7 +3147,7 @@ Category=2
 Description="<html>Whether to ignore indent for goto labels.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_label=true|indent_ignore_label=false
+TrueFalse=indent_ignore_label\s*=\s*true|indent_ignore_label\s*=\s*false
 ValueDefault=false
 
 [Indent Label]
@@ -3154,7 +3155,7 @@ Category=2
 Description="<html>How to indent goto labels. Requires indent_ignore_label=false.<br/><br/> &gt;0: Absolute column where 1 is the leftmost column<br/>&lt;=0: Subtract from brace indent<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_label="
+CallName="indent_label\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=1
@@ -3164,7 +3165,7 @@ Category=2
 Description="<html>How to indent access specifiers that are followed by a<br/>colon.<br/><br/> &gt;0: Absolute column where 1 is the leftmost column<br/>&lt;=0: Subtract from brace indent<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_access_spec="
+CallName="indent_access_spec\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=1
@@ -3174,7 +3175,7 @@ Category=2
 Description="<html>Whether to indent the code after an access specifier by one level.<br/>If true, this option forces 'indent_access_spec=0'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_access_spec_body=true|indent_access_spec_body=false
+TrueFalse=indent_access_spec_body\s*=\s*true|indent_access_spec_body\s*=\s*false
 ValueDefault=false
 
 [Indent Paren Nl]
@@ -3182,7 +3183,7 @@ Category=2
 Description="<html>If an open parenthesis is followed by a newline, whether to indent the next<br/>line so that it lines up after the open parenthesis (not recommended).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_nl=true|indent_paren_nl=false
+TrueFalse=indent_paren_nl\s*=\s*true|indent_paren_nl\s*=\s*false
 ValueDefault=false
 
 [Indent Paren Close]
@@ -3190,7 +3191,7 @@ Category=2
 Description="<html>How to indent a close parenthesis after a newline.<br/><br/> 0: Indent to body level (default)<br/> 1: Align under the open parenthesis<br/> 2: Indent to the brace level<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_paren_close="
+CallName="indent_paren_close\s*=\s*"
 MinVal=-1
 MaxVal=2
 ValueDefault=0
@@ -3200,7 +3201,7 @@ Category=2
 Description="<html>Whether to indent the open parenthesis of a function definition,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_after_func_def=true|indent_paren_after_func_def=false
+TrueFalse=indent_paren_after_func_def\s*=\s*true|indent_paren_after_func_def\s*=\s*false
 ValueDefault=false
 
 [Indent Paren After Func Decl]
@@ -3208,7 +3209,7 @@ Category=2
 Description="<html>Whether to indent the open parenthesis of a function declaration,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_after_func_decl=true|indent_paren_after_func_decl=false
+TrueFalse=indent_paren_after_func_decl\s*=\s*true|indent_paren_after_func_decl\s*=\s*false
 ValueDefault=false
 
 [Indent Paren After Func Call]
@@ -3216,7 +3217,7 @@ Category=2
 Description="<html>Whether to indent the open parenthesis of a function call,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_after_func_call=true|indent_paren_after_func_call=false
+TrueFalse=indent_paren_after_func_call\s*=\s*true|indent_paren_after_func_call\s*=\s*false
 ValueDefault=false
 
 [Indent Comma Brace]
@@ -3224,7 +3225,7 @@ Category=2
 Description="<html>How to indent a comma when inside braces.<br/> 0: Indent by one level (default)<br/> 1: Align under the open brace<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_comma_brace="
+CallName="indent_comma_brace\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=0
@@ -3234,7 +3235,7 @@ Category=2
 Description="<html>How to indent a comma when inside parentheses.<br/> 0: Indent by one level (default)<br/> 1: Align under the open parenthesis<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_comma_paren="
+CallName="indent_comma_paren\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=0
@@ -3244,7 +3245,7 @@ Category=2
 Description="<html>How to indent a Boolean operator when inside parentheses.<br/> 0: Indent by one level (default)<br/> 1: Align under the open parenthesis<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_bool_paren="
+CallName="indent_bool_paren\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=0
@@ -3254,7 +3255,7 @@ Category=2
 Description="<html>Whether to ignore the indentation of a Boolean operator when outside<br/>parentheses.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_bool=true|indent_ignore_bool=false
+TrueFalse=indent_ignore_bool\s*=\s*true|indent_ignore_bool\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Arith]
@@ -3262,7 +3263,7 @@ Category=2
 Description="<html>Whether to ignore the indentation of an arithmetic operator.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_arith=true|indent_ignore_arith=false
+TrueFalse=indent_ignore_arith\s*=\s*true|indent_ignore_arith\s*=\s*false
 ValueDefault=false
 
 [Indent Semicolon For Paren]
@@ -3270,7 +3271,7 @@ Category=2
 Description="<html>Whether to indent a semicolon when inside a for parenthesis.<br/>If true, aligns under the open for parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_semicolon_for_paren=true|indent_semicolon_for_paren=false
+TrueFalse=indent_semicolon_for_paren\s*=\s*true|indent_semicolon_for_paren\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Semicolon]
@@ -3278,7 +3279,7 @@ Category=2
 Description="<html>Whether to ignore the indentation of a semicolon outside of a 'for'<br/>statement.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_semicolon=true|indent_ignore_semicolon=false
+TrueFalse=indent_ignore_semicolon\s*=\s*true|indent_ignore_semicolon\s*=\s*false
 ValueDefault=false
 
 [Indent First Bool Expr]
@@ -3286,7 +3287,7 @@ Category=2
 Description="<html>Whether to align the first expression to following ones<br/>if indent_bool_paren=1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_first_bool_expr=true|indent_first_bool_expr=false
+TrueFalse=indent_first_bool_expr\s*=\s*true|indent_first_bool_expr\s*=\s*false
 ValueDefault=false
 
 [Indent First For Expr]
@@ -3294,7 +3295,7 @@ Category=2
 Description="<html>Whether to align the first expression to following ones<br/>if indent_semicolon_for_paren=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_first_for_expr=true|indent_first_for_expr=false
+TrueFalse=indent_first_for_expr\s*=\s*true|indent_first_for_expr\s*=\s*false
 ValueDefault=false
 
 [Indent Square Nl]
@@ -3302,7 +3303,7 @@ Category=2
 Description="<html>If an open square is followed by a newline, whether to indent the next line<br/>so that it lines up after the open square (not recommended).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_square_nl=true|indent_square_nl=false
+TrueFalse=indent_square_nl\s*=\s*true|indent_square_nl\s*=\s*false
 ValueDefault=false
 
 [Indent Preserve Sql]
@@ -3310,7 +3311,7 @@ Category=2
 Description="<html>(ESQL/C) Whether to preserve the relative indent of 'EXEC SQL' bodies.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_preserve_sql=true|indent_preserve_sql=false
+TrueFalse=indent_preserve_sql\s*=\s*true|indent_preserve_sql\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Assign]
@@ -3318,7 +3319,7 @@ Category=2
 Description="<html>Whether to ignore the indentation of an assignment operator.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_assign=true|indent_ignore_assign=false
+TrueFalse=indent_ignore_assign\s*=\s*true|indent_ignore_assign\s*=\s*false
 ValueDefault=false
 
 [Indent Align Assign]
@@ -3326,7 +3327,7 @@ Category=2
 Description="<html>Whether to align continued statements at the '='. If false or if the '=' is<br/>followed by a newline, the next line is indent one tab.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_align_assign=true|indent_align_assign=false
+TrueFalse=indent_align_assign\s*=\s*true|indent_align_assign\s*=\s*false
 ValueDefault=true
 
 [Indent Off After Assign]
@@ -3334,7 +3335,7 @@ Category=2
 Description="<html>If true, the indentation of the chunks after a '=' sequence will be set at<br/>LHS token indentation column before '='.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_off_after_assign=true|indent_off_after_assign=false
+TrueFalse=indent_off_after_assign\s*=\s*true|indent_off_after_assign\s*=\s*false
 ValueDefault=false
 
 [Indent Align Paren]
@@ -3342,7 +3343,7 @@ Category=2
 Description="<html>Whether to align continued statements at the '('. If false or the '(' is<br/>followed by a newline, the next line indent is one tab.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_align_paren=true|indent_align_paren=false
+TrueFalse=indent_align_paren\s*=\s*true|indent_align_paren\s*=\s*false
 ValueDefault=true
 
 [Indent Oc Inside Msg Sel]
@@ -3350,7 +3351,7 @@ Category=2
 Description="<html>(OC) Whether to indent Objective-C code inside message selectors.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_inside_msg_sel=true|indent_oc_inside_msg_sel=false
+TrueFalse=indent_oc_inside_msg_sel\s*=\s*true|indent_oc_inside_msg_sel\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block]
@@ -3358,7 +3359,7 @@ Category=2
 Description="<html>(OC) Whether to indent Objective-C blocks at brace level instead of usual<br/>rules.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block=true|indent_oc_block=false
+TrueFalse=indent_oc_block\s*=\s*true|indent_oc_block\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg]
@@ -3366,7 +3367,7 @@ Category=2
 Description="<html>(OC) Indent for Objective-C blocks in a message relative to the parameter<br/>name.<br/><br/>=0: Use indent_oc_block rules<br/>&gt;0: Use specified number of spaces to indent</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_oc_block_msg="
+CallName="indent_oc_block_msg\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3376,7 +3377,7 @@ Category=2
 Description="<html>(OC) Minimum indent for subsequent parameters</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_oc_msg_colon="
+CallName="indent_oc_msg_colon\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -3386,7 +3387,7 @@ Category=2
 Description="<html>(OC) Whether to prioritize aligning with initial colon (and stripping spaces<br/>from lines, if necessary).<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_msg_prioritize_first_colon=true|indent_oc_msg_prioritize_first_colon=false
+TrueFalse=indent_oc_msg_prioritize_first_colon\s*=\s*true|indent_oc_msg_prioritize_first_colon\s*=\s*false
 ValueDefault=true
 
 [Indent Oc Block Msg Xcode Style]
@@ -3394,7 +3395,7 @@ Category=2
 Description="<html>(OC) Whether to indent blocks the way that Xcode does by default<br/>(from the keyword if the parameter is on its own line; otherwise, from the<br/>previous indentation level). Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_xcode_style=true|indent_oc_block_msg_xcode_style=false
+TrueFalse=indent_oc_block_msg_xcode_style\s*=\s*true|indent_oc_block_msg_xcode_style\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg From Keyword]
@@ -3402,7 +3403,7 @@ Category=2
 Description="<html>(OC) Whether to indent blocks from where the brace is, relative to a<br/>message keyword. Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_from_keyword=true|indent_oc_block_msg_from_keyword=false
+TrueFalse=indent_oc_block_msg_from_keyword\s*=\s*true|indent_oc_block_msg_from_keyword\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg From Colon]
@@ -3410,7 +3411,7 @@ Category=2
 Description="<html>(OC) Whether to indent blocks from where the brace is, relative to a message<br/>colon. Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_from_colon=true|indent_oc_block_msg_from_colon=false
+TrueFalse=indent_oc_block_msg_from_colon\s*=\s*true|indent_oc_block_msg_from_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg From Caret]
@@ -3418,7 +3419,7 @@ Category=2
 Description="<html>(OC) Whether to indent blocks from where the block caret is.<br/>Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_from_caret=true|indent_oc_block_msg_from_caret=false
+TrueFalse=indent_oc_block_msg_from_caret\s*=\s*true|indent_oc_block_msg_from_caret\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg From Brace]
@@ -3426,7 +3427,7 @@ Category=2
 Description="<html>(OC) Whether to indent blocks from where the brace caret is.<br/>Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_from_brace=true|indent_oc_block_msg_from_brace=false
+TrueFalse=indent_oc_block_msg_from_brace\s*=\s*true|indent_oc_block_msg_from_brace\s*=\s*false
 ValueDefault=false
 
 [Indent Min Vbrace Open]
@@ -3434,7 +3435,7 @@ Category=2
 Description="<html>When indenting after virtual brace open and newline add further spaces to<br/>reach this minimum indent.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_min_vbrace_open="
+CallName="indent_min_vbrace_open\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3444,7 +3445,7 @@ Category=2
 Description="<html>Whether to add further spaces after regular indent to reach next tabstop<br/>when indenting after virtual brace open and newline.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_vbrace_open_on_tabstop=true|indent_vbrace_open_on_tabstop=false
+TrueFalse=indent_vbrace_open_on_tabstop\s*=\s*true|indent_vbrace_open_on_tabstop\s*=\s*false
 ValueDefault=false
 
 [Indent Token After Brace]
@@ -3452,7 +3453,7 @@ Category=2
 Description="<html>How to indent after a brace followed by another token (not a newline).<br/>true:  indent all contained lines to match the token<br/>false: indent all contained lines to match the brace<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_token_after_brace=true|indent_token_after_brace=false
+TrueFalse=indent_token_after_brace\s*=\s*true|indent_token_after_brace\s*=\s*false
 ValueDefault=true
 
 [Indent Cpp Lambda Body]
@@ -3460,7 +3461,7 @@ Category=2
 Description="<html>Whether to indent the body of a C++11 lambda.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cpp_lambda_body=true|indent_cpp_lambda_body=false
+TrueFalse=indent_cpp_lambda_body\s*=\s*true|indent_cpp_lambda_body\s*=\s*false
 ValueDefault=false
 
 [Indent Compound Literal Return]
@@ -3468,7 +3469,7 @@ Category=2
 Description="<html>How to indent compound literals that are being returned.<br/>true: add both the indent from return &amp; the compound literal open brace<br/>      (i.e. 2 indent levels)<br/>false: only indent 1 level, don't add the indent for the open brace, only<br/>       add the indent for the return.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_compound_literal_return=true|indent_compound_literal_return=false
+TrueFalse=indent_compound_literal_return\s*=\s*true|indent_compound_literal_return\s*=\s*false
 ValueDefault=true
 
 [Indent Using Block]
@@ -3476,7 +3477,7 @@ Category=2
 Description="<html>(C#) Whether to indent a 'using' block if no braces are used.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_using_block=true|indent_using_block=false
+TrueFalse=indent_using_block\s*=\s*true|indent_using_block\s*=\s*false
 ValueDefault=true
 
 [Indent Ternary Operator]
@@ -3484,7 +3485,7 @@ Category=2
 Description="<html>How to indent the continuation of ternary operator.<br/><br/>0: Off (default)<br/>1: When the `if_false` is a continuation, indent it under the `if_true` branch<br/>2: When the `:` is a continuation, indent it under `?`</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_ternary_operator="
+CallName="indent_ternary_operator\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -3494,7 +3495,7 @@ Category=2
 Description="<html>Whether to indent the statements inside ternary operator.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_inside_ternary_operator=true|indent_inside_ternary_operator=false
+TrueFalse=indent_inside_ternary_operator\s*=\s*true|indent_inside_ternary_operator\s*=\s*false
 ValueDefault=false
 
 [Indent Off After Return]
@@ -3502,7 +3503,7 @@ Category=2
 Description="<html>If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_off_after_return=true|indent_off_after_return=false
+TrueFalse=indent_off_after_return\s*=\s*true|indent_off_after_return\s*=\s*false
 ValueDefault=false
 
 [Indent Off After Return New]
@@ -3510,7 +3511,7 @@ Category=2
 Description="<html>If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_off_after_return_new=true|indent_off_after_return_new=false
+TrueFalse=indent_off_after_return_new\s*=\s*true|indent_off_after_return_new\s*=\s*false
 ValueDefault=false
 
 [Indent Single After Return]
@@ -3518,7 +3519,7 @@ Category=2
 Description="<html>If true, the tokens after return are indented with regular single indentation. By default (false) the indentation is after the return token.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_single_after_return=true|indent_single_after_return=false
+TrueFalse=indent_single_after_return\s*=\s*true|indent_single_after_return\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Asm Block]
@@ -3526,7 +3527,7 @@ Category=2
 Description="<html>Whether to ignore indent and alignment for 'asm' blocks (i.e. assume they<br/>have their own indentation).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_asm_block=true|indent_ignore_asm_block=false
+TrueFalse=indent_ignore_asm_block\s*=\s*true|indent_ignore_asm_block\s*=\s*false
 ValueDefault=false
 
 [Donot Indent Func Def Close Paren]
@@ -3534,7 +3535,7 @@ Category=2
 Description="<html>Don't indent the close parenthesis of a function definition,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=donot_indent_func_def_close_paren=true|donot_indent_func_def_close_paren=false
+TrueFalse=donot_indent_func_def_close_paren\s*=\s*true|donot_indent_func_def_close_paren\s*=\s*false
 ValueDefault=false
 
 [Nl Collapse Empty Body]
@@ -3542,7 +3543,7 @@ Category=3
 Description="<html>Whether to collapse empty blocks between '{' and '}' except for functions.<br/>Use nl_collapse_empty_body_functions to specify how empty function braces<br/>should be formatted.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_collapse_empty_body=true|nl_collapse_empty_body=false
+TrueFalse=nl_collapse_empty_body\s*=\s*true|nl_collapse_empty_body\s*=\s*false
 ValueDefault=false
 
 [Nl Collapse Empty Body Functions]
@@ -3550,7 +3551,7 @@ Category=3
 Description="<html>Whether to collapse empty blocks between '{' and '}' for functions only.<br/>If true, overrides nl_inside_empty_func.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_collapse_empty_body_functions=true|nl_collapse_empty_body_functions=false
+TrueFalse=nl_collapse_empty_body_functions\s*=\s*true|nl_collapse_empty_body_functions\s*=\s*false
 ValueDefault=false
 
 [Nl Assign Leave One Liners]
@@ -3558,7 +3559,7 @@ Category=3
 Description="<html>Don't split one-line braced assignments, as in 'foo_t f = { 1, 2 };'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_assign_leave_one_liners=true|nl_assign_leave_one_liners=false
+TrueFalse=nl_assign_leave_one_liners\s*=\s*true|nl_assign_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Class Leave One Liners]
@@ -3566,7 +3567,7 @@ Category=3
 Description="<html>Don't split one-line braced statements inside a 'class xx { }' body.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_class_leave_one_liners=true|nl_class_leave_one_liners=false
+TrueFalse=nl_class_leave_one_liners\s*=\s*true|nl_class_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Enum Leave One Liners]
@@ -3574,7 +3575,7 @@ Category=3
 Description="<html>Don't split one-line enums, as in 'enum foo { BAR = 15 };'</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_enum_leave_one_liners=true|nl_enum_leave_one_liners=false
+TrueFalse=nl_enum_leave_one_liners\s*=\s*true|nl_enum_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Getset Leave One Liners]
@@ -3582,7 +3583,7 @@ Category=3
 Description="<html>Don't split one-line get or set functions.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_getset_leave_one_liners=true|nl_getset_leave_one_liners=false
+TrueFalse=nl_getset_leave_one_liners\s*=\s*true|nl_getset_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Cs Property Leave One Liners]
@@ -3590,7 +3591,7 @@ Category=3
 Description="<html>(C#) Don't split one-line property get or set functions.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_cs_property_leave_one_liners=true|nl_cs_property_leave_one_liners=false
+TrueFalse=nl_cs_property_leave_one_liners\s*=\s*true|nl_cs_property_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Func Leave One Liners]
@@ -3598,7 +3599,7 @@ Category=3
 Description="<html>Don't split one-line function definitions, as in 'int foo() { return 0; }'.<br/>might modify nl_func_type_name</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_leave_one_liners=true|nl_func_leave_one_liners=false
+TrueFalse=nl_func_leave_one_liners\s*=\s*true|nl_func_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Cpp Lambda Leave One Liners]
@@ -3606,7 +3607,7 @@ Category=3
 Description="<html>Don't split one-line C++11 lambdas, as in '[]() { return 0; }'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_cpp_lambda_leave_one_liners=true|nl_cpp_lambda_leave_one_liners=false
+TrueFalse=nl_cpp_lambda_leave_one_liners\s*=\s*true|nl_cpp_lambda_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl If Leave One Liners]
@@ -3614,7 +3615,7 @@ Category=3
 Description="<html>Don't split one-line if/else statements, as in 'if(...) b++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_if_leave_one_liners=true|nl_if_leave_one_liners=false
+TrueFalse=nl_if_leave_one_liners\s*=\s*true|nl_if_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl While Leave One Liners]
@@ -3622,7 +3623,7 @@ Category=3
 Description="<html>Don't split one-line while statements, as in 'while(...) b++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_while_leave_one_liners=true|nl_while_leave_one_liners=false
+TrueFalse=nl_while_leave_one_liners\s*=\s*true|nl_while_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Do Leave One Liners]
@@ -3630,7 +3631,7 @@ Category=3
 Description="<html>Don't split one-line do statements, as in 'do { b++; } while(...);'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_do_leave_one_liners=true|nl_do_leave_one_liners=false
+TrueFalse=nl_do_leave_one_liners\s*=\s*true|nl_do_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl For Leave One Liners]
@@ -3638,7 +3639,7 @@ Category=3
 Description="<html>Don't split one-line for statements, as in 'for(...) b++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_for_leave_one_liners=true|nl_for_leave_one_liners=false
+TrueFalse=nl_for_leave_one_liners\s*=\s*true|nl_for_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Oc Msg Leave One Liner]
@@ -3646,7 +3647,7 @@ Category=3
 Description="<html>(OC) Don't split one-line Objective-C messages.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_oc_msg_leave_one_liner=true|nl_oc_msg_leave_one_liner=false
+TrueFalse=nl_oc_msg_leave_one_liner\s*=\s*true|nl_oc_msg_leave_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Oc Mdef Brace]
@@ -3654,7 +3655,7 @@ Category=3
 Description="<html>(OC) Add or remove newline between method declaration and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_mdef_brace=ignore|nl_oc_mdef_brace=add|nl_oc_mdef_brace=remove|nl_oc_mdef_brace=force|nl_oc_mdef_brace=not_defined
+Choices=nl_oc_mdef_brace\s*=\s*ignore|nl_oc_mdef_brace\s*=\s*add|nl_oc_mdef_brace\s*=\s*remove|nl_oc_mdef_brace\s*=\s*force|nl_oc_mdef_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Mdef Brace|Add Nl Oc Mdef Brace|Remove Nl Oc Mdef Brace|Force Nl Oc Mdef Brace"
 ValueDefault=ignore
 
@@ -3663,7 +3664,7 @@ Category=3
 Description="<html>(OC) Add or remove newline between Objective-C block signature and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_block_brace=ignore|nl_oc_block_brace=add|nl_oc_block_brace=remove|nl_oc_block_brace=force|nl_oc_block_brace=not_defined
+Choices=nl_oc_block_brace\s*=\s*ignore|nl_oc_block_brace\s*=\s*add|nl_oc_block_brace\s*=\s*remove|nl_oc_block_brace\s*=\s*force|nl_oc_block_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Block Brace|Add Nl Oc Block Brace|Remove Nl Oc Block Brace|Force Nl Oc Block Brace"
 ValueDefault=ignore
 
@@ -3672,7 +3673,7 @@ Category=3
 Description="<html>(OC) Add or remove blank line before '@interface' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_before_interface=ignore|nl_oc_before_interface=add|nl_oc_before_interface=remove|nl_oc_before_interface=force|nl_oc_before_interface=not_defined
+Choices=nl_oc_before_interface\s*=\s*ignore|nl_oc_before_interface\s*=\s*add|nl_oc_before_interface\s*=\s*remove|nl_oc_before_interface\s*=\s*force|nl_oc_before_interface\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Before Interface|Add Nl Oc Before Interface|Remove Nl Oc Before Interface|Force Nl Oc Before Interface"
 ValueDefault=ignore
 
@@ -3681,7 +3682,7 @@ Category=3
 Description="<html>(OC) Add or remove blank line before '@implementation' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_before_implementation=ignore|nl_oc_before_implementation=add|nl_oc_before_implementation=remove|nl_oc_before_implementation=force|nl_oc_before_implementation=not_defined
+Choices=nl_oc_before_implementation\s*=\s*ignore|nl_oc_before_implementation\s*=\s*add|nl_oc_before_implementation\s*=\s*remove|nl_oc_before_implementation\s*=\s*force|nl_oc_before_implementation\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Before Implementation|Add Nl Oc Before Implementation|Remove Nl Oc Before Implementation|Force Nl Oc Before Implementation"
 ValueDefault=ignore
 
@@ -3690,7 +3691,7 @@ Category=3
 Description="<html>(OC) Add or remove blank line before '@end' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_before_end=ignore|nl_oc_before_end=add|nl_oc_before_end=remove|nl_oc_before_end=force|nl_oc_before_end=not_defined
+Choices=nl_oc_before_end\s*=\s*ignore|nl_oc_before_end\s*=\s*add|nl_oc_before_end\s*=\s*remove|nl_oc_before_end\s*=\s*force|nl_oc_before_end\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Before End|Add Nl Oc Before End|Remove Nl Oc Before End|Force Nl Oc Before End"
 ValueDefault=ignore
 
@@ -3699,7 +3700,7 @@ Category=3
 Description="<html>(OC) Add or remove newline between '@interface' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_interface_brace=ignore|nl_oc_interface_brace=add|nl_oc_interface_brace=remove|nl_oc_interface_brace=force|nl_oc_interface_brace=not_defined
+Choices=nl_oc_interface_brace\s*=\s*ignore|nl_oc_interface_brace\s*=\s*add|nl_oc_interface_brace\s*=\s*remove|nl_oc_interface_brace\s*=\s*force|nl_oc_interface_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Interface Brace|Add Nl Oc Interface Brace|Remove Nl Oc Interface Brace|Force Nl Oc Interface Brace"
 ValueDefault=ignore
 
@@ -3708,7 +3709,7 @@ Category=3
 Description="<html>(OC) Add or remove newline between '@implementation' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_implementation_brace=ignore|nl_oc_implementation_brace=add|nl_oc_implementation_brace=remove|nl_oc_implementation_brace=force|nl_oc_implementation_brace=not_defined
+Choices=nl_oc_implementation_brace\s*=\s*ignore|nl_oc_implementation_brace\s*=\s*add|nl_oc_implementation_brace\s*=\s*remove|nl_oc_implementation_brace\s*=\s*force|nl_oc_implementation_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Implementation Brace|Add Nl Oc Implementation Brace|Remove Nl Oc Implementation Brace|Force Nl Oc Implementation Brace"
 ValueDefault=ignore
 
@@ -3717,7 +3718,7 @@ Category=3
 Description="<html>Add or remove newlines at the start of the file.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_start_of_file=ignore|nl_start_of_file=add|nl_start_of_file=remove|nl_start_of_file=force|nl_start_of_file=not_defined
+Choices=nl_start_of_file\s*=\s*ignore|nl_start_of_file\s*=\s*add|nl_start_of_file\s*=\s*remove|nl_start_of_file\s*=\s*force|nl_start_of_file\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Start Of File|Add Nl Start Of File|Remove Nl Start Of File|Force Nl Start Of File"
 ValueDefault=ignore
 
@@ -3726,7 +3727,7 @@ Category=3
 Description="<html>The minimum number of newlines at the start of the file (only used if<br/>nl_start_of_file is 'add' or 'force').</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_start_of_file_min="
+CallName="nl_start_of_file_min\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3736,7 +3737,7 @@ Category=3
 Description="<html>Add or remove newline at the end of the file.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_end_of_file=ignore|nl_end_of_file=add|nl_end_of_file=remove|nl_end_of_file=force|nl_end_of_file=not_defined
+Choices=nl_end_of_file\s*=\s*ignore|nl_end_of_file\s*=\s*add|nl_end_of_file\s*=\s*remove|nl_end_of_file\s*=\s*force|nl_end_of_file\s*=\s*not_defined
 ChoicesReadable="Ignore Nl End Of File|Add Nl End Of File|Remove Nl End Of File|Force Nl End Of File"
 ValueDefault=ignore
 
@@ -3745,7 +3746,7 @@ Category=3
 Description="<html>The minimum number of newlines at the end of the file (only used if<br/>nl_end_of_file is 'add' or 'force').</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_end_of_file_min="
+CallName="nl_end_of_file_min\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3755,7 +3756,7 @@ Category=3
 Description="<html>Add or remove newline between '=' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_assign_brace=ignore|nl_assign_brace=add|nl_assign_brace=remove|nl_assign_brace=force|nl_assign_brace=not_defined
+Choices=nl_assign_brace\s*=\s*ignore|nl_assign_brace\s*=\s*add|nl_assign_brace\s*=\s*remove|nl_assign_brace\s*=\s*force|nl_assign_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Assign Brace|Add Nl Assign Brace|Remove Nl Assign Brace|Force Nl Assign Brace"
 ValueDefault=ignore
 
@@ -3764,7 +3765,7 @@ Category=3
 Description="<html>(D) Add or remove newline between '=' and '['.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_assign_square=ignore|nl_assign_square=add|nl_assign_square=remove|nl_assign_square=force|nl_assign_square=not_defined
+Choices=nl_assign_square\s*=\s*ignore|nl_assign_square\s*=\s*add|nl_assign_square\s*=\s*remove|nl_assign_square\s*=\s*force|nl_assign_square\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Assign Square|Add Nl Assign Square|Remove Nl Assign Square|Force Nl Assign Square"
 ValueDefault=ignore
 
@@ -3773,7 +3774,7 @@ Category=3
 Description="<html>Add or remove newline between '[]' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_tsquare_brace=ignore|nl_tsquare_brace=add|nl_tsquare_brace=remove|nl_tsquare_brace=force|nl_tsquare_brace=not_defined
+Choices=nl_tsquare_brace\s*=\s*ignore|nl_tsquare_brace\s*=\s*add|nl_tsquare_brace\s*=\s*remove|nl_tsquare_brace\s*=\s*force|nl_tsquare_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Tsquare Brace|Add Nl Tsquare Brace|Remove Nl Tsquare Brace|Force Nl Tsquare Brace"
 ValueDefault=ignore
 
@@ -3782,7 +3783,7 @@ Category=3
 Description="<html>(D) Add or remove newline after '= ['. Will also affect the newline before<br/>the ']'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_square_assign=ignore|nl_after_square_assign=add|nl_after_square_assign=remove|nl_after_square_assign=force|nl_after_square_assign=not_defined
+Choices=nl_after_square_assign\s*=\s*ignore|nl_after_square_assign\s*=\s*add|nl_after_square_assign\s*=\s*remove|nl_after_square_assign\s*=\s*force|nl_after_square_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Square Assign|Add Nl After Square Assign|Remove Nl After Square Assign|Force Nl After Square Assign"
 ValueDefault=ignore
 
@@ -3791,7 +3792,7 @@ Category=3
 Description="<html>Add or remove newline between a function call's ')' and '{', as in<br/>'list_for_each(item, &amp;list) { }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_fcall_brace=ignore|nl_fcall_brace=add|nl_fcall_brace=remove|nl_fcall_brace=force|nl_fcall_brace=not_defined
+Choices=nl_fcall_brace\s*=\s*ignore|nl_fcall_brace\s*=\s*add|nl_fcall_brace\s*=\s*remove|nl_fcall_brace\s*=\s*force|nl_fcall_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Fcall Brace|Add Nl Fcall Brace|Remove Nl Fcall Brace|Force Nl Fcall Brace"
 ValueDefault=ignore
 
@@ -3800,7 +3801,7 @@ Category=3
 Description="<html>Add or remove newline between 'enum' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_brace=ignore|nl_enum_brace=add|nl_enum_brace=remove|nl_enum_brace=force|nl_enum_brace=not_defined
+Choices=nl_enum_brace\s*=\s*ignore|nl_enum_brace\s*=\s*add|nl_enum_brace\s*=\s*remove|nl_enum_brace\s*=\s*force|nl_enum_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Brace|Add Nl Enum Brace|Remove Nl Enum Brace|Force Nl Enum Brace"
 ValueDefault=ignore
 
@@ -3809,7 +3810,7 @@ Category=3
 Description="<html>Add or remove newline between 'enum' and 'class'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_class=ignore|nl_enum_class=add|nl_enum_class=remove|nl_enum_class=force|nl_enum_class=not_defined
+Choices=nl_enum_class\s*=\s*ignore|nl_enum_class\s*=\s*add|nl_enum_class\s*=\s*remove|nl_enum_class\s*=\s*force|nl_enum_class\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Class|Add Nl Enum Class|Remove Nl Enum Class|Force Nl Enum Class"
 ValueDefault=ignore
 
@@ -3818,7 +3819,7 @@ Category=3
 Description="<html>Add or remove newline between 'enum class' and the identifier.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_class_identifier=ignore|nl_enum_class_identifier=add|nl_enum_class_identifier=remove|nl_enum_class_identifier=force|nl_enum_class_identifier=not_defined
+Choices=nl_enum_class_identifier\s*=\s*ignore|nl_enum_class_identifier\s*=\s*add|nl_enum_class_identifier\s*=\s*remove|nl_enum_class_identifier\s*=\s*force|nl_enum_class_identifier\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Class Identifier|Add Nl Enum Class Identifier|Remove Nl Enum Class Identifier|Force Nl Enum Class Identifier"
 ValueDefault=ignore
 
@@ -3827,7 +3828,7 @@ Category=3
 Description="<html>Add or remove newline between 'enum class' type and ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_identifier_colon=ignore|nl_enum_identifier_colon=add|nl_enum_identifier_colon=remove|nl_enum_identifier_colon=force|nl_enum_identifier_colon=not_defined
+Choices=nl_enum_identifier_colon\s*=\s*ignore|nl_enum_identifier_colon\s*=\s*add|nl_enum_identifier_colon\s*=\s*remove|nl_enum_identifier_colon\s*=\s*force|nl_enum_identifier_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Identifier Colon|Add Nl Enum Identifier Colon|Remove Nl Enum Identifier Colon|Force Nl Enum Identifier Colon"
 ValueDefault=ignore
 
@@ -3836,7 +3837,7 @@ Category=3
 Description="<html>Add or remove newline between 'enum class identifier :' and type.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_colon_type=ignore|nl_enum_colon_type=add|nl_enum_colon_type=remove|nl_enum_colon_type=force|nl_enum_colon_type=not_defined
+Choices=nl_enum_colon_type\s*=\s*ignore|nl_enum_colon_type\s*=\s*add|nl_enum_colon_type\s*=\s*remove|nl_enum_colon_type\s*=\s*force|nl_enum_colon_type\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Colon Type|Add Nl Enum Colon Type|Remove Nl Enum Colon Type|Force Nl Enum Colon Type"
 ValueDefault=ignore
 
@@ -3845,7 +3846,7 @@ Category=3
 Description="<html>Add or remove newline between 'struct and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_struct_brace=ignore|nl_struct_brace=add|nl_struct_brace=remove|nl_struct_brace=force|nl_struct_brace=not_defined
+Choices=nl_struct_brace\s*=\s*ignore|nl_struct_brace\s*=\s*add|nl_struct_brace\s*=\s*remove|nl_struct_brace\s*=\s*force|nl_struct_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Struct Brace|Add Nl Struct Brace|Remove Nl Struct Brace|Force Nl Struct Brace"
 ValueDefault=ignore
 
@@ -3854,7 +3855,7 @@ Category=3
 Description="<html>Add or remove newline between 'union' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_union_brace=ignore|nl_union_brace=add|nl_union_brace=remove|nl_union_brace=force|nl_union_brace=not_defined
+Choices=nl_union_brace\s*=\s*ignore|nl_union_brace\s*=\s*add|nl_union_brace\s*=\s*remove|nl_union_brace\s*=\s*force|nl_union_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Union Brace|Add Nl Union Brace|Remove Nl Union Brace|Force Nl Union Brace"
 ValueDefault=ignore
 
@@ -3863,7 +3864,7 @@ Category=3
 Description="<html>Add or remove newline between 'if' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_if_brace=ignore|nl_if_brace=add|nl_if_brace=remove|nl_if_brace=force|nl_if_brace=not_defined
+Choices=nl_if_brace\s*=\s*ignore|nl_if_brace\s*=\s*add|nl_if_brace\s*=\s*remove|nl_if_brace\s*=\s*force|nl_if_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl If Brace|Add Nl If Brace|Remove Nl If Brace|Force Nl If Brace"
 ValueDefault=ignore
 
@@ -3872,7 +3873,7 @@ Category=3
 Description="<html>Add or remove newline between '}' and 'else'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_else=ignore|nl_brace_else=add|nl_brace_else=remove|nl_brace_else=force|nl_brace_else=not_defined
+Choices=nl_brace_else\s*=\s*ignore|nl_brace_else\s*=\s*add|nl_brace_else\s*=\s*remove|nl_brace_else\s*=\s*force|nl_brace_else\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Else|Add Nl Brace Else|Remove Nl Brace Else|Force Nl Brace Else"
 ValueDefault=ignore
 
@@ -3881,7 +3882,7 @@ Category=3
 Description="<html>Add or remove newline between 'else if' and '{'. If set to ignore,<br/>nl_if_brace is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_elseif_brace=ignore|nl_elseif_brace=add|nl_elseif_brace=remove|nl_elseif_brace=force|nl_elseif_brace=not_defined
+Choices=nl_elseif_brace\s*=\s*ignore|nl_elseif_brace\s*=\s*add|nl_elseif_brace\s*=\s*remove|nl_elseif_brace\s*=\s*force|nl_elseif_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Elseif Brace|Add Nl Elseif Brace|Remove Nl Elseif Brace|Force Nl Elseif Brace"
 ValueDefault=ignore
 
@@ -3890,7 +3891,7 @@ Category=3
 Description="<html>Add or remove newline between 'else' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_else_brace=ignore|nl_else_brace=add|nl_else_brace=remove|nl_else_brace=force|nl_else_brace=not_defined
+Choices=nl_else_brace\s*=\s*ignore|nl_else_brace\s*=\s*add|nl_else_brace\s*=\s*remove|nl_else_brace\s*=\s*force|nl_else_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Else Brace|Add Nl Else Brace|Remove Nl Else Brace|Force Nl Else Brace"
 ValueDefault=ignore
 
@@ -3899,7 +3900,7 @@ Category=3
 Description="<html>Add or remove newline between 'else' and 'if'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_else_if=ignore|nl_else_if=add|nl_else_if=remove|nl_else_if=force|nl_else_if=not_defined
+Choices=nl_else_if\s*=\s*ignore|nl_else_if\s*=\s*add|nl_else_if\s*=\s*remove|nl_else_if\s*=\s*force|nl_else_if\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Else If|Add Nl Else If|Remove Nl Else If|Force Nl Else If"
 ValueDefault=ignore
 
@@ -3908,7 +3909,7 @@ Category=3
 Description="<html>Add or remove newline before '{' opening brace</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_opening_brace_func_class_def=ignore|nl_before_opening_brace_func_class_def=add|nl_before_opening_brace_func_class_def=remove|nl_before_opening_brace_func_class_def=force|nl_before_opening_brace_func_class_def=not_defined
+Choices=nl_before_opening_brace_func_class_def\s*=\s*ignore|nl_before_opening_brace_func_class_def\s*=\s*add|nl_before_opening_brace_func_class_def\s*=\s*remove|nl_before_opening_brace_func_class_def\s*=\s*force|nl_before_opening_brace_func_class_def\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Opening Brace Func Class Def|Add Nl Before Opening Brace Func Class Def|Remove Nl Before Opening Brace Func Class Def|Force Nl Before Opening Brace Func Class Def"
 ValueDefault=ignore
 
@@ -3917,7 +3918,7 @@ Category=3
 Description="<html>Add or remove newline before 'if'/'else if' closing parenthesis.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_if_closing_paren=ignore|nl_before_if_closing_paren=add|nl_before_if_closing_paren=remove|nl_before_if_closing_paren=force|nl_before_if_closing_paren=not_defined
+Choices=nl_before_if_closing_paren\s*=\s*ignore|nl_before_if_closing_paren\s*=\s*add|nl_before_if_closing_paren\s*=\s*remove|nl_before_if_closing_paren\s*=\s*force|nl_before_if_closing_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before If Closing Paren|Add Nl Before If Closing Paren|Remove Nl Before If Closing Paren|Force Nl Before If Closing Paren"
 ValueDefault=ignore
 
@@ -3926,7 +3927,7 @@ Category=3
 Description="<html>Add or remove newline between '}' and 'finally'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_finally=ignore|nl_brace_finally=add|nl_brace_finally=remove|nl_brace_finally=force|nl_brace_finally=not_defined
+Choices=nl_brace_finally\s*=\s*ignore|nl_brace_finally\s*=\s*add|nl_brace_finally\s*=\s*remove|nl_brace_finally\s*=\s*force|nl_brace_finally\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Finally|Add Nl Brace Finally|Remove Nl Brace Finally|Force Nl Brace Finally"
 ValueDefault=ignore
 
@@ -3935,7 +3936,7 @@ Category=3
 Description="<html>Add or remove newline between 'finally' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_finally_brace=ignore|nl_finally_brace=add|nl_finally_brace=remove|nl_finally_brace=force|nl_finally_brace=not_defined
+Choices=nl_finally_brace\s*=\s*ignore|nl_finally_brace\s*=\s*add|nl_finally_brace\s*=\s*remove|nl_finally_brace\s*=\s*force|nl_finally_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Finally Brace|Add Nl Finally Brace|Remove Nl Finally Brace|Force Nl Finally Brace"
 ValueDefault=ignore
 
@@ -3944,7 +3945,7 @@ Category=3
 Description="<html>Add or remove newline between 'try' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_try_brace=ignore|nl_try_brace=add|nl_try_brace=remove|nl_try_brace=force|nl_try_brace=not_defined
+Choices=nl_try_brace\s*=\s*ignore|nl_try_brace\s*=\s*add|nl_try_brace\s*=\s*remove|nl_try_brace\s*=\s*force|nl_try_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Try Brace|Add Nl Try Brace|Remove Nl Try Brace|Force Nl Try Brace"
 ValueDefault=ignore
 
@@ -3953,7 +3954,7 @@ Category=3
 Description="<html>Add or remove newline between get/set and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_getset_brace=ignore|nl_getset_brace=add|nl_getset_brace=remove|nl_getset_brace=force|nl_getset_brace=not_defined
+Choices=nl_getset_brace\s*=\s*ignore|nl_getset_brace\s*=\s*add|nl_getset_brace\s*=\s*remove|nl_getset_brace\s*=\s*force|nl_getset_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Getset Brace|Add Nl Getset Brace|Remove Nl Getset Brace|Force Nl Getset Brace"
 ValueDefault=ignore
 
@@ -3962,7 +3963,7 @@ Category=3
 Description="<html>Add or remove newline between 'for' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_for_brace=ignore|nl_for_brace=add|nl_for_brace=remove|nl_for_brace=force|nl_for_brace=not_defined
+Choices=nl_for_brace\s*=\s*ignore|nl_for_brace\s*=\s*add|nl_for_brace\s*=\s*remove|nl_for_brace\s*=\s*force|nl_for_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl For Brace|Add Nl For Brace|Remove Nl For Brace|Force Nl For Brace"
 ValueDefault=ignore
 
@@ -3971,7 +3972,7 @@ Category=3
 Description="<html>Add or remove newline before the '{' of a 'catch' statement, as in<br/>'catch (decl) &lt;here&gt; {'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_catch_brace=ignore|nl_catch_brace=add|nl_catch_brace=remove|nl_catch_brace=force|nl_catch_brace=not_defined
+Choices=nl_catch_brace\s*=\s*ignore|nl_catch_brace\s*=\s*add|nl_catch_brace\s*=\s*remove|nl_catch_brace\s*=\s*force|nl_catch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Catch Brace|Add Nl Catch Brace|Remove Nl Catch Brace|Force Nl Catch Brace"
 ValueDefault=ignore
 
@@ -3980,7 +3981,7 @@ Category=3
 Description="<html>(OC) Add or remove newline before the '{' of a '@catch' statement, as in<br/>'@catch (decl) &lt;here&gt; {'. If set to ignore, nl_catch_brace is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_catch_brace=ignore|nl_oc_catch_brace=add|nl_oc_catch_brace=remove|nl_oc_catch_brace=force|nl_oc_catch_brace=not_defined
+Choices=nl_oc_catch_brace\s*=\s*ignore|nl_oc_catch_brace\s*=\s*add|nl_oc_catch_brace\s*=\s*remove|nl_oc_catch_brace\s*=\s*force|nl_oc_catch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Catch Brace|Add Nl Oc Catch Brace|Remove Nl Oc Catch Brace|Force Nl Oc Catch Brace"
 ValueDefault=ignore
 
@@ -3989,7 +3990,7 @@ Category=3
 Description="<html>Add or remove newline between '}' and 'catch'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_catch=ignore|nl_brace_catch=add|nl_brace_catch=remove|nl_brace_catch=force|nl_brace_catch=not_defined
+Choices=nl_brace_catch\s*=\s*ignore|nl_brace_catch\s*=\s*add|nl_brace_catch\s*=\s*remove|nl_brace_catch\s*=\s*force|nl_brace_catch\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Catch|Add Nl Brace Catch|Remove Nl Brace Catch|Force Nl Brace Catch"
 ValueDefault=ignore
 
@@ -3998,7 +3999,7 @@ Category=3
 Description="<html>(OC) Add or remove newline between '}' and '@catch'. If set to ignore,<br/>nl_brace_catch is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_brace_catch=ignore|nl_oc_brace_catch=add|nl_oc_brace_catch=remove|nl_oc_brace_catch=force|nl_oc_brace_catch=not_defined
+Choices=nl_oc_brace_catch\s*=\s*ignore|nl_oc_brace_catch\s*=\s*add|nl_oc_brace_catch\s*=\s*remove|nl_oc_brace_catch\s*=\s*force|nl_oc_brace_catch\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Brace Catch|Add Nl Oc Brace Catch|Remove Nl Oc Brace Catch|Force Nl Oc Brace Catch"
 ValueDefault=ignore
 
@@ -4007,7 +4008,7 @@ Category=3
 Description="<html>Add or remove newline between '}' and ']'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_square=ignore|nl_brace_square=add|nl_brace_square=remove|nl_brace_square=force|nl_brace_square=not_defined
+Choices=nl_brace_square\s*=\s*ignore|nl_brace_square\s*=\s*add|nl_brace_square\s*=\s*remove|nl_brace_square\s*=\s*force|nl_brace_square\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Square|Add Nl Brace Square|Remove Nl Brace Square|Force Nl Brace Square"
 ValueDefault=ignore
 
@@ -4016,7 +4017,7 @@ Category=3
 Description="<html>Add or remove newline between '}' and ')' in a function invocation.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_fparen=ignore|nl_brace_fparen=add|nl_brace_fparen=remove|nl_brace_fparen=force|nl_brace_fparen=not_defined
+Choices=nl_brace_fparen\s*=\s*ignore|nl_brace_fparen\s*=\s*add|nl_brace_fparen\s*=\s*remove|nl_brace_fparen\s*=\s*force|nl_brace_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Fparen|Add Nl Brace Fparen|Remove Nl Brace Fparen|Force Nl Brace Fparen"
 ValueDefault=ignore
 
@@ -4025,7 +4026,7 @@ Category=3
 Description="<html>Add or remove newline between 'while' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_while_brace=ignore|nl_while_brace=add|nl_while_brace=remove|nl_while_brace=force|nl_while_brace=not_defined
+Choices=nl_while_brace\s*=\s*ignore|nl_while_brace\s*=\s*add|nl_while_brace\s*=\s*remove|nl_while_brace\s*=\s*force|nl_while_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl While Brace|Add Nl While Brace|Remove Nl While Brace|Force Nl While Brace"
 ValueDefault=ignore
 
@@ -4034,7 +4035,7 @@ Category=3
 Description="<html>(D) Add or remove newline between 'scope (x)' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_scope_brace=ignore|nl_scope_brace=add|nl_scope_brace=remove|nl_scope_brace=force|nl_scope_brace=not_defined
+Choices=nl_scope_brace\s*=\s*ignore|nl_scope_brace\s*=\s*add|nl_scope_brace\s*=\s*remove|nl_scope_brace\s*=\s*force|nl_scope_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Scope Brace|Add Nl Scope Brace|Remove Nl Scope Brace|Force Nl Scope Brace"
 ValueDefault=ignore
 
@@ -4043,7 +4044,7 @@ Category=3
 Description="<html>(D) Add or remove newline between 'unittest' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_unittest_brace=ignore|nl_unittest_brace=add|nl_unittest_brace=remove|nl_unittest_brace=force|nl_unittest_brace=not_defined
+Choices=nl_unittest_brace\s*=\s*ignore|nl_unittest_brace\s*=\s*add|nl_unittest_brace\s*=\s*remove|nl_unittest_brace\s*=\s*force|nl_unittest_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Unittest Brace|Add Nl Unittest Brace|Remove Nl Unittest Brace|Force Nl Unittest Brace"
 ValueDefault=ignore
 
@@ -4052,7 +4053,7 @@ Category=3
 Description="<html>(D) Add or remove newline between 'version (x)' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_version_brace=ignore|nl_version_brace=add|nl_version_brace=remove|nl_version_brace=force|nl_version_brace=not_defined
+Choices=nl_version_brace\s*=\s*ignore|nl_version_brace\s*=\s*add|nl_version_brace\s*=\s*remove|nl_version_brace\s*=\s*force|nl_version_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Version Brace|Add Nl Version Brace|Remove Nl Version Brace|Force Nl Version Brace"
 ValueDefault=ignore
 
@@ -4061,7 +4062,7 @@ Category=3
 Description="<html>(C#) Add or remove newline between 'using' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_using_brace=ignore|nl_using_brace=add|nl_using_brace=remove|nl_using_brace=force|nl_using_brace=not_defined
+Choices=nl_using_brace\s*=\s*ignore|nl_using_brace\s*=\s*add|nl_using_brace\s*=\s*remove|nl_using_brace\s*=\s*force|nl_using_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Using Brace|Add Nl Using Brace|Remove Nl Using Brace|Force Nl Using Brace"
 ValueDefault=ignore
 
@@ -4070,7 +4071,7 @@ Category=3
 Description="<html>Add or remove newline between two open or close braces. Due to general<br/>newline/brace handling, REMOVE may not work.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_brace=ignore|nl_brace_brace=add|nl_brace_brace=remove|nl_brace_brace=force|nl_brace_brace=not_defined
+Choices=nl_brace_brace\s*=\s*ignore|nl_brace_brace\s*=\s*add|nl_brace_brace\s*=\s*remove|nl_brace_brace\s*=\s*force|nl_brace_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Brace|Add Nl Brace Brace|Remove Nl Brace Brace|Force Nl Brace Brace"
 ValueDefault=ignore
 
@@ -4079,7 +4080,7 @@ Category=3
 Description="<html>Add or remove newline between 'do' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_do_brace=ignore|nl_do_brace=add|nl_do_brace=remove|nl_do_brace=force|nl_do_brace=not_defined
+Choices=nl_do_brace\s*=\s*ignore|nl_do_brace\s*=\s*add|nl_do_brace\s*=\s*remove|nl_do_brace\s*=\s*force|nl_do_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Do Brace|Add Nl Do Brace|Remove Nl Do Brace|Force Nl Do Brace"
 ValueDefault=ignore
 
@@ -4088,7 +4089,7 @@ Category=3
 Description="<html>Add or remove newline between '}' and 'while' of 'do' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_while=ignore|nl_brace_while=add|nl_brace_while=remove|nl_brace_while=force|nl_brace_while=not_defined
+Choices=nl_brace_while\s*=\s*ignore|nl_brace_while\s*=\s*add|nl_brace_while\s*=\s*remove|nl_brace_while\s*=\s*force|nl_brace_while\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace While|Add Nl Brace While|Remove Nl Brace While|Force Nl Brace While"
 ValueDefault=ignore
 
@@ -4097,7 +4098,7 @@ Category=3
 Description="<html>Add or remove newline between 'switch' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_switch_brace=ignore|nl_switch_brace=add|nl_switch_brace=remove|nl_switch_brace=force|nl_switch_brace=not_defined
+Choices=nl_switch_brace\s*=\s*ignore|nl_switch_brace\s*=\s*add|nl_switch_brace\s*=\s*remove|nl_switch_brace\s*=\s*force|nl_switch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Switch Brace|Add Nl Switch Brace|Remove Nl Switch Brace|Force Nl Switch Brace"
 ValueDefault=ignore
 
@@ -4106,7 +4107,7 @@ Category=3
 Description="<html>Add or remove newline between 'synchronized' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_synchronized_brace=ignore|nl_synchronized_brace=add|nl_synchronized_brace=remove|nl_synchronized_brace=force|nl_synchronized_brace=not_defined
+Choices=nl_synchronized_brace\s*=\s*ignore|nl_synchronized_brace\s*=\s*add|nl_synchronized_brace\s*=\s*remove|nl_synchronized_brace\s*=\s*force|nl_synchronized_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Synchronized Brace|Add Nl Synchronized Brace|Remove Nl Synchronized Brace|Force Nl Synchronized Brace"
 ValueDefault=ignore
 
@@ -4115,7 +4116,7 @@ Category=3
 Description="<html>Add a newline between ')' and '{' if the ')' is on a different line than the<br/>if/for/etc.<br/><br/>Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch and<br/>nl_catch_brace.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_multi_line_cond=true|nl_multi_line_cond=false
+TrueFalse=nl_multi_line_cond\s*=\s*true|nl_multi_line_cond\s*=\s*false
 ValueDefault=false
 
 [Nl Multi Line Sparen Open]
@@ -4123,7 +4124,7 @@ Category=3
 Description="<html>Add a newline after '(' if an if/for/while/switch condition spans multiple<br/>lines</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_multi_line_sparen_open=ignore|nl_multi_line_sparen_open=add|nl_multi_line_sparen_open=remove|nl_multi_line_sparen_open=force|nl_multi_line_sparen_open=not_defined
+Choices=nl_multi_line_sparen_open\s*=\s*ignore|nl_multi_line_sparen_open\s*=\s*add|nl_multi_line_sparen_open\s*=\s*remove|nl_multi_line_sparen_open\s*=\s*force|nl_multi_line_sparen_open\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Multi Line Sparen Open|Add Nl Multi Line Sparen Open|Remove Nl Multi Line Sparen Open|Force Nl Multi Line Sparen Open"
 ValueDefault=ignore
 
@@ -4132,7 +4133,7 @@ Category=3
 Description="<html>Add a newline before ')' if an if/for/while/switch condition spans multiple<br/>lines. Overrides nl_before_if_closing_paren if both are specified.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_multi_line_sparen_close=ignore|nl_multi_line_sparen_close=add|nl_multi_line_sparen_close=remove|nl_multi_line_sparen_close=force|nl_multi_line_sparen_close=not_defined
+Choices=nl_multi_line_sparen_close\s*=\s*ignore|nl_multi_line_sparen_close\s*=\s*add|nl_multi_line_sparen_close\s*=\s*remove|nl_multi_line_sparen_close\s*=\s*force|nl_multi_line_sparen_close\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Multi Line Sparen Close|Add Nl Multi Line Sparen Close|Remove Nl Multi Line Sparen Close|Force Nl Multi Line Sparen Close"
 ValueDefault=ignore
 
@@ -4141,7 +4142,7 @@ Category=3
 Description="<html>Force a newline in a define after the macro name for multi-line defines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_multi_line_define=true|nl_multi_line_define=false
+TrueFalse=nl_multi_line_define\s*=\s*true|nl_multi_line_define\s*=\s*false
 ValueDefault=false
 
 [Nl Before Case]
@@ -4149,7 +4150,7 @@ Category=3
 Description="<html>Whether to add a newline before 'case', and a blank line before a 'case'<br/>statement that follows a ';' or '}'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_before_case=true|nl_before_case=false
+TrueFalse=nl_before_case\s*=\s*true|nl_before_case\s*=\s*false
 ValueDefault=false
 
 [Nl After Case]
@@ -4157,7 +4158,7 @@ Category=3
 Description="<html>Whether to add a newline after a 'case' statement.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_case=true|nl_after_case=false
+TrueFalse=nl_after_case\s*=\s*true|nl_after_case\s*=\s*false
 ValueDefault=false
 
 [Nl Case Colon Brace]
@@ -4165,7 +4166,7 @@ Category=3
 Description="<html>Add or remove newline between a case ':' and '{'.<br/><br/>Overrides nl_after_case.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_case_colon_brace=ignore|nl_case_colon_brace=add|nl_case_colon_brace=remove|nl_case_colon_brace=force|nl_case_colon_brace=not_defined
+Choices=nl_case_colon_brace\s*=\s*ignore|nl_case_colon_brace\s*=\s*add|nl_case_colon_brace\s*=\s*remove|nl_case_colon_brace\s*=\s*force|nl_case_colon_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Case Colon Brace|Add Nl Case Colon Brace|Remove Nl Case Colon Brace|Force Nl Case Colon Brace"
 ValueDefault=ignore
 
@@ -4174,7 +4175,7 @@ Category=3
 Description="<html>Add or remove newline between ')' and 'throw'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_throw=ignore|nl_before_throw=add|nl_before_throw=remove|nl_before_throw=force|nl_before_throw=not_defined
+Choices=nl_before_throw\s*=\s*ignore|nl_before_throw\s*=\s*add|nl_before_throw\s*=\s*remove|nl_before_throw\s*=\s*force|nl_before_throw\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Throw|Add Nl Before Throw|Remove Nl Before Throw|Force Nl Before Throw"
 ValueDefault=ignore
 
@@ -4183,7 +4184,7 @@ Category=3
 Description="<html>Add or remove newline between 'namespace' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_namespace_brace=ignore|nl_namespace_brace=add|nl_namespace_brace=remove|nl_namespace_brace=force|nl_namespace_brace=not_defined
+Choices=nl_namespace_brace\s*=\s*ignore|nl_namespace_brace\s*=\s*add|nl_namespace_brace\s*=\s*remove|nl_namespace_brace\s*=\s*force|nl_namespace_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Namespace Brace|Add Nl Namespace Brace|Remove Nl Namespace Brace|Force Nl Namespace Brace"
 ValueDefault=ignore
 
@@ -4192,7 +4193,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template class.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class=ignore|nl_template_class=add|nl_template_class=remove|nl_template_class=force|nl_template_class=not_defined
+Choices=nl_template_class\s*=\s*ignore|nl_template_class\s*=\s*add|nl_template_class\s*=\s*remove|nl_template_class\s*=\s*force|nl_template_class\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class|Add Nl Template Class|Remove Nl Template Class|Force Nl Template Class"
 ValueDefault=ignore
 
@@ -4201,7 +4202,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template class declaration.<br/><br/>Overrides nl_template_class.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class_decl=ignore|nl_template_class_decl=add|nl_template_class_decl=remove|nl_template_class_decl=force|nl_template_class_decl=not_defined
+Choices=nl_template_class_decl\s*=\s*ignore|nl_template_class_decl\s*=\s*add|nl_template_class_decl\s*=\s*remove|nl_template_class_decl\s*=\s*force|nl_template_class_decl\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class Decl|Add Nl Template Class Decl|Remove Nl Template Class Decl|Force Nl Template Class Decl"
 ValueDefault=ignore
 
@@ -4210,7 +4211,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized class declaration.<br/><br/>Overrides nl_template_class_decl.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class_decl_special=ignore|nl_template_class_decl_special=add|nl_template_class_decl_special=remove|nl_template_class_decl_special=force|nl_template_class_decl_special=not_defined
+Choices=nl_template_class_decl_special\s*=\s*ignore|nl_template_class_decl_special\s*=\s*add|nl_template_class_decl_special\s*=\s*remove|nl_template_class_decl_special\s*=\s*force|nl_template_class_decl_special\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class Decl Special|Add Nl Template Class Decl Special|Remove Nl Template Class Decl Special|Force Nl Template Class Decl Special"
 ValueDefault=ignore
 
@@ -4219,7 +4220,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template class definition.<br/><br/>Overrides nl_template_class.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class_def=ignore|nl_template_class_def=add|nl_template_class_def=remove|nl_template_class_def=force|nl_template_class_def=not_defined
+Choices=nl_template_class_def\s*=\s*ignore|nl_template_class_def\s*=\s*add|nl_template_class_def\s*=\s*remove|nl_template_class_def\s*=\s*force|nl_template_class_def\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class Def|Add Nl Template Class Def|Remove Nl Template Class Def|Force Nl Template Class Def"
 ValueDefault=ignore
 
@@ -4228,7 +4229,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized class definition.<br/><br/>Overrides nl_template_class_def.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class_def_special=ignore|nl_template_class_def_special=add|nl_template_class_def_special=remove|nl_template_class_def_special=force|nl_template_class_def_special=not_defined
+Choices=nl_template_class_def_special\s*=\s*ignore|nl_template_class_def_special\s*=\s*add|nl_template_class_def_special\s*=\s*remove|nl_template_class_def_special\s*=\s*force|nl_template_class_def_special\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class Def Special|Add Nl Template Class Def Special|Remove Nl Template Class Def Special|Force Nl Template Class Def Special"
 ValueDefault=ignore
 
@@ -4237,7 +4238,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template function.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func=ignore|nl_template_func=add|nl_template_func=remove|nl_template_func=force|nl_template_func=not_defined
+Choices=nl_template_func\s*=\s*ignore|nl_template_func\s*=\s*add|nl_template_func\s*=\s*remove|nl_template_func\s*=\s*force|nl_template_func\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func|Add Nl Template Func|Remove Nl Template Func|Force Nl Template Func"
 ValueDefault=ignore
 
@@ -4246,7 +4247,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template function<br/>declaration.<br/><br/>Overrides nl_template_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func_decl=ignore|nl_template_func_decl=add|nl_template_func_decl=remove|nl_template_func_decl=force|nl_template_func_decl=not_defined
+Choices=nl_template_func_decl\s*=\s*ignore|nl_template_func_decl\s*=\s*add|nl_template_func_decl\s*=\s*remove|nl_template_func_decl\s*=\s*force|nl_template_func_decl\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func Decl|Add Nl Template Func Decl|Remove Nl Template Func Decl|Force Nl Template Func Decl"
 ValueDefault=ignore
 
@@ -4255,7 +4256,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized function<br/>declaration.<br/><br/>Overrides nl_template_func_decl.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func_decl_special=ignore|nl_template_func_decl_special=add|nl_template_func_decl_special=remove|nl_template_func_decl_special=force|nl_template_func_decl_special=not_defined
+Choices=nl_template_func_decl_special\s*=\s*ignore|nl_template_func_decl_special\s*=\s*add|nl_template_func_decl_special\s*=\s*remove|nl_template_func_decl_special\s*=\s*force|nl_template_func_decl_special\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func Decl Special|Add Nl Template Func Decl Special|Remove Nl Template Func Decl Special|Force Nl Template Func Decl Special"
 ValueDefault=ignore
 
@@ -4264,7 +4265,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template function<br/>definition.<br/><br/>Overrides nl_template_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func_def=ignore|nl_template_func_def=add|nl_template_func_def=remove|nl_template_func_def=force|nl_template_func_def=not_defined
+Choices=nl_template_func_def\s*=\s*ignore|nl_template_func_def\s*=\s*add|nl_template_func_def\s*=\s*remove|nl_template_func_def\s*=\s*force|nl_template_func_def\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func Def|Add Nl Template Func Def|Remove Nl Template Func Def|Force Nl Template Func Def"
 ValueDefault=ignore
 
@@ -4273,7 +4274,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized function<br/>definition.<br/><br/>Overrides nl_template_func_def.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func_def_special=ignore|nl_template_func_def_special=add|nl_template_func_def_special=remove|nl_template_func_def_special=force|nl_template_func_def_special=not_defined
+Choices=nl_template_func_def_special\s*=\s*ignore|nl_template_func_def_special\s*=\s*add|nl_template_func_def_special\s*=\s*remove|nl_template_func_def_special\s*=\s*force|nl_template_func_def_special\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func Def Special|Add Nl Template Func Def Special|Remove Nl Template Func Def Special|Force Nl Template Func Def Special"
 ValueDefault=ignore
 
@@ -4282,7 +4283,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template variable.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_var=ignore|nl_template_var=add|nl_template_var=remove|nl_template_var=force|nl_template_var=not_defined
+Choices=nl_template_var\s*=\s*ignore|nl_template_var\s*=\s*add|nl_template_var\s*=\s*remove|nl_template_var\s*=\s*force|nl_template_var\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Var|Add Nl Template Var|Remove Nl Template Var|Force Nl Template Var"
 ValueDefault=ignore
 
@@ -4291,7 +4292,7 @@ Category=3
 Description="<html>Add or remove newline between 'template&lt;...&gt;' and 'using' of a templated<br/>type alias.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_using=ignore|nl_template_using=add|nl_template_using=remove|nl_template_using=force|nl_template_using=not_defined
+Choices=nl_template_using\s*=\s*ignore|nl_template_using\s*=\s*add|nl_template_using\s*=\s*remove|nl_template_using\s*=\s*force|nl_template_using\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Using|Add Nl Template Using|Remove Nl Template Using|Force Nl Template Using"
 ValueDefault=ignore
 
@@ -4300,7 +4301,7 @@ Category=3
 Description="<html>Add or remove newline between 'class' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_class_brace=ignore|nl_class_brace=add|nl_class_brace=remove|nl_class_brace=force|nl_class_brace=not_defined
+Choices=nl_class_brace\s*=\s*ignore|nl_class_brace\s*=\s*add|nl_class_brace\s*=\s*remove|nl_class_brace\s*=\s*force|nl_class_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Class Brace|Add Nl Class Brace|Remove Nl Class Brace|Force Nl Class Brace"
 ValueDefault=ignore
 
@@ -4309,7 +4310,7 @@ Category=3
 Description="<html>Add or remove newline before or after (depending on pos_class_comma,<br/>may not be IGNORE) each',' in the base class list.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_class_init_args=ignore|nl_class_init_args=add|nl_class_init_args=remove|nl_class_init_args=force|nl_class_init_args=not_defined
+Choices=nl_class_init_args\s*=\s*ignore|nl_class_init_args\s*=\s*add|nl_class_init_args\s*=\s*remove|nl_class_init_args\s*=\s*force|nl_class_init_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Class Init Args|Add Nl Class Init Args|Remove Nl Class Init Args|Force Nl Class Init Args"
 ValueDefault=ignore
 
@@ -4318,7 +4319,7 @@ Category=3
 Description="<html>Add or remove newline after each ',' in the constructor member<br/>initialization. Related to nl_constr_colon, pos_constr_colon and<br/>pos_constr_comma.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_constr_init_args=ignore|nl_constr_init_args=add|nl_constr_init_args=remove|nl_constr_init_args=force|nl_constr_init_args=not_defined
+Choices=nl_constr_init_args\s*=\s*ignore|nl_constr_init_args\s*=\s*add|nl_constr_init_args\s*=\s*remove|nl_constr_init_args\s*=\s*force|nl_constr_init_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Constr Init Args|Add Nl Constr Init Args|Remove Nl Constr Init Args|Force Nl Constr Init Args"
 ValueDefault=ignore
 
@@ -4327,7 +4328,7 @@ Category=3
 Description="<html>Add or remove newline before first element, after comma, and after last<br/>element, in 'enum'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_own_lines=ignore|nl_enum_own_lines=add|nl_enum_own_lines=remove|nl_enum_own_lines=force|nl_enum_own_lines=not_defined
+Choices=nl_enum_own_lines\s*=\s*ignore|nl_enum_own_lines\s*=\s*add|nl_enum_own_lines\s*=\s*remove|nl_enum_own_lines\s*=\s*force|nl_enum_own_lines\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Own Lines|Add Nl Enum Own Lines|Remove Nl Enum Own Lines|Force Nl Enum Own Lines"
 ValueDefault=ignore
 
@@ -4336,7 +4337,7 @@ Category=3
 Description="<html>Add or remove newline between return type and function name in a function<br/>definition.<br/>might be modified by nl_func_leave_one_liners</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_type_name=ignore|nl_func_type_name=add|nl_func_type_name=remove|nl_func_type_name=force|nl_func_type_name=not_defined
+Choices=nl_func_type_name\s*=\s*ignore|nl_func_type_name\s*=\s*add|nl_func_type_name\s*=\s*remove|nl_func_type_name\s*=\s*force|nl_func_type_name\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Type Name|Add Nl Func Type Name|Remove Nl Func Type Name|Force Nl Func Type Name"
 ValueDefault=ignore
 
@@ -4345,7 +4346,7 @@ Category=3
 Description="<html>Add or remove newline between return type and function name inside a class<br/>definition. If set to ignore, nl_func_type_name or nl_func_proto_type_name<br/>is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_type_name_class=ignore|nl_func_type_name_class=add|nl_func_type_name_class=remove|nl_func_type_name_class=force|nl_func_type_name_class=not_defined
+Choices=nl_func_type_name_class\s*=\s*ignore|nl_func_type_name_class\s*=\s*add|nl_func_type_name_class\s*=\s*remove|nl_func_type_name_class\s*=\s*force|nl_func_type_name_class\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Type Name Class|Add Nl Func Type Name Class|Remove Nl Func Type Name Class|Force Nl Func Type Name Class"
 ValueDefault=ignore
 
@@ -4354,7 +4355,7 @@ Category=3
 Description="<html>Add or remove newline between class specification and '::'<br/>in 'void A::f() { }'. Only appears in separate member implementation (does<br/>not appear with in-line implementation).</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_class_scope=ignore|nl_func_class_scope=add|nl_func_class_scope=remove|nl_func_class_scope=force|nl_func_class_scope=not_defined
+Choices=nl_func_class_scope\s*=\s*ignore|nl_func_class_scope\s*=\s*add|nl_func_class_scope\s*=\s*remove|nl_func_class_scope\s*=\s*force|nl_func_class_scope\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Class Scope|Add Nl Func Class Scope|Remove Nl Func Class Scope|Force Nl Func Class Scope"
 ValueDefault=ignore
 
@@ -4363,7 +4364,7 @@ Category=3
 Description="<html>Add or remove newline between function scope and name, as in<br/>'void A :: &lt;here&gt; f() { }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_scope_name=ignore|nl_func_scope_name=add|nl_func_scope_name=remove|nl_func_scope_name=force|nl_func_scope_name=not_defined
+Choices=nl_func_scope_name\s*=\s*ignore|nl_func_scope_name\s*=\s*add|nl_func_scope_name\s*=\s*remove|nl_func_scope_name\s*=\s*force|nl_func_scope_name\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Scope Name|Add Nl Func Scope Name|Remove Nl Func Scope Name|Force Nl Func Scope Name"
 ValueDefault=ignore
 
@@ -4372,7 +4373,7 @@ Category=3
 Description="<html>Add or remove newline between return type and function name in a prototype.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_proto_type_name=ignore|nl_func_proto_type_name=add|nl_func_proto_type_name=remove|nl_func_proto_type_name=force|nl_func_proto_type_name=not_defined
+Choices=nl_func_proto_type_name\s*=\s*ignore|nl_func_proto_type_name\s*=\s*add|nl_func_proto_type_name\s*=\s*remove|nl_func_proto_type_name\s*=\s*force|nl_func_proto_type_name\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Proto Type Name|Add Nl Func Proto Type Name|Remove Nl Func Proto Type Name|Force Nl Func Proto Type Name"
 ValueDefault=ignore
 
@@ -4381,7 +4382,7 @@ Category=3
 Description="<html>Add or remove newline between a function name and the opening '(' in the<br/>declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_paren=ignore|nl_func_paren=add|nl_func_paren=remove|nl_func_paren=force|nl_func_paren=not_defined
+Choices=nl_func_paren\s*=\s*ignore|nl_func_paren\s*=\s*add|nl_func_paren\s*=\s*remove|nl_func_paren\s*=\s*force|nl_func_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Paren|Add Nl Func Paren|Remove Nl Func Paren|Force Nl Func Paren"
 ValueDefault=ignore
 
@@ -4390,7 +4391,7 @@ Category=3
 Description="<html>Overrides nl_func_paren for functions with no parameters.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_paren_empty=ignore|nl_func_paren_empty=add|nl_func_paren_empty=remove|nl_func_paren_empty=force|nl_func_paren_empty=not_defined
+Choices=nl_func_paren_empty\s*=\s*ignore|nl_func_paren_empty\s*=\s*add|nl_func_paren_empty\s*=\s*remove|nl_func_paren_empty\s*=\s*force|nl_func_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Paren Empty|Add Nl Func Paren Empty|Remove Nl Func Paren Empty|Force Nl Func Paren Empty"
 ValueDefault=ignore
 
@@ -4399,7 +4400,7 @@ Category=3
 Description="<html>Add or remove newline between a function name and the opening '(' in the<br/>definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_paren=ignore|nl_func_def_paren=add|nl_func_def_paren=remove|nl_func_def_paren=force|nl_func_def_paren=not_defined
+Choices=nl_func_def_paren\s*=\s*ignore|nl_func_def_paren\s*=\s*add|nl_func_def_paren\s*=\s*remove|nl_func_def_paren\s*=\s*force|nl_func_def_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Paren|Add Nl Func Def Paren|Remove Nl Func Def Paren|Force Nl Func Def Paren"
 ValueDefault=ignore
 
@@ -4408,7 +4409,7 @@ Category=3
 Description="<html>Overrides nl_func_def_paren for functions with no parameters.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_paren_empty=ignore|nl_func_def_paren_empty=add|nl_func_def_paren_empty=remove|nl_func_def_paren_empty=force|nl_func_def_paren_empty=not_defined
+Choices=nl_func_def_paren_empty\s*=\s*ignore|nl_func_def_paren_empty\s*=\s*add|nl_func_def_paren_empty\s*=\s*remove|nl_func_def_paren_empty\s*=\s*force|nl_func_def_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Paren Empty|Add Nl Func Def Paren Empty|Remove Nl Func Def Paren Empty|Force Nl Func Def Paren Empty"
 ValueDefault=ignore
 
@@ -4417,7 +4418,7 @@ Category=3
 Description="<html>Add or remove newline between a function name and the opening '(' in the<br/>call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_paren=ignore|nl_func_call_paren=add|nl_func_call_paren=remove|nl_func_call_paren=force|nl_func_call_paren=not_defined
+Choices=nl_func_call_paren\s*=\s*ignore|nl_func_call_paren\s*=\s*add|nl_func_call_paren\s*=\s*remove|nl_func_call_paren\s*=\s*force|nl_func_call_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Paren|Add Nl Func Call Paren|Remove Nl Func Call Paren|Force Nl Func Call Paren"
 ValueDefault=ignore
 
@@ -4426,7 +4427,7 @@ Category=3
 Description="<html>Overrides nl_func_call_paren for functions with no parameters.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_paren_empty=ignore|nl_func_call_paren_empty=add|nl_func_call_paren_empty=remove|nl_func_call_paren_empty=force|nl_func_call_paren_empty=not_defined
+Choices=nl_func_call_paren_empty\s*=\s*ignore|nl_func_call_paren_empty\s*=\s*add|nl_func_call_paren_empty\s*=\s*remove|nl_func_call_paren_empty\s*=\s*force|nl_func_call_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Paren Empty|Add Nl Func Call Paren Empty|Remove Nl Func Call Paren Empty|Force Nl Func Call Paren Empty"
 ValueDefault=ignore
 
@@ -4435,7 +4436,7 @@ Category=3
 Description="<html>Add or remove newline after '(' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_start=ignore|nl_func_decl_start=add|nl_func_decl_start=remove|nl_func_decl_start=force|nl_func_decl_start=not_defined
+Choices=nl_func_decl_start\s*=\s*ignore|nl_func_decl_start\s*=\s*add|nl_func_decl_start\s*=\s*remove|nl_func_decl_start\s*=\s*force|nl_func_decl_start\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl Start|Add Nl Func Decl Start|Remove Nl Func Decl Start|Force Nl Func Decl Start"
 ValueDefault=ignore
 
@@ -4444,7 +4445,7 @@ Category=3
 Description="<html>Add or remove newline after '(' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_start=ignore|nl_func_def_start=add|nl_func_def_start=remove|nl_func_def_start=force|nl_func_def_start=not_defined
+Choices=nl_func_def_start\s*=\s*ignore|nl_func_def_start\s*=\s*add|nl_func_def_start\s*=\s*remove|nl_func_def_start\s*=\s*force|nl_func_def_start\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Start|Add Nl Func Def Start|Remove Nl Func Def Start|Force Nl Func Def Start"
 ValueDefault=ignore
 
@@ -4453,7 +4454,7 @@ Category=3
 Description="<html>Overrides nl_func_decl_start when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_start_single=ignore|nl_func_decl_start_single=add|nl_func_decl_start_single=remove|nl_func_decl_start_single=force|nl_func_decl_start_single=not_defined
+Choices=nl_func_decl_start_single\s*=\s*ignore|nl_func_decl_start_single\s*=\s*add|nl_func_decl_start_single\s*=\s*remove|nl_func_decl_start_single\s*=\s*force|nl_func_decl_start_single\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl Start Single|Add Nl Func Decl Start Single|Remove Nl Func Decl Start Single|Force Nl Func Decl Start Single"
 ValueDefault=ignore
 
@@ -4462,7 +4463,7 @@ Category=3
 Description="<html>Overrides nl_func_def_start when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_start_single=ignore|nl_func_def_start_single=add|nl_func_def_start_single=remove|nl_func_def_start_single=force|nl_func_def_start_single=not_defined
+Choices=nl_func_def_start_single\s*=\s*ignore|nl_func_def_start_single\s*=\s*add|nl_func_def_start_single\s*=\s*remove|nl_func_def_start_single\s*=\s*force|nl_func_def_start_single\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Start Single|Add Nl Func Def Start Single|Remove Nl Func Def Start Single|Force Nl Func Def Start Single"
 ValueDefault=ignore
 
@@ -4471,7 +4472,7 @@ Category=3
 Description="<html>Whether to add a newline after '(' in a function declaration if '(' and ')'<br/>are in different lines. If false, nl_func_decl_start is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_decl_start_multi_line=true|nl_func_decl_start_multi_line=false
+TrueFalse=nl_func_decl_start_multi_line\s*=\s*true|nl_func_decl_start_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Def Start Multi Line]
@@ -4479,7 +4480,7 @@ Category=3
 Description="<html>Whether to add a newline after '(' in a function definition if '(' and ')'<br/>are in different lines. If false, nl_func_def_start is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_def_start_multi_line=true|nl_func_def_start_multi_line=false
+TrueFalse=nl_func_def_start_multi_line\s*=\s*true|nl_func_def_start_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Decl Args]
@@ -4487,7 +4488,7 @@ Category=3
 Description="<html>Add or remove newline after each ',' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_args=ignore|nl_func_decl_args=add|nl_func_decl_args=remove|nl_func_decl_args=force|nl_func_decl_args=not_defined
+Choices=nl_func_decl_args\s*=\s*ignore|nl_func_decl_args\s*=\s*add|nl_func_decl_args\s*=\s*remove|nl_func_decl_args\s*=\s*force|nl_func_decl_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl Args|Add Nl Func Decl Args|Remove Nl Func Decl Args|Force Nl Func Decl Args"
 ValueDefault=ignore
 
@@ -4496,7 +4497,7 @@ Category=3
 Description="<html>Add or remove newline after each ',' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_args=ignore|nl_func_def_args=add|nl_func_def_args=remove|nl_func_def_args=force|nl_func_def_args=not_defined
+Choices=nl_func_def_args\s*=\s*ignore|nl_func_def_args\s*=\s*add|nl_func_def_args\s*=\s*remove|nl_func_def_args\s*=\s*force|nl_func_def_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Args|Add Nl Func Def Args|Remove Nl Func Def Args|Force Nl Func Def Args"
 ValueDefault=ignore
 
@@ -4505,7 +4506,7 @@ Category=3
 Description="<html>Add or remove newline after each ',' in a function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_args=ignore|nl_func_call_args=add|nl_func_call_args=remove|nl_func_call_args=force|nl_func_call_args=not_defined
+Choices=nl_func_call_args\s*=\s*ignore|nl_func_call_args\s*=\s*add|nl_func_call_args\s*=\s*remove|nl_func_call_args\s*=\s*force|nl_func_call_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Args|Add Nl Func Call Args|Remove Nl Func Call Args|Force Nl Func Call Args"
 ValueDefault=ignore
 
@@ -4514,7 +4515,7 @@ Category=3
 Description="<html>Whether to add a newline after each ',' in a function declaration if '('<br/>and ')' are in different lines. If false, nl_func_decl_args is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_decl_args_multi_line=true|nl_func_decl_args_multi_line=false
+TrueFalse=nl_func_decl_args_multi_line\s*=\s*true|nl_func_decl_args_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Def Args Multi Line]
@@ -4522,7 +4523,7 @@ Category=3
 Description="<html>Whether to add a newline after each ',' in a function definition if '('<br/>and ')' are in different lines. If false, nl_func_def_args is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_def_args_multi_line=true|nl_func_def_args_multi_line=false
+TrueFalse=nl_func_def_args_multi_line\s*=\s*true|nl_func_def_args_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Decl End]
@@ -4530,7 +4531,7 @@ Category=3
 Description="<html>Add or remove newline before the ')' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_end=ignore|nl_func_decl_end=add|nl_func_decl_end=remove|nl_func_decl_end=force|nl_func_decl_end=not_defined
+Choices=nl_func_decl_end\s*=\s*ignore|nl_func_decl_end\s*=\s*add|nl_func_decl_end\s*=\s*remove|nl_func_decl_end\s*=\s*force|nl_func_decl_end\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl End|Add Nl Func Decl End|Remove Nl Func Decl End|Force Nl Func Decl End"
 ValueDefault=ignore
 
@@ -4539,7 +4540,7 @@ Category=3
 Description="<html>Add or remove newline before the ')' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_end=ignore|nl_func_def_end=add|nl_func_def_end=remove|nl_func_def_end=force|nl_func_def_end=not_defined
+Choices=nl_func_def_end\s*=\s*ignore|nl_func_def_end\s*=\s*add|nl_func_def_end\s*=\s*remove|nl_func_def_end\s*=\s*force|nl_func_def_end\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def End|Add Nl Func Def End|Remove Nl Func Def End|Force Nl Func Def End"
 ValueDefault=ignore
 
@@ -4548,7 +4549,7 @@ Category=3
 Description="<html>Overrides nl_func_decl_end when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_end_single=ignore|nl_func_decl_end_single=add|nl_func_decl_end_single=remove|nl_func_decl_end_single=force|nl_func_decl_end_single=not_defined
+Choices=nl_func_decl_end_single\s*=\s*ignore|nl_func_decl_end_single\s*=\s*add|nl_func_decl_end_single\s*=\s*remove|nl_func_decl_end_single\s*=\s*force|nl_func_decl_end_single\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl End Single|Add Nl Func Decl End Single|Remove Nl Func Decl End Single|Force Nl Func Decl End Single"
 ValueDefault=ignore
 
@@ -4557,7 +4558,7 @@ Category=3
 Description="<html>Overrides nl_func_def_end when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_end_single=ignore|nl_func_def_end_single=add|nl_func_def_end_single=remove|nl_func_def_end_single=force|nl_func_def_end_single=not_defined
+Choices=nl_func_def_end_single\s*=\s*ignore|nl_func_def_end_single\s*=\s*add|nl_func_def_end_single\s*=\s*remove|nl_func_def_end_single\s*=\s*force|nl_func_def_end_single\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def End Single|Add Nl Func Def End Single|Remove Nl Func Def End Single|Force Nl Func Def End Single"
 ValueDefault=ignore
 
@@ -4566,7 +4567,7 @@ Category=3
 Description="<html>Whether to add a newline before ')' in a function declaration if '(' and ')'<br/>are in different lines. If false, nl_func_decl_end is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_decl_end_multi_line=true|nl_func_decl_end_multi_line=false
+TrueFalse=nl_func_decl_end_multi_line\s*=\s*true|nl_func_decl_end_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Def End Multi Line]
@@ -4574,7 +4575,7 @@ Category=3
 Description="<html>Whether to add a newline before ')' in a function definition if '(' and ')'<br/>are in different lines. If false, nl_func_def_end is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_def_end_multi_line=true|nl_func_def_end_multi_line=false
+TrueFalse=nl_func_def_end_multi_line\s*=\s*true|nl_func_def_end_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Decl Empty]
@@ -4582,7 +4583,7 @@ Category=3
 Description="<html>Add or remove newline between '()' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_empty=ignore|nl_func_decl_empty=add|nl_func_decl_empty=remove|nl_func_decl_empty=force|nl_func_decl_empty=not_defined
+Choices=nl_func_decl_empty\s*=\s*ignore|nl_func_decl_empty\s*=\s*add|nl_func_decl_empty\s*=\s*remove|nl_func_decl_empty\s*=\s*force|nl_func_decl_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl Empty|Add Nl Func Decl Empty|Remove Nl Func Decl Empty|Force Nl Func Decl Empty"
 ValueDefault=ignore
 
@@ -4591,7 +4592,7 @@ Category=3
 Description="<html>Add or remove newline between '()' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_empty=ignore|nl_func_def_empty=add|nl_func_def_empty=remove|nl_func_def_empty=force|nl_func_def_empty=not_defined
+Choices=nl_func_def_empty\s*=\s*ignore|nl_func_def_empty\s*=\s*add|nl_func_def_empty\s*=\s*remove|nl_func_def_empty\s*=\s*force|nl_func_def_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Empty|Add Nl Func Def Empty|Remove Nl Func Def Empty|Force Nl Func Def Empty"
 ValueDefault=ignore
 
@@ -4600,7 +4601,7 @@ Category=3
 Description="<html>Add or remove newline between '()' in a function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_empty=ignore|nl_func_call_empty=add|nl_func_call_empty=remove|nl_func_call_empty=force|nl_func_call_empty=not_defined
+Choices=nl_func_call_empty\s*=\s*ignore|nl_func_call_empty\s*=\s*add|nl_func_call_empty\s*=\s*remove|nl_func_call_empty\s*=\s*force|nl_func_call_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Empty|Add Nl Func Call Empty|Remove Nl Func Call Empty|Force Nl Func Call Empty"
 ValueDefault=ignore
 
@@ -4609,7 +4610,7 @@ Category=3
 Description="<html>Whether to add a newline after '(' in a function call,<br/>has preference over nl_func_call_start_multi_line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_start=ignore|nl_func_call_start=add|nl_func_call_start=remove|nl_func_call_start=force|nl_func_call_start=not_defined
+Choices=nl_func_call_start\s*=\s*ignore|nl_func_call_start\s*=\s*add|nl_func_call_start\s*=\s*remove|nl_func_call_start\s*=\s*force|nl_func_call_start\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Start|Add Nl Func Call Start|Remove Nl Func Call Start|Force Nl Func Call Start"
 ValueDefault=ignore
 
@@ -4618,7 +4619,7 @@ Category=3
 Description="<html>Whether to add a newline before ')' in a function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_end=ignore|nl_func_call_end=add|nl_func_call_end=remove|nl_func_call_end=force|nl_func_call_end=not_defined
+Choices=nl_func_call_end\s*=\s*ignore|nl_func_call_end\s*=\s*add|nl_func_call_end\s*=\s*remove|nl_func_call_end\s*=\s*force|nl_func_call_end\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call End|Add Nl Func Call End|Remove Nl Func Call End|Force Nl Func Call End"
 ValueDefault=ignore
 
@@ -4627,7 +4628,7 @@ Category=3
 Description="<html>Whether to add a newline after '(' in a function call if '(' and ')' are in<br/>different lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_call_start_multi_line=true|nl_func_call_start_multi_line=false
+TrueFalse=nl_func_call_start_multi_line\s*=\s*true|nl_func_call_start_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Call Args Multi Line]
@@ -4635,7 +4636,7 @@ Category=3
 Description="<html>Whether to add a newline after each ',' in a function call if '(' and ')'<br/>are in different lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_call_args_multi_line=true|nl_func_call_args_multi_line=false
+TrueFalse=nl_func_call_args_multi_line\s*=\s*true|nl_func_call_args_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Call End Multi Line]
@@ -4643,7 +4644,7 @@ Category=3
 Description="<html>Whether to add a newline before ')' in a function call if '(' and ')' are in<br/>different lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_call_end_multi_line=true|nl_func_call_end_multi_line=false
+TrueFalse=nl_func_call_end_multi_line\s*=\s*true|nl_func_call_end_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Call Args Multi Line Ignore Closures]
@@ -4651,7 +4652,7 @@ Category=3
 Description="<html>Whether to respect nl_func_call_XXX option in case of closure args.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_call_args_multi_line_ignore_closures=true|nl_func_call_args_multi_line_ignore_closures=false
+TrueFalse=nl_func_call_args_multi_line_ignore_closures\s*=\s*true|nl_func_call_args_multi_line_ignore_closures\s*=\s*false
 ValueDefault=false
 
 [Nl Template Start]
@@ -4659,7 +4660,7 @@ Category=3
 Description="<html>Whether to add a newline after '&lt;' of a template parameter list.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_template_start=true|nl_template_start=false
+TrueFalse=nl_template_start\s*=\s*true|nl_template_start\s*=\s*false
 ValueDefault=false
 
 [Nl Template Args]
@@ -4667,7 +4668,7 @@ Category=3
 Description="<html>Whether to add a newline after each ',' in a template parameter list.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_template_args=true|nl_template_args=false
+TrueFalse=nl_template_args\s*=\s*true|nl_template_args\s*=\s*false
 ValueDefault=false
 
 [Nl Template End]
@@ -4675,7 +4676,7 @@ Category=3
 Description="<html>Whether to add a newline before '&gt;' of a template parameter list.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_template_end=true|nl_template_end=false
+TrueFalse=nl_template_end\s*=\s*true|nl_template_end\s*=\s*false
 ValueDefault=false
 
 [Nl Oc Msg Args]
@@ -4683,7 +4684,7 @@ Category=3
 Description="<html>(OC) Whether to put each Objective-C message parameter on a separate line.<br/>See nl_oc_msg_leave_one_liner.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_oc_msg_args=true|nl_oc_msg_args=false
+TrueFalse=nl_oc_msg_args\s*=\s*true|nl_oc_msg_args\s*=\s*false
 ValueDefault=false
 
 [Nl Oc Msg Args Min Params]
@@ -4691,7 +4692,7 @@ Category=3
 Description="<html>(OC) Minimum number of Objective-C message parameters before applying nl_oc_msg_args.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_oc_msg_args_min_params="
+CallName="nl_oc_msg_args_min_params\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -4701,7 +4702,7 @@ Category=3
 Description="<html>(OC) Max code width of Objective-C message before applying nl_oc_msg_args.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_oc_msg_args_max_code_width="
+CallName="nl_oc_msg_args_max_code_width\s*=\s*"
 MinVal=0
 MaxVal=10000
 ValueDefault=0
@@ -4711,7 +4712,7 @@ Category=3
 Description="<html>Add or remove newline between function signature and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_fdef_brace=ignore|nl_fdef_brace=add|nl_fdef_brace=remove|nl_fdef_brace=force|nl_fdef_brace=not_defined
+Choices=nl_fdef_brace\s*=\s*ignore|nl_fdef_brace\s*=\s*add|nl_fdef_brace\s*=\s*remove|nl_fdef_brace\s*=\s*force|nl_fdef_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Fdef Brace|Add Nl Fdef Brace|Remove Nl Fdef Brace|Force Nl Fdef Brace"
 ValueDefault=ignore
 
@@ -4720,7 +4721,7 @@ Category=3
 Description="<html>Add or remove newline between function signature and '{',<br/>if signature ends with ')'. Overrides nl_fdef_brace.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_fdef_brace_cond=ignore|nl_fdef_brace_cond=add|nl_fdef_brace_cond=remove|nl_fdef_brace_cond=force|nl_fdef_brace_cond=not_defined
+Choices=nl_fdef_brace_cond\s*=\s*ignore|nl_fdef_brace_cond\s*=\s*add|nl_fdef_brace_cond\s*=\s*remove|nl_fdef_brace_cond\s*=\s*force|nl_fdef_brace_cond\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Fdef Brace Cond|Add Nl Fdef Brace Cond|Remove Nl Fdef Brace Cond|Force Nl Fdef Brace Cond"
 ValueDefault=ignore
 
@@ -4729,7 +4730,7 @@ Category=3
 Description="<html>Add or remove newline between C++11 lambda signature and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_cpp_ldef_brace=ignore|nl_cpp_ldef_brace=add|nl_cpp_ldef_brace=remove|nl_cpp_ldef_brace=force|nl_cpp_ldef_brace=not_defined
+Choices=nl_cpp_ldef_brace\s*=\s*ignore|nl_cpp_ldef_brace\s*=\s*add|nl_cpp_ldef_brace\s*=\s*remove|nl_cpp_ldef_brace\s*=\s*force|nl_cpp_ldef_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Cpp Ldef Brace|Add Nl Cpp Ldef Brace|Remove Nl Cpp Ldef Brace|Force Nl Cpp Ldef Brace"
 ValueDefault=ignore
 
@@ -4738,7 +4739,7 @@ Category=3
 Description="<html>Add or remove newline between 'return' and the return expression.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_return_expr=ignore|nl_return_expr=add|nl_return_expr=remove|nl_return_expr=force|nl_return_expr=not_defined
+Choices=nl_return_expr\s*=\s*ignore|nl_return_expr\s*=\s*add|nl_return_expr\s*=\s*remove|nl_return_expr\s*=\s*force|nl_return_expr\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Return Expr|Add Nl Return Expr|Remove Nl Return Expr|Force Nl Return Expr"
 ValueDefault=ignore
 
@@ -4747,7 +4748,7 @@ Category=3
 Description="<html>Add or remove newline between 'throw' and the throw expression.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_throw_expr=ignore|nl_throw_expr=add|nl_throw_expr=remove|nl_throw_expr=force|nl_throw_expr=not_defined
+Choices=nl_throw_expr\s*=\s*ignore|nl_throw_expr\s*=\s*add|nl_throw_expr\s*=\s*remove|nl_throw_expr\s*=\s*force|nl_throw_expr\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Throw Expr|Add Nl Throw Expr|Remove Nl Throw Expr|Force Nl Throw Expr"
 ValueDefault=ignore
 
@@ -4756,7 +4757,7 @@ Category=3
 Description="<html>Whether to add a newline after semicolons, except in 'for' statements.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_semicolon=true|nl_after_semicolon=false
+TrueFalse=nl_after_semicolon\s*=\s*true|nl_after_semicolon\s*=\s*false
 ValueDefault=false
 
 [Nl Paren Dbrace Open]
@@ -4764,7 +4765,7 @@ Category=3
 Description="<html>(Java) Add or remove newline between the ')' and '{{' of the double brace<br/>initializer.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_paren_dbrace_open=ignore|nl_paren_dbrace_open=add|nl_paren_dbrace_open=remove|nl_paren_dbrace_open=force|nl_paren_dbrace_open=not_defined
+Choices=nl_paren_dbrace_open\s*=\s*ignore|nl_paren_dbrace_open\s*=\s*add|nl_paren_dbrace_open\s*=\s*remove|nl_paren_dbrace_open\s*=\s*force|nl_paren_dbrace_open\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Paren Dbrace Open|Add Nl Paren Dbrace Open|Remove Nl Paren Dbrace Open|Force Nl Paren Dbrace Open"
 ValueDefault=ignore
 
@@ -4773,7 +4774,7 @@ Category=3
 Description="<html>Whether to add a newline after the type in an unnamed temporary<br/>direct-list-initialization, better:<br/>before a direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_type_brace_init_lst=ignore|nl_type_brace_init_lst=add|nl_type_brace_init_lst=remove|nl_type_brace_init_lst=force|nl_type_brace_init_lst=not_defined
+Choices=nl_type_brace_init_lst\s*=\s*ignore|nl_type_brace_init_lst\s*=\s*add|nl_type_brace_init_lst\s*=\s*remove|nl_type_brace_init_lst\s*=\s*force|nl_type_brace_init_lst\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Type Brace Init Lst|Add Nl Type Brace Init Lst|Remove Nl Type Brace Init Lst|Force Nl Type Brace Init Lst"
 ValueDefault=ignore
 
@@ -4782,7 +4783,7 @@ Category=3
 Description="<html>Whether to add a newline after the open brace in an unnamed temporary<br/>direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_type_brace_init_lst_open=ignore|nl_type_brace_init_lst_open=add|nl_type_brace_init_lst_open=remove|nl_type_brace_init_lst_open=force|nl_type_brace_init_lst_open=not_defined
+Choices=nl_type_brace_init_lst_open\s*=\s*ignore|nl_type_brace_init_lst_open\s*=\s*add|nl_type_brace_init_lst_open\s*=\s*remove|nl_type_brace_init_lst_open\s*=\s*force|nl_type_brace_init_lst_open\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Type Brace Init Lst Open|Add Nl Type Brace Init Lst Open|Remove Nl Type Brace Init Lst Open|Force Nl Type Brace Init Lst Open"
 ValueDefault=ignore
 
@@ -4791,7 +4792,7 @@ Category=3
 Description="<html>Whether to add a newline before the close brace in an unnamed temporary<br/>direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_type_brace_init_lst_close=ignore|nl_type_brace_init_lst_close=add|nl_type_brace_init_lst_close=remove|nl_type_brace_init_lst_close=force|nl_type_brace_init_lst_close=not_defined
+Choices=nl_type_brace_init_lst_close\s*=\s*ignore|nl_type_brace_init_lst_close\s*=\s*add|nl_type_brace_init_lst_close\s*=\s*remove|nl_type_brace_init_lst_close\s*=\s*force|nl_type_brace_init_lst_close\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Type Brace Init Lst Close|Add Nl Type Brace Init Lst Close|Remove Nl Type Brace Init Lst Close|Force Nl Type Brace Init Lst Close"
 ValueDefault=ignore
 
@@ -4800,7 +4801,7 @@ Category=3
 Description="<html>Whether to add a newline before '{'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_before_brace_open=true|nl_before_brace_open=false
+TrueFalse=nl_before_brace_open\s*=\s*true|nl_before_brace_open\s*=\s*false
 ValueDefault=false
 
 [Nl After Brace Open]
@@ -4808,7 +4809,7 @@ Category=3
 Description="<html>Whether to add a newline after '{'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_brace_open=true|nl_after_brace_open=false
+TrueFalse=nl_after_brace_open\s*=\s*true|nl_after_brace_open\s*=\s*false
 ValueDefault=false
 
 [Nl After Brace Open Cmt]
@@ -4816,7 +4817,7 @@ Category=3
 Description="<html>Whether to add a newline between the open brace and a trailing single-line<br/>comment. Requires nl_after_brace_open=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_brace_open_cmt=true|nl_after_brace_open_cmt=false
+TrueFalse=nl_after_brace_open_cmt\s*=\s*true|nl_after_brace_open_cmt\s*=\s*false
 ValueDefault=false
 
 [Nl After Vbrace Open]
@@ -4824,7 +4825,7 @@ Category=3
 Description="<html>Whether to add a newline after a virtual brace open with a non-empty body.<br/>These occur in un-braced if/while/do/for statement bodies.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_vbrace_open=true|nl_after_vbrace_open=false
+TrueFalse=nl_after_vbrace_open\s*=\s*true|nl_after_vbrace_open\s*=\s*false
 ValueDefault=false
 
 [Nl After Vbrace Open Empty]
@@ -4832,7 +4833,7 @@ Category=3
 Description="<html>Whether to add a newline after a virtual brace open with an empty body.<br/>These occur in un-braced if/while/do/for statement bodies.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_vbrace_open_empty=true|nl_after_vbrace_open_empty=false
+TrueFalse=nl_after_vbrace_open_empty\s*=\s*true|nl_after_vbrace_open_empty\s*=\s*false
 ValueDefault=false
 
 [Nl After Brace Close]
@@ -4840,7 +4841,7 @@ Category=3
 Description="<html>Whether to add a newline after '}'. Does not apply if followed by a<br/>necessary ';'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_brace_close=true|nl_after_brace_close=false
+TrueFalse=nl_after_brace_close\s*=\s*true|nl_after_brace_close\s*=\s*false
 ValueDefault=false
 
 [Nl After Vbrace Close]
@@ -4848,7 +4849,7 @@ Category=3
 Description="<html>Whether to add a newline after a virtual brace close,<br/>as in 'if (foo) a++; &lt;here&gt; return;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_vbrace_close=true|nl_after_vbrace_close=false
+TrueFalse=nl_after_vbrace_close\s*=\s*true|nl_after_vbrace_close\s*=\s*false
 ValueDefault=false
 
 [Nl Brace Struct Var]
@@ -4856,7 +4857,7 @@ Category=3
 Description="<html>Add or remove newline between the close brace and identifier,<br/>as in 'struct { int a; } &lt;here&gt; b;'. Affects enumerations, unions and<br/>structures. If set to ignore, uses nl_after_brace_close.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_struct_var=ignore|nl_brace_struct_var=add|nl_brace_struct_var=remove|nl_brace_struct_var=force|nl_brace_struct_var=not_defined
+Choices=nl_brace_struct_var\s*=\s*ignore|nl_brace_struct_var\s*=\s*add|nl_brace_struct_var\s*=\s*remove|nl_brace_struct_var\s*=\s*force|nl_brace_struct_var\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Struct Var|Add Nl Brace Struct Var|Remove Nl Brace Struct Var|Force Nl Brace Struct Var"
 ValueDefault=ignore
 
@@ -4865,7 +4866,7 @@ Category=3
 Description="<html>Whether to alter newlines in '#define' macros.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_define_macro=true|nl_define_macro=false
+TrueFalse=nl_define_macro\s*=\s*true|nl_define_macro\s*=\s*false
 ValueDefault=false
 
 [Nl Squeeze Paren Close]
@@ -4873,7 +4874,7 @@ Category=3
 Description="<html>Whether to alter newlines between consecutive parenthesis closes. The number<br/>of closing parentheses in a line will depend on respective open parenthesis<br/>lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_squeeze_paren_close=true|nl_squeeze_paren_close=false
+TrueFalse=nl_squeeze_paren_close\s*=\s*true|nl_squeeze_paren_close\s*=\s*false
 ValueDefault=false
 
 [Nl Squeeze Ifdef]
@@ -4881,7 +4882,7 @@ Category=3
 Description="<html>Whether to remove blanks after '#ifxx' and '#elxx', or before '#elxx' and<br/>'#endif'. Does not affect top-level #ifdefs.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_squeeze_ifdef=true|nl_squeeze_ifdef=false
+TrueFalse=nl_squeeze_ifdef\s*=\s*true|nl_squeeze_ifdef\s*=\s*false
 ValueDefault=false
 
 [Nl Squeeze Ifdef Top Level]
@@ -4889,7 +4890,7 @@ Category=3
 Description="<html>Makes the nl_squeeze_ifdef option affect the top-level #ifdefs as well.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_squeeze_ifdef_top_level=true|nl_squeeze_ifdef_top_level=false
+TrueFalse=nl_squeeze_ifdef_top_level\s*=\s*true|nl_squeeze_ifdef_top_level\s*=\s*false
 ValueDefault=false
 
 [Nl Before If]
@@ -4897,7 +4898,7 @@ Category=3
 Description="<html>Add or remove blank line before 'if'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_if=ignore|nl_before_if=add|nl_before_if=remove|nl_before_if=force|nl_before_if=not_defined
+Choices=nl_before_if\s*=\s*ignore|nl_before_if\s*=\s*add|nl_before_if\s*=\s*remove|nl_before_if\s*=\s*force|nl_before_if\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before If|Add Nl Before If|Remove Nl Before If|Force Nl Before If"
 ValueDefault=ignore
 
@@ -4906,7 +4907,7 @@ Category=3
 Description="<html>Add or remove blank line after 'if' statement. Add/Force work only if the<br/>next token is not a closing brace.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_if=ignore|nl_after_if=add|nl_after_if=remove|nl_after_if=force|nl_after_if=not_defined
+Choices=nl_after_if\s*=\s*ignore|nl_after_if\s*=\s*add|nl_after_if\s*=\s*remove|nl_after_if\s*=\s*force|nl_after_if\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After If|Add Nl After If|Remove Nl After If|Force Nl After If"
 ValueDefault=ignore
 
@@ -4915,7 +4916,7 @@ Category=3
 Description="<html>Add or remove blank line before 'for'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_for=ignore|nl_before_for=add|nl_before_for=remove|nl_before_for=force|nl_before_for=not_defined
+Choices=nl_before_for\s*=\s*ignore|nl_before_for\s*=\s*add|nl_before_for\s*=\s*remove|nl_before_for\s*=\s*force|nl_before_for\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before For|Add Nl Before For|Remove Nl Before For|Force Nl Before For"
 ValueDefault=ignore
 
@@ -4924,7 +4925,7 @@ Category=3
 Description="<html>Add or remove blank line after 'for' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_for=ignore|nl_after_for=add|nl_after_for=remove|nl_after_for=force|nl_after_for=not_defined
+Choices=nl_after_for\s*=\s*ignore|nl_after_for\s*=\s*add|nl_after_for\s*=\s*remove|nl_after_for\s*=\s*force|nl_after_for\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After For|Add Nl After For|Remove Nl After For|Force Nl After For"
 ValueDefault=ignore
 
@@ -4933,7 +4934,7 @@ Category=3
 Description="<html>Add or remove blank line before 'while'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_while=ignore|nl_before_while=add|nl_before_while=remove|nl_before_while=force|nl_before_while=not_defined
+Choices=nl_before_while\s*=\s*ignore|nl_before_while\s*=\s*add|nl_before_while\s*=\s*remove|nl_before_while\s*=\s*force|nl_before_while\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before While|Add Nl Before While|Remove Nl Before While|Force Nl Before While"
 ValueDefault=ignore
 
@@ -4942,7 +4943,7 @@ Category=3
 Description="<html>Add or remove blank line after 'while' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_while=ignore|nl_after_while=add|nl_after_while=remove|nl_after_while=force|nl_after_while=not_defined
+Choices=nl_after_while\s*=\s*ignore|nl_after_while\s*=\s*add|nl_after_while\s*=\s*remove|nl_after_while\s*=\s*force|nl_after_while\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After While|Add Nl After While|Remove Nl After While|Force Nl After While"
 ValueDefault=ignore
 
@@ -4951,7 +4952,7 @@ Category=3
 Description="<html>Add or remove blank line before 'switch'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_switch=ignore|nl_before_switch=add|nl_before_switch=remove|nl_before_switch=force|nl_before_switch=not_defined
+Choices=nl_before_switch\s*=\s*ignore|nl_before_switch\s*=\s*add|nl_before_switch\s*=\s*remove|nl_before_switch\s*=\s*force|nl_before_switch\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Switch|Add Nl Before Switch|Remove Nl Before Switch|Force Nl Before Switch"
 ValueDefault=ignore
 
@@ -4960,7 +4961,7 @@ Category=3
 Description="<html>Add or remove blank line after 'switch' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_switch=ignore|nl_after_switch=add|nl_after_switch=remove|nl_after_switch=force|nl_after_switch=not_defined
+Choices=nl_after_switch\s*=\s*ignore|nl_after_switch\s*=\s*add|nl_after_switch\s*=\s*remove|nl_after_switch\s*=\s*force|nl_after_switch\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Switch|Add Nl After Switch|Remove Nl After Switch|Force Nl After Switch"
 ValueDefault=ignore
 
@@ -4969,7 +4970,7 @@ Category=3
 Description="<html>Add or remove blank line before 'synchronized'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_synchronized=ignore|nl_before_synchronized=add|nl_before_synchronized=remove|nl_before_synchronized=force|nl_before_synchronized=not_defined
+Choices=nl_before_synchronized\s*=\s*ignore|nl_before_synchronized\s*=\s*add|nl_before_synchronized\s*=\s*remove|nl_before_synchronized\s*=\s*force|nl_before_synchronized\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Synchronized|Add Nl Before Synchronized|Remove Nl Before Synchronized|Force Nl Before Synchronized"
 ValueDefault=ignore
 
@@ -4978,7 +4979,7 @@ Category=3
 Description="<html>Add or remove blank line after 'synchronized' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_synchronized=ignore|nl_after_synchronized=add|nl_after_synchronized=remove|nl_after_synchronized=force|nl_after_synchronized=not_defined
+Choices=nl_after_synchronized\s*=\s*ignore|nl_after_synchronized\s*=\s*add|nl_after_synchronized\s*=\s*remove|nl_after_synchronized\s*=\s*force|nl_after_synchronized\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Synchronized|Add Nl After Synchronized|Remove Nl After Synchronized|Force Nl After Synchronized"
 ValueDefault=ignore
 
@@ -4987,7 +4988,7 @@ Category=3
 Description="<html>Add or remove blank line before 'do'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_do=ignore|nl_before_do=add|nl_before_do=remove|nl_before_do=force|nl_before_do=not_defined
+Choices=nl_before_do\s*=\s*ignore|nl_before_do\s*=\s*add|nl_before_do\s*=\s*remove|nl_before_do\s*=\s*force|nl_before_do\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Do|Add Nl Before Do|Remove Nl Before Do|Force Nl Before Do"
 ValueDefault=ignore
 
@@ -4996,7 +4997,7 @@ Category=3
 Description="<html>Add or remove blank line after 'do/while' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_do=ignore|nl_after_do=add|nl_after_do=remove|nl_after_do=force|nl_after_do=not_defined
+Choices=nl_after_do\s*=\s*ignore|nl_after_do\s*=\s*add|nl_after_do\s*=\s*remove|nl_after_do\s*=\s*force|nl_after_do\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Do|Add Nl After Do|Remove Nl After Do|Force Nl After Do"
 ValueDefault=ignore
 
@@ -5005,7 +5006,7 @@ Category=3
 Description="<html>Ignore nl_before_{if,for,switch,do,synchronized} if the control<br/>statement is immediately after a case statement.<br/>if nl_before_{if,for,switch,do} is set to remove, this option<br/>does nothing.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_before_ignore_after_case=true|nl_before_ignore_after_case=false
+TrueFalse=nl_before_ignore_after_case\s*=\s*true|nl_before_ignore_after_case\s*=\s*false
 ValueDefault=false
 
 [Nl Before Return]
@@ -5013,7 +5014,7 @@ Category=3
 Description="<html>Whether to put a blank line before 'return' statements, unless after an open<br/>brace.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_before_return=true|nl_before_return=false
+TrueFalse=nl_before_return\s*=\s*true|nl_before_return\s*=\s*false
 ValueDefault=false
 
 [Nl After Return]
@@ -5021,7 +5022,7 @@ Category=3
 Description="<html>Whether to put a blank line after 'return' statements, unless followed by a<br/>close brace.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_return=true|nl_after_return=false
+TrueFalse=nl_after_return\s*=\s*true|nl_after_return\s*=\s*false
 ValueDefault=false
 
 [Nl Before Member]
@@ -5029,7 +5030,7 @@ Category=3
 Description="<html>Whether to put a blank line before a member '.' or '-&gt;' operators.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_member=ignore|nl_before_member=add|nl_before_member=remove|nl_before_member=force|nl_before_member=not_defined
+Choices=nl_before_member\s*=\s*ignore|nl_before_member\s*=\s*add|nl_before_member\s*=\s*remove|nl_before_member\s*=\s*force|nl_before_member\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Member|Add Nl Before Member|Remove Nl Before Member|Force Nl Before Member"
 ValueDefault=ignore
 
@@ -5038,7 +5039,7 @@ Category=3
 Description="<html>(Java) Whether to put a blank line after a member '.' or '-&gt;' operators.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_member=ignore|nl_after_member=add|nl_after_member=remove|nl_after_member=force|nl_after_member=not_defined
+Choices=nl_after_member\s*=\s*ignore|nl_after_member\s*=\s*add|nl_after_member\s*=\s*remove|nl_after_member\s*=\s*force|nl_after_member\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Member|Add Nl After Member|Remove Nl After Member|Force Nl After Member"
 ValueDefault=ignore
 
@@ -5047,7 +5048,7 @@ Category=3
 Description="<html>Whether to double-space commented-entries in 'struct'/'union'/'enum'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_ds_struct_enum_cmt=true|nl_ds_struct_enum_cmt=false
+TrueFalse=nl_ds_struct_enum_cmt\s*=\s*true|nl_ds_struct_enum_cmt\s*=\s*false
 ValueDefault=false
 
 [Nl Ds Struct Enum Close Brace]
@@ -5055,7 +5056,7 @@ Category=3
 Description="<html>Whether to force a newline before '}' of a 'struct'/'union'/'enum'.<br/>(Lower priority than eat_blanks_before_close_brace.)</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_ds_struct_enum_close_brace=true|nl_ds_struct_enum_close_brace=false
+TrueFalse=nl_ds_struct_enum_close_brace\s*=\s*true|nl_ds_struct_enum_close_brace\s*=\s*false
 ValueDefault=false
 
 [Nl Class Colon]
@@ -5063,7 +5064,7 @@ Category=3
 Description="<html>Add or remove newline before or after (depending on pos_class_colon) a class<br/>colon, as in 'class Foo &lt;here&gt; : &lt;or here&gt; public Bar'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_class_colon=ignore|nl_class_colon=add|nl_class_colon=remove|nl_class_colon=force|nl_class_colon=not_defined
+Choices=nl_class_colon\s*=\s*ignore|nl_class_colon\s*=\s*add|nl_class_colon\s*=\s*remove|nl_class_colon\s*=\s*force|nl_class_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Class Colon|Add Nl Class Colon|Remove Nl Class Colon|Force Nl Class Colon"
 ValueDefault=ignore
 
@@ -5072,7 +5073,7 @@ Category=3
 Description="<html>Add or remove newline around a class constructor colon. The exact position<br/>depends on nl_constr_init_args, pos_constr_colon and pos_constr_comma.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_constr_colon=ignore|nl_constr_colon=add|nl_constr_colon=remove|nl_constr_colon=force|nl_constr_colon=not_defined
+Choices=nl_constr_colon\s*=\s*ignore|nl_constr_colon\s*=\s*add|nl_constr_colon\s*=\s*remove|nl_constr_colon\s*=\s*force|nl_constr_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Constr Colon|Add Nl Constr Colon|Remove Nl Constr Colon|Force Nl Constr Colon"
 ValueDefault=ignore
 
@@ -5081,7 +5082,7 @@ Category=3
 Description="<html>Whether to collapse a two-line namespace, like 'namespace foo\n{ decl; }'<br/>into a single line. If true, prevents other brace newline rules from turning<br/>such code into four lines. If true, it also preserves one-liner namespaces.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_namespace_two_to_one_liner=true|nl_namespace_two_to_one_liner=false
+TrueFalse=nl_namespace_two_to_one_liner\s*=\s*true|nl_namespace_two_to_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create If One Liner]
@@ -5089,7 +5090,7 @@ Category=3
 Description="<html>Whether to remove a newline in simple unbraced if statements, turning them<br/>into one-liners, as in 'if(b)\n i++;' =&gt; 'if(b) i++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_if_one_liner=true|nl_create_if_one_liner=false
+TrueFalse=nl_create_if_one_liner\s*=\s*true|nl_create_if_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create For One Liner]
@@ -5097,7 +5098,7 @@ Category=3
 Description="<html>Whether to remove a newline in simple unbraced for statements, turning them<br/>into one-liners, as in 'for (...)\n stmt;' =&gt; 'for (...) stmt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_for_one_liner=true|nl_create_for_one_liner=false
+TrueFalse=nl_create_for_one_liner\s*=\s*true|nl_create_for_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create While One Liner]
@@ -5105,7 +5106,7 @@ Category=3
 Description="<html>Whether to remove a newline in simple unbraced while statements, turning<br/>them into one-liners, as in 'while (expr)\n stmt;' =&gt; 'while (expr) stmt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_while_one_liner=true|nl_create_while_one_liner=false
+TrueFalse=nl_create_while_one_liner\s*=\s*true|nl_create_while_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create Func Def One Liner]
@@ -5113,7 +5114,7 @@ Category=3
 Description="<html>Whether to collapse a function definition whose body (not counting braces)<br/>is only one line so that the entire definition (prototype, braces, body) is<br/>a single line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_func_def_one_liner=true|nl_create_func_def_one_liner=false
+TrueFalse=nl_create_func_def_one_liner\s*=\s*true|nl_create_func_def_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create List One Liner]
@@ -5121,7 +5122,7 @@ Category=3
 Description="<html>Whether to split one-line simple list definitions into three lines by<br/>adding newlines, as in 'int a[12] = { &lt;here&gt; 0 &lt;here&gt; };'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_list_one_liner=true|nl_create_list_one_liner=false
+TrueFalse=nl_create_list_one_liner\s*=\s*true|nl_create_list_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Split If One Liner]
@@ -5129,7 +5130,7 @@ Category=3
 Description="<html>Whether to split one-line simple unbraced if statements into two lines by<br/>adding a newline, as in 'if(b) &lt;here&gt; i++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_split_if_one_liner=true|nl_split_if_one_liner=false
+TrueFalse=nl_split_if_one_liner\s*=\s*true|nl_split_if_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Split For One Liner]
@@ -5137,7 +5138,7 @@ Category=3
 Description="<html>Whether to split one-line simple unbraced for statements into two lines by<br/>adding a newline, as in 'for (...) &lt;here&gt; stmt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_split_for_one_liner=true|nl_split_for_one_liner=false
+TrueFalse=nl_split_for_one_liner\s*=\s*true|nl_split_for_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Split While One Liner]
@@ -5145,7 +5146,7 @@ Category=3
 Description="<html>Whether to split one-line simple unbraced while statements into two lines by<br/>adding a newline, as in 'while (expr) &lt;here&gt; stmt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_split_while_one_liner=true|nl_split_while_one_liner=false
+TrueFalse=nl_split_while_one_liner\s*=\s*true|nl_split_while_one_liner\s*=\s*false
 ValueDefault=false
 
 [Donot Add Nl Before Cpp Comment]
@@ -5153,7 +5154,7 @@ Category=3
 Description="<html>Don't add a newline before a cpp-comment in a parameter list of a function<br/>call.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=donot_add_nl_before_cpp_comment=true|donot_add_nl_before_cpp_comment=false
+TrueFalse=donot_add_nl_before_cpp_comment\s*=\s*true|donot_add_nl_before_cpp_comment\s*=\s*false
 ValueDefault=false
 
 [Nl Max]
@@ -5161,7 +5162,7 @@ Category=4
 Description="<html>The maximum number of consecutive newlines (3 = 2 blank lines).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_max="
+CallName="nl_max\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5171,7 +5172,7 @@ Category=4
 Description="<html>The maximum number of consecutive newlines in a function.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_max_blank_in_func="
+CallName="nl_max_blank_in_func\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5181,7 +5182,7 @@ Category=4
 Description="<html>The number of newlines inside an empty function body.<br/>This option overrides eat_blanks_after_open_brace and<br/>eat_blanks_before_close_brace, but is ignored when<br/>nl_collapse_empty_body_functions=true</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_inside_empty_func="
+CallName="nl_inside_empty_func\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5191,7 +5192,7 @@ Category=4
 Description="<html>The number of newlines before a function prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_func_body_proto="
+CallName="nl_before_func_body_proto\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5201,7 +5202,7 @@ Category=4
 Description="<html>The number of newlines before a multi-line function definition. Where<br/>applicable, this option is overridden with eat_blanks_after_open_brace=true</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_func_body_def="
+CallName="nl_before_func_body_def\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5211,7 +5212,7 @@ Category=4
 Description="<html>The number of newlines before a class constructor/destructor prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_func_class_proto="
+CallName="nl_before_func_class_proto\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5221,7 +5222,7 @@ Category=4
 Description="<html>The number of newlines before a class constructor/destructor definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_func_class_def="
+CallName="nl_before_func_class_def\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5231,7 +5232,7 @@ Category=4
 Description="<html>The number of newlines after a function prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_proto="
+CallName="nl_after_func_proto\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5241,7 +5242,7 @@ Category=4
 Description="<html>The number of newlines after a function prototype, if not followed by<br/>another function prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_proto_group="
+CallName="nl_after_func_proto_group\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5251,7 +5252,7 @@ Category=4
 Description="<html>The number of newlines after a class constructor/destructor prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_class_proto="
+CallName="nl_after_func_class_proto\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5261,7 +5262,7 @@ Category=4
 Description="<html>The number of newlines after a class constructor/destructor prototype,<br/>if not followed by another constructor/destructor prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_class_proto_group="
+CallName="nl_after_func_class_proto_group\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5271,7 +5272,7 @@ Category=4
 Description="<html>Whether one-line method definitions inside a class body should be treated<br/>as if they were prototypes for the purposes of adding newlines.<br/><br/>Requires nl_class_leave_one_liners=true. Overrides nl_before_func_body_def<br/>and nl_before_func_class_def for one-liners.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_class_leave_one_liner_groups=true|nl_class_leave_one_liner_groups=false
+TrueFalse=nl_class_leave_one_liner_groups\s*=\s*true|nl_class_leave_one_liner_groups\s*=\s*false
 ValueDefault=false
 
 [Nl After Func Body]
@@ -5279,7 +5280,7 @@ Category=4
 Description="<html>The number of newlines after '}' of a multi-line function body.<br/><br/>Overrides nl_min_after_func_body and nl_max_after_func_body.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_body="
+CallName="nl_after_func_body\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5289,7 +5290,7 @@ Category=4
 Description="<html>The minimum number of newlines after '}' of a multi-line function body.<br/><br/>Only works when nl_after_func_body is 0.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_min_after_func_body="
+CallName="nl_min_after_func_body\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5299,7 +5300,7 @@ Category=4
 Description="<html>The maximum number of newlines after '}' of a multi-line function body.<br/><br/>Only works when nl_after_func_body is 0.<br/>Takes precedence over nl_min_after_func_body.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_max_after_func_body="
+CallName="nl_max_after_func_body\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5309,7 +5310,7 @@ Category=4
 Description="<html>The number of newlines after '}' of a multi-line function body in a class<br/>declaration. Also affects class constructors/destructors.<br/><br/>Overrides nl_after_func_body.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_body_class="
+CallName="nl_after_func_body_class\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5319,7 +5320,7 @@ Category=4
 Description="<html>The number of newlines after '}' of a single line function body. Also<br/>affects class constructors/destructors.<br/><br/>Overrides nl_after_func_body and nl_after_func_body_class.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_body_one_liner="
+CallName="nl_after_func_body_one_liner\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5329,7 +5330,7 @@ Category=4
 Description="<html>The number of newlines before a block of typedefs. If nl_after_access_spec<br/>is non-zero, that option takes precedence.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_typedef_blk_start="
+CallName="nl_typedef_blk_start\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5339,7 +5340,7 @@ Category=4
 Description="<html>The number of newlines after a block of typedefs.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_typedef_blk_end="
+CallName="nl_typedef_blk_end\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5349,7 +5350,7 @@ Category=4
 Description="<html>The maximum number of consecutive newlines within a block of typedefs.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_typedef_blk_in="
+CallName="nl_typedef_blk_in\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5359,7 +5360,7 @@ Category=4
 Description="<html>The minimum number of blank lines after a block of variable definitions<br/>at the top of a function body. If any preprocessor directives appear<br/>between the opening brace of the function and the variable block, then<br/>it is considered as not at the top of the function.Newlines are added<br/>before trailing preprocessor directives, if any exist.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_var_def_blk_end_func_top="
+CallName="nl_var_def_blk_end_func_top\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5369,7 +5370,7 @@ Category=4
 Description="<html>The minimum number of empty newlines before a block of variable definitions<br/>not at the top of a function body. If nl_after_access_spec is non-zero,<br/>that option takes precedence. Newlines are not added at the top of the<br/>file or just after an opening brace. Newlines are added above any<br/>preprocessor directives before the block.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_var_def_blk_start="
+CallName="nl_var_def_blk_start\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5379,7 +5380,7 @@ Category=4
 Description="<html>The minimum number of empty newlines after a block of variable definitions<br/>not at the top of a function body. Newlines are not added if the block<br/>is at the bottom of the file or just before a preprocessor directive.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_var_def_blk_end="
+CallName="nl_var_def_blk_end\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5389,7 +5390,7 @@ Category=4
 Description="<html>The maximum number of consecutive newlines within a block of variable<br/>definitions.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_var_def_blk_in="
+CallName="nl_var_def_blk_in\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5399,7 +5400,7 @@ Category=4
 Description="<html>The minimum number of newlines before a multi-line comment.<br/>Doesn't apply if after a brace open or another multi-line comment.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_block_comment="
+CallName="nl_before_block_comment\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5409,7 +5410,7 @@ Category=4
 Description="<html>The minimum number of newlines before a single-line C comment.<br/>Doesn't apply if after a brace open or other single-line C comments.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_c_comment="
+CallName="nl_before_c_comment\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5419,7 +5420,7 @@ Category=4
 Description="<html>The minimum number of newlines before a CPP comment.<br/>Doesn't apply if after a brace open or other CPP comments.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_cpp_comment="
+CallName="nl_before_cpp_comment\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5429,7 +5430,7 @@ Category=4
 Description="<html>Whether to force a newline after a multi-line comment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_multiline_comment=true|nl_after_multiline_comment=false
+TrueFalse=nl_after_multiline_comment\s*=\s*true|nl_after_multiline_comment\s*=\s*false
 ValueDefault=false
 
 [Nl After Label Colon]
@@ -5437,7 +5438,7 @@ Category=4
 Description="<html>Whether to force a newline after a label's colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_label_colon=true|nl_after_label_colon=false
+TrueFalse=nl_after_label_colon\s*=\s*true|nl_after_label_colon\s*=\s*false
 ValueDefault=false
 
 [Nl Before Struct]
@@ -5445,7 +5446,7 @@ Category=4
 Description="<html>The number of newlines before a struct definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_struct="
+CallName="nl_before_struct\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5455,7 +5456,7 @@ Category=4
 Description="<html>The number of newlines after '}' or ';' of a struct/enum/union definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_struct="
+CallName="nl_after_struct\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5465,7 +5466,7 @@ Category=4
 Description="<html>The number of newlines before a class definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_class="
+CallName="nl_before_class\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5475,7 +5476,7 @@ Category=4
 Description="<html>The number of newlines after '}' or ';' of a class definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_class="
+CallName="nl_after_class\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5485,7 +5486,7 @@ Category=4
 Description="<html>The number of newlines before a namespace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_namespace="
+CallName="nl_before_namespace\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5495,7 +5496,7 @@ Category=4
 Description="<html>The number of newlines after '{' of a namespace. This also adds newlines<br/>before the matching '}'.<br/><br/>0: Apply eat_blanks_after_open_brace or eat_blanks_before_close_brace if<br/>    applicable, otherwise no change.<br/><br/>Overrides eat_blanks_after_open_brace and eat_blanks_before_close_brace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_inside_namespace="
+CallName="nl_inside_namespace\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5505,7 +5506,7 @@ Category=4
 Description="<html>The number of newlines after '}' of a namespace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_namespace="
+CallName="nl_after_namespace\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5515,7 +5516,7 @@ Category=4
 Description="<html>The number of newlines before an access specifier label. This also includes<br/>the Qt-specific 'signals:' and 'slots:'. Will not change the newline count<br/>if after a brace open.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_access_spec="
+CallName="nl_before_access_spec\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5525,7 +5526,7 @@ Category=4
 Description="<html>The number of newlines after an access specifier label. This also includes<br/>the Qt-specific 'signals:' and 'slots:'. Will not change the newline count<br/>if after a brace open.<br/><br/>0: No change (default).<br/><br/>Overrides nl_typedef_blk_start and nl_var_def_blk_start.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_access_spec="
+CallName="nl_after_access_spec\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5535,7 +5536,7 @@ Category=4
 Description="<html>The number of newlines between a function definition and the function<br/>comment, as in '// comment\n &lt;here&gt; void foo() {...}'.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_comment_func_def="
+CallName="nl_comment_func_def\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5545,7 +5546,7 @@ Category=4
 Description="<html>The number of newlines after a try-catch-finally block that isn't followed<br/>by a brace close.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_try_catch_finally="
+CallName="nl_after_try_catch_finally\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5555,7 +5556,7 @@ Category=4
 Description="<html>(C#) The number of newlines before and after a property, indexer or event<br/>declaration.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_around_cs_property="
+CallName="nl_around_cs_property\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5565,7 +5566,7 @@ Category=4
 Description="<html>(C#) The number of newlines between the get/set/add/remove handlers.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_between_get_set="
+CallName="nl_between_get_set\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5575,7 +5576,7 @@ Category=4
 Description="<html>(C#) Add or remove newline between property and the '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_property_brace=ignore|nl_property_brace=add|nl_property_brace=remove|nl_property_brace=force|nl_property_brace=not_defined
+Choices=nl_property_brace\s*=\s*ignore|nl_property_brace\s*=\s*add|nl_property_brace\s*=\s*remove|nl_property_brace\s*=\s*force|nl_property_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Property Brace|Add Nl Property Brace|Remove Nl Property Brace|Force Nl Property Brace"
 ValueDefault=ignore
 
@@ -5584,7 +5585,7 @@ Category=4
 Description="<html>Whether to remove blank lines after '{'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=eat_blanks_after_open_brace=true|eat_blanks_after_open_brace=false
+TrueFalse=eat_blanks_after_open_brace\s*=\s*true|eat_blanks_after_open_brace\s*=\s*false
 ValueDefault=false
 
 [Eat Blanks Before Close Brace]
@@ -5592,7 +5593,7 @@ Category=4
 Description="<html>Whether to remove blank lines before '}'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=eat_blanks_before_close_brace=true|eat_blanks_before_close_brace=false
+TrueFalse=eat_blanks_before_close_brace\s*=\s*true|eat_blanks_before_close_brace\s*=\s*false
 ValueDefault=false
 
 [Nl Remove Extra Newlines]
@@ -5600,7 +5601,7 @@ Category=4
 Description="<html>How aggressively to remove extra newlines not in preprocessor.<br/><br/>0: No change (default)<br/>1: Remove most newlines not handled by other config<br/>2: Remove all newlines and reformat completely by config</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_remove_extra_newlines="
+CallName="nl_remove_extra_newlines\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -5610,7 +5611,7 @@ Category=4
 Description="<html>(Java) Add or remove newline after an annotation statement. Only affects<br/>annotations that are after a newline.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_annotation=ignore|nl_after_annotation=add|nl_after_annotation=remove|nl_after_annotation=force|nl_after_annotation=not_defined
+Choices=nl_after_annotation\s*=\s*ignore|nl_after_annotation\s*=\s*add|nl_after_annotation\s*=\s*remove|nl_after_annotation\s*=\s*force|nl_after_annotation\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Annotation|Add Nl After Annotation|Remove Nl After Annotation|Force Nl After Annotation"
 ValueDefault=ignore
 
@@ -5619,7 +5620,7 @@ Category=4
 Description="<html>(Java) Add or remove newline between two annotations.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_between_annotation=ignore|nl_between_annotation=add|nl_between_annotation=remove|nl_between_annotation=force|nl_between_annotation=not_defined
+Choices=nl_between_annotation\s*=\s*ignore|nl_between_annotation\s*=\s*add|nl_between_annotation\s*=\s*remove|nl_between_annotation\s*=\s*force|nl_between_annotation\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Between Annotation|Add Nl Between Annotation|Remove Nl Between Annotation|Force Nl Between Annotation"
 ValueDefault=ignore
 
@@ -5628,7 +5629,7 @@ Category=4
 Description="<html>The number of newlines before a whole-file #ifdef.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_whole_file_ifdef="
+CallName="nl_before_whole_file_ifdef\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5638,7 +5639,7 @@ Category=4
 Description="<html>The number of newlines after a whole-file #ifdef.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_whole_file_ifdef="
+CallName="nl_after_whole_file_ifdef\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5648,7 +5649,7 @@ Category=4
 Description="<html>The number of newlines before a whole-file #endif.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_whole_file_endif="
+CallName="nl_before_whole_file_endif\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5658,7 +5659,7 @@ Category=4
 Description="<html>The number of newlines after a whole-file #endif.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_whole_file_endif="
+CallName="nl_after_whole_file_endif\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5668,7 +5669,7 @@ Category=5
 Description="<html>The position of arithmetic operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_arith=ignore|pos_arith=break|pos_arith=force|pos_arith=lead|pos_arith=trail|pos_arith=join|pos_arith=lead_break|pos_arith=lead_force|pos_arith=trail_break|pos_arith=trail_force
+Choices=pos_arith\s*=\s*ignore|pos_arith\s*=\s*break|pos_arith\s*=\s*force|pos_arith\s*=\s*lead|pos_arith\s*=\s*trail|pos_arith\s*=\s*join|pos_arith\s*=\s*lead_break|pos_arith\s*=\s*lead_force|pos_arith\s*=\s*trail_break|pos_arith\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Arith|Break Pos Arith|Force Pos Arith|Lead Pos Arith|Trail Pos Arith|Join Pos Arith|Lead Break Pos Arith|Lead Force Pos Arith|Trail Break Pos Arith|Trail Force Pos Arith"
 ValueDefault=ignore
 
@@ -5677,7 +5678,7 @@ Category=5
 Description="<html>The position of assignment in wrapped expressions. Do not affect '='<br/>followed by '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_assign=ignore|pos_assign=break|pos_assign=force|pos_assign=lead|pos_assign=trail|pos_assign=join|pos_assign=lead_break|pos_assign=lead_force|pos_assign=trail_break|pos_assign=trail_force
+Choices=pos_assign\s*=\s*ignore|pos_assign\s*=\s*break|pos_assign\s*=\s*force|pos_assign\s*=\s*lead|pos_assign\s*=\s*trail|pos_assign\s*=\s*join|pos_assign\s*=\s*lead_break|pos_assign\s*=\s*lead_force|pos_assign\s*=\s*trail_break|pos_assign\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Assign|Break Pos Assign|Force Pos Assign|Lead Pos Assign|Trail Pos Assign|Join Pos Assign|Lead Break Pos Assign|Lead Force Pos Assign|Trail Break Pos Assign|Trail Force Pos Assign"
 ValueDefault=ignore
 
@@ -5686,7 +5687,7 @@ Category=5
 Description="<html>The position of Boolean operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_bool=ignore|pos_bool=break|pos_bool=force|pos_bool=lead|pos_bool=trail|pos_bool=join|pos_bool=lead_break|pos_bool=lead_force|pos_bool=trail_break|pos_bool=trail_force
+Choices=pos_bool\s*=\s*ignore|pos_bool\s*=\s*break|pos_bool\s*=\s*force|pos_bool\s*=\s*lead|pos_bool\s*=\s*trail|pos_bool\s*=\s*join|pos_bool\s*=\s*lead_break|pos_bool\s*=\s*lead_force|pos_bool\s*=\s*trail_break|pos_bool\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Bool|Break Pos Bool|Force Pos Bool|Lead Pos Bool|Trail Pos Bool|Join Pos Bool|Lead Break Pos Bool|Lead Force Pos Bool|Trail Break Pos Bool|Trail Force Pos Bool"
 ValueDefault=ignore
 
@@ -5695,7 +5696,7 @@ Category=5
 Description="<html>The position of comparison operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_compare=ignore|pos_compare=break|pos_compare=force|pos_compare=lead|pos_compare=trail|pos_compare=join|pos_compare=lead_break|pos_compare=lead_force|pos_compare=trail_break|pos_compare=trail_force
+Choices=pos_compare\s*=\s*ignore|pos_compare\s*=\s*break|pos_compare\s*=\s*force|pos_compare\s*=\s*lead|pos_compare\s*=\s*trail|pos_compare\s*=\s*join|pos_compare\s*=\s*lead_break|pos_compare\s*=\s*lead_force|pos_compare\s*=\s*trail_break|pos_compare\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Compare|Break Pos Compare|Force Pos Compare|Lead Pos Compare|Trail Pos Compare|Join Pos Compare|Lead Break Pos Compare|Lead Force Pos Compare|Trail Break Pos Compare|Trail Force Pos Compare"
 ValueDefault=ignore
 
@@ -5704,7 +5705,7 @@ Category=5
 Description="<html>The position of conditional operators, as in the '?' and ':' of<br/>'expr ? stmt : stmt', in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_conditional=ignore|pos_conditional=break|pos_conditional=force|pos_conditional=lead|pos_conditional=trail|pos_conditional=join|pos_conditional=lead_break|pos_conditional=lead_force|pos_conditional=trail_break|pos_conditional=trail_force
+Choices=pos_conditional\s*=\s*ignore|pos_conditional\s*=\s*break|pos_conditional\s*=\s*force|pos_conditional\s*=\s*lead|pos_conditional\s*=\s*trail|pos_conditional\s*=\s*join|pos_conditional\s*=\s*lead_break|pos_conditional\s*=\s*lead_force|pos_conditional\s*=\s*trail_break|pos_conditional\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Conditional|Break Pos Conditional|Force Pos Conditional|Lead Pos Conditional|Trail Pos Conditional|Join Pos Conditional|Lead Break Pos Conditional|Lead Force Pos Conditional|Trail Break Pos Conditional|Trail Force Pos Conditional"
 ValueDefault=ignore
 
@@ -5713,7 +5714,7 @@ Category=5
 Description="<html>The position of the comma in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_comma=ignore|pos_comma=break|pos_comma=force|pos_comma=lead|pos_comma=trail|pos_comma=join|pos_comma=lead_break|pos_comma=lead_force|pos_comma=trail_break|pos_comma=trail_force
+Choices=pos_comma\s*=\s*ignore|pos_comma\s*=\s*break|pos_comma\s*=\s*force|pos_comma\s*=\s*lead|pos_comma\s*=\s*trail|pos_comma\s*=\s*join|pos_comma\s*=\s*lead_break|pos_comma\s*=\s*lead_force|pos_comma\s*=\s*trail_break|pos_comma\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Comma|Break Pos Comma|Force Pos Comma|Lead Pos Comma|Trail Pos Comma|Join Pos Comma|Lead Break Pos Comma|Lead Force Pos Comma|Trail Break Pos Comma|Trail Force Pos Comma"
 ValueDefault=ignore
 
@@ -5722,7 +5723,7 @@ Category=5
 Description="<html>The position of the comma in enum entries.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_enum_comma=ignore|pos_enum_comma=break|pos_enum_comma=force|pos_enum_comma=lead|pos_enum_comma=trail|pos_enum_comma=join|pos_enum_comma=lead_break|pos_enum_comma=lead_force|pos_enum_comma=trail_break|pos_enum_comma=trail_force
+Choices=pos_enum_comma\s*=\s*ignore|pos_enum_comma\s*=\s*break|pos_enum_comma\s*=\s*force|pos_enum_comma\s*=\s*lead|pos_enum_comma\s*=\s*trail|pos_enum_comma\s*=\s*join|pos_enum_comma\s*=\s*lead_break|pos_enum_comma\s*=\s*lead_force|pos_enum_comma\s*=\s*trail_break|pos_enum_comma\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Enum Comma|Break Pos Enum Comma|Force Pos Enum Comma|Lead Pos Enum Comma|Trail Pos Enum Comma|Join Pos Enum Comma|Lead Break Pos Enum Comma|Lead Force Pos Enum Comma|Trail Break Pos Enum Comma|Trail Force Pos Enum Comma"
 ValueDefault=ignore
 
@@ -5731,7 +5732,7 @@ Category=5
 Description="<html>The position of the comma in the base class list if there is more than one<br/>line. Affects nl_class_init_args.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_class_comma=ignore|pos_class_comma=break|pos_class_comma=force|pos_class_comma=lead|pos_class_comma=trail|pos_class_comma=join|pos_class_comma=lead_break|pos_class_comma=lead_force|pos_class_comma=trail_break|pos_class_comma=trail_force
+Choices=pos_class_comma\s*=\s*ignore|pos_class_comma\s*=\s*break|pos_class_comma\s*=\s*force|pos_class_comma\s*=\s*lead|pos_class_comma\s*=\s*trail|pos_class_comma\s*=\s*join|pos_class_comma\s*=\s*lead_break|pos_class_comma\s*=\s*lead_force|pos_class_comma\s*=\s*trail_break|pos_class_comma\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Class Comma|Break Pos Class Comma|Force Pos Class Comma|Lead Pos Class Comma|Trail Pos Class Comma|Join Pos Class Comma|Lead Break Pos Class Comma|Lead Force Pos Class Comma|Trail Break Pos Class Comma|Trail Force Pos Class Comma"
 ValueDefault=ignore
 
@@ -5740,7 +5741,7 @@ Category=5
 Description="<html>The position of the comma in the constructor initialization list.<br/>Related to nl_constr_colon, nl_constr_init_args and pos_constr_colon.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_constr_comma=ignore|pos_constr_comma=break|pos_constr_comma=force|pos_constr_comma=lead|pos_constr_comma=trail|pos_constr_comma=join|pos_constr_comma=lead_break|pos_constr_comma=lead_force|pos_constr_comma=trail_break|pos_constr_comma=trail_force
+Choices=pos_constr_comma\s*=\s*ignore|pos_constr_comma\s*=\s*break|pos_constr_comma\s*=\s*force|pos_constr_comma\s*=\s*lead|pos_constr_comma\s*=\s*trail|pos_constr_comma\s*=\s*join|pos_constr_comma\s*=\s*lead_break|pos_constr_comma\s*=\s*lead_force|pos_constr_comma\s*=\s*trail_break|pos_constr_comma\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Constr Comma|Break Pos Constr Comma|Force Pos Constr Comma|Lead Pos Constr Comma|Trail Pos Constr Comma|Join Pos Constr Comma|Lead Break Pos Constr Comma|Lead Force Pos Constr Comma|Trail Break Pos Constr Comma|Trail Force Pos Constr Comma"
 ValueDefault=ignore
 
@@ -5749,7 +5750,7 @@ Category=5
 Description="<html>The position of trailing/leading class colon, between class and base class<br/>list. Affects nl_class_colon.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_class_colon=ignore|pos_class_colon=break|pos_class_colon=force|pos_class_colon=lead|pos_class_colon=trail|pos_class_colon=join|pos_class_colon=lead_break|pos_class_colon=lead_force|pos_class_colon=trail_break|pos_class_colon=trail_force
+Choices=pos_class_colon\s*=\s*ignore|pos_class_colon\s*=\s*break|pos_class_colon\s*=\s*force|pos_class_colon\s*=\s*lead|pos_class_colon\s*=\s*trail|pos_class_colon\s*=\s*join|pos_class_colon\s*=\s*lead_break|pos_class_colon\s*=\s*lead_force|pos_class_colon\s*=\s*trail_break|pos_class_colon\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Class Colon|Break Pos Class Colon|Force Pos Class Colon|Lead Pos Class Colon|Trail Pos Class Colon|Join Pos Class Colon|Lead Break Pos Class Colon|Lead Force Pos Class Colon|Trail Break Pos Class Colon|Trail Force Pos Class Colon"
 ValueDefault=ignore
 
@@ -5758,7 +5759,7 @@ Category=5
 Description="<html>The position of colons between constructor and member initialization.<br/>Related to nl_constr_colon, nl_constr_init_args and pos_constr_comma.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_constr_colon=ignore|pos_constr_colon=break|pos_constr_colon=force|pos_constr_colon=lead|pos_constr_colon=trail|pos_constr_colon=join|pos_constr_colon=lead_break|pos_constr_colon=lead_force|pos_constr_colon=trail_break|pos_constr_colon=trail_force
+Choices=pos_constr_colon\s*=\s*ignore|pos_constr_colon\s*=\s*break|pos_constr_colon\s*=\s*force|pos_constr_colon\s*=\s*lead|pos_constr_colon\s*=\s*trail|pos_constr_colon\s*=\s*join|pos_constr_colon\s*=\s*lead_break|pos_constr_colon\s*=\s*lead_force|pos_constr_colon\s*=\s*trail_break|pos_constr_colon\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Constr Colon|Break Pos Constr Colon|Force Pos Constr Colon|Lead Pos Constr Colon|Trail Pos Constr Colon|Join Pos Constr Colon|Lead Break Pos Constr Colon|Lead Force Pos Constr Colon|Trail Break Pos Constr Colon|Trail Force Pos Constr Colon"
 ValueDefault=ignore
 
@@ -5767,7 +5768,7 @@ Category=5
 Description="<html>The position of shift operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_shift=ignore|pos_shift=break|pos_shift=force|pos_shift=lead|pos_shift=trail|pos_shift=join|pos_shift=lead_break|pos_shift=lead_force|pos_shift=trail_break|pos_shift=trail_force
+Choices=pos_shift\s*=\s*ignore|pos_shift\s*=\s*break|pos_shift\s*=\s*force|pos_shift\s*=\s*lead|pos_shift\s*=\s*trail|pos_shift\s*=\s*join|pos_shift\s*=\s*lead_break|pos_shift\s*=\s*lead_force|pos_shift\s*=\s*trail_break|pos_shift\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Shift|Break Pos Shift|Force Pos Shift|Lead Pos Shift|Trail Pos Shift|Join Pos Shift|Lead Break Pos Shift|Lead Force Pos Shift|Trail Break Pos Shift|Trail Force Pos Shift"
 ValueDefault=ignore
 
@@ -5776,7 +5777,7 @@ Category=6
 Description="<html>Try to limit code width to N columns.</html>"
 Enabled=false
 EditorType=numeric
-CallName="code_width="
+CallName="code_width\s*=\s*"
 MinVal=0
 MaxVal=10000
 ValueDefault=0
@@ -5786,7 +5787,7 @@ Category=6
 Description="<html>Whether to fully split long 'for' statements at semi-colons.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=ls_for_split_full=true|ls_for_split_full=false
+TrueFalse=ls_for_split_full\s*=\s*true|ls_for_split_full\s*=\s*false
 ValueDefault=false
 
 [Ls Func Split Full]
@@ -5794,7 +5795,7 @@ Category=6
 Description="<html>Whether to fully split long function prototypes/calls at commas.<br/>The option ls_code_width has priority over the option ls_func_split_full.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=ls_func_split_full=true|ls_func_split_full=false
+TrueFalse=ls_func_split_full\s*=\s*true|ls_func_split_full\s*=\s*false
 ValueDefault=false
 
 [Ls Code Width]
@@ -5802,7 +5803,7 @@ Category=6
 Description="<html>Whether to split lines as close to code_width as possible and ignore some<br/>groupings.<br/>The option ls_code_width has priority over the option ls_func_split_full.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=ls_code_width=true|ls_code_width=false
+TrueFalse=ls_code_width\s*=\s*true|ls_code_width\s*=\s*false
 ValueDefault=false
 
 [Align Keep Tabs]
@@ -5810,7 +5811,7 @@ Category=7
 Description="<html>Whether to keep non-indenting tabs.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_keep_tabs=true|align_keep_tabs=false
+TrueFalse=align_keep_tabs\s*=\s*true|align_keep_tabs\s*=\s*false
 ValueDefault=false
 
 [Align With Tabs]
@@ -5818,7 +5819,7 @@ Category=7
 Description="<html>Whether to use tabs for aligning.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_with_tabs=true|align_with_tabs=false
+TrueFalse=align_with_tabs\s*=\s*true|align_with_tabs\s*=\s*false
 ValueDefault=false
 
 [Align On Tabstop]
@@ -5826,7 +5827,7 @@ Category=7
 Description="<html>Whether to bump out to the next tab when aligning.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_on_tabstop=true|align_on_tabstop=false
+TrueFalse=align_on_tabstop\s*=\s*true|align_on_tabstop\s*=\s*false
 ValueDefault=false
 
 [Align Number Right]
@@ -5834,7 +5835,7 @@ Category=7
 Description="<html>Whether to right-align numbers.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_number_right=true|align_number_right=false
+TrueFalse=align_number_right\s*=\s*true|align_number_right\s*=\s*false
 ValueDefault=false
 
 [Align Keep Extra Space]
@@ -5842,7 +5843,7 @@ Category=7
 Description="<html>Whether to keep whitespace not required for alignment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_keep_extra_space=true|align_keep_extra_space=false
+TrueFalse=align_keep_extra_space\s*=\s*true|align_keep_extra_space\s*=\s*false
 ValueDefault=false
 
 [Align Func Params]
@@ -5850,7 +5851,7 @@ Category=7
 Description="<html>Whether to align variable definitions in prototypes and functions.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_func_params=true|align_func_params=false
+TrueFalse=align_func_params\s*=\s*true|align_func_params\s*=\s*false
 ValueDefault=false
 
 [Align Func Params Span]
@@ -5858,7 +5859,7 @@ Category=7
 Description="<html>The span for aligning parameter definitions in function on parameter name.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_params_span="
+CallName="align_func_params_span\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5868,7 +5869,7 @@ Category=7
 Description="<html>The threshold for aligning function parameter definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_params_thresh="
+CallName="align_func_params_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -5878,7 +5879,7 @@ Category=7
 Description="<html>The gap for aligning function parameter definitions.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_params_gap="
+CallName="align_func_params_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5888,7 +5889,7 @@ Category=7
 Description="<html>The span for aligning constructor value.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_constr_value_span="
+CallName="align_constr_value_span\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5898,7 +5899,7 @@ Category=7
 Description="<html>The threshold for aligning constructor value.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_constr_value_thresh="
+CallName="align_constr_value_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -5908,7 +5909,7 @@ Category=7
 Description="<html>The gap for aligning constructor value.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_constr_value_gap="
+CallName="align_constr_value_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5918,7 +5919,7 @@ Category=7
 Description="<html>Whether to align parameters in single-line functions that have the same<br/>name. The function names must already be aligned with each other.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_same_func_call_params=true|align_same_func_call_params=false
+TrueFalse=align_same_func_call_params\s*=\s*true|align_same_func_call_params\s*=\s*false
 ValueDefault=false
 
 [Align Same Func Call Params Span]
@@ -5926,7 +5927,7 @@ Category=7
 Description="<html>The span for aligning function-call parameters for single line functions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_same_func_call_params_span="
+CallName="align_same_func_call_params_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -5936,7 +5937,7 @@ Category=7
 Description="<html>The threshold for aligning function-call parameters for single line<br/>functions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_same_func_call_params_thresh="
+CallName="align_same_func_call_params_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -5946,7 +5947,7 @@ Category=7
 Description="<html>The span for aligning variable definitions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_span="
+CallName="align_var_def_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -5956,7 +5957,7 @@ Category=7
 Description="<html>How to consider (or treat) the '*' in the alignment of variable definitions.<br/><br/>0: Part of the type     'void *   foo;' (default)<br/>1: Part of the variable 'void     *foo;'<br/>2: Dangling             'void    *foo;'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_star_style="
+CallName="align_var_def_star_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -5966,7 +5967,7 @@ Category=7
 Description="<html>How to consider (or treat) the '&amp;' in the alignment of variable definitions.<br/><br/>0: Part of the type     'long &amp;   foo;' (default)<br/>1: Part of the variable 'long     &amp;foo;'<br/>2: Dangling             'long    &amp;foo;'<br/>Dangling: the '&amp;' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_amp_style="
+CallName="align_var_def_amp_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -5976,7 +5977,7 @@ Category=7
 Description="<html>The threshold for aligning variable definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_thresh="
+CallName="align_var_def_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -5986,7 +5987,7 @@ Category=7
 Description="<html>The gap for aligning variable definitions.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_gap="
+CallName="align_var_def_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5996,7 +5997,7 @@ Category=7
 Description="<html>Whether to align the colon in struct bit fields.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_var_def_colon=true|align_var_def_colon=false
+TrueFalse=align_var_def_colon\s*=\s*true|align_var_def_colon\s*=\s*false
 ValueDefault=false
 
 [Align Var Def Colon Gap]
@@ -6004,7 +6005,7 @@ Category=7
 Description="<html>The gap for aligning the colon in struct bit fields.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_colon_gap="
+CallName="align_var_def_colon_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6014,7 +6015,7 @@ Category=7
 Description="<html>Whether to align any attribute after the variable name.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_var_def_attribute=true|align_var_def_attribute=false
+TrueFalse=align_var_def_attribute\s*=\s*true|align_var_def_attribute\s*=\s*false
 ValueDefault=false
 
 [Align Var Def Inline]
@@ -6022,7 +6023,7 @@ Category=7
 Description="<html>Whether to align inline struct/enum/union variable definitions.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_var_def_inline=true|align_var_def_inline=false
+TrueFalse=align_var_def_inline\s*=\s*true|align_var_def_inline\s*=\s*false
 ValueDefault=false
 
 [Align Assign Span]
@@ -6030,7 +6031,7 @@ Category=7
 Description="<html>The span for aligning on '=' in assignments.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_assign_span="
+CallName="align_assign_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6040,7 +6041,7 @@ Category=7
 Description="<html>The span for aligning on '=' in function prototype modifier.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_assign_func_proto_span="
+CallName="align_assign_func_proto_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6050,7 +6051,7 @@ Category=7
 Description="<html>The threshold for aligning on '=' in assignments.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_assign_thresh="
+CallName="align_assign_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6060,7 +6061,7 @@ Category=7
 Description="<html>Whether to align on the left most assignment when multiple<br/>definitions are found on the same line.<br/>Depends on 'align_assign_span' and 'align_assign_thresh' settings.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_assign_on_multi_var_defs=true|align_assign_on_multi_var_defs=false
+TrueFalse=align_assign_on_multi_var_defs\s*=\s*true|align_assign_on_multi_var_defs\s*=\s*false
 ValueDefault=false
 
 [Align Braced Init List Span]
@@ -6068,7 +6069,7 @@ Category=7
 Description="<html>The span for aligning on '{' in braced init list.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_braced_init_list_span="
+CallName="align_braced_init_list_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6078,7 +6079,7 @@ Category=7
 Description="<html>The threshold for aligning on '{' in braced init list.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_braced_init_list_thresh="
+CallName="align_braced_init_list_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6088,7 +6089,7 @@ Category=7
 Description="<html>How to apply align_assign_span to function declaration "assignments", i.e.<br/>'virtual void foo() = 0' or '~foo() = {default|delete}'.<br/><br/>0: Align with other assignments (default)<br/>1: Align with each other, ignoring regular assignments<br/>2: Don't align</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_assign_decl_func="
+CallName="align_assign_decl_func\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6098,7 +6099,7 @@ Category=7
 Description="<html>The span for aligning on '=' in enums.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_enum_equ_span="
+CallName="align_enum_equ_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6108,7 +6109,7 @@ Category=7
 Description="<html>The threshold for aligning on '=' in enums.<br/>Use a negative number for absolute thresholds.<br/><br/>0: no limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_enum_equ_thresh="
+CallName="align_enum_equ_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6118,7 +6119,7 @@ Category=7
 Description="<html>The span for aligning class member definitions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_class_span="
+CallName="align_var_class_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6128,7 +6129,7 @@ Category=7
 Description="<html>The threshold for aligning class member definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_class_thresh="
+CallName="align_var_class_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6138,7 +6139,7 @@ Category=7
 Description="<html>The gap for aligning class member definitions.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_class_gap="
+CallName="align_var_class_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6148,7 +6149,7 @@ Category=7
 Description="<html>The span for aligning struct/union member definitions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_struct_span="
+CallName="align_var_struct_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6158,7 +6159,7 @@ Category=7
 Description="<html>The threshold for aligning struct/union member definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_struct_thresh="
+CallName="align_var_struct_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6168,7 +6169,7 @@ Category=7
 Description="<html>The gap for aligning struct/union member definitions.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_struct_gap="
+CallName="align_var_struct_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6178,7 +6179,7 @@ Category=7
 Description="<html>The span for aligning struct initializer values.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_struct_init_span="
+CallName="align_struct_init_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6188,7 +6189,7 @@ Category=7
 Description="<html>The span for aligning single-line typedefs.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_span="
+CallName="align_typedef_span\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6198,7 +6199,7 @@ Category=7
 Description="<html>The minimum space between the type and the synonym of a typedef.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_gap="
+CallName="align_typedef_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6208,7 +6209,7 @@ Category=7
 Description="<html>How to align typedef'd functions with other typedefs.<br/><br/>0: Don't mix them at all (default)<br/>1: Align the open parenthesis with the types<br/>2: Align the function type name with the other type names</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_func="
+CallName="align_typedef_func\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6218,7 +6219,7 @@ Category=7
 Description="<html>How to consider (or treat) the '*' in the alignment of typedefs.<br/><br/>0: Part of the typedef type, 'typedef int * pint;' (default)<br/>1: Part of type name:        'typedef int   *pint;'<br/>2: Dangling:                 'typedef int  *pint;'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_star_style="
+CallName="align_typedef_star_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6228,7 +6229,7 @@ Category=7
 Description="<html>How to consider (or treat) the '&amp;' in the alignment of typedefs.<br/><br/>0: Part of the typedef type, 'typedef int &amp; intref;' (default)<br/>1: Part of type name:        'typedef int   &amp;intref;'<br/>2: Dangling:                 'typedef int  &amp;intref;'<br/>Dangling: the '&amp;' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_amp_style="
+CallName="align_typedef_amp_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6238,7 +6239,7 @@ Category=7
 Description="<html>The span for aligning comments that end lines.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_right_cmt_span="
+CallName="align_right_cmt_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6248,7 +6249,7 @@ Category=7
 Description="<html>Minimum number of columns between preceding text and a trailing comment in<br/>order for the comment to qualify for being aligned. Must be non-zero to have<br/>an effect.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_right_cmt_gap="
+CallName="align_right_cmt_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6258,7 +6259,7 @@ Category=7
 Description="<html>If aligning comments, whether to mix with comments after '}' and #endif with<br/>less than three spaces before the comment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_right_cmt_mix=true|align_right_cmt_mix=false
+TrueFalse=align_right_cmt_mix\s*=\s*true|align_right_cmt_mix\s*=\s*false
 ValueDefault=false
 
 [Align Right Cmt Same Level]
@@ -6266,7 +6267,7 @@ Category=7
 Description="<html>Whether to only align trailing comments that are at the same brace level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_right_cmt_same_level=true|align_right_cmt_same_level=false
+TrueFalse=align_right_cmt_same_level\s*=\s*true|align_right_cmt_same_level\s*=\s*false
 ValueDefault=false
 
 [Align Right Cmt At Col]
@@ -6274,7 +6275,7 @@ Category=7
 Description="<html>Minimum column at which to align trailing comments. Comments which are<br/>aligned beyond this column, but which can be aligned in a lesser column,<br/>may be "pulled in".<br/><br/>0: Ignore (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_right_cmt_at_col="
+CallName="align_right_cmt_at_col\s*=\s*"
 MinVal=0
 MaxVal=200
 ValueDefault=0
@@ -6284,7 +6285,7 @@ Category=7
 Description="<html>The span for aligning function prototypes.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_span="
+CallName="align_func_proto_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6294,7 +6295,7 @@ Category=7
 Description="<html>Whether to ignore continuation lines when evaluating the number of<br/>new lines for the function prototype alignment's span.<br/><br/>false: continuation lines are part of the newlines count<br/>true:  continuation lines are not counted</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_func_proto_span_ignore_cont_lines=true|align_func_proto_span_ignore_cont_lines=false
+TrueFalse=align_func_proto_span_ignore_cont_lines\s*=\s*true|align_func_proto_span_ignore_cont_lines\s*=\s*false
 ValueDefault=false
 
 [Align Func Proto Star Style]
@@ -6302,7 +6303,7 @@ Category=7
 Description="<html>How to consider (or treat) the '*' in the alignment of function prototypes.<br/><br/>0: Part of the type     'void *   foo();' (default)<br/>1: Part of the function 'void     *foo();'<br/>2: Dangling             'void    *foo();'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_star_style="
+CallName="align_func_proto_star_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6312,7 +6313,7 @@ Category=7
 Description="<html>How to consider (or treat) the '&amp;' in the alignment of function prototypes.<br/><br/>0: Part of the type     'long &amp;   foo();' (default)<br/>1: Part of the function 'long     &amp;foo();'<br/>2: Dangling             'long    &amp;foo();'<br/>Dangling: the '&amp;' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_amp_style="
+CallName="align_func_proto_amp_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6322,7 +6323,7 @@ Category=7
 Description="<html>The threshold for aligning function prototypes.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_thresh="
+CallName="align_func_proto_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6332,7 +6333,7 @@ Category=7
 Description="<html>Minimum gap between the return type and the function name.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_gap="
+CallName="align_func_proto_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6342,7 +6343,7 @@ Category=7
 Description="<html>Whether to align function prototypes on the 'operator' keyword instead of<br/>what follows.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_on_operator=true|align_on_operator=false
+TrueFalse=align_on_operator\s*=\s*true|align_on_operator\s*=\s*false
 ValueDefault=false
 
 [Align Mix Var Proto]
@@ -6350,7 +6351,7 @@ Category=7
 Description="<html>Whether to mix aligning prototype and variable declarations. If true,<br/>align_var_def_XXX options are used instead of align_func_proto_XXX options.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_mix_var_proto=true|align_mix_var_proto=false
+TrueFalse=align_mix_var_proto\s*=\s*true|align_mix_var_proto\s*=\s*false
 ValueDefault=false
 
 [Align Single Line Func]
@@ -6358,7 +6359,7 @@ Category=7
 Description="<html>Whether to align single-line functions with function prototypes.<br/>Uses align_func_proto_span.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_single_line_func=true|align_single_line_func=false
+TrueFalse=align_single_line_func\s*=\s*true|align_single_line_func\s*=\s*false
 ValueDefault=false
 
 [Align Single Line Brace]
@@ -6366,7 +6367,7 @@ Category=7
 Description="<html>Whether to align the open brace of single-line functions.<br/>Requires align_single_line_func=true. Uses align_func_proto_span.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_single_line_brace=true|align_single_line_brace=false
+TrueFalse=align_single_line_brace\s*=\s*true|align_single_line_brace\s*=\s*false
 ValueDefault=false
 
 [Align Single Line Brace Gap]
@@ -6374,7 +6375,7 @@ Category=7
 Description="<html>Gap for align_single_line_brace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_single_line_brace_gap="
+CallName="align_single_line_brace_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6384,7 +6385,7 @@ Category=7
 Description="<html>(OC) The span for aligning Objective-C message specifications.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_oc_msg_spec_span="
+CallName="align_oc_msg_spec_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6394,7 +6395,7 @@ Category=7
 Description="<html>Whether and how to align backslashes that split a macro onto multiple lines.<br/>This will not work right if the macro contains a multi-line comment.<br/><br/>0: Do nothing (default)<br/>1: Align the backslashes in the column at the end of the longest line<br/>2: Align with the backslash that is farthest to the left, or, if that<br/>   backslash is farther left than the end of the longest line, at the end of<br/>   the longest line<br/>3: Align with the backslash that is farthest to the right</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_nl_cont="
+CallName="align_nl_cont\s*=\s*"
 MinVal=0
 MaxVal=3
 ValueDefault=0
@@ -6404,7 +6405,7 @@ Category=7
 Description="<html>The minimum number of spaces between the end of a line and its continuation<br/>backslash. Requires align_nl_cont.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_nl_cont_spaces="
+CallName="align_nl_cont_spaces\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -6414,7 +6415,7 @@ Category=7
 Description="<html>Whether to align macro functions and variables together.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_pp_define_together=true|align_pp_define_together=false
+TrueFalse=align_pp_define_together\s*=\s*true|align_pp_define_together\s*=\s*false
 ValueDefault=false
 
 [Align Pp Define Span]
@@ -6422,7 +6423,7 @@ Category=7
 Description="<html>The span for aligning on '#define' bodies.<br/><br/>=0: Don't align (default)<br/>&gt;0: Number of lines (including comments) between blocks</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_pp_define_span="
+CallName="align_pp_define_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6432,7 +6433,7 @@ Category=7
 Description="<html>The minimum space between label and value of a preprocessor define.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_pp_define_gap="
+CallName="align_pp_define_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6442,7 +6443,7 @@ Category=7
 Description="<html>Whether to align lines that start with '&lt;&lt;' with previous '&lt;&lt;'.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_left_shift=true|align_left_shift=false
+TrueFalse=align_left_shift\s*=\s*true|align_left_shift\s*=\s*false
 ValueDefault=true
 
 [Align Eigen Comma Init]
@@ -6450,7 +6451,7 @@ Category=7
 Description="<html>Whether to align comma-separated statements following '&lt;&lt;' (as used to<br/>initialize Eigen matrices).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_eigen_comma_init=true|align_eigen_comma_init=false
+TrueFalse=align_eigen_comma_init\s*=\s*true|align_eigen_comma_init\s*=\s*false
 ValueDefault=false
 
 [Align Asm Colon]
@@ -6458,7 +6459,7 @@ Category=7
 Description="<html>Whether to align text after 'asm volatile ()' colons.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_asm_colon=true|align_asm_colon=false
+TrueFalse=align_asm_colon\s*=\s*true|align_asm_colon\s*=\s*false
 ValueDefault=false
 
 [Align Oc Msg Colon Span]
@@ -6466,7 +6467,7 @@ Category=7
 Description="<html>(OC) Span for aligning parameters in an Objective-C message call<br/>on the ':'.<br/><br/>0: Don't align.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_oc_msg_colon_span="
+CallName="align_oc_msg_colon_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6476,7 +6477,7 @@ Category=7
 Description="<html>(OC) Whether to always align with the first parameter, even if it is too<br/>short.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_oc_msg_colon_first=true|align_oc_msg_colon_first=false
+TrueFalse=align_oc_msg_colon_first\s*=\s*true|align_oc_msg_colon_first\s*=\s*false
 ValueDefault=false
 
 [Align Oc Decl Colon]
@@ -6484,7 +6485,7 @@ Category=7
 Description="<html>(OC) Whether to align parameters in an Objective-C '+' or '-' declaration<br/>on the ':'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_oc_decl_colon=true|align_oc_decl_colon=false
+TrueFalse=align_oc_decl_colon\s*=\s*true|align_oc_decl_colon\s*=\s*false
 ValueDefault=false
 
 [Align Oc Msg Colon Xcode Like]
@@ -6492,7 +6493,7 @@ Category=7
 Description="<html>(OC) Whether to not align parameters in an Objectve-C message call if first<br/>colon is not on next line of the message call (the same way Xcode does<br/>alignment)</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_oc_msg_colon_xcode_like=true|align_oc_msg_colon_xcode_like=false
+TrueFalse=align_oc_msg_colon_xcode_like\s*=\s*true|align_oc_msg_colon_xcode_like\s*=\s*false
 ValueDefault=false
 
 [Cmt Width]
@@ -6500,7 +6501,7 @@ Category=8
 Description="<html>Try to wrap comments at N columns.</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_width="
+CallName="cmt_width\s*=\s*"
 MinVal=0
 MaxVal=256
 ValueDefault=0
@@ -6510,7 +6511,7 @@ Category=8
 Description="<html>How to reflow comments.<br/><br/>0: No reflowing (apart from the line wrapping due to cmt_width) (default)<br/>1: No touching at all<br/>2: Full reflow (enable cmt_indent_multi for indent with line wrapping due to cmt_width)</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_reflow_mode="
+CallName="cmt_reflow_mode\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6519,7 +6520,7 @@ ValueDefault=0
 Category=8
 Description="<html>Path to a file that contains regular expressions describing patterns for<br/>which the end of one line and the beginning of the next will be folded into<br/>the same sentence or paragraph during full comment reflow. The regular<br/>expressions are described using ECMAScript syntax. The syntax for this<br/>specification is as follows, where "..." indicates the custom regular<br/>expression and "n" indicates the nth end_of_prev_line_regex and<br/>beg_of_next_line_regex regular expression pair:<br/><br/>end_of_prev_line_regex[1] = "...$"<br/>beg_of_next_line_regex[1] = "^..."<br/>end_of_prev_line_regex[2] = "...$"<br/>beg_of_next_line_regex[2] = "^..."<br/>            .<br/>            .<br/>            .<br/>end_of_prev_line_regex[n] = "...$"<br/>beg_of_next_line_regex[n] = "^..."<br/><br/>Note that use of this option overrides the default reflow fold regular<br/>expressions, which are internally defined as follows:<br/><br/>end_of_prev_line_regex[1] = "[\w,\]\)]$"<br/>beg_of_next_line_regex[1] = "^[\w,\[\(]"<br/>end_of_prev_line_regex[2] = "\.$"<br/>beg_of_next_line_regex[2] = "^[A-Z]"</html>"
 Enabled=false
-CallName=cmt_reflow_fold_regex_file=
+CallName=cmt_reflow_fold_regex_file\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6528,7 +6529,7 @@ Category=8
 Description="<html>Whether to indent wrapped lines to the start of the encompassing paragraph<br/>during full comment reflow (cmt_reflow_mode = 2). Overrides the value<br/>specified by cmt_sp_after_star_cont.<br/><br/>Note that cmt_align_doxygen_javadoc_tags overrides this option for<br/>paragraphs associated with javadoc tags</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_reflow_indent_to_paragraph_start=true|cmt_reflow_indent_to_paragraph_start=false
+TrueFalse=cmt_reflow_indent_to_paragraph_start\s*=\s*true|cmt_reflow_indent_to_paragraph_start\s*=\s*false
 ValueDefault=false
 
 [Cmt Convert Tab To Spaces]
@@ -6536,7 +6537,7 @@ Category=8
 Description="<html>Whether to convert all tabs to spaces in comments. If false, tabs in<br/>comments are left alone, unless used for indenting.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_convert_tab_to_spaces=true|cmt_convert_tab_to_spaces=false
+TrueFalse=cmt_convert_tab_to_spaces\s*=\s*true|cmt_convert_tab_to_spaces\s*=\s*false
 ValueDefault=false
 
 [Cmt Indent Multi]
@@ -6544,7 +6545,7 @@ Category=8
 Description="<html>Whether to apply changes to multi-line comments, including cmt_width,<br/>keyword substitution and leading chars.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_indent_multi=true|cmt_indent_multi=false
+TrueFalse=cmt_indent_multi\s*=\s*true|cmt_indent_multi\s*=\s*false
 ValueDefault=true
 
 [Cmt Align Doxygen Javadoc Tags]
@@ -6552,7 +6553,7 @@ Category=8
 Description="<html>Whether to align doxygen javadoc-style tags ('@param', '@return', etc.)<br/>and corresponding fields such that groups of consecutive block tags,<br/>parameter names, and descriptions align with one another. Overrides that<br/>which is specified by the cmt_sp_after_star_cont. If cmt_width &gt; 0, it may<br/>be necessary to enable cmt_indent_multi and set cmt_reflow_mode = 2<br/>in order to achieve the desired alignment for line-wrapping.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_align_doxygen_javadoc_tags=true|cmt_align_doxygen_javadoc_tags=false
+TrueFalse=cmt_align_doxygen_javadoc_tags\s*=\s*true|cmt_align_doxygen_javadoc_tags\s*=\s*false
 ValueDefault=false
 
 [Cmt Sp Before Doxygen Javadoc Tags]
@@ -6560,7 +6561,7 @@ Category=8
 Description="<html>The number of spaces to insert after the star and before doxygen<br/>javadoc-style tags (@param, @return, etc). Requires enabling<br/>cmt_align_doxygen_javadoc_tags. Overrides that which is specified by the<br/>cmt_sp_after_star_cont.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_sp_before_doxygen_javadoc_tags="
+CallName="cmt_sp_before_doxygen_javadoc_tags\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -6570,7 +6571,7 @@ Category=8
 Description="<html>Whether to change trailing, single-line c-comments into cpp-comments.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_trailing_single_line_c_to_cpp=true|cmt_trailing_single_line_c_to_cpp=false
+TrueFalse=cmt_trailing_single_line_c_to_cpp\s*=\s*true|cmt_trailing_single_line_c_to_cpp\s*=\s*false
 ValueDefault=false
 
 [Cmt C Group]
@@ -6578,7 +6579,7 @@ Category=8
 Description="<html>Whether to group c-comments that look like they are in a block.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_c_group=true|cmt_c_group=false
+TrueFalse=cmt_c_group\s*=\s*true|cmt_c_group\s*=\s*false
 ValueDefault=false
 
 [Cmt C Nl Start]
@@ -6586,7 +6587,7 @@ Category=8
 Description="<html>Whether to put an empty '/*' on the first line of the combined c-comment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_c_nl_start=true|cmt_c_nl_start=false
+TrueFalse=cmt_c_nl_start\s*=\s*true|cmt_c_nl_start\s*=\s*false
 ValueDefault=false
 
 [Cmt C Nl End]
@@ -6594,7 +6595,7 @@ Category=8
 Description="<html>Whether to add a newline before the closing '*/' of the combined c-comment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_c_nl_end=true|cmt_c_nl_end=false
+TrueFalse=cmt_c_nl_end\s*=\s*true|cmt_c_nl_end\s*=\s*false
 ValueDefault=false
 
 [Cmt Cpp To C]
@@ -6602,7 +6603,7 @@ Category=8
 Description="<html>Whether to change cpp-comments into c-comments.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_cpp_to_c=true|cmt_cpp_to_c=false
+TrueFalse=cmt_cpp_to_c\s*=\s*true|cmt_cpp_to_c\s*=\s*false
 ValueDefault=false
 
 [Cmt Cpp Group]
@@ -6610,7 +6611,7 @@ Category=8
 Description="<html>Whether to group cpp-comments that look like they are in a block. Only<br/>meaningful if cmt_cpp_to_c=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_cpp_group=true|cmt_cpp_group=false
+TrueFalse=cmt_cpp_group\s*=\s*true|cmt_cpp_group\s*=\s*false
 ValueDefault=false
 
 [Cmt Cpp Nl Start]
@@ -6618,7 +6619,7 @@ Category=8
 Description="<html>Whether to put an empty '/*' on the first line of the combined cpp-comment<br/>when converting to a c-comment.<br/><br/>Requires cmt_cpp_to_c=true and cmt_cpp_group=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_cpp_nl_start=true|cmt_cpp_nl_start=false
+TrueFalse=cmt_cpp_nl_start\s*=\s*true|cmt_cpp_nl_start\s*=\s*false
 ValueDefault=false
 
 [Cmt Cpp Nl End]
@@ -6626,7 +6627,7 @@ Category=8
 Description="<html>Whether to add a newline before the closing '*/' of the combined cpp-comment<br/>when converting to a c-comment.<br/><br/>Requires cmt_cpp_to_c=true and cmt_cpp_group=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_cpp_nl_end=true|cmt_cpp_nl_end=false
+TrueFalse=cmt_cpp_nl_end\s*=\s*true|cmt_cpp_nl_end\s*=\s*false
 ValueDefault=false
 
 [Cmt Star Cont]
@@ -6634,7 +6635,7 @@ Category=8
 Description="<html>Whether to put a star on subsequent comment lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_star_cont=true|cmt_star_cont=false
+TrueFalse=cmt_star_cont\s*=\s*true|cmt_star_cont\s*=\s*false
 ValueDefault=false
 
 [Cmt Sp Before Star Cont]
@@ -6642,7 +6643,7 @@ Category=8
 Description="<html>The number of spaces to insert at the start of subsequent comment lines.</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_sp_before_star_cont="
+CallName="cmt_sp_before_star_cont\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6652,7 +6653,7 @@ Category=8
 Description="<html>The number of spaces to insert after the star on subsequent comment lines.</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_sp_after_star_cont="
+CallName="cmt_sp_after_star_cont\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6662,7 +6663,7 @@ Category=8
 Description="<html>For multi-line comments with a '*' lead, remove leading spaces if the first<br/>and last lines of the comment are the same length.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_multi_check_last=true|cmt_multi_check_last=false
+TrueFalse=cmt_multi_check_last\s*=\s*true|cmt_multi_check_last\s*=\s*false
 ValueDefault=true
 
 [Cmt Multi First Len Minimum]
@@ -6670,7 +6671,7 @@ Category=8
 Description="<html>For multi-line comments with a '*' lead, remove leading spaces if the first<br/>and last lines of the comment are the same length AND if the length is<br/>bigger as the first_len minimum.<br/><br/>Default: 4</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_multi_first_len_minimum="
+CallName="cmt_multi_first_len_minimum\s*=\s*"
 MinVal=1
 MaxVal=20
 ValueDefault=4
@@ -6679,7 +6680,7 @@ ValueDefault=4
 Category=8
 Description="<html>Path to a file that contains text to insert at the beginning of a file if<br/>the file doesn't start with a C/C++ comment. If the inserted text contains<br/>'$(filename)', that will be replaced with the current file's name.</html>"
 Enabled=false
-CallName=cmt_insert_file_header=
+CallName=cmt_insert_file_header\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6687,7 +6688,7 @@ ValueDefault=
 Category=8
 Description="<html>Path to a file that contains text to insert at the end of a file if the<br/>file doesn't end with a C/C++ comment. If the inserted text contains<br/>'$(filename)', that will be replaced with the current file's name.</html>"
 Enabled=false
-CallName=cmt_insert_file_footer=
+CallName=cmt_insert_file_footer\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6695,7 +6696,7 @@ ValueDefault=
 Category=8
 Description="<html>Path to a file that contains text to insert before a function definition if<br/>the function isn't preceded by a C/C++ comment. If the inserted text<br/>contains '$(function)', '$(javaparam)' or '$(fclass)', these will be<br/>replaced with, respectively, the name of the function, the javadoc '@param'<br/>and '@return' stuff, or the name of the class to which the member function<br/>belongs.</html>"
 Enabled=false
-CallName=cmt_insert_func_header=
+CallName=cmt_insert_func_header\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6703,7 +6704,7 @@ ValueDefault=
 Category=8
 Description="<html>Path to a file that contains text to insert before a class if the class<br/>isn't preceded by a C/C++ comment. If the inserted text contains '$(class)',<br/>that will be replaced with the class name.</html>"
 Enabled=false
-CallName=cmt_insert_class_header=
+CallName=cmt_insert_class_header\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6711,7 +6712,7 @@ ValueDefault=
 Category=8
 Description="<html>Path to a file that contains text to insert before an Objective-C message<br/>specification, if the method isn't preceded by a C/C++ comment. If the<br/>inserted text contains '$(message)' or '$(javaparam)', these will be<br/>replaced with, respectively, the name of the function, or the javadoc<br/>'@param' and '@return' stuff.</html>"
 Enabled=false
-CallName=cmt_insert_oc_msg_header=
+CallName=cmt_insert_oc_msg_header\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6720,7 +6721,7 @@ Category=8
 Description="<html>Whether a comment should be inserted if a preprocessor is encountered when<br/>stepping backwards from a function name.<br/><br/>Applies to cmt_insert_oc_msg_header, cmt_insert_func_header and<br/>cmt_insert_class_header.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_insert_before_preproc=true|cmt_insert_before_preproc=false
+TrueFalse=cmt_insert_before_preproc\s*=\s*true|cmt_insert_before_preproc\s*=\s*false
 ValueDefault=false
 
 [Cmt Insert Before Inlines]
@@ -6728,7 +6729,7 @@ Category=8
 Description="<html>Whether a comment should be inserted if a function is declared inline to a<br/>class definition.<br/><br/>Applies to cmt_insert_func_header.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_insert_before_inlines=true|cmt_insert_before_inlines=false
+TrueFalse=cmt_insert_before_inlines\s*=\s*true|cmt_insert_before_inlines\s*=\s*false
 ValueDefault=true
 
 [Cmt Insert Before Ctor Dtor]
@@ -6736,7 +6737,7 @@ Category=8
 Description="<html>Whether a comment should be inserted if the function is a class constructor<br/>or destructor.<br/><br/>Applies to cmt_insert_func_header.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_insert_before_ctor_dtor=true|cmt_insert_before_ctor_dtor=false
+TrueFalse=cmt_insert_before_ctor_dtor\s*=\s*true|cmt_insert_before_ctor_dtor\s*=\s*false
 ValueDefault=false
 
 [Mod Full Brace Do]
@@ -6744,7 +6745,7 @@ Category=9
 Description="<html>Add or remove braces on a single-line 'do' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_do=ignore|mod_full_brace_do=add|mod_full_brace_do=remove|mod_full_brace_do=force|mod_full_brace_do=not_defined
+Choices=mod_full_brace_do\s*=\s*ignore|mod_full_brace_do\s*=\s*add|mod_full_brace_do\s*=\s*remove|mod_full_brace_do\s*=\s*force|mod_full_brace_do\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace Do|Add Mod Full Brace Do|Remove Mod Full Brace Do|Force Mod Full Brace Do"
 ValueDefault=ignore
 
@@ -6753,7 +6754,7 @@ Category=9
 Description="<html>Add or remove braces on a single-line 'for' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_for=ignore|mod_full_brace_for=add|mod_full_brace_for=remove|mod_full_brace_for=force|mod_full_brace_for=not_defined
+Choices=mod_full_brace_for\s*=\s*ignore|mod_full_brace_for\s*=\s*add|mod_full_brace_for\s*=\s*remove|mod_full_brace_for\s*=\s*force|mod_full_brace_for\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace For|Add Mod Full Brace For|Remove Mod Full Brace For|Force Mod Full Brace For"
 ValueDefault=ignore
 
@@ -6762,7 +6763,7 @@ Category=9
 Description="<html>(Pawn) Add or remove braces on a single-line function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_function=ignore|mod_full_brace_function=add|mod_full_brace_function=remove|mod_full_brace_function=force|mod_full_brace_function=not_defined
+Choices=mod_full_brace_function\s*=\s*ignore|mod_full_brace_function\s*=\s*add|mod_full_brace_function\s*=\s*remove|mod_full_brace_function\s*=\s*force|mod_full_brace_function\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace Function|Add Mod Full Brace Function|Remove Mod Full Brace Function|Force Mod Full Brace Function"
 ValueDefault=ignore
 
@@ -6771,7 +6772,7 @@ Category=9
 Description="<html>Add or remove braces on a single-line 'if' statement. Braces will not be<br/>removed if the braced statement contains an 'else'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_if=ignore|mod_full_brace_if=add|mod_full_brace_if=remove|mod_full_brace_if=force|mod_full_brace_if=not_defined
+Choices=mod_full_brace_if\s*=\s*ignore|mod_full_brace_if\s*=\s*add|mod_full_brace_if\s*=\s*remove|mod_full_brace_if\s*=\s*force|mod_full_brace_if\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace If|Add Mod Full Brace If|Remove Mod Full Brace If|Force Mod Full Brace If"
 ValueDefault=ignore
 
@@ -6780,7 +6781,7 @@ Category=9
 Description="<html>Whether to enforce that all blocks of an 'if'/'else if'/'else' chain either<br/>have, or do not have, braces. Overrides mod_full_brace_if.<br/><br/>0: Don't override mod_full_brace_if<br/>1: Add braces to all blocks if any block needs braces and remove braces if<br/>   they can be removed from all blocks<br/>2: Add braces to all blocks if any block already has braces, regardless of<br/>   whether it needs them<br/>3: Add braces to all blocks if any block needs braces and remove braces if<br/>   they can be removed from all blocks, except if all blocks have braces<br/>   despite none needing them</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_full_brace_if_chain="
+CallName="mod_full_brace_if_chain\s*=\s*"
 MinVal=0
 MaxVal=3
 ValueDefault=0
@@ -6790,7 +6791,7 @@ Category=9
 Description="<html>Whether to add braces to all blocks of an 'if'/'else if'/'else' chain.<br/>If true, mod_full_brace_if_chain will only remove braces from an 'if' that<br/>does not have an 'else if' or 'else'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_brace_if_chain_only=true|mod_full_brace_if_chain_only=false
+TrueFalse=mod_full_brace_if_chain_only\s*=\s*true|mod_full_brace_if_chain_only\s*=\s*false
 ValueDefault=false
 
 [Mod Full Brace While]
@@ -6798,7 +6799,7 @@ Category=9
 Description="<html>Add or remove braces on single-line 'while' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_while=ignore|mod_full_brace_while=add|mod_full_brace_while=remove|mod_full_brace_while=force|mod_full_brace_while=not_defined
+Choices=mod_full_brace_while\s*=\s*ignore|mod_full_brace_while\s*=\s*add|mod_full_brace_while\s*=\s*remove|mod_full_brace_while\s*=\s*force|mod_full_brace_while\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace While|Add Mod Full Brace While|Remove Mod Full Brace While|Force Mod Full Brace While"
 ValueDefault=ignore
 
@@ -6807,7 +6808,7 @@ Category=9
 Description="<html>Add or remove braces on single-line 'using ()' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_using=ignore|mod_full_brace_using=add|mod_full_brace_using=remove|mod_full_brace_using=force|mod_full_brace_using=not_defined
+Choices=mod_full_brace_using\s*=\s*ignore|mod_full_brace_using\s*=\s*add|mod_full_brace_using\s*=\s*remove|mod_full_brace_using\s*=\s*force|mod_full_brace_using\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace Using|Add Mod Full Brace Using|Remove Mod Full Brace Using|Force Mod Full Brace Using"
 ValueDefault=ignore
 
@@ -6816,7 +6817,7 @@ Category=9
 Description="<html>Don't remove braces around statements that span N newlines</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_full_brace_nl="
+CallName="mod_full_brace_nl\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6826,7 +6827,7 @@ Category=9
 Description="<html>Whether to prevent removal of braces from 'if'/'for'/'while'/etc. blocks<br/>which span multiple lines.<br/><br/>Affects:<br/>  mod_full_brace_for<br/>  mod_full_brace_if<br/>  mod_full_brace_if_chain<br/>  mod_full_brace_if_chain_only<br/>  mod_full_brace_while<br/>  mod_full_brace_using<br/><br/>Does not affect:<br/>  mod_full_brace_do<br/>  mod_full_brace_function</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_brace_nl_block_rem_mlcond=true|mod_full_brace_nl_block_rem_mlcond=false
+TrueFalse=mod_full_brace_nl_block_rem_mlcond\s*=\s*true|mod_full_brace_nl_block_rem_mlcond\s*=\s*false
 ValueDefault=false
 
 [Mod Paren On Return]
@@ -6834,7 +6835,7 @@ Category=9
 Description="<html>Add or remove unnecessary parentheses on 'return' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_paren_on_return=ignore|mod_paren_on_return=add|mod_paren_on_return=remove|mod_paren_on_return=force|mod_paren_on_return=not_defined
+Choices=mod_paren_on_return\s*=\s*ignore|mod_paren_on_return\s*=\s*add|mod_paren_on_return\s*=\s*remove|mod_paren_on_return\s*=\s*force|mod_paren_on_return\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Paren On Return|Add Mod Paren On Return|Remove Mod Paren On Return|Force Mod Paren On Return"
 ValueDefault=ignore
 
@@ -6843,7 +6844,7 @@ Category=9
 Description="<html>Add or remove unnecessary parentheses on 'throw' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_paren_on_throw=ignore|mod_paren_on_throw=add|mod_paren_on_throw=remove|mod_paren_on_throw=force|mod_paren_on_throw=not_defined
+Choices=mod_paren_on_throw\s*=\s*ignore|mod_paren_on_throw\s*=\s*add|mod_paren_on_throw\s*=\s*remove|mod_paren_on_throw\s*=\s*force|mod_paren_on_throw\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Paren On Throw|Add Mod Paren On Throw|Remove Mod Paren On Throw|Force Mod Paren On Throw"
 ValueDefault=ignore
 
@@ -6852,7 +6853,7 @@ Category=9
 Description="<html>(Pawn) Whether to change optional semicolons to real semicolons.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_pawn_semicolon=true|mod_pawn_semicolon=false
+TrueFalse=mod_pawn_semicolon\s*=\s*true|mod_pawn_semicolon\s*=\s*false
 ValueDefault=false
 
 [Mod Full Paren If Bool]
@@ -6860,7 +6861,7 @@ Category=9
 Description="<html>Whether to fully parenthesize Boolean expressions in 'while' and 'if'<br/>statement, as in 'if (a &amp;&amp; b &gt; c)' =&gt; 'if (a &amp;&amp; (b &gt; c))'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_paren_if_bool=true|mod_full_paren_if_bool=false
+TrueFalse=mod_full_paren_if_bool\s*=\s*true|mod_full_paren_if_bool\s*=\s*false
 ValueDefault=false
 
 [Mod Full Paren Assign Bool]
@@ -6868,7 +6869,7 @@ Category=9
 Description="<html>Whether to fully parenthesize Boolean expressions after '='<br/>statement, as in 'x = a &amp;&amp; b &gt; c;' =&gt; 'x = (a &amp;&amp; (b &gt; c));'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_paren_assign_bool=true|mod_full_paren_assign_bool=false
+TrueFalse=mod_full_paren_assign_bool\s*=\s*true|mod_full_paren_assign_bool\s*=\s*false
 ValueDefault=false
 
 [Mod Full Paren Return Bool]
@@ -6876,7 +6877,7 @@ Category=9
 Description="<html>Whether to fully parenthesize Boolean expressions after '='<br/>statement, as in 'return  a &amp;&amp; b &gt; c;' =&gt; 'return (a &amp;&amp; (b &gt; c));'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_paren_return_bool=true|mod_full_paren_return_bool=false
+TrueFalse=mod_full_paren_return_bool\s*=\s*true|mod_full_paren_return_bool\s*=\s*false
 ValueDefault=false
 
 [Mod Remove Extra Semicolon]
@@ -6884,7 +6885,7 @@ Category=9
 Description="<html>Whether to remove superfluous semicolons.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_remove_extra_semicolon=true|mod_remove_extra_semicolon=false
+TrueFalse=mod_remove_extra_semicolon\s*=\s*true|mod_remove_extra_semicolon\s*=\s*false
 ValueDefault=false
 
 [Mod Remove Duplicate Include]
@@ -6892,7 +6893,7 @@ Category=9
 Description="<html>Whether to remove duplicate include.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_remove_duplicate_include=true|mod_remove_duplicate_include=false
+TrueFalse=mod_remove_duplicate_include\s*=\s*true|mod_remove_duplicate_include\s*=\s*false
 ValueDefault=false
 
 [Mod Add Force C Closebrace Comment]
@@ -6900,7 +6901,7 @@ Category=9
 Description="<html>the following options (mod_XX_closebrace_comment) use different comment,<br/>depending of the setting of the next option.<br/>false: Use the c comment (default)<br/>true : Use the cpp comment</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_add_force_c_closebrace_comment=true|mod_add_force_c_closebrace_comment=false
+TrueFalse=mod_add_force_c_closebrace_comment\s*=\s*true|mod_add_force_c_closebrace_comment\s*=\s*false
 ValueDefault=false
 
 [Mod Add Long Function Closebrace Comment]
@@ -6908,7 +6909,7 @@ Category=9
 Description="<html>If a function body exceeds the specified number of newlines and doesn't have<br/>a comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_function_closebrace_comment="
+CallName="mod_add_long_function_closebrace_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6918,7 +6919,7 @@ Category=9
 Description="<html>If a namespace body exceeds the specified number of newlines and doesn't<br/>have a comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_namespace_closebrace_comment="
+CallName="mod_add_long_namespace_closebrace_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6928,7 +6929,7 @@ Category=9
 Description="<html>If a class body exceeds the specified number of newlines and doesn't have a<br/>comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_class_closebrace_comment="
+CallName="mod_add_long_class_closebrace_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6938,7 +6939,7 @@ Category=9
 Description="<html>If a switch body exceeds the specified number of newlines and doesn't have a<br/>comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_switch_closebrace_comment="
+CallName="mod_add_long_switch_closebrace_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6948,7 +6949,7 @@ Category=9
 Description="<html>If an #ifdef body exceeds the specified number of newlines and doesn't have<br/>a comment after the #endif, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_ifdef_endif_comment="
+CallName="mod_add_long_ifdef_endif_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6958,7 +6959,7 @@ Category=9
 Description="<html>If an #ifdef or #else body exceeds the specified number of newlines and<br/>doesn't have a comment after the #else, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_ifdef_else_comment="
+CallName="mod_add_long_ifdef_else_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6968,7 +6969,7 @@ Category=9
 Description="<html>Whether to take care of the case by the mod_sort_xx options.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_case_sensitive=true|mod_sort_case_sensitive=false
+TrueFalse=mod_sort_case_sensitive\s*=\s*true|mod_sort_case_sensitive\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Import]
@@ -6976,7 +6977,7 @@ Category=9
 Description="<html>Whether to sort consecutive single-line 'import' statements.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_import=true|mod_sort_import=false
+TrueFalse=mod_sort_import\s*=\s*true|mod_sort_import\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Using]
@@ -6984,7 +6985,7 @@ Category=9
 Description="<html>(C#) Whether to sort consecutive single-line 'using' statements.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_using=true|mod_sort_using=false
+TrueFalse=mod_sort_using\s*=\s*true|mod_sort_using\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Include]
@@ -6992,7 +6993,7 @@ Category=9
 Description="<html>Whether to sort consecutive single-line '#include' statements (C/C++) and<br/>'#import' statements (Objective-C). Be aware that this has the potential to<br/>break your code if your includes/imports have ordering dependencies.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_include=true|mod_sort_include=false
+TrueFalse=mod_sort_include\s*=\s*true|mod_sort_include\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Prioritize Filename]
@@ -7000,7 +7001,7 @@ Category=9
 Description="<html>Whether to prioritize '#include' and '#import' statements that contain<br/>filename without extension when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_prioritize_filename=true|mod_sort_incl_import_prioritize_filename=false
+TrueFalse=mod_sort_incl_import_prioritize_filename\s*=\s*true|mod_sort_incl_import_prioritize_filename\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Prioritize Extensionless]
@@ -7008,7 +7009,7 @@ Category=9
 Description="<html>Whether to prioritize '#include' and '#import' statements that does not<br/>contain extensions when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_prioritize_extensionless=true|mod_sort_incl_import_prioritize_extensionless=false
+TrueFalse=mod_sort_incl_import_prioritize_extensionless\s*=\s*true|mod_sort_incl_import_prioritize_extensionless\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Prioritize Angle Over Quotes]
@@ -7016,7 +7017,7 @@ Category=9
 Description="<html>Whether to prioritize '#include' and '#import' statements that contain<br/>angle over quotes when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_prioritize_angle_over_quotes=true|mod_sort_incl_import_prioritize_angle_over_quotes=false
+TrueFalse=mod_sort_incl_import_prioritize_angle_over_quotes\s*=\s*true|mod_sort_incl_import_prioritize_angle_over_quotes\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Ignore Extension]
@@ -7024,7 +7025,7 @@ Category=9
 Description="<html>Whether to ignore file extension in '#include' and '#import' statements<br/>for sorting comparison.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_ignore_extension=true|mod_sort_incl_import_ignore_extension=false
+TrueFalse=mod_sort_incl_import_ignore_extension\s*=\s*true|mod_sort_incl_import_ignore_extension\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Grouping Enabled]
@@ -7032,7 +7033,7 @@ Category=9
 Description="<html>Whether to group '#include' and '#import' statements when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_grouping_enabled=true|mod_sort_incl_import_grouping_enabled=false
+TrueFalse=mod_sort_incl_import_grouping_enabled\s*=\s*true|mod_sort_incl_import_grouping_enabled\s*=\s*false
 ValueDefault=false
 
 [Mod Move Case Break]
@@ -7040,7 +7041,7 @@ Category=9
 Description="<html>Whether to move a 'break' that appears after a fully braced 'case' before<br/>the close brace, as in 'case X: { ... } break;' =&gt; 'case X: { ... break; }'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_move_case_break=true|mod_move_case_break=false
+TrueFalse=mod_move_case_break\s*=\s*true|mod_move_case_break\s*=\s*false
 ValueDefault=false
 
 [Mod Move Case Return]
@@ -7048,7 +7049,7 @@ Category=9
 Description="<html>Whether to move a 'return' that appears after a fully braced 'case' before<br/>the close brace, as in 'case X: { ... } return;' =&gt; 'case X: { ... return; }'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_move_case_return=true|mod_move_case_return=false
+TrueFalse=mod_move_case_return\s*=\s*true|mod_move_case_return\s*=\s*false
 ValueDefault=false
 
 [Mod Case Brace]
@@ -7056,7 +7057,7 @@ Category=9
 Description="<html>Add or remove braces around a fully braced case statement. Will only remove<br/>braces if there are no variable declarations in the block.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_case_brace=ignore|mod_case_brace=add|mod_case_brace=remove|mod_case_brace=force|mod_case_brace=not_defined
+Choices=mod_case_brace\s*=\s*ignore|mod_case_brace\s*=\s*add|mod_case_brace\s*=\s*remove|mod_case_brace\s*=\s*force|mod_case_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Case Brace|Add Mod Case Brace|Remove Mod Case Brace|Force Mod Case Brace"
 ValueDefault=ignore
 
@@ -7065,7 +7066,7 @@ Category=9
 Description="<html>Whether to remove a void 'return;' that appears as the last statement in a<br/>function.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_remove_empty_return=true|mod_remove_empty_return=false
+TrueFalse=mod_remove_empty_return\s*=\s*true|mod_remove_empty_return\s*=\s*false
 ValueDefault=false
 
 [Mod Enum Last Comma]
@@ -7073,7 +7074,7 @@ Category=9
 Description="<html>Add or remove the comma after the last value of an enumeration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_enum_last_comma=ignore|mod_enum_last_comma=add|mod_enum_last_comma=remove|mod_enum_last_comma=force|mod_enum_last_comma=not_defined
+Choices=mod_enum_last_comma\s*=\s*ignore|mod_enum_last_comma\s*=\s*add|mod_enum_last_comma\s*=\s*remove|mod_enum_last_comma\s*=\s*force|mod_enum_last_comma\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Enum Last Comma|Add Mod Enum Last Comma|Remove Mod Enum Last Comma|Force Mod Enum Last Comma"
 ValueDefault=ignore
 
@@ -7082,7 +7083,7 @@ Category=9
 Description="<html>Syntax to use for infinite loops.<br/><br/>0: Leave syntax alone (default)<br/>1: Rewrite as `for(;;)`<br/>2: Rewrite as `while(true)`<br/>3: Rewrite as `do`...`while(true);`<br/>4: Rewrite as `while(1)`<br/>5: Rewrite as `do`...`while(1);`<br/><br/>Infinite loops that do not already match one of these syntaxes are ignored.<br/>Other options that affect loop formatting will be applied after transforming<br/>the syntax.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_infinite_loop="
+CallName="mod_infinite_loop\s*=\s*"
 MinVal=0
 MaxVal=5
 ValueDefault=0
@@ -7092,7 +7093,7 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'int short'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_int_short=ignore|mod_int_short=add|mod_int_short=remove|mod_int_short=force|mod_int_short=not_defined
+Choices=mod_int_short\s*=\s*ignore|mod_int_short\s*=\s*add|mod_int_short\s*=\s*remove|mod_int_short\s*=\s*force|mod_int_short\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Int Short|Add Mod Int Short|Remove Mod Int Short|Force Mod Int Short"
 ValueDefault=ignore
 
@@ -7101,7 +7102,7 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'short int'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_short_int=ignore|mod_short_int=add|mod_short_int=remove|mod_short_int=force|mod_short_int=not_defined
+Choices=mod_short_int\s*=\s*ignore|mod_short_int\s*=\s*add|mod_short_int\s*=\s*remove|mod_short_int\s*=\s*force|mod_short_int\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Short Int|Add Mod Short Int|Remove Mod Short Int|Force Mod Short Int"
 ValueDefault=ignore
 
@@ -7110,7 +7111,7 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'int long'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_int_long=ignore|mod_int_long=add|mod_int_long=remove|mod_int_long=force|mod_int_long=not_defined
+Choices=mod_int_long\s*=\s*ignore|mod_int_long\s*=\s*add|mod_int_long\s*=\s*remove|mod_int_long\s*=\s*force|mod_int_long\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Int Long|Add Mod Int Long|Remove Mod Int Long|Force Mod Int Long"
 ValueDefault=ignore
 
@@ -7119,7 +7120,7 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'long int'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_long_int=ignore|mod_long_int=add|mod_long_int=remove|mod_long_int=force|mod_long_int=not_defined
+Choices=mod_long_int\s*=\s*ignore|mod_long_int\s*=\s*add|mod_long_int\s*=\s*remove|mod_long_int\s*=\s*force|mod_long_int\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Long Int|Add Mod Long Int|Remove Mod Long Int|Force Mod Long Int"
 ValueDefault=ignore
 
@@ -7128,7 +7129,7 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'int signed'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_int_signed=ignore|mod_int_signed=add|mod_int_signed=remove|mod_int_signed=force|mod_int_signed=not_defined
+Choices=mod_int_signed\s*=\s*ignore|mod_int_signed\s*=\s*add|mod_int_signed\s*=\s*remove|mod_int_signed\s*=\s*force|mod_int_signed\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Int Signed|Add Mod Int Signed|Remove Mod Int Signed|Force Mod Int Signed"
 ValueDefault=ignore
 
@@ -7137,7 +7138,7 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'signed int'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_signed_int=ignore|mod_signed_int=add|mod_signed_int=remove|mod_signed_int=force|mod_signed_int=not_defined
+Choices=mod_signed_int\s*=\s*ignore|mod_signed_int\s*=\s*add|mod_signed_int\s*=\s*remove|mod_signed_int\s*=\s*force|mod_signed_int\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Signed Int|Add Mod Signed Int|Remove Mod Signed Int|Force Mod Signed Int"
 ValueDefault=ignore
 
@@ -7146,7 +7147,7 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'int unsigned'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_int_unsigned=ignore|mod_int_unsigned=add|mod_int_unsigned=remove|mod_int_unsigned=force|mod_int_unsigned=not_defined
+Choices=mod_int_unsigned\s*=\s*ignore|mod_int_unsigned\s*=\s*add|mod_int_unsigned\s*=\s*remove|mod_int_unsigned\s*=\s*force|mod_int_unsigned\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Int Unsigned|Add Mod Int Unsigned|Remove Mod Int Unsigned|Force Mod Int Unsigned"
 ValueDefault=ignore
 
@@ -7155,7 +7156,7 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'unsigned int'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_unsigned_int=ignore|mod_unsigned_int=add|mod_unsigned_int=remove|mod_unsigned_int=force|mod_unsigned_int=not_defined
+Choices=mod_unsigned_int\s*=\s*ignore|mod_unsigned_int\s*=\s*add|mod_unsigned_int\s*=\s*remove|mod_unsigned_int\s*=\s*force|mod_unsigned_int\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Unsigned Int|Add Mod Unsigned Int|Remove Mod Unsigned Int|Force Mod Unsigned Int"
 ValueDefault=ignore
 
@@ -7164,7 +7165,7 @@ Category=9
 Description="<html>If there is a situation where mod_int_* and mod_*_int would result in<br/>multiple int keywords, whether to keep the rightmost int (the default) or the<br/>leftmost int.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_int_prefer_int_on_left=true|mod_int_prefer_int_on_left=false
+TrueFalse=mod_int_prefer_int_on_left\s*=\s*true|mod_int_prefer_int_on_left\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Oc Properties]
@@ -7172,7 +7173,7 @@ Category=9
 Description="<html>(OC) Whether to organize the properties. If true, properties will be<br/>rearranged according to the mod_sort_oc_property_*_weight factors.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_oc_properties=true|mod_sort_oc_properties=false
+TrueFalse=mod_sort_oc_properties\s*=\s*true|mod_sort_oc_properties\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Oc Property Class Weight]
@@ -7180,7 +7181,7 @@ Category=9
 Description="<html>(OC) Weight of a class property modifier.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_class_weight="
+CallName="mod_sort_oc_property_class_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7190,7 +7191,7 @@ Category=9
 Description="<html>(OC) Weight of 'atomic' and 'nonatomic'.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_thread_safe_weight="
+CallName="mod_sort_oc_property_thread_safe_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7200,7 +7201,7 @@ Category=9
 Description="<html>(OC) Weight of 'readwrite' when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_readwrite_weight="
+CallName="mod_sort_oc_property_readwrite_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7210,7 +7211,7 @@ Category=9
 Description="<html>(OC) Weight of a reference type specifier ('retain', 'copy', 'assign',<br/>'weak', 'strong') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_reference_weight="
+CallName="mod_sort_oc_property_reference_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7220,7 +7221,7 @@ Category=9
 Description="<html>(OC) Weight of getter type ('getter=') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_getter_weight="
+CallName="mod_sort_oc_property_getter_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7230,7 +7231,7 @@ Category=9
 Description="<html>(OC) Weight of setter type ('setter=') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_setter_weight="
+CallName="mod_sort_oc_property_setter_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7240,7 +7241,7 @@ Category=9
 Description="<html>(OC) Weight of nullability type ('nullable', 'nonnull', 'null_unspecified',<br/>'null_resettable') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_nullability_weight="
+CallName="mod_sort_oc_property_nullability_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7250,7 +7251,7 @@ Category=10
 Description="<html>How to use tabs when indenting preprocessor code.<br/><br/>-1: Use 'indent_with_tabs' setting (default)<br/> 0: Spaces only<br/> 1: Indent with tabs to brace level, align with spaces<br/> 2: Indent and align with tabs, using spaces when not on a tabstop<br/><br/>Default: -1</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_with_tabs="
+CallName="pp_indent_with_tabs\s*=\s*"
 MinVal=-1
 MaxVal=2
 ValueDefault=-1
@@ -7260,7 +7261,7 @@ Category=10
 Description="<html>Add or remove indentation of preprocessor directives inside #if blocks<br/>at brace level 0 (file-level).</html>"
 Enabled=false
 EditorType=multiple
-Choices=pp_indent=ignore|pp_indent=add|pp_indent=remove|pp_indent=force|pp_indent=not_defined
+Choices=pp_indent\s*=\s*ignore|pp_indent\s*=\s*add|pp_indent\s*=\s*remove|pp_indent\s*=\s*force|pp_indent\s*=\s*not_defined
 ChoicesReadable="Ignore Pp Indent|Add Pp Indent|Remove Pp Indent|Force Pp Indent"
 ValueDefault=ignore
 
@@ -7269,7 +7270,7 @@ Category=10
 Description="<html>Whether to indent #if/#else/#endif at the brace level. If false, these are<br/>indented from column 1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_at_level=true|pp_indent_at_level=false
+TrueFalse=pp_indent_at_level\s*=\s*true|pp_indent_at_level\s*=\s*false
 ValueDefault=false
 
 [Pp Indent At Level0]
@@ -7277,7 +7278,7 @@ Category=10
 Description="<html>Whether to indent #if/#else/#endif at the parenthesis level if the brace<br/>level is 0. If false, these are indented from column 1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_at_level0=true|pp_indent_at_level0=false
+TrueFalse=pp_indent_at_level0\s*=\s*true|pp_indent_at_level0\s*=\s*false
 ValueDefault=false
 
 [Pp Indent Count]
@@ -7285,7 +7286,7 @@ Category=10
 Description="<html>Specifies the number of columns to indent preprocessors per level<br/>at brace level 0 (file-level). If pp_indent_at_level=false, also specifies<br/>the number of columns to indent preprocessors per level<br/>at brace level &gt; 0 (function-level).<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_count="
+CallName="pp_indent_count\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -7295,7 +7296,7 @@ Category=10
 Description="<html>Add or remove space after # based on pp level of #if blocks.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pp_space_after=ignore|pp_space_after=add|pp_space_after=remove|pp_space_after=force|pp_space_after=not_defined
+Choices=pp_space_after\s*=\s*ignore|pp_space_after\s*=\s*add|pp_space_after\s*=\s*remove|pp_space_after\s*=\s*force|pp_space_after\s*=\s*not_defined
 ChoicesReadable="Ignore Pp Space After|Add Pp Space After|Remove Pp Space After|Force Pp Space After"
 ValueDefault=ignore
 
@@ -7304,7 +7305,7 @@ Category=10
 Description="<html>Sets the number of spaces per level added with pp_space_after.</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_space_count="
+CallName="pp_space_count\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -7314,7 +7315,7 @@ Category=10
 Description="<html>The indent for '#region' and '#endregion' in C# and '#pragma region' in<br/>C/C++. Negative values decrease indent down to the first column.</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_region="
+CallName="pp_indent_region\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -7324,7 +7325,7 @@ Category=10
 Description="<html>Whether to indent the code between #region and #endregion.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_region_indent_code=true|pp_region_indent_code=false
+TrueFalse=pp_region_indent_code\s*=\s*true|pp_region_indent_code\s*=\s*false
 ValueDefault=false
 
 [Pp Indent If]
@@ -7332,7 +7333,7 @@ Category=10
 Description="<html>If pp_indent_at_level=true, sets the indent for #if, #else and #endif when<br/>not at file-level. Negative values decrease indent down to the first column.<br/><br/>=0: Indent preprocessors using output_tab_size<br/>&gt;0: Column at which all preprocessors will be indented</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_if="
+CallName="pp_indent_if\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -7342,7 +7343,7 @@ Category=10
 Description="<html>Whether to indent the code between #if, #else and #endif.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_if_indent_code=true|pp_if_indent_code=false
+TrueFalse=pp_if_indent_code\s*=\s*true|pp_if_indent_code\s*=\s*false
 ValueDefault=false
 
 [Pp Indent In Guard]
@@ -7350,7 +7351,7 @@ Category=10
 Description="<html>Whether to indent the body of an #if that encompasses all the code in the file.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_in_guard=true|pp_indent_in_guard=false
+TrueFalse=pp_indent_in_guard\s*=\s*true|pp_indent_in_guard\s*=\s*false
 ValueDefault=false
 
 [Pp Define At Level]
@@ -7358,7 +7359,7 @@ Category=10
 Description="<html>Whether to indent '#define' at the brace level. If false, these are<br/>indented from column 1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_define_at_level=true|pp_define_at_level=false
+TrueFalse=pp_define_at_level\s*=\s*true|pp_define_at_level\s*=\s*false
 ValueDefault=false
 
 [Pp Include At Level]
@@ -7366,7 +7367,7 @@ Category=10
 Description="<html>Whether to indent '#include' at the brace level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_include_at_level=true|pp_include_at_level=false
+TrueFalse=pp_include_at_level\s*=\s*true|pp_include_at_level\s*=\s*false
 ValueDefault=false
 
 [Pp Ignore Define Body]
@@ -7374,7 +7375,7 @@ Category=10
 Description="<html>Whether to ignore the '#define' body while formatting.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_ignore_define_body=true|pp_ignore_define_body=false
+TrueFalse=pp_ignore_define_body\s*=\s*true|pp_ignore_define_body\s*=\s*false
 ValueDefault=false
 
 [Pp Multiline Define Body Indent]
@@ -7382,7 +7383,7 @@ Category=10
 Description="<html>An offset value that controls the indentation of the body of a multiline #define.<br/>'body' refers to all the lines of a multiline #define except the first line.<br/>Requires 'pp_ignore_define_body = false'.<br/><br/> &lt;0: Absolute column: the body indentation starts off at the specified column<br/>     (ex. -3 ==&gt; the body is indented starting from column 3)<br/>&gt;=0: Relative to the column of the '#' of '#define'<br/>     (ex.  3 ==&gt; the body is indented starting 3 columns at the right of '#')<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_multiline_define_body_indent="
+CallName="pp_multiline_define_body_indent\s*=\s*"
 MinVal=-32
 MaxVal=32
 ValueDefault=8
@@ -7392,7 +7393,7 @@ Category=10
 Description="<html>Whether to indent case statements between #if, #else, and #endif.<br/>Only applies to the indent of the preprocessor that the case statements<br/>directly inside of.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_case=true|pp_indent_case=false
+TrueFalse=pp_indent_case\s*=\s*true|pp_indent_case\s*=\s*false
 ValueDefault=true
 
 [Pp Indent Func Def]
@@ -7400,7 +7401,7 @@ Category=10
 Description="<html>Whether to indent whole function definitions between #if, #else, and #endif.<br/>Only applies to the indent of the preprocessor that the function definition<br/>is directly inside of.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_func_def=true|pp_indent_func_def=false
+TrueFalse=pp_indent_func_def\s*=\s*true|pp_indent_func_def\s*=\s*false
 ValueDefault=true
 
 [Pp Indent Extern]
@@ -7408,7 +7409,7 @@ Category=10
 Description="<html>Whether to indent extern C blocks between #if, #else, and #endif.<br/>Only applies to the indent of the preprocessor that the extern block is<br/>directly inside of.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_extern=true|pp_indent_extern=false
+TrueFalse=pp_indent_extern\s*=\s*true|pp_indent_extern\s*=\s*false
 ValueDefault=true
 
 [Pp Indent Brace]
@@ -7416,7 +7417,7 @@ Category=10
 Description="<html>How to indent braces directly inside #if, #else, and #endif.<br/>Requires pp_if_indent_code=true and only applies to the indent of the<br/>preprocessor that the braces are directly inside of.<br/> 0: No extra indent<br/> 1: Indent by one level<br/>-1: Preserve original indentation<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_brace="
+CallName="pp_indent_brace\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=1
@@ -7426,14 +7427,14 @@ Category=10
 Description="<html>Whether to print warning messages for unbalanced #if and #else blocks.<br/>This will print a message in the following cases:<br/>- if an #ifdef block ends on a different indent level than<br/>  where it started from. Example:<br/><br/>   #ifdef TEST<br/>     int i;<br/>     {<br/>       int j;<br/>   #endif<br/><br/>- an #elif/#else block ends on a different indent level than<br/>  the corresponding #ifdef block. Example:<br/><br/>   #ifdef TEST<br/>       int i;<br/>   #else<br/>       }<br/>     int j;<br/>   #endif</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_warn_unbalanced_if=true|pp_warn_unbalanced_if=false
+TrueFalse=pp_warn_unbalanced_if\s*=\s*true|pp_warn_unbalanced_if\s*=\s*false
 ValueDefault=false
 
 [Include Category 0]
 Category=11
 Description="<html>The regex for include category with priority 0.</html>"
 Enabled=false
-CallName=include_category_0=
+CallName=include_category_0\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -7441,7 +7442,7 @@ ValueDefault=
 Category=11
 Description="<html>The regex for include category with priority 1.</html>"
 Enabled=false
-CallName=include_category_1=
+CallName=include_category_1\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -7449,7 +7450,7 @@ ValueDefault=
 Category=11
 Description="<html>The regex for include category with priority 2.</html>"
 Enabled=false
-CallName=include_category_2=
+CallName=include_category_2\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -7458,7 +7459,7 @@ Category=12
 Description="<html>true:  indent_func_call_param will be used (default)<br/>false: indent_func_call_param will NOT be used<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_indent_func_call_param=true|use_indent_func_call_param=false
+TrueFalse=use_indent_func_call_param\s*=\s*true|use_indent_func_call_param\s*=\s*false
 ValueDefault=true
 
 [Use Indent Continue Only Once]
@@ -7466,7 +7467,7 @@ Category=12
 Description="<html>The value of the indentation for a continuation line is calculated<br/>differently if the statement is:<br/>- a declaration: your case with QString fileName ...<br/>- an assignment: your case with pSettings = new QSettings( ...<br/><br/>At the second case the indentation value might be used twice:<br/>- at the assignment<br/>- at the function call (if present)<br/><br/>To prevent the double use of the indentation value, use this option with the<br/>value 'true'.<br/><br/>true:  indent_continue will be used only once<br/>false: indent_continue will be used every time (default)<br/><br/>Requires indent_ignore_first_continue=false.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_indent_continue_only_once=true|use_indent_continue_only_once=false
+TrueFalse=use_indent_continue_only_once\s*=\s*true|use_indent_continue_only_once\s*=\s*false
 ValueDefault=false
 
 [Indent Cpp Lambda Only Once]
@@ -7474,7 +7475,7 @@ Category=12
 Description="<html>The indentation can be:<br/>- after the assignment, at the '[' character<br/>- at the beginning of the lambda body<br/><br/>true:  indentation will be at the beginning of the lambda body<br/>false: indentation will be after the assignment (default)</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cpp_lambda_only_once=true|indent_cpp_lambda_only_once=false
+TrueFalse=indent_cpp_lambda_only_once\s*=\s*true|indent_cpp_lambda_only_once\s*=\s*false
 ValueDefault=false
 
 [Use Sp After Angle Always]
@@ -7482,7 +7483,7 @@ Category=12
 Description="<html>Whether sp_after_angle takes precedence over sp_inside_fparen. This was the<br/>historic behavior, but is probably not the desired behavior, so this is off<br/>by default.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_sp_after_angle_always=true|use_sp_after_angle_always=false
+TrueFalse=use_sp_after_angle_always\s*=\s*true|use_sp_after_angle_always\s*=\s*false
 ValueDefault=false
 
 [Use Options Overriding For Qt Macros]
@@ -7490,7 +7491,7 @@ Category=12
 Description="<html>Whether to apply special formatting for Qt SIGNAL/SLOT macros. Essentially,<br/>this tries to format these so that they match Qt's normalized form (i.e. the<br/>result of QMetaObject::normalizedSignature), which can slightly improve the<br/>performance of the QObject::connect call, rather than how they would<br/>otherwise be formatted.<br/><br/>See options_for_QT.cpp for details.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_options_overriding_for_qt_macros=true|use_options_overriding_for_qt_macros=false
+TrueFalse=use_options_overriding_for_qt_macros\s*=\s*true|use_options_overriding_for_qt_macros\s*=\s*false
 ValueDefault=true
 
 [Use Form Feed No More As Whitespace Character]
@@ -7498,7 +7499,7 @@ Category=12
 Description="<html>If true: the form feed character is removed from the list of whitespace<br/>characters. See https://en.cppreference.com/w/cpp/string/byte/isspace.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_form_feed_no_more_as_whitespace_character=true|use_form_feed_no_more_as_whitespace_character=false
+TrueFalse=use_form_feed_no_more_as_whitespace_character\s*=\s*true|use_form_feed_no_more_as_whitespace_character\s*=\s*false
 ValueDefault=false
 
 [Warn Level Tabs Found In Verbatim String Literals]
@@ -7506,7 +7507,7 @@ Category=13
 Description="<html>(C#) Warning is given if doing tab-to-\t replacement and we have found one<br/>in a C# verbatim string literal.<br/><br/>Default: 2</html>"
 Enabled=false
 EditorType=numeric
-CallName="warn_level_tabs_found_in_verbatim_string_literals="
+CallName="warn_level_tabs_found_in_verbatim_string_literals\s*=\s*"
 MinVal=1
 MaxVal=3
 ValueDefault=2
@@ -7516,7 +7517,7 @@ Category=13
 Description="<html>Limit the number of loops.<br/>Used by uncrustify.cpp to exit from infinite loop.<br/>0: no limit.</html>"
 Enabled=false
 EditorType=numeric
-CallName="debug_max_number_of_loops="
+CallName="debug_max_number_of_loops\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7526,7 +7527,7 @@ Category=13
 Description="<html>Set the number of the line to protocol;<br/>Used in the function prot_the_line if the 2. parameter is zero.<br/>0: nothing protocol.</html>"
 Enabled=false
 EditorType=numeric
-CallName="debug_line_number_to_protocol="
+CallName="debug_line_number_to_protocol\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7536,7 +7537,7 @@ Category=13
 Description="<html>Set the number of second(s) before terminating formatting the current file,<br/>0: no timeout.<br/>only for linux</html>"
 Enabled=false
 EditorType=numeric
-CallName="debug_timeout="
+CallName="debug_timeout\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7546,7 +7547,7 @@ Category=13
 Description="<html>Set the number of characters to be printed if the text is too long,<br/>0: do not truncate.</html>"
 Enabled=false
 EditorType=numeric
-CallName="debug_truncate="
+CallName="debug_truncate\s*=\s*"
 MinVal=0
 MaxVal=960
 ValueDefault=0
@@ -7556,7 +7557,7 @@ Category=13
 Description="<html>sort (or not) the tracking info.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=debug_sort_the_tracks=true|debug_sort_the_tracks=false
+TrueFalse=debug_sort_the_tracks\s*=\s*true|debug_sort_the_tracks\s*=\s*false
 ValueDefault=true
 
 [Debug Decode The Flags]
@@ -7564,7 +7565,7 @@ Category=13
 Description="<html>decode (or not) the flags as a new line.<br/>only if the -p option is set.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=debug_decode_the_flags=true|debug_decode_the_flags=false
+TrueFalse=debug_decode_the_flags\s*=\s*true|debug_decode_the_flags\s*=\s*false
 ValueDefault=false
 
 [Debug Use The Exit Function Pop]
@@ -7572,7 +7573,7 @@ Category=13
 Description="<html>use (or not) the exit(EX_SOFTWARE) function.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=debug_use_the_exit_function_pop=true|debug_use_the_exit_function_pop=false
+TrueFalse=debug_use_the_exit_function_pop\s*=\s*true|debug_use_the_exit_function_pop\s*=\s*false
 ValueDefault=true
 
 [Set Numbering For Html Output]
@@ -7580,5 +7581,5 @@ Category=13
 Description="<html>insert the number of the line at the beginning of each line</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=set_numbering_for_html_output=true|set_numbering_for_html_output=false
+TrueFalse=set_numbering_for_html_output\s*=\s*true|set_numbering_for_html_output\s*=\s*false
 ValueDefault=false

--- a/src/universalindentgui.cpp
+++ b/src/universalindentgui.cpp
@@ -46,7 +46,7 @@ void print_option_choices(FILE *pfile, uncrustify::GenericOption *option,
 
    for (auto c = option->possibleValues(); *c; ++c)
    {
-      fprintf(pfile, "%s=%s%c", option->name(), *c, c[1] ? '|' : '\n');
+      fprintf(pfile, "%s\\s*=\\s*%s%c", option->name(), *c, c[1] ? '|' : '\n');
    }
 }
 
@@ -152,7 +152,8 @@ void print_universal_indent_cfg(FILE *pfile)
            "parameterOrder=ipo\n"
            "showHelpParameter=-h\n"
            "stringparaminquotes=false\n"
-           "useCfgFileParameter=\"-c \"\n");
+           "useCfgFileParameter=\"-c \"\n"
+           "useRegex=true\n");
 
    fprintf(pfile, "version=%s\n", UNCRUSTIFY_VERSION);
 
@@ -249,7 +250,7 @@ void print_universal_indent_cfg(FILE *pfile)
             // only a number. Also it is by default enabled.
             fprintf(pfile, "Enabled=true\n");
             fprintf(pfile, "EditorType=multiple\n");
-            fprintf(pfile, "Choices=\"%s=0|%s=1|%s=2\"\n",
+            fprintf(pfile, "Choices=\"%s\\s*=\\s*0|%s\\s*=\\s*1|%s\\s*=\\s*2\"\n",
                     option->name(), option->name(), option->name());
 #if defined (DEBUG) && !defined (WIN32)
             fprintf(pfile, "ChoicesReadable=\"(%zu)Spaces only|(%zu)Indent with tabs, align with spaces|(%zu)Indent and align with tabs\"\n",
@@ -292,7 +293,7 @@ void print_universal_indent_cfg(FILE *pfile)
 
             case uncrustify::OT_NUM:
                fprintf(pfile, "EditorType=numeric\n");
-               fprintf(pfile, "CallName=\"%s=\"\n", option->name());
+               fprintf(pfile, "CallName=\"%s\\s*=\\s*\"\n", option->name());
                fprintf(pfile, "MinVal=%s\n", option->minStr().c_str());
                fprintf(pfile, "MaxVal=%s\n", option->maxStr().c_str());
                fprintf(pfile, "ValueDefault=%s\n", option->str().c_str());
@@ -300,7 +301,7 @@ void print_universal_indent_cfg(FILE *pfile)
 
             case uncrustify::OT_UNUM:
                fprintf(pfile, "EditorType=numeric\n");
-               fprintf(pfile, "CallName=\"%s=\"\n", option->name());
+               fprintf(pfile, "CallName=\"%s\\s*=\\s*\"\n", option->name());
                fprintf(pfile, "MinVal=%s\n", option->minStr().c_str());
                fprintf(pfile, "MaxVal=%s\n", option->maxStr().c_str());
                fprintf(pfile, "ValueDefault=%s\n", option->str().c_str());
@@ -353,7 +354,7 @@ void print_universal_indent_cfg(FILE *pfile)
 
             case uncrustify::OT_STRING:
             {
-               fprintf(pfile, "CallName=%s=\n", option->name());
+               fprintf(pfile, "CallName=%s\\s*=\\s*\n", option->name());
                fprintf(pfile, "EditorType=string\n");
                fprintf(pfile, "ValueDefault=%s\n", option->str().c_str());
                break;

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -15,6 +15,7 @@ parameterOrder=ipo
 showHelpParameter=-h
 stringparaminquotes=false
 useCfgFileParameter="-c "
+useRegex=true
 
 
 [Newlines]
@@ -22,7 +23,7 @@ Category=0
 Description="<html>The type of line endings.<br/><br/>Default: auto</html>"
 Enabled=false
 EditorType=multiple
-Choices=newlines=lf|newlines=crlf|newlines=cr|newlines=auto
+Choices=newlines\s*=\s*lf|newlines\s*=\s*crlf|newlines\s*=\s*cr|newlines\s*=\s*auto
 ChoicesReadable="Newlines Unix|Newlines Win|Newlines Mac|Newlines Auto"
 ValueDefault=auto
 
@@ -31,7 +32,7 @@ Category=0
 Description="<html>The original size of tabs in the input.<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
-CallName="input_tab_size="
+CallName="input_tab_size\s*=\s*"
 MinVal=1
 MaxVal=32
 ValueDefault=8
@@ -41,7 +42,7 @@ Category=0
 Description="<html>The size of tabs in the output (only used if align_with_tabs=true).<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
-CallName="output_tab_size="
+CallName="output_tab_size\s*=\s*"
 MinVal=1
 MaxVal=32
 ValueDefault=8
@@ -51,7 +52,7 @@ Category=0
 Description="<html>The ASCII value of the string escape char, usually 92 (\) or (Pawn) 94 (^).<br/><br/>Default: 92</html>"
 Enabled=false
 EditorType=numeric
-CallName="string_escape_char="
+CallName="string_escape_char\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=92
@@ -61,7 +62,7 @@ Category=0
 Description="<html>Alternate string escape char (usually only used for Pawn).<br/>Only works right before the quote char.</html>"
 Enabled=false
 EditorType=numeric
-CallName="string_escape_char2="
+CallName="string_escape_char2\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -71,7 +72,7 @@ Category=0
 Description="<html>Replace tab characters found in string literals with the escape sequence \t<br/>instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=string_replace_tab_chars=true|string_replace_tab_chars=false
+TrueFalse=string_replace_tab_chars\s*=\s*true|string_replace_tab_chars\s*=\s*false
 ValueDefault=false
 
 [Tok Split Gte]
@@ -79,7 +80,7 @@ Category=0
 Description="<html>Allow interpreting '&gt;=' and '&gt;&gt;=' as part of a template in code like<br/>'void f(list&lt;list&lt;B&gt;&gt;=val);'. If true, 'assert(x&lt;0 &amp;&amp; y&gt;=3)' will be broken.<br/>Improvements to template detection may make this option obsolete.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=tok_split_gte=true|tok_split_gte=false
+TrueFalse=tok_split_gte\s*=\s*true|tok_split_gte\s*=\s*false
 ValueDefault=false
 
 [Disable Processing Nl Cont]
@@ -87,14 +88,14 @@ Category=0
 Description="<html>Disable formatting of NL_CONT ('\\n') ended lines (e.g. multi-line macros).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=disable_processing_nl_cont=true|disable_processing_nl_cont=false
+TrueFalse=disable_processing_nl_cont\s*=\s*true|disable_processing_nl_cont\s*=\s*false
 ValueDefault=false
 
 [Disable Processing Cmt]
 Category=0
 Description="<html>Specify the marker used in comments to disable processing of part of the<br/>file.<br/><br/>Default:  *INDENT-OFF*</html>"
 Enabled=false
-CallName=disable_processing_cmt=
+CallName=disable_processing_cmt\s*=\s*
 EditorType=string
 ValueDefault= *INDENT-OFF*
 
@@ -102,7 +103,7 @@ ValueDefault= *INDENT-OFF*
 Category=0
 Description="<html>Specify the marker used in comments to (re)enable processing in a file.<br/><br/>Default:  *INDENT-ON*</html>"
 Enabled=false
-CallName=enable_processing_cmt=
+CallName=enable_processing_cmt\s*=\s*
 EditorType=string
 ValueDefault= *INDENT-ON*
 
@@ -111,7 +112,7 @@ Category=0
 Description="<html>Enable parsing of digraphs.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=enable_digraphs=true|enable_digraphs=false
+TrueFalse=enable_digraphs\s*=\s*true|enable_digraphs\s*=\s*false
 ValueDefault=false
 
 [Processing Cmt As Regex]
@@ -119,7 +120,7 @@ Category=0
 Description="<html>Option to allow both disable_processing_cmt and enable_processing_cmt<br/>strings, if specified, to be interpreted as ECMAScript regular expressions.<br/>If true, a regex search will be performed within comments according to the<br/>specified patterns in order to disable/enable processing.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=processing_cmt_as_regex=true|processing_cmt_as_regex=false
+TrueFalse=processing_cmt_as_regex\s*=\s*true|processing_cmt_as_regex\s*=\s*false
 ValueDefault=false
 
 [Utf8 Bom]
@@ -127,7 +128,7 @@ Category=0
 Description="<html>Add or remove the UTF-8 BOM (recommend 'remove').</html>"
 Enabled=false
 EditorType=multiple
-Choices=utf8_bom=ignore|utf8_bom=add|utf8_bom=remove|utf8_bom=force|utf8_bom=not_defined
+Choices=utf8_bom\s*=\s*ignore|utf8_bom\s*=\s*add|utf8_bom\s*=\s*remove|utf8_bom\s*=\s*force|utf8_bom\s*=\s*not_defined
 ChoicesReadable="Ignore Utf8 Bom|Add Utf8 Bom|Remove Utf8 Bom|Force Utf8 Bom"
 ValueDefault=ignore
 
@@ -136,7 +137,7 @@ Category=0
 Description="<html>If the file contains bytes with values between 128 and 255, but is not<br/>UTF-8, then output as UTF-8.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=utf8_byte=true|utf8_byte=false
+TrueFalse=utf8_byte\s*=\s*true|utf8_byte\s*=\s*false
 ValueDefault=false
 
 [Utf8 Force]
@@ -144,7 +145,7 @@ Category=0
 Description="<html>Force the output encoding to UTF-8.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=utf8_force=true|utf8_force=false
+TrueFalse=utf8_force\s*=\s*true|utf8_force\s*=\s*false
 ValueDefault=false
 
 [Sp Arith]
@@ -152,7 +153,7 @@ Category=1
 Description="<html>Add or remove space around non-assignment symbolic operators ('+', '/', '%',<br/>'&lt;&lt;', and so forth).</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_arith=ignore|sp_arith=add|sp_arith=remove|sp_arith=force|sp_arith=not_defined
+Choices=sp_arith\s*=\s*ignore|sp_arith\s*=\s*add|sp_arith\s*=\s*remove|sp_arith\s*=\s*force|sp_arith\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Arith|Add Sp Arith|Remove Sp Arith|Force Sp Arith"
 ValueDefault=ignore
 
@@ -161,7 +162,7 @@ Category=1
 Description="<html>Add or remove space around arithmetic operators '+' and '-'.<br/><br/>Overrides sp_arith.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_arith_additive=ignore|sp_arith_additive=add|sp_arith_additive=remove|sp_arith_additive=force|sp_arith_additive=not_defined
+Choices=sp_arith_additive\s*=\s*ignore|sp_arith_additive\s*=\s*add|sp_arith_additive\s*=\s*remove|sp_arith_additive\s*=\s*force|sp_arith_additive\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Arith Additive|Add Sp Arith Additive|Remove Sp Arith Additive|Force Sp Arith Additive"
 ValueDefault=ignore
 
@@ -170,7 +171,7 @@ Category=1
 Description="<html>Add or remove space around assignment operator '=', '+=', etc.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_assign=ignore|sp_assign=add|sp_assign=remove|sp_assign=force|sp_assign=not_defined
+Choices=sp_assign\s*=\s*ignore|sp_assign\s*=\s*add|sp_assign\s*=\s*remove|sp_assign\s*=\s*force|sp_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Assign|Add Sp Assign|Remove Sp Assign|Force Sp Assign"
 ValueDefault=ignore
 
@@ -179,7 +180,7 @@ Category=1
 Description="<html>Add or remove space around '=' in C++11 lambda capture specifications.<br/><br/>Overrides sp_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_assign=ignore|sp_cpp_lambda_assign=add|sp_cpp_lambda_assign=remove|sp_cpp_lambda_assign=force|sp_cpp_lambda_assign=not_defined
+Choices=sp_cpp_lambda_assign\s*=\s*ignore|sp_cpp_lambda_assign\s*=\s*add|sp_cpp_lambda_assign\s*=\s*remove|sp_cpp_lambda_assign\s*=\s*force|sp_cpp_lambda_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Assign|Add Sp Cpp Lambda Assign|Remove Sp Cpp Lambda Assign|Force Sp Cpp Lambda Assign"
 ValueDefault=ignore
 
@@ -188,7 +189,7 @@ Category=1
 Description="<html>Add or remove space after the capture specification of a C++11 lambda when<br/>an argument list is present, as in '[] &lt;here&gt; (int x){ ... }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_square_paren=ignore|sp_cpp_lambda_square_paren=add|sp_cpp_lambda_square_paren=remove|sp_cpp_lambda_square_paren=force|sp_cpp_lambda_square_paren=not_defined
+Choices=sp_cpp_lambda_square_paren\s*=\s*ignore|sp_cpp_lambda_square_paren\s*=\s*add|sp_cpp_lambda_square_paren\s*=\s*remove|sp_cpp_lambda_square_paren\s*=\s*force|sp_cpp_lambda_square_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Square Paren|Add Sp Cpp Lambda Square Paren|Remove Sp Cpp Lambda Square Paren|Force Sp Cpp Lambda Square Paren"
 ValueDefault=ignore
 
@@ -197,7 +198,7 @@ Category=1
 Description="<html>Add or remove space after the capture specification of a C++11 lambda with<br/>no argument list is present, as in '[] &lt;here&gt; { ... }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_square_brace=ignore|sp_cpp_lambda_square_brace=add|sp_cpp_lambda_square_brace=remove|sp_cpp_lambda_square_brace=force|sp_cpp_lambda_square_brace=not_defined
+Choices=sp_cpp_lambda_square_brace\s*=\s*ignore|sp_cpp_lambda_square_brace\s*=\s*add|sp_cpp_lambda_square_brace\s*=\s*remove|sp_cpp_lambda_square_brace\s*=\s*force|sp_cpp_lambda_square_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Square Brace|Add Sp Cpp Lambda Square Brace|Remove Sp Cpp Lambda Square Brace|Force Sp Cpp Lambda Square Brace"
 ValueDefault=ignore
 
@@ -206,7 +207,7 @@ Category=1
 Description="<html>Add or remove space after the opening parenthesis and before the closing<br/>parenthesis of a argument list of a C++11 lambda, as in<br/>'[]( &lt;here&gt; ){ ... }'<br/>with an empty list.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_argument_list_empty=ignore|sp_cpp_lambda_argument_list_empty=add|sp_cpp_lambda_argument_list_empty=remove|sp_cpp_lambda_argument_list_empty=force|sp_cpp_lambda_argument_list_empty=not_defined
+Choices=sp_cpp_lambda_argument_list_empty\s*=\s*ignore|sp_cpp_lambda_argument_list_empty\s*=\s*add|sp_cpp_lambda_argument_list_empty\s*=\s*remove|sp_cpp_lambda_argument_list_empty\s*=\s*force|sp_cpp_lambda_argument_list_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Argument List Empty|Add Sp Cpp Lambda Argument List Empty|Remove Sp Cpp Lambda Argument List Empty|Force Sp Cpp Lambda Argument List Empty"
 ValueDefault=ignore
 
@@ -215,7 +216,7 @@ Category=1
 Description="<html>Add or remove space after the opening parenthesis and before the closing<br/>parenthesis of a argument list of a C++11 lambda, as in<br/>'[]( &lt;here&gt; int x &lt;here&gt; ){ ... }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_argument_list=ignore|sp_cpp_lambda_argument_list=add|sp_cpp_lambda_argument_list=remove|sp_cpp_lambda_argument_list=force|sp_cpp_lambda_argument_list=not_defined
+Choices=sp_cpp_lambda_argument_list\s*=\s*ignore|sp_cpp_lambda_argument_list\s*=\s*add|sp_cpp_lambda_argument_list\s*=\s*remove|sp_cpp_lambda_argument_list\s*=\s*force|sp_cpp_lambda_argument_list\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Argument List|Add Sp Cpp Lambda Argument List|Remove Sp Cpp Lambda Argument List|Force Sp Cpp Lambda Argument List"
 ValueDefault=ignore
 
@@ -224,7 +225,7 @@ Category=1
 Description="<html>Add or remove space after the argument list of a C++11 lambda, as in<br/>'[](int x) &lt;here&gt; { ... }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_paren_brace=ignore|sp_cpp_lambda_paren_brace=add|sp_cpp_lambda_paren_brace=remove|sp_cpp_lambda_paren_brace=force|sp_cpp_lambda_paren_brace=not_defined
+Choices=sp_cpp_lambda_paren_brace\s*=\s*ignore|sp_cpp_lambda_paren_brace\s*=\s*add|sp_cpp_lambda_paren_brace\s*=\s*remove|sp_cpp_lambda_paren_brace\s*=\s*force|sp_cpp_lambda_paren_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Paren Brace|Add Sp Cpp Lambda Paren Brace|Remove Sp Cpp Lambda Paren Brace|Force Sp Cpp Lambda Paren Brace"
 ValueDefault=ignore
 
@@ -233,7 +234,7 @@ Category=1
 Description="<html>Add or remove space between a lambda body and its call operator of an<br/>immediately invoked lambda, as in '[]( ... ){ ... } &lt;here&gt; ( ... )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_fparen=ignore|sp_cpp_lambda_fparen=add|sp_cpp_lambda_fparen=remove|sp_cpp_lambda_fparen=force|sp_cpp_lambda_fparen=not_defined
+Choices=sp_cpp_lambda_fparen\s*=\s*ignore|sp_cpp_lambda_fparen\s*=\s*add|sp_cpp_lambda_fparen\s*=\s*remove|sp_cpp_lambda_fparen\s*=\s*force|sp_cpp_lambda_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Fparen|Add Sp Cpp Lambda Fparen|Remove Sp Cpp Lambda Fparen|Force Sp Cpp Lambda Fparen"
 ValueDefault=ignore
 
@@ -242,7 +243,7 @@ Category=1
 Description="<html>Add or remove space around assignment operator '=' in a prototype.<br/><br/>If set to ignore, use sp_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_assign_default=ignore|sp_assign_default=add|sp_assign_default=remove|sp_assign_default=force|sp_assign_default=not_defined
+Choices=sp_assign_default\s*=\s*ignore|sp_assign_default\s*=\s*add|sp_assign_default\s*=\s*remove|sp_assign_default\s*=\s*force|sp_assign_default\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Assign Default|Add Sp Assign Default|Remove Sp Assign Default|Force Sp Assign Default"
 ValueDefault=ignore
 
@@ -251,7 +252,7 @@ Category=1
 Description="<html>Add or remove space before assignment operator '=', '+=', etc.<br/><br/>Overrides sp_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_assign=ignore|sp_before_assign=add|sp_before_assign=remove|sp_before_assign=force|sp_before_assign=not_defined
+Choices=sp_before_assign\s*=\s*ignore|sp_before_assign\s*=\s*add|sp_before_assign\s*=\s*remove|sp_before_assign\s*=\s*force|sp_before_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Assign|Add Sp Before Assign|Remove Sp Before Assign|Force Sp Before Assign"
 ValueDefault=ignore
 
@@ -260,7 +261,7 @@ Category=1
 Description="<html>Add or remove space after assignment operator '=', '+=', etc.<br/><br/>Overrides sp_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_assign=ignore|sp_after_assign=add|sp_after_assign=remove|sp_after_assign=force|sp_after_assign=not_defined
+Choices=sp_after_assign\s*=\s*ignore|sp_after_assign\s*=\s*add|sp_after_assign\s*=\s*remove|sp_after_assign\s*=\s*force|sp_after_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Assign|Add Sp After Assign|Remove Sp After Assign|Force Sp After Assign"
 ValueDefault=ignore
 
@@ -269,7 +270,7 @@ Category=1
 Description="<html>Add or remove space in 'enum {'.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_brace=ignore|sp_enum_brace=add|sp_enum_brace=remove|sp_enum_brace=force|sp_enum_brace=not_defined
+Choices=sp_enum_brace\s*=\s*ignore|sp_enum_brace\s*=\s*add|sp_enum_brace\s*=\s*remove|sp_enum_brace\s*=\s*force|sp_enum_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Brace|Add Sp Enum Brace|Remove Sp Enum Brace|Force Sp Enum Brace"
 ValueDefault=add
 
@@ -278,7 +279,7 @@ Category=1
 Description="<html>Add or remove space in 'NS_ENUM ('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_paren=ignore|sp_enum_paren=add|sp_enum_paren=remove|sp_enum_paren=force|sp_enum_paren=not_defined
+Choices=sp_enum_paren\s*=\s*ignore|sp_enum_paren\s*=\s*add|sp_enum_paren\s*=\s*remove|sp_enum_paren\s*=\s*force|sp_enum_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Paren|Add Sp Enum Paren|Remove Sp Enum Paren|Force Sp Enum Paren"
 ValueDefault=ignore
 
@@ -287,7 +288,7 @@ Category=1
 Description="<html>Add or remove space around assignment '=' in enum.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_assign=ignore|sp_enum_assign=add|sp_enum_assign=remove|sp_enum_assign=force|sp_enum_assign=not_defined
+Choices=sp_enum_assign\s*=\s*ignore|sp_enum_assign\s*=\s*add|sp_enum_assign\s*=\s*remove|sp_enum_assign\s*=\s*force|sp_enum_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Assign|Add Sp Enum Assign|Remove Sp Enum Assign|Force Sp Enum Assign"
 ValueDefault=ignore
 
@@ -296,7 +297,7 @@ Category=1
 Description="<html>Add or remove space before assignment '=' in enum.<br/><br/>Overrides sp_enum_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_before_assign=ignore|sp_enum_before_assign=add|sp_enum_before_assign=remove|sp_enum_before_assign=force|sp_enum_before_assign=not_defined
+Choices=sp_enum_before_assign\s*=\s*ignore|sp_enum_before_assign\s*=\s*add|sp_enum_before_assign\s*=\s*remove|sp_enum_before_assign\s*=\s*force|sp_enum_before_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Before Assign|Add Sp Enum Before Assign|Remove Sp Enum Before Assign|Force Sp Enum Before Assign"
 ValueDefault=ignore
 
@@ -305,7 +306,7 @@ Category=1
 Description="<html>Add or remove space after assignment '=' in enum.<br/><br/>Overrides sp_enum_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_after_assign=ignore|sp_enum_after_assign=add|sp_enum_after_assign=remove|sp_enum_after_assign=force|sp_enum_after_assign=not_defined
+Choices=sp_enum_after_assign\s*=\s*ignore|sp_enum_after_assign\s*=\s*add|sp_enum_after_assign\s*=\s*remove|sp_enum_after_assign\s*=\s*force|sp_enum_after_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum After Assign|Add Sp Enum After Assign|Remove Sp Enum After Assign|Force Sp Enum After Assign"
 ValueDefault=ignore
 
@@ -314,7 +315,7 @@ Category=1
 Description="<html>Add or remove space around assignment ':' in enum.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_colon=ignore|sp_enum_colon=add|sp_enum_colon=remove|sp_enum_colon=force|sp_enum_colon=not_defined
+Choices=sp_enum_colon\s*=\s*ignore|sp_enum_colon\s*=\s*add|sp_enum_colon\s*=\s*remove|sp_enum_colon\s*=\s*force|sp_enum_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Colon|Add Sp Enum Colon|Remove Sp Enum Colon|Force Sp Enum Colon"
 ValueDefault=ignore
 
@@ -323,7 +324,7 @@ Category=1
 Description="<html>Add or remove space around preprocessor '##' concatenation operator.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_pp_concat=ignore|sp_pp_concat=add|sp_pp_concat=remove|sp_pp_concat=force|sp_pp_concat=not_defined
+Choices=sp_pp_concat\s*=\s*ignore|sp_pp_concat\s*=\s*add|sp_pp_concat\s*=\s*remove|sp_pp_concat\s*=\s*force|sp_pp_concat\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Pp Concat|Add Sp Pp Concat|Remove Sp Pp Concat|Force Sp Pp Concat"
 ValueDefault=add
 
@@ -332,7 +333,7 @@ Category=1
 Description="<html>Add or remove space after preprocessor '#' stringify operator.<br/>Also affects the '#@' charizing operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_pp_stringify=ignore|sp_pp_stringify=add|sp_pp_stringify=remove|sp_pp_stringify=force|sp_pp_stringify=not_defined
+Choices=sp_pp_stringify\s*=\s*ignore|sp_pp_stringify\s*=\s*add|sp_pp_stringify\s*=\s*remove|sp_pp_stringify\s*=\s*force|sp_pp_stringify\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Pp Stringify|Add Sp Pp Stringify|Remove Sp Pp Stringify|Force Sp Pp Stringify"
 ValueDefault=ignore
 
@@ -341,7 +342,7 @@ Category=1
 Description="<html>Add or remove space before preprocessor '#' stringify operator<br/>as in '#define x(y) L#y'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_pp_stringify=ignore|sp_before_pp_stringify=add|sp_before_pp_stringify=remove|sp_before_pp_stringify=force|sp_before_pp_stringify=not_defined
+Choices=sp_before_pp_stringify\s*=\s*ignore|sp_before_pp_stringify\s*=\s*add|sp_before_pp_stringify\s*=\s*remove|sp_before_pp_stringify\s*=\s*force|sp_before_pp_stringify\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Pp Stringify|Add Sp Before Pp Stringify|Remove Sp Before Pp Stringify|Force Sp Before Pp Stringify"
 ValueDefault=ignore
 
@@ -350,7 +351,7 @@ Category=1
 Description="<html>Add or remove space around boolean operators '&amp;&amp;' and '||'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_bool=ignore|sp_bool=add|sp_bool=remove|sp_bool=force|sp_bool=not_defined
+Choices=sp_bool\s*=\s*ignore|sp_bool\s*=\s*add|sp_bool\s*=\s*remove|sp_bool\s*=\s*force|sp_bool\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Bool|Add Sp Bool|Remove Sp Bool|Force Sp Bool"
 ValueDefault=ignore
 
@@ -359,7 +360,7 @@ Category=1
 Description="<html>Add or remove space around compare operator '&lt;', '&gt;', '==', etc.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_compare=ignore|sp_compare=add|sp_compare=remove|sp_compare=force|sp_compare=not_defined
+Choices=sp_compare\s*=\s*ignore|sp_compare\s*=\s*add|sp_compare\s*=\s*remove|sp_compare\s*=\s*force|sp_compare\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Compare|Add Sp Compare|Remove Sp Compare|Force Sp Compare"
 ValueDefault=ignore
 
@@ -368,7 +369,7 @@ Category=1
 Description="<html>Add or remove space inside '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_paren=ignore|sp_inside_paren=add|sp_inside_paren=remove|sp_inside_paren=force|sp_inside_paren=not_defined
+Choices=sp_inside_paren\s*=\s*ignore|sp_inside_paren\s*=\s*add|sp_inside_paren\s*=\s*remove|sp_inside_paren\s*=\s*force|sp_inside_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Paren|Add Sp Inside Paren|Remove Sp Inside Paren|Force Sp Inside Paren"
 ValueDefault=ignore
 
@@ -377,7 +378,7 @@ Category=1
 Description="<html>Add or remove space between nested parentheses, i.e. '((' vs. ') )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_paren=ignore|sp_paren_paren=add|sp_paren_paren=remove|sp_paren_paren=force|sp_paren_paren=not_defined
+Choices=sp_paren_paren\s*=\s*ignore|sp_paren_paren\s*=\s*add|sp_paren_paren\s*=\s*remove|sp_paren_paren\s*=\s*force|sp_paren_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Paren|Add Sp Paren Paren|Remove Sp Paren Paren|Force Sp Paren Paren"
 ValueDefault=ignore
 
@@ -386,7 +387,7 @@ Category=1
 Description="<html>Add or remove space between back-to-back parentheses, i.e. ')(' vs. ') ('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cparen_oparen=ignore|sp_cparen_oparen=add|sp_cparen_oparen=remove|sp_cparen_oparen=force|sp_cparen_oparen=not_defined
+Choices=sp_cparen_oparen\s*=\s*ignore|sp_cparen_oparen\s*=\s*add|sp_cparen_oparen\s*=\s*remove|sp_cparen_oparen\s*=\s*force|sp_cparen_oparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cparen Oparen|Add Sp Cparen Oparen|Remove Sp Cparen Oparen|Force Sp Cparen Oparen"
 ValueDefault=ignore
 
@@ -395,7 +396,7 @@ Category=1
 Description="<html>Whether to balance spaces inside nested parentheses.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_balance_nested_parens=true|sp_balance_nested_parens=false
+TrueFalse=sp_balance_nested_parens\s*=\s*true|sp_balance_nested_parens\s*=\s*false
 ValueDefault=false
 
 [Sp Paren Brace]
@@ -403,7 +404,7 @@ Category=1
 Description="<html>Add or remove space between ')' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_brace=ignore|sp_paren_brace=add|sp_paren_brace=remove|sp_paren_brace=force|sp_paren_brace=not_defined
+Choices=sp_paren_brace\s*=\s*ignore|sp_paren_brace\s*=\s*add|sp_paren_brace\s*=\s*remove|sp_paren_brace\s*=\s*force|sp_paren_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Brace|Add Sp Paren Brace|Remove Sp Paren Brace|Force Sp Paren Brace"
 ValueDefault=ignore
 
@@ -412,7 +413,7 @@ Category=1
 Description="<html>Add or remove space between nested braces, i.e. '{{' vs. '{ {'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_brace=ignore|sp_brace_brace=add|sp_brace_brace=remove|sp_brace_brace=force|sp_brace_brace=not_defined
+Choices=sp_brace_brace\s*=\s*ignore|sp_brace_brace\s*=\s*add|sp_brace_brace\s*=\s*remove|sp_brace_brace\s*=\s*force|sp_brace_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Brace|Add Sp Brace Brace|Remove Sp Brace Brace|Force Sp Brace Brace"
 ValueDefault=ignore
 
@@ -421,7 +422,7 @@ Category=1
 Description="<html>Add or remove space before pointer star '*'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_ptr_star=ignore|sp_before_ptr_star=add|sp_before_ptr_star=remove|sp_before_ptr_star=force|sp_before_ptr_star=not_defined
+Choices=sp_before_ptr_star\s*=\s*ignore|sp_before_ptr_star\s*=\s*add|sp_before_ptr_star\s*=\s*remove|sp_before_ptr_star\s*=\s*force|sp_before_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Ptr Star|Add Sp Before Ptr Star|Remove Sp Before Ptr Star|Force Sp Before Ptr Star"
 ValueDefault=ignore
 
@@ -430,7 +431,7 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that isn't followed by a<br/>variable name. If set to ignore, sp_before_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_unnamed_ptr_star=ignore|sp_before_unnamed_ptr_star=add|sp_before_unnamed_ptr_star=remove|sp_before_unnamed_ptr_star=force|sp_before_unnamed_ptr_star=not_defined
+Choices=sp_before_unnamed_ptr_star\s*=\s*ignore|sp_before_unnamed_ptr_star\s*=\s*add|sp_before_unnamed_ptr_star\s*=\s*remove|sp_before_unnamed_ptr_star\s*=\s*force|sp_before_unnamed_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Unnamed Ptr Star|Add Sp Before Unnamed Ptr Star|Remove Sp Before Unnamed Ptr Star|Force Sp Before Unnamed Ptr Star"
 ValueDefault=ignore
 
@@ -439,7 +440,7 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that is followed by a qualifier.<br/>If set to ignore, sp_before_unnamed_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_qualifier_ptr_star=ignore|sp_before_qualifier_ptr_star=add|sp_before_qualifier_ptr_star=remove|sp_before_qualifier_ptr_star=force|sp_before_qualifier_ptr_star=not_defined
+Choices=sp_before_qualifier_ptr_star\s*=\s*ignore|sp_before_qualifier_ptr_star\s*=\s*add|sp_before_qualifier_ptr_star\s*=\s*remove|sp_before_qualifier_ptr_star\s*=\s*force|sp_before_qualifier_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Qualifier Ptr Star|Add Sp Before Qualifier Ptr Star|Remove Sp Before Qualifier Ptr Star|Force Sp Before Qualifier Ptr Star"
 ValueDefault=ignore
 
@@ -448,7 +449,7 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that is followed by 'operator' keyword.<br/>If set to ignore, sp_before_unnamed_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_operator_ptr_star=ignore|sp_before_operator_ptr_star=add|sp_before_operator_ptr_star=remove|sp_before_operator_ptr_star=force|sp_before_operator_ptr_star=not_defined
+Choices=sp_before_operator_ptr_star\s*=\s*ignore|sp_before_operator_ptr_star\s*=\s*add|sp_before_operator_ptr_star\s*=\s*remove|sp_before_operator_ptr_star\s*=\s*force|sp_before_operator_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Operator Ptr Star|Add Sp Before Operator Ptr Star|Remove Sp Before Operator Ptr Star|Force Sp Before Operator Ptr Star"
 ValueDefault=ignore
 
@@ -457,7 +458,7 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that is followed by<br/>a class scope (as in 'int *MyClass::method()') or namespace scope<br/>(as in 'int *my_ns::func()').<br/>If set to ignore, sp_before_unnamed_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_scope_ptr_star=ignore|sp_before_scope_ptr_star=add|sp_before_scope_ptr_star=remove|sp_before_scope_ptr_star=force|sp_before_scope_ptr_star=not_defined
+Choices=sp_before_scope_ptr_star\s*=\s*ignore|sp_before_scope_ptr_star\s*=\s*add|sp_before_scope_ptr_star\s*=\s*remove|sp_before_scope_ptr_star\s*=\s*force|sp_before_scope_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Scope Ptr Star|Add Sp Before Scope Ptr Star|Remove Sp Before Scope Ptr Star|Force Sp Before Scope Ptr Star"
 ValueDefault=ignore
 
@@ -466,7 +467,7 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that is followed by '::',<br/>as in 'int *::func()'.<br/>If set to ignore, sp_before_unnamed_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_global_scope_ptr_star=ignore|sp_before_global_scope_ptr_star=add|sp_before_global_scope_ptr_star=remove|sp_before_global_scope_ptr_star=force|sp_before_global_scope_ptr_star=not_defined
+Choices=sp_before_global_scope_ptr_star\s*=\s*ignore|sp_before_global_scope_ptr_star\s*=\s*add|sp_before_global_scope_ptr_star\s*=\s*remove|sp_before_global_scope_ptr_star\s*=\s*force|sp_before_global_scope_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Global Scope Ptr Star|Add Sp Before Global Scope Ptr Star|Remove Sp Before Global Scope Ptr Star|Force Sp Before Global Scope Ptr Star"
 ValueDefault=ignore
 
@@ -475,7 +476,7 @@ Category=1
 Description="<html>Add or remove space between a qualifier and a pointer star '*' that isn't<br/>followed by a variable name, as in '(char const *)'. If set to ignore,<br/>sp_before_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_qualifier_unnamed_ptr_star=ignore|sp_qualifier_unnamed_ptr_star=add|sp_qualifier_unnamed_ptr_star=remove|sp_qualifier_unnamed_ptr_star=force|sp_qualifier_unnamed_ptr_star=not_defined
+Choices=sp_qualifier_unnamed_ptr_star\s*=\s*ignore|sp_qualifier_unnamed_ptr_star\s*=\s*add|sp_qualifier_unnamed_ptr_star\s*=\s*remove|sp_qualifier_unnamed_ptr_star\s*=\s*force|sp_qualifier_unnamed_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Qualifier Unnamed Ptr Star|Add Sp Qualifier Unnamed Ptr Star|Remove Sp Qualifier Unnamed Ptr Star|Force Sp Qualifier Unnamed Ptr Star"
 ValueDefault=ignore
 
@@ -484,7 +485,7 @@ Category=1
 Description="<html>Add or remove space between pointer stars '*', as in 'int ***a;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_ptr_star=ignore|sp_between_ptr_star=add|sp_between_ptr_star=remove|sp_between_ptr_star=force|sp_between_ptr_star=not_defined
+Choices=sp_between_ptr_star\s*=\s*ignore|sp_between_ptr_star\s*=\s*add|sp_between_ptr_star\s*=\s*remove|sp_between_ptr_star\s*=\s*force|sp_between_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between Ptr Star|Add Sp Between Ptr Star|Remove Sp Between Ptr Star|Force Sp Between Ptr Star"
 ValueDefault=ignore
 
@@ -493,7 +494,7 @@ Category=1
 Description="<html>Add or remove space between pointer star '*' and reference '&amp;', as in 'int *&amp; a;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_ptr_ref=ignore|sp_between_ptr_ref=add|sp_between_ptr_ref=remove|sp_between_ptr_ref=force|sp_between_ptr_ref=not_defined
+Choices=sp_between_ptr_ref\s*=\s*ignore|sp_between_ptr_ref\s*=\s*add|sp_between_ptr_ref\s*=\s*remove|sp_between_ptr_ref\s*=\s*force|sp_between_ptr_ref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between Ptr Ref|Add Sp Between Ptr Ref|Remove Sp Between Ptr Ref|Force Sp Between Ptr Ref"
 ValueDefault=ignore
 
@@ -502,7 +503,7 @@ Category=1
 Description="<html>Add or remove space after pointer star '*', if followed by a word.<br/><br/>Overrides sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_star=ignore|sp_after_ptr_star=add|sp_after_ptr_star=remove|sp_after_ptr_star=force|sp_after_ptr_star=not_defined
+Choices=sp_after_ptr_star\s*=\s*ignore|sp_after_ptr_star\s*=\s*add|sp_after_ptr_star\s*=\s*remove|sp_after_ptr_star\s*=\s*force|sp_after_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Star|Add Sp After Ptr Star|Remove Sp After Ptr Star|Force Sp After Ptr Star"
 ValueDefault=ignore
 
@@ -511,7 +512,7 @@ Category=1
 Description="<html>Add or remove space after pointer caret '^', if followed by a word.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_block_caret=ignore|sp_after_ptr_block_caret=add|sp_after_ptr_block_caret=remove|sp_after_ptr_block_caret=force|sp_after_ptr_block_caret=not_defined
+Choices=sp_after_ptr_block_caret\s*=\s*ignore|sp_after_ptr_block_caret\s*=\s*add|sp_after_ptr_block_caret\s*=\s*remove|sp_after_ptr_block_caret\s*=\s*force|sp_after_ptr_block_caret\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Block Caret|Add Sp After Ptr Block Caret|Remove Sp After Ptr Block Caret|Force Sp After Ptr Block Caret"
 ValueDefault=ignore
 
@@ -520,7 +521,7 @@ Category=1
 Description="<html>Add or remove space after pointer star '*', if followed by a qualifier.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_star_qualifier=ignore|sp_after_ptr_star_qualifier=add|sp_after_ptr_star_qualifier=remove|sp_after_ptr_star_qualifier=force|sp_after_ptr_star_qualifier=not_defined
+Choices=sp_after_ptr_star_qualifier\s*=\s*ignore|sp_after_ptr_star_qualifier\s*=\s*add|sp_after_ptr_star_qualifier\s*=\s*remove|sp_after_ptr_star_qualifier\s*=\s*force|sp_after_ptr_star_qualifier\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Star Qualifier|Add Sp After Ptr Star Qualifier|Remove Sp After Ptr Star Qualifier|Force Sp After Ptr Star Qualifier"
 ValueDefault=ignore
 
@@ -529,7 +530,7 @@ Category=1
 Description="<html>Add or remove space after a pointer star '*', if followed by a function<br/>prototype or function definition.<br/><br/>Overrides sp_after_ptr_star and sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_star_func=ignore|sp_after_ptr_star_func=add|sp_after_ptr_star_func=remove|sp_after_ptr_star_func=force|sp_after_ptr_star_func=not_defined
+Choices=sp_after_ptr_star_func\s*=\s*ignore|sp_after_ptr_star_func\s*=\s*add|sp_after_ptr_star_func\s*=\s*remove|sp_after_ptr_star_func\s*=\s*force|sp_after_ptr_star_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Star Func|Add Sp After Ptr Star Func|Remove Sp After Ptr Star Func|Force Sp After Ptr Star Func"
 ValueDefault=ignore
 
@@ -538,7 +539,7 @@ Category=1
 Description="<html>Add or remove space after a pointer star '*' in the trailing return of a<br/>function prototype or function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_star_trailing=ignore|sp_after_ptr_star_trailing=add|sp_after_ptr_star_trailing=remove|sp_after_ptr_star_trailing=force|sp_after_ptr_star_trailing=not_defined
+Choices=sp_after_ptr_star_trailing\s*=\s*ignore|sp_after_ptr_star_trailing\s*=\s*add|sp_after_ptr_star_trailing\s*=\s*remove|sp_after_ptr_star_trailing\s*=\s*force|sp_after_ptr_star_trailing\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Star Trailing|Add Sp After Ptr Star Trailing|Remove Sp After Ptr Star Trailing|Force Sp After Ptr Star Trailing"
 ValueDefault=ignore
 
@@ -547,7 +548,7 @@ Category=1
 Description="<html>Add or remove space between the pointer star '*' and the name of the variable<br/>in a function pointer definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ptr_star_func_var=ignore|sp_ptr_star_func_var=add|sp_ptr_star_func_var=remove|sp_ptr_star_func_var=force|sp_ptr_star_func_var=not_defined
+Choices=sp_ptr_star_func_var\s*=\s*ignore|sp_ptr_star_func_var\s*=\s*add|sp_ptr_star_func_var\s*=\s*remove|sp_ptr_star_func_var\s*=\s*force|sp_ptr_star_func_var\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ptr Star Func Var|Add Sp Ptr Star Func Var|Remove Sp Ptr Star Func Var|Force Sp Ptr Star Func Var"
 ValueDefault=ignore
 
@@ -556,7 +557,7 @@ Category=1
 Description="<html>Add or remove space between the pointer star '*' and the name of the type<br/>in a function pointer type definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ptr_star_func_type=ignore|sp_ptr_star_func_type=add|sp_ptr_star_func_type=remove|sp_ptr_star_func_type=force|sp_ptr_star_func_type=not_defined
+Choices=sp_ptr_star_func_type\s*=\s*ignore|sp_ptr_star_func_type\s*=\s*add|sp_ptr_star_func_type\s*=\s*remove|sp_ptr_star_func_type\s*=\s*force|sp_ptr_star_func_type\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ptr Star Func Type|Add Sp Ptr Star Func Type|Remove Sp Ptr Star Func Type|Force Sp Ptr Star Func Type"
 ValueDefault=ignore
 
@@ -565,7 +566,7 @@ Category=1
 Description="<html>Add or remove space after a pointer star '*', if followed by an open<br/>parenthesis, as in 'void* (*)()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ptr_star_paren=ignore|sp_ptr_star_paren=add|sp_ptr_star_paren=remove|sp_ptr_star_paren=force|sp_ptr_star_paren=not_defined
+Choices=sp_ptr_star_paren\s*=\s*ignore|sp_ptr_star_paren\s*=\s*add|sp_ptr_star_paren\s*=\s*remove|sp_ptr_star_paren\s*=\s*force|sp_ptr_star_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ptr Star Paren|Add Sp Ptr Star Paren|Remove Sp Ptr Star Paren|Force Sp Ptr Star Paren"
 ValueDefault=ignore
 
@@ -574,7 +575,7 @@ Category=1
 Description="<html>Add or remove space before a pointer star '*', if followed by a function<br/>prototype or function definition. If set to ignore, sp_before_ptr_star is<br/>used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_ptr_star_func=ignore|sp_before_ptr_star_func=add|sp_before_ptr_star_func=remove|sp_before_ptr_star_func=force|sp_before_ptr_star_func=not_defined
+Choices=sp_before_ptr_star_func\s*=\s*ignore|sp_before_ptr_star_func\s*=\s*add|sp_before_ptr_star_func\s*=\s*remove|sp_before_ptr_star_func\s*=\s*force|sp_before_ptr_star_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Ptr Star Func|Add Sp Before Ptr Star Func|Remove Sp Before Ptr Star Func|Force Sp Before Ptr Star Func"
 ValueDefault=ignore
 
@@ -583,7 +584,7 @@ Category=1
 Description="<html>Add or remove space between a qualifier and a pointer star '*' followed by<br/>the name of the function in a function prototype or definition, as in<br/>'char const *foo()`. If set to ignore, sp_before_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_qualifier_ptr_star_func=ignore|sp_qualifier_ptr_star_func=add|sp_qualifier_ptr_star_func=remove|sp_qualifier_ptr_star_func=force|sp_qualifier_ptr_star_func=not_defined
+Choices=sp_qualifier_ptr_star_func\s*=\s*ignore|sp_qualifier_ptr_star_func\s*=\s*add|sp_qualifier_ptr_star_func\s*=\s*remove|sp_qualifier_ptr_star_func\s*=\s*force|sp_qualifier_ptr_star_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Qualifier Ptr Star Func|Add Sp Qualifier Ptr Star Func|Remove Sp Qualifier Ptr Star Func|Force Sp Qualifier Ptr Star Func"
 ValueDefault=ignore
 
@@ -592,7 +593,7 @@ Category=1
 Description="<html>Add or remove space before a pointer star '*' in the trailing return of a<br/>function prototype or function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_ptr_star_trailing=ignore|sp_before_ptr_star_trailing=add|sp_before_ptr_star_trailing=remove|sp_before_ptr_star_trailing=force|sp_before_ptr_star_trailing=not_defined
+Choices=sp_before_ptr_star_trailing\s*=\s*ignore|sp_before_ptr_star_trailing\s*=\s*add|sp_before_ptr_star_trailing\s*=\s*remove|sp_before_ptr_star_trailing\s*=\s*force|sp_before_ptr_star_trailing\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Ptr Star Trailing|Add Sp Before Ptr Star Trailing|Remove Sp Before Ptr Star Trailing|Force Sp Before Ptr Star Trailing"
 ValueDefault=ignore
 
@@ -601,7 +602,7 @@ Category=1
 Description="<html>Add or remove space between a qualifier and a pointer star '*' in the<br/>trailing return of a function prototype or function definition, as in<br/>'auto foo() -&gt; char const *'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_qualifier_ptr_star_trailing=ignore|sp_qualifier_ptr_star_trailing=add|sp_qualifier_ptr_star_trailing=remove|sp_qualifier_ptr_star_trailing=force|sp_qualifier_ptr_star_trailing=not_defined
+Choices=sp_qualifier_ptr_star_trailing\s*=\s*ignore|sp_qualifier_ptr_star_trailing\s*=\s*add|sp_qualifier_ptr_star_trailing\s*=\s*remove|sp_qualifier_ptr_star_trailing\s*=\s*force|sp_qualifier_ptr_star_trailing\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Qualifier Ptr Star Trailing|Add Sp Qualifier Ptr Star Trailing|Remove Sp Qualifier Ptr Star Trailing|Force Sp Qualifier Ptr Star Trailing"
 ValueDefault=ignore
 
@@ -610,7 +611,7 @@ Category=1
 Description="<html>Add or remove space before a reference sign '&amp;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_byref=ignore|sp_before_byref=add|sp_before_byref=remove|sp_before_byref=force|sp_before_byref=not_defined
+Choices=sp_before_byref\s*=\s*ignore|sp_before_byref\s*=\s*add|sp_before_byref\s*=\s*remove|sp_before_byref\s*=\s*force|sp_before_byref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Byref|Add Sp Before Byref|Remove Sp Before Byref|Force Sp Before Byref"
 ValueDefault=ignore
 
@@ -619,7 +620,7 @@ Category=1
 Description="<html>Add or remove space before a reference sign '&amp;' that isn't followed by a<br/>variable name. If set to ignore, sp_before_byref is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_unnamed_byref=ignore|sp_before_unnamed_byref=add|sp_before_unnamed_byref=remove|sp_before_unnamed_byref=force|sp_before_unnamed_byref=not_defined
+Choices=sp_before_unnamed_byref\s*=\s*ignore|sp_before_unnamed_byref\s*=\s*add|sp_before_unnamed_byref\s*=\s*remove|sp_before_unnamed_byref\s*=\s*force|sp_before_unnamed_byref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Unnamed Byref|Add Sp Before Unnamed Byref|Remove Sp Before Unnamed Byref|Force Sp Before Unnamed Byref"
 ValueDefault=ignore
 
@@ -628,7 +629,7 @@ Category=1
 Description="<html>Add or remove space after reference sign '&amp;', if followed by a word.<br/><br/>Overrides sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_byref=ignore|sp_after_byref=add|sp_after_byref=remove|sp_after_byref=force|sp_after_byref=not_defined
+Choices=sp_after_byref\s*=\s*ignore|sp_after_byref\s*=\s*add|sp_after_byref\s*=\s*remove|sp_after_byref\s*=\s*force|sp_after_byref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Byref|Add Sp After Byref|Remove Sp After Byref|Force Sp After Byref"
 ValueDefault=ignore
 
@@ -637,7 +638,7 @@ Category=1
 Description="<html>Add or remove space after a reference sign '&amp;', if followed by a function<br/>prototype or function definition.<br/><br/>Overrides sp_after_byref and sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_byref_func=ignore|sp_after_byref_func=add|sp_after_byref_func=remove|sp_after_byref_func=force|sp_after_byref_func=not_defined
+Choices=sp_after_byref_func\s*=\s*ignore|sp_after_byref_func\s*=\s*add|sp_after_byref_func\s*=\s*remove|sp_after_byref_func\s*=\s*force|sp_after_byref_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Byref Func|Add Sp After Byref Func|Remove Sp After Byref Func|Force Sp After Byref Func"
 ValueDefault=ignore
 
@@ -646,7 +647,7 @@ Category=1
 Description="<html>Add or remove space before a reference sign '&amp;', if followed by a function<br/>prototype or function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_byref_func=ignore|sp_before_byref_func=add|sp_before_byref_func=remove|sp_before_byref_func=force|sp_before_byref_func=not_defined
+Choices=sp_before_byref_func\s*=\s*ignore|sp_before_byref_func\s*=\s*add|sp_before_byref_func\s*=\s*remove|sp_before_byref_func\s*=\s*force|sp_before_byref_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Byref Func|Add Sp Before Byref Func|Remove Sp Before Byref Func|Force Sp Before Byref Func"
 ValueDefault=ignore
 
@@ -655,7 +656,7 @@ Category=1
 Description="<html>Add or remove space after a reference sign '&amp;', if followed by an open<br/>parenthesis, as in 'char&amp; (*)()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_byref_paren=ignore|sp_byref_paren=add|sp_byref_paren=remove|sp_byref_paren=force|sp_byref_paren=not_defined
+Choices=sp_byref_paren\s*=\s*ignore|sp_byref_paren\s*=\s*add|sp_byref_paren\s*=\s*remove|sp_byref_paren\s*=\s*force|sp_byref_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Byref Paren|Add Sp Byref Paren|Remove Sp Byref Paren|Force Sp Byref Paren"
 ValueDefault=ignore
 
@@ -664,7 +665,7 @@ Category=1
 Description="<html>Add or remove space between type and word. In cases where total removal of<br/>whitespace would be a syntax error, a value of 'remove' is treated the same<br/>as 'force'.<br/><br/>This also affects some other instances of space following a type that are<br/>not covered by other options; for example, between the return type and<br/>parenthesis of a function type template argument, between the type and<br/>parenthesis of an array parameter, or between 'decltype(...)' and the<br/>following word.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_type=ignore|sp_after_type=add|sp_after_type=remove|sp_after_type=force|sp_after_type=not_defined
+Choices=sp_after_type\s*=\s*ignore|sp_after_type\s*=\s*add|sp_after_type\s*=\s*remove|sp_after_type\s*=\s*force|sp_after_type\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Type|Add Sp After Type|Remove Sp After Type|Force Sp After Type"
 ValueDefault=force
 
@@ -673,7 +674,7 @@ Category=1
 Description="<html>Add or remove space between 'decltype(...)' and word,<br/>brace or function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_decltype=ignore|sp_after_decltype=add|sp_after_decltype=remove|sp_after_decltype=force|sp_after_decltype=not_defined
+Choices=sp_after_decltype\s*=\s*ignore|sp_after_decltype\s*=\s*add|sp_after_decltype\s*=\s*remove|sp_after_decltype\s*=\s*force|sp_after_decltype\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Decltype|Add Sp After Decltype|Remove Sp After Decltype|Force Sp After Decltype"
 ValueDefault=ignore
 
@@ -682,7 +683,7 @@ Category=1
 Description="<html>(D) Add or remove space before the parenthesis in the D constructs<br/>'template Foo(' and 'class Foo('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_template_paren=ignore|sp_before_template_paren=add|sp_before_template_paren=remove|sp_before_template_paren=force|sp_before_template_paren=not_defined
+Choices=sp_before_template_paren\s*=\s*ignore|sp_before_template_paren\s*=\s*add|sp_before_template_paren\s*=\s*remove|sp_before_template_paren\s*=\s*force|sp_before_template_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Template Paren|Add Sp Before Template Paren|Remove Sp Before Template Paren|Force Sp Before Template Paren"
 ValueDefault=ignore
 
@@ -691,7 +692,7 @@ Category=1
 Description="<html>Add or remove space between 'template' and '&lt;'.<br/>If set to ignore, sp_before_angle is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_template_angle=ignore|sp_template_angle=add|sp_template_angle=remove|sp_template_angle=force|sp_template_angle=not_defined
+Choices=sp_template_angle\s*=\s*ignore|sp_template_angle\s*=\s*add|sp_template_angle\s*=\s*remove|sp_template_angle\s*=\s*force|sp_template_angle\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Template Angle|Add Sp Template Angle|Remove Sp Template Angle|Force Sp Template Angle"
 ValueDefault=ignore
 
@@ -700,7 +701,7 @@ Category=1
 Description="<html>Add or remove space before '&lt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_angle=ignore|sp_before_angle=add|sp_before_angle=remove|sp_before_angle=force|sp_before_angle=not_defined
+Choices=sp_before_angle\s*=\s*ignore|sp_before_angle\s*=\s*add|sp_before_angle\s*=\s*remove|sp_before_angle\s*=\s*force|sp_before_angle\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Angle|Add Sp Before Angle|Remove Sp Before Angle|Force Sp Before Angle"
 ValueDefault=ignore
 
@@ -709,7 +710,7 @@ Category=1
 Description="<html>Add or remove space inside '&lt;' and '&gt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_angle=ignore|sp_inside_angle=add|sp_inside_angle=remove|sp_inside_angle=force|sp_inside_angle=not_defined
+Choices=sp_inside_angle\s*=\s*ignore|sp_inside_angle\s*=\s*add|sp_inside_angle\s*=\s*remove|sp_inside_angle\s*=\s*force|sp_inside_angle\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Angle|Add Sp Inside Angle|Remove Sp Inside Angle|Force Sp Inside Angle"
 ValueDefault=ignore
 
@@ -718,7 +719,7 @@ Category=1
 Description="<html>Add or remove space inside '&lt;&gt;'.<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_angle_empty=ignore|sp_inside_angle_empty=add|sp_inside_angle_empty=remove|sp_inside_angle_empty=force|sp_inside_angle_empty=not_defined
+Choices=sp_inside_angle_empty\s*=\s*ignore|sp_inside_angle_empty\s*=\s*add|sp_inside_angle_empty\s*=\s*remove|sp_inside_angle_empty\s*=\s*force|sp_inside_angle_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Angle Empty|Add Sp Inside Angle Empty|Remove Sp Inside Angle Empty|Force Sp Inside Angle Empty"
 ValueDefault=ignore
 
@@ -727,7 +728,7 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_colon=ignore|sp_angle_colon=add|sp_angle_colon=remove|sp_angle_colon=force|sp_angle_colon=not_defined
+Choices=sp_angle_colon\s*=\s*ignore|sp_angle_colon\s*=\s*add|sp_angle_colon\s*=\s*remove|sp_angle_colon\s*=\s*force|sp_angle_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Colon|Add Sp Angle Colon|Remove Sp Angle Colon|Force Sp Angle Colon"
 ValueDefault=ignore
 
@@ -736,7 +737,7 @@ Category=1
 Description="<html>Add or remove space after '&gt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_angle=ignore|sp_after_angle=add|sp_after_angle=remove|sp_after_angle=force|sp_after_angle=not_defined
+Choices=sp_after_angle\s*=\s*ignore|sp_after_angle\s*=\s*add|sp_after_angle\s*=\s*remove|sp_after_angle\s*=\s*force|sp_after_angle\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Angle|Add Sp After Angle|Remove Sp After Angle|Force Sp After Angle"
 ValueDefault=ignore
 
@@ -745,7 +746,7 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and '(' as found in 'new List&lt;byte&gt;(foo);'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_paren=ignore|sp_angle_paren=add|sp_angle_paren=remove|sp_angle_paren=force|sp_angle_paren=not_defined
+Choices=sp_angle_paren\s*=\s*ignore|sp_angle_paren\s*=\s*add|sp_angle_paren\s*=\s*remove|sp_angle_paren\s*=\s*force|sp_angle_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Paren|Add Sp Angle Paren|Remove Sp Angle Paren|Force Sp Angle Paren"
 ValueDefault=ignore
 
@@ -754,7 +755,7 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and '()' as found in 'new List&lt;byte&gt;();'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_paren_empty=ignore|sp_angle_paren_empty=add|sp_angle_paren_empty=remove|sp_angle_paren_empty=force|sp_angle_paren_empty=not_defined
+Choices=sp_angle_paren_empty\s*=\s*ignore|sp_angle_paren_empty\s*=\s*add|sp_angle_paren_empty\s*=\s*remove|sp_angle_paren_empty\s*=\s*force|sp_angle_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Paren Empty|Add Sp Angle Paren Empty|Remove Sp Angle Paren Empty|Force Sp Angle Paren Empty"
 ValueDefault=ignore
 
@@ -763,7 +764,7 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and a word as in 'List&lt;byte&gt; m;' or<br/>'template &lt;typename T&gt; static ...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_word=ignore|sp_angle_word=add|sp_angle_word=remove|sp_angle_word=force|sp_angle_word=not_defined
+Choices=sp_angle_word\s*=\s*ignore|sp_angle_word\s*=\s*add|sp_angle_word\s*=\s*remove|sp_angle_word\s*=\s*force|sp_angle_word\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Word|Add Sp Angle Word|Remove Sp Angle Word|Force Sp Angle Word"
 ValueDefault=ignore
 
@@ -772,7 +773,7 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and '&gt;' in '&gt;&gt;' (template stuff).<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_shift=ignore|sp_angle_shift=add|sp_angle_shift=remove|sp_angle_shift=force|sp_angle_shift=not_defined
+Choices=sp_angle_shift\s*=\s*ignore|sp_angle_shift\s*=\s*add|sp_angle_shift\s*=\s*remove|sp_angle_shift\s*=\s*force|sp_angle_shift\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Shift|Add Sp Angle Shift|Remove Sp Angle Shift|Force Sp Angle Shift"
 ValueDefault=add
 
@@ -781,7 +782,7 @@ Category=1
 Description="<html>(C++11) Permit removal of the space between '&gt;&gt;' in 'foo&lt;bar&lt;int&gt; &gt;'. Note<br/>that sp_angle_shift cannot remove the space without this option.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_permit_cpp11_shift=true|sp_permit_cpp11_shift=false
+TrueFalse=sp_permit_cpp11_shift\s*=\s*true|sp_permit_cpp11_shift\s*=\s*false
 ValueDefault=false
 
 [Sp Before Sparen]
@@ -789,7 +790,7 @@ Category=1
 Description="<html>Add or remove space before '(' of control statements ('if', 'for', 'switch',<br/>'while', etc.).</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_sparen=ignore|sp_before_sparen=add|sp_before_sparen=remove|sp_before_sparen=force|sp_before_sparen=not_defined
+Choices=sp_before_sparen\s*=\s*ignore|sp_before_sparen\s*=\s*add|sp_before_sparen\s*=\s*remove|sp_before_sparen\s*=\s*force|sp_before_sparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Sparen|Add Sp Before Sparen|Remove Sp Before Sparen|Force Sp Before Sparen"
 ValueDefault=ignore
 
@@ -798,7 +799,7 @@ Category=1
 Description="<html>Add or remove space inside '(' and ')' of control statements other than<br/>'for'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_sparen=ignore|sp_inside_sparen=add|sp_inside_sparen=remove|sp_inside_sparen=force|sp_inside_sparen=not_defined
+Choices=sp_inside_sparen\s*=\s*ignore|sp_inside_sparen\s*=\s*add|sp_inside_sparen\s*=\s*remove|sp_inside_sparen\s*=\s*force|sp_inside_sparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Sparen|Add Sp Inside Sparen|Remove Sp Inside Sparen|Force Sp Inside Sparen"
 ValueDefault=ignore
 
@@ -807,7 +808,7 @@ Category=1
 Description="<html>Add or remove space after '(' of control statements other than 'for'.<br/><br/>Overrides sp_inside_sparen.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_sparen_open=ignore|sp_inside_sparen_open=add|sp_inside_sparen_open=remove|sp_inside_sparen_open=force|sp_inside_sparen_open=not_defined
+Choices=sp_inside_sparen_open\s*=\s*ignore|sp_inside_sparen_open\s*=\s*add|sp_inside_sparen_open\s*=\s*remove|sp_inside_sparen_open\s*=\s*force|sp_inside_sparen_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Sparen Open|Add Sp Inside Sparen Open|Remove Sp Inside Sparen Open|Force Sp Inside Sparen Open"
 ValueDefault=ignore
 
@@ -816,7 +817,7 @@ Category=1
 Description="<html>Add or remove space before ')' of control statements other than 'for'.<br/><br/>Overrides sp_inside_sparen.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_sparen_close=ignore|sp_inside_sparen_close=add|sp_inside_sparen_close=remove|sp_inside_sparen_close=force|sp_inside_sparen_close=not_defined
+Choices=sp_inside_sparen_close\s*=\s*ignore|sp_inside_sparen_close\s*=\s*add|sp_inside_sparen_close\s*=\s*remove|sp_inside_sparen_close\s*=\s*force|sp_inside_sparen_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Sparen Close|Add Sp Inside Sparen Close|Remove Sp Inside Sparen Close|Force Sp Inside Sparen Close"
 ValueDefault=ignore
 
@@ -825,7 +826,7 @@ Category=1
 Description="<html>Add or remove space inside '(' and ')' of 'for' statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_for=ignore|sp_inside_for=add|sp_inside_for=remove|sp_inside_for=force|sp_inside_for=not_defined
+Choices=sp_inside_for\s*=\s*ignore|sp_inside_for\s*=\s*add|sp_inside_for\s*=\s*remove|sp_inside_for\s*=\s*force|sp_inside_for\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside For|Add Sp Inside For|Remove Sp Inside For|Force Sp Inside For"
 ValueDefault=ignore
 
@@ -834,7 +835,7 @@ Category=1
 Description="<html>Add or remove space after '(' of 'for' statements.<br/><br/>Overrides sp_inside_for.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_for_open=ignore|sp_inside_for_open=add|sp_inside_for_open=remove|sp_inside_for_open=force|sp_inside_for_open=not_defined
+Choices=sp_inside_for_open\s*=\s*ignore|sp_inside_for_open\s*=\s*add|sp_inside_for_open\s*=\s*remove|sp_inside_for_open\s*=\s*force|sp_inside_for_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside For Open|Add Sp Inside For Open|Remove Sp Inside For Open|Force Sp Inside For Open"
 ValueDefault=ignore
 
@@ -843,7 +844,7 @@ Category=1
 Description="<html>Add or remove space before ')' of 'for' statements.<br/><br/>Overrides sp_inside_for.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_for_close=ignore|sp_inside_for_close=add|sp_inside_for_close=remove|sp_inside_for_close=force|sp_inside_for_close=not_defined
+Choices=sp_inside_for_close\s*=\s*ignore|sp_inside_for_close\s*=\s*add|sp_inside_for_close\s*=\s*remove|sp_inside_for_close\s*=\s*force|sp_inside_for_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside For Close|Add Sp Inside For Close|Remove Sp Inside For Close|Force Sp Inside For Close"
 ValueDefault=ignore
 
@@ -852,7 +853,7 @@ Category=1
 Description="<html>Add or remove space between '((' or '))' of control statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sparen_paren=ignore|sp_sparen_paren=add|sp_sparen_paren=remove|sp_sparen_paren=force|sp_sparen_paren=not_defined
+Choices=sp_sparen_paren\s*=\s*ignore|sp_sparen_paren\s*=\s*add|sp_sparen_paren\s*=\s*remove|sp_sparen_paren\s*=\s*force|sp_sparen_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sparen Paren|Add Sp Sparen Paren|Remove Sp Sparen Paren|Force Sp Sparen Paren"
 ValueDefault=ignore
 
@@ -861,7 +862,7 @@ Category=1
 Description="<html>Add or remove space after ')' of control statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_sparen=ignore|sp_after_sparen=add|sp_after_sparen=remove|sp_after_sparen=force|sp_after_sparen=not_defined
+Choices=sp_after_sparen\s*=\s*ignore|sp_after_sparen\s*=\s*add|sp_after_sparen\s*=\s*remove|sp_after_sparen\s*=\s*force|sp_after_sparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Sparen|Add Sp After Sparen|Remove Sp After Sparen|Force Sp After Sparen"
 ValueDefault=ignore
 
@@ -870,7 +871,7 @@ Category=1
 Description="<html>Add or remove space between ')' and '{' of control statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sparen_brace=ignore|sp_sparen_brace=add|sp_sparen_brace=remove|sp_sparen_brace=force|sp_sparen_brace=not_defined
+Choices=sp_sparen_brace\s*=\s*ignore|sp_sparen_brace\s*=\s*add|sp_sparen_brace\s*=\s*remove|sp_sparen_brace\s*=\s*force|sp_sparen_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sparen Brace|Add Sp Sparen Brace|Remove Sp Sparen Brace|Force Sp Sparen Brace"
 ValueDefault=ignore
 
@@ -879,7 +880,7 @@ Category=1
 Description="<html>Add or remove space between 'do' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_do_brace_open=ignore|sp_do_brace_open=add|sp_do_brace_open=remove|sp_do_brace_open=force|sp_do_brace_open=not_defined
+Choices=sp_do_brace_open\s*=\s*ignore|sp_do_brace_open\s*=\s*add|sp_do_brace_open\s*=\s*remove|sp_do_brace_open\s*=\s*force|sp_do_brace_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Do Brace Open|Add Sp Do Brace Open|Remove Sp Do Brace Open|Force Sp Do Brace Open"
 ValueDefault=ignore
 
@@ -888,7 +889,7 @@ Category=1
 Description="<html>Add or remove space between '}' and 'while'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_close_while=ignore|sp_brace_close_while=add|sp_brace_close_while=remove|sp_brace_close_while=force|sp_brace_close_while=not_defined
+Choices=sp_brace_close_while\s*=\s*ignore|sp_brace_close_while\s*=\s*add|sp_brace_close_while\s*=\s*remove|sp_brace_close_while\s*=\s*force|sp_brace_close_while\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Close While|Add Sp Brace Close While|Remove Sp Brace Close While|Force Sp Brace Close While"
 ValueDefault=ignore
 
@@ -897,7 +898,7 @@ Category=1
 Description="<html>Add or remove space between 'while' and '('. Overrides sp_before_sparen.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_while_paren_open=ignore|sp_while_paren_open=add|sp_while_paren_open=remove|sp_while_paren_open=force|sp_while_paren_open=not_defined
+Choices=sp_while_paren_open\s*=\s*ignore|sp_while_paren_open\s*=\s*add|sp_while_paren_open\s*=\s*remove|sp_while_paren_open\s*=\s*force|sp_while_paren_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp While Paren Open|Add Sp While Paren Open|Remove Sp While Paren Open|Force Sp While Paren Open"
 ValueDefault=ignore
 
@@ -906,7 +907,7 @@ Category=1
 Description="<html>(D) Add or remove space between 'invariant' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_invariant_paren=ignore|sp_invariant_paren=add|sp_invariant_paren=remove|sp_invariant_paren=force|sp_invariant_paren=not_defined
+Choices=sp_invariant_paren\s*=\s*ignore|sp_invariant_paren\s*=\s*add|sp_invariant_paren\s*=\s*remove|sp_invariant_paren\s*=\s*force|sp_invariant_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Invariant Paren|Add Sp Invariant Paren|Remove Sp Invariant Paren|Force Sp Invariant Paren"
 ValueDefault=ignore
 
@@ -915,7 +916,7 @@ Category=1
 Description="<html>(D) Add or remove space after the ')' in 'invariant (C) c'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_invariant_paren=ignore|sp_after_invariant_paren=add|sp_after_invariant_paren=remove|sp_after_invariant_paren=force|sp_after_invariant_paren=not_defined
+Choices=sp_after_invariant_paren\s*=\s*ignore|sp_after_invariant_paren\s*=\s*add|sp_after_invariant_paren\s*=\s*remove|sp_after_invariant_paren\s*=\s*force|sp_after_invariant_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Invariant Paren|Add Sp After Invariant Paren|Remove Sp After Invariant Paren|Force Sp After Invariant Paren"
 ValueDefault=ignore
 
@@ -924,7 +925,7 @@ Category=1
 Description="<html>Add or remove space before empty statement ';' on 'if', 'for' and 'while'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_special_semi=ignore|sp_special_semi=add|sp_special_semi=remove|sp_special_semi=force|sp_special_semi=not_defined
+Choices=sp_special_semi\s*=\s*ignore|sp_special_semi\s*=\s*add|sp_special_semi\s*=\s*remove|sp_special_semi\s*=\s*force|sp_special_semi\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Special Semi|Add Sp Special Semi|Remove Sp Special Semi|Force Sp Special Semi"
 ValueDefault=ignore
 
@@ -933,7 +934,7 @@ Category=1
 Description="<html>Add or remove space before ';'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_semi=ignore|sp_before_semi=add|sp_before_semi=remove|sp_before_semi=force|sp_before_semi=not_defined
+Choices=sp_before_semi\s*=\s*ignore|sp_before_semi\s*=\s*add|sp_before_semi\s*=\s*remove|sp_before_semi\s*=\s*force|sp_before_semi\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Semi|Add Sp Before Semi|Remove Sp Before Semi|Force Sp Before Semi"
 ValueDefault=remove
 
@@ -942,7 +943,7 @@ Category=1
 Description="<html>Add or remove space before ';' in non-empty 'for' statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_semi_for=ignore|sp_before_semi_for=add|sp_before_semi_for=remove|sp_before_semi_for=force|sp_before_semi_for=not_defined
+Choices=sp_before_semi_for\s*=\s*ignore|sp_before_semi_for\s*=\s*add|sp_before_semi_for\s*=\s*remove|sp_before_semi_for\s*=\s*force|sp_before_semi_for\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Semi For|Add Sp Before Semi For|Remove Sp Before Semi For|Force Sp Before Semi For"
 ValueDefault=ignore
 
@@ -951,7 +952,7 @@ Category=1
 Description="<html>Add or remove space before a semicolon of an empty left part of a for<br/>statement, as in 'for ( &lt;here&gt; ; ; )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_semi_for_empty=ignore|sp_before_semi_for_empty=add|sp_before_semi_for_empty=remove|sp_before_semi_for_empty=force|sp_before_semi_for_empty=not_defined
+Choices=sp_before_semi_for_empty\s*=\s*ignore|sp_before_semi_for_empty\s*=\s*add|sp_before_semi_for_empty\s*=\s*remove|sp_before_semi_for_empty\s*=\s*force|sp_before_semi_for_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Semi For Empty|Add Sp Before Semi For Empty|Remove Sp Before Semi For Empty|Force Sp Before Semi For Empty"
 ValueDefault=ignore
 
@@ -960,7 +961,7 @@ Category=1
 Description="<html>Add or remove space between the semicolons of an empty middle part of a for<br/>statement, as in 'for ( ; &lt;here&gt; ; )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_semi_for_empty=ignore|sp_between_semi_for_empty=add|sp_between_semi_for_empty=remove|sp_between_semi_for_empty=force|sp_between_semi_for_empty=not_defined
+Choices=sp_between_semi_for_empty\s*=\s*ignore|sp_between_semi_for_empty\s*=\s*add|sp_between_semi_for_empty\s*=\s*remove|sp_between_semi_for_empty\s*=\s*force|sp_between_semi_for_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between Semi For Empty|Add Sp Between Semi For Empty|Remove Sp Between Semi For Empty|Force Sp Between Semi For Empty"
 ValueDefault=ignore
 
@@ -969,7 +970,7 @@ Category=1
 Description="<html>Add or remove space after ';', except when followed by a comment.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_semi=ignore|sp_after_semi=add|sp_after_semi=remove|sp_after_semi=force|sp_after_semi=not_defined
+Choices=sp_after_semi\s*=\s*ignore|sp_after_semi\s*=\s*add|sp_after_semi\s*=\s*remove|sp_after_semi\s*=\s*force|sp_after_semi\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Semi|Add Sp After Semi|Remove Sp After Semi|Force Sp After Semi"
 ValueDefault=add
 
@@ -978,7 +979,7 @@ Category=1
 Description="<html>Add or remove space after ';' in non-empty 'for' statements.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_semi_for=ignore|sp_after_semi_for=add|sp_after_semi_for=remove|sp_after_semi_for=force|sp_after_semi_for=not_defined
+Choices=sp_after_semi_for\s*=\s*ignore|sp_after_semi_for\s*=\s*add|sp_after_semi_for\s*=\s*remove|sp_after_semi_for\s*=\s*force|sp_after_semi_for\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Semi For|Add Sp After Semi For|Remove Sp After Semi For|Force Sp After Semi For"
 ValueDefault=force
 
@@ -987,7 +988,7 @@ Category=1
 Description="<html>Add or remove space after the final semicolon of an empty part of a for<br/>statement, as in 'for ( ; ; &lt;here&gt; )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_semi_for_empty=ignore|sp_after_semi_for_empty=add|sp_after_semi_for_empty=remove|sp_after_semi_for_empty=force|sp_after_semi_for_empty=not_defined
+Choices=sp_after_semi_for_empty\s*=\s*ignore|sp_after_semi_for_empty\s*=\s*add|sp_after_semi_for_empty\s*=\s*remove|sp_after_semi_for_empty\s*=\s*force|sp_after_semi_for_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Semi For Empty|Add Sp After Semi For Empty|Remove Sp After Semi For Empty|Force Sp After Semi For Empty"
 ValueDefault=ignore
 
@@ -996,7 +997,7 @@ Category=1
 Description="<html>Add or remove space before '[' (except '[]').</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_square=ignore|sp_before_square=add|sp_before_square=remove|sp_before_square=force|sp_before_square=not_defined
+Choices=sp_before_square\s*=\s*ignore|sp_before_square\s*=\s*add|sp_before_square\s*=\s*remove|sp_before_square\s*=\s*force|sp_before_square\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Square|Add Sp Before Square|Remove Sp Before Square|Force Sp Before Square"
 ValueDefault=ignore
 
@@ -1005,7 +1006,7 @@ Category=1
 Description="<html>Add or remove space before '[' for a variable definition.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_vardef_square=ignore|sp_before_vardef_square=add|sp_before_vardef_square=remove|sp_before_vardef_square=force|sp_before_vardef_square=not_defined
+Choices=sp_before_vardef_square\s*=\s*ignore|sp_before_vardef_square\s*=\s*add|sp_before_vardef_square\s*=\s*remove|sp_before_vardef_square\s*=\s*force|sp_before_vardef_square\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Vardef Square|Add Sp Before Vardef Square|Remove Sp Before Vardef Square|Force Sp Before Vardef Square"
 ValueDefault=remove
 
@@ -1014,7 +1015,7 @@ Category=1
 Description="<html>Add or remove space before '[' for asm block.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_square_asm_block=ignore|sp_before_square_asm_block=add|sp_before_square_asm_block=remove|sp_before_square_asm_block=force|sp_before_square_asm_block=not_defined
+Choices=sp_before_square_asm_block\s*=\s*ignore|sp_before_square_asm_block\s*=\s*add|sp_before_square_asm_block\s*=\s*remove|sp_before_square_asm_block\s*=\s*force|sp_before_square_asm_block\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Square Asm Block|Add Sp Before Square Asm Block|Remove Sp Before Square Asm Block|Force Sp Before Square Asm Block"
 ValueDefault=ignore
 
@@ -1023,7 +1024,7 @@ Category=1
 Description="<html>Add or remove space before '[]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_squares=ignore|sp_before_squares=add|sp_before_squares=remove|sp_before_squares=force|sp_before_squares=not_defined
+Choices=sp_before_squares\s*=\s*ignore|sp_before_squares\s*=\s*add|sp_before_squares\s*=\s*remove|sp_before_squares\s*=\s*force|sp_before_squares\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Squares|Add Sp Before Squares|Remove Sp Before Squares|Force Sp Before Squares"
 ValueDefault=ignore
 
@@ -1032,7 +1033,7 @@ Category=1
 Description="<html>Add or remove space before C++17 structured bindings.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_before_struct_binding=ignore|sp_cpp_before_struct_binding=add|sp_cpp_before_struct_binding=remove|sp_cpp_before_struct_binding=force|sp_cpp_before_struct_binding=not_defined
+Choices=sp_cpp_before_struct_binding\s*=\s*ignore|sp_cpp_before_struct_binding\s*=\s*add|sp_cpp_before_struct_binding\s*=\s*remove|sp_cpp_before_struct_binding\s*=\s*force|sp_cpp_before_struct_binding\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Before Struct Binding|Add Sp Cpp Before Struct Binding|Remove Sp Cpp Before Struct Binding|Force Sp Cpp Before Struct Binding"
 ValueDefault=ignore
 
@@ -1041,7 +1042,7 @@ Category=1
 Description="<html>Add or remove space inside a non-empty '[' and ']'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_square=ignore|sp_inside_square=add|sp_inside_square=remove|sp_inside_square=force|sp_inside_square=not_defined
+Choices=sp_inside_square\s*=\s*ignore|sp_inside_square\s*=\s*add|sp_inside_square\s*=\s*remove|sp_inside_square\s*=\s*force|sp_inside_square\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Square|Add Sp Inside Square|Remove Sp Inside Square|Force Sp Inside Square"
 ValueDefault=ignore
 
@@ -1050,7 +1051,7 @@ Category=1
 Description="<html>Add or remove space inside '[]'.<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_square_empty=ignore|sp_inside_square_empty=add|sp_inside_square_empty=remove|sp_inside_square_empty=force|sp_inside_square_empty=not_defined
+Choices=sp_inside_square_empty\s*=\s*ignore|sp_inside_square_empty\s*=\s*add|sp_inside_square_empty\s*=\s*remove|sp_inside_square_empty\s*=\s*force|sp_inside_square_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Square Empty|Add Sp Inside Square Empty|Remove Sp Inside Square Empty|Force Sp Inside Square Empty"
 ValueDefault=ignore
 
@@ -1059,7 +1060,7 @@ Category=1
 Description="<html>(OC) Add or remove space inside a non-empty Objective-C boxed array '@[' and<br/>']'. If set to ignore, sp_inside_square is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_square_oc_array=ignore|sp_inside_square_oc_array=add|sp_inside_square_oc_array=remove|sp_inside_square_oc_array=force|sp_inside_square_oc_array=not_defined
+Choices=sp_inside_square_oc_array\s*=\s*ignore|sp_inside_square_oc_array\s*=\s*add|sp_inside_square_oc_array\s*=\s*remove|sp_inside_square_oc_array\s*=\s*force|sp_inside_square_oc_array\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Square Oc Array|Add Sp Inside Square Oc Array|Remove Sp Inside Square Oc Array|Force Sp Inside Square Oc Array"
 ValueDefault=ignore
 
@@ -1068,7 +1069,7 @@ Category=1
 Description="<html>Add or remove space after ',', i.e. 'a,b' vs. 'a, b'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_comma=ignore|sp_after_comma=add|sp_after_comma=remove|sp_after_comma=force|sp_after_comma=not_defined
+Choices=sp_after_comma\s*=\s*ignore|sp_after_comma\s*=\s*add|sp_after_comma\s*=\s*remove|sp_after_comma\s*=\s*force|sp_after_comma\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Comma|Add Sp After Comma|Remove Sp After Comma|Force Sp After Comma"
 ValueDefault=ignore
 
@@ -1077,7 +1078,7 @@ Category=1
 Description="<html>Add or remove space before ',', i.e. 'a,b' vs. 'a ,b'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_comma=ignore|sp_before_comma=add|sp_before_comma=remove|sp_before_comma=force|sp_before_comma=not_defined
+Choices=sp_before_comma\s*=\s*ignore|sp_before_comma\s*=\s*add|sp_before_comma\s*=\s*remove|sp_before_comma\s*=\s*force|sp_before_comma\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Comma|Add Sp Before Comma|Remove Sp Before Comma|Force Sp Before Comma"
 ValueDefault=remove
 
@@ -1086,7 +1087,7 @@ Category=1
 Description="<html>(C#, Vala) Add or remove space between ',' and ']' in multidimensional array type<br/>like 'int[,,]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_mdatype_commas=ignore|sp_after_mdatype_commas=add|sp_after_mdatype_commas=remove|sp_after_mdatype_commas=force|sp_after_mdatype_commas=not_defined
+Choices=sp_after_mdatype_commas\s*=\s*ignore|sp_after_mdatype_commas\s*=\s*add|sp_after_mdatype_commas\s*=\s*remove|sp_after_mdatype_commas\s*=\s*force|sp_after_mdatype_commas\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Mdatype Commas|Add Sp After Mdatype Commas|Remove Sp After Mdatype Commas|Force Sp After Mdatype Commas"
 ValueDefault=ignore
 
@@ -1095,7 +1096,7 @@ Category=1
 Description="<html>(C#, Vala) Add or remove space between '[' and ',' in multidimensional array type<br/>like 'int[,,]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_mdatype_commas=ignore|sp_before_mdatype_commas=add|sp_before_mdatype_commas=remove|sp_before_mdatype_commas=force|sp_before_mdatype_commas=not_defined
+Choices=sp_before_mdatype_commas\s*=\s*ignore|sp_before_mdatype_commas\s*=\s*add|sp_before_mdatype_commas\s*=\s*remove|sp_before_mdatype_commas\s*=\s*force|sp_before_mdatype_commas\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Mdatype Commas|Add Sp Before Mdatype Commas|Remove Sp Before Mdatype Commas|Force Sp Before Mdatype Commas"
 ValueDefault=ignore
 
@@ -1104,7 +1105,7 @@ Category=1
 Description="<html>(C#, Vala) Add or remove space between ',' in multidimensional array type<br/>like 'int[,,]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_mdatype_commas=ignore|sp_between_mdatype_commas=add|sp_between_mdatype_commas=remove|sp_between_mdatype_commas=force|sp_between_mdatype_commas=not_defined
+Choices=sp_between_mdatype_commas\s*=\s*ignore|sp_between_mdatype_commas\s*=\s*add|sp_between_mdatype_commas\s*=\s*remove|sp_between_mdatype_commas\s*=\s*force|sp_between_mdatype_commas\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between Mdatype Commas|Add Sp Between Mdatype Commas|Remove Sp Between Mdatype Commas|Force Sp Between Mdatype Commas"
 ValueDefault=ignore
 
@@ -1113,7 +1114,7 @@ Category=1
 Description="<html>Add or remove space between an open parenthesis and comma,<br/>i.e. '(,' vs. '( ,'.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_comma=ignore|sp_paren_comma=add|sp_paren_comma=remove|sp_paren_comma=force|sp_paren_comma=not_defined
+Choices=sp_paren_comma\s*=\s*ignore|sp_paren_comma\s*=\s*add|sp_paren_comma\s*=\s*remove|sp_paren_comma\s*=\s*force|sp_paren_comma\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Comma|Add Sp Paren Comma|Remove Sp Paren Comma|Force Sp Paren Comma"
 ValueDefault=force
 
@@ -1122,7 +1123,7 @@ Category=1
 Description="<html>Add or remove space between a type and ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_type_colon=ignore|sp_type_colon=add|sp_type_colon=remove|sp_type_colon=force|sp_type_colon=not_defined
+Choices=sp_type_colon\s*=\s*ignore|sp_type_colon\s*=\s*add|sp_type_colon\s*=\s*remove|sp_type_colon\s*=\s*force|sp_type_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Type Colon|Add Sp Type Colon|Remove Sp Type Colon|Force Sp Type Colon"
 ValueDefault=ignore
 
@@ -1131,7 +1132,7 @@ Category=1
 Description="<html>Add or remove space after the variadic '...' when preceded by a<br/>non-punctuator.<br/>The value REMOVE will be overridden with FORCE</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ellipsis=ignore|sp_after_ellipsis=add|sp_after_ellipsis=remove|sp_after_ellipsis=force|sp_after_ellipsis=not_defined
+Choices=sp_after_ellipsis\s*=\s*ignore|sp_after_ellipsis\s*=\s*add|sp_after_ellipsis\s*=\s*remove|sp_after_ellipsis\s*=\s*force|sp_after_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ellipsis|Add Sp After Ellipsis|Remove Sp After Ellipsis|Force Sp After Ellipsis"
 ValueDefault=ignore
 
@@ -1140,7 +1141,7 @@ Category=1
 Description="<html>Add or remove space before the variadic '...' when preceded by a<br/>non-punctuator.<br/>The value REMOVE will be overridden with FORCE</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_ellipsis=ignore|sp_before_ellipsis=add|sp_before_ellipsis=remove|sp_before_ellipsis=force|sp_before_ellipsis=not_defined
+Choices=sp_before_ellipsis\s*=\s*ignore|sp_before_ellipsis\s*=\s*add|sp_before_ellipsis\s*=\s*remove|sp_before_ellipsis\s*=\s*force|sp_before_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Ellipsis|Add Sp Before Ellipsis|Remove Sp Before Ellipsis|Force Sp Before Ellipsis"
 ValueDefault=ignore
 
@@ -1149,7 +1150,7 @@ Category=1
 Description="<html>Add or remove space between a type and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_type_ellipsis=ignore|sp_type_ellipsis=add|sp_type_ellipsis=remove|sp_type_ellipsis=force|sp_type_ellipsis=not_defined
+Choices=sp_type_ellipsis\s*=\s*ignore|sp_type_ellipsis\s*=\s*add|sp_type_ellipsis\s*=\s*remove|sp_type_ellipsis\s*=\s*force|sp_type_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Type Ellipsis|Add Sp Type Ellipsis|Remove Sp Type Ellipsis|Force Sp Type Ellipsis"
 ValueDefault=ignore
 
@@ -1158,7 +1159,7 @@ Category=1
 Description="<html>Add or remove space between a '*' and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ptr_type_ellipsis=ignore|sp_ptr_type_ellipsis=add|sp_ptr_type_ellipsis=remove|sp_ptr_type_ellipsis=force|sp_ptr_type_ellipsis=not_defined
+Choices=sp_ptr_type_ellipsis\s*=\s*ignore|sp_ptr_type_ellipsis\s*=\s*add|sp_ptr_type_ellipsis\s*=\s*remove|sp_ptr_type_ellipsis\s*=\s*force|sp_ptr_type_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ptr Type Ellipsis|Add Sp Ptr Type Ellipsis|Remove Sp Ptr Type Ellipsis|Force Sp Ptr Type Ellipsis"
 ValueDefault=ignore
 
@@ -1167,7 +1168,7 @@ Category=1
 Description="<html>Add or remove space between ')' and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_ellipsis=ignore|sp_paren_ellipsis=add|sp_paren_ellipsis=remove|sp_paren_ellipsis=force|sp_paren_ellipsis=not_defined
+Choices=sp_paren_ellipsis\s*=\s*ignore|sp_paren_ellipsis\s*=\s*add|sp_paren_ellipsis\s*=\s*remove|sp_paren_ellipsis\s*=\s*force|sp_paren_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Ellipsis|Add Sp Paren Ellipsis|Remove Sp Paren Ellipsis|Force Sp Paren Ellipsis"
 ValueDefault=ignore
 
@@ -1176,7 +1177,7 @@ Category=1
 Description="<html>Add or remove space between '&amp;&amp;' and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_byref_ellipsis=ignore|sp_byref_ellipsis=add|sp_byref_ellipsis=remove|sp_byref_ellipsis=force|sp_byref_ellipsis=not_defined
+Choices=sp_byref_ellipsis\s*=\s*ignore|sp_byref_ellipsis\s*=\s*add|sp_byref_ellipsis\s*=\s*remove|sp_byref_ellipsis\s*=\s*force|sp_byref_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Byref Ellipsis|Add Sp Byref Ellipsis|Remove Sp Byref Ellipsis|Force Sp Byref Ellipsis"
 ValueDefault=ignore
 
@@ -1185,7 +1186,7 @@ Category=1
 Description="<html>Add or remove space between ')' and a qualifier such as 'const'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_qualifier=ignore|sp_paren_qualifier=add|sp_paren_qualifier=remove|sp_paren_qualifier=force|sp_paren_qualifier=not_defined
+Choices=sp_paren_qualifier\s*=\s*ignore|sp_paren_qualifier\s*=\s*add|sp_paren_qualifier\s*=\s*remove|sp_paren_qualifier\s*=\s*force|sp_paren_qualifier\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Qualifier|Add Sp Paren Qualifier|Remove Sp Paren Qualifier|Force Sp Paren Qualifier"
 ValueDefault=ignore
 
@@ -1194,7 +1195,7 @@ Category=1
 Description="<html>Add or remove space between ')' and 'noexcept'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_noexcept=ignore|sp_paren_noexcept=add|sp_paren_noexcept=remove|sp_paren_noexcept=force|sp_paren_noexcept=not_defined
+Choices=sp_paren_noexcept\s*=\s*ignore|sp_paren_noexcept\s*=\s*add|sp_paren_noexcept\s*=\s*remove|sp_paren_noexcept\s*=\s*force|sp_paren_noexcept\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Noexcept|Add Sp Paren Noexcept|Remove Sp Paren Noexcept|Force Sp Paren Noexcept"
 ValueDefault=ignore
 
@@ -1203,7 +1204,7 @@ Category=1
 Description="<html>Add or remove space after class ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_class_colon=ignore|sp_after_class_colon=add|sp_after_class_colon=remove|sp_after_class_colon=force|sp_after_class_colon=not_defined
+Choices=sp_after_class_colon\s*=\s*ignore|sp_after_class_colon\s*=\s*add|sp_after_class_colon\s*=\s*remove|sp_after_class_colon\s*=\s*force|sp_after_class_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Class Colon|Add Sp After Class Colon|Remove Sp After Class Colon|Force Sp After Class Colon"
 ValueDefault=ignore
 
@@ -1212,7 +1213,7 @@ Category=1
 Description="<html>Add or remove space before class ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_class_colon=ignore|sp_before_class_colon=add|sp_before_class_colon=remove|sp_before_class_colon=force|sp_before_class_colon=not_defined
+Choices=sp_before_class_colon\s*=\s*ignore|sp_before_class_colon\s*=\s*add|sp_before_class_colon\s*=\s*remove|sp_before_class_colon\s*=\s*force|sp_before_class_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Class Colon|Add Sp Before Class Colon|Remove Sp Before Class Colon|Force Sp Before Class Colon"
 ValueDefault=ignore
 
@@ -1221,7 +1222,7 @@ Category=1
 Description="<html>Add or remove space after class constructor ':'.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_constr_colon=ignore|sp_after_constr_colon=add|sp_after_constr_colon=remove|sp_after_constr_colon=force|sp_after_constr_colon=not_defined
+Choices=sp_after_constr_colon\s*=\s*ignore|sp_after_constr_colon\s*=\s*add|sp_after_constr_colon\s*=\s*remove|sp_after_constr_colon\s*=\s*force|sp_after_constr_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Constr Colon|Add Sp After Constr Colon|Remove Sp After Constr Colon|Force Sp After Constr Colon"
 ValueDefault=add
 
@@ -1230,7 +1231,7 @@ Category=1
 Description="<html>Add or remove space before class constructor ':'.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_constr_colon=ignore|sp_before_constr_colon=add|sp_before_constr_colon=remove|sp_before_constr_colon=force|sp_before_constr_colon=not_defined
+Choices=sp_before_constr_colon\s*=\s*ignore|sp_before_constr_colon\s*=\s*add|sp_before_constr_colon\s*=\s*remove|sp_before_constr_colon\s*=\s*force|sp_before_constr_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Constr Colon|Add Sp Before Constr Colon|Remove Sp Before Constr Colon|Force Sp Before Constr Colon"
 ValueDefault=add
 
@@ -1239,7 +1240,7 @@ Category=1
 Description="<html>Add or remove space before case ':'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_case_colon=ignore|sp_before_case_colon=add|sp_before_case_colon=remove|sp_before_case_colon=force|sp_before_case_colon=not_defined
+Choices=sp_before_case_colon\s*=\s*ignore|sp_before_case_colon\s*=\s*add|sp_before_case_colon\s*=\s*remove|sp_before_case_colon\s*=\s*force|sp_before_case_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Case Colon|Add Sp Before Case Colon|Remove Sp Before Case Colon|Force Sp Before Case Colon"
 ValueDefault=remove
 
@@ -1248,7 +1249,7 @@ Category=1
 Description="<html>Add or remove space between 'operator' and operator sign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_operator=ignore|sp_after_operator=add|sp_after_operator=remove|sp_after_operator=force|sp_after_operator=not_defined
+Choices=sp_after_operator\s*=\s*ignore|sp_after_operator\s*=\s*add|sp_after_operator\s*=\s*remove|sp_after_operator\s*=\s*force|sp_after_operator\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Operator|Add Sp After Operator|Remove Sp After Operator|Force Sp After Operator"
 ValueDefault=ignore
 
@@ -1257,7 +1258,7 @@ Category=1
 Description="<html>Add or remove space between the operator symbol and the open parenthesis, as<br/>in 'operator ++('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_operator_sym=ignore|sp_after_operator_sym=add|sp_after_operator_sym=remove|sp_after_operator_sym=force|sp_after_operator_sym=not_defined
+Choices=sp_after_operator_sym\s*=\s*ignore|sp_after_operator_sym\s*=\s*add|sp_after_operator_sym\s*=\s*remove|sp_after_operator_sym\s*=\s*force|sp_after_operator_sym\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Operator Sym|Add Sp After Operator Sym|Remove Sp After Operator Sym|Force Sp After Operator Sym"
 ValueDefault=ignore
 
@@ -1266,7 +1267,7 @@ Category=1
 Description="<html>Overrides sp_after_operator_sym when the operator has no arguments, as in<br/>'operator *()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_operator_sym_empty=ignore|sp_after_operator_sym_empty=add|sp_after_operator_sym_empty=remove|sp_after_operator_sym_empty=force|sp_after_operator_sym_empty=not_defined
+Choices=sp_after_operator_sym_empty\s*=\s*ignore|sp_after_operator_sym_empty\s*=\s*add|sp_after_operator_sym_empty\s*=\s*remove|sp_after_operator_sym_empty\s*=\s*force|sp_after_operator_sym_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Operator Sym Empty|Add Sp After Operator Sym Empty|Remove Sp After Operator Sym Empty|Force Sp After Operator Sym Empty"
 ValueDefault=ignore
 
@@ -1275,7 +1276,7 @@ Category=1
 Description="<html>Add or remove space after C/D cast, i.e. 'cast(int)a' vs. 'cast(int) a' or<br/>'(int)a' vs. '(int) a'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_cast=ignore|sp_after_cast=add|sp_after_cast=remove|sp_after_cast=force|sp_after_cast=not_defined
+Choices=sp_after_cast\s*=\s*ignore|sp_after_cast\s*=\s*add|sp_after_cast\s*=\s*remove|sp_after_cast\s*=\s*force|sp_after_cast\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Cast|Add Sp After Cast|Remove Sp After Cast|Force Sp After Cast"
 ValueDefault=ignore
 
@@ -1284,7 +1285,7 @@ Category=1
 Description="<html>Add or remove spaces inside cast parentheses.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_paren_cast=ignore|sp_inside_paren_cast=add|sp_inside_paren_cast=remove|sp_inside_paren_cast=force|sp_inside_paren_cast=not_defined
+Choices=sp_inside_paren_cast\s*=\s*ignore|sp_inside_paren_cast\s*=\s*add|sp_inside_paren_cast\s*=\s*remove|sp_inside_paren_cast\s*=\s*force|sp_inside_paren_cast\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Paren Cast|Add Sp Inside Paren Cast|Remove Sp Inside Paren Cast|Force Sp Inside Paren Cast"
 ValueDefault=ignore
 
@@ -1293,7 +1294,7 @@ Category=1
 Description="<html>Add or remove space between the type and open parenthesis in a C++ cast,<br/>i.e. 'int(exp)' vs. 'int (exp)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_cast_paren=ignore|sp_cpp_cast_paren=add|sp_cpp_cast_paren=remove|sp_cpp_cast_paren=force|sp_cpp_cast_paren=not_defined
+Choices=sp_cpp_cast_paren\s*=\s*ignore|sp_cpp_cast_paren\s*=\s*add|sp_cpp_cast_paren\s*=\s*remove|sp_cpp_cast_paren\s*=\s*force|sp_cpp_cast_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Cast Paren|Add Sp Cpp Cast Paren|Remove Sp Cpp Cast Paren|Force Sp Cpp Cast Paren"
 ValueDefault=ignore
 
@@ -1302,7 +1303,7 @@ Category=1
 Description="<html>Add or remove space between 'sizeof' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sizeof_paren=ignore|sp_sizeof_paren=add|sp_sizeof_paren=remove|sp_sizeof_paren=force|sp_sizeof_paren=not_defined
+Choices=sp_sizeof_paren\s*=\s*ignore|sp_sizeof_paren\s*=\s*add|sp_sizeof_paren\s*=\s*remove|sp_sizeof_paren\s*=\s*force|sp_sizeof_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sizeof Paren|Add Sp Sizeof Paren|Remove Sp Sizeof Paren|Force Sp Sizeof Paren"
 ValueDefault=ignore
 
@@ -1311,7 +1312,7 @@ Category=1
 Description="<html>Add or remove space between 'sizeof' and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sizeof_ellipsis=ignore|sp_sizeof_ellipsis=add|sp_sizeof_ellipsis=remove|sp_sizeof_ellipsis=force|sp_sizeof_ellipsis=not_defined
+Choices=sp_sizeof_ellipsis\s*=\s*ignore|sp_sizeof_ellipsis\s*=\s*add|sp_sizeof_ellipsis\s*=\s*remove|sp_sizeof_ellipsis\s*=\s*force|sp_sizeof_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sizeof Ellipsis|Add Sp Sizeof Ellipsis|Remove Sp Sizeof Ellipsis|Force Sp Sizeof Ellipsis"
 ValueDefault=ignore
 
@@ -1320,7 +1321,7 @@ Category=1
 Description="<html>Add or remove space between 'sizeof...' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sizeof_ellipsis_paren=ignore|sp_sizeof_ellipsis_paren=add|sp_sizeof_ellipsis_paren=remove|sp_sizeof_ellipsis_paren=force|sp_sizeof_ellipsis_paren=not_defined
+Choices=sp_sizeof_ellipsis_paren\s*=\s*ignore|sp_sizeof_ellipsis_paren\s*=\s*add|sp_sizeof_ellipsis_paren\s*=\s*remove|sp_sizeof_ellipsis_paren\s*=\s*force|sp_sizeof_ellipsis_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sizeof Ellipsis Paren|Add Sp Sizeof Ellipsis Paren|Remove Sp Sizeof Ellipsis Paren|Force Sp Sizeof Ellipsis Paren"
 ValueDefault=ignore
 
@@ -1329,7 +1330,7 @@ Category=1
 Description="<html>Add or remove space between '...' and a parameter pack.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ellipsis_parameter_pack=ignore|sp_ellipsis_parameter_pack=add|sp_ellipsis_parameter_pack=remove|sp_ellipsis_parameter_pack=force|sp_ellipsis_parameter_pack=not_defined
+Choices=sp_ellipsis_parameter_pack\s*=\s*ignore|sp_ellipsis_parameter_pack\s*=\s*add|sp_ellipsis_parameter_pack\s*=\s*remove|sp_ellipsis_parameter_pack\s*=\s*force|sp_ellipsis_parameter_pack\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ellipsis Parameter Pack|Add Sp Ellipsis Parameter Pack|Remove Sp Ellipsis Parameter Pack|Force Sp Ellipsis Parameter Pack"
 ValueDefault=ignore
 
@@ -1338,7 +1339,7 @@ Category=1
 Description="<html>Add or remove space between a parameter pack and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_parameter_pack_ellipsis=ignore|sp_parameter_pack_ellipsis=add|sp_parameter_pack_ellipsis=remove|sp_parameter_pack_ellipsis=force|sp_parameter_pack_ellipsis=not_defined
+Choices=sp_parameter_pack_ellipsis\s*=\s*ignore|sp_parameter_pack_ellipsis\s*=\s*add|sp_parameter_pack_ellipsis\s*=\s*remove|sp_parameter_pack_ellipsis\s*=\s*force|sp_parameter_pack_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Parameter Pack Ellipsis|Add Sp Parameter Pack Ellipsis|Remove Sp Parameter Pack Ellipsis|Force Sp Parameter Pack Ellipsis"
 ValueDefault=ignore
 
@@ -1347,7 +1348,7 @@ Category=1
 Description="<html>Add or remove space between 'decltype' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_decltype_paren=ignore|sp_decltype_paren=add|sp_decltype_paren=remove|sp_decltype_paren=force|sp_decltype_paren=not_defined
+Choices=sp_decltype_paren\s*=\s*ignore|sp_decltype_paren\s*=\s*add|sp_decltype_paren\s*=\s*remove|sp_decltype_paren\s*=\s*force|sp_decltype_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Decltype Paren|Add Sp Decltype Paren|Remove Sp Decltype Paren|Force Sp Decltype Paren"
 ValueDefault=ignore
 
@@ -1356,7 +1357,7 @@ Category=1
 Description="<html>(Pawn) Add or remove space after the tag keyword.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_tag=ignore|sp_after_tag=add|sp_after_tag=remove|sp_after_tag=force|sp_after_tag=not_defined
+Choices=sp_after_tag\s*=\s*ignore|sp_after_tag\s*=\s*add|sp_after_tag\s*=\s*remove|sp_after_tag\s*=\s*force|sp_after_tag\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Tag|Add Sp After Tag|Remove Sp After Tag|Force Sp After Tag"
 ValueDefault=ignore
 
@@ -1365,7 +1366,7 @@ Category=1
 Description="<html>Add or remove space inside enum '{' and '}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces_enum=ignore|sp_inside_braces_enum=add|sp_inside_braces_enum=remove|sp_inside_braces_enum=force|sp_inside_braces_enum=not_defined
+Choices=sp_inside_braces_enum\s*=\s*ignore|sp_inside_braces_enum\s*=\s*add|sp_inside_braces_enum\s*=\s*remove|sp_inside_braces_enum\s*=\s*force|sp_inside_braces_enum\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces Enum|Add Sp Inside Braces Enum|Remove Sp Inside Braces Enum|Force Sp Inside Braces Enum"
 ValueDefault=ignore
 
@@ -1374,7 +1375,7 @@ Category=1
 Description="<html>Add or remove space inside struct/union '{' and '}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces_struct=ignore|sp_inside_braces_struct=add|sp_inside_braces_struct=remove|sp_inside_braces_struct=force|sp_inside_braces_struct=not_defined
+Choices=sp_inside_braces_struct\s*=\s*ignore|sp_inside_braces_struct\s*=\s*add|sp_inside_braces_struct\s*=\s*remove|sp_inside_braces_struct\s*=\s*force|sp_inside_braces_struct\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces Struct|Add Sp Inside Braces Struct|Remove Sp Inside Braces Struct|Force Sp Inside Braces Struct"
 ValueDefault=ignore
 
@@ -1383,7 +1384,7 @@ Category=1
 Description="<html>(OC) Add or remove space inside Objective-C boxed dictionary '{' and '}'</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces_oc_dict=ignore|sp_inside_braces_oc_dict=add|sp_inside_braces_oc_dict=remove|sp_inside_braces_oc_dict=force|sp_inside_braces_oc_dict=not_defined
+Choices=sp_inside_braces_oc_dict\s*=\s*ignore|sp_inside_braces_oc_dict\s*=\s*add|sp_inside_braces_oc_dict\s*=\s*remove|sp_inside_braces_oc_dict\s*=\s*force|sp_inside_braces_oc_dict\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces Oc Dict|Add Sp Inside Braces Oc Dict|Remove Sp Inside Braces Oc Dict|Force Sp Inside Braces Oc Dict"
 ValueDefault=ignore
 
@@ -1392,7 +1393,7 @@ Category=1
 Description="<html>Add or remove space after open brace in an unnamed temporary<br/>direct-list-initialization<br/>if statement is a brace_init_lst<br/>works only if sp_brace_brace is set to ignore.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_type_brace_init_lst_open=ignore|sp_after_type_brace_init_lst_open=add|sp_after_type_brace_init_lst_open=remove|sp_after_type_brace_init_lst_open=force|sp_after_type_brace_init_lst_open=not_defined
+Choices=sp_after_type_brace_init_lst_open\s*=\s*ignore|sp_after_type_brace_init_lst_open\s*=\s*add|sp_after_type_brace_init_lst_open\s*=\s*remove|sp_after_type_brace_init_lst_open\s*=\s*force|sp_after_type_brace_init_lst_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Type Brace Init Lst Open|Add Sp After Type Brace Init Lst Open|Remove Sp After Type Brace Init Lst Open|Force Sp After Type Brace Init Lst Open"
 ValueDefault=ignore
 
@@ -1401,7 +1402,7 @@ Category=1
 Description="<html>Add or remove space before close brace in an unnamed temporary<br/>direct-list-initialization<br/>if statement is a brace_init_lst<br/>works only if sp_brace_brace is set to ignore.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_type_brace_init_lst_close=ignore|sp_before_type_brace_init_lst_close=add|sp_before_type_brace_init_lst_close=remove|sp_before_type_brace_init_lst_close=force|sp_before_type_brace_init_lst_close=not_defined
+Choices=sp_before_type_brace_init_lst_close\s*=\s*ignore|sp_before_type_brace_init_lst_close\s*=\s*add|sp_before_type_brace_init_lst_close\s*=\s*remove|sp_before_type_brace_init_lst_close\s*=\s*force|sp_before_type_brace_init_lst_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Type Brace Init Lst Close|Add Sp Before Type Brace Init Lst Close|Remove Sp Before Type Brace Init Lst Close|Force Sp Before Type Brace Init Lst Close"
 ValueDefault=ignore
 
@@ -1410,7 +1411,7 @@ Category=1
 Description="<html>Add or remove space inside an unnamed temporary direct-list-initialization<br/>if statement is a brace_init_lst<br/>works only if sp_brace_brace is set to ignore<br/>works only if sp_before_type_brace_init_lst_close is set to ignore.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_type_brace_init_lst=ignore|sp_inside_type_brace_init_lst=add|sp_inside_type_brace_init_lst=remove|sp_inside_type_brace_init_lst=force|sp_inside_type_brace_init_lst=not_defined
+Choices=sp_inside_type_brace_init_lst\s*=\s*ignore|sp_inside_type_brace_init_lst\s*=\s*add|sp_inside_type_brace_init_lst\s*=\s*remove|sp_inside_type_brace_init_lst\s*=\s*force|sp_inside_type_brace_init_lst\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Type Brace Init Lst|Add Sp Inside Type Brace Init Lst|Remove Sp Inside Type Brace Init Lst|Force Sp Inside Type Brace Init Lst"
 ValueDefault=ignore
 
@@ -1419,7 +1420,7 @@ Category=1
 Description="<html>Add or remove space inside '{' and '}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces=ignore|sp_inside_braces=add|sp_inside_braces=remove|sp_inside_braces=force|sp_inside_braces=not_defined
+Choices=sp_inside_braces\s*=\s*ignore|sp_inside_braces\s*=\s*add|sp_inside_braces\s*=\s*remove|sp_inside_braces\s*=\s*force|sp_inside_braces\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces|Add Sp Inside Braces|Remove Sp Inside Braces|Force Sp Inside Braces"
 ValueDefault=ignore
 
@@ -1428,7 +1429,7 @@ Category=1
 Description="<html>Add or remove space inside '{}'.<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces_empty=ignore|sp_inside_braces_empty=add|sp_inside_braces_empty=remove|sp_inside_braces_empty=force|sp_inside_braces_empty=not_defined
+Choices=sp_inside_braces_empty\s*=\s*ignore|sp_inside_braces_empty\s*=\s*add|sp_inside_braces_empty\s*=\s*remove|sp_inside_braces_empty\s*=\s*force|sp_inside_braces_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces Empty|Add Sp Inside Braces Empty|Remove Sp Inside Braces Empty|Force Sp Inside Braces Empty"
 ValueDefault=ignore
 
@@ -1437,7 +1438,7 @@ Category=1
 Description="<html>Add or remove space around trailing return operator '-&gt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_trailing_return=ignore|sp_trailing_return=add|sp_trailing_return=remove|sp_trailing_return=force|sp_trailing_return=not_defined
+Choices=sp_trailing_return\s*=\s*ignore|sp_trailing_return\s*=\s*add|sp_trailing_return\s*=\s*remove|sp_trailing_return\s*=\s*force|sp_trailing_return\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Trailing Return|Add Sp Trailing Return|Remove Sp Trailing Return|Force Sp Trailing Return"
 ValueDefault=ignore
 
@@ -1446,7 +1447,7 @@ Category=1
 Description="<html>Add or remove space between return type and function name. A minimum of 1<br/>is forced except for pointer return types.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_type_func=ignore|sp_type_func=add|sp_type_func=remove|sp_type_func=force|sp_type_func=not_defined
+Choices=sp_type_func\s*=\s*ignore|sp_type_func\s*=\s*add|sp_type_func\s*=\s*remove|sp_type_func\s*=\s*force|sp_type_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Type Func|Add Sp Type Func|Remove Sp Type Func|Force Sp Type Func"
 ValueDefault=ignore
 
@@ -1455,7 +1456,7 @@ Category=1
 Description="<html>Add or remove space between type and open brace of an unnamed temporary<br/>direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_type_brace_init_lst=ignore|sp_type_brace_init_lst=add|sp_type_brace_init_lst=remove|sp_type_brace_init_lst=force|sp_type_brace_init_lst=not_defined
+Choices=sp_type_brace_init_lst\s*=\s*ignore|sp_type_brace_init_lst\s*=\s*add|sp_type_brace_init_lst\s*=\s*remove|sp_type_brace_init_lst\s*=\s*force|sp_type_brace_init_lst\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Type Brace Init Lst|Add Sp Type Brace Init Lst|Remove Sp Type Brace Init Lst|Force Sp Type Brace Init Lst"
 ValueDefault=ignore
 
@@ -1464,7 +1465,7 @@ Category=1
 Description="<html>Add or remove space between function name and '(' on function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_proto_paren=ignore|sp_func_proto_paren=add|sp_func_proto_paren=remove|sp_func_proto_paren=force|sp_func_proto_paren=not_defined
+Choices=sp_func_proto_paren\s*=\s*ignore|sp_func_proto_paren\s*=\s*add|sp_func_proto_paren\s*=\s*remove|sp_func_proto_paren\s*=\s*force|sp_func_proto_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Proto Paren|Add Sp Func Proto Paren|Remove Sp Func Proto Paren|Force Sp Func Proto Paren"
 ValueDefault=ignore
 
@@ -1473,7 +1474,7 @@ Category=1
 Description="<html>Add or remove space between function name and '()' on function declaration<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_proto_paren_empty=ignore|sp_func_proto_paren_empty=add|sp_func_proto_paren_empty=remove|sp_func_proto_paren_empty=force|sp_func_proto_paren_empty=not_defined
+Choices=sp_func_proto_paren_empty\s*=\s*ignore|sp_func_proto_paren_empty\s*=\s*add|sp_func_proto_paren_empty\s*=\s*remove|sp_func_proto_paren_empty\s*=\s*force|sp_func_proto_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Proto Paren Empty|Add Sp Func Proto Paren Empty|Remove Sp Func Proto Paren Empty|Force Sp Func Proto Paren Empty"
 ValueDefault=ignore
 
@@ -1482,7 +1483,7 @@ Category=1
 Description="<html>Add or remove space between function name and '(' with a typedef specifier.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_type_paren=ignore|sp_func_type_paren=add|sp_func_type_paren=remove|sp_func_type_paren=force|sp_func_type_paren=not_defined
+Choices=sp_func_type_paren\s*=\s*ignore|sp_func_type_paren\s*=\s*add|sp_func_type_paren\s*=\s*remove|sp_func_type_paren\s*=\s*force|sp_func_type_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Type Paren|Add Sp Func Type Paren|Remove Sp Func Type Paren|Force Sp Func Type Paren"
 ValueDefault=ignore
 
@@ -1491,7 +1492,7 @@ Category=1
 Description="<html>Add or remove space between alias name and '(' of a non-pointer function type typedef.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_def_paren=ignore|sp_func_def_paren=add|sp_func_def_paren=remove|sp_func_def_paren=force|sp_func_def_paren=not_defined
+Choices=sp_func_def_paren\s*=\s*ignore|sp_func_def_paren\s*=\s*add|sp_func_def_paren\s*=\s*remove|sp_func_def_paren\s*=\s*force|sp_func_def_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Def Paren|Add Sp Func Def Paren|Remove Sp Func Def Paren|Force Sp Func Def Paren"
 ValueDefault=ignore
 
@@ -1500,7 +1501,7 @@ Category=1
 Description="<html>Add or remove space between function name and '()' on function definition<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_def_paren_empty=ignore|sp_func_def_paren_empty=add|sp_func_def_paren_empty=remove|sp_func_def_paren_empty=force|sp_func_def_paren_empty=not_defined
+Choices=sp_func_def_paren_empty\s*=\s*ignore|sp_func_def_paren_empty\s*=\s*add|sp_func_def_paren_empty\s*=\s*remove|sp_func_def_paren_empty\s*=\s*force|sp_func_def_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Def Paren Empty|Add Sp Func Def Paren Empty|Remove Sp Func Def Paren Empty|Force Sp Func Def Paren Empty"
 ValueDefault=ignore
 
@@ -1509,7 +1510,7 @@ Category=1
 Description="<html>Add or remove space inside empty function '()'.<br/>Overrides sp_after_angle unless use_sp_after_angle_always is set to true.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_fparens=ignore|sp_inside_fparens=add|sp_inside_fparens=remove|sp_inside_fparens=force|sp_inside_fparens=not_defined
+Choices=sp_inside_fparens\s*=\s*ignore|sp_inside_fparens\s*=\s*add|sp_inside_fparens\s*=\s*remove|sp_inside_fparens\s*=\s*force|sp_inside_fparens\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Fparens|Add Sp Inside Fparens|Remove Sp Inside Fparens|Force Sp Inside Fparens"
 ValueDefault=ignore
 
@@ -1518,7 +1519,7 @@ Category=1
 Description="<html>Add or remove space inside function '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_fparen=ignore|sp_inside_fparen=add|sp_inside_fparen=remove|sp_inside_fparen=force|sp_inside_fparen=not_defined
+Choices=sp_inside_fparen\s*=\s*ignore|sp_inside_fparen\s*=\s*add|sp_inside_fparen\s*=\s*remove|sp_inside_fparen\s*=\s*force|sp_inside_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Fparen|Add Sp Inside Fparen|Remove Sp Inside Fparen|Force Sp Inside Fparen"
 ValueDefault=ignore
 
@@ -1527,7 +1528,7 @@ Category=1
 Description="<html>Add or remove space inside user functor '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_user_inside_rparen=ignore|sp_func_call_user_inside_rparen=add|sp_func_call_user_inside_rparen=remove|sp_func_call_user_inside_rparen=force|sp_func_call_user_inside_rparen=not_defined
+Choices=sp_func_call_user_inside_rparen\s*=\s*ignore|sp_func_call_user_inside_rparen\s*=\s*add|sp_func_call_user_inside_rparen\s*=\s*remove|sp_func_call_user_inside_rparen\s*=\s*force|sp_func_call_user_inside_rparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call User Inside Rparen|Add Sp Func Call User Inside Rparen|Remove Sp Func Call User Inside Rparen|Force Sp Func Call User Inside Rparen"
 ValueDefault=ignore
 
@@ -1536,7 +1537,7 @@ Category=1
 Description="<html>Add or remove space inside empty functor '()'.<br/>Overrides sp_after_angle unless use_sp_after_angle_always is set to true.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_rparens=ignore|sp_inside_rparens=add|sp_inside_rparens=remove|sp_inside_rparens=force|sp_inside_rparens=not_defined
+Choices=sp_inside_rparens\s*=\s*ignore|sp_inside_rparens\s*=\s*add|sp_inside_rparens\s*=\s*remove|sp_inside_rparens\s*=\s*force|sp_inside_rparens\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Rparens|Add Sp Inside Rparens|Remove Sp Inside Rparens|Force Sp Inside Rparens"
 ValueDefault=ignore
 
@@ -1545,7 +1546,7 @@ Category=1
 Description="<html>Add or remove space inside functor '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_rparen=ignore|sp_inside_rparen=add|sp_inside_rparen=remove|sp_inside_rparen=force|sp_inside_rparen=not_defined
+Choices=sp_inside_rparen\s*=\s*ignore|sp_inside_rparen\s*=\s*add|sp_inside_rparen\s*=\s*remove|sp_inside_rparen\s*=\s*force|sp_inside_rparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Rparen|Add Sp Inside Rparen|Remove Sp Inside Rparen|Force Sp Inside Rparen"
 ValueDefault=ignore
 
@@ -1554,7 +1555,7 @@ Category=1
 Description="<html>Add or remove space inside the first parentheses in a function type, as in<br/>'void (*x)(...)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_tparen=ignore|sp_inside_tparen=add|sp_inside_tparen=remove|sp_inside_tparen=force|sp_inside_tparen=not_defined
+Choices=sp_inside_tparen\s*=\s*ignore|sp_inside_tparen\s*=\s*add|sp_inside_tparen\s*=\s*remove|sp_inside_tparen\s*=\s*force|sp_inside_tparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Tparen|Add Sp Inside Tparen|Remove Sp Inside Tparen|Force Sp Inside Tparen"
 ValueDefault=ignore
 
@@ -1563,7 +1564,7 @@ Category=1
 Description="<html>Add or remove space between the ')' and '(' in a function type, as in<br/>'void (*x)(...)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_tparen_close=ignore|sp_after_tparen_close=add|sp_after_tparen_close=remove|sp_after_tparen_close=force|sp_after_tparen_close=not_defined
+Choices=sp_after_tparen_close\s*=\s*ignore|sp_after_tparen_close\s*=\s*add|sp_after_tparen_close\s*=\s*remove|sp_after_tparen_close\s*=\s*force|sp_after_tparen_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Tparen Close|Add Sp After Tparen Close|Remove Sp After Tparen Close|Force Sp After Tparen Close"
 ValueDefault=ignore
 
@@ -1572,7 +1573,7 @@ Category=1
 Description="<html>Add or remove space between ']' and '(' when part of a function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_square_fparen=ignore|sp_square_fparen=add|sp_square_fparen=remove|sp_square_fparen=force|sp_square_fparen=not_defined
+Choices=sp_square_fparen\s*=\s*ignore|sp_square_fparen\s*=\s*add|sp_square_fparen\s*=\s*remove|sp_square_fparen\s*=\s*force|sp_square_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Square Fparen|Add Sp Square Fparen|Remove Sp Square Fparen|Force Sp Square Fparen"
 ValueDefault=ignore
 
@@ -1581,7 +1582,7 @@ Category=1
 Description="<html>Add or remove space between ')' and '{' of function.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_fparen_brace=ignore|sp_fparen_brace=add|sp_fparen_brace=remove|sp_fparen_brace=force|sp_fparen_brace=not_defined
+Choices=sp_fparen_brace\s*=\s*ignore|sp_fparen_brace\s*=\s*add|sp_fparen_brace\s*=\s*remove|sp_fparen_brace\s*=\s*force|sp_fparen_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Fparen Brace|Add Sp Fparen Brace|Remove Sp Fparen Brace|Force Sp Fparen Brace"
 ValueDefault=ignore
 
@@ -1590,7 +1591,7 @@ Category=1
 Description="<html>Add or remove space between ')' and '{' of a function call in object<br/>initialization.<br/><br/>Overrides sp_fparen_brace.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_fparen_brace_initializer=ignore|sp_fparen_brace_initializer=add|sp_fparen_brace_initializer=remove|sp_fparen_brace_initializer=force|sp_fparen_brace_initializer=not_defined
+Choices=sp_fparen_brace_initializer\s*=\s*ignore|sp_fparen_brace_initializer\s*=\s*add|sp_fparen_brace_initializer\s*=\s*remove|sp_fparen_brace_initializer\s*=\s*force|sp_fparen_brace_initializer\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Fparen Brace Initializer|Add Sp Fparen Brace Initializer|Remove Sp Fparen Brace Initializer|Force Sp Fparen Brace Initializer"
 ValueDefault=ignore
 
@@ -1599,7 +1600,7 @@ Category=1
 Description="<html>(Java) Add or remove space between ')' and '{{' of double brace initializer.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_fparen_dbrace=ignore|sp_fparen_dbrace=add|sp_fparen_dbrace=remove|sp_fparen_dbrace=force|sp_fparen_dbrace=not_defined
+Choices=sp_fparen_dbrace\s*=\s*ignore|sp_fparen_dbrace\s*=\s*add|sp_fparen_dbrace\s*=\s*remove|sp_fparen_dbrace\s*=\s*force|sp_fparen_dbrace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Fparen Dbrace|Add Sp Fparen Dbrace|Remove Sp Fparen Dbrace|Force Sp Fparen Dbrace"
 ValueDefault=ignore
 
@@ -1608,7 +1609,7 @@ Category=1
 Description="<html>Add or remove space between function name and '(' on function calls.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_paren=ignore|sp_func_call_paren=add|sp_func_call_paren=remove|sp_func_call_paren=force|sp_func_call_paren=not_defined
+Choices=sp_func_call_paren\s*=\s*ignore|sp_func_call_paren\s*=\s*add|sp_func_call_paren\s*=\s*remove|sp_func_call_paren\s*=\s*force|sp_func_call_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call Paren|Add Sp Func Call Paren|Remove Sp Func Call Paren|Force Sp Func Call Paren"
 ValueDefault=ignore
 
@@ -1617,7 +1618,7 @@ Category=1
 Description="<html>Add or remove space between function name and '()' on function calls without<br/>parameters. If set to ignore (the default), sp_func_call_paren is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_paren_empty=ignore|sp_func_call_paren_empty=add|sp_func_call_paren_empty=remove|sp_func_call_paren_empty=force|sp_func_call_paren_empty=not_defined
+Choices=sp_func_call_paren_empty\s*=\s*ignore|sp_func_call_paren_empty\s*=\s*add|sp_func_call_paren_empty\s*=\s*remove|sp_func_call_paren_empty\s*=\s*force|sp_func_call_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call Paren Empty|Add Sp Func Call Paren Empty|Remove Sp Func Call Paren Empty|Force Sp Func Call Paren Empty"
 ValueDefault=ignore
 
@@ -1626,7 +1627,7 @@ Category=1
 Description="<html>Add or remove space between the user function name and '(' on function<br/>calls. You need to set a keyword to be a user function in the config file,<br/>like:<br/>  set func_call_user tr _ i18n</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_user_paren=ignore|sp_func_call_user_paren=add|sp_func_call_user_paren=remove|sp_func_call_user_paren=force|sp_func_call_user_paren=not_defined
+Choices=sp_func_call_user_paren\s*=\s*ignore|sp_func_call_user_paren\s*=\s*add|sp_func_call_user_paren\s*=\s*remove|sp_func_call_user_paren\s*=\s*force|sp_func_call_user_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call User Paren|Add Sp Func Call User Paren|Remove Sp Func Call User Paren|Force Sp Func Call User Paren"
 ValueDefault=ignore
 
@@ -1635,7 +1636,7 @@ Category=1
 Description="<html>Add or remove space inside user function '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_user_inside_fparen=ignore|sp_func_call_user_inside_fparen=add|sp_func_call_user_inside_fparen=remove|sp_func_call_user_inside_fparen=force|sp_func_call_user_inside_fparen=not_defined
+Choices=sp_func_call_user_inside_fparen\s*=\s*ignore|sp_func_call_user_inside_fparen\s*=\s*add|sp_func_call_user_inside_fparen\s*=\s*remove|sp_func_call_user_inside_fparen\s*=\s*force|sp_func_call_user_inside_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call User Inside Fparen|Add Sp Func Call User Inside Fparen|Remove Sp Func Call User Inside Fparen|Force Sp Func Call User Inside Fparen"
 ValueDefault=ignore
 
@@ -1644,7 +1645,7 @@ Category=1
 Description="<html>Add or remove space between nested parentheses with user functions,<br/>i.e. '((' vs. '( ('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_user_paren_paren=ignore|sp_func_call_user_paren_paren=add|sp_func_call_user_paren_paren=remove|sp_func_call_user_paren_paren=force|sp_func_call_user_paren_paren=not_defined
+Choices=sp_func_call_user_paren_paren\s*=\s*ignore|sp_func_call_user_paren_paren\s*=\s*add|sp_func_call_user_paren_paren\s*=\s*remove|sp_func_call_user_paren_paren\s*=\s*force|sp_func_call_user_paren_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call User Paren Paren|Add Sp Func Call User Paren Paren|Remove Sp Func Call User Paren Paren|Force Sp Func Call User Paren Paren"
 ValueDefault=ignore
 
@@ -1653,7 +1654,7 @@ Category=1
 Description="<html>Add or remove space between a constructor/destructor and the open<br/>parenthesis.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_class_paren=ignore|sp_func_class_paren=add|sp_func_class_paren=remove|sp_func_class_paren=force|sp_func_class_paren=not_defined
+Choices=sp_func_class_paren\s*=\s*ignore|sp_func_class_paren\s*=\s*add|sp_func_class_paren\s*=\s*remove|sp_func_class_paren\s*=\s*force|sp_func_class_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Class Paren|Add Sp Func Class Paren|Remove Sp Func Class Paren|Force Sp Func Class Paren"
 ValueDefault=ignore
 
@@ -1662,7 +1663,7 @@ Category=1
 Description="<html>Add or remove space between a constructor without parameters or destructor<br/>and '()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_class_paren_empty=ignore|sp_func_class_paren_empty=add|sp_func_class_paren_empty=remove|sp_func_class_paren_empty=force|sp_func_class_paren_empty=not_defined
+Choices=sp_func_class_paren_empty\s*=\s*ignore|sp_func_class_paren_empty\s*=\s*add|sp_func_class_paren_empty\s*=\s*remove|sp_func_class_paren_empty\s*=\s*force|sp_func_class_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Class Paren Empty|Add Sp Func Class Paren Empty|Remove Sp Func Class Paren Empty|Force Sp Func Class Paren Empty"
 ValueDefault=ignore
 
@@ -1671,7 +1672,7 @@ Category=1
 Description="<html>Add or remove space after 'return'.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_return=ignore|sp_return=add|sp_return=remove|sp_return=force|sp_return=not_defined
+Choices=sp_return\s*=\s*ignore|sp_return\s*=\s*add|sp_return\s*=\s*remove|sp_return\s*=\s*force|sp_return\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Return|Add Sp Return|Remove Sp Return|Force Sp Return"
 ValueDefault=force
 
@@ -1680,7 +1681,7 @@ Category=1
 Description="<html>Add or remove space between 'return' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_return_paren=ignore|sp_return_paren=add|sp_return_paren=remove|sp_return_paren=force|sp_return_paren=not_defined
+Choices=sp_return_paren\s*=\s*ignore|sp_return_paren\s*=\s*add|sp_return_paren\s*=\s*remove|sp_return_paren\s*=\s*force|sp_return_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Return Paren|Add Sp Return Paren|Remove Sp Return Paren|Force Sp Return Paren"
 ValueDefault=ignore
 
@@ -1689,7 +1690,7 @@ Category=1
 Description="<html>Add or remove space between 'return' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_return_brace=ignore|sp_return_brace=add|sp_return_brace=remove|sp_return_brace=force|sp_return_brace=not_defined
+Choices=sp_return_brace\s*=\s*ignore|sp_return_brace\s*=\s*add|sp_return_brace\s*=\s*remove|sp_return_brace\s*=\s*force|sp_return_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Return Brace|Add Sp Return Brace|Remove Sp Return Brace|Force Sp Return Brace"
 ValueDefault=ignore
 
@@ -1698,7 +1699,7 @@ Category=1
 Description="<html>Add or remove space between '__attribute__' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_attribute_paren=ignore|sp_attribute_paren=add|sp_attribute_paren=remove|sp_attribute_paren=force|sp_attribute_paren=not_defined
+Choices=sp_attribute_paren\s*=\s*ignore|sp_attribute_paren\s*=\s*add|sp_attribute_paren\s*=\s*remove|sp_attribute_paren\s*=\s*force|sp_attribute_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Attribute Paren|Add Sp Attribute Paren|Remove Sp Attribute Paren|Force Sp Attribute Paren"
 ValueDefault=ignore
 
@@ -1707,7 +1708,7 @@ Category=1
 Description="<html>Add or remove space between 'defined' and '(' in '#if defined (FOO)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_defined_paren=ignore|sp_defined_paren=add|sp_defined_paren=remove|sp_defined_paren=force|sp_defined_paren=not_defined
+Choices=sp_defined_paren\s*=\s*ignore|sp_defined_paren\s*=\s*add|sp_defined_paren\s*=\s*remove|sp_defined_paren\s*=\s*force|sp_defined_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Defined Paren|Add Sp Defined Paren|Remove Sp Defined Paren|Force Sp Defined Paren"
 ValueDefault=ignore
 
@@ -1716,7 +1717,7 @@ Category=1
 Description="<html>Add or remove space between 'throw' and '(' in 'throw (something)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_throw_paren=ignore|sp_throw_paren=add|sp_throw_paren=remove|sp_throw_paren=force|sp_throw_paren=not_defined
+Choices=sp_throw_paren\s*=\s*ignore|sp_throw_paren\s*=\s*add|sp_throw_paren\s*=\s*remove|sp_throw_paren\s*=\s*force|sp_throw_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Throw Paren|Add Sp Throw Paren|Remove Sp Throw Paren|Force Sp Throw Paren"
 ValueDefault=ignore
 
@@ -1725,7 +1726,7 @@ Category=1
 Description="<html>Add or remove space between 'throw' and anything other than '(' as in<br/>'@throw [...];'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_throw=ignore|sp_after_throw=add|sp_after_throw=remove|sp_after_throw=force|sp_after_throw=not_defined
+Choices=sp_after_throw\s*=\s*ignore|sp_after_throw\s*=\s*add|sp_after_throw\s*=\s*remove|sp_after_throw\s*=\s*force|sp_after_throw\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Throw|Add Sp After Throw|Remove Sp After Throw|Force Sp After Throw"
 ValueDefault=ignore
 
@@ -1734,7 +1735,7 @@ Category=1
 Description="<html>Add or remove space between 'catch' and '(' in 'catch (something) { }'.<br/>If set to ignore, sp_before_sparen is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_catch_paren=ignore|sp_catch_paren=add|sp_catch_paren=remove|sp_catch_paren=force|sp_catch_paren=not_defined
+Choices=sp_catch_paren\s*=\s*ignore|sp_catch_paren\s*=\s*add|sp_catch_paren\s*=\s*remove|sp_catch_paren\s*=\s*force|sp_catch_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Catch Paren|Add Sp Catch Paren|Remove Sp Catch Paren|Force Sp Catch Paren"
 ValueDefault=ignore
 
@@ -1743,7 +1744,7 @@ Category=1
 Description="<html>(OC) Add or remove space between '@catch' and '('<br/>in '@catch (something) { }'. If set to ignore, sp_catch_paren is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_oc_catch_paren=ignore|sp_oc_catch_paren=add|sp_oc_catch_paren=remove|sp_oc_catch_paren=force|sp_oc_catch_paren=not_defined
+Choices=sp_oc_catch_paren\s*=\s*ignore|sp_oc_catch_paren\s*=\s*add|sp_oc_catch_paren\s*=\s*remove|sp_oc_catch_paren\s*=\s*force|sp_oc_catch_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Oc Catch Paren|Add Sp Oc Catch Paren|Remove Sp Oc Catch Paren|Force Sp Oc Catch Paren"
 ValueDefault=ignore
 
@@ -1752,7 +1753,7 @@ Category=1
 Description="<html>(OC) Add or remove space before Objective-C protocol list<br/>as in '@protocol Protocol&lt;here&gt;&lt;Protocol_A&gt;' or '@interface MyClass : NSObject&lt;here&gt;&lt;MyProtocol&gt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_oc_proto_list=ignore|sp_before_oc_proto_list=add|sp_before_oc_proto_list=remove|sp_before_oc_proto_list=force|sp_before_oc_proto_list=not_defined
+Choices=sp_before_oc_proto_list\s*=\s*ignore|sp_before_oc_proto_list\s*=\s*add|sp_before_oc_proto_list\s*=\s*remove|sp_before_oc_proto_list\s*=\s*force|sp_before_oc_proto_list\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Oc Proto List|Add Sp Before Oc Proto List|Remove Sp Before Oc Proto List|Force Sp Before Oc Proto List"
 ValueDefault=ignore
 
@@ -1761,7 +1762,7 @@ Category=1
 Description="<html>(OC) Add or remove space between class name and '('<br/>in '@interface className(categoryName)&lt;ProtocolName&gt;:BaseClass'</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_oc_classname_paren=ignore|sp_oc_classname_paren=add|sp_oc_classname_paren=remove|sp_oc_classname_paren=force|sp_oc_classname_paren=not_defined
+Choices=sp_oc_classname_paren\s*=\s*ignore|sp_oc_classname_paren\s*=\s*add|sp_oc_classname_paren\s*=\s*remove|sp_oc_classname_paren\s*=\s*force|sp_oc_classname_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Oc Classname Paren|Add Sp Oc Classname Paren|Remove Sp Oc Classname Paren|Force Sp Oc Classname Paren"
 ValueDefault=ignore
 
@@ -1770,7 +1771,7 @@ Category=1
 Description="<html>(D) Add or remove space between 'version' and '('<br/>in 'version (something) { }'. If set to ignore, sp_before_sparen is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_version_paren=ignore|sp_version_paren=add|sp_version_paren=remove|sp_version_paren=force|sp_version_paren=not_defined
+Choices=sp_version_paren\s*=\s*ignore|sp_version_paren\s*=\s*add|sp_version_paren\s*=\s*remove|sp_version_paren\s*=\s*force|sp_version_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Version Paren|Add Sp Version Paren|Remove Sp Version Paren|Force Sp Version Paren"
 ValueDefault=ignore
 
@@ -1779,7 +1780,7 @@ Category=1
 Description="<html>(D) Add or remove space between 'scope' and '('<br/>in 'scope (something) { }'. If set to ignore, sp_before_sparen is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_scope_paren=ignore|sp_scope_paren=add|sp_scope_paren=remove|sp_scope_paren=force|sp_scope_paren=not_defined
+Choices=sp_scope_paren\s*=\s*ignore|sp_scope_paren\s*=\s*add|sp_scope_paren\s*=\s*remove|sp_scope_paren\s*=\s*force|sp_scope_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Scope Paren|Add Sp Scope Paren|Remove Sp Scope Paren|Force Sp Scope Paren"
 ValueDefault=ignore
 
@@ -1788,7 +1789,7 @@ Category=1
 Description="<html>Add or remove space between 'super' and '(' in 'super (something)'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_super_paren=ignore|sp_super_paren=add|sp_super_paren=remove|sp_super_paren=force|sp_super_paren=not_defined
+Choices=sp_super_paren\s*=\s*ignore|sp_super_paren\s*=\s*add|sp_super_paren\s*=\s*remove|sp_super_paren\s*=\s*force|sp_super_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Super Paren|Add Sp Super Paren|Remove Sp Super Paren|Force Sp Super Paren"
 ValueDefault=remove
 
@@ -1797,7 +1798,7 @@ Category=1
 Description="<html>Add or remove space between 'this' and '(' in 'this (something)'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_this_paren=ignore|sp_this_paren=add|sp_this_paren=remove|sp_this_paren=force|sp_this_paren=not_defined
+Choices=sp_this_paren\s*=\s*ignore|sp_this_paren\s*=\s*add|sp_this_paren\s*=\s*remove|sp_this_paren\s*=\s*force|sp_this_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp This Paren|Add Sp This Paren|Remove Sp This Paren|Force Sp This Paren"
 ValueDefault=remove
 
@@ -1806,7 +1807,7 @@ Category=1
 Description="<html>Add or remove space between a macro name and its definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_macro=ignore|sp_macro=add|sp_macro=remove|sp_macro=force|sp_macro=not_defined
+Choices=sp_macro\s*=\s*ignore|sp_macro\s*=\s*add|sp_macro\s*=\s*remove|sp_macro\s*=\s*force|sp_macro\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Macro|Add Sp Macro|Remove Sp Macro|Force Sp Macro"
 ValueDefault=ignore
 
@@ -1815,7 +1816,7 @@ Category=1
 Description="<html>Add or remove space between a macro function ')' and its definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_macro_func=ignore|sp_macro_func=add|sp_macro_func=remove|sp_macro_func=force|sp_macro_func=not_defined
+Choices=sp_macro_func\s*=\s*ignore|sp_macro_func\s*=\s*add|sp_macro_func\s*=\s*remove|sp_macro_func\s*=\s*force|sp_macro_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Macro Func|Add Sp Macro Func|Remove Sp Macro Func|Force Sp Macro Func"
 ValueDefault=ignore
 
@@ -1824,7 +1825,7 @@ Category=1
 Description="<html>Add or remove space between 'else' and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_else_brace=ignore|sp_else_brace=add|sp_else_brace=remove|sp_else_brace=force|sp_else_brace=not_defined
+Choices=sp_else_brace\s*=\s*ignore|sp_else_brace\s*=\s*add|sp_else_brace\s*=\s*remove|sp_else_brace\s*=\s*force|sp_else_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Else Brace|Add Sp Else Brace|Remove Sp Else Brace|Force Sp Else Brace"
 ValueDefault=ignore
 
@@ -1833,7 +1834,7 @@ Category=1
 Description="<html>Add or remove space between '}' and 'else' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_else=ignore|sp_brace_else=add|sp_brace_else=remove|sp_brace_else=force|sp_brace_else=not_defined
+Choices=sp_brace_else\s*=\s*ignore|sp_brace_else\s*=\s*add|sp_brace_else\s*=\s*remove|sp_brace_else\s*=\s*force|sp_brace_else\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Else|Add Sp Brace Else|Remove Sp Brace Else|Force Sp Brace Else"
 ValueDefault=ignore
 
@@ -1842,7 +1843,7 @@ Category=1
 Description="<html>Add or remove space between '}' and the name of a typedef on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_typedef=ignore|sp_brace_typedef=add|sp_brace_typedef=remove|sp_brace_typedef=force|sp_brace_typedef=not_defined
+Choices=sp_brace_typedef\s*=\s*ignore|sp_brace_typedef\s*=\s*add|sp_brace_typedef\s*=\s*remove|sp_brace_typedef\s*=\s*force|sp_brace_typedef\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Typedef|Add Sp Brace Typedef|Remove Sp Brace Typedef|Force Sp Brace Typedef"
 ValueDefault=ignore
 
@@ -1851,7 +1852,7 @@ Category=1
 Description="<html>Add or remove space before the '{' of a 'catch' statement, if the '{' and<br/>'catch' are on the same line, as in 'catch (decl) &lt;here&gt; {'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_catch_brace=ignore|sp_catch_brace=add|sp_catch_brace=remove|sp_catch_brace=force|sp_catch_brace=not_defined
+Choices=sp_catch_brace\s*=\s*ignore|sp_catch_brace\s*=\s*add|sp_catch_brace\s*=\s*remove|sp_catch_brace\s*=\s*force|sp_catch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Catch Brace|Add Sp Catch Brace|Remove Sp Catch Brace|Force Sp Catch Brace"
 ValueDefault=ignore
 
@@ -1860,7 +1861,7 @@ Category=1
 Description="<html>(OC) Add or remove space before the '{' of a '@catch' statement, if the '{'<br/>and '@catch' are on the same line, as in '@catch (decl) &lt;here&gt; {'.<br/>If set to ignore, sp_catch_brace is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_oc_catch_brace=ignore|sp_oc_catch_brace=add|sp_oc_catch_brace=remove|sp_oc_catch_brace=force|sp_oc_catch_brace=not_defined
+Choices=sp_oc_catch_brace\s*=\s*ignore|sp_oc_catch_brace\s*=\s*add|sp_oc_catch_brace\s*=\s*remove|sp_oc_catch_brace\s*=\s*force|sp_oc_catch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Oc Catch Brace|Add Sp Oc Catch Brace|Remove Sp Oc Catch Brace|Force Sp Oc Catch Brace"
 ValueDefault=ignore
 
@@ -1869,7 +1870,7 @@ Category=1
 Description="<html>Add or remove space between '}' and 'catch' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_catch=ignore|sp_brace_catch=add|sp_brace_catch=remove|sp_brace_catch=force|sp_brace_catch=not_defined
+Choices=sp_brace_catch\s*=\s*ignore|sp_brace_catch\s*=\s*add|sp_brace_catch\s*=\s*remove|sp_brace_catch\s*=\s*force|sp_brace_catch\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Catch|Add Sp Brace Catch|Remove Sp Brace Catch|Force Sp Brace Catch"
 ValueDefault=ignore
 
@@ -1878,7 +1879,7 @@ Category=1
 Description="<html>(OC) Add or remove space between '}' and '@catch' if on the same line.<br/>If set to ignore, sp_brace_catch is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_oc_brace_catch=ignore|sp_oc_brace_catch=add|sp_oc_brace_catch=remove|sp_oc_brace_catch=force|sp_oc_brace_catch=not_defined
+Choices=sp_oc_brace_catch\s*=\s*ignore|sp_oc_brace_catch\s*=\s*add|sp_oc_brace_catch\s*=\s*remove|sp_oc_brace_catch\s*=\s*force|sp_oc_brace_catch\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Oc Brace Catch|Add Sp Oc Brace Catch|Remove Sp Oc Brace Catch|Force Sp Oc Brace Catch"
 ValueDefault=ignore
 
@@ -1887,7 +1888,7 @@ Category=1
 Description="<html>Add or remove space between 'finally' and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_finally_brace=ignore|sp_finally_brace=add|sp_finally_brace=remove|sp_finally_brace=force|sp_finally_brace=not_defined
+Choices=sp_finally_brace\s*=\s*ignore|sp_finally_brace\s*=\s*add|sp_finally_brace\s*=\s*remove|sp_finally_brace\s*=\s*force|sp_finally_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Finally Brace|Add Sp Finally Brace|Remove Sp Finally Brace|Force Sp Finally Brace"
 ValueDefault=ignore
 
@@ -1896,7 +1897,7 @@ Category=1
 Description="<html>Add or remove space between '}' and 'finally' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_finally=ignore|sp_brace_finally=add|sp_brace_finally=remove|sp_brace_finally=force|sp_brace_finally=not_defined
+Choices=sp_brace_finally\s*=\s*ignore|sp_brace_finally\s*=\s*add|sp_brace_finally\s*=\s*remove|sp_brace_finally\s*=\s*force|sp_brace_finally\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Finally|Add Sp Brace Finally|Remove Sp Brace Finally|Force Sp Brace Finally"
 ValueDefault=ignore
 
@@ -1905,7 +1906,7 @@ Category=1
 Description="<html>Add or remove space between 'try' and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_try_brace=ignore|sp_try_brace=add|sp_try_brace=remove|sp_try_brace=force|sp_try_brace=not_defined
+Choices=sp_try_brace\s*=\s*ignore|sp_try_brace\s*=\s*add|sp_try_brace\s*=\s*remove|sp_try_brace\s*=\s*force|sp_try_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Try Brace|Add Sp Try Brace|Remove Sp Try Brace|Force Sp Try Brace"
 ValueDefault=ignore
 
@@ -1914,7 +1915,7 @@ Category=1
 Description="<html>Add or remove space between get/set and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_getset_brace=ignore|sp_getset_brace=add|sp_getset_brace=remove|sp_getset_brace=force|sp_getset_brace=not_defined
+Choices=sp_getset_brace\s*=\s*ignore|sp_getset_brace\s*=\s*add|sp_getset_brace\s*=\s*remove|sp_getset_brace\s*=\s*force|sp_getset_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Getset Brace|Add Sp Getset Brace|Remove Sp Getset Brace|Force Sp Getset Brace"
 ValueDefault=ignore
 
@@ -1923,7 +1924,7 @@ Category=1
 Description="<html>Add or remove space between a variable and '{' for C++ uniform<br/>initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_word_brace_init_lst=ignore|sp_word_brace_init_lst=add|sp_word_brace_init_lst=remove|sp_word_brace_init_lst=force|sp_word_brace_init_lst=not_defined
+Choices=sp_word_brace_init_lst\s*=\s*ignore|sp_word_brace_init_lst\s*=\s*add|sp_word_brace_init_lst\s*=\s*remove|sp_word_brace_init_lst\s*=\s*force|sp_word_brace_init_lst\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Word Brace Init Lst|Add Sp Word Brace Init Lst|Remove Sp Word Brace Init Lst|Force Sp Word Brace Init Lst"
 ValueDefault=ignore
 
@@ -1932,7 +1933,7 @@ Category=1
 Description="<html>Add or remove space between a variable and '{' for a namespace.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_word_brace_ns=ignore|sp_word_brace_ns=add|sp_word_brace_ns=remove|sp_word_brace_ns=force|sp_word_brace_ns=not_defined
+Choices=sp_word_brace_ns\s*=\s*ignore|sp_word_brace_ns\s*=\s*add|sp_word_brace_ns\s*=\s*remove|sp_word_brace_ns\s*=\s*force|sp_word_brace_ns\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Word Brace Ns|Add Sp Word Brace Ns|Remove Sp Word Brace Ns|Force Sp Word Brace Ns"
 ValueDefault=add
 
@@ -1941,7 +1942,7 @@ Category=1
 Description="<html>Add or remove space before the '::' operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_dc=ignore|sp_before_dc=add|sp_before_dc=remove|sp_before_dc=force|sp_before_dc=not_defined
+Choices=sp_before_dc\s*=\s*ignore|sp_before_dc\s*=\s*add|sp_before_dc\s*=\s*remove|sp_before_dc\s*=\s*force|sp_before_dc\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Dc|Add Sp Before Dc|Remove Sp Before Dc|Force Sp Before Dc"
 ValueDefault=ignore
 
@@ -1950,7 +1951,7 @@ Category=1
 Description="<html>Add or remove space after the '::' operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_dc=ignore|sp_after_dc=add|sp_after_dc=remove|sp_after_dc=force|sp_after_dc=not_defined
+Choices=sp_after_dc\s*=\s*ignore|sp_after_dc\s*=\s*add|sp_after_dc\s*=\s*remove|sp_after_dc\s*=\s*force|sp_after_dc\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Dc|Add Sp After Dc|Remove Sp After Dc|Force Sp After Dc"
 ValueDefault=ignore
 
@@ -1959,7 +1960,7 @@ Category=1
 Description="<html>(D) Add or remove around the D named array initializer ':' operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_d_array_colon=ignore|sp_d_array_colon=add|sp_d_array_colon=remove|sp_d_array_colon=force|sp_d_array_colon=not_defined
+Choices=sp_d_array_colon\s*=\s*ignore|sp_d_array_colon\s*=\s*add|sp_d_array_colon\s*=\s*remove|sp_d_array_colon\s*=\s*force|sp_d_array_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp D Array Colon|Add Sp D Array Colon|Remove Sp D Array Colon|Force Sp D Array Colon"
 ValueDefault=ignore
 
@@ -1968,7 +1969,7 @@ Category=1
 Description="<html>Add or remove space after the '!' (not) unary operator.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_not=ignore|sp_not=add|sp_not=remove|sp_not=force|sp_not=not_defined
+Choices=sp_not\s*=\s*ignore|sp_not\s*=\s*add|sp_not\s*=\s*remove|sp_not\s*=\s*force|sp_not\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Not|Add Sp Not|Remove Sp Not|Force Sp Not"
 ValueDefault=remove
 
@@ -1977,7 +1978,7 @@ Category=1
 Description="<html>Add or remove space between two '!' (not) unary operators.<br/>If set to ignore, sp_not will be used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_not_not=ignore|sp_not_not=add|sp_not_not=remove|sp_not_not=force|sp_not_not=not_defined
+Choices=sp_not_not\s*=\s*ignore|sp_not_not\s*=\s*add|sp_not_not\s*=\s*remove|sp_not_not\s*=\s*force|sp_not_not\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Not Not|Add Sp Not Not|Remove Sp Not Not|Force Sp Not Not"
 ValueDefault=ignore
 
@@ -1986,7 +1987,7 @@ Category=1
 Description="<html>Add or remove space after the '~' (invert) unary operator.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inv=ignore|sp_inv=add|sp_inv=remove|sp_inv=force|sp_inv=not_defined
+Choices=sp_inv\s*=\s*ignore|sp_inv\s*=\s*add|sp_inv\s*=\s*remove|sp_inv\s*=\s*force|sp_inv\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inv|Add Sp Inv|Remove Sp Inv|Force Sp Inv"
 ValueDefault=remove
 
@@ -1995,7 +1996,7 @@ Category=1
 Description="<html>Add or remove space after the '&amp;' (address-of) unary operator. This does not<br/>affect the spacing after a '&amp;' that is part of a type.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_addr=ignore|sp_addr=add|sp_addr=remove|sp_addr=force|sp_addr=not_defined
+Choices=sp_addr\s*=\s*ignore|sp_addr\s*=\s*add|sp_addr\s*=\s*remove|sp_addr\s*=\s*force|sp_addr\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Addr|Add Sp Addr|Remove Sp Addr|Force Sp Addr"
 ValueDefault=remove
 
@@ -2004,7 +2005,7 @@ Category=1
 Description="<html>Add or remove space around the '.' or '-&gt;' operators.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_member=ignore|sp_member=add|sp_member=remove|sp_member=force|sp_member=not_defined
+Choices=sp_member\s*=\s*ignore|sp_member\s*=\s*add|sp_member\s*=\s*remove|sp_member\s*=\s*force|sp_member\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Member|Add Sp Member|Remove Sp Member|Force Sp Member"
 ValueDefault=remove
 
@@ -2013,7 +2014,7 @@ Category=1
 Description="<html>Add or remove space after the '*' (dereference) unary operator. This does<br/>not affect the spacing after a '*' that is part of a type.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_deref=ignore|sp_deref=add|sp_deref=remove|sp_deref=force|sp_deref=not_defined
+Choices=sp_deref\s*=\s*ignore|sp_deref\s*=\s*add|sp_deref\s*=\s*remove|sp_deref\s*=\s*force|sp_deref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Deref|Add Sp Deref|Remove Sp Deref|Force Sp Deref"
 ValueDefault=remove
 
@@ -2022,7 +2023,7 @@ Category=1
 Description="<html>Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sign=ignore|sp_sign=add|sp_sign=remove|sp_sign=force|sp_sign=not_defined
+Choices=sp_sign\s*=\s*ignore|sp_sign\s*=\s*add|sp_sign\s*=\s*remove|sp_sign\s*=\s*force|sp_sign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sign|Add Sp Sign|Remove Sp Sign|Force Sp Sign"
 ValueDefault=remove
 
@@ -2031,7 +2032,7 @@ Category=1
 Description="<html>Add or remove space between '++' and '--' the word to which it is being<br/>applied, as in '(--x)' or 'y++;'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_incdec=ignore|sp_incdec=add|sp_incdec=remove|sp_incdec=force|sp_incdec=not_defined
+Choices=sp_incdec\s*=\s*ignore|sp_incdec\s*=\s*add|sp_incdec\s*=\s*remove|sp_incdec\s*=\s*force|sp_incdec\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Incdec|Add Sp Incdec|Remove Sp Incdec|Force Sp Incdec"
 ValueDefault=remove
 
@@ -2040,7 +2041,7 @@ Category=1
 Description="<html>Add or remove space before a backslash-newline at the end of a line.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_nl_cont=ignore|sp_before_nl_cont=add|sp_before_nl_cont=remove|sp_before_nl_cont=force|sp_before_nl_cont=not_defined
+Choices=sp_before_nl_cont\s*=\s*ignore|sp_before_nl_cont\s*=\s*add|sp_before_nl_cont\s*=\s*remove|sp_before_nl_cont\s*=\s*force|sp_before_nl_cont\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Nl Cont|Add Sp Before Nl Cont|Remove Sp Before Nl Cont|Force Sp Before Nl Cont"
 ValueDefault=add
 
@@ -2049,7 +2050,7 @@ Category=1
 Description="<html>(OC) Add or remove space after the scope '+' or '-', as in '-(void) foo;'<br/>or '+(int) bar;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_scope=ignore|sp_after_oc_scope=add|sp_after_oc_scope=remove|sp_after_oc_scope=force|sp_after_oc_scope=not_defined
+Choices=sp_after_oc_scope\s*=\s*ignore|sp_after_oc_scope\s*=\s*add|sp_after_oc_scope\s*=\s*remove|sp_after_oc_scope\s*=\s*force|sp_after_oc_scope\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Scope|Add Sp After Oc Scope|Remove Sp After Oc Scope|Force Sp After Oc Scope"
 ValueDefault=ignore
 
@@ -2058,7 +2059,7 @@ Category=1
 Description="<html>(OC) Add or remove space after the colon in message specs,<br/>i.e. '-(int) f:(int) x;' vs. '-(int) f: (int) x;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_colon=ignore|sp_after_oc_colon=add|sp_after_oc_colon=remove|sp_after_oc_colon=force|sp_after_oc_colon=not_defined
+Choices=sp_after_oc_colon\s*=\s*ignore|sp_after_oc_colon\s*=\s*add|sp_after_oc_colon\s*=\s*remove|sp_after_oc_colon\s*=\s*force|sp_after_oc_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Colon|Add Sp After Oc Colon|Remove Sp After Oc Colon|Force Sp After Oc Colon"
 ValueDefault=ignore
 
@@ -2067,7 +2068,7 @@ Category=1
 Description="<html>(OC) Add or remove space before the colon in message specs,<br/>i.e. '-(int) f: (int) x;' vs. '-(int) f : (int) x;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_oc_colon=ignore|sp_before_oc_colon=add|sp_before_oc_colon=remove|sp_before_oc_colon=force|sp_before_oc_colon=not_defined
+Choices=sp_before_oc_colon\s*=\s*ignore|sp_before_oc_colon\s*=\s*add|sp_before_oc_colon\s*=\s*remove|sp_before_oc_colon\s*=\s*force|sp_before_oc_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Oc Colon|Add Sp Before Oc Colon|Remove Sp Before Oc Colon|Force Sp Before Oc Colon"
 ValueDefault=ignore
 
@@ -2076,7 +2077,7 @@ Category=1
 Description="<html>(OC) Add or remove space after the colon in immutable dictionary expression<br/>'NSDictionary *test = @{@"foo" :@"bar"};'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_dict_colon=ignore|sp_after_oc_dict_colon=add|sp_after_oc_dict_colon=remove|sp_after_oc_dict_colon=force|sp_after_oc_dict_colon=not_defined
+Choices=sp_after_oc_dict_colon\s*=\s*ignore|sp_after_oc_dict_colon\s*=\s*add|sp_after_oc_dict_colon\s*=\s*remove|sp_after_oc_dict_colon\s*=\s*force|sp_after_oc_dict_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Dict Colon|Add Sp After Oc Dict Colon|Remove Sp After Oc Dict Colon|Force Sp After Oc Dict Colon"
 ValueDefault=ignore
 
@@ -2085,7 +2086,7 @@ Category=1
 Description="<html>(OC) Add or remove space before the colon in immutable dictionary expression<br/>'NSDictionary *test = @{@"foo" :@"bar"};'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_oc_dict_colon=ignore|sp_before_oc_dict_colon=add|sp_before_oc_dict_colon=remove|sp_before_oc_dict_colon=force|sp_before_oc_dict_colon=not_defined
+Choices=sp_before_oc_dict_colon\s*=\s*ignore|sp_before_oc_dict_colon\s*=\s*add|sp_before_oc_dict_colon\s*=\s*remove|sp_before_oc_dict_colon\s*=\s*force|sp_before_oc_dict_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Oc Dict Colon|Add Sp Before Oc Dict Colon|Remove Sp Before Oc Dict Colon|Force Sp Before Oc Dict Colon"
 ValueDefault=ignore
 
@@ -2094,7 +2095,7 @@ Category=1
 Description="<html>(OC) Add or remove space after the colon in message specs,<br/>i.e. '[object setValue:1];' vs. '[object setValue: 1];'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_send_oc_colon=ignore|sp_after_send_oc_colon=add|sp_after_send_oc_colon=remove|sp_after_send_oc_colon=force|sp_after_send_oc_colon=not_defined
+Choices=sp_after_send_oc_colon\s*=\s*ignore|sp_after_send_oc_colon\s*=\s*add|sp_after_send_oc_colon\s*=\s*remove|sp_after_send_oc_colon\s*=\s*force|sp_after_send_oc_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Send Oc Colon|Add Sp After Send Oc Colon|Remove Sp After Send Oc Colon|Force Sp After Send Oc Colon"
 ValueDefault=ignore
 
@@ -2103,7 +2104,7 @@ Category=1
 Description="<html>(OC) Add or remove space before the colon in message specs,<br/>i.e. '[object setValue:1];' vs. '[object setValue :1];'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_send_oc_colon=ignore|sp_before_send_oc_colon=add|sp_before_send_oc_colon=remove|sp_before_send_oc_colon=force|sp_before_send_oc_colon=not_defined
+Choices=sp_before_send_oc_colon\s*=\s*ignore|sp_before_send_oc_colon\s*=\s*add|sp_before_send_oc_colon\s*=\s*remove|sp_before_send_oc_colon\s*=\s*force|sp_before_send_oc_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Send Oc Colon|Add Sp Before Send Oc Colon|Remove Sp Before Send Oc Colon|Force Sp Before Send Oc Colon"
 ValueDefault=ignore
 
@@ -2112,7 +2113,7 @@ Category=1
 Description="<html>(OC) Add or remove space after the (type) in message specs,<br/>i.e. '-(int)f: (int) x;' vs. '-(int)f: (int)x;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_type=ignore|sp_after_oc_type=add|sp_after_oc_type=remove|sp_after_oc_type=force|sp_after_oc_type=not_defined
+Choices=sp_after_oc_type\s*=\s*ignore|sp_after_oc_type\s*=\s*add|sp_after_oc_type\s*=\s*remove|sp_after_oc_type\s*=\s*force|sp_after_oc_type\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Type|Add Sp After Oc Type|Remove Sp After Oc Type|Force Sp After Oc Type"
 ValueDefault=ignore
 
@@ -2121,7 +2122,7 @@ Category=1
 Description="<html>(OC) Add or remove space after the first (type) in message specs,<br/>i.e. '-(int) f:(int)x;' vs. '-(int)f:(int)x;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_return_type=ignore|sp_after_oc_return_type=add|sp_after_oc_return_type=remove|sp_after_oc_return_type=force|sp_after_oc_return_type=not_defined
+Choices=sp_after_oc_return_type\s*=\s*ignore|sp_after_oc_return_type\s*=\s*add|sp_after_oc_return_type\s*=\s*remove|sp_after_oc_return_type\s*=\s*force|sp_after_oc_return_type\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Return Type|Add Sp After Oc Return Type|Remove Sp After Oc Return Type|Force Sp After Oc Return Type"
 ValueDefault=ignore
 
@@ -2130,7 +2131,7 @@ Category=1
 Description="<html>(OC) Add or remove space between '@selector' and '(',<br/>i.e. '@selector(msgName)' vs. '@selector (msgName)'.<br/>Also applies to '@protocol()' constructs.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_at_sel=ignore|sp_after_oc_at_sel=add|sp_after_oc_at_sel=remove|sp_after_oc_at_sel=force|sp_after_oc_at_sel=not_defined
+Choices=sp_after_oc_at_sel\s*=\s*ignore|sp_after_oc_at_sel\s*=\s*add|sp_after_oc_at_sel\s*=\s*remove|sp_after_oc_at_sel\s*=\s*force|sp_after_oc_at_sel\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc At Sel|Add Sp After Oc At Sel|Remove Sp After Oc At Sel|Force Sp After Oc At Sel"
 ValueDefault=ignore
 
@@ -2139,7 +2140,7 @@ Category=1
 Description="<html>(OC) Add or remove space between '@selector(x)' and the following word,<br/>i.e. '@selector(foo) a:' vs. '@selector(foo)a:'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_at_sel_parens=ignore|sp_after_oc_at_sel_parens=add|sp_after_oc_at_sel_parens=remove|sp_after_oc_at_sel_parens=force|sp_after_oc_at_sel_parens=not_defined
+Choices=sp_after_oc_at_sel_parens\s*=\s*ignore|sp_after_oc_at_sel_parens\s*=\s*add|sp_after_oc_at_sel_parens\s*=\s*remove|sp_after_oc_at_sel_parens\s*=\s*force|sp_after_oc_at_sel_parens\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc At Sel Parens|Add Sp After Oc At Sel Parens|Remove Sp After Oc At Sel Parens|Force Sp After Oc At Sel Parens"
 ValueDefault=ignore
 
@@ -2148,7 +2149,7 @@ Category=1
 Description="<html>(OC) Add or remove space inside '@selector' parentheses,<br/>i.e. '@selector(foo)' vs. '@selector( foo )'.<br/>Also applies to '@protocol()' constructs.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_oc_at_sel_parens=ignore|sp_inside_oc_at_sel_parens=add|sp_inside_oc_at_sel_parens=remove|sp_inside_oc_at_sel_parens=force|sp_inside_oc_at_sel_parens=not_defined
+Choices=sp_inside_oc_at_sel_parens\s*=\s*ignore|sp_inside_oc_at_sel_parens\s*=\s*add|sp_inside_oc_at_sel_parens\s*=\s*remove|sp_inside_oc_at_sel_parens\s*=\s*force|sp_inside_oc_at_sel_parens\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Oc At Sel Parens|Add Sp Inside Oc At Sel Parens|Remove Sp Inside Oc At Sel Parens|Force Sp Inside Oc At Sel Parens"
 ValueDefault=ignore
 
@@ -2157,7 +2158,7 @@ Category=1
 Description="<html>(OC) Add or remove space before a block pointer caret,<br/>i.e. '^int (int arg){...}' vs. ' ^int (int arg){...}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_oc_block_caret=ignore|sp_before_oc_block_caret=add|sp_before_oc_block_caret=remove|sp_before_oc_block_caret=force|sp_before_oc_block_caret=not_defined
+Choices=sp_before_oc_block_caret\s*=\s*ignore|sp_before_oc_block_caret\s*=\s*add|sp_before_oc_block_caret\s*=\s*remove|sp_before_oc_block_caret\s*=\s*force|sp_before_oc_block_caret\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Oc Block Caret|Add Sp Before Oc Block Caret|Remove Sp Before Oc Block Caret|Force Sp Before Oc Block Caret"
 ValueDefault=ignore
 
@@ -2166,7 +2167,7 @@ Category=1
 Description="<html>(OC) Add or remove space after a block pointer caret,<br/>i.e. '^int (int arg){...}' vs. '^ int (int arg){...}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_block_caret=ignore|sp_after_oc_block_caret=add|sp_after_oc_block_caret=remove|sp_after_oc_block_caret=force|sp_after_oc_block_caret=not_defined
+Choices=sp_after_oc_block_caret\s*=\s*ignore|sp_after_oc_block_caret\s*=\s*add|sp_after_oc_block_caret\s*=\s*remove|sp_after_oc_block_caret\s*=\s*force|sp_after_oc_block_caret\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Block Caret|Add Sp After Oc Block Caret|Remove Sp After Oc Block Caret|Force Sp After Oc Block Caret"
 ValueDefault=ignore
 
@@ -2175,7 +2176,7 @@ Category=1
 Description="<html>(OC) Add or remove space between the receiver and selector in a message,<br/>as in '[receiver selector ...]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_msg_receiver=ignore|sp_after_oc_msg_receiver=add|sp_after_oc_msg_receiver=remove|sp_after_oc_msg_receiver=force|sp_after_oc_msg_receiver=not_defined
+Choices=sp_after_oc_msg_receiver\s*=\s*ignore|sp_after_oc_msg_receiver\s*=\s*add|sp_after_oc_msg_receiver\s*=\s*remove|sp_after_oc_msg_receiver\s*=\s*force|sp_after_oc_msg_receiver\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Msg Receiver|Add Sp After Oc Msg Receiver|Remove Sp After Oc Msg Receiver|Force Sp After Oc Msg Receiver"
 ValueDefault=ignore
 
@@ -2184,7 +2185,7 @@ Category=1
 Description="<html>(OC) Add or remove space after '@property'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_property=ignore|sp_after_oc_property=add|sp_after_oc_property=remove|sp_after_oc_property=force|sp_after_oc_property=not_defined
+Choices=sp_after_oc_property\s*=\s*ignore|sp_after_oc_property\s*=\s*add|sp_after_oc_property\s*=\s*remove|sp_after_oc_property\s*=\s*force|sp_after_oc_property\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Property|Add Sp After Oc Property|Remove Sp After Oc Property|Force Sp After Oc Property"
 ValueDefault=ignore
 
@@ -2193,7 +2194,7 @@ Category=1
 Description="<html>(OC) Add or remove space between '@synchronized' and the open parenthesis,<br/>i.e. '@synchronized(foo)' vs. '@synchronized (foo)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_synchronized=ignore|sp_after_oc_synchronized=add|sp_after_oc_synchronized=remove|sp_after_oc_synchronized=force|sp_after_oc_synchronized=not_defined
+Choices=sp_after_oc_synchronized\s*=\s*ignore|sp_after_oc_synchronized\s*=\s*add|sp_after_oc_synchronized\s*=\s*remove|sp_after_oc_synchronized\s*=\s*force|sp_after_oc_synchronized\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Synchronized|Add Sp After Oc Synchronized|Remove Sp After Oc Synchronized|Force Sp After Oc Synchronized"
 ValueDefault=ignore
 
@@ -2202,7 +2203,7 @@ Category=1
 Description="<html>Add or remove space around the ':' in 'b ? t : f'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_colon=ignore|sp_cond_colon=add|sp_cond_colon=remove|sp_cond_colon=force|sp_cond_colon=not_defined
+Choices=sp_cond_colon\s*=\s*ignore|sp_cond_colon\s*=\s*add|sp_cond_colon\s*=\s*remove|sp_cond_colon\s*=\s*force|sp_cond_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Colon|Add Sp Cond Colon|Remove Sp Cond Colon|Force Sp Cond Colon"
 ValueDefault=ignore
 
@@ -2211,7 +2212,7 @@ Category=1
 Description="<html>Add or remove space before the ':' in 'b ? t : f'.<br/><br/>Overrides sp_cond_colon.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_colon_before=ignore|sp_cond_colon_before=add|sp_cond_colon_before=remove|sp_cond_colon_before=force|sp_cond_colon_before=not_defined
+Choices=sp_cond_colon_before\s*=\s*ignore|sp_cond_colon_before\s*=\s*add|sp_cond_colon_before\s*=\s*remove|sp_cond_colon_before\s*=\s*force|sp_cond_colon_before\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Colon Before|Add Sp Cond Colon Before|Remove Sp Cond Colon Before|Force Sp Cond Colon Before"
 ValueDefault=ignore
 
@@ -2220,7 +2221,7 @@ Category=1
 Description="<html>Add or remove space after the ':' in 'b ? t : f'.<br/><br/>Overrides sp_cond_colon.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_colon_after=ignore|sp_cond_colon_after=add|sp_cond_colon_after=remove|sp_cond_colon_after=force|sp_cond_colon_after=not_defined
+Choices=sp_cond_colon_after\s*=\s*ignore|sp_cond_colon_after\s*=\s*add|sp_cond_colon_after\s*=\s*remove|sp_cond_colon_after\s*=\s*force|sp_cond_colon_after\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Colon After|Add Sp Cond Colon After|Remove Sp Cond Colon After|Force Sp Cond Colon After"
 ValueDefault=ignore
 
@@ -2229,7 +2230,7 @@ Category=1
 Description="<html>Add or remove space around the '?' in 'b ? t : f'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_question=ignore|sp_cond_question=add|sp_cond_question=remove|sp_cond_question=force|sp_cond_question=not_defined
+Choices=sp_cond_question\s*=\s*ignore|sp_cond_question\s*=\s*add|sp_cond_question\s*=\s*remove|sp_cond_question\s*=\s*force|sp_cond_question\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Question|Add Sp Cond Question|Remove Sp Cond Question|Force Sp Cond Question"
 ValueDefault=ignore
 
@@ -2238,7 +2239,7 @@ Category=1
 Description="<html>Add or remove space before the '?' in 'b ? t : f'.<br/><br/>Overrides sp_cond_question.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_question_before=ignore|sp_cond_question_before=add|sp_cond_question_before=remove|sp_cond_question_before=force|sp_cond_question_before=not_defined
+Choices=sp_cond_question_before\s*=\s*ignore|sp_cond_question_before\s*=\s*add|sp_cond_question_before\s*=\s*remove|sp_cond_question_before\s*=\s*force|sp_cond_question_before\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Question Before|Add Sp Cond Question Before|Remove Sp Cond Question Before|Force Sp Cond Question Before"
 ValueDefault=ignore
 
@@ -2247,7 +2248,7 @@ Category=1
 Description="<html>Add or remove space after the '?' in 'b ? t : f'.<br/><br/>Overrides sp_cond_question.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_question_after=ignore|sp_cond_question_after=add|sp_cond_question_after=remove|sp_cond_question_after=force|sp_cond_question_after=not_defined
+Choices=sp_cond_question_after\s*=\s*ignore|sp_cond_question_after\s*=\s*add|sp_cond_question_after\s*=\s*remove|sp_cond_question_after\s*=\s*force|sp_cond_question_after\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Question After|Add Sp Cond Question After|Remove Sp Cond Question After|Force Sp Cond Question After"
 ValueDefault=ignore
 
@@ -2256,7 +2257,7 @@ Category=1
 Description="<html>In the abbreviated ternary form '(a ?: b)', add or remove space between '?'<br/>and ':'.<br/><br/>Overrides all other sp_cond_* options.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_ternary_short=ignore|sp_cond_ternary_short=add|sp_cond_ternary_short=remove|sp_cond_ternary_short=force|sp_cond_ternary_short=not_defined
+Choices=sp_cond_ternary_short\s*=\s*ignore|sp_cond_ternary_short\s*=\s*add|sp_cond_ternary_short\s*=\s*remove|sp_cond_ternary_short\s*=\s*force|sp_cond_ternary_short\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Ternary Short|Add Sp Cond Ternary Short|Remove Sp Cond Ternary Short|Force Sp Cond Ternary Short"
 ValueDefault=ignore
 
@@ -2265,7 +2266,7 @@ Category=1
 Description="<html>Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make<br/>sense here.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_case_label=ignore|sp_case_label=add|sp_case_label=remove|sp_case_label=force|sp_case_label=not_defined
+Choices=sp_case_label\s*=\s*ignore|sp_case_label\s*=\s*add|sp_case_label\s*=\s*remove|sp_case_label\s*=\s*force|sp_case_label\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Case Label|Add Sp Case Label|Remove Sp Case Label|Force Sp Case Label"
 ValueDefault=ignore
 
@@ -2274,7 +2275,7 @@ Category=1
 Description="<html>(D) Add or remove space around the D '..' operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_range=ignore|sp_range=add|sp_range=remove|sp_range=force|sp_range=not_defined
+Choices=sp_range\s*=\s*ignore|sp_range\s*=\s*add|sp_range\s*=\s*remove|sp_range\s*=\s*force|sp_range\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Range|Add Sp Range|Remove Sp Range|Force Sp Range"
 ValueDefault=ignore
 
@@ -2283,7 +2284,7 @@ Category=1
 Description="<html>Add or remove space after ':' in a Java/C++11 range-based 'for',<br/>as in 'for (Type var : &lt;here&gt; expr)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_for_colon=ignore|sp_after_for_colon=add|sp_after_for_colon=remove|sp_after_for_colon=force|sp_after_for_colon=not_defined
+Choices=sp_after_for_colon\s*=\s*ignore|sp_after_for_colon\s*=\s*add|sp_after_for_colon\s*=\s*remove|sp_after_for_colon\s*=\s*force|sp_after_for_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After For Colon|Add Sp After For Colon|Remove Sp After For Colon|Force Sp After For Colon"
 ValueDefault=ignore
 
@@ -2292,7 +2293,7 @@ Category=1
 Description="<html>Add or remove space before ':' in a Java/C++11 range-based 'for',<br/>as in 'for (Type var &lt;here&gt; : expr)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_for_colon=ignore|sp_before_for_colon=add|sp_before_for_colon=remove|sp_before_for_colon=force|sp_before_for_colon=not_defined
+Choices=sp_before_for_colon\s*=\s*ignore|sp_before_for_colon\s*=\s*add|sp_before_for_colon\s*=\s*remove|sp_before_for_colon\s*=\s*force|sp_before_for_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before For Colon|Add Sp Before For Colon|Remove Sp Before For Colon|Force Sp Before For Colon"
 ValueDefault=ignore
 
@@ -2301,7 +2302,7 @@ Category=1
 Description="<html>(D) Add or remove space between 'extern' and '(' as in 'extern &lt;here&gt; (C)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_extern_paren=ignore|sp_extern_paren=add|sp_extern_paren=remove|sp_extern_paren=force|sp_extern_paren=not_defined
+Choices=sp_extern_paren\s*=\s*ignore|sp_extern_paren\s*=\s*add|sp_extern_paren\s*=\s*remove|sp_extern_paren\s*=\s*force|sp_extern_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Extern Paren|Add Sp Extern Paren|Remove Sp Extern Paren|Force Sp Extern Paren"
 ValueDefault=ignore
 
@@ -2310,7 +2311,7 @@ Category=1
 Description="<html>Add or remove space after the opening of a C++ comment, as in '// &lt;here&gt; A'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cmt_cpp_start=ignore|sp_cmt_cpp_start=add|sp_cmt_cpp_start=remove|sp_cmt_cpp_start=force|sp_cmt_cpp_start=not_defined
+Choices=sp_cmt_cpp_start\s*=\s*ignore|sp_cmt_cpp_start\s*=\s*add|sp_cmt_cpp_start\s*=\s*remove|sp_cmt_cpp_start\s*=\s*force|sp_cmt_cpp_start\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cmt Cpp Start|Add Sp Cmt Cpp Start|Remove Sp Cmt Cpp Start|Force Sp Cmt Cpp Start"
 ValueDefault=ignore
 
@@ -2319,7 +2320,7 @@ Category=1
 Description="<html>remove space after the '//' and the pvs command '-V1234',<br/>only works with sp_cmt_cpp_start set to add or force.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_cmt_cpp_pvs=true|sp_cmt_cpp_pvs=false
+TrueFalse=sp_cmt_cpp_pvs\s*=\s*true|sp_cmt_cpp_pvs\s*=\s*false
 ValueDefault=false
 
 [Sp Cmt Cpp Lint]
@@ -2327,7 +2328,7 @@ Category=1
 Description="<html>remove space after the '//' and the command 'lint',<br/>only works with sp_cmt_cpp_start set to add or force.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_cmt_cpp_lint=true|sp_cmt_cpp_lint=false
+TrueFalse=sp_cmt_cpp_lint\s*=\s*true|sp_cmt_cpp_lint\s*=\s*false
 ValueDefault=false
 
 [Sp Cmt Cpp Region]
@@ -2335,7 +2336,7 @@ Category=1
 Description="<html>Add or remove space in a C++ region marker comment, as in '// &lt;here&gt; BEGIN'.<br/>A region marker is defined as a comment which is not preceded by other text<br/>(i.e. the comment is the first non-whitespace on the line), and which starts<br/>with either 'BEGIN' or 'END'.<br/><br/>Overrides sp_cmt_cpp_start.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cmt_cpp_region=ignore|sp_cmt_cpp_region=add|sp_cmt_cpp_region=remove|sp_cmt_cpp_region=force|sp_cmt_cpp_region=not_defined
+Choices=sp_cmt_cpp_region\s*=\s*ignore|sp_cmt_cpp_region\s*=\s*add|sp_cmt_cpp_region\s*=\s*remove|sp_cmt_cpp_region\s*=\s*force|sp_cmt_cpp_region\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cmt Cpp Region|Add Sp Cmt Cpp Region|Remove Sp Cmt Cpp Region|Force Sp Cmt Cpp Region"
 ValueDefault=ignore
 
@@ -2344,7 +2345,7 @@ Category=1
 Description="<html>If true, space added with sp_cmt_cpp_start will be added after Doxygen<br/>sequences like '///', '///&lt;', '//!' and '//!&lt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_cmt_cpp_doxygen=true|sp_cmt_cpp_doxygen=false
+TrueFalse=sp_cmt_cpp_doxygen\s*=\s*true|sp_cmt_cpp_doxygen\s*=\s*false
 ValueDefault=false
 
 [Sp Cmt Cpp Qttr]
@@ -2352,7 +2353,7 @@ Category=1
 Description="<html>If true, space added with sp_cmt_cpp_start will be added after Qt translator<br/>or meta-data comments like '//:', '//=', and '//~'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_cmt_cpp_qttr=true|sp_cmt_cpp_qttr=false
+TrueFalse=sp_cmt_cpp_qttr\s*=\s*true|sp_cmt_cpp_qttr\s*=\s*false
 ValueDefault=false
 
 [Sp Endif Cmt]
@@ -2360,7 +2361,7 @@ Category=1
 Description="<html>Add or remove space between #else or #endif and a trailing comment.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_endif_cmt=ignore|sp_endif_cmt=add|sp_endif_cmt=remove|sp_endif_cmt=force|sp_endif_cmt=not_defined
+Choices=sp_endif_cmt\s*=\s*ignore|sp_endif_cmt\s*=\s*add|sp_endif_cmt\s*=\s*remove|sp_endif_cmt\s*=\s*force|sp_endif_cmt\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Endif Cmt|Add Sp Endif Cmt|Remove Sp Endif Cmt|Force Sp Endif Cmt"
 ValueDefault=ignore
 
@@ -2369,7 +2370,7 @@ Category=1
 Description="<html>Add or remove space after 'new', 'delete' and 'delete[]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_new=ignore|sp_after_new=add|sp_after_new=remove|sp_after_new=force|sp_after_new=not_defined
+Choices=sp_after_new\s*=\s*ignore|sp_after_new\s*=\s*add|sp_after_new\s*=\s*remove|sp_after_new\s*=\s*force|sp_after_new\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After New|Add Sp After New|Remove Sp After New|Force Sp After New"
 ValueDefault=ignore
 
@@ -2378,7 +2379,7 @@ Category=1
 Description="<html>Add or remove space between 'new' and '(' in 'new()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_new_paren=ignore|sp_between_new_paren=add|sp_between_new_paren=remove|sp_between_new_paren=force|sp_between_new_paren=not_defined
+Choices=sp_between_new_paren\s*=\s*ignore|sp_between_new_paren\s*=\s*add|sp_between_new_paren\s*=\s*remove|sp_between_new_paren\s*=\s*force|sp_between_new_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between New Paren|Add Sp Between New Paren|Remove Sp Between New Paren|Force Sp Between New Paren"
 ValueDefault=ignore
 
@@ -2387,7 +2388,7 @@ Category=1
 Description="<html>Add or remove space between ')' and type in 'new(foo) BAR'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_newop_paren=ignore|sp_after_newop_paren=add|sp_after_newop_paren=remove|sp_after_newop_paren=force|sp_after_newop_paren=not_defined
+Choices=sp_after_newop_paren\s*=\s*ignore|sp_after_newop_paren\s*=\s*add|sp_after_newop_paren\s*=\s*remove|sp_after_newop_paren\s*=\s*force|sp_after_newop_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Newop Paren|Add Sp After Newop Paren|Remove Sp After Newop Paren|Force Sp After Newop Paren"
 ValueDefault=ignore
 
@@ -2396,7 +2397,7 @@ Category=1
 Description="<html>Add or remove space inside parentheses of the new operator<br/>as in 'new(foo) BAR'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_newop_paren=ignore|sp_inside_newop_paren=add|sp_inside_newop_paren=remove|sp_inside_newop_paren=force|sp_inside_newop_paren=not_defined
+Choices=sp_inside_newop_paren\s*=\s*ignore|sp_inside_newop_paren\s*=\s*add|sp_inside_newop_paren\s*=\s*remove|sp_inside_newop_paren\s*=\s*force|sp_inside_newop_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Newop Paren|Add Sp Inside Newop Paren|Remove Sp Inside Newop Paren|Force Sp Inside Newop Paren"
 ValueDefault=ignore
 
@@ -2405,7 +2406,7 @@ Category=1
 Description="<html>Add or remove space after the open parenthesis of the new operator,<br/>as in 'new(foo) BAR'.<br/><br/>Overrides sp_inside_newop_paren.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_newop_paren_open=ignore|sp_inside_newop_paren_open=add|sp_inside_newop_paren_open=remove|sp_inside_newop_paren_open=force|sp_inside_newop_paren_open=not_defined
+Choices=sp_inside_newop_paren_open\s*=\s*ignore|sp_inside_newop_paren_open\s*=\s*add|sp_inside_newop_paren_open\s*=\s*remove|sp_inside_newop_paren_open\s*=\s*force|sp_inside_newop_paren_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Newop Paren Open|Add Sp Inside Newop Paren Open|Remove Sp Inside Newop Paren Open|Force Sp Inside Newop Paren Open"
 ValueDefault=ignore
 
@@ -2414,7 +2415,7 @@ Category=1
 Description="<html>Add or remove space before the close parenthesis of the new operator,<br/>as in 'new(foo) BAR'.<br/><br/>Overrides sp_inside_newop_paren.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_newop_paren_close=ignore|sp_inside_newop_paren_close=add|sp_inside_newop_paren_close=remove|sp_inside_newop_paren_close=force|sp_inside_newop_paren_close=not_defined
+Choices=sp_inside_newop_paren_close\s*=\s*ignore|sp_inside_newop_paren_close\s*=\s*add|sp_inside_newop_paren_close\s*=\s*remove|sp_inside_newop_paren_close\s*=\s*force|sp_inside_newop_paren_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Newop Paren Close|Add Sp Inside Newop Paren Close|Remove Sp Inside Newop Paren Close|Force Sp Inside Newop Paren Close"
 ValueDefault=ignore
 
@@ -2423,7 +2424,7 @@ Category=1
 Description="<html>Add or remove space before a trailing comment.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_tr_cmt=ignore|sp_before_tr_cmt=add|sp_before_tr_cmt=remove|sp_before_tr_cmt=force|sp_before_tr_cmt=not_defined
+Choices=sp_before_tr_cmt\s*=\s*ignore|sp_before_tr_cmt\s*=\s*add|sp_before_tr_cmt\s*=\s*remove|sp_before_tr_cmt\s*=\s*force|sp_before_tr_cmt\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Tr Cmt|Add Sp Before Tr Cmt|Remove Sp Before Tr Cmt|Force Sp Before Tr Cmt"
 ValueDefault=ignore
 
@@ -2432,7 +2433,7 @@ Category=1
 Description="<html>Number of spaces before a trailing comment.</html>"
 Enabled=false
 EditorType=numeric
-CallName="sp_num_before_tr_cmt="
+CallName="sp_num_before_tr_cmt\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2442,7 +2443,7 @@ Category=1
 Description="<html>Add or remove space before an embedded comment.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_emb_cmt=ignore|sp_before_emb_cmt=add|sp_before_emb_cmt=remove|sp_before_emb_cmt=force|sp_before_emb_cmt=not_defined
+Choices=sp_before_emb_cmt\s*=\s*ignore|sp_before_emb_cmt\s*=\s*add|sp_before_emb_cmt\s*=\s*remove|sp_before_emb_cmt\s*=\s*force|sp_before_emb_cmt\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Emb Cmt|Add Sp Before Emb Cmt|Remove Sp Before Emb Cmt|Force Sp Before Emb Cmt"
 ValueDefault=force
 
@@ -2451,7 +2452,7 @@ Category=1
 Description="<html>Number of spaces before an embedded comment.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="sp_num_before_emb_cmt="
+CallName="sp_num_before_emb_cmt\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -2461,7 +2462,7 @@ Category=1
 Description="<html>Add or remove space after an embedded comment.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_emb_cmt=ignore|sp_after_emb_cmt=add|sp_after_emb_cmt=remove|sp_after_emb_cmt=force|sp_after_emb_cmt=not_defined
+Choices=sp_after_emb_cmt\s*=\s*ignore|sp_after_emb_cmt\s*=\s*add|sp_after_emb_cmt\s*=\s*remove|sp_after_emb_cmt\s*=\s*force|sp_after_emb_cmt\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Emb Cmt|Add Sp After Emb Cmt|Remove Sp After Emb Cmt|Force Sp After Emb Cmt"
 ValueDefault=force
 
@@ -2470,7 +2471,7 @@ Category=1
 Description="<html>Number of spaces after an embedded comment.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="sp_num_after_emb_cmt="
+CallName="sp_num_after_emb_cmt\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -2480,7 +2481,7 @@ Category=1
 Description="<html>(Java) Add or remove space between an annotation and the open parenthesis.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_annotation_paren=ignore|sp_annotation_paren=add|sp_annotation_paren=remove|sp_annotation_paren=force|sp_annotation_paren=not_defined
+Choices=sp_annotation_paren\s*=\s*ignore|sp_annotation_paren\s*=\s*add|sp_annotation_paren\s*=\s*remove|sp_annotation_paren\s*=\s*force|sp_annotation_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Annotation Paren|Add Sp Annotation Paren|Remove Sp Annotation Paren|Force Sp Annotation Paren"
 ValueDefault=ignore
 
@@ -2489,7 +2490,7 @@ Category=1
 Description="<html>If true, vbrace tokens are dropped to the previous token and skipped.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_skip_vbrace_tokens=true|sp_skip_vbrace_tokens=false
+TrueFalse=sp_skip_vbrace_tokens\s*=\s*true|sp_skip_vbrace_tokens\s*=\s*false
 ValueDefault=false
 
 [Sp After Noexcept]
@@ -2497,7 +2498,7 @@ Category=1
 Description="<html>Add or remove space after 'noexcept'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_noexcept=ignore|sp_after_noexcept=add|sp_after_noexcept=remove|sp_after_noexcept=force|sp_after_noexcept=not_defined
+Choices=sp_after_noexcept\s*=\s*ignore|sp_after_noexcept\s*=\s*add|sp_after_noexcept\s*=\s*remove|sp_after_noexcept\s*=\s*force|sp_after_noexcept\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Noexcept|Add Sp After Noexcept|Remove Sp After Noexcept|Force Sp After Noexcept"
 ValueDefault=ignore
 
@@ -2506,7 +2507,7 @@ Category=1
 Description="<html>Add or remove space after '_'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_vala_after_translation=ignore|sp_vala_after_translation=add|sp_vala_after_translation=remove|sp_vala_after_translation=force|sp_vala_after_translation=not_defined
+Choices=sp_vala_after_translation\s*=\s*ignore|sp_vala_after_translation\s*=\s*add|sp_vala_after_translation\s*=\s*remove|sp_vala_after_translation\s*=\s*force|sp_vala_after_translation\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Vala After Translation|Add Sp Vala After Translation|Remove Sp Vala After Translation|Force Sp Vala After Translation"
 ValueDefault=ignore
 
@@ -2515,7 +2516,7 @@ Category=1
 Description="<html>Add or remove space before a bit colon ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_bit_colon=ignore|sp_before_bit_colon=add|sp_before_bit_colon=remove|sp_before_bit_colon=force|sp_before_bit_colon=not_defined
+Choices=sp_before_bit_colon\s*=\s*ignore|sp_before_bit_colon\s*=\s*add|sp_before_bit_colon\s*=\s*remove|sp_before_bit_colon\s*=\s*force|sp_before_bit_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Bit Colon|Add Sp Before Bit Colon|Remove Sp Before Bit Colon|Force Sp Before Bit Colon"
 ValueDefault=ignore
 
@@ -2524,7 +2525,7 @@ Category=1
 Description="<html>Add or remove space after a bit colon ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_bit_colon=ignore|sp_after_bit_colon=add|sp_after_bit_colon=remove|sp_after_bit_colon=force|sp_after_bit_colon=not_defined
+Choices=sp_after_bit_colon\s*=\s*ignore|sp_after_bit_colon\s*=\s*add|sp_after_bit_colon\s*=\s*remove|sp_after_bit_colon\s*=\s*force|sp_after_bit_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Bit Colon|Add Sp After Bit Colon|Remove Sp After Bit Colon|Force Sp After Bit Colon"
 ValueDefault=ignore
 
@@ -2533,7 +2534,7 @@ Category=1
 Description="<html>If true, a &lt;TAB&gt; is inserted after #define.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=force_tab_after_define=true|force_tab_after_define=false
+TrueFalse=force_tab_after_define\s*=\s*true|force_tab_after_define\s*=\s*false
 ValueDefault=false
 
 [Indent Columns]
@@ -2541,7 +2542,7 @@ Category=2
 Description="<html>The number of columns to indent per level. Usually 2, 3, 4, or 8.<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_columns="
+CallName="indent_columns\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=8
@@ -2551,7 +2552,7 @@ Category=2
 Description="<html>Whether to ignore indent for the first continuation line. Subsequent<br/>continuation lines will still be indented to match the first.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_first_continue=true|indent_ignore_first_continue=false
+TrueFalse=indent_ignore_first_continue\s*=\s*true|indent_ignore_first_continue\s*=\s*false
 ValueDefault=false
 
 [Indent Continue]
@@ -2559,7 +2560,7 @@ Category=2
 Description="<html>The continuation indent. If non-zero, this overrides the indent of '(', '['<br/>and '=' continuation indents. Negative values are OK; negative value is<br/>absolute and not increased for each '(' or '[' level.<br/><br/>For FreeBSD, this is set to 4.<br/>Requires indent_ignore_first_continue=false.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_continue="
+CallName="indent_continue\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -2569,7 +2570,7 @@ Category=2
 Description="<html>The continuation indent, only for class header line(s). If non-zero, this<br/>overrides the indent of 'class' continuation indents.<br/>Requires indent_ignore_first_continue=false.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_continue_class_head="
+CallName="indent_continue_class_head\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2579,7 +2580,7 @@ Category=2
 Description="<html>Whether to indent empty lines (i.e. lines which contain only spaces before<br/>the newline character).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_single_newlines=true|indent_single_newlines=false
+TrueFalse=indent_single_newlines\s*=\s*true|indent_single_newlines\s*=\s*false
 ValueDefault=false
 
 [Indent Param]
@@ -2587,7 +2588,7 @@ Category=2
 Description="<html>The continuation indent for func_*_param if they are true. If non-zero, this<br/>overrides the indent.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_param="
+CallName="indent_param\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2597,7 +2598,7 @@ Category=2
 Description="<html>How to use tabs when indenting code.<br/><br/>0: Spaces only<br/>1: Indent with tabs to brace level, align with spaces (default)<br/>2: Indent and align with tabs, using spaces when not on a tabstop<br/><br/>Default: 1</html>"
 Enabled=true
 EditorType=multiple
-Choices="indent_with_tabs=0|indent_with_tabs=1|indent_with_tabs=2"
+Choices="indent_with_tabs\s*=\s*0|indent_with_tabs\s*=\s*1|indent_with_tabs\s*=\s*2"
 ChoicesReadable="Spaces only|Indent with tabs, align with spaces|Indent and align with tabs"
 ValueDefault=1
 
@@ -2606,7 +2607,7 @@ Category=2
 Description="<html>Whether to indent comments that are not at a brace level with tabs on a<br/>tabstop. Requires indent_with_tabs=2. If false, will use spaces.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cmt_with_tabs=true|indent_cmt_with_tabs=false
+TrueFalse=indent_cmt_with_tabs\s*=\s*true|indent_cmt_with_tabs\s*=\s*false
 ValueDefault=false
 
 [Indent Align String]
@@ -2614,7 +2615,7 @@ Category=2
 Description="<html>Whether to indent strings broken by '\' so that they line up.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_align_string=true|indent_align_string=false
+TrueFalse=indent_align_string\s*=\s*true|indent_align_string\s*=\s*false
 ValueDefault=false
 
 [Indent Xml String]
@@ -2622,7 +2623,7 @@ Category=2
 Description="<html>The number of spaces to indent multi-line XML strings.<br/>Requires indent_align_string=true.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_xml_string="
+CallName="indent_xml_string\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2632,7 +2633,7 @@ Category=2
 Description="<html>Spaces to indent '{' from level.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_brace="
+CallName="indent_brace\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2642,7 +2643,7 @@ Category=2
 Description="<html>Whether braces are indented to the body level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_braces=true|indent_braces=false
+TrueFalse=indent_braces\s*=\s*true|indent_braces\s*=\s*false
 ValueDefault=false
 
 [Indent Braces No Func]
@@ -2650,7 +2651,7 @@ Category=2
 Description="<html>Whether to disable indenting function braces if indent_braces=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_braces_no_func=true|indent_braces_no_func=false
+TrueFalse=indent_braces_no_func\s*=\s*true|indent_braces_no_func\s*=\s*false
 ValueDefault=false
 
 [Indent Braces No Class]
@@ -2658,7 +2659,7 @@ Category=2
 Description="<html>Whether to disable indenting class braces if indent_braces=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_braces_no_class=true|indent_braces_no_class=false
+TrueFalse=indent_braces_no_class\s*=\s*true|indent_braces_no_class\s*=\s*false
 ValueDefault=false
 
 [Indent Braces No Struct]
@@ -2666,7 +2667,7 @@ Category=2
 Description="<html>Whether to disable indenting struct braces if indent_braces=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_braces_no_struct=true|indent_braces_no_struct=false
+TrueFalse=indent_braces_no_struct\s*=\s*true|indent_braces_no_struct\s*=\s*false
 ValueDefault=false
 
 [Indent Brace Parent]
@@ -2674,7 +2675,7 @@ Category=2
 Description="<html>Whether to indent based on the size of the brace parent,<br/>i.e. 'if' =&gt; 3 spaces, 'for' =&gt; 4 spaces, etc.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_brace_parent=true|indent_brace_parent=false
+TrueFalse=indent_brace_parent\s*=\s*true|indent_brace_parent\s*=\s*false
 ValueDefault=false
 
 [Indent Paren Open Brace]
@@ -2682,7 +2683,7 @@ Category=2
 Description="<html>Whether to indent based on the open parenthesis instead of the open brace<br/>in '({\n'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_open_brace=true|indent_paren_open_brace=false
+TrueFalse=indent_paren_open_brace\s*=\s*true|indent_paren_open_brace\s*=\s*false
 ValueDefault=false
 
 [Indent Cs Delegate Brace]
@@ -2690,7 +2691,7 @@ Category=2
 Description="<html>(C#) Whether to indent the brace of a C# delegate by another level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cs_delegate_brace=true|indent_cs_delegate_brace=false
+TrueFalse=indent_cs_delegate_brace\s*=\s*true|indent_cs_delegate_brace\s*=\s*false
 ValueDefault=false
 
 [Indent Cs Delegate Body]
@@ -2698,7 +2699,7 @@ Category=2
 Description="<html>(C#) Whether to indent a C# delegate (to handle delegates with no brace) by<br/>another level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cs_delegate_body=true|indent_cs_delegate_body=false
+TrueFalse=indent_cs_delegate_body\s*=\s*true|indent_cs_delegate_body\s*=\s*false
 ValueDefault=false
 
 [Indent Namespace]
@@ -2706,7 +2707,7 @@ Category=2
 Description="<html>Whether to indent the body of a 'namespace'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_namespace=true|indent_namespace=false
+TrueFalse=indent_namespace\s*=\s*true|indent_namespace\s*=\s*false
 ValueDefault=false
 
 [Indent Namespace Single Indent]
@@ -2714,7 +2715,7 @@ Category=2
 Description="<html>Whether to indent only the first namespace, and not any nested namespaces.<br/>Requires indent_namespace=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_namespace_single_indent=true|indent_namespace_single_indent=false
+TrueFalse=indent_namespace_single_indent\s*=\s*true|indent_namespace_single_indent\s*=\s*false
 ValueDefault=false
 
 [Indent Namespace Level]
@@ -2722,7 +2723,7 @@ Category=2
 Description="<html>The number of spaces to indent a namespace block.<br/>If set to zero, use the value indent_columns</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_namespace_level="
+CallName="indent_namespace_level\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2732,7 +2733,7 @@ Category=2
 Description="<html>If the body of the namespace is longer than this number, it won't be<br/>indented. Requires indent_namespace=true. 0 means no limit.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_namespace_limit="
+CallName="indent_namespace_limit\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -2742,7 +2743,7 @@ Category=2
 Description="<html>Whether to indent only in inner namespaces (nested in other namespaces).<br/>Requires indent_namespace=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_namespace_inner_only=true|indent_namespace_inner_only=false
+TrueFalse=indent_namespace_inner_only\s*=\s*true|indent_namespace_inner_only\s*=\s*false
 ValueDefault=false
 
 [Indent Extern]
@@ -2750,7 +2751,7 @@ Category=2
 Description="<html>Whether the 'extern "C"' body is indented.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_extern=true|indent_extern=false
+TrueFalse=indent_extern\s*=\s*true|indent_extern\s*=\s*false
 ValueDefault=false
 
 [Indent Class]
@@ -2758,7 +2759,7 @@ Category=2
 Description="<html>Whether the 'class' body is indented.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_class=true|indent_class=false
+TrueFalse=indent_class\s*=\s*true|indent_class\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Before Class Colon]
@@ -2766,7 +2767,7 @@ Category=2
 Description="<html>Whether to ignore indent for the leading base class colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_before_class_colon=true|indent_ignore_before_class_colon=false
+TrueFalse=indent_ignore_before_class_colon\s*=\s*true|indent_ignore_before_class_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Before Class Colon]
@@ -2774,7 +2775,7 @@ Category=2
 Description="<html>Additional indent before the leading base class colon.<br/>Negative values decrease indent down to the first column.<br/>Requires indent_ignore_before_class_colon=false and a newline break before<br/>the colon (see pos_class_colon and nl_class_colon)</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_before_class_colon="
+CallName="indent_before_class_colon\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -2784,7 +2785,7 @@ Category=2
 Description="<html>Whether to indent the stuff after a leading base class colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_class_colon=true|indent_class_colon=false
+TrueFalse=indent_class_colon\s*=\s*true|indent_class_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Class On Colon]
@@ -2792,7 +2793,7 @@ Category=2
 Description="<html>Whether to indent based on a class colon instead of the stuff after the<br/>colon. Requires indent_class_colon=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_class_on_colon=true|indent_class_on_colon=false
+TrueFalse=indent_class_on_colon\s*=\s*true|indent_class_on_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Before Constr Colon]
@@ -2800,7 +2801,7 @@ Category=2
 Description="<html>Whether to ignore indent for a leading class initializer colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_before_constr_colon=true|indent_ignore_before_constr_colon=false
+TrueFalse=indent_ignore_before_constr_colon\s*=\s*true|indent_ignore_before_constr_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Constr Colon]
@@ -2808,7 +2809,7 @@ Category=2
 Description="<html>Whether to indent the stuff after a leading class initializer colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_constr_colon=true|indent_constr_colon=false
+TrueFalse=indent_constr_colon\s*=\s*true|indent_constr_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Ctor Init Leading]
@@ -2816,7 +2817,7 @@ Category=2
 Description="<html>Virtual indent from the ':' for leading member initializers.<br/><br/>Default: 2</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_ctor_init_leading="
+CallName="indent_ctor_init_leading\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=2
@@ -2826,7 +2827,7 @@ Category=2
 Description="<html>Virtual indent from the ':' for following member initializers.<br/><br/>Default: 2</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_ctor_init_following="
+CallName="indent_ctor_init_following\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=2
@@ -2836,7 +2837,7 @@ Category=2
 Description="<html>Additional indent for constructor initializer list.<br/>Negative values decrease indent down to the first column.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_ctor_init="
+CallName="indent_ctor_init\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -2846,7 +2847,7 @@ Category=2
 Description="<html>Whether to indent 'if' following 'else' as a new block under the 'else'.<br/>If false, 'else\nif' is treated as 'else if' for indenting purposes.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_else_if=true|indent_else_if=false
+TrueFalse=indent_else_if\s*=\s*true|indent_else_if\s*=\s*false
 ValueDefault=false
 
 [Indent Var Def Blk]
@@ -2854,7 +2855,7 @@ Category=2
 Description="<html>Amount to indent variable declarations after a open brace.<br/><br/> &lt;0: Relative<br/>&gt;=0: Absolute</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_var_def_blk="
+CallName="indent_var_def_blk\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -2864,7 +2865,7 @@ Category=2
 Description="<html>Whether to indent continued variable declarations instead of aligning.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_var_def_cont=true|indent_var_def_cont=false
+TrueFalse=indent_var_def_cont\s*=\s*true|indent_var_def_cont\s*=\s*false
 ValueDefault=false
 
 [Indent Shift]
@@ -2872,7 +2873,7 @@ Category=2
 Description="<html>How to indent continued shift expressions ('&lt;&lt;' and '&gt;&gt;').<br/>Set align_left_shift=false when using this.<br/> 0: Align shift operators instead of indenting them (default)<br/> 1: Indent by one level<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_shift="
+CallName="indent_shift\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=0
@@ -2882,7 +2883,7 @@ Category=2
 Description="<html>Whether to force indentation of function definitions to start in column 1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_def_force_col1=true|indent_func_def_force_col1=false
+TrueFalse=indent_func_def_force_col1\s*=\s*true|indent_func_def_force_col1\s*=\s*false
 ValueDefault=false
 
 [Indent Func Call Param]
@@ -2890,7 +2891,7 @@ Category=2
 Description="<html>Whether to indent continued function call parameters one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_call_param=true|indent_func_call_param=false
+TrueFalse=indent_func_call_param\s*=\s*true|indent_func_call_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Def Param]
@@ -2898,7 +2899,7 @@ Category=2
 Description="<html>Whether to indent continued function definition parameters one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_def_param=true|indent_func_def_param=false
+TrueFalse=indent_func_def_param\s*=\s*true|indent_func_def_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Def Param Paren Pos Threshold]
@@ -2906,7 +2907,7 @@ Category=2
 Description="<html>for function definitions, only if indent_func_def_param is false<br/>Allows to align params when appropriate and indent them when not<br/>behave as if it was true if paren position is more than this value<br/>if paren position is more than the option value</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_func_def_param_paren_pos_threshold="
+CallName="indent_func_def_param_paren_pos_threshold\s*=\s*"
 MinVal=0
 MaxVal=160
 ValueDefault=0
@@ -2916,7 +2917,7 @@ Category=2
 Description="<html>Whether to indent continued function call prototype one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_proto_param=true|indent_func_proto_param=false
+TrueFalse=indent_func_proto_param\s*=\s*true|indent_func_proto_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Class Param]
@@ -2924,7 +2925,7 @@ Category=2
 Description="<html>Whether to indent continued function call declaration one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_class_param=true|indent_func_class_param=false
+TrueFalse=indent_func_class_param\s*=\s*true|indent_func_class_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Ctor Var Param]
@@ -2932,7 +2933,7 @@ Category=2
 Description="<html>Whether to indent continued class variable constructors one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_ctor_var_param=true|indent_func_ctor_var_param=false
+TrueFalse=indent_func_ctor_var_param\s*=\s*true|indent_func_ctor_var_param\s*=\s*false
 ValueDefault=false
 
 [Indent Template Param]
@@ -2940,7 +2941,7 @@ Category=2
 Description="<html>Whether to indent continued template parameter list one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_template_param=true|indent_template_param=false
+TrueFalse=indent_template_param\s*=\s*true|indent_template_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Param Double]
@@ -2948,7 +2949,7 @@ Category=2
 Description="<html>Double the indent for indent_func_xxx_param options.<br/>Use both values of the options indent_columns and indent_param.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_param_double=true|indent_func_param_double=false
+TrueFalse=indent_func_param_double\s*=\s*true|indent_func_param_double\s*=\s*false
 ValueDefault=false
 
 [Indent Func Const]
@@ -2956,7 +2957,7 @@ Category=2
 Description="<html>Indentation column for standalone 'const' qualifier on a function<br/>prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_func_const="
+CallName="indent_func_const\s*=\s*"
 MinVal=0
 MaxVal=69
 ValueDefault=0
@@ -2966,7 +2967,7 @@ Category=2
 Description="<html>Indentation column for standalone 'throw' qualifier on a function<br/>prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_func_throw="
+CallName="indent_func_throw\s*=\s*"
 MinVal=0
 MaxVal=41
 ValueDefault=0
@@ -2976,7 +2977,7 @@ Category=2
 Description="<html>How to indent within a macro followed by a brace on the same line<br/>This allows reducing the indent in macros that have (for example)<br/>`do { ... } while ` blocks bracketing them.<br/><br/>true:  add an indent for the brace on the same line as the macro<br/>false: do not add an indent for the brace on the same line as the macro<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_macro_brace=true|indent_macro_brace=false
+TrueFalse=indent_macro_brace\s*=\s*true|indent_macro_brace\s*=\s*false
 ValueDefault=true
 
 [Indent Member]
@@ -2984,7 +2985,7 @@ Category=2
 Description="<html>The number of spaces to indent a continued '-&gt;' or '.'.<br/>Usually set to 0, 1, or indent_columns.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_member="
+CallName="indent_member\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2994,7 +2995,7 @@ Category=2
 Description="<html>Whether lines broken at '.' or '-&gt;' should be indented by a single indent.<br/>The indent_member option will not be effective if this is set to true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_member_single=true|indent_member_single=false
+TrueFalse=indent_member_single\s*=\s*true|indent_member_single\s*=\s*false
 ValueDefault=false
 
 [Indent Single Line Comments Before]
@@ -3002,7 +3003,7 @@ Category=2
 Description="<html>Spaces to indent single line ('//') comments on lines before code.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_single_line_comments_before="
+CallName="indent_single_line_comments_before\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3012,7 +3013,7 @@ Category=2
 Description="<html>Spaces to indent single line ('//') comments on lines after code.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_single_line_comments_after="
+CallName="indent_single_line_comments_after\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3022,7 +3023,7 @@ Category=2
 Description="<html>When opening a paren for a control statement (if, for, while, etc), increase<br/>the indent level by this value. Negative values decrease the indent level.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_sparen_extra="
+CallName="indent_sparen_extra\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -3032,7 +3033,7 @@ Category=2
 Description="<html>Whether to indent trailing single line ('//') comments relative to the code<br/>instead of trying to keep the same absolute column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_relative_single_line_comments=true|indent_relative_single_line_comments=false
+TrueFalse=indent_relative_single_line_comments\s*=\s*true|indent_relative_single_line_comments\s*=\s*false
 ValueDefault=false
 
 [Indent Switch Case]
@@ -3040,7 +3041,7 @@ Category=2
 Description="<html>Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.<br/>It might be wise to choose the same value for the option indent_case_brace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_switch_case="
+CallName="indent_switch_case\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3050,7 +3051,7 @@ Category=2
 Description="<html>Spaces to indent the body of a 'switch' before any 'case'.<br/>Usually the same as indent_columns or indent_switch_case.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_switch_body="
+CallName="indent_switch_body\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3060,7 +3061,7 @@ Category=2
 Description="<html>Whether to ignore indent for '{' following 'case'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_case_brace=true|indent_ignore_case_brace=false
+TrueFalse=indent_ignore_case_brace\s*=\s*true|indent_ignore_case_brace\s*=\s*false
 ValueDefault=false
 
 [Indent Case Brace]
@@ -3068,7 +3069,7 @@ Category=2
 Description="<html>Spaces to indent '{' from 'case'. By default, the brace will appear under<br/>the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.<br/>It might be wise to choose the same value for the option indent_switch_case.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_case_brace="
+CallName="indent_case_brace\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -3078,7 +3079,7 @@ Category=2
 Description="<html>indent 'break' with 'case' from 'switch'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_switch_break_with_case=true|indent_switch_break_with_case=false
+TrueFalse=indent_switch_break_with_case\s*=\s*true|indent_switch_break_with_case\s*=\s*false
 ValueDefault=false
 
 [Indent Switch Pp]
@@ -3086,7 +3087,7 @@ Category=2
 Description="<html>Whether to indent preprocessor statements inside of switch statements.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_switch_pp=true|indent_switch_pp=false
+TrueFalse=indent_switch_pp\s*=\s*true|indent_switch_pp\s*=\s*false
 ValueDefault=true
 
 [Indent Case Shift]
@@ -3094,7 +3095,7 @@ Category=2
 Description="<html>Spaces to shift the 'case' line, without affecting any other lines.<br/>Usually 0.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_case_shift="
+CallName="indent_case_shift\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3104,7 +3105,7 @@ Category=2
 Description="<html>Whether to align comments before 'case' with the 'case'.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_case_comment=true|indent_case_comment=false
+TrueFalse=indent_case_comment\s*=\s*true|indent_case_comment\s*=\s*false
 ValueDefault=true
 
 [Indent Comment]
@@ -3112,7 +3113,7 @@ Category=2
 Description="<html>Whether to indent comments not found in first column.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_comment=true|indent_comment=false
+TrueFalse=indent_comment\s*=\s*true|indent_comment\s*=\s*false
 ValueDefault=true
 
 [Indent Col1 Comment]
@@ -3120,7 +3121,7 @@ Category=2
 Description="<html>Whether to indent comments found in first column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_col1_comment=true|indent_col1_comment=false
+TrueFalse=indent_col1_comment\s*=\s*true|indent_col1_comment\s*=\s*false
 ValueDefault=false
 
 [Indent Col1 Multi String Literal]
@@ -3128,7 +3129,7 @@ Category=2
 Description="<html>Whether to indent multi string literal in first column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_col1_multi_string_literal=true|indent_col1_multi_string_literal=false
+TrueFalse=indent_col1_multi_string_literal\s*=\s*true|indent_col1_multi_string_literal\s*=\s*false
 ValueDefault=false
 
 [Indent Comment Align Thresh]
@@ -3136,7 +3137,7 @@ Category=2
 Description="<html>Align comments on adjacent lines that are this many columns apart or less.<br/><br/>Default: 3</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_comment_align_thresh="
+CallName="indent_comment_align_thresh\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=3
@@ -3146,7 +3147,7 @@ Category=2
 Description="<html>Whether to ignore indent for goto labels.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_label=true|indent_ignore_label=false
+TrueFalse=indent_ignore_label\s*=\s*true|indent_ignore_label\s*=\s*false
 ValueDefault=false
 
 [Indent Label]
@@ -3154,7 +3155,7 @@ Category=2
 Description="<html>How to indent goto labels. Requires indent_ignore_label=false.<br/><br/> &gt;0: Absolute column where 1 is the leftmost column<br/>&lt;=0: Subtract from brace indent<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_label="
+CallName="indent_label\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=1
@@ -3164,7 +3165,7 @@ Category=2
 Description="<html>How to indent access specifiers that are followed by a<br/>colon.<br/><br/> &gt;0: Absolute column where 1 is the leftmost column<br/>&lt;=0: Subtract from brace indent<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_access_spec="
+CallName="indent_access_spec\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=1
@@ -3174,7 +3175,7 @@ Category=2
 Description="<html>Whether to indent the code after an access specifier by one level.<br/>If true, this option forces 'indent_access_spec=0'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_access_spec_body=true|indent_access_spec_body=false
+TrueFalse=indent_access_spec_body\s*=\s*true|indent_access_spec_body\s*=\s*false
 ValueDefault=false
 
 [Indent Paren Nl]
@@ -3182,7 +3183,7 @@ Category=2
 Description="<html>If an open parenthesis is followed by a newline, whether to indent the next<br/>line so that it lines up after the open parenthesis (not recommended).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_nl=true|indent_paren_nl=false
+TrueFalse=indent_paren_nl\s*=\s*true|indent_paren_nl\s*=\s*false
 ValueDefault=false
 
 [Indent Paren Close]
@@ -3190,7 +3191,7 @@ Category=2
 Description="<html>How to indent a close parenthesis after a newline.<br/><br/> 0: Indent to body level (default)<br/> 1: Align under the open parenthesis<br/> 2: Indent to the brace level<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_paren_close="
+CallName="indent_paren_close\s*=\s*"
 MinVal=-1
 MaxVal=2
 ValueDefault=0
@@ -3200,7 +3201,7 @@ Category=2
 Description="<html>Whether to indent the open parenthesis of a function definition,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_after_func_def=true|indent_paren_after_func_def=false
+TrueFalse=indent_paren_after_func_def\s*=\s*true|indent_paren_after_func_def\s*=\s*false
 ValueDefault=false
 
 [Indent Paren After Func Decl]
@@ -3208,7 +3209,7 @@ Category=2
 Description="<html>Whether to indent the open parenthesis of a function declaration,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_after_func_decl=true|indent_paren_after_func_decl=false
+TrueFalse=indent_paren_after_func_decl\s*=\s*true|indent_paren_after_func_decl\s*=\s*false
 ValueDefault=false
 
 [Indent Paren After Func Call]
@@ -3216,7 +3217,7 @@ Category=2
 Description="<html>Whether to indent the open parenthesis of a function call,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_after_func_call=true|indent_paren_after_func_call=false
+TrueFalse=indent_paren_after_func_call\s*=\s*true|indent_paren_after_func_call\s*=\s*false
 ValueDefault=false
 
 [Indent Comma Brace]
@@ -3224,7 +3225,7 @@ Category=2
 Description="<html>How to indent a comma when inside braces.<br/> 0: Indent by one level (default)<br/> 1: Align under the open brace<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_comma_brace="
+CallName="indent_comma_brace\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=0
@@ -3234,7 +3235,7 @@ Category=2
 Description="<html>How to indent a comma when inside parentheses.<br/> 0: Indent by one level (default)<br/> 1: Align under the open parenthesis<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_comma_paren="
+CallName="indent_comma_paren\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=0
@@ -3244,7 +3245,7 @@ Category=2
 Description="<html>How to indent a Boolean operator when inside parentheses.<br/> 0: Indent by one level (default)<br/> 1: Align under the open parenthesis<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_bool_paren="
+CallName="indent_bool_paren\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=0
@@ -3254,7 +3255,7 @@ Category=2
 Description="<html>Whether to ignore the indentation of a Boolean operator when outside<br/>parentheses.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_bool=true|indent_ignore_bool=false
+TrueFalse=indent_ignore_bool\s*=\s*true|indent_ignore_bool\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Arith]
@@ -3262,7 +3263,7 @@ Category=2
 Description="<html>Whether to ignore the indentation of an arithmetic operator.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_arith=true|indent_ignore_arith=false
+TrueFalse=indent_ignore_arith\s*=\s*true|indent_ignore_arith\s*=\s*false
 ValueDefault=false
 
 [Indent Semicolon For Paren]
@@ -3270,7 +3271,7 @@ Category=2
 Description="<html>Whether to indent a semicolon when inside a for parenthesis.<br/>If true, aligns under the open for parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_semicolon_for_paren=true|indent_semicolon_for_paren=false
+TrueFalse=indent_semicolon_for_paren\s*=\s*true|indent_semicolon_for_paren\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Semicolon]
@@ -3278,7 +3279,7 @@ Category=2
 Description="<html>Whether to ignore the indentation of a semicolon outside of a 'for'<br/>statement.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_semicolon=true|indent_ignore_semicolon=false
+TrueFalse=indent_ignore_semicolon\s*=\s*true|indent_ignore_semicolon\s*=\s*false
 ValueDefault=false
 
 [Indent First Bool Expr]
@@ -3286,7 +3287,7 @@ Category=2
 Description="<html>Whether to align the first expression to following ones<br/>if indent_bool_paren=1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_first_bool_expr=true|indent_first_bool_expr=false
+TrueFalse=indent_first_bool_expr\s*=\s*true|indent_first_bool_expr\s*=\s*false
 ValueDefault=false
 
 [Indent First For Expr]
@@ -3294,7 +3295,7 @@ Category=2
 Description="<html>Whether to align the first expression to following ones<br/>if indent_semicolon_for_paren=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_first_for_expr=true|indent_first_for_expr=false
+TrueFalse=indent_first_for_expr\s*=\s*true|indent_first_for_expr\s*=\s*false
 ValueDefault=false
 
 [Indent Square Nl]
@@ -3302,7 +3303,7 @@ Category=2
 Description="<html>If an open square is followed by a newline, whether to indent the next line<br/>so that it lines up after the open square (not recommended).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_square_nl=true|indent_square_nl=false
+TrueFalse=indent_square_nl\s*=\s*true|indent_square_nl\s*=\s*false
 ValueDefault=false
 
 [Indent Preserve Sql]
@@ -3310,7 +3311,7 @@ Category=2
 Description="<html>(ESQL/C) Whether to preserve the relative indent of 'EXEC SQL' bodies.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_preserve_sql=true|indent_preserve_sql=false
+TrueFalse=indent_preserve_sql\s*=\s*true|indent_preserve_sql\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Assign]
@@ -3318,7 +3319,7 @@ Category=2
 Description="<html>Whether to ignore the indentation of an assignment operator.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_assign=true|indent_ignore_assign=false
+TrueFalse=indent_ignore_assign\s*=\s*true|indent_ignore_assign\s*=\s*false
 ValueDefault=false
 
 [Indent Align Assign]
@@ -3326,7 +3327,7 @@ Category=2
 Description="<html>Whether to align continued statements at the '='. If false or if the '=' is<br/>followed by a newline, the next line is indent one tab.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_align_assign=true|indent_align_assign=false
+TrueFalse=indent_align_assign\s*=\s*true|indent_align_assign\s*=\s*false
 ValueDefault=true
 
 [Indent Off After Assign]
@@ -3334,7 +3335,7 @@ Category=2
 Description="<html>If true, the indentation of the chunks after a '=' sequence will be set at<br/>LHS token indentation column before '='.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_off_after_assign=true|indent_off_after_assign=false
+TrueFalse=indent_off_after_assign\s*=\s*true|indent_off_after_assign\s*=\s*false
 ValueDefault=false
 
 [Indent Align Paren]
@@ -3342,7 +3343,7 @@ Category=2
 Description="<html>Whether to align continued statements at the '('. If false or the '(' is<br/>followed by a newline, the next line indent is one tab.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_align_paren=true|indent_align_paren=false
+TrueFalse=indent_align_paren\s*=\s*true|indent_align_paren\s*=\s*false
 ValueDefault=true
 
 [Indent Oc Inside Msg Sel]
@@ -3350,7 +3351,7 @@ Category=2
 Description="<html>(OC) Whether to indent Objective-C code inside message selectors.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_inside_msg_sel=true|indent_oc_inside_msg_sel=false
+TrueFalse=indent_oc_inside_msg_sel\s*=\s*true|indent_oc_inside_msg_sel\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block]
@@ -3358,7 +3359,7 @@ Category=2
 Description="<html>(OC) Whether to indent Objective-C blocks at brace level instead of usual<br/>rules.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block=true|indent_oc_block=false
+TrueFalse=indent_oc_block\s*=\s*true|indent_oc_block\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg]
@@ -3366,7 +3367,7 @@ Category=2
 Description="<html>(OC) Indent for Objective-C blocks in a message relative to the parameter<br/>name.<br/><br/>=0: Use indent_oc_block rules<br/>&gt;0: Use specified number of spaces to indent</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_oc_block_msg="
+CallName="indent_oc_block_msg\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3376,7 +3377,7 @@ Category=2
 Description="<html>(OC) Minimum indent for subsequent parameters</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_oc_msg_colon="
+CallName="indent_oc_msg_colon\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -3386,7 +3387,7 @@ Category=2
 Description="<html>(OC) Whether to prioritize aligning with initial colon (and stripping spaces<br/>from lines, if necessary).<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_msg_prioritize_first_colon=true|indent_oc_msg_prioritize_first_colon=false
+TrueFalse=indent_oc_msg_prioritize_first_colon\s*=\s*true|indent_oc_msg_prioritize_first_colon\s*=\s*false
 ValueDefault=true
 
 [Indent Oc Block Msg Xcode Style]
@@ -3394,7 +3395,7 @@ Category=2
 Description="<html>(OC) Whether to indent blocks the way that Xcode does by default<br/>(from the keyword if the parameter is on its own line; otherwise, from the<br/>previous indentation level). Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_xcode_style=true|indent_oc_block_msg_xcode_style=false
+TrueFalse=indent_oc_block_msg_xcode_style\s*=\s*true|indent_oc_block_msg_xcode_style\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg From Keyword]
@@ -3402,7 +3403,7 @@ Category=2
 Description="<html>(OC) Whether to indent blocks from where the brace is, relative to a<br/>message keyword. Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_from_keyword=true|indent_oc_block_msg_from_keyword=false
+TrueFalse=indent_oc_block_msg_from_keyword\s*=\s*true|indent_oc_block_msg_from_keyword\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg From Colon]
@@ -3410,7 +3411,7 @@ Category=2
 Description="<html>(OC) Whether to indent blocks from where the brace is, relative to a message<br/>colon. Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_from_colon=true|indent_oc_block_msg_from_colon=false
+TrueFalse=indent_oc_block_msg_from_colon\s*=\s*true|indent_oc_block_msg_from_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg From Caret]
@@ -3418,7 +3419,7 @@ Category=2
 Description="<html>(OC) Whether to indent blocks from where the block caret is.<br/>Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_from_caret=true|indent_oc_block_msg_from_caret=false
+TrueFalse=indent_oc_block_msg_from_caret\s*=\s*true|indent_oc_block_msg_from_caret\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg From Brace]
@@ -3426,7 +3427,7 @@ Category=2
 Description="<html>(OC) Whether to indent blocks from where the brace caret is.<br/>Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_from_brace=true|indent_oc_block_msg_from_brace=false
+TrueFalse=indent_oc_block_msg_from_brace\s*=\s*true|indent_oc_block_msg_from_brace\s*=\s*false
 ValueDefault=false
 
 [Indent Min Vbrace Open]
@@ -3434,7 +3435,7 @@ Category=2
 Description="<html>When indenting after virtual brace open and newline add further spaces to<br/>reach this minimum indent.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_min_vbrace_open="
+CallName="indent_min_vbrace_open\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3444,7 +3445,7 @@ Category=2
 Description="<html>Whether to add further spaces after regular indent to reach next tabstop<br/>when indenting after virtual brace open and newline.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_vbrace_open_on_tabstop=true|indent_vbrace_open_on_tabstop=false
+TrueFalse=indent_vbrace_open_on_tabstop\s*=\s*true|indent_vbrace_open_on_tabstop\s*=\s*false
 ValueDefault=false
 
 [Indent Token After Brace]
@@ -3452,7 +3453,7 @@ Category=2
 Description="<html>How to indent after a brace followed by another token (not a newline).<br/>true:  indent all contained lines to match the token<br/>false: indent all contained lines to match the brace<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_token_after_brace=true|indent_token_after_brace=false
+TrueFalse=indent_token_after_brace\s*=\s*true|indent_token_after_brace\s*=\s*false
 ValueDefault=true
 
 [Indent Cpp Lambda Body]
@@ -3460,7 +3461,7 @@ Category=2
 Description="<html>Whether to indent the body of a C++11 lambda.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cpp_lambda_body=true|indent_cpp_lambda_body=false
+TrueFalse=indent_cpp_lambda_body\s*=\s*true|indent_cpp_lambda_body\s*=\s*false
 ValueDefault=false
 
 [Indent Compound Literal Return]
@@ -3468,7 +3469,7 @@ Category=2
 Description="<html>How to indent compound literals that are being returned.<br/>true: add both the indent from return &amp; the compound literal open brace<br/>      (i.e. 2 indent levels)<br/>false: only indent 1 level, don't add the indent for the open brace, only<br/>       add the indent for the return.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_compound_literal_return=true|indent_compound_literal_return=false
+TrueFalse=indent_compound_literal_return\s*=\s*true|indent_compound_literal_return\s*=\s*false
 ValueDefault=true
 
 [Indent Using Block]
@@ -3476,7 +3477,7 @@ Category=2
 Description="<html>(C#) Whether to indent a 'using' block if no braces are used.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_using_block=true|indent_using_block=false
+TrueFalse=indent_using_block\s*=\s*true|indent_using_block\s*=\s*false
 ValueDefault=true
 
 [Indent Ternary Operator]
@@ -3484,7 +3485,7 @@ Category=2
 Description="<html>How to indent the continuation of ternary operator.<br/><br/>0: Off (default)<br/>1: When the `if_false` is a continuation, indent it under the `if_true` branch<br/>2: When the `:` is a continuation, indent it under `?`</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_ternary_operator="
+CallName="indent_ternary_operator\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -3494,7 +3495,7 @@ Category=2
 Description="<html>Whether to indent the statements inside ternary operator.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_inside_ternary_operator=true|indent_inside_ternary_operator=false
+TrueFalse=indent_inside_ternary_operator\s*=\s*true|indent_inside_ternary_operator\s*=\s*false
 ValueDefault=false
 
 [Indent Off After Return]
@@ -3502,7 +3503,7 @@ Category=2
 Description="<html>If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_off_after_return=true|indent_off_after_return=false
+TrueFalse=indent_off_after_return\s*=\s*true|indent_off_after_return\s*=\s*false
 ValueDefault=false
 
 [Indent Off After Return New]
@@ -3510,7 +3511,7 @@ Category=2
 Description="<html>If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_off_after_return_new=true|indent_off_after_return_new=false
+TrueFalse=indent_off_after_return_new\s*=\s*true|indent_off_after_return_new\s*=\s*false
 ValueDefault=false
 
 [Indent Single After Return]
@@ -3518,7 +3519,7 @@ Category=2
 Description="<html>If true, the tokens after return are indented with regular single indentation. By default (false) the indentation is after the return token.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_single_after_return=true|indent_single_after_return=false
+TrueFalse=indent_single_after_return\s*=\s*true|indent_single_after_return\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Asm Block]
@@ -3526,7 +3527,7 @@ Category=2
 Description="<html>Whether to ignore indent and alignment for 'asm' blocks (i.e. assume they<br/>have their own indentation).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_asm_block=true|indent_ignore_asm_block=false
+TrueFalse=indent_ignore_asm_block\s*=\s*true|indent_ignore_asm_block\s*=\s*false
 ValueDefault=false
 
 [Donot Indent Func Def Close Paren]
@@ -3534,7 +3535,7 @@ Category=2
 Description="<html>Don't indent the close parenthesis of a function definition,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=donot_indent_func_def_close_paren=true|donot_indent_func_def_close_paren=false
+TrueFalse=donot_indent_func_def_close_paren\s*=\s*true|donot_indent_func_def_close_paren\s*=\s*false
 ValueDefault=false
 
 [Nl Collapse Empty Body]
@@ -3542,7 +3543,7 @@ Category=3
 Description="<html>Whether to collapse empty blocks between '{' and '}' except for functions.<br/>Use nl_collapse_empty_body_functions to specify how empty function braces<br/>should be formatted.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_collapse_empty_body=true|nl_collapse_empty_body=false
+TrueFalse=nl_collapse_empty_body\s*=\s*true|nl_collapse_empty_body\s*=\s*false
 ValueDefault=false
 
 [Nl Collapse Empty Body Functions]
@@ -3550,7 +3551,7 @@ Category=3
 Description="<html>Whether to collapse empty blocks between '{' and '}' for functions only.<br/>If true, overrides nl_inside_empty_func.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_collapse_empty_body_functions=true|nl_collapse_empty_body_functions=false
+TrueFalse=nl_collapse_empty_body_functions\s*=\s*true|nl_collapse_empty_body_functions\s*=\s*false
 ValueDefault=false
 
 [Nl Assign Leave One Liners]
@@ -3558,7 +3559,7 @@ Category=3
 Description="<html>Don't split one-line braced assignments, as in 'foo_t f = { 1, 2 };'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_assign_leave_one_liners=true|nl_assign_leave_one_liners=false
+TrueFalse=nl_assign_leave_one_liners\s*=\s*true|nl_assign_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Class Leave One Liners]
@@ -3566,7 +3567,7 @@ Category=3
 Description="<html>Don't split one-line braced statements inside a 'class xx { }' body.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_class_leave_one_liners=true|nl_class_leave_one_liners=false
+TrueFalse=nl_class_leave_one_liners\s*=\s*true|nl_class_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Enum Leave One Liners]
@@ -3574,7 +3575,7 @@ Category=3
 Description="<html>Don't split one-line enums, as in 'enum foo { BAR = 15 };'</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_enum_leave_one_liners=true|nl_enum_leave_one_liners=false
+TrueFalse=nl_enum_leave_one_liners\s*=\s*true|nl_enum_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Getset Leave One Liners]
@@ -3582,7 +3583,7 @@ Category=3
 Description="<html>Don't split one-line get or set functions.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_getset_leave_one_liners=true|nl_getset_leave_one_liners=false
+TrueFalse=nl_getset_leave_one_liners\s*=\s*true|nl_getset_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Cs Property Leave One Liners]
@@ -3590,7 +3591,7 @@ Category=3
 Description="<html>(C#) Don't split one-line property get or set functions.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_cs_property_leave_one_liners=true|nl_cs_property_leave_one_liners=false
+TrueFalse=nl_cs_property_leave_one_liners\s*=\s*true|nl_cs_property_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Func Leave One Liners]
@@ -3598,7 +3599,7 @@ Category=3
 Description="<html>Don't split one-line function definitions, as in 'int foo() { return 0; }'.<br/>might modify nl_func_type_name</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_leave_one_liners=true|nl_func_leave_one_liners=false
+TrueFalse=nl_func_leave_one_liners\s*=\s*true|nl_func_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Cpp Lambda Leave One Liners]
@@ -3606,7 +3607,7 @@ Category=3
 Description="<html>Don't split one-line C++11 lambdas, as in '[]() { return 0; }'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_cpp_lambda_leave_one_liners=true|nl_cpp_lambda_leave_one_liners=false
+TrueFalse=nl_cpp_lambda_leave_one_liners\s*=\s*true|nl_cpp_lambda_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl If Leave One Liners]
@@ -3614,7 +3615,7 @@ Category=3
 Description="<html>Don't split one-line if/else statements, as in 'if(...) b++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_if_leave_one_liners=true|nl_if_leave_one_liners=false
+TrueFalse=nl_if_leave_one_liners\s*=\s*true|nl_if_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl While Leave One Liners]
@@ -3622,7 +3623,7 @@ Category=3
 Description="<html>Don't split one-line while statements, as in 'while(...) b++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_while_leave_one_liners=true|nl_while_leave_one_liners=false
+TrueFalse=nl_while_leave_one_liners\s*=\s*true|nl_while_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Do Leave One Liners]
@@ -3630,7 +3631,7 @@ Category=3
 Description="<html>Don't split one-line do statements, as in 'do { b++; } while(...);'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_do_leave_one_liners=true|nl_do_leave_one_liners=false
+TrueFalse=nl_do_leave_one_liners\s*=\s*true|nl_do_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl For Leave One Liners]
@@ -3638,7 +3639,7 @@ Category=3
 Description="<html>Don't split one-line for statements, as in 'for(...) b++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_for_leave_one_liners=true|nl_for_leave_one_liners=false
+TrueFalse=nl_for_leave_one_liners\s*=\s*true|nl_for_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Oc Msg Leave One Liner]
@@ -3646,7 +3647,7 @@ Category=3
 Description="<html>(OC) Don't split one-line Objective-C messages.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_oc_msg_leave_one_liner=true|nl_oc_msg_leave_one_liner=false
+TrueFalse=nl_oc_msg_leave_one_liner\s*=\s*true|nl_oc_msg_leave_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Oc Mdef Brace]
@@ -3654,7 +3655,7 @@ Category=3
 Description="<html>(OC) Add or remove newline between method declaration and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_mdef_brace=ignore|nl_oc_mdef_brace=add|nl_oc_mdef_brace=remove|nl_oc_mdef_brace=force|nl_oc_mdef_brace=not_defined
+Choices=nl_oc_mdef_brace\s*=\s*ignore|nl_oc_mdef_brace\s*=\s*add|nl_oc_mdef_brace\s*=\s*remove|nl_oc_mdef_brace\s*=\s*force|nl_oc_mdef_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Mdef Brace|Add Nl Oc Mdef Brace|Remove Nl Oc Mdef Brace|Force Nl Oc Mdef Brace"
 ValueDefault=ignore
 
@@ -3663,7 +3664,7 @@ Category=3
 Description="<html>(OC) Add or remove newline between Objective-C block signature and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_block_brace=ignore|nl_oc_block_brace=add|nl_oc_block_brace=remove|nl_oc_block_brace=force|nl_oc_block_brace=not_defined
+Choices=nl_oc_block_brace\s*=\s*ignore|nl_oc_block_brace\s*=\s*add|nl_oc_block_brace\s*=\s*remove|nl_oc_block_brace\s*=\s*force|nl_oc_block_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Block Brace|Add Nl Oc Block Brace|Remove Nl Oc Block Brace|Force Nl Oc Block Brace"
 ValueDefault=ignore
 
@@ -3672,7 +3673,7 @@ Category=3
 Description="<html>(OC) Add or remove blank line before '@interface' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_before_interface=ignore|nl_oc_before_interface=add|nl_oc_before_interface=remove|nl_oc_before_interface=force|nl_oc_before_interface=not_defined
+Choices=nl_oc_before_interface\s*=\s*ignore|nl_oc_before_interface\s*=\s*add|nl_oc_before_interface\s*=\s*remove|nl_oc_before_interface\s*=\s*force|nl_oc_before_interface\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Before Interface|Add Nl Oc Before Interface|Remove Nl Oc Before Interface|Force Nl Oc Before Interface"
 ValueDefault=ignore
 
@@ -3681,7 +3682,7 @@ Category=3
 Description="<html>(OC) Add or remove blank line before '@implementation' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_before_implementation=ignore|nl_oc_before_implementation=add|nl_oc_before_implementation=remove|nl_oc_before_implementation=force|nl_oc_before_implementation=not_defined
+Choices=nl_oc_before_implementation\s*=\s*ignore|nl_oc_before_implementation\s*=\s*add|nl_oc_before_implementation\s*=\s*remove|nl_oc_before_implementation\s*=\s*force|nl_oc_before_implementation\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Before Implementation|Add Nl Oc Before Implementation|Remove Nl Oc Before Implementation|Force Nl Oc Before Implementation"
 ValueDefault=ignore
 
@@ -3690,7 +3691,7 @@ Category=3
 Description="<html>(OC) Add or remove blank line before '@end' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_before_end=ignore|nl_oc_before_end=add|nl_oc_before_end=remove|nl_oc_before_end=force|nl_oc_before_end=not_defined
+Choices=nl_oc_before_end\s*=\s*ignore|nl_oc_before_end\s*=\s*add|nl_oc_before_end\s*=\s*remove|nl_oc_before_end\s*=\s*force|nl_oc_before_end\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Before End|Add Nl Oc Before End|Remove Nl Oc Before End|Force Nl Oc Before End"
 ValueDefault=ignore
 
@@ -3699,7 +3700,7 @@ Category=3
 Description="<html>(OC) Add or remove newline between '@interface' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_interface_brace=ignore|nl_oc_interface_brace=add|nl_oc_interface_brace=remove|nl_oc_interface_brace=force|nl_oc_interface_brace=not_defined
+Choices=nl_oc_interface_brace\s*=\s*ignore|nl_oc_interface_brace\s*=\s*add|nl_oc_interface_brace\s*=\s*remove|nl_oc_interface_brace\s*=\s*force|nl_oc_interface_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Interface Brace|Add Nl Oc Interface Brace|Remove Nl Oc Interface Brace|Force Nl Oc Interface Brace"
 ValueDefault=ignore
 
@@ -3708,7 +3709,7 @@ Category=3
 Description="<html>(OC) Add or remove newline between '@implementation' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_implementation_brace=ignore|nl_oc_implementation_brace=add|nl_oc_implementation_brace=remove|nl_oc_implementation_brace=force|nl_oc_implementation_brace=not_defined
+Choices=nl_oc_implementation_brace\s*=\s*ignore|nl_oc_implementation_brace\s*=\s*add|nl_oc_implementation_brace\s*=\s*remove|nl_oc_implementation_brace\s*=\s*force|nl_oc_implementation_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Implementation Brace|Add Nl Oc Implementation Brace|Remove Nl Oc Implementation Brace|Force Nl Oc Implementation Brace"
 ValueDefault=ignore
 
@@ -3717,7 +3718,7 @@ Category=3
 Description="<html>Add or remove newlines at the start of the file.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_start_of_file=ignore|nl_start_of_file=add|nl_start_of_file=remove|nl_start_of_file=force|nl_start_of_file=not_defined
+Choices=nl_start_of_file\s*=\s*ignore|nl_start_of_file\s*=\s*add|nl_start_of_file\s*=\s*remove|nl_start_of_file\s*=\s*force|nl_start_of_file\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Start Of File|Add Nl Start Of File|Remove Nl Start Of File|Force Nl Start Of File"
 ValueDefault=ignore
 
@@ -3726,7 +3727,7 @@ Category=3
 Description="<html>The minimum number of newlines at the start of the file (only used if<br/>nl_start_of_file is 'add' or 'force').</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_start_of_file_min="
+CallName="nl_start_of_file_min\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3736,7 +3737,7 @@ Category=3
 Description="<html>Add or remove newline at the end of the file.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_end_of_file=ignore|nl_end_of_file=add|nl_end_of_file=remove|nl_end_of_file=force|nl_end_of_file=not_defined
+Choices=nl_end_of_file\s*=\s*ignore|nl_end_of_file\s*=\s*add|nl_end_of_file\s*=\s*remove|nl_end_of_file\s*=\s*force|nl_end_of_file\s*=\s*not_defined
 ChoicesReadable="Ignore Nl End Of File|Add Nl End Of File|Remove Nl End Of File|Force Nl End Of File"
 ValueDefault=ignore
 
@@ -3745,7 +3746,7 @@ Category=3
 Description="<html>The minimum number of newlines at the end of the file (only used if<br/>nl_end_of_file is 'add' or 'force').</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_end_of_file_min="
+CallName="nl_end_of_file_min\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3755,7 +3756,7 @@ Category=3
 Description="<html>Add or remove newline between '=' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_assign_brace=ignore|nl_assign_brace=add|nl_assign_brace=remove|nl_assign_brace=force|nl_assign_brace=not_defined
+Choices=nl_assign_brace\s*=\s*ignore|nl_assign_brace\s*=\s*add|nl_assign_brace\s*=\s*remove|nl_assign_brace\s*=\s*force|nl_assign_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Assign Brace|Add Nl Assign Brace|Remove Nl Assign Brace|Force Nl Assign Brace"
 ValueDefault=ignore
 
@@ -3764,7 +3765,7 @@ Category=3
 Description="<html>(D) Add or remove newline between '=' and '['.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_assign_square=ignore|nl_assign_square=add|nl_assign_square=remove|nl_assign_square=force|nl_assign_square=not_defined
+Choices=nl_assign_square\s*=\s*ignore|nl_assign_square\s*=\s*add|nl_assign_square\s*=\s*remove|nl_assign_square\s*=\s*force|nl_assign_square\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Assign Square|Add Nl Assign Square|Remove Nl Assign Square|Force Nl Assign Square"
 ValueDefault=ignore
 
@@ -3773,7 +3774,7 @@ Category=3
 Description="<html>Add or remove newline between '[]' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_tsquare_brace=ignore|nl_tsquare_brace=add|nl_tsquare_brace=remove|nl_tsquare_brace=force|nl_tsquare_brace=not_defined
+Choices=nl_tsquare_brace\s*=\s*ignore|nl_tsquare_brace\s*=\s*add|nl_tsquare_brace\s*=\s*remove|nl_tsquare_brace\s*=\s*force|nl_tsquare_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Tsquare Brace|Add Nl Tsquare Brace|Remove Nl Tsquare Brace|Force Nl Tsquare Brace"
 ValueDefault=ignore
 
@@ -3782,7 +3783,7 @@ Category=3
 Description="<html>(D) Add or remove newline after '= ['. Will also affect the newline before<br/>the ']'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_square_assign=ignore|nl_after_square_assign=add|nl_after_square_assign=remove|nl_after_square_assign=force|nl_after_square_assign=not_defined
+Choices=nl_after_square_assign\s*=\s*ignore|nl_after_square_assign\s*=\s*add|nl_after_square_assign\s*=\s*remove|nl_after_square_assign\s*=\s*force|nl_after_square_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Square Assign|Add Nl After Square Assign|Remove Nl After Square Assign|Force Nl After Square Assign"
 ValueDefault=ignore
 
@@ -3791,7 +3792,7 @@ Category=3
 Description="<html>Add or remove newline between a function call's ')' and '{', as in<br/>'list_for_each(item, &amp;list) { }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_fcall_brace=ignore|nl_fcall_brace=add|nl_fcall_brace=remove|nl_fcall_brace=force|nl_fcall_brace=not_defined
+Choices=nl_fcall_brace\s*=\s*ignore|nl_fcall_brace\s*=\s*add|nl_fcall_brace\s*=\s*remove|nl_fcall_brace\s*=\s*force|nl_fcall_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Fcall Brace|Add Nl Fcall Brace|Remove Nl Fcall Brace|Force Nl Fcall Brace"
 ValueDefault=ignore
 
@@ -3800,7 +3801,7 @@ Category=3
 Description="<html>Add or remove newline between 'enum' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_brace=ignore|nl_enum_brace=add|nl_enum_brace=remove|nl_enum_brace=force|nl_enum_brace=not_defined
+Choices=nl_enum_brace\s*=\s*ignore|nl_enum_brace\s*=\s*add|nl_enum_brace\s*=\s*remove|nl_enum_brace\s*=\s*force|nl_enum_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Brace|Add Nl Enum Brace|Remove Nl Enum Brace|Force Nl Enum Brace"
 ValueDefault=ignore
 
@@ -3809,7 +3810,7 @@ Category=3
 Description="<html>Add or remove newline between 'enum' and 'class'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_class=ignore|nl_enum_class=add|nl_enum_class=remove|nl_enum_class=force|nl_enum_class=not_defined
+Choices=nl_enum_class\s*=\s*ignore|nl_enum_class\s*=\s*add|nl_enum_class\s*=\s*remove|nl_enum_class\s*=\s*force|nl_enum_class\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Class|Add Nl Enum Class|Remove Nl Enum Class|Force Nl Enum Class"
 ValueDefault=ignore
 
@@ -3818,7 +3819,7 @@ Category=3
 Description="<html>Add or remove newline between 'enum class' and the identifier.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_class_identifier=ignore|nl_enum_class_identifier=add|nl_enum_class_identifier=remove|nl_enum_class_identifier=force|nl_enum_class_identifier=not_defined
+Choices=nl_enum_class_identifier\s*=\s*ignore|nl_enum_class_identifier\s*=\s*add|nl_enum_class_identifier\s*=\s*remove|nl_enum_class_identifier\s*=\s*force|nl_enum_class_identifier\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Class Identifier|Add Nl Enum Class Identifier|Remove Nl Enum Class Identifier|Force Nl Enum Class Identifier"
 ValueDefault=ignore
 
@@ -3827,7 +3828,7 @@ Category=3
 Description="<html>Add or remove newline between 'enum class' type and ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_identifier_colon=ignore|nl_enum_identifier_colon=add|nl_enum_identifier_colon=remove|nl_enum_identifier_colon=force|nl_enum_identifier_colon=not_defined
+Choices=nl_enum_identifier_colon\s*=\s*ignore|nl_enum_identifier_colon\s*=\s*add|nl_enum_identifier_colon\s*=\s*remove|nl_enum_identifier_colon\s*=\s*force|nl_enum_identifier_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Identifier Colon|Add Nl Enum Identifier Colon|Remove Nl Enum Identifier Colon|Force Nl Enum Identifier Colon"
 ValueDefault=ignore
 
@@ -3836,7 +3837,7 @@ Category=3
 Description="<html>Add or remove newline between 'enum class identifier :' and type.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_colon_type=ignore|nl_enum_colon_type=add|nl_enum_colon_type=remove|nl_enum_colon_type=force|nl_enum_colon_type=not_defined
+Choices=nl_enum_colon_type\s*=\s*ignore|nl_enum_colon_type\s*=\s*add|nl_enum_colon_type\s*=\s*remove|nl_enum_colon_type\s*=\s*force|nl_enum_colon_type\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Colon Type|Add Nl Enum Colon Type|Remove Nl Enum Colon Type|Force Nl Enum Colon Type"
 ValueDefault=ignore
 
@@ -3845,7 +3846,7 @@ Category=3
 Description="<html>Add or remove newline between 'struct and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_struct_brace=ignore|nl_struct_brace=add|nl_struct_brace=remove|nl_struct_brace=force|nl_struct_brace=not_defined
+Choices=nl_struct_brace\s*=\s*ignore|nl_struct_brace\s*=\s*add|nl_struct_brace\s*=\s*remove|nl_struct_brace\s*=\s*force|nl_struct_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Struct Brace|Add Nl Struct Brace|Remove Nl Struct Brace|Force Nl Struct Brace"
 ValueDefault=ignore
 
@@ -3854,7 +3855,7 @@ Category=3
 Description="<html>Add or remove newline between 'union' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_union_brace=ignore|nl_union_brace=add|nl_union_brace=remove|nl_union_brace=force|nl_union_brace=not_defined
+Choices=nl_union_brace\s*=\s*ignore|nl_union_brace\s*=\s*add|nl_union_brace\s*=\s*remove|nl_union_brace\s*=\s*force|nl_union_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Union Brace|Add Nl Union Brace|Remove Nl Union Brace|Force Nl Union Brace"
 ValueDefault=ignore
 
@@ -3863,7 +3864,7 @@ Category=3
 Description="<html>Add or remove newline between 'if' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_if_brace=ignore|nl_if_brace=add|nl_if_brace=remove|nl_if_brace=force|nl_if_brace=not_defined
+Choices=nl_if_brace\s*=\s*ignore|nl_if_brace\s*=\s*add|nl_if_brace\s*=\s*remove|nl_if_brace\s*=\s*force|nl_if_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl If Brace|Add Nl If Brace|Remove Nl If Brace|Force Nl If Brace"
 ValueDefault=ignore
 
@@ -3872,7 +3873,7 @@ Category=3
 Description="<html>Add or remove newline between '}' and 'else'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_else=ignore|nl_brace_else=add|nl_brace_else=remove|nl_brace_else=force|nl_brace_else=not_defined
+Choices=nl_brace_else\s*=\s*ignore|nl_brace_else\s*=\s*add|nl_brace_else\s*=\s*remove|nl_brace_else\s*=\s*force|nl_brace_else\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Else|Add Nl Brace Else|Remove Nl Brace Else|Force Nl Brace Else"
 ValueDefault=ignore
 
@@ -3881,7 +3882,7 @@ Category=3
 Description="<html>Add or remove newline between 'else if' and '{'. If set to ignore,<br/>nl_if_brace is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_elseif_brace=ignore|nl_elseif_brace=add|nl_elseif_brace=remove|nl_elseif_brace=force|nl_elseif_brace=not_defined
+Choices=nl_elseif_brace\s*=\s*ignore|nl_elseif_brace\s*=\s*add|nl_elseif_brace\s*=\s*remove|nl_elseif_brace\s*=\s*force|nl_elseif_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Elseif Brace|Add Nl Elseif Brace|Remove Nl Elseif Brace|Force Nl Elseif Brace"
 ValueDefault=ignore
 
@@ -3890,7 +3891,7 @@ Category=3
 Description="<html>Add or remove newline between 'else' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_else_brace=ignore|nl_else_brace=add|nl_else_brace=remove|nl_else_brace=force|nl_else_brace=not_defined
+Choices=nl_else_brace\s*=\s*ignore|nl_else_brace\s*=\s*add|nl_else_brace\s*=\s*remove|nl_else_brace\s*=\s*force|nl_else_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Else Brace|Add Nl Else Brace|Remove Nl Else Brace|Force Nl Else Brace"
 ValueDefault=ignore
 
@@ -3899,7 +3900,7 @@ Category=3
 Description="<html>Add or remove newline between 'else' and 'if'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_else_if=ignore|nl_else_if=add|nl_else_if=remove|nl_else_if=force|nl_else_if=not_defined
+Choices=nl_else_if\s*=\s*ignore|nl_else_if\s*=\s*add|nl_else_if\s*=\s*remove|nl_else_if\s*=\s*force|nl_else_if\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Else If|Add Nl Else If|Remove Nl Else If|Force Nl Else If"
 ValueDefault=ignore
 
@@ -3908,7 +3909,7 @@ Category=3
 Description="<html>Add or remove newline before '{' opening brace</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_opening_brace_func_class_def=ignore|nl_before_opening_brace_func_class_def=add|nl_before_opening_brace_func_class_def=remove|nl_before_opening_brace_func_class_def=force|nl_before_opening_brace_func_class_def=not_defined
+Choices=nl_before_opening_brace_func_class_def\s*=\s*ignore|nl_before_opening_brace_func_class_def\s*=\s*add|nl_before_opening_brace_func_class_def\s*=\s*remove|nl_before_opening_brace_func_class_def\s*=\s*force|nl_before_opening_brace_func_class_def\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Opening Brace Func Class Def|Add Nl Before Opening Brace Func Class Def|Remove Nl Before Opening Brace Func Class Def|Force Nl Before Opening Brace Func Class Def"
 ValueDefault=ignore
 
@@ -3917,7 +3918,7 @@ Category=3
 Description="<html>Add or remove newline before 'if'/'else if' closing parenthesis.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_if_closing_paren=ignore|nl_before_if_closing_paren=add|nl_before_if_closing_paren=remove|nl_before_if_closing_paren=force|nl_before_if_closing_paren=not_defined
+Choices=nl_before_if_closing_paren\s*=\s*ignore|nl_before_if_closing_paren\s*=\s*add|nl_before_if_closing_paren\s*=\s*remove|nl_before_if_closing_paren\s*=\s*force|nl_before_if_closing_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before If Closing Paren|Add Nl Before If Closing Paren|Remove Nl Before If Closing Paren|Force Nl Before If Closing Paren"
 ValueDefault=ignore
 
@@ -3926,7 +3927,7 @@ Category=3
 Description="<html>Add or remove newline between '}' and 'finally'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_finally=ignore|nl_brace_finally=add|nl_brace_finally=remove|nl_brace_finally=force|nl_brace_finally=not_defined
+Choices=nl_brace_finally\s*=\s*ignore|nl_brace_finally\s*=\s*add|nl_brace_finally\s*=\s*remove|nl_brace_finally\s*=\s*force|nl_brace_finally\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Finally|Add Nl Brace Finally|Remove Nl Brace Finally|Force Nl Brace Finally"
 ValueDefault=ignore
 
@@ -3935,7 +3936,7 @@ Category=3
 Description="<html>Add or remove newline between 'finally' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_finally_brace=ignore|nl_finally_brace=add|nl_finally_brace=remove|nl_finally_brace=force|nl_finally_brace=not_defined
+Choices=nl_finally_brace\s*=\s*ignore|nl_finally_brace\s*=\s*add|nl_finally_brace\s*=\s*remove|nl_finally_brace\s*=\s*force|nl_finally_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Finally Brace|Add Nl Finally Brace|Remove Nl Finally Brace|Force Nl Finally Brace"
 ValueDefault=ignore
 
@@ -3944,7 +3945,7 @@ Category=3
 Description="<html>Add or remove newline between 'try' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_try_brace=ignore|nl_try_brace=add|nl_try_brace=remove|nl_try_brace=force|nl_try_brace=not_defined
+Choices=nl_try_brace\s*=\s*ignore|nl_try_brace\s*=\s*add|nl_try_brace\s*=\s*remove|nl_try_brace\s*=\s*force|nl_try_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Try Brace|Add Nl Try Brace|Remove Nl Try Brace|Force Nl Try Brace"
 ValueDefault=ignore
 
@@ -3953,7 +3954,7 @@ Category=3
 Description="<html>Add or remove newline between get/set and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_getset_brace=ignore|nl_getset_brace=add|nl_getset_brace=remove|nl_getset_brace=force|nl_getset_brace=not_defined
+Choices=nl_getset_brace\s*=\s*ignore|nl_getset_brace\s*=\s*add|nl_getset_brace\s*=\s*remove|nl_getset_brace\s*=\s*force|nl_getset_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Getset Brace|Add Nl Getset Brace|Remove Nl Getset Brace|Force Nl Getset Brace"
 ValueDefault=ignore
 
@@ -3962,7 +3963,7 @@ Category=3
 Description="<html>Add or remove newline between 'for' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_for_brace=ignore|nl_for_brace=add|nl_for_brace=remove|nl_for_brace=force|nl_for_brace=not_defined
+Choices=nl_for_brace\s*=\s*ignore|nl_for_brace\s*=\s*add|nl_for_brace\s*=\s*remove|nl_for_brace\s*=\s*force|nl_for_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl For Brace|Add Nl For Brace|Remove Nl For Brace|Force Nl For Brace"
 ValueDefault=ignore
 
@@ -3971,7 +3972,7 @@ Category=3
 Description="<html>Add or remove newline before the '{' of a 'catch' statement, as in<br/>'catch (decl) &lt;here&gt; {'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_catch_brace=ignore|nl_catch_brace=add|nl_catch_brace=remove|nl_catch_brace=force|nl_catch_brace=not_defined
+Choices=nl_catch_brace\s*=\s*ignore|nl_catch_brace\s*=\s*add|nl_catch_brace\s*=\s*remove|nl_catch_brace\s*=\s*force|nl_catch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Catch Brace|Add Nl Catch Brace|Remove Nl Catch Brace|Force Nl Catch Brace"
 ValueDefault=ignore
 
@@ -3980,7 +3981,7 @@ Category=3
 Description="<html>(OC) Add or remove newline before the '{' of a '@catch' statement, as in<br/>'@catch (decl) &lt;here&gt; {'. If set to ignore, nl_catch_brace is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_catch_brace=ignore|nl_oc_catch_brace=add|nl_oc_catch_brace=remove|nl_oc_catch_brace=force|nl_oc_catch_brace=not_defined
+Choices=nl_oc_catch_brace\s*=\s*ignore|nl_oc_catch_brace\s*=\s*add|nl_oc_catch_brace\s*=\s*remove|nl_oc_catch_brace\s*=\s*force|nl_oc_catch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Catch Brace|Add Nl Oc Catch Brace|Remove Nl Oc Catch Brace|Force Nl Oc Catch Brace"
 ValueDefault=ignore
 
@@ -3989,7 +3990,7 @@ Category=3
 Description="<html>Add or remove newline between '}' and 'catch'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_catch=ignore|nl_brace_catch=add|nl_brace_catch=remove|nl_brace_catch=force|nl_brace_catch=not_defined
+Choices=nl_brace_catch\s*=\s*ignore|nl_brace_catch\s*=\s*add|nl_brace_catch\s*=\s*remove|nl_brace_catch\s*=\s*force|nl_brace_catch\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Catch|Add Nl Brace Catch|Remove Nl Brace Catch|Force Nl Brace Catch"
 ValueDefault=ignore
 
@@ -3998,7 +3999,7 @@ Category=3
 Description="<html>(OC) Add or remove newline between '}' and '@catch'. If set to ignore,<br/>nl_brace_catch is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_brace_catch=ignore|nl_oc_brace_catch=add|nl_oc_brace_catch=remove|nl_oc_brace_catch=force|nl_oc_brace_catch=not_defined
+Choices=nl_oc_brace_catch\s*=\s*ignore|nl_oc_brace_catch\s*=\s*add|nl_oc_brace_catch\s*=\s*remove|nl_oc_brace_catch\s*=\s*force|nl_oc_brace_catch\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Brace Catch|Add Nl Oc Brace Catch|Remove Nl Oc Brace Catch|Force Nl Oc Brace Catch"
 ValueDefault=ignore
 
@@ -4007,7 +4008,7 @@ Category=3
 Description="<html>Add or remove newline between '}' and ']'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_square=ignore|nl_brace_square=add|nl_brace_square=remove|nl_brace_square=force|nl_brace_square=not_defined
+Choices=nl_brace_square\s*=\s*ignore|nl_brace_square\s*=\s*add|nl_brace_square\s*=\s*remove|nl_brace_square\s*=\s*force|nl_brace_square\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Square|Add Nl Brace Square|Remove Nl Brace Square|Force Nl Brace Square"
 ValueDefault=ignore
 
@@ -4016,7 +4017,7 @@ Category=3
 Description="<html>Add or remove newline between '}' and ')' in a function invocation.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_fparen=ignore|nl_brace_fparen=add|nl_brace_fparen=remove|nl_brace_fparen=force|nl_brace_fparen=not_defined
+Choices=nl_brace_fparen\s*=\s*ignore|nl_brace_fparen\s*=\s*add|nl_brace_fparen\s*=\s*remove|nl_brace_fparen\s*=\s*force|nl_brace_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Fparen|Add Nl Brace Fparen|Remove Nl Brace Fparen|Force Nl Brace Fparen"
 ValueDefault=ignore
 
@@ -4025,7 +4026,7 @@ Category=3
 Description="<html>Add or remove newline between 'while' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_while_brace=ignore|nl_while_brace=add|nl_while_brace=remove|nl_while_brace=force|nl_while_brace=not_defined
+Choices=nl_while_brace\s*=\s*ignore|nl_while_brace\s*=\s*add|nl_while_brace\s*=\s*remove|nl_while_brace\s*=\s*force|nl_while_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl While Brace|Add Nl While Brace|Remove Nl While Brace|Force Nl While Brace"
 ValueDefault=ignore
 
@@ -4034,7 +4035,7 @@ Category=3
 Description="<html>(D) Add or remove newline between 'scope (x)' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_scope_brace=ignore|nl_scope_brace=add|nl_scope_brace=remove|nl_scope_brace=force|nl_scope_brace=not_defined
+Choices=nl_scope_brace\s*=\s*ignore|nl_scope_brace\s*=\s*add|nl_scope_brace\s*=\s*remove|nl_scope_brace\s*=\s*force|nl_scope_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Scope Brace|Add Nl Scope Brace|Remove Nl Scope Brace|Force Nl Scope Brace"
 ValueDefault=ignore
 
@@ -4043,7 +4044,7 @@ Category=3
 Description="<html>(D) Add or remove newline between 'unittest' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_unittest_brace=ignore|nl_unittest_brace=add|nl_unittest_brace=remove|nl_unittest_brace=force|nl_unittest_brace=not_defined
+Choices=nl_unittest_brace\s*=\s*ignore|nl_unittest_brace\s*=\s*add|nl_unittest_brace\s*=\s*remove|nl_unittest_brace\s*=\s*force|nl_unittest_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Unittest Brace|Add Nl Unittest Brace|Remove Nl Unittest Brace|Force Nl Unittest Brace"
 ValueDefault=ignore
 
@@ -4052,7 +4053,7 @@ Category=3
 Description="<html>(D) Add or remove newline between 'version (x)' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_version_brace=ignore|nl_version_brace=add|nl_version_brace=remove|nl_version_brace=force|nl_version_brace=not_defined
+Choices=nl_version_brace\s*=\s*ignore|nl_version_brace\s*=\s*add|nl_version_brace\s*=\s*remove|nl_version_brace\s*=\s*force|nl_version_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Version Brace|Add Nl Version Brace|Remove Nl Version Brace|Force Nl Version Brace"
 ValueDefault=ignore
 
@@ -4061,7 +4062,7 @@ Category=3
 Description="<html>(C#) Add or remove newline between 'using' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_using_brace=ignore|nl_using_brace=add|nl_using_brace=remove|nl_using_brace=force|nl_using_brace=not_defined
+Choices=nl_using_brace\s*=\s*ignore|nl_using_brace\s*=\s*add|nl_using_brace\s*=\s*remove|nl_using_brace\s*=\s*force|nl_using_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Using Brace|Add Nl Using Brace|Remove Nl Using Brace|Force Nl Using Brace"
 ValueDefault=ignore
 
@@ -4070,7 +4071,7 @@ Category=3
 Description="<html>Add or remove newline between two open or close braces. Due to general<br/>newline/brace handling, REMOVE may not work.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_brace=ignore|nl_brace_brace=add|nl_brace_brace=remove|nl_brace_brace=force|nl_brace_brace=not_defined
+Choices=nl_brace_brace\s*=\s*ignore|nl_brace_brace\s*=\s*add|nl_brace_brace\s*=\s*remove|nl_brace_brace\s*=\s*force|nl_brace_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Brace|Add Nl Brace Brace|Remove Nl Brace Brace|Force Nl Brace Brace"
 ValueDefault=ignore
 
@@ -4079,7 +4080,7 @@ Category=3
 Description="<html>Add or remove newline between 'do' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_do_brace=ignore|nl_do_brace=add|nl_do_brace=remove|nl_do_brace=force|nl_do_brace=not_defined
+Choices=nl_do_brace\s*=\s*ignore|nl_do_brace\s*=\s*add|nl_do_brace\s*=\s*remove|nl_do_brace\s*=\s*force|nl_do_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Do Brace|Add Nl Do Brace|Remove Nl Do Brace|Force Nl Do Brace"
 ValueDefault=ignore
 
@@ -4088,7 +4089,7 @@ Category=3
 Description="<html>Add or remove newline between '}' and 'while' of 'do' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_while=ignore|nl_brace_while=add|nl_brace_while=remove|nl_brace_while=force|nl_brace_while=not_defined
+Choices=nl_brace_while\s*=\s*ignore|nl_brace_while\s*=\s*add|nl_brace_while\s*=\s*remove|nl_brace_while\s*=\s*force|nl_brace_while\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace While|Add Nl Brace While|Remove Nl Brace While|Force Nl Brace While"
 ValueDefault=ignore
 
@@ -4097,7 +4098,7 @@ Category=3
 Description="<html>Add or remove newline between 'switch' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_switch_brace=ignore|nl_switch_brace=add|nl_switch_brace=remove|nl_switch_brace=force|nl_switch_brace=not_defined
+Choices=nl_switch_brace\s*=\s*ignore|nl_switch_brace\s*=\s*add|nl_switch_brace\s*=\s*remove|nl_switch_brace\s*=\s*force|nl_switch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Switch Brace|Add Nl Switch Brace|Remove Nl Switch Brace|Force Nl Switch Brace"
 ValueDefault=ignore
 
@@ -4106,7 +4107,7 @@ Category=3
 Description="<html>Add or remove newline between 'synchronized' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_synchronized_brace=ignore|nl_synchronized_brace=add|nl_synchronized_brace=remove|nl_synchronized_brace=force|nl_synchronized_brace=not_defined
+Choices=nl_synchronized_brace\s*=\s*ignore|nl_synchronized_brace\s*=\s*add|nl_synchronized_brace\s*=\s*remove|nl_synchronized_brace\s*=\s*force|nl_synchronized_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Synchronized Brace|Add Nl Synchronized Brace|Remove Nl Synchronized Brace|Force Nl Synchronized Brace"
 ValueDefault=ignore
 
@@ -4115,7 +4116,7 @@ Category=3
 Description="<html>Add a newline between ')' and '{' if the ')' is on a different line than the<br/>if/for/etc.<br/><br/>Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch and<br/>nl_catch_brace.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_multi_line_cond=true|nl_multi_line_cond=false
+TrueFalse=nl_multi_line_cond\s*=\s*true|nl_multi_line_cond\s*=\s*false
 ValueDefault=false
 
 [Nl Multi Line Sparen Open]
@@ -4123,7 +4124,7 @@ Category=3
 Description="<html>Add a newline after '(' if an if/for/while/switch condition spans multiple<br/>lines</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_multi_line_sparen_open=ignore|nl_multi_line_sparen_open=add|nl_multi_line_sparen_open=remove|nl_multi_line_sparen_open=force|nl_multi_line_sparen_open=not_defined
+Choices=nl_multi_line_sparen_open\s*=\s*ignore|nl_multi_line_sparen_open\s*=\s*add|nl_multi_line_sparen_open\s*=\s*remove|nl_multi_line_sparen_open\s*=\s*force|nl_multi_line_sparen_open\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Multi Line Sparen Open|Add Nl Multi Line Sparen Open|Remove Nl Multi Line Sparen Open|Force Nl Multi Line Sparen Open"
 ValueDefault=ignore
 
@@ -4132,7 +4133,7 @@ Category=3
 Description="<html>Add a newline before ')' if an if/for/while/switch condition spans multiple<br/>lines. Overrides nl_before_if_closing_paren if both are specified.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_multi_line_sparen_close=ignore|nl_multi_line_sparen_close=add|nl_multi_line_sparen_close=remove|nl_multi_line_sparen_close=force|nl_multi_line_sparen_close=not_defined
+Choices=nl_multi_line_sparen_close\s*=\s*ignore|nl_multi_line_sparen_close\s*=\s*add|nl_multi_line_sparen_close\s*=\s*remove|nl_multi_line_sparen_close\s*=\s*force|nl_multi_line_sparen_close\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Multi Line Sparen Close|Add Nl Multi Line Sparen Close|Remove Nl Multi Line Sparen Close|Force Nl Multi Line Sparen Close"
 ValueDefault=ignore
 
@@ -4141,7 +4142,7 @@ Category=3
 Description="<html>Force a newline in a define after the macro name for multi-line defines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_multi_line_define=true|nl_multi_line_define=false
+TrueFalse=nl_multi_line_define\s*=\s*true|nl_multi_line_define\s*=\s*false
 ValueDefault=false
 
 [Nl Before Case]
@@ -4149,7 +4150,7 @@ Category=3
 Description="<html>Whether to add a newline before 'case', and a blank line before a 'case'<br/>statement that follows a ';' or '}'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_before_case=true|nl_before_case=false
+TrueFalse=nl_before_case\s*=\s*true|nl_before_case\s*=\s*false
 ValueDefault=false
 
 [Nl After Case]
@@ -4157,7 +4158,7 @@ Category=3
 Description="<html>Whether to add a newline after a 'case' statement.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_case=true|nl_after_case=false
+TrueFalse=nl_after_case\s*=\s*true|nl_after_case\s*=\s*false
 ValueDefault=false
 
 [Nl Case Colon Brace]
@@ -4165,7 +4166,7 @@ Category=3
 Description="<html>Add or remove newline between a case ':' and '{'.<br/><br/>Overrides nl_after_case.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_case_colon_brace=ignore|nl_case_colon_brace=add|nl_case_colon_brace=remove|nl_case_colon_brace=force|nl_case_colon_brace=not_defined
+Choices=nl_case_colon_brace\s*=\s*ignore|nl_case_colon_brace\s*=\s*add|nl_case_colon_brace\s*=\s*remove|nl_case_colon_brace\s*=\s*force|nl_case_colon_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Case Colon Brace|Add Nl Case Colon Brace|Remove Nl Case Colon Brace|Force Nl Case Colon Brace"
 ValueDefault=ignore
 
@@ -4174,7 +4175,7 @@ Category=3
 Description="<html>Add or remove newline between ')' and 'throw'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_throw=ignore|nl_before_throw=add|nl_before_throw=remove|nl_before_throw=force|nl_before_throw=not_defined
+Choices=nl_before_throw\s*=\s*ignore|nl_before_throw\s*=\s*add|nl_before_throw\s*=\s*remove|nl_before_throw\s*=\s*force|nl_before_throw\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Throw|Add Nl Before Throw|Remove Nl Before Throw|Force Nl Before Throw"
 ValueDefault=ignore
 
@@ -4183,7 +4184,7 @@ Category=3
 Description="<html>Add or remove newline between 'namespace' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_namespace_brace=ignore|nl_namespace_brace=add|nl_namespace_brace=remove|nl_namespace_brace=force|nl_namespace_brace=not_defined
+Choices=nl_namespace_brace\s*=\s*ignore|nl_namespace_brace\s*=\s*add|nl_namespace_brace\s*=\s*remove|nl_namespace_brace\s*=\s*force|nl_namespace_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Namespace Brace|Add Nl Namespace Brace|Remove Nl Namespace Brace|Force Nl Namespace Brace"
 ValueDefault=ignore
 
@@ -4192,7 +4193,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template class.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class=ignore|nl_template_class=add|nl_template_class=remove|nl_template_class=force|nl_template_class=not_defined
+Choices=nl_template_class\s*=\s*ignore|nl_template_class\s*=\s*add|nl_template_class\s*=\s*remove|nl_template_class\s*=\s*force|nl_template_class\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class|Add Nl Template Class|Remove Nl Template Class|Force Nl Template Class"
 ValueDefault=ignore
 
@@ -4201,7 +4202,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template class declaration.<br/><br/>Overrides nl_template_class.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class_decl=ignore|nl_template_class_decl=add|nl_template_class_decl=remove|nl_template_class_decl=force|nl_template_class_decl=not_defined
+Choices=nl_template_class_decl\s*=\s*ignore|nl_template_class_decl\s*=\s*add|nl_template_class_decl\s*=\s*remove|nl_template_class_decl\s*=\s*force|nl_template_class_decl\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class Decl|Add Nl Template Class Decl|Remove Nl Template Class Decl|Force Nl Template Class Decl"
 ValueDefault=ignore
 
@@ -4210,7 +4211,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized class declaration.<br/><br/>Overrides nl_template_class_decl.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class_decl_special=ignore|nl_template_class_decl_special=add|nl_template_class_decl_special=remove|nl_template_class_decl_special=force|nl_template_class_decl_special=not_defined
+Choices=nl_template_class_decl_special\s*=\s*ignore|nl_template_class_decl_special\s*=\s*add|nl_template_class_decl_special\s*=\s*remove|nl_template_class_decl_special\s*=\s*force|nl_template_class_decl_special\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class Decl Special|Add Nl Template Class Decl Special|Remove Nl Template Class Decl Special|Force Nl Template Class Decl Special"
 ValueDefault=ignore
 
@@ -4219,7 +4220,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template class definition.<br/><br/>Overrides nl_template_class.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class_def=ignore|nl_template_class_def=add|nl_template_class_def=remove|nl_template_class_def=force|nl_template_class_def=not_defined
+Choices=nl_template_class_def\s*=\s*ignore|nl_template_class_def\s*=\s*add|nl_template_class_def\s*=\s*remove|nl_template_class_def\s*=\s*force|nl_template_class_def\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class Def|Add Nl Template Class Def|Remove Nl Template Class Def|Force Nl Template Class Def"
 ValueDefault=ignore
 
@@ -4228,7 +4229,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized class definition.<br/><br/>Overrides nl_template_class_def.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class_def_special=ignore|nl_template_class_def_special=add|nl_template_class_def_special=remove|nl_template_class_def_special=force|nl_template_class_def_special=not_defined
+Choices=nl_template_class_def_special\s*=\s*ignore|nl_template_class_def_special\s*=\s*add|nl_template_class_def_special\s*=\s*remove|nl_template_class_def_special\s*=\s*force|nl_template_class_def_special\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class Def Special|Add Nl Template Class Def Special|Remove Nl Template Class Def Special|Force Nl Template Class Def Special"
 ValueDefault=ignore
 
@@ -4237,7 +4238,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template function.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func=ignore|nl_template_func=add|nl_template_func=remove|nl_template_func=force|nl_template_func=not_defined
+Choices=nl_template_func\s*=\s*ignore|nl_template_func\s*=\s*add|nl_template_func\s*=\s*remove|nl_template_func\s*=\s*force|nl_template_func\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func|Add Nl Template Func|Remove Nl Template Func|Force Nl Template Func"
 ValueDefault=ignore
 
@@ -4246,7 +4247,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template function<br/>declaration.<br/><br/>Overrides nl_template_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func_decl=ignore|nl_template_func_decl=add|nl_template_func_decl=remove|nl_template_func_decl=force|nl_template_func_decl=not_defined
+Choices=nl_template_func_decl\s*=\s*ignore|nl_template_func_decl\s*=\s*add|nl_template_func_decl\s*=\s*remove|nl_template_func_decl\s*=\s*force|nl_template_func_decl\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func Decl|Add Nl Template Func Decl|Remove Nl Template Func Decl|Force Nl Template Func Decl"
 ValueDefault=ignore
 
@@ -4255,7 +4256,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized function<br/>declaration.<br/><br/>Overrides nl_template_func_decl.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func_decl_special=ignore|nl_template_func_decl_special=add|nl_template_func_decl_special=remove|nl_template_func_decl_special=force|nl_template_func_decl_special=not_defined
+Choices=nl_template_func_decl_special\s*=\s*ignore|nl_template_func_decl_special\s*=\s*add|nl_template_func_decl_special\s*=\s*remove|nl_template_func_decl_special\s*=\s*force|nl_template_func_decl_special\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func Decl Special|Add Nl Template Func Decl Special|Remove Nl Template Func Decl Special|Force Nl Template Func Decl Special"
 ValueDefault=ignore
 
@@ -4264,7 +4265,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template function<br/>definition.<br/><br/>Overrides nl_template_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func_def=ignore|nl_template_func_def=add|nl_template_func_def=remove|nl_template_func_def=force|nl_template_func_def=not_defined
+Choices=nl_template_func_def\s*=\s*ignore|nl_template_func_def\s*=\s*add|nl_template_func_def\s*=\s*remove|nl_template_func_def\s*=\s*force|nl_template_func_def\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func Def|Add Nl Template Func Def|Remove Nl Template Func Def|Force Nl Template Func Def"
 ValueDefault=ignore
 
@@ -4273,7 +4274,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized function<br/>definition.<br/><br/>Overrides nl_template_func_def.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func_def_special=ignore|nl_template_func_def_special=add|nl_template_func_def_special=remove|nl_template_func_def_special=force|nl_template_func_def_special=not_defined
+Choices=nl_template_func_def_special\s*=\s*ignore|nl_template_func_def_special\s*=\s*add|nl_template_func_def_special\s*=\s*remove|nl_template_func_def_special\s*=\s*force|nl_template_func_def_special\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func Def Special|Add Nl Template Func Def Special|Remove Nl Template Func Def Special|Force Nl Template Func Def Special"
 ValueDefault=ignore
 
@@ -4282,7 +4283,7 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template variable.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_var=ignore|nl_template_var=add|nl_template_var=remove|nl_template_var=force|nl_template_var=not_defined
+Choices=nl_template_var\s*=\s*ignore|nl_template_var\s*=\s*add|nl_template_var\s*=\s*remove|nl_template_var\s*=\s*force|nl_template_var\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Var|Add Nl Template Var|Remove Nl Template Var|Force Nl Template Var"
 ValueDefault=ignore
 
@@ -4291,7 +4292,7 @@ Category=3
 Description="<html>Add or remove newline between 'template&lt;...&gt;' and 'using' of a templated<br/>type alias.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_using=ignore|nl_template_using=add|nl_template_using=remove|nl_template_using=force|nl_template_using=not_defined
+Choices=nl_template_using\s*=\s*ignore|nl_template_using\s*=\s*add|nl_template_using\s*=\s*remove|nl_template_using\s*=\s*force|nl_template_using\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Using|Add Nl Template Using|Remove Nl Template Using|Force Nl Template Using"
 ValueDefault=ignore
 
@@ -4300,7 +4301,7 @@ Category=3
 Description="<html>Add or remove newline between 'class' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_class_brace=ignore|nl_class_brace=add|nl_class_brace=remove|nl_class_brace=force|nl_class_brace=not_defined
+Choices=nl_class_brace\s*=\s*ignore|nl_class_brace\s*=\s*add|nl_class_brace\s*=\s*remove|nl_class_brace\s*=\s*force|nl_class_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Class Brace|Add Nl Class Brace|Remove Nl Class Brace|Force Nl Class Brace"
 ValueDefault=ignore
 
@@ -4309,7 +4310,7 @@ Category=3
 Description="<html>Add or remove newline before or after (depending on pos_class_comma,<br/>may not be IGNORE) each',' in the base class list.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_class_init_args=ignore|nl_class_init_args=add|nl_class_init_args=remove|nl_class_init_args=force|nl_class_init_args=not_defined
+Choices=nl_class_init_args\s*=\s*ignore|nl_class_init_args\s*=\s*add|nl_class_init_args\s*=\s*remove|nl_class_init_args\s*=\s*force|nl_class_init_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Class Init Args|Add Nl Class Init Args|Remove Nl Class Init Args|Force Nl Class Init Args"
 ValueDefault=ignore
 
@@ -4318,7 +4319,7 @@ Category=3
 Description="<html>Add or remove newline after each ',' in the constructor member<br/>initialization. Related to nl_constr_colon, pos_constr_colon and<br/>pos_constr_comma.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_constr_init_args=ignore|nl_constr_init_args=add|nl_constr_init_args=remove|nl_constr_init_args=force|nl_constr_init_args=not_defined
+Choices=nl_constr_init_args\s*=\s*ignore|nl_constr_init_args\s*=\s*add|nl_constr_init_args\s*=\s*remove|nl_constr_init_args\s*=\s*force|nl_constr_init_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Constr Init Args|Add Nl Constr Init Args|Remove Nl Constr Init Args|Force Nl Constr Init Args"
 ValueDefault=ignore
 
@@ -4327,7 +4328,7 @@ Category=3
 Description="<html>Add or remove newline before first element, after comma, and after last<br/>element, in 'enum'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_own_lines=ignore|nl_enum_own_lines=add|nl_enum_own_lines=remove|nl_enum_own_lines=force|nl_enum_own_lines=not_defined
+Choices=nl_enum_own_lines\s*=\s*ignore|nl_enum_own_lines\s*=\s*add|nl_enum_own_lines\s*=\s*remove|nl_enum_own_lines\s*=\s*force|nl_enum_own_lines\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Own Lines|Add Nl Enum Own Lines|Remove Nl Enum Own Lines|Force Nl Enum Own Lines"
 ValueDefault=ignore
 
@@ -4336,7 +4337,7 @@ Category=3
 Description="<html>Add or remove newline between return type and function name in a function<br/>definition.<br/>might be modified by nl_func_leave_one_liners</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_type_name=ignore|nl_func_type_name=add|nl_func_type_name=remove|nl_func_type_name=force|nl_func_type_name=not_defined
+Choices=nl_func_type_name\s*=\s*ignore|nl_func_type_name\s*=\s*add|nl_func_type_name\s*=\s*remove|nl_func_type_name\s*=\s*force|nl_func_type_name\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Type Name|Add Nl Func Type Name|Remove Nl Func Type Name|Force Nl Func Type Name"
 ValueDefault=ignore
 
@@ -4345,7 +4346,7 @@ Category=3
 Description="<html>Add or remove newline between return type and function name inside a class<br/>definition. If set to ignore, nl_func_type_name or nl_func_proto_type_name<br/>is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_type_name_class=ignore|nl_func_type_name_class=add|nl_func_type_name_class=remove|nl_func_type_name_class=force|nl_func_type_name_class=not_defined
+Choices=nl_func_type_name_class\s*=\s*ignore|nl_func_type_name_class\s*=\s*add|nl_func_type_name_class\s*=\s*remove|nl_func_type_name_class\s*=\s*force|nl_func_type_name_class\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Type Name Class|Add Nl Func Type Name Class|Remove Nl Func Type Name Class|Force Nl Func Type Name Class"
 ValueDefault=ignore
 
@@ -4354,7 +4355,7 @@ Category=3
 Description="<html>Add or remove newline between class specification and '::'<br/>in 'void A::f() { }'. Only appears in separate member implementation (does<br/>not appear with in-line implementation).</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_class_scope=ignore|nl_func_class_scope=add|nl_func_class_scope=remove|nl_func_class_scope=force|nl_func_class_scope=not_defined
+Choices=nl_func_class_scope\s*=\s*ignore|nl_func_class_scope\s*=\s*add|nl_func_class_scope\s*=\s*remove|nl_func_class_scope\s*=\s*force|nl_func_class_scope\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Class Scope|Add Nl Func Class Scope|Remove Nl Func Class Scope|Force Nl Func Class Scope"
 ValueDefault=ignore
 
@@ -4363,7 +4364,7 @@ Category=3
 Description="<html>Add or remove newline between function scope and name, as in<br/>'void A :: &lt;here&gt; f() { }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_scope_name=ignore|nl_func_scope_name=add|nl_func_scope_name=remove|nl_func_scope_name=force|nl_func_scope_name=not_defined
+Choices=nl_func_scope_name\s*=\s*ignore|nl_func_scope_name\s*=\s*add|nl_func_scope_name\s*=\s*remove|nl_func_scope_name\s*=\s*force|nl_func_scope_name\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Scope Name|Add Nl Func Scope Name|Remove Nl Func Scope Name|Force Nl Func Scope Name"
 ValueDefault=ignore
 
@@ -4372,7 +4373,7 @@ Category=3
 Description="<html>Add or remove newline between return type and function name in a prototype.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_proto_type_name=ignore|nl_func_proto_type_name=add|nl_func_proto_type_name=remove|nl_func_proto_type_name=force|nl_func_proto_type_name=not_defined
+Choices=nl_func_proto_type_name\s*=\s*ignore|nl_func_proto_type_name\s*=\s*add|nl_func_proto_type_name\s*=\s*remove|nl_func_proto_type_name\s*=\s*force|nl_func_proto_type_name\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Proto Type Name|Add Nl Func Proto Type Name|Remove Nl Func Proto Type Name|Force Nl Func Proto Type Name"
 ValueDefault=ignore
 
@@ -4381,7 +4382,7 @@ Category=3
 Description="<html>Add or remove newline between a function name and the opening '(' in the<br/>declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_paren=ignore|nl_func_paren=add|nl_func_paren=remove|nl_func_paren=force|nl_func_paren=not_defined
+Choices=nl_func_paren\s*=\s*ignore|nl_func_paren\s*=\s*add|nl_func_paren\s*=\s*remove|nl_func_paren\s*=\s*force|nl_func_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Paren|Add Nl Func Paren|Remove Nl Func Paren|Force Nl Func Paren"
 ValueDefault=ignore
 
@@ -4390,7 +4391,7 @@ Category=3
 Description="<html>Overrides nl_func_paren for functions with no parameters.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_paren_empty=ignore|nl_func_paren_empty=add|nl_func_paren_empty=remove|nl_func_paren_empty=force|nl_func_paren_empty=not_defined
+Choices=nl_func_paren_empty\s*=\s*ignore|nl_func_paren_empty\s*=\s*add|nl_func_paren_empty\s*=\s*remove|nl_func_paren_empty\s*=\s*force|nl_func_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Paren Empty|Add Nl Func Paren Empty|Remove Nl Func Paren Empty|Force Nl Func Paren Empty"
 ValueDefault=ignore
 
@@ -4399,7 +4400,7 @@ Category=3
 Description="<html>Add or remove newline between a function name and the opening '(' in the<br/>definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_paren=ignore|nl_func_def_paren=add|nl_func_def_paren=remove|nl_func_def_paren=force|nl_func_def_paren=not_defined
+Choices=nl_func_def_paren\s*=\s*ignore|nl_func_def_paren\s*=\s*add|nl_func_def_paren\s*=\s*remove|nl_func_def_paren\s*=\s*force|nl_func_def_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Paren|Add Nl Func Def Paren|Remove Nl Func Def Paren|Force Nl Func Def Paren"
 ValueDefault=ignore
 
@@ -4408,7 +4409,7 @@ Category=3
 Description="<html>Overrides nl_func_def_paren for functions with no parameters.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_paren_empty=ignore|nl_func_def_paren_empty=add|nl_func_def_paren_empty=remove|nl_func_def_paren_empty=force|nl_func_def_paren_empty=not_defined
+Choices=nl_func_def_paren_empty\s*=\s*ignore|nl_func_def_paren_empty\s*=\s*add|nl_func_def_paren_empty\s*=\s*remove|nl_func_def_paren_empty\s*=\s*force|nl_func_def_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Paren Empty|Add Nl Func Def Paren Empty|Remove Nl Func Def Paren Empty|Force Nl Func Def Paren Empty"
 ValueDefault=ignore
 
@@ -4417,7 +4418,7 @@ Category=3
 Description="<html>Add or remove newline between a function name and the opening '(' in the<br/>call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_paren=ignore|nl_func_call_paren=add|nl_func_call_paren=remove|nl_func_call_paren=force|nl_func_call_paren=not_defined
+Choices=nl_func_call_paren\s*=\s*ignore|nl_func_call_paren\s*=\s*add|nl_func_call_paren\s*=\s*remove|nl_func_call_paren\s*=\s*force|nl_func_call_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Paren|Add Nl Func Call Paren|Remove Nl Func Call Paren|Force Nl Func Call Paren"
 ValueDefault=ignore
 
@@ -4426,7 +4427,7 @@ Category=3
 Description="<html>Overrides nl_func_call_paren for functions with no parameters.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_paren_empty=ignore|nl_func_call_paren_empty=add|nl_func_call_paren_empty=remove|nl_func_call_paren_empty=force|nl_func_call_paren_empty=not_defined
+Choices=nl_func_call_paren_empty\s*=\s*ignore|nl_func_call_paren_empty\s*=\s*add|nl_func_call_paren_empty\s*=\s*remove|nl_func_call_paren_empty\s*=\s*force|nl_func_call_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Paren Empty|Add Nl Func Call Paren Empty|Remove Nl Func Call Paren Empty|Force Nl Func Call Paren Empty"
 ValueDefault=ignore
 
@@ -4435,7 +4436,7 @@ Category=3
 Description="<html>Add or remove newline after '(' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_start=ignore|nl_func_decl_start=add|nl_func_decl_start=remove|nl_func_decl_start=force|nl_func_decl_start=not_defined
+Choices=nl_func_decl_start\s*=\s*ignore|nl_func_decl_start\s*=\s*add|nl_func_decl_start\s*=\s*remove|nl_func_decl_start\s*=\s*force|nl_func_decl_start\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl Start|Add Nl Func Decl Start|Remove Nl Func Decl Start|Force Nl Func Decl Start"
 ValueDefault=ignore
 
@@ -4444,7 +4445,7 @@ Category=3
 Description="<html>Add or remove newline after '(' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_start=ignore|nl_func_def_start=add|nl_func_def_start=remove|nl_func_def_start=force|nl_func_def_start=not_defined
+Choices=nl_func_def_start\s*=\s*ignore|nl_func_def_start\s*=\s*add|nl_func_def_start\s*=\s*remove|nl_func_def_start\s*=\s*force|nl_func_def_start\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Start|Add Nl Func Def Start|Remove Nl Func Def Start|Force Nl Func Def Start"
 ValueDefault=ignore
 
@@ -4453,7 +4454,7 @@ Category=3
 Description="<html>Overrides nl_func_decl_start when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_start_single=ignore|nl_func_decl_start_single=add|nl_func_decl_start_single=remove|nl_func_decl_start_single=force|nl_func_decl_start_single=not_defined
+Choices=nl_func_decl_start_single\s*=\s*ignore|nl_func_decl_start_single\s*=\s*add|nl_func_decl_start_single\s*=\s*remove|nl_func_decl_start_single\s*=\s*force|nl_func_decl_start_single\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl Start Single|Add Nl Func Decl Start Single|Remove Nl Func Decl Start Single|Force Nl Func Decl Start Single"
 ValueDefault=ignore
 
@@ -4462,7 +4463,7 @@ Category=3
 Description="<html>Overrides nl_func_def_start when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_start_single=ignore|nl_func_def_start_single=add|nl_func_def_start_single=remove|nl_func_def_start_single=force|nl_func_def_start_single=not_defined
+Choices=nl_func_def_start_single\s*=\s*ignore|nl_func_def_start_single\s*=\s*add|nl_func_def_start_single\s*=\s*remove|nl_func_def_start_single\s*=\s*force|nl_func_def_start_single\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Start Single|Add Nl Func Def Start Single|Remove Nl Func Def Start Single|Force Nl Func Def Start Single"
 ValueDefault=ignore
 
@@ -4471,7 +4472,7 @@ Category=3
 Description="<html>Whether to add a newline after '(' in a function declaration if '(' and ')'<br/>are in different lines. If false, nl_func_decl_start is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_decl_start_multi_line=true|nl_func_decl_start_multi_line=false
+TrueFalse=nl_func_decl_start_multi_line\s*=\s*true|nl_func_decl_start_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Def Start Multi Line]
@@ -4479,7 +4480,7 @@ Category=3
 Description="<html>Whether to add a newline after '(' in a function definition if '(' and ')'<br/>are in different lines. If false, nl_func_def_start is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_def_start_multi_line=true|nl_func_def_start_multi_line=false
+TrueFalse=nl_func_def_start_multi_line\s*=\s*true|nl_func_def_start_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Decl Args]
@@ -4487,7 +4488,7 @@ Category=3
 Description="<html>Add or remove newline after each ',' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_args=ignore|nl_func_decl_args=add|nl_func_decl_args=remove|nl_func_decl_args=force|nl_func_decl_args=not_defined
+Choices=nl_func_decl_args\s*=\s*ignore|nl_func_decl_args\s*=\s*add|nl_func_decl_args\s*=\s*remove|nl_func_decl_args\s*=\s*force|nl_func_decl_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl Args|Add Nl Func Decl Args|Remove Nl Func Decl Args|Force Nl Func Decl Args"
 ValueDefault=ignore
 
@@ -4496,7 +4497,7 @@ Category=3
 Description="<html>Add or remove newline after each ',' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_args=ignore|nl_func_def_args=add|nl_func_def_args=remove|nl_func_def_args=force|nl_func_def_args=not_defined
+Choices=nl_func_def_args\s*=\s*ignore|nl_func_def_args\s*=\s*add|nl_func_def_args\s*=\s*remove|nl_func_def_args\s*=\s*force|nl_func_def_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Args|Add Nl Func Def Args|Remove Nl Func Def Args|Force Nl Func Def Args"
 ValueDefault=ignore
 
@@ -4505,7 +4506,7 @@ Category=3
 Description="<html>Add or remove newline after each ',' in a function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_args=ignore|nl_func_call_args=add|nl_func_call_args=remove|nl_func_call_args=force|nl_func_call_args=not_defined
+Choices=nl_func_call_args\s*=\s*ignore|nl_func_call_args\s*=\s*add|nl_func_call_args\s*=\s*remove|nl_func_call_args\s*=\s*force|nl_func_call_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Args|Add Nl Func Call Args|Remove Nl Func Call Args|Force Nl Func Call Args"
 ValueDefault=ignore
 
@@ -4514,7 +4515,7 @@ Category=3
 Description="<html>Whether to add a newline after each ',' in a function declaration if '('<br/>and ')' are in different lines. If false, nl_func_decl_args is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_decl_args_multi_line=true|nl_func_decl_args_multi_line=false
+TrueFalse=nl_func_decl_args_multi_line\s*=\s*true|nl_func_decl_args_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Def Args Multi Line]
@@ -4522,7 +4523,7 @@ Category=3
 Description="<html>Whether to add a newline after each ',' in a function definition if '('<br/>and ')' are in different lines. If false, nl_func_def_args is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_def_args_multi_line=true|nl_func_def_args_multi_line=false
+TrueFalse=nl_func_def_args_multi_line\s*=\s*true|nl_func_def_args_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Decl End]
@@ -4530,7 +4531,7 @@ Category=3
 Description="<html>Add or remove newline before the ')' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_end=ignore|nl_func_decl_end=add|nl_func_decl_end=remove|nl_func_decl_end=force|nl_func_decl_end=not_defined
+Choices=nl_func_decl_end\s*=\s*ignore|nl_func_decl_end\s*=\s*add|nl_func_decl_end\s*=\s*remove|nl_func_decl_end\s*=\s*force|nl_func_decl_end\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl End|Add Nl Func Decl End|Remove Nl Func Decl End|Force Nl Func Decl End"
 ValueDefault=ignore
 
@@ -4539,7 +4540,7 @@ Category=3
 Description="<html>Add or remove newline before the ')' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_end=ignore|nl_func_def_end=add|nl_func_def_end=remove|nl_func_def_end=force|nl_func_def_end=not_defined
+Choices=nl_func_def_end\s*=\s*ignore|nl_func_def_end\s*=\s*add|nl_func_def_end\s*=\s*remove|nl_func_def_end\s*=\s*force|nl_func_def_end\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def End|Add Nl Func Def End|Remove Nl Func Def End|Force Nl Func Def End"
 ValueDefault=ignore
 
@@ -4548,7 +4549,7 @@ Category=3
 Description="<html>Overrides nl_func_decl_end when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_end_single=ignore|nl_func_decl_end_single=add|nl_func_decl_end_single=remove|nl_func_decl_end_single=force|nl_func_decl_end_single=not_defined
+Choices=nl_func_decl_end_single\s*=\s*ignore|nl_func_decl_end_single\s*=\s*add|nl_func_decl_end_single\s*=\s*remove|nl_func_decl_end_single\s*=\s*force|nl_func_decl_end_single\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl End Single|Add Nl Func Decl End Single|Remove Nl Func Decl End Single|Force Nl Func Decl End Single"
 ValueDefault=ignore
 
@@ -4557,7 +4558,7 @@ Category=3
 Description="<html>Overrides nl_func_def_end when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_end_single=ignore|nl_func_def_end_single=add|nl_func_def_end_single=remove|nl_func_def_end_single=force|nl_func_def_end_single=not_defined
+Choices=nl_func_def_end_single\s*=\s*ignore|nl_func_def_end_single\s*=\s*add|nl_func_def_end_single\s*=\s*remove|nl_func_def_end_single\s*=\s*force|nl_func_def_end_single\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def End Single|Add Nl Func Def End Single|Remove Nl Func Def End Single|Force Nl Func Def End Single"
 ValueDefault=ignore
 
@@ -4566,7 +4567,7 @@ Category=3
 Description="<html>Whether to add a newline before ')' in a function declaration if '(' and ')'<br/>are in different lines. If false, nl_func_decl_end is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_decl_end_multi_line=true|nl_func_decl_end_multi_line=false
+TrueFalse=nl_func_decl_end_multi_line\s*=\s*true|nl_func_decl_end_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Def End Multi Line]
@@ -4574,7 +4575,7 @@ Category=3
 Description="<html>Whether to add a newline before ')' in a function definition if '(' and ')'<br/>are in different lines. If false, nl_func_def_end is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_def_end_multi_line=true|nl_func_def_end_multi_line=false
+TrueFalse=nl_func_def_end_multi_line\s*=\s*true|nl_func_def_end_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Decl Empty]
@@ -4582,7 +4583,7 @@ Category=3
 Description="<html>Add or remove newline between '()' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_empty=ignore|nl_func_decl_empty=add|nl_func_decl_empty=remove|nl_func_decl_empty=force|nl_func_decl_empty=not_defined
+Choices=nl_func_decl_empty\s*=\s*ignore|nl_func_decl_empty\s*=\s*add|nl_func_decl_empty\s*=\s*remove|nl_func_decl_empty\s*=\s*force|nl_func_decl_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl Empty|Add Nl Func Decl Empty|Remove Nl Func Decl Empty|Force Nl Func Decl Empty"
 ValueDefault=ignore
 
@@ -4591,7 +4592,7 @@ Category=3
 Description="<html>Add or remove newline between '()' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_empty=ignore|nl_func_def_empty=add|nl_func_def_empty=remove|nl_func_def_empty=force|nl_func_def_empty=not_defined
+Choices=nl_func_def_empty\s*=\s*ignore|nl_func_def_empty\s*=\s*add|nl_func_def_empty\s*=\s*remove|nl_func_def_empty\s*=\s*force|nl_func_def_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Empty|Add Nl Func Def Empty|Remove Nl Func Def Empty|Force Nl Func Def Empty"
 ValueDefault=ignore
 
@@ -4600,7 +4601,7 @@ Category=3
 Description="<html>Add or remove newline between '()' in a function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_empty=ignore|nl_func_call_empty=add|nl_func_call_empty=remove|nl_func_call_empty=force|nl_func_call_empty=not_defined
+Choices=nl_func_call_empty\s*=\s*ignore|nl_func_call_empty\s*=\s*add|nl_func_call_empty\s*=\s*remove|nl_func_call_empty\s*=\s*force|nl_func_call_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Empty|Add Nl Func Call Empty|Remove Nl Func Call Empty|Force Nl Func Call Empty"
 ValueDefault=ignore
 
@@ -4609,7 +4610,7 @@ Category=3
 Description="<html>Whether to add a newline after '(' in a function call,<br/>has preference over nl_func_call_start_multi_line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_start=ignore|nl_func_call_start=add|nl_func_call_start=remove|nl_func_call_start=force|nl_func_call_start=not_defined
+Choices=nl_func_call_start\s*=\s*ignore|nl_func_call_start\s*=\s*add|nl_func_call_start\s*=\s*remove|nl_func_call_start\s*=\s*force|nl_func_call_start\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Start|Add Nl Func Call Start|Remove Nl Func Call Start|Force Nl Func Call Start"
 ValueDefault=ignore
 
@@ -4618,7 +4619,7 @@ Category=3
 Description="<html>Whether to add a newline before ')' in a function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_end=ignore|nl_func_call_end=add|nl_func_call_end=remove|nl_func_call_end=force|nl_func_call_end=not_defined
+Choices=nl_func_call_end\s*=\s*ignore|nl_func_call_end\s*=\s*add|nl_func_call_end\s*=\s*remove|nl_func_call_end\s*=\s*force|nl_func_call_end\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call End|Add Nl Func Call End|Remove Nl Func Call End|Force Nl Func Call End"
 ValueDefault=ignore
 
@@ -4627,7 +4628,7 @@ Category=3
 Description="<html>Whether to add a newline after '(' in a function call if '(' and ')' are in<br/>different lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_call_start_multi_line=true|nl_func_call_start_multi_line=false
+TrueFalse=nl_func_call_start_multi_line\s*=\s*true|nl_func_call_start_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Call Args Multi Line]
@@ -4635,7 +4636,7 @@ Category=3
 Description="<html>Whether to add a newline after each ',' in a function call if '(' and ')'<br/>are in different lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_call_args_multi_line=true|nl_func_call_args_multi_line=false
+TrueFalse=nl_func_call_args_multi_line\s*=\s*true|nl_func_call_args_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Call End Multi Line]
@@ -4643,7 +4644,7 @@ Category=3
 Description="<html>Whether to add a newline before ')' in a function call if '(' and ')' are in<br/>different lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_call_end_multi_line=true|nl_func_call_end_multi_line=false
+TrueFalse=nl_func_call_end_multi_line\s*=\s*true|nl_func_call_end_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Call Args Multi Line Ignore Closures]
@@ -4651,7 +4652,7 @@ Category=3
 Description="<html>Whether to respect nl_func_call_XXX option in case of closure args.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_call_args_multi_line_ignore_closures=true|nl_func_call_args_multi_line_ignore_closures=false
+TrueFalse=nl_func_call_args_multi_line_ignore_closures\s*=\s*true|nl_func_call_args_multi_line_ignore_closures\s*=\s*false
 ValueDefault=false
 
 [Nl Template Start]
@@ -4659,7 +4660,7 @@ Category=3
 Description="<html>Whether to add a newline after '&lt;' of a template parameter list.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_template_start=true|nl_template_start=false
+TrueFalse=nl_template_start\s*=\s*true|nl_template_start\s*=\s*false
 ValueDefault=false
 
 [Nl Template Args]
@@ -4667,7 +4668,7 @@ Category=3
 Description="<html>Whether to add a newline after each ',' in a template parameter list.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_template_args=true|nl_template_args=false
+TrueFalse=nl_template_args\s*=\s*true|nl_template_args\s*=\s*false
 ValueDefault=false
 
 [Nl Template End]
@@ -4675,7 +4676,7 @@ Category=3
 Description="<html>Whether to add a newline before '&gt;' of a template parameter list.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_template_end=true|nl_template_end=false
+TrueFalse=nl_template_end\s*=\s*true|nl_template_end\s*=\s*false
 ValueDefault=false
 
 [Nl Oc Msg Args]
@@ -4683,7 +4684,7 @@ Category=3
 Description="<html>(OC) Whether to put each Objective-C message parameter on a separate line.<br/>See nl_oc_msg_leave_one_liner.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_oc_msg_args=true|nl_oc_msg_args=false
+TrueFalse=nl_oc_msg_args\s*=\s*true|nl_oc_msg_args\s*=\s*false
 ValueDefault=false
 
 [Nl Oc Msg Args Min Params]
@@ -4691,7 +4692,7 @@ Category=3
 Description="<html>(OC) Minimum number of Objective-C message parameters before applying nl_oc_msg_args.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_oc_msg_args_min_params="
+CallName="nl_oc_msg_args_min_params\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -4701,7 +4702,7 @@ Category=3
 Description="<html>(OC) Max code width of Objective-C message before applying nl_oc_msg_args.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_oc_msg_args_max_code_width="
+CallName="nl_oc_msg_args_max_code_width\s*=\s*"
 MinVal=0
 MaxVal=10000
 ValueDefault=0
@@ -4711,7 +4712,7 @@ Category=3
 Description="<html>Add or remove newline between function signature and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_fdef_brace=ignore|nl_fdef_brace=add|nl_fdef_brace=remove|nl_fdef_brace=force|nl_fdef_brace=not_defined
+Choices=nl_fdef_brace\s*=\s*ignore|nl_fdef_brace\s*=\s*add|nl_fdef_brace\s*=\s*remove|nl_fdef_brace\s*=\s*force|nl_fdef_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Fdef Brace|Add Nl Fdef Brace|Remove Nl Fdef Brace|Force Nl Fdef Brace"
 ValueDefault=ignore
 
@@ -4720,7 +4721,7 @@ Category=3
 Description="<html>Add or remove newline between function signature and '{',<br/>if signature ends with ')'. Overrides nl_fdef_brace.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_fdef_brace_cond=ignore|nl_fdef_brace_cond=add|nl_fdef_brace_cond=remove|nl_fdef_brace_cond=force|nl_fdef_brace_cond=not_defined
+Choices=nl_fdef_brace_cond\s*=\s*ignore|nl_fdef_brace_cond\s*=\s*add|nl_fdef_brace_cond\s*=\s*remove|nl_fdef_brace_cond\s*=\s*force|nl_fdef_brace_cond\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Fdef Brace Cond|Add Nl Fdef Brace Cond|Remove Nl Fdef Brace Cond|Force Nl Fdef Brace Cond"
 ValueDefault=ignore
 
@@ -4729,7 +4730,7 @@ Category=3
 Description="<html>Add or remove newline between C++11 lambda signature and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_cpp_ldef_brace=ignore|nl_cpp_ldef_brace=add|nl_cpp_ldef_brace=remove|nl_cpp_ldef_brace=force|nl_cpp_ldef_brace=not_defined
+Choices=nl_cpp_ldef_brace\s*=\s*ignore|nl_cpp_ldef_brace\s*=\s*add|nl_cpp_ldef_brace\s*=\s*remove|nl_cpp_ldef_brace\s*=\s*force|nl_cpp_ldef_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Cpp Ldef Brace|Add Nl Cpp Ldef Brace|Remove Nl Cpp Ldef Brace|Force Nl Cpp Ldef Brace"
 ValueDefault=ignore
 
@@ -4738,7 +4739,7 @@ Category=3
 Description="<html>Add or remove newline between 'return' and the return expression.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_return_expr=ignore|nl_return_expr=add|nl_return_expr=remove|nl_return_expr=force|nl_return_expr=not_defined
+Choices=nl_return_expr\s*=\s*ignore|nl_return_expr\s*=\s*add|nl_return_expr\s*=\s*remove|nl_return_expr\s*=\s*force|nl_return_expr\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Return Expr|Add Nl Return Expr|Remove Nl Return Expr|Force Nl Return Expr"
 ValueDefault=ignore
 
@@ -4747,7 +4748,7 @@ Category=3
 Description="<html>Add or remove newline between 'throw' and the throw expression.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_throw_expr=ignore|nl_throw_expr=add|nl_throw_expr=remove|nl_throw_expr=force|nl_throw_expr=not_defined
+Choices=nl_throw_expr\s*=\s*ignore|nl_throw_expr\s*=\s*add|nl_throw_expr\s*=\s*remove|nl_throw_expr\s*=\s*force|nl_throw_expr\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Throw Expr|Add Nl Throw Expr|Remove Nl Throw Expr|Force Nl Throw Expr"
 ValueDefault=ignore
 
@@ -4756,7 +4757,7 @@ Category=3
 Description="<html>Whether to add a newline after semicolons, except in 'for' statements.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_semicolon=true|nl_after_semicolon=false
+TrueFalse=nl_after_semicolon\s*=\s*true|nl_after_semicolon\s*=\s*false
 ValueDefault=false
 
 [Nl Paren Dbrace Open]
@@ -4764,7 +4765,7 @@ Category=3
 Description="<html>(Java) Add or remove newline between the ')' and '{{' of the double brace<br/>initializer.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_paren_dbrace_open=ignore|nl_paren_dbrace_open=add|nl_paren_dbrace_open=remove|nl_paren_dbrace_open=force|nl_paren_dbrace_open=not_defined
+Choices=nl_paren_dbrace_open\s*=\s*ignore|nl_paren_dbrace_open\s*=\s*add|nl_paren_dbrace_open\s*=\s*remove|nl_paren_dbrace_open\s*=\s*force|nl_paren_dbrace_open\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Paren Dbrace Open|Add Nl Paren Dbrace Open|Remove Nl Paren Dbrace Open|Force Nl Paren Dbrace Open"
 ValueDefault=ignore
 
@@ -4773,7 +4774,7 @@ Category=3
 Description="<html>Whether to add a newline after the type in an unnamed temporary<br/>direct-list-initialization, better:<br/>before a direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_type_brace_init_lst=ignore|nl_type_brace_init_lst=add|nl_type_brace_init_lst=remove|nl_type_brace_init_lst=force|nl_type_brace_init_lst=not_defined
+Choices=nl_type_brace_init_lst\s*=\s*ignore|nl_type_brace_init_lst\s*=\s*add|nl_type_brace_init_lst\s*=\s*remove|nl_type_brace_init_lst\s*=\s*force|nl_type_brace_init_lst\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Type Brace Init Lst|Add Nl Type Brace Init Lst|Remove Nl Type Brace Init Lst|Force Nl Type Brace Init Lst"
 ValueDefault=ignore
 
@@ -4782,7 +4783,7 @@ Category=3
 Description="<html>Whether to add a newline after the open brace in an unnamed temporary<br/>direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_type_brace_init_lst_open=ignore|nl_type_brace_init_lst_open=add|nl_type_brace_init_lst_open=remove|nl_type_brace_init_lst_open=force|nl_type_brace_init_lst_open=not_defined
+Choices=nl_type_brace_init_lst_open\s*=\s*ignore|nl_type_brace_init_lst_open\s*=\s*add|nl_type_brace_init_lst_open\s*=\s*remove|nl_type_brace_init_lst_open\s*=\s*force|nl_type_brace_init_lst_open\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Type Brace Init Lst Open|Add Nl Type Brace Init Lst Open|Remove Nl Type Brace Init Lst Open|Force Nl Type Brace Init Lst Open"
 ValueDefault=ignore
 
@@ -4791,7 +4792,7 @@ Category=3
 Description="<html>Whether to add a newline before the close brace in an unnamed temporary<br/>direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_type_brace_init_lst_close=ignore|nl_type_brace_init_lst_close=add|nl_type_brace_init_lst_close=remove|nl_type_brace_init_lst_close=force|nl_type_brace_init_lst_close=not_defined
+Choices=nl_type_brace_init_lst_close\s*=\s*ignore|nl_type_brace_init_lst_close\s*=\s*add|nl_type_brace_init_lst_close\s*=\s*remove|nl_type_brace_init_lst_close\s*=\s*force|nl_type_brace_init_lst_close\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Type Brace Init Lst Close|Add Nl Type Brace Init Lst Close|Remove Nl Type Brace Init Lst Close|Force Nl Type Brace Init Lst Close"
 ValueDefault=ignore
 
@@ -4800,7 +4801,7 @@ Category=3
 Description="<html>Whether to add a newline before '{'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_before_brace_open=true|nl_before_brace_open=false
+TrueFalse=nl_before_brace_open\s*=\s*true|nl_before_brace_open\s*=\s*false
 ValueDefault=false
 
 [Nl After Brace Open]
@@ -4808,7 +4809,7 @@ Category=3
 Description="<html>Whether to add a newline after '{'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_brace_open=true|nl_after_brace_open=false
+TrueFalse=nl_after_brace_open\s*=\s*true|nl_after_brace_open\s*=\s*false
 ValueDefault=false
 
 [Nl After Brace Open Cmt]
@@ -4816,7 +4817,7 @@ Category=3
 Description="<html>Whether to add a newline between the open brace and a trailing single-line<br/>comment. Requires nl_after_brace_open=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_brace_open_cmt=true|nl_after_brace_open_cmt=false
+TrueFalse=nl_after_brace_open_cmt\s*=\s*true|nl_after_brace_open_cmt\s*=\s*false
 ValueDefault=false
 
 [Nl After Vbrace Open]
@@ -4824,7 +4825,7 @@ Category=3
 Description="<html>Whether to add a newline after a virtual brace open with a non-empty body.<br/>These occur in un-braced if/while/do/for statement bodies.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_vbrace_open=true|nl_after_vbrace_open=false
+TrueFalse=nl_after_vbrace_open\s*=\s*true|nl_after_vbrace_open\s*=\s*false
 ValueDefault=false
 
 [Nl After Vbrace Open Empty]
@@ -4832,7 +4833,7 @@ Category=3
 Description="<html>Whether to add a newline after a virtual brace open with an empty body.<br/>These occur in un-braced if/while/do/for statement bodies.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_vbrace_open_empty=true|nl_after_vbrace_open_empty=false
+TrueFalse=nl_after_vbrace_open_empty\s*=\s*true|nl_after_vbrace_open_empty\s*=\s*false
 ValueDefault=false
 
 [Nl After Brace Close]
@@ -4840,7 +4841,7 @@ Category=3
 Description="<html>Whether to add a newline after '}'. Does not apply if followed by a<br/>necessary ';'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_brace_close=true|nl_after_brace_close=false
+TrueFalse=nl_after_brace_close\s*=\s*true|nl_after_brace_close\s*=\s*false
 ValueDefault=false
 
 [Nl After Vbrace Close]
@@ -4848,7 +4849,7 @@ Category=3
 Description="<html>Whether to add a newline after a virtual brace close,<br/>as in 'if (foo) a++; &lt;here&gt; return;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_vbrace_close=true|nl_after_vbrace_close=false
+TrueFalse=nl_after_vbrace_close\s*=\s*true|nl_after_vbrace_close\s*=\s*false
 ValueDefault=false
 
 [Nl Brace Struct Var]
@@ -4856,7 +4857,7 @@ Category=3
 Description="<html>Add or remove newline between the close brace and identifier,<br/>as in 'struct { int a; } &lt;here&gt; b;'. Affects enumerations, unions and<br/>structures. If set to ignore, uses nl_after_brace_close.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_struct_var=ignore|nl_brace_struct_var=add|nl_brace_struct_var=remove|nl_brace_struct_var=force|nl_brace_struct_var=not_defined
+Choices=nl_brace_struct_var\s*=\s*ignore|nl_brace_struct_var\s*=\s*add|nl_brace_struct_var\s*=\s*remove|nl_brace_struct_var\s*=\s*force|nl_brace_struct_var\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Struct Var|Add Nl Brace Struct Var|Remove Nl Brace Struct Var|Force Nl Brace Struct Var"
 ValueDefault=ignore
 
@@ -4865,7 +4866,7 @@ Category=3
 Description="<html>Whether to alter newlines in '#define' macros.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_define_macro=true|nl_define_macro=false
+TrueFalse=nl_define_macro\s*=\s*true|nl_define_macro\s*=\s*false
 ValueDefault=false
 
 [Nl Squeeze Paren Close]
@@ -4873,7 +4874,7 @@ Category=3
 Description="<html>Whether to alter newlines between consecutive parenthesis closes. The number<br/>of closing parentheses in a line will depend on respective open parenthesis<br/>lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_squeeze_paren_close=true|nl_squeeze_paren_close=false
+TrueFalse=nl_squeeze_paren_close\s*=\s*true|nl_squeeze_paren_close\s*=\s*false
 ValueDefault=false
 
 [Nl Squeeze Ifdef]
@@ -4881,7 +4882,7 @@ Category=3
 Description="<html>Whether to remove blanks after '#ifxx' and '#elxx', or before '#elxx' and<br/>'#endif'. Does not affect top-level #ifdefs.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_squeeze_ifdef=true|nl_squeeze_ifdef=false
+TrueFalse=nl_squeeze_ifdef\s*=\s*true|nl_squeeze_ifdef\s*=\s*false
 ValueDefault=false
 
 [Nl Squeeze Ifdef Top Level]
@@ -4889,7 +4890,7 @@ Category=3
 Description="<html>Makes the nl_squeeze_ifdef option affect the top-level #ifdefs as well.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_squeeze_ifdef_top_level=true|nl_squeeze_ifdef_top_level=false
+TrueFalse=nl_squeeze_ifdef_top_level\s*=\s*true|nl_squeeze_ifdef_top_level\s*=\s*false
 ValueDefault=false
 
 [Nl Before If]
@@ -4897,7 +4898,7 @@ Category=3
 Description="<html>Add or remove blank line before 'if'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_if=ignore|nl_before_if=add|nl_before_if=remove|nl_before_if=force|nl_before_if=not_defined
+Choices=nl_before_if\s*=\s*ignore|nl_before_if\s*=\s*add|nl_before_if\s*=\s*remove|nl_before_if\s*=\s*force|nl_before_if\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before If|Add Nl Before If|Remove Nl Before If|Force Nl Before If"
 ValueDefault=ignore
 
@@ -4906,7 +4907,7 @@ Category=3
 Description="<html>Add or remove blank line after 'if' statement. Add/Force work only if the<br/>next token is not a closing brace.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_if=ignore|nl_after_if=add|nl_after_if=remove|nl_after_if=force|nl_after_if=not_defined
+Choices=nl_after_if\s*=\s*ignore|nl_after_if\s*=\s*add|nl_after_if\s*=\s*remove|nl_after_if\s*=\s*force|nl_after_if\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After If|Add Nl After If|Remove Nl After If|Force Nl After If"
 ValueDefault=ignore
 
@@ -4915,7 +4916,7 @@ Category=3
 Description="<html>Add or remove blank line before 'for'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_for=ignore|nl_before_for=add|nl_before_for=remove|nl_before_for=force|nl_before_for=not_defined
+Choices=nl_before_for\s*=\s*ignore|nl_before_for\s*=\s*add|nl_before_for\s*=\s*remove|nl_before_for\s*=\s*force|nl_before_for\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before For|Add Nl Before For|Remove Nl Before For|Force Nl Before For"
 ValueDefault=ignore
 
@@ -4924,7 +4925,7 @@ Category=3
 Description="<html>Add or remove blank line after 'for' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_for=ignore|nl_after_for=add|nl_after_for=remove|nl_after_for=force|nl_after_for=not_defined
+Choices=nl_after_for\s*=\s*ignore|nl_after_for\s*=\s*add|nl_after_for\s*=\s*remove|nl_after_for\s*=\s*force|nl_after_for\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After For|Add Nl After For|Remove Nl After For|Force Nl After For"
 ValueDefault=ignore
 
@@ -4933,7 +4934,7 @@ Category=3
 Description="<html>Add or remove blank line before 'while'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_while=ignore|nl_before_while=add|nl_before_while=remove|nl_before_while=force|nl_before_while=not_defined
+Choices=nl_before_while\s*=\s*ignore|nl_before_while\s*=\s*add|nl_before_while\s*=\s*remove|nl_before_while\s*=\s*force|nl_before_while\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before While|Add Nl Before While|Remove Nl Before While|Force Nl Before While"
 ValueDefault=ignore
 
@@ -4942,7 +4943,7 @@ Category=3
 Description="<html>Add or remove blank line after 'while' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_while=ignore|nl_after_while=add|nl_after_while=remove|nl_after_while=force|nl_after_while=not_defined
+Choices=nl_after_while\s*=\s*ignore|nl_after_while\s*=\s*add|nl_after_while\s*=\s*remove|nl_after_while\s*=\s*force|nl_after_while\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After While|Add Nl After While|Remove Nl After While|Force Nl After While"
 ValueDefault=ignore
 
@@ -4951,7 +4952,7 @@ Category=3
 Description="<html>Add or remove blank line before 'switch'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_switch=ignore|nl_before_switch=add|nl_before_switch=remove|nl_before_switch=force|nl_before_switch=not_defined
+Choices=nl_before_switch\s*=\s*ignore|nl_before_switch\s*=\s*add|nl_before_switch\s*=\s*remove|nl_before_switch\s*=\s*force|nl_before_switch\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Switch|Add Nl Before Switch|Remove Nl Before Switch|Force Nl Before Switch"
 ValueDefault=ignore
 
@@ -4960,7 +4961,7 @@ Category=3
 Description="<html>Add or remove blank line after 'switch' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_switch=ignore|nl_after_switch=add|nl_after_switch=remove|nl_after_switch=force|nl_after_switch=not_defined
+Choices=nl_after_switch\s*=\s*ignore|nl_after_switch\s*=\s*add|nl_after_switch\s*=\s*remove|nl_after_switch\s*=\s*force|nl_after_switch\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Switch|Add Nl After Switch|Remove Nl After Switch|Force Nl After Switch"
 ValueDefault=ignore
 
@@ -4969,7 +4970,7 @@ Category=3
 Description="<html>Add or remove blank line before 'synchronized'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_synchronized=ignore|nl_before_synchronized=add|nl_before_synchronized=remove|nl_before_synchronized=force|nl_before_synchronized=not_defined
+Choices=nl_before_synchronized\s*=\s*ignore|nl_before_synchronized\s*=\s*add|nl_before_synchronized\s*=\s*remove|nl_before_synchronized\s*=\s*force|nl_before_synchronized\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Synchronized|Add Nl Before Synchronized|Remove Nl Before Synchronized|Force Nl Before Synchronized"
 ValueDefault=ignore
 
@@ -4978,7 +4979,7 @@ Category=3
 Description="<html>Add or remove blank line after 'synchronized' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_synchronized=ignore|nl_after_synchronized=add|nl_after_synchronized=remove|nl_after_synchronized=force|nl_after_synchronized=not_defined
+Choices=nl_after_synchronized\s*=\s*ignore|nl_after_synchronized\s*=\s*add|nl_after_synchronized\s*=\s*remove|nl_after_synchronized\s*=\s*force|nl_after_synchronized\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Synchronized|Add Nl After Synchronized|Remove Nl After Synchronized|Force Nl After Synchronized"
 ValueDefault=ignore
 
@@ -4987,7 +4988,7 @@ Category=3
 Description="<html>Add or remove blank line before 'do'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_do=ignore|nl_before_do=add|nl_before_do=remove|nl_before_do=force|nl_before_do=not_defined
+Choices=nl_before_do\s*=\s*ignore|nl_before_do\s*=\s*add|nl_before_do\s*=\s*remove|nl_before_do\s*=\s*force|nl_before_do\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Do|Add Nl Before Do|Remove Nl Before Do|Force Nl Before Do"
 ValueDefault=ignore
 
@@ -4996,7 +4997,7 @@ Category=3
 Description="<html>Add or remove blank line after 'do/while' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_do=ignore|nl_after_do=add|nl_after_do=remove|nl_after_do=force|nl_after_do=not_defined
+Choices=nl_after_do\s*=\s*ignore|nl_after_do\s*=\s*add|nl_after_do\s*=\s*remove|nl_after_do\s*=\s*force|nl_after_do\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Do|Add Nl After Do|Remove Nl After Do|Force Nl After Do"
 ValueDefault=ignore
 
@@ -5005,7 +5006,7 @@ Category=3
 Description="<html>Ignore nl_before_{if,for,switch,do,synchronized} if the control<br/>statement is immediately after a case statement.<br/>if nl_before_{if,for,switch,do} is set to remove, this option<br/>does nothing.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_before_ignore_after_case=true|nl_before_ignore_after_case=false
+TrueFalse=nl_before_ignore_after_case\s*=\s*true|nl_before_ignore_after_case\s*=\s*false
 ValueDefault=false
 
 [Nl Before Return]
@@ -5013,7 +5014,7 @@ Category=3
 Description="<html>Whether to put a blank line before 'return' statements, unless after an open<br/>brace.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_before_return=true|nl_before_return=false
+TrueFalse=nl_before_return\s*=\s*true|nl_before_return\s*=\s*false
 ValueDefault=false
 
 [Nl After Return]
@@ -5021,7 +5022,7 @@ Category=3
 Description="<html>Whether to put a blank line after 'return' statements, unless followed by a<br/>close brace.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_return=true|nl_after_return=false
+TrueFalse=nl_after_return\s*=\s*true|nl_after_return\s*=\s*false
 ValueDefault=false
 
 [Nl Before Member]
@@ -5029,7 +5030,7 @@ Category=3
 Description="<html>Whether to put a blank line before a member '.' or '-&gt;' operators.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_member=ignore|nl_before_member=add|nl_before_member=remove|nl_before_member=force|nl_before_member=not_defined
+Choices=nl_before_member\s*=\s*ignore|nl_before_member\s*=\s*add|nl_before_member\s*=\s*remove|nl_before_member\s*=\s*force|nl_before_member\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Member|Add Nl Before Member|Remove Nl Before Member|Force Nl Before Member"
 ValueDefault=ignore
 
@@ -5038,7 +5039,7 @@ Category=3
 Description="<html>(Java) Whether to put a blank line after a member '.' or '-&gt;' operators.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_member=ignore|nl_after_member=add|nl_after_member=remove|nl_after_member=force|nl_after_member=not_defined
+Choices=nl_after_member\s*=\s*ignore|nl_after_member\s*=\s*add|nl_after_member\s*=\s*remove|nl_after_member\s*=\s*force|nl_after_member\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Member|Add Nl After Member|Remove Nl After Member|Force Nl After Member"
 ValueDefault=ignore
 
@@ -5047,7 +5048,7 @@ Category=3
 Description="<html>Whether to double-space commented-entries in 'struct'/'union'/'enum'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_ds_struct_enum_cmt=true|nl_ds_struct_enum_cmt=false
+TrueFalse=nl_ds_struct_enum_cmt\s*=\s*true|nl_ds_struct_enum_cmt\s*=\s*false
 ValueDefault=false
 
 [Nl Ds Struct Enum Close Brace]
@@ -5055,7 +5056,7 @@ Category=3
 Description="<html>Whether to force a newline before '}' of a 'struct'/'union'/'enum'.<br/>(Lower priority than eat_blanks_before_close_brace.)</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_ds_struct_enum_close_brace=true|nl_ds_struct_enum_close_brace=false
+TrueFalse=nl_ds_struct_enum_close_brace\s*=\s*true|nl_ds_struct_enum_close_brace\s*=\s*false
 ValueDefault=false
 
 [Nl Class Colon]
@@ -5063,7 +5064,7 @@ Category=3
 Description="<html>Add or remove newline before or after (depending on pos_class_colon) a class<br/>colon, as in 'class Foo &lt;here&gt; : &lt;or here&gt; public Bar'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_class_colon=ignore|nl_class_colon=add|nl_class_colon=remove|nl_class_colon=force|nl_class_colon=not_defined
+Choices=nl_class_colon\s*=\s*ignore|nl_class_colon\s*=\s*add|nl_class_colon\s*=\s*remove|nl_class_colon\s*=\s*force|nl_class_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Class Colon|Add Nl Class Colon|Remove Nl Class Colon|Force Nl Class Colon"
 ValueDefault=ignore
 
@@ -5072,7 +5073,7 @@ Category=3
 Description="<html>Add or remove newline around a class constructor colon. The exact position<br/>depends on nl_constr_init_args, pos_constr_colon and pos_constr_comma.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_constr_colon=ignore|nl_constr_colon=add|nl_constr_colon=remove|nl_constr_colon=force|nl_constr_colon=not_defined
+Choices=nl_constr_colon\s*=\s*ignore|nl_constr_colon\s*=\s*add|nl_constr_colon\s*=\s*remove|nl_constr_colon\s*=\s*force|nl_constr_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Constr Colon|Add Nl Constr Colon|Remove Nl Constr Colon|Force Nl Constr Colon"
 ValueDefault=ignore
 
@@ -5081,7 +5082,7 @@ Category=3
 Description="<html>Whether to collapse a two-line namespace, like 'namespace foo\n{ decl; }'<br/>into a single line. If true, prevents other brace newline rules from turning<br/>such code into four lines. If true, it also preserves one-liner namespaces.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_namespace_two_to_one_liner=true|nl_namespace_two_to_one_liner=false
+TrueFalse=nl_namespace_two_to_one_liner\s*=\s*true|nl_namespace_two_to_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create If One Liner]
@@ -5089,7 +5090,7 @@ Category=3
 Description="<html>Whether to remove a newline in simple unbraced if statements, turning them<br/>into one-liners, as in 'if(b)\n i++;' =&gt; 'if(b) i++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_if_one_liner=true|nl_create_if_one_liner=false
+TrueFalse=nl_create_if_one_liner\s*=\s*true|nl_create_if_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create For One Liner]
@@ -5097,7 +5098,7 @@ Category=3
 Description="<html>Whether to remove a newline in simple unbraced for statements, turning them<br/>into one-liners, as in 'for (...)\n stmt;' =&gt; 'for (...) stmt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_for_one_liner=true|nl_create_for_one_liner=false
+TrueFalse=nl_create_for_one_liner\s*=\s*true|nl_create_for_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create While One Liner]
@@ -5105,7 +5106,7 @@ Category=3
 Description="<html>Whether to remove a newline in simple unbraced while statements, turning<br/>them into one-liners, as in 'while (expr)\n stmt;' =&gt; 'while (expr) stmt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_while_one_liner=true|nl_create_while_one_liner=false
+TrueFalse=nl_create_while_one_liner\s*=\s*true|nl_create_while_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create Func Def One Liner]
@@ -5113,7 +5114,7 @@ Category=3
 Description="<html>Whether to collapse a function definition whose body (not counting braces)<br/>is only one line so that the entire definition (prototype, braces, body) is<br/>a single line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_func_def_one_liner=true|nl_create_func_def_one_liner=false
+TrueFalse=nl_create_func_def_one_liner\s*=\s*true|nl_create_func_def_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create List One Liner]
@@ -5121,7 +5122,7 @@ Category=3
 Description="<html>Whether to split one-line simple list definitions into three lines by<br/>adding newlines, as in 'int a[12] = { &lt;here&gt; 0 &lt;here&gt; };'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_list_one_liner=true|nl_create_list_one_liner=false
+TrueFalse=nl_create_list_one_liner\s*=\s*true|nl_create_list_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Split If One Liner]
@@ -5129,7 +5130,7 @@ Category=3
 Description="<html>Whether to split one-line simple unbraced if statements into two lines by<br/>adding a newline, as in 'if(b) &lt;here&gt; i++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_split_if_one_liner=true|nl_split_if_one_liner=false
+TrueFalse=nl_split_if_one_liner\s*=\s*true|nl_split_if_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Split For One Liner]
@@ -5137,7 +5138,7 @@ Category=3
 Description="<html>Whether to split one-line simple unbraced for statements into two lines by<br/>adding a newline, as in 'for (...) &lt;here&gt; stmt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_split_for_one_liner=true|nl_split_for_one_liner=false
+TrueFalse=nl_split_for_one_liner\s*=\s*true|nl_split_for_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Split While One Liner]
@@ -5145,7 +5146,7 @@ Category=3
 Description="<html>Whether to split one-line simple unbraced while statements into two lines by<br/>adding a newline, as in 'while (expr) &lt;here&gt; stmt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_split_while_one_liner=true|nl_split_while_one_liner=false
+TrueFalse=nl_split_while_one_liner\s*=\s*true|nl_split_while_one_liner\s*=\s*false
 ValueDefault=false
 
 [Donot Add Nl Before Cpp Comment]
@@ -5153,7 +5154,7 @@ Category=3
 Description="<html>Don't add a newline before a cpp-comment in a parameter list of a function<br/>call.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=donot_add_nl_before_cpp_comment=true|donot_add_nl_before_cpp_comment=false
+TrueFalse=donot_add_nl_before_cpp_comment\s*=\s*true|donot_add_nl_before_cpp_comment\s*=\s*false
 ValueDefault=false
 
 [Nl Max]
@@ -5161,7 +5162,7 @@ Category=4
 Description="<html>The maximum number of consecutive newlines (3 = 2 blank lines).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_max="
+CallName="nl_max\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5171,7 +5172,7 @@ Category=4
 Description="<html>The maximum number of consecutive newlines in a function.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_max_blank_in_func="
+CallName="nl_max_blank_in_func\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5181,7 +5182,7 @@ Category=4
 Description="<html>The number of newlines inside an empty function body.<br/>This option overrides eat_blanks_after_open_brace and<br/>eat_blanks_before_close_brace, but is ignored when<br/>nl_collapse_empty_body_functions=true</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_inside_empty_func="
+CallName="nl_inside_empty_func\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5191,7 +5192,7 @@ Category=4
 Description="<html>The number of newlines before a function prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_func_body_proto="
+CallName="nl_before_func_body_proto\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5201,7 +5202,7 @@ Category=4
 Description="<html>The number of newlines before a multi-line function definition. Where<br/>applicable, this option is overridden with eat_blanks_after_open_brace=true</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_func_body_def="
+CallName="nl_before_func_body_def\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5211,7 +5212,7 @@ Category=4
 Description="<html>The number of newlines before a class constructor/destructor prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_func_class_proto="
+CallName="nl_before_func_class_proto\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5221,7 +5222,7 @@ Category=4
 Description="<html>The number of newlines before a class constructor/destructor definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_func_class_def="
+CallName="nl_before_func_class_def\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5231,7 +5232,7 @@ Category=4
 Description="<html>The number of newlines after a function prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_proto="
+CallName="nl_after_func_proto\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5241,7 +5242,7 @@ Category=4
 Description="<html>The number of newlines after a function prototype, if not followed by<br/>another function prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_proto_group="
+CallName="nl_after_func_proto_group\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5251,7 +5252,7 @@ Category=4
 Description="<html>The number of newlines after a class constructor/destructor prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_class_proto="
+CallName="nl_after_func_class_proto\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5261,7 +5262,7 @@ Category=4
 Description="<html>The number of newlines after a class constructor/destructor prototype,<br/>if not followed by another constructor/destructor prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_class_proto_group="
+CallName="nl_after_func_class_proto_group\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5271,7 +5272,7 @@ Category=4
 Description="<html>Whether one-line method definitions inside a class body should be treated<br/>as if they were prototypes for the purposes of adding newlines.<br/><br/>Requires nl_class_leave_one_liners=true. Overrides nl_before_func_body_def<br/>and nl_before_func_class_def for one-liners.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_class_leave_one_liner_groups=true|nl_class_leave_one_liner_groups=false
+TrueFalse=nl_class_leave_one_liner_groups\s*=\s*true|nl_class_leave_one_liner_groups\s*=\s*false
 ValueDefault=false
 
 [Nl After Func Body]
@@ -5279,7 +5280,7 @@ Category=4
 Description="<html>The number of newlines after '}' of a multi-line function body.<br/><br/>Overrides nl_min_after_func_body and nl_max_after_func_body.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_body="
+CallName="nl_after_func_body\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5289,7 +5290,7 @@ Category=4
 Description="<html>The minimum number of newlines after '}' of a multi-line function body.<br/><br/>Only works when nl_after_func_body is 0.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_min_after_func_body="
+CallName="nl_min_after_func_body\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5299,7 +5300,7 @@ Category=4
 Description="<html>The maximum number of newlines after '}' of a multi-line function body.<br/><br/>Only works when nl_after_func_body is 0.<br/>Takes precedence over nl_min_after_func_body.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_max_after_func_body="
+CallName="nl_max_after_func_body\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5309,7 +5310,7 @@ Category=4
 Description="<html>The number of newlines after '}' of a multi-line function body in a class<br/>declaration. Also affects class constructors/destructors.<br/><br/>Overrides nl_after_func_body.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_body_class="
+CallName="nl_after_func_body_class\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5319,7 +5320,7 @@ Category=4
 Description="<html>The number of newlines after '}' of a single line function body. Also<br/>affects class constructors/destructors.<br/><br/>Overrides nl_after_func_body and nl_after_func_body_class.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_body_one_liner="
+CallName="nl_after_func_body_one_liner\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5329,7 +5330,7 @@ Category=4
 Description="<html>The number of newlines before a block of typedefs. If nl_after_access_spec<br/>is non-zero, that option takes precedence.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_typedef_blk_start="
+CallName="nl_typedef_blk_start\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5339,7 +5340,7 @@ Category=4
 Description="<html>The number of newlines after a block of typedefs.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_typedef_blk_end="
+CallName="nl_typedef_blk_end\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5349,7 +5350,7 @@ Category=4
 Description="<html>The maximum number of consecutive newlines within a block of typedefs.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_typedef_blk_in="
+CallName="nl_typedef_blk_in\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5359,7 +5360,7 @@ Category=4
 Description="<html>The minimum number of blank lines after a block of variable definitions<br/>at the top of a function body. If any preprocessor directives appear<br/>between the opening brace of the function and the variable block, then<br/>it is considered as not at the top of the function.Newlines are added<br/>before trailing preprocessor directives, if any exist.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_var_def_blk_end_func_top="
+CallName="nl_var_def_blk_end_func_top\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5369,7 +5370,7 @@ Category=4
 Description="<html>The minimum number of empty newlines before a block of variable definitions<br/>not at the top of a function body. If nl_after_access_spec is non-zero,<br/>that option takes precedence. Newlines are not added at the top of the<br/>file or just after an opening brace. Newlines are added above any<br/>preprocessor directives before the block.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_var_def_blk_start="
+CallName="nl_var_def_blk_start\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5379,7 +5380,7 @@ Category=4
 Description="<html>The minimum number of empty newlines after a block of variable definitions<br/>not at the top of a function body. Newlines are not added if the block<br/>is at the bottom of the file or just before a preprocessor directive.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_var_def_blk_end="
+CallName="nl_var_def_blk_end\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5389,7 +5390,7 @@ Category=4
 Description="<html>The maximum number of consecutive newlines within a block of variable<br/>definitions.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_var_def_blk_in="
+CallName="nl_var_def_blk_in\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5399,7 +5400,7 @@ Category=4
 Description="<html>The minimum number of newlines before a multi-line comment.<br/>Doesn't apply if after a brace open or another multi-line comment.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_block_comment="
+CallName="nl_before_block_comment\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5409,7 +5410,7 @@ Category=4
 Description="<html>The minimum number of newlines before a single-line C comment.<br/>Doesn't apply if after a brace open or other single-line C comments.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_c_comment="
+CallName="nl_before_c_comment\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5419,7 +5420,7 @@ Category=4
 Description="<html>The minimum number of newlines before a CPP comment.<br/>Doesn't apply if after a brace open or other CPP comments.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_cpp_comment="
+CallName="nl_before_cpp_comment\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5429,7 +5430,7 @@ Category=4
 Description="<html>Whether to force a newline after a multi-line comment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_multiline_comment=true|nl_after_multiline_comment=false
+TrueFalse=nl_after_multiline_comment\s*=\s*true|nl_after_multiline_comment\s*=\s*false
 ValueDefault=false
 
 [Nl After Label Colon]
@@ -5437,7 +5438,7 @@ Category=4
 Description="<html>Whether to force a newline after a label's colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_label_colon=true|nl_after_label_colon=false
+TrueFalse=nl_after_label_colon\s*=\s*true|nl_after_label_colon\s*=\s*false
 ValueDefault=false
 
 [Nl Before Struct]
@@ -5445,7 +5446,7 @@ Category=4
 Description="<html>The number of newlines before a struct definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_struct="
+CallName="nl_before_struct\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5455,7 +5456,7 @@ Category=4
 Description="<html>The number of newlines after '}' or ';' of a struct/enum/union definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_struct="
+CallName="nl_after_struct\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5465,7 +5466,7 @@ Category=4
 Description="<html>The number of newlines before a class definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_class="
+CallName="nl_before_class\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5475,7 +5476,7 @@ Category=4
 Description="<html>The number of newlines after '}' or ';' of a class definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_class="
+CallName="nl_after_class\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5485,7 +5486,7 @@ Category=4
 Description="<html>The number of newlines before a namespace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_namespace="
+CallName="nl_before_namespace\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5495,7 +5496,7 @@ Category=4
 Description="<html>The number of newlines after '{' of a namespace. This also adds newlines<br/>before the matching '}'.<br/><br/>0: Apply eat_blanks_after_open_brace or eat_blanks_before_close_brace if<br/>    applicable, otherwise no change.<br/><br/>Overrides eat_blanks_after_open_brace and eat_blanks_before_close_brace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_inside_namespace="
+CallName="nl_inside_namespace\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5505,7 +5506,7 @@ Category=4
 Description="<html>The number of newlines after '}' of a namespace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_namespace="
+CallName="nl_after_namespace\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5515,7 +5516,7 @@ Category=4
 Description="<html>The number of newlines before an access specifier label. This also includes<br/>the Qt-specific 'signals:' and 'slots:'. Will not change the newline count<br/>if after a brace open.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_access_spec="
+CallName="nl_before_access_spec\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5525,7 +5526,7 @@ Category=4
 Description="<html>The number of newlines after an access specifier label. This also includes<br/>the Qt-specific 'signals:' and 'slots:'. Will not change the newline count<br/>if after a brace open.<br/><br/>0: No change (default).<br/><br/>Overrides nl_typedef_blk_start and nl_var_def_blk_start.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_access_spec="
+CallName="nl_after_access_spec\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5535,7 +5536,7 @@ Category=4
 Description="<html>The number of newlines between a function definition and the function<br/>comment, as in '// comment\n &lt;here&gt; void foo() {...}'.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_comment_func_def="
+CallName="nl_comment_func_def\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5545,7 +5546,7 @@ Category=4
 Description="<html>The number of newlines after a try-catch-finally block that isn't followed<br/>by a brace close.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_try_catch_finally="
+CallName="nl_after_try_catch_finally\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5555,7 +5556,7 @@ Category=4
 Description="<html>(C#) The number of newlines before and after a property, indexer or event<br/>declaration.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_around_cs_property="
+CallName="nl_around_cs_property\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5565,7 +5566,7 @@ Category=4
 Description="<html>(C#) The number of newlines between the get/set/add/remove handlers.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_between_get_set="
+CallName="nl_between_get_set\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5575,7 +5576,7 @@ Category=4
 Description="<html>(C#) Add or remove newline between property and the '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_property_brace=ignore|nl_property_brace=add|nl_property_brace=remove|nl_property_brace=force|nl_property_brace=not_defined
+Choices=nl_property_brace\s*=\s*ignore|nl_property_brace\s*=\s*add|nl_property_brace\s*=\s*remove|nl_property_brace\s*=\s*force|nl_property_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Property Brace|Add Nl Property Brace|Remove Nl Property Brace|Force Nl Property Brace"
 ValueDefault=ignore
 
@@ -5584,7 +5585,7 @@ Category=4
 Description="<html>Whether to remove blank lines after '{'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=eat_blanks_after_open_brace=true|eat_blanks_after_open_brace=false
+TrueFalse=eat_blanks_after_open_brace\s*=\s*true|eat_blanks_after_open_brace\s*=\s*false
 ValueDefault=false
 
 [Eat Blanks Before Close Brace]
@@ -5592,7 +5593,7 @@ Category=4
 Description="<html>Whether to remove blank lines before '}'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=eat_blanks_before_close_brace=true|eat_blanks_before_close_brace=false
+TrueFalse=eat_blanks_before_close_brace\s*=\s*true|eat_blanks_before_close_brace\s*=\s*false
 ValueDefault=false
 
 [Nl Remove Extra Newlines]
@@ -5600,7 +5601,7 @@ Category=4
 Description="<html>How aggressively to remove extra newlines not in preprocessor.<br/><br/>0: No change (default)<br/>1: Remove most newlines not handled by other config<br/>2: Remove all newlines and reformat completely by config</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_remove_extra_newlines="
+CallName="nl_remove_extra_newlines\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -5610,7 +5611,7 @@ Category=4
 Description="<html>(Java) Add or remove newline after an annotation statement. Only affects<br/>annotations that are after a newline.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_annotation=ignore|nl_after_annotation=add|nl_after_annotation=remove|nl_after_annotation=force|nl_after_annotation=not_defined
+Choices=nl_after_annotation\s*=\s*ignore|nl_after_annotation\s*=\s*add|nl_after_annotation\s*=\s*remove|nl_after_annotation\s*=\s*force|nl_after_annotation\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Annotation|Add Nl After Annotation|Remove Nl After Annotation|Force Nl After Annotation"
 ValueDefault=ignore
 
@@ -5619,7 +5620,7 @@ Category=4
 Description="<html>(Java) Add or remove newline between two annotations.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_between_annotation=ignore|nl_between_annotation=add|nl_between_annotation=remove|nl_between_annotation=force|nl_between_annotation=not_defined
+Choices=nl_between_annotation\s*=\s*ignore|nl_between_annotation\s*=\s*add|nl_between_annotation\s*=\s*remove|nl_between_annotation\s*=\s*force|nl_between_annotation\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Between Annotation|Add Nl Between Annotation|Remove Nl Between Annotation|Force Nl Between Annotation"
 ValueDefault=ignore
 
@@ -5628,7 +5629,7 @@ Category=4
 Description="<html>The number of newlines before a whole-file #ifdef.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_whole_file_ifdef="
+CallName="nl_before_whole_file_ifdef\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5638,7 +5639,7 @@ Category=4
 Description="<html>The number of newlines after a whole-file #ifdef.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_whole_file_ifdef="
+CallName="nl_after_whole_file_ifdef\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5648,7 +5649,7 @@ Category=4
 Description="<html>The number of newlines before a whole-file #endif.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_whole_file_endif="
+CallName="nl_before_whole_file_endif\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5658,7 +5659,7 @@ Category=4
 Description="<html>The number of newlines after a whole-file #endif.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_whole_file_endif="
+CallName="nl_after_whole_file_endif\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5668,7 +5669,7 @@ Category=5
 Description="<html>The position of arithmetic operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_arith=ignore|pos_arith=break|pos_arith=force|pos_arith=lead|pos_arith=trail|pos_arith=join|pos_arith=lead_break|pos_arith=lead_force|pos_arith=trail_break|pos_arith=trail_force
+Choices=pos_arith\s*=\s*ignore|pos_arith\s*=\s*break|pos_arith\s*=\s*force|pos_arith\s*=\s*lead|pos_arith\s*=\s*trail|pos_arith\s*=\s*join|pos_arith\s*=\s*lead_break|pos_arith\s*=\s*lead_force|pos_arith\s*=\s*trail_break|pos_arith\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Arith|Break Pos Arith|Force Pos Arith|Lead Pos Arith|Trail Pos Arith|Join Pos Arith|Lead Break Pos Arith|Lead Force Pos Arith|Trail Break Pos Arith|Trail Force Pos Arith"
 ValueDefault=ignore
 
@@ -5677,7 +5678,7 @@ Category=5
 Description="<html>The position of assignment in wrapped expressions. Do not affect '='<br/>followed by '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_assign=ignore|pos_assign=break|pos_assign=force|pos_assign=lead|pos_assign=trail|pos_assign=join|pos_assign=lead_break|pos_assign=lead_force|pos_assign=trail_break|pos_assign=trail_force
+Choices=pos_assign\s*=\s*ignore|pos_assign\s*=\s*break|pos_assign\s*=\s*force|pos_assign\s*=\s*lead|pos_assign\s*=\s*trail|pos_assign\s*=\s*join|pos_assign\s*=\s*lead_break|pos_assign\s*=\s*lead_force|pos_assign\s*=\s*trail_break|pos_assign\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Assign|Break Pos Assign|Force Pos Assign|Lead Pos Assign|Trail Pos Assign|Join Pos Assign|Lead Break Pos Assign|Lead Force Pos Assign|Trail Break Pos Assign|Trail Force Pos Assign"
 ValueDefault=ignore
 
@@ -5686,7 +5687,7 @@ Category=5
 Description="<html>The position of Boolean operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_bool=ignore|pos_bool=break|pos_bool=force|pos_bool=lead|pos_bool=trail|pos_bool=join|pos_bool=lead_break|pos_bool=lead_force|pos_bool=trail_break|pos_bool=trail_force
+Choices=pos_bool\s*=\s*ignore|pos_bool\s*=\s*break|pos_bool\s*=\s*force|pos_bool\s*=\s*lead|pos_bool\s*=\s*trail|pos_bool\s*=\s*join|pos_bool\s*=\s*lead_break|pos_bool\s*=\s*lead_force|pos_bool\s*=\s*trail_break|pos_bool\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Bool|Break Pos Bool|Force Pos Bool|Lead Pos Bool|Trail Pos Bool|Join Pos Bool|Lead Break Pos Bool|Lead Force Pos Bool|Trail Break Pos Bool|Trail Force Pos Bool"
 ValueDefault=ignore
 
@@ -5695,7 +5696,7 @@ Category=5
 Description="<html>The position of comparison operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_compare=ignore|pos_compare=break|pos_compare=force|pos_compare=lead|pos_compare=trail|pos_compare=join|pos_compare=lead_break|pos_compare=lead_force|pos_compare=trail_break|pos_compare=trail_force
+Choices=pos_compare\s*=\s*ignore|pos_compare\s*=\s*break|pos_compare\s*=\s*force|pos_compare\s*=\s*lead|pos_compare\s*=\s*trail|pos_compare\s*=\s*join|pos_compare\s*=\s*lead_break|pos_compare\s*=\s*lead_force|pos_compare\s*=\s*trail_break|pos_compare\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Compare|Break Pos Compare|Force Pos Compare|Lead Pos Compare|Trail Pos Compare|Join Pos Compare|Lead Break Pos Compare|Lead Force Pos Compare|Trail Break Pos Compare|Trail Force Pos Compare"
 ValueDefault=ignore
 
@@ -5704,7 +5705,7 @@ Category=5
 Description="<html>The position of conditional operators, as in the '?' and ':' of<br/>'expr ? stmt : stmt', in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_conditional=ignore|pos_conditional=break|pos_conditional=force|pos_conditional=lead|pos_conditional=trail|pos_conditional=join|pos_conditional=lead_break|pos_conditional=lead_force|pos_conditional=trail_break|pos_conditional=trail_force
+Choices=pos_conditional\s*=\s*ignore|pos_conditional\s*=\s*break|pos_conditional\s*=\s*force|pos_conditional\s*=\s*lead|pos_conditional\s*=\s*trail|pos_conditional\s*=\s*join|pos_conditional\s*=\s*lead_break|pos_conditional\s*=\s*lead_force|pos_conditional\s*=\s*trail_break|pos_conditional\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Conditional|Break Pos Conditional|Force Pos Conditional|Lead Pos Conditional|Trail Pos Conditional|Join Pos Conditional|Lead Break Pos Conditional|Lead Force Pos Conditional|Trail Break Pos Conditional|Trail Force Pos Conditional"
 ValueDefault=ignore
 
@@ -5713,7 +5714,7 @@ Category=5
 Description="<html>The position of the comma in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_comma=ignore|pos_comma=break|pos_comma=force|pos_comma=lead|pos_comma=trail|pos_comma=join|pos_comma=lead_break|pos_comma=lead_force|pos_comma=trail_break|pos_comma=trail_force
+Choices=pos_comma\s*=\s*ignore|pos_comma\s*=\s*break|pos_comma\s*=\s*force|pos_comma\s*=\s*lead|pos_comma\s*=\s*trail|pos_comma\s*=\s*join|pos_comma\s*=\s*lead_break|pos_comma\s*=\s*lead_force|pos_comma\s*=\s*trail_break|pos_comma\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Comma|Break Pos Comma|Force Pos Comma|Lead Pos Comma|Trail Pos Comma|Join Pos Comma|Lead Break Pos Comma|Lead Force Pos Comma|Trail Break Pos Comma|Trail Force Pos Comma"
 ValueDefault=ignore
 
@@ -5722,7 +5723,7 @@ Category=5
 Description="<html>The position of the comma in enum entries.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_enum_comma=ignore|pos_enum_comma=break|pos_enum_comma=force|pos_enum_comma=lead|pos_enum_comma=trail|pos_enum_comma=join|pos_enum_comma=lead_break|pos_enum_comma=lead_force|pos_enum_comma=trail_break|pos_enum_comma=trail_force
+Choices=pos_enum_comma\s*=\s*ignore|pos_enum_comma\s*=\s*break|pos_enum_comma\s*=\s*force|pos_enum_comma\s*=\s*lead|pos_enum_comma\s*=\s*trail|pos_enum_comma\s*=\s*join|pos_enum_comma\s*=\s*lead_break|pos_enum_comma\s*=\s*lead_force|pos_enum_comma\s*=\s*trail_break|pos_enum_comma\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Enum Comma|Break Pos Enum Comma|Force Pos Enum Comma|Lead Pos Enum Comma|Trail Pos Enum Comma|Join Pos Enum Comma|Lead Break Pos Enum Comma|Lead Force Pos Enum Comma|Trail Break Pos Enum Comma|Trail Force Pos Enum Comma"
 ValueDefault=ignore
 
@@ -5731,7 +5732,7 @@ Category=5
 Description="<html>The position of the comma in the base class list if there is more than one<br/>line. Affects nl_class_init_args.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_class_comma=ignore|pos_class_comma=break|pos_class_comma=force|pos_class_comma=lead|pos_class_comma=trail|pos_class_comma=join|pos_class_comma=lead_break|pos_class_comma=lead_force|pos_class_comma=trail_break|pos_class_comma=trail_force
+Choices=pos_class_comma\s*=\s*ignore|pos_class_comma\s*=\s*break|pos_class_comma\s*=\s*force|pos_class_comma\s*=\s*lead|pos_class_comma\s*=\s*trail|pos_class_comma\s*=\s*join|pos_class_comma\s*=\s*lead_break|pos_class_comma\s*=\s*lead_force|pos_class_comma\s*=\s*trail_break|pos_class_comma\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Class Comma|Break Pos Class Comma|Force Pos Class Comma|Lead Pos Class Comma|Trail Pos Class Comma|Join Pos Class Comma|Lead Break Pos Class Comma|Lead Force Pos Class Comma|Trail Break Pos Class Comma|Trail Force Pos Class Comma"
 ValueDefault=ignore
 
@@ -5740,7 +5741,7 @@ Category=5
 Description="<html>The position of the comma in the constructor initialization list.<br/>Related to nl_constr_colon, nl_constr_init_args and pos_constr_colon.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_constr_comma=ignore|pos_constr_comma=break|pos_constr_comma=force|pos_constr_comma=lead|pos_constr_comma=trail|pos_constr_comma=join|pos_constr_comma=lead_break|pos_constr_comma=lead_force|pos_constr_comma=trail_break|pos_constr_comma=trail_force
+Choices=pos_constr_comma\s*=\s*ignore|pos_constr_comma\s*=\s*break|pos_constr_comma\s*=\s*force|pos_constr_comma\s*=\s*lead|pos_constr_comma\s*=\s*trail|pos_constr_comma\s*=\s*join|pos_constr_comma\s*=\s*lead_break|pos_constr_comma\s*=\s*lead_force|pos_constr_comma\s*=\s*trail_break|pos_constr_comma\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Constr Comma|Break Pos Constr Comma|Force Pos Constr Comma|Lead Pos Constr Comma|Trail Pos Constr Comma|Join Pos Constr Comma|Lead Break Pos Constr Comma|Lead Force Pos Constr Comma|Trail Break Pos Constr Comma|Trail Force Pos Constr Comma"
 ValueDefault=ignore
 
@@ -5749,7 +5750,7 @@ Category=5
 Description="<html>The position of trailing/leading class colon, between class and base class<br/>list. Affects nl_class_colon.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_class_colon=ignore|pos_class_colon=break|pos_class_colon=force|pos_class_colon=lead|pos_class_colon=trail|pos_class_colon=join|pos_class_colon=lead_break|pos_class_colon=lead_force|pos_class_colon=trail_break|pos_class_colon=trail_force
+Choices=pos_class_colon\s*=\s*ignore|pos_class_colon\s*=\s*break|pos_class_colon\s*=\s*force|pos_class_colon\s*=\s*lead|pos_class_colon\s*=\s*trail|pos_class_colon\s*=\s*join|pos_class_colon\s*=\s*lead_break|pos_class_colon\s*=\s*lead_force|pos_class_colon\s*=\s*trail_break|pos_class_colon\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Class Colon|Break Pos Class Colon|Force Pos Class Colon|Lead Pos Class Colon|Trail Pos Class Colon|Join Pos Class Colon|Lead Break Pos Class Colon|Lead Force Pos Class Colon|Trail Break Pos Class Colon|Trail Force Pos Class Colon"
 ValueDefault=ignore
 
@@ -5758,7 +5759,7 @@ Category=5
 Description="<html>The position of colons between constructor and member initialization.<br/>Related to nl_constr_colon, nl_constr_init_args and pos_constr_comma.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_constr_colon=ignore|pos_constr_colon=break|pos_constr_colon=force|pos_constr_colon=lead|pos_constr_colon=trail|pos_constr_colon=join|pos_constr_colon=lead_break|pos_constr_colon=lead_force|pos_constr_colon=trail_break|pos_constr_colon=trail_force
+Choices=pos_constr_colon\s*=\s*ignore|pos_constr_colon\s*=\s*break|pos_constr_colon\s*=\s*force|pos_constr_colon\s*=\s*lead|pos_constr_colon\s*=\s*trail|pos_constr_colon\s*=\s*join|pos_constr_colon\s*=\s*lead_break|pos_constr_colon\s*=\s*lead_force|pos_constr_colon\s*=\s*trail_break|pos_constr_colon\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Constr Colon|Break Pos Constr Colon|Force Pos Constr Colon|Lead Pos Constr Colon|Trail Pos Constr Colon|Join Pos Constr Colon|Lead Break Pos Constr Colon|Lead Force Pos Constr Colon|Trail Break Pos Constr Colon|Trail Force Pos Constr Colon"
 ValueDefault=ignore
 
@@ -5767,7 +5768,7 @@ Category=5
 Description="<html>The position of shift operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_shift=ignore|pos_shift=break|pos_shift=force|pos_shift=lead|pos_shift=trail|pos_shift=join|pos_shift=lead_break|pos_shift=lead_force|pos_shift=trail_break|pos_shift=trail_force
+Choices=pos_shift\s*=\s*ignore|pos_shift\s*=\s*break|pos_shift\s*=\s*force|pos_shift\s*=\s*lead|pos_shift\s*=\s*trail|pos_shift\s*=\s*join|pos_shift\s*=\s*lead_break|pos_shift\s*=\s*lead_force|pos_shift\s*=\s*trail_break|pos_shift\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Shift|Break Pos Shift|Force Pos Shift|Lead Pos Shift|Trail Pos Shift|Join Pos Shift|Lead Break Pos Shift|Lead Force Pos Shift|Trail Break Pos Shift|Trail Force Pos Shift"
 ValueDefault=ignore
 
@@ -5776,7 +5777,7 @@ Category=6
 Description="<html>Try to limit code width to N columns.</html>"
 Enabled=false
 EditorType=numeric
-CallName="code_width="
+CallName="code_width\s*=\s*"
 MinVal=0
 MaxVal=10000
 ValueDefault=0
@@ -5786,7 +5787,7 @@ Category=6
 Description="<html>Whether to fully split long 'for' statements at semi-colons.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=ls_for_split_full=true|ls_for_split_full=false
+TrueFalse=ls_for_split_full\s*=\s*true|ls_for_split_full\s*=\s*false
 ValueDefault=false
 
 [Ls Func Split Full]
@@ -5794,7 +5795,7 @@ Category=6
 Description="<html>Whether to fully split long function prototypes/calls at commas.<br/>The option ls_code_width has priority over the option ls_func_split_full.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=ls_func_split_full=true|ls_func_split_full=false
+TrueFalse=ls_func_split_full\s*=\s*true|ls_func_split_full\s*=\s*false
 ValueDefault=false
 
 [Ls Code Width]
@@ -5802,7 +5803,7 @@ Category=6
 Description="<html>Whether to split lines as close to code_width as possible and ignore some<br/>groupings.<br/>The option ls_code_width has priority over the option ls_func_split_full.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=ls_code_width=true|ls_code_width=false
+TrueFalse=ls_code_width\s*=\s*true|ls_code_width\s*=\s*false
 ValueDefault=false
 
 [Align Keep Tabs]
@@ -5810,7 +5811,7 @@ Category=7
 Description="<html>Whether to keep non-indenting tabs.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_keep_tabs=true|align_keep_tabs=false
+TrueFalse=align_keep_tabs\s*=\s*true|align_keep_tabs\s*=\s*false
 ValueDefault=false
 
 [Align With Tabs]
@@ -5818,7 +5819,7 @@ Category=7
 Description="<html>Whether to use tabs for aligning.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_with_tabs=true|align_with_tabs=false
+TrueFalse=align_with_tabs\s*=\s*true|align_with_tabs\s*=\s*false
 ValueDefault=false
 
 [Align On Tabstop]
@@ -5826,7 +5827,7 @@ Category=7
 Description="<html>Whether to bump out to the next tab when aligning.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_on_tabstop=true|align_on_tabstop=false
+TrueFalse=align_on_tabstop\s*=\s*true|align_on_tabstop\s*=\s*false
 ValueDefault=false
 
 [Align Number Right]
@@ -5834,7 +5835,7 @@ Category=7
 Description="<html>Whether to right-align numbers.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_number_right=true|align_number_right=false
+TrueFalse=align_number_right\s*=\s*true|align_number_right\s*=\s*false
 ValueDefault=false
 
 [Align Keep Extra Space]
@@ -5842,7 +5843,7 @@ Category=7
 Description="<html>Whether to keep whitespace not required for alignment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_keep_extra_space=true|align_keep_extra_space=false
+TrueFalse=align_keep_extra_space\s*=\s*true|align_keep_extra_space\s*=\s*false
 ValueDefault=false
 
 [Align Func Params]
@@ -5850,7 +5851,7 @@ Category=7
 Description="<html>Whether to align variable definitions in prototypes and functions.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_func_params=true|align_func_params=false
+TrueFalse=align_func_params\s*=\s*true|align_func_params\s*=\s*false
 ValueDefault=false
 
 [Align Func Params Span]
@@ -5858,7 +5859,7 @@ Category=7
 Description="<html>The span for aligning parameter definitions in function on parameter name.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_params_span="
+CallName="align_func_params_span\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5868,7 +5869,7 @@ Category=7
 Description="<html>The threshold for aligning function parameter definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_params_thresh="
+CallName="align_func_params_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -5878,7 +5879,7 @@ Category=7
 Description="<html>The gap for aligning function parameter definitions.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_params_gap="
+CallName="align_func_params_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5888,7 +5889,7 @@ Category=7
 Description="<html>The span for aligning constructor value.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_constr_value_span="
+CallName="align_constr_value_span\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5898,7 +5899,7 @@ Category=7
 Description="<html>The threshold for aligning constructor value.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_constr_value_thresh="
+CallName="align_constr_value_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -5908,7 +5909,7 @@ Category=7
 Description="<html>The gap for aligning constructor value.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_constr_value_gap="
+CallName="align_constr_value_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5918,7 +5919,7 @@ Category=7
 Description="<html>Whether to align parameters in single-line functions that have the same<br/>name. The function names must already be aligned with each other.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_same_func_call_params=true|align_same_func_call_params=false
+TrueFalse=align_same_func_call_params\s*=\s*true|align_same_func_call_params\s*=\s*false
 ValueDefault=false
 
 [Align Same Func Call Params Span]
@@ -5926,7 +5927,7 @@ Category=7
 Description="<html>The span for aligning function-call parameters for single line functions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_same_func_call_params_span="
+CallName="align_same_func_call_params_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -5936,7 +5937,7 @@ Category=7
 Description="<html>The threshold for aligning function-call parameters for single line<br/>functions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_same_func_call_params_thresh="
+CallName="align_same_func_call_params_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -5946,7 +5947,7 @@ Category=7
 Description="<html>The span for aligning variable definitions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_span="
+CallName="align_var_def_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -5956,7 +5957,7 @@ Category=7
 Description="<html>How to consider (or treat) the '*' in the alignment of variable definitions.<br/><br/>0: Part of the type     'void *   foo;' (default)<br/>1: Part of the variable 'void     *foo;'<br/>2: Dangling             'void    *foo;'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_star_style="
+CallName="align_var_def_star_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -5966,7 +5967,7 @@ Category=7
 Description="<html>How to consider (or treat) the '&amp;' in the alignment of variable definitions.<br/><br/>0: Part of the type     'long &amp;   foo;' (default)<br/>1: Part of the variable 'long     &amp;foo;'<br/>2: Dangling             'long    &amp;foo;'<br/>Dangling: the '&amp;' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_amp_style="
+CallName="align_var_def_amp_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -5976,7 +5977,7 @@ Category=7
 Description="<html>The threshold for aligning variable definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_thresh="
+CallName="align_var_def_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -5986,7 +5987,7 @@ Category=7
 Description="<html>The gap for aligning variable definitions.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_gap="
+CallName="align_var_def_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5996,7 +5997,7 @@ Category=7
 Description="<html>Whether to align the colon in struct bit fields.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_var_def_colon=true|align_var_def_colon=false
+TrueFalse=align_var_def_colon\s*=\s*true|align_var_def_colon\s*=\s*false
 ValueDefault=false
 
 [Align Var Def Colon Gap]
@@ -6004,7 +6005,7 @@ Category=7
 Description="<html>The gap for aligning the colon in struct bit fields.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_colon_gap="
+CallName="align_var_def_colon_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6014,7 +6015,7 @@ Category=7
 Description="<html>Whether to align any attribute after the variable name.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_var_def_attribute=true|align_var_def_attribute=false
+TrueFalse=align_var_def_attribute\s*=\s*true|align_var_def_attribute\s*=\s*false
 ValueDefault=false
 
 [Align Var Def Inline]
@@ -6022,7 +6023,7 @@ Category=7
 Description="<html>Whether to align inline struct/enum/union variable definitions.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_var_def_inline=true|align_var_def_inline=false
+TrueFalse=align_var_def_inline\s*=\s*true|align_var_def_inline\s*=\s*false
 ValueDefault=false
 
 [Align Assign Span]
@@ -6030,7 +6031,7 @@ Category=7
 Description="<html>The span for aligning on '=' in assignments.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_assign_span="
+CallName="align_assign_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6040,7 +6041,7 @@ Category=7
 Description="<html>The span for aligning on '=' in function prototype modifier.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_assign_func_proto_span="
+CallName="align_assign_func_proto_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6050,7 +6051,7 @@ Category=7
 Description="<html>The threshold for aligning on '=' in assignments.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_assign_thresh="
+CallName="align_assign_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6060,7 +6061,7 @@ Category=7
 Description="<html>Whether to align on the left most assignment when multiple<br/>definitions are found on the same line.<br/>Depends on 'align_assign_span' and 'align_assign_thresh' settings.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_assign_on_multi_var_defs=true|align_assign_on_multi_var_defs=false
+TrueFalse=align_assign_on_multi_var_defs\s*=\s*true|align_assign_on_multi_var_defs\s*=\s*false
 ValueDefault=false
 
 [Align Braced Init List Span]
@@ -6068,7 +6069,7 @@ Category=7
 Description="<html>The span for aligning on '{' in braced init list.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_braced_init_list_span="
+CallName="align_braced_init_list_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6078,7 +6079,7 @@ Category=7
 Description="<html>The threshold for aligning on '{' in braced init list.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_braced_init_list_thresh="
+CallName="align_braced_init_list_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6088,7 +6089,7 @@ Category=7
 Description="<html>How to apply align_assign_span to function declaration "assignments", i.e.<br/>'virtual void foo() = 0' or '~foo() = {default|delete}'.<br/><br/>0: Align with other assignments (default)<br/>1: Align with each other, ignoring regular assignments<br/>2: Don't align</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_assign_decl_func="
+CallName="align_assign_decl_func\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6098,7 +6099,7 @@ Category=7
 Description="<html>The span for aligning on '=' in enums.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_enum_equ_span="
+CallName="align_enum_equ_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6108,7 +6109,7 @@ Category=7
 Description="<html>The threshold for aligning on '=' in enums.<br/>Use a negative number for absolute thresholds.<br/><br/>0: no limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_enum_equ_thresh="
+CallName="align_enum_equ_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6118,7 +6119,7 @@ Category=7
 Description="<html>The span for aligning class member definitions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_class_span="
+CallName="align_var_class_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6128,7 +6129,7 @@ Category=7
 Description="<html>The threshold for aligning class member definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_class_thresh="
+CallName="align_var_class_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6138,7 +6139,7 @@ Category=7
 Description="<html>The gap for aligning class member definitions.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_class_gap="
+CallName="align_var_class_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6148,7 +6149,7 @@ Category=7
 Description="<html>The span for aligning struct/union member definitions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_struct_span="
+CallName="align_var_struct_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6158,7 +6159,7 @@ Category=7
 Description="<html>The threshold for aligning struct/union member definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_struct_thresh="
+CallName="align_var_struct_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6168,7 +6169,7 @@ Category=7
 Description="<html>The gap for aligning struct/union member definitions.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_struct_gap="
+CallName="align_var_struct_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6178,7 +6179,7 @@ Category=7
 Description="<html>The span for aligning struct initializer values.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_struct_init_span="
+CallName="align_struct_init_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6188,7 +6189,7 @@ Category=7
 Description="<html>The span for aligning single-line typedefs.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_span="
+CallName="align_typedef_span\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6198,7 +6199,7 @@ Category=7
 Description="<html>The minimum space between the type and the synonym of a typedef.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_gap="
+CallName="align_typedef_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6208,7 +6209,7 @@ Category=7
 Description="<html>How to align typedef'd functions with other typedefs.<br/><br/>0: Don't mix them at all (default)<br/>1: Align the open parenthesis with the types<br/>2: Align the function type name with the other type names</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_func="
+CallName="align_typedef_func\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6218,7 +6219,7 @@ Category=7
 Description="<html>How to consider (or treat) the '*' in the alignment of typedefs.<br/><br/>0: Part of the typedef type, 'typedef int * pint;' (default)<br/>1: Part of type name:        'typedef int   *pint;'<br/>2: Dangling:                 'typedef int  *pint;'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_star_style="
+CallName="align_typedef_star_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6228,7 +6229,7 @@ Category=7
 Description="<html>How to consider (or treat) the '&amp;' in the alignment of typedefs.<br/><br/>0: Part of the typedef type, 'typedef int &amp; intref;' (default)<br/>1: Part of type name:        'typedef int   &amp;intref;'<br/>2: Dangling:                 'typedef int  &amp;intref;'<br/>Dangling: the '&amp;' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_amp_style="
+CallName="align_typedef_amp_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6238,7 +6239,7 @@ Category=7
 Description="<html>The span for aligning comments that end lines.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_right_cmt_span="
+CallName="align_right_cmt_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6248,7 +6249,7 @@ Category=7
 Description="<html>Minimum number of columns between preceding text and a trailing comment in<br/>order for the comment to qualify for being aligned. Must be non-zero to have<br/>an effect.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_right_cmt_gap="
+CallName="align_right_cmt_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6258,7 +6259,7 @@ Category=7
 Description="<html>If aligning comments, whether to mix with comments after '}' and #endif with<br/>less than three spaces before the comment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_right_cmt_mix=true|align_right_cmt_mix=false
+TrueFalse=align_right_cmt_mix\s*=\s*true|align_right_cmt_mix\s*=\s*false
 ValueDefault=false
 
 [Align Right Cmt Same Level]
@@ -6266,7 +6267,7 @@ Category=7
 Description="<html>Whether to only align trailing comments that are at the same brace level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_right_cmt_same_level=true|align_right_cmt_same_level=false
+TrueFalse=align_right_cmt_same_level\s*=\s*true|align_right_cmt_same_level\s*=\s*false
 ValueDefault=false
 
 [Align Right Cmt At Col]
@@ -6274,7 +6275,7 @@ Category=7
 Description="<html>Minimum column at which to align trailing comments. Comments which are<br/>aligned beyond this column, but which can be aligned in a lesser column,<br/>may be "pulled in".<br/><br/>0: Ignore (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_right_cmt_at_col="
+CallName="align_right_cmt_at_col\s*=\s*"
 MinVal=0
 MaxVal=200
 ValueDefault=0
@@ -6284,7 +6285,7 @@ Category=7
 Description="<html>The span for aligning function prototypes.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_span="
+CallName="align_func_proto_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6294,7 +6295,7 @@ Category=7
 Description="<html>Whether to ignore continuation lines when evaluating the number of<br/>new lines for the function prototype alignment's span.<br/><br/>false: continuation lines are part of the newlines count<br/>true:  continuation lines are not counted</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_func_proto_span_ignore_cont_lines=true|align_func_proto_span_ignore_cont_lines=false
+TrueFalse=align_func_proto_span_ignore_cont_lines\s*=\s*true|align_func_proto_span_ignore_cont_lines\s*=\s*false
 ValueDefault=false
 
 [Align Func Proto Star Style]
@@ -6302,7 +6303,7 @@ Category=7
 Description="<html>How to consider (or treat) the '*' in the alignment of function prototypes.<br/><br/>0: Part of the type     'void *   foo();' (default)<br/>1: Part of the function 'void     *foo();'<br/>2: Dangling             'void    *foo();'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_star_style="
+CallName="align_func_proto_star_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6312,7 +6313,7 @@ Category=7
 Description="<html>How to consider (or treat) the '&amp;' in the alignment of function prototypes.<br/><br/>0: Part of the type     'long &amp;   foo();' (default)<br/>1: Part of the function 'long     &amp;foo();'<br/>2: Dangling             'long    &amp;foo();'<br/>Dangling: the '&amp;' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_amp_style="
+CallName="align_func_proto_amp_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6322,7 +6323,7 @@ Category=7
 Description="<html>The threshold for aligning function prototypes.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_thresh="
+CallName="align_func_proto_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6332,7 +6333,7 @@ Category=7
 Description="<html>Minimum gap between the return type and the function name.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_gap="
+CallName="align_func_proto_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6342,7 +6343,7 @@ Category=7
 Description="<html>Whether to align function prototypes on the 'operator' keyword instead of<br/>what follows.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_on_operator=true|align_on_operator=false
+TrueFalse=align_on_operator\s*=\s*true|align_on_operator\s*=\s*false
 ValueDefault=false
 
 [Align Mix Var Proto]
@@ -6350,7 +6351,7 @@ Category=7
 Description="<html>Whether to mix aligning prototype and variable declarations. If true,<br/>align_var_def_XXX options are used instead of align_func_proto_XXX options.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_mix_var_proto=true|align_mix_var_proto=false
+TrueFalse=align_mix_var_proto\s*=\s*true|align_mix_var_proto\s*=\s*false
 ValueDefault=false
 
 [Align Single Line Func]
@@ -6358,7 +6359,7 @@ Category=7
 Description="<html>Whether to align single-line functions with function prototypes.<br/>Uses align_func_proto_span.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_single_line_func=true|align_single_line_func=false
+TrueFalse=align_single_line_func\s*=\s*true|align_single_line_func\s*=\s*false
 ValueDefault=false
 
 [Align Single Line Brace]
@@ -6366,7 +6367,7 @@ Category=7
 Description="<html>Whether to align the open brace of single-line functions.<br/>Requires align_single_line_func=true. Uses align_func_proto_span.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_single_line_brace=true|align_single_line_brace=false
+TrueFalse=align_single_line_brace\s*=\s*true|align_single_line_brace\s*=\s*false
 ValueDefault=false
 
 [Align Single Line Brace Gap]
@@ -6374,7 +6375,7 @@ Category=7
 Description="<html>Gap for align_single_line_brace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_single_line_brace_gap="
+CallName="align_single_line_brace_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6384,7 +6385,7 @@ Category=7
 Description="<html>(OC) The span for aligning Objective-C message specifications.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_oc_msg_spec_span="
+CallName="align_oc_msg_spec_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6394,7 +6395,7 @@ Category=7
 Description="<html>Whether and how to align backslashes that split a macro onto multiple lines.<br/>This will not work right if the macro contains a multi-line comment.<br/><br/>0: Do nothing (default)<br/>1: Align the backslashes in the column at the end of the longest line<br/>2: Align with the backslash that is farthest to the left, or, if that<br/>   backslash is farther left than the end of the longest line, at the end of<br/>   the longest line<br/>3: Align with the backslash that is farthest to the right</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_nl_cont="
+CallName="align_nl_cont\s*=\s*"
 MinVal=0
 MaxVal=3
 ValueDefault=0
@@ -6404,7 +6405,7 @@ Category=7
 Description="<html>The minimum number of spaces between the end of a line and its continuation<br/>backslash. Requires align_nl_cont.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_nl_cont_spaces="
+CallName="align_nl_cont_spaces\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -6414,7 +6415,7 @@ Category=7
 Description="<html>Whether to align macro functions and variables together.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_pp_define_together=true|align_pp_define_together=false
+TrueFalse=align_pp_define_together\s*=\s*true|align_pp_define_together\s*=\s*false
 ValueDefault=false
 
 [Align Pp Define Span]
@@ -6422,7 +6423,7 @@ Category=7
 Description="<html>The span for aligning on '#define' bodies.<br/><br/>=0: Don't align (default)<br/>&gt;0: Number of lines (including comments) between blocks</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_pp_define_span="
+CallName="align_pp_define_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6432,7 +6433,7 @@ Category=7
 Description="<html>The minimum space between label and value of a preprocessor define.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_pp_define_gap="
+CallName="align_pp_define_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6442,7 +6443,7 @@ Category=7
 Description="<html>Whether to align lines that start with '&lt;&lt;' with previous '&lt;&lt;'.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_left_shift=true|align_left_shift=false
+TrueFalse=align_left_shift\s*=\s*true|align_left_shift\s*=\s*false
 ValueDefault=true
 
 [Align Eigen Comma Init]
@@ -6450,7 +6451,7 @@ Category=7
 Description="<html>Whether to align comma-separated statements following '&lt;&lt;' (as used to<br/>initialize Eigen matrices).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_eigen_comma_init=true|align_eigen_comma_init=false
+TrueFalse=align_eigen_comma_init\s*=\s*true|align_eigen_comma_init\s*=\s*false
 ValueDefault=false
 
 [Align Asm Colon]
@@ -6458,7 +6459,7 @@ Category=7
 Description="<html>Whether to align text after 'asm volatile ()' colons.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_asm_colon=true|align_asm_colon=false
+TrueFalse=align_asm_colon\s*=\s*true|align_asm_colon\s*=\s*false
 ValueDefault=false
 
 [Align Oc Msg Colon Span]
@@ -6466,7 +6467,7 @@ Category=7
 Description="<html>(OC) Span for aligning parameters in an Objective-C message call<br/>on the ':'.<br/><br/>0: Don't align.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_oc_msg_colon_span="
+CallName="align_oc_msg_colon_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6476,7 +6477,7 @@ Category=7
 Description="<html>(OC) Whether to always align with the first parameter, even if it is too<br/>short.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_oc_msg_colon_first=true|align_oc_msg_colon_first=false
+TrueFalse=align_oc_msg_colon_first\s*=\s*true|align_oc_msg_colon_first\s*=\s*false
 ValueDefault=false
 
 [Align Oc Decl Colon]
@@ -6484,7 +6485,7 @@ Category=7
 Description="<html>(OC) Whether to align parameters in an Objective-C '+' or '-' declaration<br/>on the ':'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_oc_decl_colon=true|align_oc_decl_colon=false
+TrueFalse=align_oc_decl_colon\s*=\s*true|align_oc_decl_colon\s*=\s*false
 ValueDefault=false
 
 [Align Oc Msg Colon Xcode Like]
@@ -6492,7 +6493,7 @@ Category=7
 Description="<html>(OC) Whether to not align parameters in an Objectve-C message call if first<br/>colon is not on next line of the message call (the same way Xcode does<br/>alignment)</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_oc_msg_colon_xcode_like=true|align_oc_msg_colon_xcode_like=false
+TrueFalse=align_oc_msg_colon_xcode_like\s*=\s*true|align_oc_msg_colon_xcode_like\s*=\s*false
 ValueDefault=false
 
 [Cmt Width]
@@ -6500,7 +6501,7 @@ Category=8
 Description="<html>Try to wrap comments at N columns.</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_width="
+CallName="cmt_width\s*=\s*"
 MinVal=0
 MaxVal=256
 ValueDefault=0
@@ -6510,7 +6511,7 @@ Category=8
 Description="<html>How to reflow comments.<br/><br/>0: No reflowing (apart from the line wrapping due to cmt_width) (default)<br/>1: No touching at all<br/>2: Full reflow (enable cmt_indent_multi for indent with line wrapping due to cmt_width)</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_reflow_mode="
+CallName="cmt_reflow_mode\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6519,7 +6520,7 @@ ValueDefault=0
 Category=8
 Description="<html>Path to a file that contains regular expressions describing patterns for<br/>which the end of one line and the beginning of the next will be folded into<br/>the same sentence or paragraph during full comment reflow. The regular<br/>expressions are described using ECMAScript syntax. The syntax for this<br/>specification is as follows, where "..." indicates the custom regular<br/>expression and "n" indicates the nth end_of_prev_line_regex and<br/>beg_of_next_line_regex regular expression pair:<br/><br/>end_of_prev_line_regex[1] = "...$"<br/>beg_of_next_line_regex[1] = "^..."<br/>end_of_prev_line_regex[2] = "...$"<br/>beg_of_next_line_regex[2] = "^..."<br/>            .<br/>            .<br/>            .<br/>end_of_prev_line_regex[n] = "...$"<br/>beg_of_next_line_regex[n] = "^..."<br/><br/>Note that use of this option overrides the default reflow fold regular<br/>expressions, which are internally defined as follows:<br/><br/>end_of_prev_line_regex[1] = "[\w,\]\)]$"<br/>beg_of_next_line_regex[1] = "^[\w,\[\(]"<br/>end_of_prev_line_regex[2] = "\.$"<br/>beg_of_next_line_regex[2] = "^[A-Z]"</html>"
 Enabled=false
-CallName=cmt_reflow_fold_regex_file=
+CallName=cmt_reflow_fold_regex_file\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6528,7 +6529,7 @@ Category=8
 Description="<html>Whether to indent wrapped lines to the start of the encompassing paragraph<br/>during full comment reflow (cmt_reflow_mode = 2). Overrides the value<br/>specified by cmt_sp_after_star_cont.<br/><br/>Note that cmt_align_doxygen_javadoc_tags overrides this option for<br/>paragraphs associated with javadoc tags</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_reflow_indent_to_paragraph_start=true|cmt_reflow_indent_to_paragraph_start=false
+TrueFalse=cmt_reflow_indent_to_paragraph_start\s*=\s*true|cmt_reflow_indent_to_paragraph_start\s*=\s*false
 ValueDefault=false
 
 [Cmt Convert Tab To Spaces]
@@ -6536,7 +6537,7 @@ Category=8
 Description="<html>Whether to convert all tabs to spaces in comments. If false, tabs in<br/>comments are left alone, unless used for indenting.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_convert_tab_to_spaces=true|cmt_convert_tab_to_spaces=false
+TrueFalse=cmt_convert_tab_to_spaces\s*=\s*true|cmt_convert_tab_to_spaces\s*=\s*false
 ValueDefault=false
 
 [Cmt Indent Multi]
@@ -6544,7 +6545,7 @@ Category=8
 Description="<html>Whether to apply changes to multi-line comments, including cmt_width,<br/>keyword substitution and leading chars.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_indent_multi=true|cmt_indent_multi=false
+TrueFalse=cmt_indent_multi\s*=\s*true|cmt_indent_multi\s*=\s*false
 ValueDefault=true
 
 [Cmt Align Doxygen Javadoc Tags]
@@ -6552,7 +6553,7 @@ Category=8
 Description="<html>Whether to align doxygen javadoc-style tags ('@param', '@return', etc.)<br/>and corresponding fields such that groups of consecutive block tags,<br/>parameter names, and descriptions align with one another. Overrides that<br/>which is specified by the cmt_sp_after_star_cont. If cmt_width &gt; 0, it may<br/>be necessary to enable cmt_indent_multi and set cmt_reflow_mode = 2<br/>in order to achieve the desired alignment for line-wrapping.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_align_doxygen_javadoc_tags=true|cmt_align_doxygen_javadoc_tags=false
+TrueFalse=cmt_align_doxygen_javadoc_tags\s*=\s*true|cmt_align_doxygen_javadoc_tags\s*=\s*false
 ValueDefault=false
 
 [Cmt Sp Before Doxygen Javadoc Tags]
@@ -6560,7 +6561,7 @@ Category=8
 Description="<html>The number of spaces to insert after the star and before doxygen<br/>javadoc-style tags (@param, @return, etc). Requires enabling<br/>cmt_align_doxygen_javadoc_tags. Overrides that which is specified by the<br/>cmt_sp_after_star_cont.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_sp_before_doxygen_javadoc_tags="
+CallName="cmt_sp_before_doxygen_javadoc_tags\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -6570,7 +6571,7 @@ Category=8
 Description="<html>Whether to change trailing, single-line c-comments into cpp-comments.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_trailing_single_line_c_to_cpp=true|cmt_trailing_single_line_c_to_cpp=false
+TrueFalse=cmt_trailing_single_line_c_to_cpp\s*=\s*true|cmt_trailing_single_line_c_to_cpp\s*=\s*false
 ValueDefault=false
 
 [Cmt C Group]
@@ -6578,7 +6579,7 @@ Category=8
 Description="<html>Whether to group c-comments that look like they are in a block.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_c_group=true|cmt_c_group=false
+TrueFalse=cmt_c_group\s*=\s*true|cmt_c_group\s*=\s*false
 ValueDefault=false
 
 [Cmt C Nl Start]
@@ -6586,7 +6587,7 @@ Category=8
 Description="<html>Whether to put an empty '/*' on the first line of the combined c-comment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_c_nl_start=true|cmt_c_nl_start=false
+TrueFalse=cmt_c_nl_start\s*=\s*true|cmt_c_nl_start\s*=\s*false
 ValueDefault=false
 
 [Cmt C Nl End]
@@ -6594,7 +6595,7 @@ Category=8
 Description="<html>Whether to add a newline before the closing '*/' of the combined c-comment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_c_nl_end=true|cmt_c_nl_end=false
+TrueFalse=cmt_c_nl_end\s*=\s*true|cmt_c_nl_end\s*=\s*false
 ValueDefault=false
 
 [Cmt Cpp To C]
@@ -6602,7 +6603,7 @@ Category=8
 Description="<html>Whether to change cpp-comments into c-comments.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_cpp_to_c=true|cmt_cpp_to_c=false
+TrueFalse=cmt_cpp_to_c\s*=\s*true|cmt_cpp_to_c\s*=\s*false
 ValueDefault=false
 
 [Cmt Cpp Group]
@@ -6610,7 +6611,7 @@ Category=8
 Description="<html>Whether to group cpp-comments that look like they are in a block. Only<br/>meaningful if cmt_cpp_to_c=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_cpp_group=true|cmt_cpp_group=false
+TrueFalse=cmt_cpp_group\s*=\s*true|cmt_cpp_group\s*=\s*false
 ValueDefault=false
 
 [Cmt Cpp Nl Start]
@@ -6618,7 +6619,7 @@ Category=8
 Description="<html>Whether to put an empty '/*' on the first line of the combined cpp-comment<br/>when converting to a c-comment.<br/><br/>Requires cmt_cpp_to_c=true and cmt_cpp_group=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_cpp_nl_start=true|cmt_cpp_nl_start=false
+TrueFalse=cmt_cpp_nl_start\s*=\s*true|cmt_cpp_nl_start\s*=\s*false
 ValueDefault=false
 
 [Cmt Cpp Nl End]
@@ -6626,7 +6627,7 @@ Category=8
 Description="<html>Whether to add a newline before the closing '*/' of the combined cpp-comment<br/>when converting to a c-comment.<br/><br/>Requires cmt_cpp_to_c=true and cmt_cpp_group=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_cpp_nl_end=true|cmt_cpp_nl_end=false
+TrueFalse=cmt_cpp_nl_end\s*=\s*true|cmt_cpp_nl_end\s*=\s*false
 ValueDefault=false
 
 [Cmt Star Cont]
@@ -6634,7 +6635,7 @@ Category=8
 Description="<html>Whether to put a star on subsequent comment lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_star_cont=true|cmt_star_cont=false
+TrueFalse=cmt_star_cont\s*=\s*true|cmt_star_cont\s*=\s*false
 ValueDefault=false
 
 [Cmt Sp Before Star Cont]
@@ -6642,7 +6643,7 @@ Category=8
 Description="<html>The number of spaces to insert at the start of subsequent comment lines.</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_sp_before_star_cont="
+CallName="cmt_sp_before_star_cont\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6652,7 +6653,7 @@ Category=8
 Description="<html>The number of spaces to insert after the star on subsequent comment lines.</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_sp_after_star_cont="
+CallName="cmt_sp_after_star_cont\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6662,7 +6663,7 @@ Category=8
 Description="<html>For multi-line comments with a '*' lead, remove leading spaces if the first<br/>and last lines of the comment are the same length.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_multi_check_last=true|cmt_multi_check_last=false
+TrueFalse=cmt_multi_check_last\s*=\s*true|cmt_multi_check_last\s*=\s*false
 ValueDefault=true
 
 [Cmt Multi First Len Minimum]
@@ -6670,7 +6671,7 @@ Category=8
 Description="<html>For multi-line comments with a '*' lead, remove leading spaces if the first<br/>and last lines of the comment are the same length AND if the length is<br/>bigger as the first_len minimum.<br/><br/>Default: 4</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_multi_first_len_minimum="
+CallName="cmt_multi_first_len_minimum\s*=\s*"
 MinVal=1
 MaxVal=20
 ValueDefault=4
@@ -6679,7 +6680,7 @@ ValueDefault=4
 Category=8
 Description="<html>Path to a file that contains text to insert at the beginning of a file if<br/>the file doesn't start with a C/C++ comment. If the inserted text contains<br/>'$(filename)', that will be replaced with the current file's name.</html>"
 Enabled=false
-CallName=cmt_insert_file_header=
+CallName=cmt_insert_file_header\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6687,7 +6688,7 @@ ValueDefault=
 Category=8
 Description="<html>Path to a file that contains text to insert at the end of a file if the<br/>file doesn't end with a C/C++ comment. If the inserted text contains<br/>'$(filename)', that will be replaced with the current file's name.</html>"
 Enabled=false
-CallName=cmt_insert_file_footer=
+CallName=cmt_insert_file_footer\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6695,7 +6696,7 @@ ValueDefault=
 Category=8
 Description="<html>Path to a file that contains text to insert before a function definition if<br/>the function isn't preceded by a C/C++ comment. If the inserted text<br/>contains '$(function)', '$(javaparam)' or '$(fclass)', these will be<br/>replaced with, respectively, the name of the function, the javadoc '@param'<br/>and '@return' stuff, or the name of the class to which the member function<br/>belongs.</html>"
 Enabled=false
-CallName=cmt_insert_func_header=
+CallName=cmt_insert_func_header\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6703,7 +6704,7 @@ ValueDefault=
 Category=8
 Description="<html>Path to a file that contains text to insert before a class if the class<br/>isn't preceded by a C/C++ comment. If the inserted text contains '$(class)',<br/>that will be replaced with the class name.</html>"
 Enabled=false
-CallName=cmt_insert_class_header=
+CallName=cmt_insert_class_header\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6711,7 +6712,7 @@ ValueDefault=
 Category=8
 Description="<html>Path to a file that contains text to insert before an Objective-C message<br/>specification, if the method isn't preceded by a C/C++ comment. If the<br/>inserted text contains '$(message)' or '$(javaparam)', these will be<br/>replaced with, respectively, the name of the function, or the javadoc<br/>'@param' and '@return' stuff.</html>"
 Enabled=false
-CallName=cmt_insert_oc_msg_header=
+CallName=cmt_insert_oc_msg_header\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6720,7 +6721,7 @@ Category=8
 Description="<html>Whether a comment should be inserted if a preprocessor is encountered when<br/>stepping backwards from a function name.<br/><br/>Applies to cmt_insert_oc_msg_header, cmt_insert_func_header and<br/>cmt_insert_class_header.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_insert_before_preproc=true|cmt_insert_before_preproc=false
+TrueFalse=cmt_insert_before_preproc\s*=\s*true|cmt_insert_before_preproc\s*=\s*false
 ValueDefault=false
 
 [Cmt Insert Before Inlines]
@@ -6728,7 +6729,7 @@ Category=8
 Description="<html>Whether a comment should be inserted if a function is declared inline to a<br/>class definition.<br/><br/>Applies to cmt_insert_func_header.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_insert_before_inlines=true|cmt_insert_before_inlines=false
+TrueFalse=cmt_insert_before_inlines\s*=\s*true|cmt_insert_before_inlines\s*=\s*false
 ValueDefault=true
 
 [Cmt Insert Before Ctor Dtor]
@@ -6736,7 +6737,7 @@ Category=8
 Description="<html>Whether a comment should be inserted if the function is a class constructor<br/>or destructor.<br/><br/>Applies to cmt_insert_func_header.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_insert_before_ctor_dtor=true|cmt_insert_before_ctor_dtor=false
+TrueFalse=cmt_insert_before_ctor_dtor\s*=\s*true|cmt_insert_before_ctor_dtor\s*=\s*false
 ValueDefault=false
 
 [Mod Full Brace Do]
@@ -6744,7 +6745,7 @@ Category=9
 Description="<html>Add or remove braces on a single-line 'do' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_do=ignore|mod_full_brace_do=add|mod_full_brace_do=remove|mod_full_brace_do=force|mod_full_brace_do=not_defined
+Choices=mod_full_brace_do\s*=\s*ignore|mod_full_brace_do\s*=\s*add|mod_full_brace_do\s*=\s*remove|mod_full_brace_do\s*=\s*force|mod_full_brace_do\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace Do|Add Mod Full Brace Do|Remove Mod Full Brace Do|Force Mod Full Brace Do"
 ValueDefault=ignore
 
@@ -6753,7 +6754,7 @@ Category=9
 Description="<html>Add or remove braces on a single-line 'for' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_for=ignore|mod_full_brace_for=add|mod_full_brace_for=remove|mod_full_brace_for=force|mod_full_brace_for=not_defined
+Choices=mod_full_brace_for\s*=\s*ignore|mod_full_brace_for\s*=\s*add|mod_full_brace_for\s*=\s*remove|mod_full_brace_for\s*=\s*force|mod_full_brace_for\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace For|Add Mod Full Brace For|Remove Mod Full Brace For|Force Mod Full Brace For"
 ValueDefault=ignore
 
@@ -6762,7 +6763,7 @@ Category=9
 Description="<html>(Pawn) Add or remove braces on a single-line function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_function=ignore|mod_full_brace_function=add|mod_full_brace_function=remove|mod_full_brace_function=force|mod_full_brace_function=not_defined
+Choices=mod_full_brace_function\s*=\s*ignore|mod_full_brace_function\s*=\s*add|mod_full_brace_function\s*=\s*remove|mod_full_brace_function\s*=\s*force|mod_full_brace_function\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace Function|Add Mod Full Brace Function|Remove Mod Full Brace Function|Force Mod Full Brace Function"
 ValueDefault=ignore
 
@@ -6771,7 +6772,7 @@ Category=9
 Description="<html>Add or remove braces on a single-line 'if' statement. Braces will not be<br/>removed if the braced statement contains an 'else'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_if=ignore|mod_full_brace_if=add|mod_full_brace_if=remove|mod_full_brace_if=force|mod_full_brace_if=not_defined
+Choices=mod_full_brace_if\s*=\s*ignore|mod_full_brace_if\s*=\s*add|mod_full_brace_if\s*=\s*remove|mod_full_brace_if\s*=\s*force|mod_full_brace_if\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace If|Add Mod Full Brace If|Remove Mod Full Brace If|Force Mod Full Brace If"
 ValueDefault=ignore
 
@@ -6780,7 +6781,7 @@ Category=9
 Description="<html>Whether to enforce that all blocks of an 'if'/'else if'/'else' chain either<br/>have, or do not have, braces. Overrides mod_full_brace_if.<br/><br/>0: Don't override mod_full_brace_if<br/>1: Add braces to all blocks if any block needs braces and remove braces if<br/>   they can be removed from all blocks<br/>2: Add braces to all blocks if any block already has braces, regardless of<br/>   whether it needs them<br/>3: Add braces to all blocks if any block needs braces and remove braces if<br/>   they can be removed from all blocks, except if all blocks have braces<br/>   despite none needing them</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_full_brace_if_chain="
+CallName="mod_full_brace_if_chain\s*=\s*"
 MinVal=0
 MaxVal=3
 ValueDefault=0
@@ -6790,7 +6791,7 @@ Category=9
 Description="<html>Whether to add braces to all blocks of an 'if'/'else if'/'else' chain.<br/>If true, mod_full_brace_if_chain will only remove braces from an 'if' that<br/>does not have an 'else if' or 'else'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_brace_if_chain_only=true|mod_full_brace_if_chain_only=false
+TrueFalse=mod_full_brace_if_chain_only\s*=\s*true|mod_full_brace_if_chain_only\s*=\s*false
 ValueDefault=false
 
 [Mod Full Brace While]
@@ -6798,7 +6799,7 @@ Category=9
 Description="<html>Add or remove braces on single-line 'while' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_while=ignore|mod_full_brace_while=add|mod_full_brace_while=remove|mod_full_brace_while=force|mod_full_brace_while=not_defined
+Choices=mod_full_brace_while\s*=\s*ignore|mod_full_brace_while\s*=\s*add|mod_full_brace_while\s*=\s*remove|mod_full_brace_while\s*=\s*force|mod_full_brace_while\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace While|Add Mod Full Brace While|Remove Mod Full Brace While|Force Mod Full Brace While"
 ValueDefault=ignore
 
@@ -6807,7 +6808,7 @@ Category=9
 Description="<html>Add or remove braces on single-line 'using ()' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_using=ignore|mod_full_brace_using=add|mod_full_brace_using=remove|mod_full_brace_using=force|mod_full_brace_using=not_defined
+Choices=mod_full_brace_using\s*=\s*ignore|mod_full_brace_using\s*=\s*add|mod_full_brace_using\s*=\s*remove|mod_full_brace_using\s*=\s*force|mod_full_brace_using\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace Using|Add Mod Full Brace Using|Remove Mod Full Brace Using|Force Mod Full Brace Using"
 ValueDefault=ignore
 
@@ -6816,7 +6817,7 @@ Category=9
 Description="<html>Don't remove braces around statements that span N newlines</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_full_brace_nl="
+CallName="mod_full_brace_nl\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6826,7 +6827,7 @@ Category=9
 Description="<html>Whether to prevent removal of braces from 'if'/'for'/'while'/etc. blocks<br/>which span multiple lines.<br/><br/>Affects:<br/>  mod_full_brace_for<br/>  mod_full_brace_if<br/>  mod_full_brace_if_chain<br/>  mod_full_brace_if_chain_only<br/>  mod_full_brace_while<br/>  mod_full_brace_using<br/><br/>Does not affect:<br/>  mod_full_brace_do<br/>  mod_full_brace_function</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_brace_nl_block_rem_mlcond=true|mod_full_brace_nl_block_rem_mlcond=false
+TrueFalse=mod_full_brace_nl_block_rem_mlcond\s*=\s*true|mod_full_brace_nl_block_rem_mlcond\s*=\s*false
 ValueDefault=false
 
 [Mod Paren On Return]
@@ -6834,7 +6835,7 @@ Category=9
 Description="<html>Add or remove unnecessary parentheses on 'return' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_paren_on_return=ignore|mod_paren_on_return=add|mod_paren_on_return=remove|mod_paren_on_return=force|mod_paren_on_return=not_defined
+Choices=mod_paren_on_return\s*=\s*ignore|mod_paren_on_return\s*=\s*add|mod_paren_on_return\s*=\s*remove|mod_paren_on_return\s*=\s*force|mod_paren_on_return\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Paren On Return|Add Mod Paren On Return|Remove Mod Paren On Return|Force Mod Paren On Return"
 ValueDefault=ignore
 
@@ -6843,7 +6844,7 @@ Category=9
 Description="<html>Add or remove unnecessary parentheses on 'throw' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_paren_on_throw=ignore|mod_paren_on_throw=add|mod_paren_on_throw=remove|mod_paren_on_throw=force|mod_paren_on_throw=not_defined
+Choices=mod_paren_on_throw\s*=\s*ignore|mod_paren_on_throw\s*=\s*add|mod_paren_on_throw\s*=\s*remove|mod_paren_on_throw\s*=\s*force|mod_paren_on_throw\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Paren On Throw|Add Mod Paren On Throw|Remove Mod Paren On Throw|Force Mod Paren On Throw"
 ValueDefault=ignore
 
@@ -6852,7 +6853,7 @@ Category=9
 Description="<html>(Pawn) Whether to change optional semicolons to real semicolons.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_pawn_semicolon=true|mod_pawn_semicolon=false
+TrueFalse=mod_pawn_semicolon\s*=\s*true|mod_pawn_semicolon\s*=\s*false
 ValueDefault=false
 
 [Mod Full Paren If Bool]
@@ -6860,7 +6861,7 @@ Category=9
 Description="<html>Whether to fully parenthesize Boolean expressions in 'while' and 'if'<br/>statement, as in 'if (a &amp;&amp; b &gt; c)' =&gt; 'if (a &amp;&amp; (b &gt; c))'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_paren_if_bool=true|mod_full_paren_if_bool=false
+TrueFalse=mod_full_paren_if_bool\s*=\s*true|mod_full_paren_if_bool\s*=\s*false
 ValueDefault=false
 
 [Mod Full Paren Assign Bool]
@@ -6868,7 +6869,7 @@ Category=9
 Description="<html>Whether to fully parenthesize Boolean expressions after '='<br/>statement, as in 'x = a &amp;&amp; b &gt; c;' =&gt; 'x = (a &amp;&amp; (b &gt; c));'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_paren_assign_bool=true|mod_full_paren_assign_bool=false
+TrueFalse=mod_full_paren_assign_bool\s*=\s*true|mod_full_paren_assign_bool\s*=\s*false
 ValueDefault=false
 
 [Mod Full Paren Return Bool]
@@ -6876,7 +6877,7 @@ Category=9
 Description="<html>Whether to fully parenthesize Boolean expressions after '='<br/>statement, as in 'return  a &amp;&amp; b &gt; c;' =&gt; 'return (a &amp;&amp; (b &gt; c));'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_paren_return_bool=true|mod_full_paren_return_bool=false
+TrueFalse=mod_full_paren_return_bool\s*=\s*true|mod_full_paren_return_bool\s*=\s*false
 ValueDefault=false
 
 [Mod Remove Extra Semicolon]
@@ -6884,7 +6885,7 @@ Category=9
 Description="<html>Whether to remove superfluous semicolons.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_remove_extra_semicolon=true|mod_remove_extra_semicolon=false
+TrueFalse=mod_remove_extra_semicolon\s*=\s*true|mod_remove_extra_semicolon\s*=\s*false
 ValueDefault=false
 
 [Mod Remove Duplicate Include]
@@ -6892,7 +6893,7 @@ Category=9
 Description="<html>Whether to remove duplicate include.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_remove_duplicate_include=true|mod_remove_duplicate_include=false
+TrueFalse=mod_remove_duplicate_include\s*=\s*true|mod_remove_duplicate_include\s*=\s*false
 ValueDefault=false
 
 [Mod Add Force C Closebrace Comment]
@@ -6900,7 +6901,7 @@ Category=9
 Description="<html>the following options (mod_XX_closebrace_comment) use different comment,<br/>depending of the setting of the next option.<br/>false: Use the c comment (default)<br/>true : Use the cpp comment</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_add_force_c_closebrace_comment=true|mod_add_force_c_closebrace_comment=false
+TrueFalse=mod_add_force_c_closebrace_comment\s*=\s*true|mod_add_force_c_closebrace_comment\s*=\s*false
 ValueDefault=false
 
 [Mod Add Long Function Closebrace Comment]
@@ -6908,7 +6909,7 @@ Category=9
 Description="<html>If a function body exceeds the specified number of newlines and doesn't have<br/>a comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_function_closebrace_comment="
+CallName="mod_add_long_function_closebrace_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6918,7 +6919,7 @@ Category=9
 Description="<html>If a namespace body exceeds the specified number of newlines and doesn't<br/>have a comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_namespace_closebrace_comment="
+CallName="mod_add_long_namespace_closebrace_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6928,7 +6929,7 @@ Category=9
 Description="<html>If a class body exceeds the specified number of newlines and doesn't have a<br/>comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_class_closebrace_comment="
+CallName="mod_add_long_class_closebrace_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6938,7 +6939,7 @@ Category=9
 Description="<html>If a switch body exceeds the specified number of newlines and doesn't have a<br/>comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_switch_closebrace_comment="
+CallName="mod_add_long_switch_closebrace_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6948,7 +6949,7 @@ Category=9
 Description="<html>If an #ifdef body exceeds the specified number of newlines and doesn't have<br/>a comment after the #endif, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_ifdef_endif_comment="
+CallName="mod_add_long_ifdef_endif_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6958,7 +6959,7 @@ Category=9
 Description="<html>If an #ifdef or #else body exceeds the specified number of newlines and<br/>doesn't have a comment after the #else, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_ifdef_else_comment="
+CallName="mod_add_long_ifdef_else_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6968,7 +6969,7 @@ Category=9
 Description="<html>Whether to take care of the case by the mod_sort_xx options.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_case_sensitive=true|mod_sort_case_sensitive=false
+TrueFalse=mod_sort_case_sensitive\s*=\s*true|mod_sort_case_sensitive\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Import]
@@ -6976,7 +6977,7 @@ Category=9
 Description="<html>Whether to sort consecutive single-line 'import' statements.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_import=true|mod_sort_import=false
+TrueFalse=mod_sort_import\s*=\s*true|mod_sort_import\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Using]
@@ -6984,7 +6985,7 @@ Category=9
 Description="<html>(C#) Whether to sort consecutive single-line 'using' statements.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_using=true|mod_sort_using=false
+TrueFalse=mod_sort_using\s*=\s*true|mod_sort_using\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Include]
@@ -6992,7 +6993,7 @@ Category=9
 Description="<html>Whether to sort consecutive single-line '#include' statements (C/C++) and<br/>'#import' statements (Objective-C). Be aware that this has the potential to<br/>break your code if your includes/imports have ordering dependencies.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_include=true|mod_sort_include=false
+TrueFalse=mod_sort_include\s*=\s*true|mod_sort_include\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Prioritize Filename]
@@ -7000,7 +7001,7 @@ Category=9
 Description="<html>Whether to prioritize '#include' and '#import' statements that contain<br/>filename without extension when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_prioritize_filename=true|mod_sort_incl_import_prioritize_filename=false
+TrueFalse=mod_sort_incl_import_prioritize_filename\s*=\s*true|mod_sort_incl_import_prioritize_filename\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Prioritize Extensionless]
@@ -7008,7 +7009,7 @@ Category=9
 Description="<html>Whether to prioritize '#include' and '#import' statements that does not<br/>contain extensions when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_prioritize_extensionless=true|mod_sort_incl_import_prioritize_extensionless=false
+TrueFalse=mod_sort_incl_import_prioritize_extensionless\s*=\s*true|mod_sort_incl_import_prioritize_extensionless\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Prioritize Angle Over Quotes]
@@ -7016,7 +7017,7 @@ Category=9
 Description="<html>Whether to prioritize '#include' and '#import' statements that contain<br/>angle over quotes when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_prioritize_angle_over_quotes=true|mod_sort_incl_import_prioritize_angle_over_quotes=false
+TrueFalse=mod_sort_incl_import_prioritize_angle_over_quotes\s*=\s*true|mod_sort_incl_import_prioritize_angle_over_quotes\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Ignore Extension]
@@ -7024,7 +7025,7 @@ Category=9
 Description="<html>Whether to ignore file extension in '#include' and '#import' statements<br/>for sorting comparison.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_ignore_extension=true|mod_sort_incl_import_ignore_extension=false
+TrueFalse=mod_sort_incl_import_ignore_extension\s*=\s*true|mod_sort_incl_import_ignore_extension\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Grouping Enabled]
@@ -7032,7 +7033,7 @@ Category=9
 Description="<html>Whether to group '#include' and '#import' statements when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_grouping_enabled=true|mod_sort_incl_import_grouping_enabled=false
+TrueFalse=mod_sort_incl_import_grouping_enabled\s*=\s*true|mod_sort_incl_import_grouping_enabled\s*=\s*false
 ValueDefault=false
 
 [Mod Move Case Break]
@@ -7040,7 +7041,7 @@ Category=9
 Description="<html>Whether to move a 'break' that appears after a fully braced 'case' before<br/>the close brace, as in 'case X: { ... } break;' =&gt; 'case X: { ... break; }'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_move_case_break=true|mod_move_case_break=false
+TrueFalse=mod_move_case_break\s*=\s*true|mod_move_case_break\s*=\s*false
 ValueDefault=false
 
 [Mod Move Case Return]
@@ -7048,7 +7049,7 @@ Category=9
 Description="<html>Whether to move a 'return' that appears after a fully braced 'case' before<br/>the close brace, as in 'case X: { ... } return;' =&gt; 'case X: { ... return; }'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_move_case_return=true|mod_move_case_return=false
+TrueFalse=mod_move_case_return\s*=\s*true|mod_move_case_return\s*=\s*false
 ValueDefault=false
 
 [Mod Case Brace]
@@ -7056,7 +7057,7 @@ Category=9
 Description="<html>Add or remove braces around a fully braced case statement. Will only remove<br/>braces if there are no variable declarations in the block.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_case_brace=ignore|mod_case_brace=add|mod_case_brace=remove|mod_case_brace=force|mod_case_brace=not_defined
+Choices=mod_case_brace\s*=\s*ignore|mod_case_brace\s*=\s*add|mod_case_brace\s*=\s*remove|mod_case_brace\s*=\s*force|mod_case_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Case Brace|Add Mod Case Brace|Remove Mod Case Brace|Force Mod Case Brace"
 ValueDefault=ignore
 
@@ -7065,7 +7066,7 @@ Category=9
 Description="<html>Whether to remove a void 'return;' that appears as the last statement in a<br/>function.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_remove_empty_return=true|mod_remove_empty_return=false
+TrueFalse=mod_remove_empty_return\s*=\s*true|mod_remove_empty_return\s*=\s*false
 ValueDefault=false
 
 [Mod Enum Last Comma]
@@ -7073,7 +7074,7 @@ Category=9
 Description="<html>Add or remove the comma after the last value of an enumeration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_enum_last_comma=ignore|mod_enum_last_comma=add|mod_enum_last_comma=remove|mod_enum_last_comma=force|mod_enum_last_comma=not_defined
+Choices=mod_enum_last_comma\s*=\s*ignore|mod_enum_last_comma\s*=\s*add|mod_enum_last_comma\s*=\s*remove|mod_enum_last_comma\s*=\s*force|mod_enum_last_comma\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Enum Last Comma|Add Mod Enum Last Comma|Remove Mod Enum Last Comma|Force Mod Enum Last Comma"
 ValueDefault=ignore
 
@@ -7082,7 +7083,7 @@ Category=9
 Description="<html>Syntax to use for infinite loops.<br/><br/>0: Leave syntax alone (default)<br/>1: Rewrite as `for(;;)`<br/>2: Rewrite as `while(true)`<br/>3: Rewrite as `do`...`while(true);`<br/>4: Rewrite as `while`<br/>5: Rewrite as `do`...`while;`<br/><br/>Infinite loops that do not already match one of these syntaxes are ignored.<br/>Other options that affect loop formatting will be applied after transforming<br/>the syntax.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_infinite_loop="
+CallName="mod_infinite_loop\s*=\s*"
 MinVal=0
 MaxVal=5
 ValueDefault=0
@@ -7092,7 +7093,7 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'int short'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_int_short=ignore|mod_int_short=add|mod_int_short=remove|mod_int_short=force|mod_int_short=not_defined
+Choices=mod_int_short\s*=\s*ignore|mod_int_short\s*=\s*add|mod_int_short\s*=\s*remove|mod_int_short\s*=\s*force|mod_int_short\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Int Short|Add Mod Int Short|Remove Mod Int Short|Force Mod Int Short"
 ValueDefault=ignore
 
@@ -7101,7 +7102,7 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'short int'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_short_int=ignore|mod_short_int=add|mod_short_int=remove|mod_short_int=force|mod_short_int=not_defined
+Choices=mod_short_int\s*=\s*ignore|mod_short_int\s*=\s*add|mod_short_int\s*=\s*remove|mod_short_int\s*=\s*force|mod_short_int\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Short Int|Add Mod Short Int|Remove Mod Short Int|Force Mod Short Int"
 ValueDefault=ignore
 
@@ -7110,7 +7111,7 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'int long'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_int_long=ignore|mod_int_long=add|mod_int_long=remove|mod_int_long=force|mod_int_long=not_defined
+Choices=mod_int_long\s*=\s*ignore|mod_int_long\s*=\s*add|mod_int_long\s*=\s*remove|mod_int_long\s*=\s*force|mod_int_long\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Int Long|Add Mod Int Long|Remove Mod Int Long|Force Mod Int Long"
 ValueDefault=ignore
 
@@ -7119,7 +7120,7 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'long int'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_long_int=ignore|mod_long_int=add|mod_long_int=remove|mod_long_int=force|mod_long_int=not_defined
+Choices=mod_long_int\s*=\s*ignore|mod_long_int\s*=\s*add|mod_long_int\s*=\s*remove|mod_long_int\s*=\s*force|mod_long_int\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Long Int|Add Mod Long Int|Remove Mod Long Int|Force Mod Long Int"
 ValueDefault=ignore
 
@@ -7128,7 +7129,7 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'int signed'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_int_signed=ignore|mod_int_signed=add|mod_int_signed=remove|mod_int_signed=force|mod_int_signed=not_defined
+Choices=mod_int_signed\s*=\s*ignore|mod_int_signed\s*=\s*add|mod_int_signed\s*=\s*remove|mod_int_signed\s*=\s*force|mod_int_signed\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Int Signed|Add Mod Int Signed|Remove Mod Int Signed|Force Mod Int Signed"
 ValueDefault=ignore
 
@@ -7137,7 +7138,7 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'signed int'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_signed_int=ignore|mod_signed_int=add|mod_signed_int=remove|mod_signed_int=force|mod_signed_int=not_defined
+Choices=mod_signed_int\s*=\s*ignore|mod_signed_int\s*=\s*add|mod_signed_int\s*=\s*remove|mod_signed_int\s*=\s*force|mod_signed_int\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Signed Int|Add Mod Signed Int|Remove Mod Signed Int|Force Mod Signed Int"
 ValueDefault=ignore
 
@@ -7146,7 +7147,7 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'int unsigned'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_int_unsigned=ignore|mod_int_unsigned=add|mod_int_unsigned=remove|mod_int_unsigned=force|mod_int_unsigned=not_defined
+Choices=mod_int_unsigned\s*=\s*ignore|mod_int_unsigned\s*=\s*add|mod_int_unsigned\s*=\s*remove|mod_int_unsigned\s*=\s*force|mod_int_unsigned\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Int Unsigned|Add Mod Int Unsigned|Remove Mod Int Unsigned|Force Mod Int Unsigned"
 ValueDefault=ignore
 
@@ -7155,7 +7156,7 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'unsigned int'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_unsigned_int=ignore|mod_unsigned_int=add|mod_unsigned_int=remove|mod_unsigned_int=force|mod_unsigned_int=not_defined
+Choices=mod_unsigned_int\s*=\s*ignore|mod_unsigned_int\s*=\s*add|mod_unsigned_int\s*=\s*remove|mod_unsigned_int\s*=\s*force|mod_unsigned_int\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Unsigned Int|Add Mod Unsigned Int|Remove Mod Unsigned Int|Force Mod Unsigned Int"
 ValueDefault=ignore
 
@@ -7164,7 +7165,7 @@ Category=9
 Description="<html>If there is a situation where mod_int_* and mod_*_int would result in<br/>multiple int keywords, whether to keep the rightmost int (the default) or the<br/>leftmost int.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_int_prefer_int_on_left=true|mod_int_prefer_int_on_left=false
+TrueFalse=mod_int_prefer_int_on_left\s*=\s*true|mod_int_prefer_int_on_left\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Oc Properties]
@@ -7172,7 +7173,7 @@ Category=9
 Description="<html>(OC) Whether to organize the properties. If true, properties will be<br/>rearranged according to the mod_sort_oc_property_*_weight factors.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_oc_properties=true|mod_sort_oc_properties=false
+TrueFalse=mod_sort_oc_properties\s*=\s*true|mod_sort_oc_properties\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Oc Property Class Weight]
@@ -7180,7 +7181,7 @@ Category=9
 Description="<html>(OC) Weight of a class property modifier.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_class_weight="
+CallName="mod_sort_oc_property_class_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7190,7 +7191,7 @@ Category=9
 Description="<html>(OC) Weight of 'atomic' and 'nonatomic'.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_thread_safe_weight="
+CallName="mod_sort_oc_property_thread_safe_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7200,7 +7201,7 @@ Category=9
 Description="<html>(OC) Weight of 'readwrite' when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_readwrite_weight="
+CallName="mod_sort_oc_property_readwrite_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7210,7 +7211,7 @@ Category=9
 Description="<html>(OC) Weight of a reference type specifier ('retain', 'copy', 'assign',<br/>'weak', 'strong') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_reference_weight="
+CallName="mod_sort_oc_property_reference_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7220,7 +7221,7 @@ Category=9
 Description="<html>(OC) Weight of getter type ('getter=') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_getter_weight="
+CallName="mod_sort_oc_property_getter_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7230,7 +7231,7 @@ Category=9
 Description="<html>(OC) Weight of setter type ('setter=') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_setter_weight="
+CallName="mod_sort_oc_property_setter_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7240,7 +7241,7 @@ Category=9
 Description="<html>(OC) Weight of nullability type ('nullable', 'nonnull', 'null_unspecified',<br/>'null_resettable') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_nullability_weight="
+CallName="mod_sort_oc_property_nullability_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7250,7 +7251,7 @@ Category=10
 Description="<html>How to use tabs when indenting preprocessor code.<br/><br/>-1: Use 'indent_with_tabs' setting (default)<br/> 0: Spaces only<br/> 1: Indent with tabs to brace level, align with spaces<br/> 2: Indent and align with tabs, using spaces when not on a tabstop<br/><br/>Default: -1</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_with_tabs="
+CallName="pp_indent_with_tabs\s*=\s*"
 MinVal=-1
 MaxVal=2
 ValueDefault=-1
@@ -7260,7 +7261,7 @@ Category=10
 Description="<html>Add or remove indentation of preprocessor directives inside #if blocks<br/>at brace level 0 (file-level).</html>"
 Enabled=false
 EditorType=multiple
-Choices=pp_indent=ignore|pp_indent=add|pp_indent=remove|pp_indent=force|pp_indent=not_defined
+Choices=pp_indent\s*=\s*ignore|pp_indent\s*=\s*add|pp_indent\s*=\s*remove|pp_indent\s*=\s*force|pp_indent\s*=\s*not_defined
 ChoicesReadable="Ignore Pp Indent|Add Pp Indent|Remove Pp Indent|Force Pp Indent"
 ValueDefault=ignore
 
@@ -7269,7 +7270,7 @@ Category=10
 Description="<html>Whether to indent #if/#else/#endif at the brace level. If false, these are<br/>indented from column 1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_at_level=true|pp_indent_at_level=false
+TrueFalse=pp_indent_at_level\s*=\s*true|pp_indent_at_level\s*=\s*false
 ValueDefault=false
 
 [Pp Indent At Level0]
@@ -7277,7 +7278,7 @@ Category=10
 Description="<html>Whether to indent #if/#else/#endif at the parenthesis level if the brace<br/>level is 0. If false, these are indented from column 1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_at_level0=true|pp_indent_at_level0=false
+TrueFalse=pp_indent_at_level0\s*=\s*true|pp_indent_at_level0\s*=\s*false
 ValueDefault=false
 
 [Pp Indent Count]
@@ -7285,7 +7286,7 @@ Category=10
 Description="<html>Specifies the number of columns to indent preprocessors per level<br/>at brace level 0 (file-level). If pp_indent_at_level=false, also specifies<br/>the number of columns to indent preprocessors per level<br/>at brace level &gt; 0 (function-level).<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_count="
+CallName="pp_indent_count\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -7295,7 +7296,7 @@ Category=10
 Description="<html>Add or remove space after # based on pp level of #if blocks.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pp_space_after=ignore|pp_space_after=add|pp_space_after=remove|pp_space_after=force|pp_space_after=not_defined
+Choices=pp_space_after\s*=\s*ignore|pp_space_after\s*=\s*add|pp_space_after\s*=\s*remove|pp_space_after\s*=\s*force|pp_space_after\s*=\s*not_defined
 ChoicesReadable="Ignore Pp Space After|Add Pp Space After|Remove Pp Space After|Force Pp Space After"
 ValueDefault=ignore
 
@@ -7304,7 +7305,7 @@ Category=10
 Description="<html>Sets the number of spaces per level added with pp_space_after.</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_space_count="
+CallName="pp_space_count\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -7314,7 +7315,7 @@ Category=10
 Description="<html>The indent for '#region' and '#endregion' in C# and '#pragma region' in<br/>C/C++. Negative values decrease indent down to the first column.</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_region="
+CallName="pp_indent_region\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -7324,7 +7325,7 @@ Category=10
 Description="<html>Whether to indent the code between #region and #endregion.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_region_indent_code=true|pp_region_indent_code=false
+TrueFalse=pp_region_indent_code\s*=\s*true|pp_region_indent_code\s*=\s*false
 ValueDefault=false
 
 [Pp Indent If]
@@ -7332,7 +7333,7 @@ Category=10
 Description="<html>If pp_indent_at_level=true, sets the indent for #if, #else and #endif when<br/>not at file-level. Negative values decrease indent down to the first column.<br/><br/>=0: Indent preprocessors using output_tab_size<br/>&gt;0: Column at which all preprocessors will be indented</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_if="
+CallName="pp_indent_if\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -7342,7 +7343,7 @@ Category=10
 Description="<html>Whether to indent the code between #if, #else and #endif.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_if_indent_code=true|pp_if_indent_code=false
+TrueFalse=pp_if_indent_code\s*=\s*true|pp_if_indent_code\s*=\s*false
 ValueDefault=false
 
 [Pp Indent In Guard]
@@ -7350,7 +7351,7 @@ Category=10
 Description="<html>Whether to indent the body of an #if that encompasses all the code in the file.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_in_guard=true|pp_indent_in_guard=false
+TrueFalse=pp_indent_in_guard\s*=\s*true|pp_indent_in_guard\s*=\s*false
 ValueDefault=false
 
 [Pp Define At Level]
@@ -7358,7 +7359,7 @@ Category=10
 Description="<html>Whether to indent '#define' at the brace level. If false, these are<br/>indented from column 1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_define_at_level=true|pp_define_at_level=false
+TrueFalse=pp_define_at_level\s*=\s*true|pp_define_at_level\s*=\s*false
 ValueDefault=false
 
 [Pp Include At Level]
@@ -7366,7 +7367,7 @@ Category=10
 Description="<html>Whether to indent '#include' at the brace level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_include_at_level=true|pp_include_at_level=false
+TrueFalse=pp_include_at_level\s*=\s*true|pp_include_at_level\s*=\s*false
 ValueDefault=false
 
 [Pp Ignore Define Body]
@@ -7374,7 +7375,7 @@ Category=10
 Description="<html>Whether to ignore the '#define' body while formatting.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_ignore_define_body=true|pp_ignore_define_body=false
+TrueFalse=pp_ignore_define_body\s*=\s*true|pp_ignore_define_body\s*=\s*false
 ValueDefault=false
 
 [Pp Multiline Define Body Indent]
@@ -7382,7 +7383,7 @@ Category=10
 Description="<html>An offset value that controls the indentation of the body of a multiline #define.<br/>'body' refers to all the lines of a multiline #define except the first line.<br/>Requires 'pp_ignore_define_body = false'.<br/><br/> &lt;0: Absolute column: the body indentation starts off at the specified column<br/>     (ex. -3 ==&gt; the body is indented starting from column 3)<br/>&gt;=0: Relative to the column of the '#' of '#define'<br/>     (ex.  3 ==&gt; the body is indented starting 3 columns at the right of '#')<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_multiline_define_body_indent="
+CallName="pp_multiline_define_body_indent\s*=\s*"
 MinVal=-32
 MaxVal=32
 ValueDefault=8
@@ -7392,7 +7393,7 @@ Category=10
 Description="<html>Whether to indent case statements between #if, #else, and #endif.<br/>Only applies to the indent of the preprocessor that the case statements<br/>directly inside of.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_case=true|pp_indent_case=false
+TrueFalse=pp_indent_case\s*=\s*true|pp_indent_case\s*=\s*false
 ValueDefault=true
 
 [Pp Indent Func Def]
@@ -7400,7 +7401,7 @@ Category=10
 Description="<html>Whether to indent whole function definitions between #if, #else, and #endif.<br/>Only applies to the indent of the preprocessor that the function definition<br/>is directly inside of.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_func_def=true|pp_indent_func_def=false
+TrueFalse=pp_indent_func_def\s*=\s*true|pp_indent_func_def\s*=\s*false
 ValueDefault=true
 
 [Pp Indent Extern]
@@ -7408,7 +7409,7 @@ Category=10
 Description="<html>Whether to indent extern C blocks between #if, #else, and #endif.<br/>Only applies to the indent of the preprocessor that the extern block is<br/>directly inside of.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_extern=true|pp_indent_extern=false
+TrueFalse=pp_indent_extern\s*=\s*true|pp_indent_extern\s*=\s*false
 ValueDefault=true
 
 [Pp Indent Brace]
@@ -7416,7 +7417,7 @@ Category=10
 Description="<html>How to indent braces directly inside #if, #else, and #endif.<br/>Requires pp_if_indent_code=true and only applies to the indent of the<br/>preprocessor that the braces are directly inside of.<br/> 0: No extra indent<br/> 1: Indent by one level<br/>-1: Preserve original indentation<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_brace="
+CallName="pp_indent_brace\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=1
@@ -7426,14 +7427,14 @@ Category=10
 Description="<html>Whether to print warning messages for unbalanced #if and #else blocks.<br/>This will print a message in the following cases:<br/>- if an #ifdef block ends on a different indent level than<br/>  where it started from. Example:<br/><br/>   #ifdef TEST<br/>     int i;<br/>     {<br/>       int j;<br/>   #endif<br/><br/>- an #elif/#else block ends on a different indent level than<br/>  the corresponding #ifdef block. Example:<br/><br/>   #ifdef TEST<br/>       int i;<br/>   #else<br/>       }<br/>     int j;<br/>   #endif</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_warn_unbalanced_if=true|pp_warn_unbalanced_if=false
+TrueFalse=pp_warn_unbalanced_if\s*=\s*true|pp_warn_unbalanced_if\s*=\s*false
 ValueDefault=false
 
 [Include Category 0]
 Category=11
 Description="<html>The regex for include category with priority 0.</html>"
 Enabled=false
-CallName=include_category_0=
+CallName=include_category_0\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -7441,7 +7442,7 @@ ValueDefault=
 Category=11
 Description="<html>The regex for include category with priority 1.</html>"
 Enabled=false
-CallName=include_category_1=
+CallName=include_category_1\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -7449,7 +7450,7 @@ ValueDefault=
 Category=11
 Description="<html>The regex for include category with priority 2.</html>"
 Enabled=false
-CallName=include_category_2=
+CallName=include_category_2\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -7458,7 +7459,7 @@ Category=12
 Description="<html>true:  indent_func_call_param will be used (default)<br/>false: indent_func_call_param will NOT be used<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_indent_func_call_param=true|use_indent_func_call_param=false
+TrueFalse=use_indent_func_call_param\s*=\s*true|use_indent_func_call_param\s*=\s*false
 ValueDefault=true
 
 [Use Indent Continue Only Once]
@@ -7466,7 +7467,7 @@ Category=12
 Description="<html>The value of the indentation for a continuation line is calculated<br/>differently if the statement is:<br/>- a declaration: your case with QString fileName ...<br/>- an assignment: your case with pSettings = new QSettings( ...<br/><br/>At the second case the indentation value might be used twice:<br/>- at the assignment<br/>- at the function call (if present)<br/><br/>To prevent the double use of the indentation value, use this option with the<br/>value 'true'.<br/><br/>true:  indent_continue will be used only once<br/>false: indent_continue will be used every time (default)<br/><br/>Requires indent_ignore_first_continue=false.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_indent_continue_only_once=true|use_indent_continue_only_once=false
+TrueFalse=use_indent_continue_only_once\s*=\s*true|use_indent_continue_only_once\s*=\s*false
 ValueDefault=false
 
 [Indent Cpp Lambda Only Once]
@@ -7474,7 +7475,7 @@ Category=12
 Description="<html>The indentation can be:<br/>- after the assignment, at the '[' character<br/>- at the beginning of the lambda body<br/><br/>true:  indentation will be at the beginning of the lambda body<br/>false: indentation will be after the assignment (default)</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cpp_lambda_only_once=true|indent_cpp_lambda_only_once=false
+TrueFalse=indent_cpp_lambda_only_once\s*=\s*true|indent_cpp_lambda_only_once\s*=\s*false
 ValueDefault=false
 
 [Use Sp After Angle Always]
@@ -7482,7 +7483,7 @@ Category=12
 Description="<html>Whether sp_after_angle takes precedence over sp_inside_fparen. This was the<br/>historic behavior, but is probably not the desired behavior, so this is off<br/>by default.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_sp_after_angle_always=true|use_sp_after_angle_always=false
+TrueFalse=use_sp_after_angle_always\s*=\s*true|use_sp_after_angle_always\s*=\s*false
 ValueDefault=false
 
 [Use Options Overriding For Qt Macros]
@@ -7490,7 +7491,7 @@ Category=12
 Description="<html>Whether to apply special formatting for Qt SIGNAL/SLOT macros. Essentially,<br/>this tries to format these so that they match Qt's normalized form (i.e. the<br/>result of QMetaObject::normalizedSignature), which can slightly improve the<br/>performance of the QObject::connect call, rather than how they would<br/>otherwise be formatted.<br/><br/>See options_for_QT.cpp for details.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_options_overriding_for_qt_macros=true|use_options_overriding_for_qt_macros=false
+TrueFalse=use_options_overriding_for_qt_macros\s*=\s*true|use_options_overriding_for_qt_macros\s*=\s*false
 ValueDefault=true
 
 [Use Form Feed No More As Whitespace Character]
@@ -7498,7 +7499,7 @@ Category=12
 Description="<html>If true: the form feed character is removed from the list of whitespace<br/>characters. See https://en.cppreference.com/w/cpp/string/byte/isspace.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_form_feed_no_more_as_whitespace_character=true|use_form_feed_no_more_as_whitespace_character=false
+TrueFalse=use_form_feed_no_more_as_whitespace_character\s*=\s*true|use_form_feed_no_more_as_whitespace_character\s*=\s*false
 ValueDefault=false
 
 [Warn Level Tabs Found In Verbatim String Literals]
@@ -7506,7 +7507,7 @@ Category=13
 Description="<html>(C#) Warning is given if doing tab-to-\t replacement and we have found one<br/>in a C# verbatim string literal.<br/><br/>Default: 2</html>"
 Enabled=false
 EditorType=numeric
-CallName="warn_level_tabs_found_in_verbatim_string_literals="
+CallName="warn_level_tabs_found_in_verbatim_string_literals\s*=\s*"
 MinVal=1
 MaxVal=3
 ValueDefault=2
@@ -7516,7 +7517,7 @@ Category=13
 Description="<html>Limit the number of loops.<br/>Used by uncrustify.cpp to exit from infinite loop.<br/>0: no limit.</html>"
 Enabled=false
 EditorType=numeric
-CallName="debug_max_number_of_loops="
+CallName="debug_max_number_of_loops\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7526,7 +7527,7 @@ Category=13
 Description="<html>Set the number of the line to protocol;<br/>Used in the function prot_the_line if the 2. parameter is zero.<br/>0: nothing protocol.</html>"
 Enabled=false
 EditorType=numeric
-CallName="debug_line_number_to_protocol="
+CallName="debug_line_number_to_protocol\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7536,7 +7537,7 @@ Category=13
 Description="<html>Set the number of second(s) before terminating formatting the current file,<br/>0: no timeout.<br/>only for linux</html>"
 Enabled=false
 EditorType=numeric
-CallName="debug_timeout="
+CallName="debug_timeout\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7546,7 +7547,7 @@ Category=13
 Description="<html>Set the number of characters to be printed if the text is too long,<br/>0: do not truncate.</html>"
 Enabled=false
 EditorType=numeric
-CallName="debug_truncate="
+CallName="debug_truncate\s*=\s*"
 MinVal=0
 MaxVal=960
 ValueDefault=0
@@ -7556,7 +7557,7 @@ Category=13
 Description="<html>sort (or not) the tracking info.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=debug_sort_the_tracks=true|debug_sort_the_tracks=false
+TrueFalse=debug_sort_the_tracks\s*=\s*true|debug_sort_the_tracks\s*=\s*false
 ValueDefault=true
 
 [Debug Decode The Flags]
@@ -7564,7 +7565,7 @@ Category=13
 Description="<html>decode (or not) the flags as a new line.<br/>only if the -p option is set.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=debug_decode_the_flags=true|debug_decode_the_flags=false
+TrueFalse=debug_decode_the_flags\s*=\s*true|debug_decode_the_flags\s*=\s*false
 ValueDefault=false
 
 [Debug Use The Exit Function Pop]
@@ -7572,7 +7573,7 @@ Category=13
 Description="<html>use (or not) the exit(EX_SOFTWARE) function.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=debug_use_the_exit_function_pop=true|debug_use_the_exit_function_pop=false
+TrueFalse=debug_use_the_exit_function_pop\s*=\s*true|debug_use_the_exit_function_pop\s*=\s*false
 ValueDefault=true
 
 [Set Numbering For Html Output]
@@ -7580,5 +7581,5 @@ Category=13
 Description="<html>insert the number of the line at the beginning of each line</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=set_numbering_for_html_output=true|set_numbering_for_html_output=false
+TrueFalse=set_numbering_for_html_output\s*=\s*true|set_numbering_for_html_output\s*=\s*false
 ValueDefault=false


### PR DESCRIPTION
This allows universalIndentGUI-tqt to parse configuration files with separators around the '=' sign.

@guy-maurel please test before I merge.