### PR TITLE
Fix VBRACE semicolon

### DIFF
--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -513,7 +513,8 @@ static void parse_cleanup(BraceState &braceState, ParsingFrame &frm, Chunk *pc)
          frm.pop(__func__, __LINE__, pc);
          print_stack(LBCSPOP, "-Close  ", frm);
 
-         if (  frm.top().GetStage() == E_BraceStage::NONE
+         if (  language_is_set(LANG_D)
+            && frm.top().GetStage() == E_BraceStage::NONE
             && (  pc->Is(CT_VBRACE_CLOSE)
                || pc->Is(CT_BRACE_CLOSE)
                || pc->Is(CT_SEMICOLON))

--- a/tests/config/cpp/Issue_3191.cfg
+++ b/tests/config/cpp/Issue_3191.cfg
@@ -1,0 +1,1 @@
+nl_after_if = add

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -1210,3 +1210,4 @@
 60161  cpp/nl_min_after_func_body.cfg                       cpp/nl_func-2.cpp
 60162  cpp/nl_max_after_func_body.cfg                       cpp/nl_func.cpp
 60163  cpp/nl_max_after_func_body.cfg                       cpp/nl_func-2.cpp
+60164  cpp/Issue_3191.cfg                                   cpp/Issue_3191.cpp

--- a/tests/expected/cpp/60164-Issue_3191.cpp
+++ b/tests/expected/cpp/60164-Issue_3191.cpp
@@ -1,0 +1,4 @@
+if (foo)
+	return {};
+
+int i = 0;

--- a/tests/input/cpp/Issue_3191.cpp
+++ b/tests/input/cpp/Issue_3191.cpp
@@ -1,0 +1,3 @@
+if (foo)
+	return {};
+int i = 0;


### PR DESCRIPTION
Fixes https://github.com/uncrustify/uncrustify/issues/3191 which was caused by https://github.com/uncrustify/uncrustify/commit/2748cfc041bc59c1de6389945dc0fb1b76c312e4. 
Mentioned commit causes that code like 

```
if (foo)
    return {};
```
is formatted to
```
if (foo)
    return {}

;
```

which is obviously not allright. Original commit fixed some D lang issues, so I have fixed it by wrapping its changes in condition so they are only applied for D lang.  When this is merged, I will be finally able to upgrade uncrustify after more than three years.