### PR TITLE
Fix execution of `scripts/release_tool.py update` command 

### DIFF
--- a/scripts/release_tool.py
+++ b/scripts/release_tool.py
@@ -273,7 +273,7 @@ def main():
 
     parser_update = subparsers.add_parser(
         'update', help='update version information')
-    parser_update.set_defaults(func=cmd_update)
+    parser_update.set_defaults(func=cmd_update, keepversion=False)
     parser_update.add_argument('executable',
                                help='path to uncrustify executable')
 


### PR DESCRIPTION
As per title. This was blocking the release process.