### PR TITLE
Make nl_var_def_blk_end work correctly with class code

### DIFF
--- a/tests/expected/cpp/31662-var_def_blks.cpp
+++ b/tests/expected/cpp/31662-var_def_blks.cpp
@@ -1,3 +1,20 @@
+class SomeClass {
+enum Things {
+	This,
+	That,
+	TheOther,
+};
+explicit SomeClass(const char * instr) :
+	_inchar(instr[0]) {
+}
+};
+bool SomeClass::dothething = true;
+SomeClass::SomeClass( char input ) :
+	_inchar(input) {
+	if (dothething) {
+		// do it!
+	}
+}
 unsigned a;
 char b;
 int bar(void);

--- a/tests/expected/cpp/31663-var_def_blks.cpp
+++ b/tests/expected/cpp/31663-var_def_blks.cpp
@@ -1,3 +1,24 @@
+class SomeClass {
+enum Things {
+	This,
+	That,
+	TheOther,
+};
+explicit SomeClass(const char * instr) :
+	_inchar(instr[0]) {
+}
+};
+
+
+bool SomeClass::dothething = true;
+SomeClass::SomeClass( char input ) :
+	_inchar(input) {
+	if (dothething) {
+		// do it!
+	}
+}
+
+
 unsigned a;
 char b;
 int bar(void);

--- a/tests/expected/cpp/31664-var_def_blks.cpp
+++ b/tests/expected/cpp/31664-var_def_blks.cpp
@@ -1,3 +1,28 @@
+class SomeClass {
+enum Things {
+	This,
+	That,
+	TheOther,
+};
+
+
+
+
+explicit SomeClass(const char * instr) :
+	_inchar(instr[0]) {
+}
+};
+bool SomeClass::dothething = true;
+
+
+
+
+SomeClass::SomeClass( char input ) :
+	_inchar(input) {
+	if (dothething) {
+		// do it!
+	}
+}
 unsigned a;
 char b;
 

--- a/tests/expected/cpp/31665-var_def_blks.cpp
+++ b/tests/expected/cpp/31665-var_def_blks.cpp
@@ -1,3 +1,24 @@
+class SomeClass {
+enum Things {
+	This,
+	That,
+	TheOther,
+};
+explicit SomeClass(const char * instr) :
+	_inchar(instr[0]) {
+}
+};
+
+
+bool SomeClass::dothething = true;
+SomeClass::SomeClass( char input ) :
+	_inchar(input) {
+	if (dothething) {
+		// do it!
+	}
+}
+
+
 unsigned a;
 char b;
 int bar(void);

--- a/tests/expected/cpp/31666-var_def_blks.cpp
+++ b/tests/expected/cpp/31666-var_def_blks.cpp
@@ -1,3 +1,28 @@
+class SomeClass {
+enum Things {
+	This,
+	That,
+	TheOther,
+};
+
+
+
+
+explicit SomeClass(const char * instr) :
+	_inchar(instr[0]) {
+}
+};
+bool SomeClass::dothething = true;
+
+
+
+
+SomeClass::SomeClass( char input ) :
+	_inchar(input) {
+	if (dothething) {
+		// do it!
+	}
+}
 unsigned a;
 char b;
 

--- a/tests/expected/cpp/31667-var_def_blks.cpp
+++ b/tests/expected/cpp/31667-var_def_blks.cpp
@@ -1,3 +1,32 @@
+class SomeClass {
+enum Things {
+	This,
+	That,
+	TheOther,
+};
+
+
+
+
+explicit SomeClass(const char * instr) :
+	_inchar(instr[0]) {
+}
+};
+
+
+bool SomeClass::dothething = true;
+
+
+
+
+SomeClass::SomeClass( char input ) :
+	_inchar(input) {
+	if (dothething) {
+		// do it!
+	}
+}
+
+
 unsigned a;
 char b;
 

--- a/tests/expected/cpp/31668-var_def_blks.cpp
+++ b/tests/expected/cpp/31668-var_def_blks.cpp
@@ -1,3 +1,32 @@
+class SomeClass {
+enum Things {
+	This,
+	That,
+	TheOther,
+};
+
+
+
+
+explicit SomeClass(const char * instr) :
+	_inchar(instr[0]) {
+}
+};
+
+
+bool SomeClass::dothething = true;
+
+
+
+
+SomeClass::SomeClass( char input ) :
+	_inchar(input) {
+	if (dothething) {
+		// do it!
+	}
+}
+
+
 unsigned a;
 char b;
 

--- a/tests/input/cpp/var_def_blks.cpp
+++ b/tests/input/cpp/var_def_blks.cpp
@@ -1,3 +1,20 @@
+class SomeClass {
+    enum Things {
+        This,
+        That,
+        TheOther,
+    };
+    explicit SomeClass(const char * instr) :
+        _inchar(instr[0]) {
+    }
+};
+bool SomeClass::dothething = true;
+SomeClass::SomeClass( char input ) :
+    _inchar(input) {
+    if (dothething) {
+        // do it!
+    }
+}
 unsigned a;
 char b;
 int bar(void);


### PR DESCRIPTION
This is a fix for https://github.com/uncrustify/uncrustify/discussions/4138. 

This is a smaller change than it seems. It reuses the logic for computing the "prev" pointer from the variable-definition-block case for the class (member) definition case. This way the code to add a newline to the end of a variable definition block will do that instead of adding it to the end of the "current" line, when that block is followed by class code.

The way it does this is to rearrange the code so that "prev" and "next" pointers are computed for all cases inside the outermost if() clause, even if they are not needed. This seems better than adding more redundant if() clauses and having sometimes-uninitialized or sometimes-badly-initialized pointers, or fully reorganizing the code.

This also fixes some logging statements in this block of code.