### PR TITLE
Add support for both regex and non regex in etc/uigui_uncrustify.ini

### DIFF
--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -15,7 +15,6 @@ parameterOrder=ipo
 showHelpParameter=-h
 stringparaminquotes=false
 useCfgFileParameter="-c "
-useRegex=true
 version=Uncrustify-0.78.1
 
 [Newlines]
@@ -23,7 +22,8 @@ Category=0
 Description="<html>The type of line endings.<br/><br/>Default: auto</html>"
 Enabled=false
 EditorType=multiple
-Choices=newlines\s*=\s*lf|newlines\s*=\s*crlf|newlines\s*=\s*cr|newlines\s*=\s*auto
+Choices=newlines=lf|newlines=crlf|newlines=cr|newlines=auto
+ChoicesRegex=newlines\s*=\s*lf|newlines\s*=\s*crlf|newlines\s*=\s*cr|newlines\s*=\s*auto
 ChoicesReadable="Newlines Unix|Newlines Win|Newlines Mac|Newlines Auto"
 ValueDefault=auto
 
@@ -32,7 +32,8 @@ Category=0
 Description="<html>The original size of tabs in the input.<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
-CallName="input_tab_size\s*=\s*"
+CallName="input_tab_size="
+CallNameRegex="input_tab_size\s*=\s*"
 MinVal=1
 MaxVal=32
 ValueDefault=8
@@ -42,7 +43,8 @@ Category=0
 Description="<html>The size of tabs in the output (only used if align_with_tabs=true).<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
-CallName="output_tab_size\s*=\s*"
+CallName="output_tab_size="
+CallNameRegex="output_tab_size\s*=\s*"
 MinVal=1
 MaxVal=32
 ValueDefault=8
@@ -52,7 +54,8 @@ Category=0
 Description="<html>The ASCII value of the string escape char, usually 92 (\) or (Pawn) 94 (^).<br/><br/>Default: 92</html>"
 Enabled=false
 EditorType=numeric
-CallName="string_escape_char\s*=\s*"
+CallName="string_escape_char="
+CallNameRegex="string_escape_char\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=92
@@ -62,7 +65,8 @@ Category=0
 Description="<html>Alternate string escape char (usually only used for Pawn).<br/>Only works right before the quote char.</html>"
 Enabled=false
 EditorType=numeric
-CallName="string_escape_char2\s*=\s*"
+CallName="string_escape_char2="
+CallNameRegex="string_escape_char2\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -72,7 +76,8 @@ Category=0
 Description="<html>Replace tab characters found in string literals with the escape sequence \t<br/>instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=string_replace_tab_chars\s*=\s*true|string_replace_tab_chars\s*=\s*false
+TrueFalse=string_replace_tab_chars=true|string_replace_tab_chars=false
+TrueFalseRegex=string_replace_tab_chars\s*=\s*true|string_replace_tab_chars\s*=\s*false
 ValueDefault=false
 
 [Tok Split Gte]
@@ -80,7 +85,8 @@ Category=0
 Description="<html>Allow interpreting '&gt;=' and '&gt;&gt;=' as part of a template in code like<br/>'void f(list&lt;list&lt;B&gt;&gt;=val);'. If true, 'assert(x&lt;0 &amp;&amp; y&gt;=3)' will be broken.<br/>Improvements to template detection may make this option obsolete.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=tok_split_gte\s*=\s*true|tok_split_gte\s*=\s*false
+TrueFalse=tok_split_gte=true|tok_split_gte=false
+TrueFalseRegex=tok_split_gte\s*=\s*true|tok_split_gte\s*=\s*false
 ValueDefault=false
 
 [Disable Processing Nl Cont]
@@ -88,14 +94,16 @@ Category=0
 Description="<html>Disable formatting of NL_CONT ('\\n') ended lines (e.g. multi-line macros).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=disable_processing_nl_cont\s*=\s*true|disable_processing_nl_cont\s*=\s*false
+TrueFalse=disable_processing_nl_cont=true|disable_processing_nl_cont=false
+TrueFalseRegex=disable_processing_nl_cont\s*=\s*true|disable_processing_nl_cont\s*=\s*false
 ValueDefault=false
 
 [Disable Processing Cmt]
 Category=0
 Description="<html>Specify the marker used in comments to disable processing of part of the<br/>file.<br/><br/>Default:  *INDENT-OFF*</html>"
 Enabled=false
-CallName=disable_processing_cmt\s*=\s*
+CallName=disable_processing_cmt=
+CallNameRegex=disable_processing_cmt\s*=\s*
 EditorType=string
 ValueDefault= *INDENT-OFF*
 
@@ -103,7 +111,8 @@ ValueDefault= *INDENT-OFF*
 Category=0
 Description="<html>Specify the marker used in comments to (re)enable processing in a file.<br/><br/>Default:  *INDENT-ON*</html>"
 Enabled=false
-CallName=enable_processing_cmt\s*=\s*
+CallName=enable_processing_cmt=
+CallNameRegex=enable_processing_cmt\s*=\s*
 EditorType=string
 ValueDefault= *INDENT-ON*
 
@@ -112,7 +121,8 @@ Category=0
 Description="<html>Enable parsing of digraphs.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=enable_digraphs\s*=\s*true|enable_digraphs\s*=\s*false
+TrueFalse=enable_digraphs=true|enable_digraphs=false
+TrueFalseRegex=enable_digraphs\s*=\s*true|enable_digraphs\s*=\s*false
 ValueDefault=false
 
 [Processing Cmt As Regex]
@@ -120,7 +130,8 @@ Category=0
 Description="<html>Option to allow both disable_processing_cmt and enable_processing_cmt<br/>strings, if specified, to be interpreted as ECMAScript regular expressions.<br/>If true, a regex search will be performed within comments according to the<br/>specified patterns in order to disable/enable processing.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=processing_cmt_as_regex\s*=\s*true|processing_cmt_as_regex\s*=\s*false
+TrueFalse=processing_cmt_as_regex=true|processing_cmt_as_regex=false
+TrueFalseRegex=processing_cmt_as_regex\s*=\s*true|processing_cmt_as_regex\s*=\s*false
 ValueDefault=false
 
 [Utf8 Bom]
@@ -128,7 +139,8 @@ Category=0
 Description="<html>Add or remove the UTF-8 BOM (recommend 'remove').</html>"
 Enabled=false
 EditorType=multiple
-Choices=utf8_bom\s*=\s*ignore|utf8_bom\s*=\s*add|utf8_bom\s*=\s*remove|utf8_bom\s*=\s*force|utf8_bom\s*=\s*not_defined
+Choices=utf8_bom=ignore|utf8_bom=add|utf8_bom=remove|utf8_bom=force|utf8_bom=not_defined
+ChoicesRegex=utf8_bom\s*=\s*ignore|utf8_bom\s*=\s*add|utf8_bom\s*=\s*remove|utf8_bom\s*=\s*force|utf8_bom\s*=\s*not_defined
 ChoicesReadable="Ignore Utf8 Bom|Add Utf8 Bom|Remove Utf8 Bom|Force Utf8 Bom"
 ValueDefault=ignore
 
@@ -137,7 +149,8 @@ Category=0
 Description="<html>If the file contains bytes with values between 128 and 255, but is not<br/>UTF-8, then output as UTF-8.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=utf8_byte\s*=\s*true|utf8_byte\s*=\s*false
+TrueFalse=utf8_byte=true|utf8_byte=false
+TrueFalseRegex=utf8_byte\s*=\s*true|utf8_byte\s*=\s*false
 ValueDefault=false
 
 [Utf8 Force]
@@ -145,7 +158,8 @@ Category=0
 Description="<html>Force the output encoding to UTF-8.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=utf8_force\s*=\s*true|utf8_force\s*=\s*false
+TrueFalse=utf8_force=true|utf8_force=false
+TrueFalseRegex=utf8_force\s*=\s*true|utf8_force\s*=\s*false
 ValueDefault=false
 
 [Sp Arith]
@@ -153,7 +167,8 @@ Category=1
 Description="<html>Add or remove space around non-assignment symbolic operators ('+', '/', '%',<br/>'&lt;&lt;', and so forth).</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_arith\s*=\s*ignore|sp_arith\s*=\s*add|sp_arith\s*=\s*remove|sp_arith\s*=\s*force|sp_arith\s*=\s*not_defined
+Choices=sp_arith=ignore|sp_arith=add|sp_arith=remove|sp_arith=force|sp_arith=not_defined
+ChoicesRegex=sp_arith\s*=\s*ignore|sp_arith\s*=\s*add|sp_arith\s*=\s*remove|sp_arith\s*=\s*force|sp_arith\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Arith|Add Sp Arith|Remove Sp Arith|Force Sp Arith"
 ValueDefault=ignore
 
@@ -162,7 +177,8 @@ Category=1
 Description="<html>Add or remove space around arithmetic operators '+' and '-'.<br/><br/>Overrides sp_arith.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_arith_additive\s*=\s*ignore|sp_arith_additive\s*=\s*add|sp_arith_additive\s*=\s*remove|sp_arith_additive\s*=\s*force|sp_arith_additive\s*=\s*not_defined
+Choices=sp_arith_additive=ignore|sp_arith_additive=add|sp_arith_additive=remove|sp_arith_additive=force|sp_arith_additive=not_defined
+ChoicesRegex=sp_arith_additive\s*=\s*ignore|sp_arith_additive\s*=\s*add|sp_arith_additive\s*=\s*remove|sp_arith_additive\s*=\s*force|sp_arith_additive\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Arith Additive|Add Sp Arith Additive|Remove Sp Arith Additive|Force Sp Arith Additive"
 ValueDefault=ignore
 
@@ -171,7 +187,8 @@ Category=1
 Description="<html>Add or remove space around assignment operator '=', '+=', etc.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_assign\s*=\s*ignore|sp_assign\s*=\s*add|sp_assign\s*=\s*remove|sp_assign\s*=\s*force|sp_assign\s*=\s*not_defined
+Choices=sp_assign=ignore|sp_assign=add|sp_assign=remove|sp_assign=force|sp_assign=not_defined
+ChoicesRegex=sp_assign\s*=\s*ignore|sp_assign\s*=\s*add|sp_assign\s*=\s*remove|sp_assign\s*=\s*force|sp_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Assign|Add Sp Assign|Remove Sp Assign|Force Sp Assign"
 ValueDefault=ignore
 
@@ -180,7 +197,8 @@ Category=1
 Description="<html>Add or remove space around '=' in C++11 lambda capture specifications.<br/><br/>Overrides sp_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_assign\s*=\s*ignore|sp_cpp_lambda_assign\s*=\s*add|sp_cpp_lambda_assign\s*=\s*remove|sp_cpp_lambda_assign\s*=\s*force|sp_cpp_lambda_assign\s*=\s*not_defined
+Choices=sp_cpp_lambda_assign=ignore|sp_cpp_lambda_assign=add|sp_cpp_lambda_assign=remove|sp_cpp_lambda_assign=force|sp_cpp_lambda_assign=not_defined
+ChoicesRegex=sp_cpp_lambda_assign\s*=\s*ignore|sp_cpp_lambda_assign\s*=\s*add|sp_cpp_lambda_assign\s*=\s*remove|sp_cpp_lambda_assign\s*=\s*force|sp_cpp_lambda_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Assign|Add Sp Cpp Lambda Assign|Remove Sp Cpp Lambda Assign|Force Sp Cpp Lambda Assign"
 ValueDefault=ignore
 
@@ -189,7 +207,8 @@ Category=1
 Description="<html>Add or remove space after the capture specification of a C++11 lambda when<br/>an argument list is present, as in '[] &lt;here&gt; (int x){ ... }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_square_paren\s*=\s*ignore|sp_cpp_lambda_square_paren\s*=\s*add|sp_cpp_lambda_square_paren\s*=\s*remove|sp_cpp_lambda_square_paren\s*=\s*force|sp_cpp_lambda_square_paren\s*=\s*not_defined
+Choices=sp_cpp_lambda_square_paren=ignore|sp_cpp_lambda_square_paren=add|sp_cpp_lambda_square_paren=remove|sp_cpp_lambda_square_paren=force|sp_cpp_lambda_square_paren=not_defined
+ChoicesRegex=sp_cpp_lambda_square_paren\s*=\s*ignore|sp_cpp_lambda_square_paren\s*=\s*add|sp_cpp_lambda_square_paren\s*=\s*remove|sp_cpp_lambda_square_paren\s*=\s*force|sp_cpp_lambda_square_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Square Paren|Add Sp Cpp Lambda Square Paren|Remove Sp Cpp Lambda Square Paren|Force Sp Cpp Lambda Square Paren"
 ValueDefault=ignore
 
@@ -198,7 +217,8 @@ Category=1
 Description="<html>Add or remove space after the capture specification of a C++11 lambda with<br/>no argument list is present, as in '[] &lt;here&gt; { ... }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_square_brace\s*=\s*ignore|sp_cpp_lambda_square_brace\s*=\s*add|sp_cpp_lambda_square_brace\s*=\s*remove|sp_cpp_lambda_square_brace\s*=\s*force|sp_cpp_lambda_square_brace\s*=\s*not_defined
+Choices=sp_cpp_lambda_square_brace=ignore|sp_cpp_lambda_square_brace=add|sp_cpp_lambda_square_brace=remove|sp_cpp_lambda_square_brace=force|sp_cpp_lambda_square_brace=not_defined
+ChoicesRegex=sp_cpp_lambda_square_brace\s*=\s*ignore|sp_cpp_lambda_square_brace\s*=\s*add|sp_cpp_lambda_square_brace\s*=\s*remove|sp_cpp_lambda_square_brace\s*=\s*force|sp_cpp_lambda_square_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Square Brace|Add Sp Cpp Lambda Square Brace|Remove Sp Cpp Lambda Square Brace|Force Sp Cpp Lambda Square Brace"
 ValueDefault=ignore
 
@@ -207,7 +227,8 @@ Category=1
 Description="<html>Add or remove space after the opening parenthesis and before the closing<br/>parenthesis of a argument list of a C++11 lambda, as in<br/>'[]( &lt;here&gt; ){ ... }'<br/>with an empty list.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_argument_list_empty\s*=\s*ignore|sp_cpp_lambda_argument_list_empty\s*=\s*add|sp_cpp_lambda_argument_list_empty\s*=\s*remove|sp_cpp_lambda_argument_list_empty\s*=\s*force|sp_cpp_lambda_argument_list_empty\s*=\s*not_defined
+Choices=sp_cpp_lambda_argument_list_empty=ignore|sp_cpp_lambda_argument_list_empty=add|sp_cpp_lambda_argument_list_empty=remove|sp_cpp_lambda_argument_list_empty=force|sp_cpp_lambda_argument_list_empty=not_defined
+ChoicesRegex=sp_cpp_lambda_argument_list_empty\s*=\s*ignore|sp_cpp_lambda_argument_list_empty\s*=\s*add|sp_cpp_lambda_argument_list_empty\s*=\s*remove|sp_cpp_lambda_argument_list_empty\s*=\s*force|sp_cpp_lambda_argument_list_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Argument List Empty|Add Sp Cpp Lambda Argument List Empty|Remove Sp Cpp Lambda Argument List Empty|Force Sp Cpp Lambda Argument List Empty"
 ValueDefault=ignore
 
@@ -216,7 +237,8 @@ Category=1
 Description="<html>Add or remove space after the opening parenthesis and before the closing<br/>parenthesis of a argument list of a C++11 lambda, as in<br/>'[]( &lt;here&gt; int x &lt;here&gt; ){ ... }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_argument_list\s*=\s*ignore|sp_cpp_lambda_argument_list\s*=\s*add|sp_cpp_lambda_argument_list\s*=\s*remove|sp_cpp_lambda_argument_list\s*=\s*force|sp_cpp_lambda_argument_list\s*=\s*not_defined
+Choices=sp_cpp_lambda_argument_list=ignore|sp_cpp_lambda_argument_list=add|sp_cpp_lambda_argument_list=remove|sp_cpp_lambda_argument_list=force|sp_cpp_lambda_argument_list=not_defined
+ChoicesRegex=sp_cpp_lambda_argument_list\s*=\s*ignore|sp_cpp_lambda_argument_list\s*=\s*add|sp_cpp_lambda_argument_list\s*=\s*remove|sp_cpp_lambda_argument_list\s*=\s*force|sp_cpp_lambda_argument_list\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Argument List|Add Sp Cpp Lambda Argument List|Remove Sp Cpp Lambda Argument List|Force Sp Cpp Lambda Argument List"
 ValueDefault=ignore
 
@@ -225,7 +247,8 @@ Category=1
 Description="<html>Add or remove space after the argument list of a C++11 lambda, as in<br/>'[](int x) &lt;here&gt; { ... }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_paren_brace\s*=\s*ignore|sp_cpp_lambda_paren_brace\s*=\s*add|sp_cpp_lambda_paren_brace\s*=\s*remove|sp_cpp_lambda_paren_brace\s*=\s*force|sp_cpp_lambda_paren_brace\s*=\s*not_defined
+Choices=sp_cpp_lambda_paren_brace=ignore|sp_cpp_lambda_paren_brace=add|sp_cpp_lambda_paren_brace=remove|sp_cpp_lambda_paren_brace=force|sp_cpp_lambda_paren_brace=not_defined
+ChoicesRegex=sp_cpp_lambda_paren_brace\s*=\s*ignore|sp_cpp_lambda_paren_brace\s*=\s*add|sp_cpp_lambda_paren_brace\s*=\s*remove|sp_cpp_lambda_paren_brace\s*=\s*force|sp_cpp_lambda_paren_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Paren Brace|Add Sp Cpp Lambda Paren Brace|Remove Sp Cpp Lambda Paren Brace|Force Sp Cpp Lambda Paren Brace"
 ValueDefault=ignore
 
@@ -234,7 +257,8 @@ Category=1
 Description="<html>Add or remove space between a lambda body and its call operator of an<br/>immediately invoked lambda, as in '[]( ... ){ ... } &lt;here&gt; ( ... )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_fparen\s*=\s*ignore|sp_cpp_lambda_fparen\s*=\s*add|sp_cpp_lambda_fparen\s*=\s*remove|sp_cpp_lambda_fparen\s*=\s*force|sp_cpp_lambda_fparen\s*=\s*not_defined
+Choices=sp_cpp_lambda_fparen=ignore|sp_cpp_lambda_fparen=add|sp_cpp_lambda_fparen=remove|sp_cpp_lambda_fparen=force|sp_cpp_lambda_fparen=not_defined
+ChoicesRegex=sp_cpp_lambda_fparen\s*=\s*ignore|sp_cpp_lambda_fparen\s*=\s*add|sp_cpp_lambda_fparen\s*=\s*remove|sp_cpp_lambda_fparen\s*=\s*force|sp_cpp_lambda_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Fparen|Add Sp Cpp Lambda Fparen|Remove Sp Cpp Lambda Fparen|Force Sp Cpp Lambda Fparen"
 ValueDefault=ignore
 
@@ -243,7 +267,8 @@ Category=1
 Description="<html>Add or remove space around assignment operator '=' in a prototype.<br/><br/>If set to ignore, use sp_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_assign_default\s*=\s*ignore|sp_assign_default\s*=\s*add|sp_assign_default\s*=\s*remove|sp_assign_default\s*=\s*force|sp_assign_default\s*=\s*not_defined
+Choices=sp_assign_default=ignore|sp_assign_default=add|sp_assign_default=remove|sp_assign_default=force|sp_assign_default=not_defined
+ChoicesRegex=sp_assign_default\s*=\s*ignore|sp_assign_default\s*=\s*add|sp_assign_default\s*=\s*remove|sp_assign_default\s*=\s*force|sp_assign_default\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Assign Default|Add Sp Assign Default|Remove Sp Assign Default|Force Sp Assign Default"
 ValueDefault=ignore
 
@@ -252,7 +277,8 @@ Category=1
 Description="<html>Add or remove space before assignment operator '=', '+=', etc.<br/><br/>Overrides sp_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_assign\s*=\s*ignore|sp_before_assign\s*=\s*add|sp_before_assign\s*=\s*remove|sp_before_assign\s*=\s*force|sp_before_assign\s*=\s*not_defined
+Choices=sp_before_assign=ignore|sp_before_assign=add|sp_before_assign=remove|sp_before_assign=force|sp_before_assign=not_defined
+ChoicesRegex=sp_before_assign\s*=\s*ignore|sp_before_assign\s*=\s*add|sp_before_assign\s*=\s*remove|sp_before_assign\s*=\s*force|sp_before_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Assign|Add Sp Before Assign|Remove Sp Before Assign|Force Sp Before Assign"
 ValueDefault=ignore
 
@@ -261,7 +287,8 @@ Category=1
 Description="<html>Add or remove space after assignment operator '=', '+=', etc.<br/><br/>Overrides sp_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_assign\s*=\s*ignore|sp_after_assign\s*=\s*add|sp_after_assign\s*=\s*remove|sp_after_assign\s*=\s*force|sp_after_assign\s*=\s*not_defined
+Choices=sp_after_assign=ignore|sp_after_assign=add|sp_after_assign=remove|sp_after_assign=force|sp_after_assign=not_defined
+ChoicesRegex=sp_after_assign\s*=\s*ignore|sp_after_assign\s*=\s*add|sp_after_assign\s*=\s*remove|sp_after_assign\s*=\s*force|sp_after_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Assign|Add Sp After Assign|Remove Sp After Assign|Force Sp After Assign"
 ValueDefault=ignore
 
@@ -270,7 +297,8 @@ Category=1
 Description="<html>Add or remove space in 'enum {'.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_brace\s*=\s*ignore|sp_enum_brace\s*=\s*add|sp_enum_brace\s*=\s*remove|sp_enum_brace\s*=\s*force|sp_enum_brace\s*=\s*not_defined
+Choices=sp_enum_brace=ignore|sp_enum_brace=add|sp_enum_brace=remove|sp_enum_brace=force|sp_enum_brace=not_defined
+ChoicesRegex=sp_enum_brace\s*=\s*ignore|sp_enum_brace\s*=\s*add|sp_enum_brace\s*=\s*remove|sp_enum_brace\s*=\s*force|sp_enum_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Brace|Add Sp Enum Brace|Remove Sp Enum Brace|Force Sp Enum Brace"
 ValueDefault=add
 
@@ -279,7 +307,8 @@ Category=1
 Description="<html>Add or remove space in 'NS_ENUM ('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_paren\s*=\s*ignore|sp_enum_paren\s*=\s*add|sp_enum_paren\s*=\s*remove|sp_enum_paren\s*=\s*force|sp_enum_paren\s*=\s*not_defined
+Choices=sp_enum_paren=ignore|sp_enum_paren=add|sp_enum_paren=remove|sp_enum_paren=force|sp_enum_paren=not_defined
+ChoicesRegex=sp_enum_paren\s*=\s*ignore|sp_enum_paren\s*=\s*add|sp_enum_paren\s*=\s*remove|sp_enum_paren\s*=\s*force|sp_enum_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Paren|Add Sp Enum Paren|Remove Sp Enum Paren|Force Sp Enum Paren"
 ValueDefault=ignore
 
@@ -288,7 +317,8 @@ Category=1
 Description="<html>Add or remove space around assignment '=' in enum.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_assign\s*=\s*ignore|sp_enum_assign\s*=\s*add|sp_enum_assign\s*=\s*remove|sp_enum_assign\s*=\s*force|sp_enum_assign\s*=\s*not_defined
+Choices=sp_enum_assign=ignore|sp_enum_assign=add|sp_enum_assign=remove|sp_enum_assign=force|sp_enum_assign=not_defined
+ChoicesRegex=sp_enum_assign\s*=\s*ignore|sp_enum_assign\s*=\s*add|sp_enum_assign\s*=\s*remove|sp_enum_assign\s*=\s*force|sp_enum_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Assign|Add Sp Enum Assign|Remove Sp Enum Assign|Force Sp Enum Assign"
 ValueDefault=ignore
 
@@ -297,7 +327,8 @@ Category=1
 Description="<html>Add or remove space before assignment '=' in enum.<br/><br/>Overrides sp_enum_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_before_assign\s*=\s*ignore|sp_enum_before_assign\s*=\s*add|sp_enum_before_assign\s*=\s*remove|sp_enum_before_assign\s*=\s*force|sp_enum_before_assign\s*=\s*not_defined
+Choices=sp_enum_before_assign=ignore|sp_enum_before_assign=add|sp_enum_before_assign=remove|sp_enum_before_assign=force|sp_enum_before_assign=not_defined
+ChoicesRegex=sp_enum_before_assign\s*=\s*ignore|sp_enum_before_assign\s*=\s*add|sp_enum_before_assign\s*=\s*remove|sp_enum_before_assign\s*=\s*force|sp_enum_before_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Before Assign|Add Sp Enum Before Assign|Remove Sp Enum Before Assign|Force Sp Enum Before Assign"
 ValueDefault=ignore
 
@@ -306,7 +337,8 @@ Category=1
 Description="<html>Add or remove space after assignment '=' in enum.<br/><br/>Overrides sp_enum_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_after_assign\s*=\s*ignore|sp_enum_after_assign\s*=\s*add|sp_enum_after_assign\s*=\s*remove|sp_enum_after_assign\s*=\s*force|sp_enum_after_assign\s*=\s*not_defined
+Choices=sp_enum_after_assign=ignore|sp_enum_after_assign=add|sp_enum_after_assign=remove|sp_enum_after_assign=force|sp_enum_after_assign=not_defined
+ChoicesRegex=sp_enum_after_assign\s*=\s*ignore|sp_enum_after_assign\s*=\s*add|sp_enum_after_assign\s*=\s*remove|sp_enum_after_assign\s*=\s*force|sp_enum_after_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum After Assign|Add Sp Enum After Assign|Remove Sp Enum After Assign|Force Sp Enum After Assign"
 ValueDefault=ignore
 
@@ -315,7 +347,8 @@ Category=1
 Description="<html>Add or remove space around assignment ':' in enum.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_colon\s*=\s*ignore|sp_enum_colon\s*=\s*add|sp_enum_colon\s*=\s*remove|sp_enum_colon\s*=\s*force|sp_enum_colon\s*=\s*not_defined
+Choices=sp_enum_colon=ignore|sp_enum_colon=add|sp_enum_colon=remove|sp_enum_colon=force|sp_enum_colon=not_defined
+ChoicesRegex=sp_enum_colon\s*=\s*ignore|sp_enum_colon\s*=\s*add|sp_enum_colon\s*=\s*remove|sp_enum_colon\s*=\s*force|sp_enum_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Colon|Add Sp Enum Colon|Remove Sp Enum Colon|Force Sp Enum Colon"
 ValueDefault=ignore
 
@@ -324,7 +357,8 @@ Category=1
 Description="<html>Add or remove space around preprocessor '##' concatenation operator.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_pp_concat\s*=\s*ignore|sp_pp_concat\s*=\s*add|sp_pp_concat\s*=\s*remove|sp_pp_concat\s*=\s*force|sp_pp_concat\s*=\s*not_defined
+Choices=sp_pp_concat=ignore|sp_pp_concat=add|sp_pp_concat=remove|sp_pp_concat=force|sp_pp_concat=not_defined
+ChoicesRegex=sp_pp_concat\s*=\s*ignore|sp_pp_concat\s*=\s*add|sp_pp_concat\s*=\s*remove|sp_pp_concat\s*=\s*force|sp_pp_concat\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Pp Concat|Add Sp Pp Concat|Remove Sp Pp Concat|Force Sp Pp Concat"
 ValueDefault=add
 
@@ -333,7 +367,8 @@ Category=1
 Description="<html>Add or remove space after preprocessor '#' stringify operator.<br/>Also affects the '#@' charizing operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_pp_stringify\s*=\s*ignore|sp_pp_stringify\s*=\s*add|sp_pp_stringify\s*=\s*remove|sp_pp_stringify\s*=\s*force|sp_pp_stringify\s*=\s*not_defined
+Choices=sp_pp_stringify=ignore|sp_pp_stringify=add|sp_pp_stringify=remove|sp_pp_stringify=force|sp_pp_stringify=not_defined
+ChoicesRegex=sp_pp_stringify\s*=\s*ignore|sp_pp_stringify\s*=\s*add|sp_pp_stringify\s*=\s*remove|sp_pp_stringify\s*=\s*force|sp_pp_stringify\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Pp Stringify|Add Sp Pp Stringify|Remove Sp Pp Stringify|Force Sp Pp Stringify"
 ValueDefault=ignore
 
@@ -342,7 +377,8 @@ Category=1
 Description="<html>Add or remove space before preprocessor '#' stringify operator<br/>as in '#define x(y) L#y'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_pp_stringify\s*=\s*ignore|sp_before_pp_stringify\s*=\s*add|sp_before_pp_stringify\s*=\s*remove|sp_before_pp_stringify\s*=\s*force|sp_before_pp_stringify\s*=\s*not_defined
+Choices=sp_before_pp_stringify=ignore|sp_before_pp_stringify=add|sp_before_pp_stringify=remove|sp_before_pp_stringify=force|sp_before_pp_stringify=not_defined
+ChoicesRegex=sp_before_pp_stringify\s*=\s*ignore|sp_before_pp_stringify\s*=\s*add|sp_before_pp_stringify\s*=\s*remove|sp_before_pp_stringify\s*=\s*force|sp_before_pp_stringify\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Pp Stringify|Add Sp Before Pp Stringify|Remove Sp Before Pp Stringify|Force Sp Before Pp Stringify"
 ValueDefault=ignore
 
@@ -351,7 +387,8 @@ Category=1
 Description="<html>Add or remove space around boolean operators '&amp;&amp;' and '||'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_bool\s*=\s*ignore|sp_bool\s*=\s*add|sp_bool\s*=\s*remove|sp_bool\s*=\s*force|sp_bool\s*=\s*not_defined
+Choices=sp_bool=ignore|sp_bool=add|sp_bool=remove|sp_bool=force|sp_bool=not_defined
+ChoicesRegex=sp_bool\s*=\s*ignore|sp_bool\s*=\s*add|sp_bool\s*=\s*remove|sp_bool\s*=\s*force|sp_bool\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Bool|Add Sp Bool|Remove Sp Bool|Force Sp Bool"
 ValueDefault=ignore
 
@@ -360,7 +397,8 @@ Category=1
 Description="<html>Add or remove space around compare operator '&lt;', '&gt;', '==', etc.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_compare\s*=\s*ignore|sp_compare\s*=\s*add|sp_compare\s*=\s*remove|sp_compare\s*=\s*force|sp_compare\s*=\s*not_defined
+Choices=sp_compare=ignore|sp_compare=add|sp_compare=remove|sp_compare=force|sp_compare=not_defined
+ChoicesRegex=sp_compare\s*=\s*ignore|sp_compare\s*=\s*add|sp_compare\s*=\s*remove|sp_compare\s*=\s*force|sp_compare\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Compare|Add Sp Compare|Remove Sp Compare|Force Sp Compare"
 ValueDefault=ignore
 
@@ -369,7 +407,8 @@ Category=1
 Description="<html>Add or remove space inside '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_paren\s*=\s*ignore|sp_inside_paren\s*=\s*add|sp_inside_paren\s*=\s*remove|sp_inside_paren\s*=\s*force|sp_inside_paren\s*=\s*not_defined
+Choices=sp_inside_paren=ignore|sp_inside_paren=add|sp_inside_paren=remove|sp_inside_paren=force|sp_inside_paren=not_defined
+ChoicesRegex=sp_inside_paren\s*=\s*ignore|sp_inside_paren\s*=\s*add|sp_inside_paren\s*=\s*remove|sp_inside_paren\s*=\s*force|sp_inside_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Paren|Add Sp Inside Paren|Remove Sp Inside Paren|Force Sp Inside Paren"
 ValueDefault=ignore
 
@@ -378,7 +417,8 @@ Category=1
 Description="<html>Add or remove space between nested parentheses, i.e. '((' vs. ') )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_paren\s*=\s*ignore|sp_paren_paren\s*=\s*add|sp_paren_paren\s*=\s*remove|sp_paren_paren\s*=\s*force|sp_paren_paren\s*=\s*not_defined
+Choices=sp_paren_paren=ignore|sp_paren_paren=add|sp_paren_paren=remove|sp_paren_paren=force|sp_paren_paren=not_defined
+ChoicesRegex=sp_paren_paren\s*=\s*ignore|sp_paren_paren\s*=\s*add|sp_paren_paren\s*=\s*remove|sp_paren_paren\s*=\s*force|sp_paren_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Paren|Add Sp Paren Paren|Remove Sp Paren Paren|Force Sp Paren Paren"
 ValueDefault=ignore
 
@@ -387,7 +427,8 @@ Category=1
 Description="<html>Add or remove space between back-to-back parentheses, i.e. ')(' vs. ') ('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cparen_oparen\s*=\s*ignore|sp_cparen_oparen\s*=\s*add|sp_cparen_oparen\s*=\s*remove|sp_cparen_oparen\s*=\s*force|sp_cparen_oparen\s*=\s*not_defined
+Choices=sp_cparen_oparen=ignore|sp_cparen_oparen=add|sp_cparen_oparen=remove|sp_cparen_oparen=force|sp_cparen_oparen=not_defined
+ChoicesRegex=sp_cparen_oparen\s*=\s*ignore|sp_cparen_oparen\s*=\s*add|sp_cparen_oparen\s*=\s*remove|sp_cparen_oparen\s*=\s*force|sp_cparen_oparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cparen Oparen|Add Sp Cparen Oparen|Remove Sp Cparen Oparen|Force Sp Cparen Oparen"
 ValueDefault=ignore
 
@@ -396,7 +437,8 @@ Category=1
 Description="<html>Whether to balance spaces inside nested parentheses.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_balance_nested_parens\s*=\s*true|sp_balance_nested_parens\s*=\s*false
+TrueFalse=sp_balance_nested_parens=true|sp_balance_nested_parens=false
+TrueFalseRegex=sp_balance_nested_parens\s*=\s*true|sp_balance_nested_parens\s*=\s*false
 ValueDefault=false
 
 [Sp Paren Brace]
@@ -404,7 +446,8 @@ Category=1
 Description="<html>Add or remove space between ')' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_brace\s*=\s*ignore|sp_paren_brace\s*=\s*add|sp_paren_brace\s*=\s*remove|sp_paren_brace\s*=\s*force|sp_paren_brace\s*=\s*not_defined
+Choices=sp_paren_brace=ignore|sp_paren_brace=add|sp_paren_brace=remove|sp_paren_brace=force|sp_paren_brace=not_defined
+ChoicesRegex=sp_paren_brace\s*=\s*ignore|sp_paren_brace\s*=\s*add|sp_paren_brace\s*=\s*remove|sp_paren_brace\s*=\s*force|sp_paren_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Brace|Add Sp Paren Brace|Remove Sp Paren Brace|Force Sp Paren Brace"
 ValueDefault=ignore
 
@@ -413,7 +456,8 @@ Category=1
 Description="<html>Add or remove space between nested braces, i.e. '{{' vs. '{ {'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_brace\s*=\s*ignore|sp_brace_brace\s*=\s*add|sp_brace_brace\s*=\s*remove|sp_brace_brace\s*=\s*force|sp_brace_brace\s*=\s*not_defined
+Choices=sp_brace_brace=ignore|sp_brace_brace=add|sp_brace_brace=remove|sp_brace_brace=force|sp_brace_brace=not_defined
+ChoicesRegex=sp_brace_brace\s*=\s*ignore|sp_brace_brace\s*=\s*add|sp_brace_brace\s*=\s*remove|sp_brace_brace\s*=\s*force|sp_brace_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Brace|Add Sp Brace Brace|Remove Sp Brace Brace|Force Sp Brace Brace"
 ValueDefault=ignore
 
@@ -422,7 +466,8 @@ Category=1
 Description="<html>Add or remove space before pointer star '*'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_ptr_star\s*=\s*ignore|sp_before_ptr_star\s*=\s*add|sp_before_ptr_star\s*=\s*remove|sp_before_ptr_star\s*=\s*force|sp_before_ptr_star\s*=\s*not_defined
+Choices=sp_before_ptr_star=ignore|sp_before_ptr_star=add|sp_before_ptr_star=remove|sp_before_ptr_star=force|sp_before_ptr_star=not_defined
+ChoicesRegex=sp_before_ptr_star\s*=\s*ignore|sp_before_ptr_star\s*=\s*add|sp_before_ptr_star\s*=\s*remove|sp_before_ptr_star\s*=\s*force|sp_before_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Ptr Star|Add Sp Before Ptr Star|Remove Sp Before Ptr Star|Force Sp Before Ptr Star"
 ValueDefault=ignore
 
@@ -431,7 +476,8 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that isn't followed by a<br/>variable name. If set to ignore, sp_before_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_unnamed_ptr_star\s*=\s*ignore|sp_before_unnamed_ptr_star\s*=\s*add|sp_before_unnamed_ptr_star\s*=\s*remove|sp_before_unnamed_ptr_star\s*=\s*force|sp_before_unnamed_ptr_star\s*=\s*not_defined
+Choices=sp_before_unnamed_ptr_star=ignore|sp_before_unnamed_ptr_star=add|sp_before_unnamed_ptr_star=remove|sp_before_unnamed_ptr_star=force|sp_before_unnamed_ptr_star=not_defined
+ChoicesRegex=sp_before_unnamed_ptr_star\s*=\s*ignore|sp_before_unnamed_ptr_star\s*=\s*add|sp_before_unnamed_ptr_star\s*=\s*remove|sp_before_unnamed_ptr_star\s*=\s*force|sp_before_unnamed_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Unnamed Ptr Star|Add Sp Before Unnamed Ptr Star|Remove Sp Before Unnamed Ptr Star|Force Sp Before Unnamed Ptr Star"
 ValueDefault=ignore
 
@@ -440,7 +486,8 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that is followed by a qualifier.<br/>If set to ignore, sp_before_unnamed_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_qualifier_ptr_star\s*=\s*ignore|sp_before_qualifier_ptr_star\s*=\s*add|sp_before_qualifier_ptr_star\s*=\s*remove|sp_before_qualifier_ptr_star\s*=\s*force|sp_before_qualifier_ptr_star\s*=\s*not_defined
+Choices=sp_before_qualifier_ptr_star=ignore|sp_before_qualifier_ptr_star=add|sp_before_qualifier_ptr_star=remove|sp_before_qualifier_ptr_star=force|sp_before_qualifier_ptr_star=not_defined
+ChoicesRegex=sp_before_qualifier_ptr_star\s*=\s*ignore|sp_before_qualifier_ptr_star\s*=\s*add|sp_before_qualifier_ptr_star\s*=\s*remove|sp_before_qualifier_ptr_star\s*=\s*force|sp_before_qualifier_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Qualifier Ptr Star|Add Sp Before Qualifier Ptr Star|Remove Sp Before Qualifier Ptr Star|Force Sp Before Qualifier Ptr Star"
 ValueDefault=ignore
 
@@ -449,7 +496,8 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that is followed by 'operator' keyword.<br/>If set to ignore, sp_before_unnamed_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_operator_ptr_star\s*=\s*ignore|sp_before_operator_ptr_star\s*=\s*add|sp_before_operator_ptr_star\s*=\s*remove|sp_before_operator_ptr_star\s*=\s*force|sp_before_operator_ptr_star\s*=\s*not_defined
+Choices=sp_before_operator_ptr_star=ignore|sp_before_operator_ptr_star=add|sp_before_operator_ptr_star=remove|sp_before_operator_ptr_star=force|sp_before_operator_ptr_star=not_defined
+ChoicesRegex=sp_before_operator_ptr_star\s*=\s*ignore|sp_before_operator_ptr_star\s*=\s*add|sp_before_operator_ptr_star\s*=\s*remove|sp_before_operator_ptr_star\s*=\s*force|sp_before_operator_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Operator Ptr Star|Add Sp Before Operator Ptr Star|Remove Sp Before Operator Ptr Star|Force Sp Before Operator Ptr Star"
 ValueDefault=ignore
 
@@ -458,7 +506,8 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that is followed by<br/>a class scope (as in 'int *MyClass::method()') or namespace scope<br/>(as in 'int *my_ns::func()').<br/>If set to ignore, sp_before_unnamed_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_scope_ptr_star\s*=\s*ignore|sp_before_scope_ptr_star\s*=\s*add|sp_before_scope_ptr_star\s*=\s*remove|sp_before_scope_ptr_star\s*=\s*force|sp_before_scope_ptr_star\s*=\s*not_defined
+Choices=sp_before_scope_ptr_star=ignore|sp_before_scope_ptr_star=add|sp_before_scope_ptr_star=remove|sp_before_scope_ptr_star=force|sp_before_scope_ptr_star=not_defined
+ChoicesRegex=sp_before_scope_ptr_star\s*=\s*ignore|sp_before_scope_ptr_star\s*=\s*add|sp_before_scope_ptr_star\s*=\s*remove|sp_before_scope_ptr_star\s*=\s*force|sp_before_scope_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Scope Ptr Star|Add Sp Before Scope Ptr Star|Remove Sp Before Scope Ptr Star|Force Sp Before Scope Ptr Star"
 ValueDefault=ignore
 
@@ -467,7 +516,8 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that is followed by '::',<br/>as in 'int *::func()'.<br/>If set to ignore, sp_before_unnamed_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_global_scope_ptr_star\s*=\s*ignore|sp_before_global_scope_ptr_star\s*=\s*add|sp_before_global_scope_ptr_star\s*=\s*remove|sp_before_global_scope_ptr_star\s*=\s*force|sp_before_global_scope_ptr_star\s*=\s*not_defined
+Choices=sp_before_global_scope_ptr_star=ignore|sp_before_global_scope_ptr_star=add|sp_before_global_scope_ptr_star=remove|sp_before_global_scope_ptr_star=force|sp_before_global_scope_ptr_star=not_defined
+ChoicesRegex=sp_before_global_scope_ptr_star\s*=\s*ignore|sp_before_global_scope_ptr_star\s*=\s*add|sp_before_global_scope_ptr_star\s*=\s*remove|sp_before_global_scope_ptr_star\s*=\s*force|sp_before_global_scope_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Global Scope Ptr Star|Add Sp Before Global Scope Ptr Star|Remove Sp Before Global Scope Ptr Star|Force Sp Before Global Scope Ptr Star"
 ValueDefault=ignore
 
@@ -476,7 +526,8 @@ Category=1
 Description="<html>Add or remove space between a qualifier and a pointer star '*' that isn't<br/>followed by a variable name, as in '(char const *)'. If set to ignore,<br/>sp_before_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_qualifier_unnamed_ptr_star\s*=\s*ignore|sp_qualifier_unnamed_ptr_star\s*=\s*add|sp_qualifier_unnamed_ptr_star\s*=\s*remove|sp_qualifier_unnamed_ptr_star\s*=\s*force|sp_qualifier_unnamed_ptr_star\s*=\s*not_defined
+Choices=sp_qualifier_unnamed_ptr_star=ignore|sp_qualifier_unnamed_ptr_star=add|sp_qualifier_unnamed_ptr_star=remove|sp_qualifier_unnamed_ptr_star=force|sp_qualifier_unnamed_ptr_star=not_defined
+ChoicesRegex=sp_qualifier_unnamed_ptr_star\s*=\s*ignore|sp_qualifier_unnamed_ptr_star\s*=\s*add|sp_qualifier_unnamed_ptr_star\s*=\s*remove|sp_qualifier_unnamed_ptr_star\s*=\s*force|sp_qualifier_unnamed_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Qualifier Unnamed Ptr Star|Add Sp Qualifier Unnamed Ptr Star|Remove Sp Qualifier Unnamed Ptr Star|Force Sp Qualifier Unnamed Ptr Star"
 ValueDefault=ignore
 
@@ -485,7 +536,8 @@ Category=1
 Description="<html>Add or remove space between pointer stars '*', as in 'int ***a;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_ptr_star\s*=\s*ignore|sp_between_ptr_star\s*=\s*add|sp_between_ptr_star\s*=\s*remove|sp_between_ptr_star\s*=\s*force|sp_between_ptr_star\s*=\s*not_defined
+Choices=sp_between_ptr_star=ignore|sp_between_ptr_star=add|sp_between_ptr_star=remove|sp_between_ptr_star=force|sp_between_ptr_star=not_defined
+ChoicesRegex=sp_between_ptr_star\s*=\s*ignore|sp_between_ptr_star\s*=\s*add|sp_between_ptr_star\s*=\s*remove|sp_between_ptr_star\s*=\s*force|sp_between_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between Ptr Star|Add Sp Between Ptr Star|Remove Sp Between Ptr Star|Force Sp Between Ptr Star"
 ValueDefault=ignore
 
@@ -494,7 +546,8 @@ Category=1
 Description="<html>Add or remove space between pointer star '*' and reference '&amp;', as in 'int *&amp; a;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_ptr_ref\s*=\s*ignore|sp_between_ptr_ref\s*=\s*add|sp_between_ptr_ref\s*=\s*remove|sp_between_ptr_ref\s*=\s*force|sp_between_ptr_ref\s*=\s*not_defined
+Choices=sp_between_ptr_ref=ignore|sp_between_ptr_ref=add|sp_between_ptr_ref=remove|sp_between_ptr_ref=force|sp_between_ptr_ref=not_defined
+ChoicesRegex=sp_between_ptr_ref\s*=\s*ignore|sp_between_ptr_ref\s*=\s*add|sp_between_ptr_ref\s*=\s*remove|sp_between_ptr_ref\s*=\s*force|sp_between_ptr_ref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between Ptr Ref|Add Sp Between Ptr Ref|Remove Sp Between Ptr Ref|Force Sp Between Ptr Ref"
 ValueDefault=ignore
 
@@ -503,7 +556,8 @@ Category=1
 Description="<html>Add or remove space after pointer star '*', if followed by a word.<br/><br/>Overrides sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_star\s*=\s*ignore|sp_after_ptr_star\s*=\s*add|sp_after_ptr_star\s*=\s*remove|sp_after_ptr_star\s*=\s*force|sp_after_ptr_star\s*=\s*not_defined
+Choices=sp_after_ptr_star=ignore|sp_after_ptr_star=add|sp_after_ptr_star=remove|sp_after_ptr_star=force|sp_after_ptr_star=not_defined
+ChoicesRegex=sp_after_ptr_star\s*=\s*ignore|sp_after_ptr_star\s*=\s*add|sp_after_ptr_star\s*=\s*remove|sp_after_ptr_star\s*=\s*force|sp_after_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Star|Add Sp After Ptr Star|Remove Sp After Ptr Star|Force Sp After Ptr Star"
 ValueDefault=ignore
 
@@ -512,7 +566,8 @@ Category=1
 Description="<html>Add or remove space after pointer caret '^', if followed by a word.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_block_caret\s*=\s*ignore|sp_after_ptr_block_caret\s*=\s*add|sp_after_ptr_block_caret\s*=\s*remove|sp_after_ptr_block_caret\s*=\s*force|sp_after_ptr_block_caret\s*=\s*not_defined
+Choices=sp_after_ptr_block_caret=ignore|sp_after_ptr_block_caret=add|sp_after_ptr_block_caret=remove|sp_after_ptr_block_caret=force|sp_after_ptr_block_caret=not_defined
+ChoicesRegex=sp_after_ptr_block_caret\s*=\s*ignore|sp_after_ptr_block_caret\s*=\s*add|sp_after_ptr_block_caret\s*=\s*remove|sp_after_ptr_block_caret\s*=\s*force|sp_after_ptr_block_caret\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Block Caret|Add Sp After Ptr Block Caret|Remove Sp After Ptr Block Caret|Force Sp After Ptr Block Caret"
 ValueDefault=ignore
 
@@ -521,7 +576,8 @@ Category=1
 Description="<html>Add or remove space after pointer star '*', if followed by a qualifier.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_star_qualifier\s*=\s*ignore|sp_after_ptr_star_qualifier\s*=\s*add|sp_after_ptr_star_qualifier\s*=\s*remove|sp_after_ptr_star_qualifier\s*=\s*force|sp_after_ptr_star_qualifier\s*=\s*not_defined
+Choices=sp_after_ptr_star_qualifier=ignore|sp_after_ptr_star_qualifier=add|sp_after_ptr_star_qualifier=remove|sp_after_ptr_star_qualifier=force|sp_after_ptr_star_qualifier=not_defined
+ChoicesRegex=sp_after_ptr_star_qualifier\s*=\s*ignore|sp_after_ptr_star_qualifier\s*=\s*add|sp_after_ptr_star_qualifier\s*=\s*remove|sp_after_ptr_star_qualifier\s*=\s*force|sp_after_ptr_star_qualifier\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Star Qualifier|Add Sp After Ptr Star Qualifier|Remove Sp After Ptr Star Qualifier|Force Sp After Ptr Star Qualifier"
 ValueDefault=ignore
 
@@ -530,7 +586,8 @@ Category=1
 Description="<html>Add or remove space after a pointer star '*', if followed by a function<br/>prototype or function definition.<br/><br/>Overrides sp_after_ptr_star and sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_star_func\s*=\s*ignore|sp_after_ptr_star_func\s*=\s*add|sp_after_ptr_star_func\s*=\s*remove|sp_after_ptr_star_func\s*=\s*force|sp_after_ptr_star_func\s*=\s*not_defined
+Choices=sp_after_ptr_star_func=ignore|sp_after_ptr_star_func=add|sp_after_ptr_star_func=remove|sp_after_ptr_star_func=force|sp_after_ptr_star_func=not_defined
+ChoicesRegex=sp_after_ptr_star_func\s*=\s*ignore|sp_after_ptr_star_func\s*=\s*add|sp_after_ptr_star_func\s*=\s*remove|sp_after_ptr_star_func\s*=\s*force|sp_after_ptr_star_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Star Func|Add Sp After Ptr Star Func|Remove Sp After Ptr Star Func|Force Sp After Ptr Star Func"
 ValueDefault=ignore
 
@@ -539,7 +596,8 @@ Category=1
 Description="<html>Add or remove space after a pointer star '*' in the trailing return of a<br/>function prototype or function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_star_trailing\s*=\s*ignore|sp_after_ptr_star_trailing\s*=\s*add|sp_after_ptr_star_trailing\s*=\s*remove|sp_after_ptr_star_trailing\s*=\s*force|sp_after_ptr_star_trailing\s*=\s*not_defined
+Choices=sp_after_ptr_star_trailing=ignore|sp_after_ptr_star_trailing=add|sp_after_ptr_star_trailing=remove|sp_after_ptr_star_trailing=force|sp_after_ptr_star_trailing=not_defined
+ChoicesRegex=sp_after_ptr_star_trailing\s*=\s*ignore|sp_after_ptr_star_trailing\s*=\s*add|sp_after_ptr_star_trailing\s*=\s*remove|sp_after_ptr_star_trailing\s*=\s*force|sp_after_ptr_star_trailing\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Star Trailing|Add Sp After Ptr Star Trailing|Remove Sp After Ptr Star Trailing|Force Sp After Ptr Star Trailing"
 ValueDefault=ignore
 
@@ -548,7 +606,8 @@ Category=1
 Description="<html>Add or remove space between the pointer star '*' and the name of the variable<br/>in a function pointer definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ptr_star_func_var\s*=\s*ignore|sp_ptr_star_func_var\s*=\s*add|sp_ptr_star_func_var\s*=\s*remove|sp_ptr_star_func_var\s*=\s*force|sp_ptr_star_func_var\s*=\s*not_defined
+Choices=sp_ptr_star_func_var=ignore|sp_ptr_star_func_var=add|sp_ptr_star_func_var=remove|sp_ptr_star_func_var=force|sp_ptr_star_func_var=not_defined
+ChoicesRegex=sp_ptr_star_func_var\s*=\s*ignore|sp_ptr_star_func_var\s*=\s*add|sp_ptr_star_func_var\s*=\s*remove|sp_ptr_star_func_var\s*=\s*force|sp_ptr_star_func_var\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ptr Star Func Var|Add Sp Ptr Star Func Var|Remove Sp Ptr Star Func Var|Force Sp Ptr Star Func Var"
 ValueDefault=ignore
 
@@ -557,7 +616,8 @@ Category=1
 Description="<html>Add or remove space between the pointer star '*' and the name of the type<br/>in a function pointer type definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ptr_star_func_type\s*=\s*ignore|sp_ptr_star_func_type\s*=\s*add|sp_ptr_star_func_type\s*=\s*remove|sp_ptr_star_func_type\s*=\s*force|sp_ptr_star_func_type\s*=\s*not_defined
+Choices=sp_ptr_star_func_type=ignore|sp_ptr_star_func_type=add|sp_ptr_star_func_type=remove|sp_ptr_star_func_type=force|sp_ptr_star_func_type=not_defined
+ChoicesRegex=sp_ptr_star_func_type\s*=\s*ignore|sp_ptr_star_func_type\s*=\s*add|sp_ptr_star_func_type\s*=\s*remove|sp_ptr_star_func_type\s*=\s*force|sp_ptr_star_func_type\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ptr Star Func Type|Add Sp Ptr Star Func Type|Remove Sp Ptr Star Func Type|Force Sp Ptr Star Func Type"
 ValueDefault=ignore
 
@@ -566,7 +626,8 @@ Category=1
 Description="<html>Add or remove space after a pointer star '*', if followed by an open<br/>parenthesis, as in 'void* (*)()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ptr_star_paren\s*=\s*ignore|sp_ptr_star_paren\s*=\s*add|sp_ptr_star_paren\s*=\s*remove|sp_ptr_star_paren\s*=\s*force|sp_ptr_star_paren\s*=\s*not_defined
+Choices=sp_ptr_star_paren=ignore|sp_ptr_star_paren=add|sp_ptr_star_paren=remove|sp_ptr_star_paren=force|sp_ptr_star_paren=not_defined
+ChoicesRegex=sp_ptr_star_paren\s*=\s*ignore|sp_ptr_star_paren\s*=\s*add|sp_ptr_star_paren\s*=\s*remove|sp_ptr_star_paren\s*=\s*force|sp_ptr_star_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ptr Star Paren|Add Sp Ptr Star Paren|Remove Sp Ptr Star Paren|Force Sp Ptr Star Paren"
 ValueDefault=ignore
 
@@ -575,7 +636,8 @@ Category=1
 Description="<html>Add or remove space before a pointer star '*', if followed by a function<br/>prototype or function definition. If set to ignore, sp_before_ptr_star is<br/>used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_ptr_star_func\s*=\s*ignore|sp_before_ptr_star_func\s*=\s*add|sp_before_ptr_star_func\s*=\s*remove|sp_before_ptr_star_func\s*=\s*force|sp_before_ptr_star_func\s*=\s*not_defined
+Choices=sp_before_ptr_star_func=ignore|sp_before_ptr_star_func=add|sp_before_ptr_star_func=remove|sp_before_ptr_star_func=force|sp_before_ptr_star_func=not_defined
+ChoicesRegex=sp_before_ptr_star_func\s*=\s*ignore|sp_before_ptr_star_func\s*=\s*add|sp_before_ptr_star_func\s*=\s*remove|sp_before_ptr_star_func\s*=\s*force|sp_before_ptr_star_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Ptr Star Func|Add Sp Before Ptr Star Func|Remove Sp Before Ptr Star Func|Force Sp Before Ptr Star Func"
 ValueDefault=ignore
 
@@ -584,7 +646,8 @@ Category=1
 Description="<html>Add or remove space between a qualifier and a pointer star '*' followed by<br/>the name of the function in a function prototype or definition, as in<br/>'char const *foo()`. If set to ignore, sp_before_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_qualifier_ptr_star_func\s*=\s*ignore|sp_qualifier_ptr_star_func\s*=\s*add|sp_qualifier_ptr_star_func\s*=\s*remove|sp_qualifier_ptr_star_func\s*=\s*force|sp_qualifier_ptr_star_func\s*=\s*not_defined
+Choices=sp_qualifier_ptr_star_func=ignore|sp_qualifier_ptr_star_func=add|sp_qualifier_ptr_star_func=remove|sp_qualifier_ptr_star_func=force|sp_qualifier_ptr_star_func=not_defined
+ChoicesRegex=sp_qualifier_ptr_star_func\s*=\s*ignore|sp_qualifier_ptr_star_func\s*=\s*add|sp_qualifier_ptr_star_func\s*=\s*remove|sp_qualifier_ptr_star_func\s*=\s*force|sp_qualifier_ptr_star_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Qualifier Ptr Star Func|Add Sp Qualifier Ptr Star Func|Remove Sp Qualifier Ptr Star Func|Force Sp Qualifier Ptr Star Func"
 ValueDefault=ignore
 
@@ -593,7 +656,8 @@ Category=1
 Description="<html>Add or remove space before a pointer star '*' in the trailing return of a<br/>function prototype or function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_ptr_star_trailing\s*=\s*ignore|sp_before_ptr_star_trailing\s*=\s*add|sp_before_ptr_star_trailing\s*=\s*remove|sp_before_ptr_star_trailing\s*=\s*force|sp_before_ptr_star_trailing\s*=\s*not_defined
+Choices=sp_before_ptr_star_trailing=ignore|sp_before_ptr_star_trailing=add|sp_before_ptr_star_trailing=remove|sp_before_ptr_star_trailing=force|sp_before_ptr_star_trailing=not_defined
+ChoicesRegex=sp_before_ptr_star_trailing\s*=\s*ignore|sp_before_ptr_star_trailing\s*=\s*add|sp_before_ptr_star_trailing\s*=\s*remove|sp_before_ptr_star_trailing\s*=\s*force|sp_before_ptr_star_trailing\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Ptr Star Trailing|Add Sp Before Ptr Star Trailing|Remove Sp Before Ptr Star Trailing|Force Sp Before Ptr Star Trailing"
 ValueDefault=ignore
 
@@ -602,7 +666,8 @@ Category=1
 Description="<html>Add or remove space between a qualifier and a pointer star '*' in the<br/>trailing return of a function prototype or function definition, as in<br/>'auto foo() -&gt; char const *'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_qualifier_ptr_star_trailing\s*=\s*ignore|sp_qualifier_ptr_star_trailing\s*=\s*add|sp_qualifier_ptr_star_trailing\s*=\s*remove|sp_qualifier_ptr_star_trailing\s*=\s*force|sp_qualifier_ptr_star_trailing\s*=\s*not_defined
+Choices=sp_qualifier_ptr_star_trailing=ignore|sp_qualifier_ptr_star_trailing=add|sp_qualifier_ptr_star_trailing=remove|sp_qualifier_ptr_star_trailing=force|sp_qualifier_ptr_star_trailing=not_defined
+ChoicesRegex=sp_qualifier_ptr_star_trailing\s*=\s*ignore|sp_qualifier_ptr_star_trailing\s*=\s*add|sp_qualifier_ptr_star_trailing\s*=\s*remove|sp_qualifier_ptr_star_trailing\s*=\s*force|sp_qualifier_ptr_star_trailing\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Qualifier Ptr Star Trailing|Add Sp Qualifier Ptr Star Trailing|Remove Sp Qualifier Ptr Star Trailing|Force Sp Qualifier Ptr Star Trailing"
 ValueDefault=ignore
 
@@ -611,7 +676,8 @@ Category=1
 Description="<html>Add or remove space before a reference sign '&amp;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_byref\s*=\s*ignore|sp_before_byref\s*=\s*add|sp_before_byref\s*=\s*remove|sp_before_byref\s*=\s*force|sp_before_byref\s*=\s*not_defined
+Choices=sp_before_byref=ignore|sp_before_byref=add|sp_before_byref=remove|sp_before_byref=force|sp_before_byref=not_defined
+ChoicesRegex=sp_before_byref\s*=\s*ignore|sp_before_byref\s*=\s*add|sp_before_byref\s*=\s*remove|sp_before_byref\s*=\s*force|sp_before_byref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Byref|Add Sp Before Byref|Remove Sp Before Byref|Force Sp Before Byref"
 ValueDefault=ignore
 
@@ -620,7 +686,8 @@ Category=1
 Description="<html>Add or remove space before a reference sign '&amp;' that isn't followed by a<br/>variable name. If set to ignore, sp_before_byref is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_unnamed_byref\s*=\s*ignore|sp_before_unnamed_byref\s*=\s*add|sp_before_unnamed_byref\s*=\s*remove|sp_before_unnamed_byref\s*=\s*force|sp_before_unnamed_byref\s*=\s*not_defined
+Choices=sp_before_unnamed_byref=ignore|sp_before_unnamed_byref=add|sp_before_unnamed_byref=remove|sp_before_unnamed_byref=force|sp_before_unnamed_byref=not_defined
+ChoicesRegex=sp_before_unnamed_byref\s*=\s*ignore|sp_before_unnamed_byref\s*=\s*add|sp_before_unnamed_byref\s*=\s*remove|sp_before_unnamed_byref\s*=\s*force|sp_before_unnamed_byref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Unnamed Byref|Add Sp Before Unnamed Byref|Remove Sp Before Unnamed Byref|Force Sp Before Unnamed Byref"
 ValueDefault=ignore
 
@@ -629,7 +696,8 @@ Category=1
 Description="<html>Add or remove space after reference sign '&amp;', if followed by a word.<br/><br/>Overrides sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_byref\s*=\s*ignore|sp_after_byref\s*=\s*add|sp_after_byref\s*=\s*remove|sp_after_byref\s*=\s*force|sp_after_byref\s*=\s*not_defined
+Choices=sp_after_byref=ignore|sp_after_byref=add|sp_after_byref=remove|sp_after_byref=force|sp_after_byref=not_defined
+ChoicesRegex=sp_after_byref\s*=\s*ignore|sp_after_byref\s*=\s*add|sp_after_byref\s*=\s*remove|sp_after_byref\s*=\s*force|sp_after_byref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Byref|Add Sp After Byref|Remove Sp After Byref|Force Sp After Byref"
 ValueDefault=ignore
 
@@ -638,7 +706,8 @@ Category=1
 Description="<html>Add or remove space after a reference sign '&amp;', if followed by a function<br/>prototype or function definition.<br/><br/>Overrides sp_after_byref and sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_byref_func\s*=\s*ignore|sp_after_byref_func\s*=\s*add|sp_after_byref_func\s*=\s*remove|sp_after_byref_func\s*=\s*force|sp_after_byref_func\s*=\s*not_defined
+Choices=sp_after_byref_func=ignore|sp_after_byref_func=add|sp_after_byref_func=remove|sp_after_byref_func=force|sp_after_byref_func=not_defined
+ChoicesRegex=sp_after_byref_func\s*=\s*ignore|sp_after_byref_func\s*=\s*add|sp_after_byref_func\s*=\s*remove|sp_after_byref_func\s*=\s*force|sp_after_byref_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Byref Func|Add Sp After Byref Func|Remove Sp After Byref Func|Force Sp After Byref Func"
 ValueDefault=ignore
 
@@ -647,7 +716,8 @@ Category=1
 Description="<html>Add or remove space before a reference sign '&amp;', if followed by a function<br/>prototype or function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_byref_func\s*=\s*ignore|sp_before_byref_func\s*=\s*add|sp_before_byref_func\s*=\s*remove|sp_before_byref_func\s*=\s*force|sp_before_byref_func\s*=\s*not_defined
+Choices=sp_before_byref_func=ignore|sp_before_byref_func=add|sp_before_byref_func=remove|sp_before_byref_func=force|sp_before_byref_func=not_defined
+ChoicesRegex=sp_before_byref_func\s*=\s*ignore|sp_before_byref_func\s*=\s*add|sp_before_byref_func\s*=\s*remove|sp_before_byref_func\s*=\s*force|sp_before_byref_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Byref Func|Add Sp Before Byref Func|Remove Sp Before Byref Func|Force Sp Before Byref Func"
 ValueDefault=ignore
 
@@ -656,7 +726,8 @@ Category=1
 Description="<html>Add or remove space after a reference sign '&amp;', if followed by an open<br/>parenthesis, as in 'char&amp; (*)()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_byref_paren\s*=\s*ignore|sp_byref_paren\s*=\s*add|sp_byref_paren\s*=\s*remove|sp_byref_paren\s*=\s*force|sp_byref_paren\s*=\s*not_defined
+Choices=sp_byref_paren=ignore|sp_byref_paren=add|sp_byref_paren=remove|sp_byref_paren=force|sp_byref_paren=not_defined
+ChoicesRegex=sp_byref_paren\s*=\s*ignore|sp_byref_paren\s*=\s*add|sp_byref_paren\s*=\s*remove|sp_byref_paren\s*=\s*force|sp_byref_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Byref Paren|Add Sp Byref Paren|Remove Sp Byref Paren|Force Sp Byref Paren"
 ValueDefault=ignore
 
@@ -665,7 +736,8 @@ Category=1
 Description="<html>Add or remove space between type and word. In cases where total removal of<br/>whitespace would be a syntax error, a value of 'remove' is treated the same<br/>as 'force'.<br/><br/>This also affects some other instances of space following a type that are<br/>not covered by other options; for example, between the return type and<br/>parenthesis of a function type template argument, between the type and<br/>parenthesis of an array parameter, or between 'decltype(...)' and the<br/>following word.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_type\s*=\s*ignore|sp_after_type\s*=\s*add|sp_after_type\s*=\s*remove|sp_after_type\s*=\s*force|sp_after_type\s*=\s*not_defined
+Choices=sp_after_type=ignore|sp_after_type=add|sp_after_type=remove|sp_after_type=force|sp_after_type=not_defined
+ChoicesRegex=sp_after_type\s*=\s*ignore|sp_after_type\s*=\s*add|sp_after_type\s*=\s*remove|sp_after_type\s*=\s*force|sp_after_type\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Type|Add Sp After Type|Remove Sp After Type|Force Sp After Type"
 ValueDefault=force
 
@@ -674,7 +746,8 @@ Category=1
 Description="<html>Add or remove space between 'decltype(...)' and word,<br/>brace or function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_decltype\s*=\s*ignore|sp_after_decltype\s*=\s*add|sp_after_decltype\s*=\s*remove|sp_after_decltype\s*=\s*force|sp_after_decltype\s*=\s*not_defined
+Choices=sp_after_decltype=ignore|sp_after_decltype=add|sp_after_decltype=remove|sp_after_decltype=force|sp_after_decltype=not_defined
+ChoicesRegex=sp_after_decltype\s*=\s*ignore|sp_after_decltype\s*=\s*add|sp_after_decltype\s*=\s*remove|sp_after_decltype\s*=\s*force|sp_after_decltype\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Decltype|Add Sp After Decltype|Remove Sp After Decltype|Force Sp After Decltype"
 ValueDefault=ignore
 
@@ -683,7 +756,8 @@ Category=1
 Description="<html>(D) Add or remove space before the parenthesis in the D constructs<br/>'template Foo(' and 'class Foo('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_template_paren\s*=\s*ignore|sp_before_template_paren\s*=\s*add|sp_before_template_paren\s*=\s*remove|sp_before_template_paren\s*=\s*force|sp_before_template_paren\s*=\s*not_defined
+Choices=sp_before_template_paren=ignore|sp_before_template_paren=add|sp_before_template_paren=remove|sp_before_template_paren=force|sp_before_template_paren=not_defined
+ChoicesRegex=sp_before_template_paren\s*=\s*ignore|sp_before_template_paren\s*=\s*add|sp_before_template_paren\s*=\s*remove|sp_before_template_paren\s*=\s*force|sp_before_template_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Template Paren|Add Sp Before Template Paren|Remove Sp Before Template Paren|Force Sp Before Template Paren"
 ValueDefault=ignore
 
@@ -692,7 +766,8 @@ Category=1
 Description="<html>Add or remove space between 'template' and '&lt;'.<br/>If set to ignore, sp_before_angle is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_template_angle\s*=\s*ignore|sp_template_angle\s*=\s*add|sp_template_angle\s*=\s*remove|sp_template_angle\s*=\s*force|sp_template_angle\s*=\s*not_defined
+Choices=sp_template_angle=ignore|sp_template_angle=add|sp_template_angle=remove|sp_template_angle=force|sp_template_angle=not_defined
+ChoicesRegex=sp_template_angle\s*=\s*ignore|sp_template_angle\s*=\s*add|sp_template_angle\s*=\s*remove|sp_template_angle\s*=\s*force|sp_template_angle\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Template Angle|Add Sp Template Angle|Remove Sp Template Angle|Force Sp Template Angle"
 ValueDefault=ignore
 
@@ -701,7 +776,8 @@ Category=1
 Description="<html>Add or remove space before '&lt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_angle\s*=\s*ignore|sp_before_angle\s*=\s*add|sp_before_angle\s*=\s*remove|sp_before_angle\s*=\s*force|sp_before_angle\s*=\s*not_defined
+Choices=sp_before_angle=ignore|sp_before_angle=add|sp_before_angle=remove|sp_before_angle=force|sp_before_angle=not_defined
+ChoicesRegex=sp_before_angle\s*=\s*ignore|sp_before_angle\s*=\s*add|sp_before_angle\s*=\s*remove|sp_before_angle\s*=\s*force|sp_before_angle\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Angle|Add Sp Before Angle|Remove Sp Before Angle|Force Sp Before Angle"
 ValueDefault=ignore
 
@@ -710,7 +786,8 @@ Category=1
 Description="<html>Add or remove space inside '&lt;' and '&gt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_angle\s*=\s*ignore|sp_inside_angle\s*=\s*add|sp_inside_angle\s*=\s*remove|sp_inside_angle\s*=\s*force|sp_inside_angle\s*=\s*not_defined
+Choices=sp_inside_angle=ignore|sp_inside_angle=add|sp_inside_angle=remove|sp_inside_angle=force|sp_inside_angle=not_defined
+ChoicesRegex=sp_inside_angle\s*=\s*ignore|sp_inside_angle\s*=\s*add|sp_inside_angle\s*=\s*remove|sp_inside_angle\s*=\s*force|sp_inside_angle\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Angle|Add Sp Inside Angle|Remove Sp Inside Angle|Force Sp Inside Angle"
 ValueDefault=ignore
 
@@ -719,7 +796,8 @@ Category=1
 Description="<html>Add or remove space inside '&lt;&gt;'.<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_angle_empty\s*=\s*ignore|sp_inside_angle_empty\s*=\s*add|sp_inside_angle_empty\s*=\s*remove|sp_inside_angle_empty\s*=\s*force|sp_inside_angle_empty\s*=\s*not_defined
+Choices=sp_inside_angle_empty=ignore|sp_inside_angle_empty=add|sp_inside_angle_empty=remove|sp_inside_angle_empty=force|sp_inside_angle_empty=not_defined
+ChoicesRegex=sp_inside_angle_empty\s*=\s*ignore|sp_inside_angle_empty\s*=\s*add|sp_inside_angle_empty\s*=\s*remove|sp_inside_angle_empty\s*=\s*force|sp_inside_angle_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Angle Empty|Add Sp Inside Angle Empty|Remove Sp Inside Angle Empty|Force Sp Inside Angle Empty"
 ValueDefault=ignore
 
@@ -728,7 +806,8 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_colon\s*=\s*ignore|sp_angle_colon\s*=\s*add|sp_angle_colon\s*=\s*remove|sp_angle_colon\s*=\s*force|sp_angle_colon\s*=\s*not_defined
+Choices=sp_angle_colon=ignore|sp_angle_colon=add|sp_angle_colon=remove|sp_angle_colon=force|sp_angle_colon=not_defined
+ChoicesRegex=sp_angle_colon\s*=\s*ignore|sp_angle_colon\s*=\s*add|sp_angle_colon\s*=\s*remove|sp_angle_colon\s*=\s*force|sp_angle_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Colon|Add Sp Angle Colon|Remove Sp Angle Colon|Force Sp Angle Colon"
 ValueDefault=ignore
 
@@ -737,7 +816,8 @@ Category=1
 Description="<html>Add or remove space after '&gt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_angle\s*=\s*ignore|sp_after_angle\s*=\s*add|sp_after_angle\s*=\s*remove|sp_after_angle\s*=\s*force|sp_after_angle\s*=\s*not_defined
+Choices=sp_after_angle=ignore|sp_after_angle=add|sp_after_angle=remove|sp_after_angle=force|sp_after_angle=not_defined
+ChoicesRegex=sp_after_angle\s*=\s*ignore|sp_after_angle\s*=\s*add|sp_after_angle\s*=\s*remove|sp_after_angle\s*=\s*force|sp_after_angle\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Angle|Add Sp After Angle|Remove Sp After Angle|Force Sp After Angle"
 ValueDefault=ignore
 
@@ -746,7 +826,8 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and '(' as found in 'new List&lt;byte&gt;(foo);'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_paren\s*=\s*ignore|sp_angle_paren\s*=\s*add|sp_angle_paren\s*=\s*remove|sp_angle_paren\s*=\s*force|sp_angle_paren\s*=\s*not_defined
+Choices=sp_angle_paren=ignore|sp_angle_paren=add|sp_angle_paren=remove|sp_angle_paren=force|sp_angle_paren=not_defined
+ChoicesRegex=sp_angle_paren\s*=\s*ignore|sp_angle_paren\s*=\s*add|sp_angle_paren\s*=\s*remove|sp_angle_paren\s*=\s*force|sp_angle_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Paren|Add Sp Angle Paren|Remove Sp Angle Paren|Force Sp Angle Paren"
 ValueDefault=ignore
 
@@ -755,7 +836,8 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and '()' as found in 'new List&lt;byte&gt;();'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_paren_empty\s*=\s*ignore|sp_angle_paren_empty\s*=\s*add|sp_angle_paren_empty\s*=\s*remove|sp_angle_paren_empty\s*=\s*force|sp_angle_paren_empty\s*=\s*not_defined
+Choices=sp_angle_paren_empty=ignore|sp_angle_paren_empty=add|sp_angle_paren_empty=remove|sp_angle_paren_empty=force|sp_angle_paren_empty=not_defined
+ChoicesRegex=sp_angle_paren_empty\s*=\s*ignore|sp_angle_paren_empty\s*=\s*add|sp_angle_paren_empty\s*=\s*remove|sp_angle_paren_empty\s*=\s*force|sp_angle_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Paren Empty|Add Sp Angle Paren Empty|Remove Sp Angle Paren Empty|Force Sp Angle Paren Empty"
 ValueDefault=ignore
 
@@ -764,7 +846,8 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and a word as in 'List&lt;byte&gt; m;' or<br/>'template &lt;typename T&gt; static ...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_word\s*=\s*ignore|sp_angle_word\s*=\s*add|sp_angle_word\s*=\s*remove|sp_angle_word\s*=\s*force|sp_angle_word\s*=\s*not_defined
+Choices=sp_angle_word=ignore|sp_angle_word=add|sp_angle_word=remove|sp_angle_word=force|sp_angle_word=not_defined
+ChoicesRegex=sp_angle_word\s*=\s*ignore|sp_angle_word\s*=\s*add|sp_angle_word\s*=\s*remove|sp_angle_word\s*=\s*force|sp_angle_word\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Word|Add Sp Angle Word|Remove Sp Angle Word|Force Sp Angle Word"
 ValueDefault=ignore
 
@@ -773,7 +856,8 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and '&gt;' in '&gt;&gt;' (template stuff).<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_shift\s*=\s*ignore|sp_angle_shift\s*=\s*add|sp_angle_shift\s*=\s*remove|sp_angle_shift\s*=\s*force|sp_angle_shift\s*=\s*not_defined
+Choices=sp_angle_shift=ignore|sp_angle_shift=add|sp_angle_shift=remove|sp_angle_shift=force|sp_angle_shift=not_defined
+ChoicesRegex=sp_angle_shift\s*=\s*ignore|sp_angle_shift\s*=\s*add|sp_angle_shift\s*=\s*remove|sp_angle_shift\s*=\s*force|sp_angle_shift\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Shift|Add Sp Angle Shift|Remove Sp Angle Shift|Force Sp Angle Shift"
 ValueDefault=add
 
@@ -782,7 +866,8 @@ Category=1
 Description="<html>(C++11) Permit removal of the space between '&gt;&gt;' in 'foo&lt;bar&lt;int&gt; &gt;'. Note<br/>that sp_angle_shift cannot remove the space without this option.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_permit_cpp11_shift\s*=\s*true|sp_permit_cpp11_shift\s*=\s*false
+TrueFalse=sp_permit_cpp11_shift=true|sp_permit_cpp11_shift=false
+TrueFalseRegex=sp_permit_cpp11_shift\s*=\s*true|sp_permit_cpp11_shift\s*=\s*false
 ValueDefault=false
 
 [Sp Before Sparen]
@@ -790,7 +875,8 @@ Category=1
 Description="<html>Add or remove space before '(' of control statements ('if', 'for', 'switch',<br/>'while', etc.).</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_sparen\s*=\s*ignore|sp_before_sparen\s*=\s*add|sp_before_sparen\s*=\s*remove|sp_before_sparen\s*=\s*force|sp_before_sparen\s*=\s*not_defined
+Choices=sp_before_sparen=ignore|sp_before_sparen=add|sp_before_sparen=remove|sp_before_sparen=force|sp_before_sparen=not_defined
+ChoicesRegex=sp_before_sparen\s*=\s*ignore|sp_before_sparen\s*=\s*add|sp_before_sparen\s*=\s*remove|sp_before_sparen\s*=\s*force|sp_before_sparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Sparen|Add Sp Before Sparen|Remove Sp Before Sparen|Force Sp Before Sparen"
 ValueDefault=ignore
 
@@ -799,7 +885,8 @@ Category=1
 Description="<html>Add or remove space inside '(' and ')' of control statements other than<br/>'for'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_sparen\s*=\s*ignore|sp_inside_sparen\s*=\s*add|sp_inside_sparen\s*=\s*remove|sp_inside_sparen\s*=\s*force|sp_inside_sparen\s*=\s*not_defined
+Choices=sp_inside_sparen=ignore|sp_inside_sparen=add|sp_inside_sparen=remove|sp_inside_sparen=force|sp_inside_sparen=not_defined
+ChoicesRegex=sp_inside_sparen\s*=\s*ignore|sp_inside_sparen\s*=\s*add|sp_inside_sparen\s*=\s*remove|sp_inside_sparen\s*=\s*force|sp_inside_sparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Sparen|Add Sp Inside Sparen|Remove Sp Inside Sparen|Force Sp Inside Sparen"
 ValueDefault=ignore
 
@@ -808,7 +895,8 @@ Category=1
 Description="<html>Add or remove space after '(' of control statements other than 'for'.<br/><br/>Overrides sp_inside_sparen.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_sparen_open\s*=\s*ignore|sp_inside_sparen_open\s*=\s*add|sp_inside_sparen_open\s*=\s*remove|sp_inside_sparen_open\s*=\s*force|sp_inside_sparen_open\s*=\s*not_defined
+Choices=sp_inside_sparen_open=ignore|sp_inside_sparen_open=add|sp_inside_sparen_open=remove|sp_inside_sparen_open=force|sp_inside_sparen_open=not_defined
+ChoicesRegex=sp_inside_sparen_open\s*=\s*ignore|sp_inside_sparen_open\s*=\s*add|sp_inside_sparen_open\s*=\s*remove|sp_inside_sparen_open\s*=\s*force|sp_inside_sparen_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Sparen Open|Add Sp Inside Sparen Open|Remove Sp Inside Sparen Open|Force Sp Inside Sparen Open"
 ValueDefault=ignore
 
@@ -817,7 +905,8 @@ Category=1
 Description="<html>Add or remove space before ')' of control statements other than 'for'.<br/><br/>Overrides sp_inside_sparen.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_sparen_close\s*=\s*ignore|sp_inside_sparen_close\s*=\s*add|sp_inside_sparen_close\s*=\s*remove|sp_inside_sparen_close\s*=\s*force|sp_inside_sparen_close\s*=\s*not_defined
+Choices=sp_inside_sparen_close=ignore|sp_inside_sparen_close=add|sp_inside_sparen_close=remove|sp_inside_sparen_close=force|sp_inside_sparen_close=not_defined
+ChoicesRegex=sp_inside_sparen_close\s*=\s*ignore|sp_inside_sparen_close\s*=\s*add|sp_inside_sparen_close\s*=\s*remove|sp_inside_sparen_close\s*=\s*force|sp_inside_sparen_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Sparen Close|Add Sp Inside Sparen Close|Remove Sp Inside Sparen Close|Force Sp Inside Sparen Close"
 ValueDefault=ignore
 
@@ -826,7 +915,8 @@ Category=1
 Description="<html>Add or remove space inside '(' and ')' of 'for' statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_for\s*=\s*ignore|sp_inside_for\s*=\s*add|sp_inside_for\s*=\s*remove|sp_inside_for\s*=\s*force|sp_inside_for\s*=\s*not_defined
+Choices=sp_inside_for=ignore|sp_inside_for=add|sp_inside_for=remove|sp_inside_for=force|sp_inside_for=not_defined
+ChoicesRegex=sp_inside_for\s*=\s*ignore|sp_inside_for\s*=\s*add|sp_inside_for\s*=\s*remove|sp_inside_for\s*=\s*force|sp_inside_for\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside For|Add Sp Inside For|Remove Sp Inside For|Force Sp Inside For"
 ValueDefault=ignore
 
@@ -835,7 +925,8 @@ Category=1
 Description="<html>Add or remove space after '(' of 'for' statements.<br/><br/>Overrides sp_inside_for.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_for_open\s*=\s*ignore|sp_inside_for_open\s*=\s*add|sp_inside_for_open\s*=\s*remove|sp_inside_for_open\s*=\s*force|sp_inside_for_open\s*=\s*not_defined
+Choices=sp_inside_for_open=ignore|sp_inside_for_open=add|sp_inside_for_open=remove|sp_inside_for_open=force|sp_inside_for_open=not_defined
+ChoicesRegex=sp_inside_for_open\s*=\s*ignore|sp_inside_for_open\s*=\s*add|sp_inside_for_open\s*=\s*remove|sp_inside_for_open\s*=\s*force|sp_inside_for_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside For Open|Add Sp Inside For Open|Remove Sp Inside For Open|Force Sp Inside For Open"
 ValueDefault=ignore
 
@@ -844,7 +935,8 @@ Category=1
 Description="<html>Add or remove space before ')' of 'for' statements.<br/><br/>Overrides sp_inside_for.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_for_close\s*=\s*ignore|sp_inside_for_close\s*=\s*add|sp_inside_for_close\s*=\s*remove|sp_inside_for_close\s*=\s*force|sp_inside_for_close\s*=\s*not_defined
+Choices=sp_inside_for_close=ignore|sp_inside_for_close=add|sp_inside_for_close=remove|sp_inside_for_close=force|sp_inside_for_close=not_defined
+ChoicesRegex=sp_inside_for_close\s*=\s*ignore|sp_inside_for_close\s*=\s*add|sp_inside_for_close\s*=\s*remove|sp_inside_for_close\s*=\s*force|sp_inside_for_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside For Close|Add Sp Inside For Close|Remove Sp Inside For Close|Force Sp Inside For Close"
 ValueDefault=ignore
 
@@ -853,7 +945,8 @@ Category=1
 Description="<html>Add or remove space between '((' or '))' of control statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sparen_paren\s*=\s*ignore|sp_sparen_paren\s*=\s*add|sp_sparen_paren\s*=\s*remove|sp_sparen_paren\s*=\s*force|sp_sparen_paren\s*=\s*not_defined
+Choices=sp_sparen_paren=ignore|sp_sparen_paren=add|sp_sparen_paren=remove|sp_sparen_paren=force|sp_sparen_paren=not_defined
+ChoicesRegex=sp_sparen_paren\s*=\s*ignore|sp_sparen_paren\s*=\s*add|sp_sparen_paren\s*=\s*remove|sp_sparen_paren\s*=\s*force|sp_sparen_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sparen Paren|Add Sp Sparen Paren|Remove Sp Sparen Paren|Force Sp Sparen Paren"
 ValueDefault=ignore
 
@@ -862,7 +955,8 @@ Category=1
 Description="<html>Add or remove space after ')' of control statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_sparen\s*=\s*ignore|sp_after_sparen\s*=\s*add|sp_after_sparen\s*=\s*remove|sp_after_sparen\s*=\s*force|sp_after_sparen\s*=\s*not_defined
+Choices=sp_after_sparen=ignore|sp_after_sparen=add|sp_after_sparen=remove|sp_after_sparen=force|sp_after_sparen=not_defined
+ChoicesRegex=sp_after_sparen\s*=\s*ignore|sp_after_sparen\s*=\s*add|sp_after_sparen\s*=\s*remove|sp_after_sparen\s*=\s*force|sp_after_sparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Sparen|Add Sp After Sparen|Remove Sp After Sparen|Force Sp After Sparen"
 ValueDefault=ignore
 
@@ -871,7 +965,8 @@ Category=1
 Description="<html>Add or remove space between ')' and '{' of control statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sparen_brace\s*=\s*ignore|sp_sparen_brace\s*=\s*add|sp_sparen_brace\s*=\s*remove|sp_sparen_brace\s*=\s*force|sp_sparen_brace\s*=\s*not_defined
+Choices=sp_sparen_brace=ignore|sp_sparen_brace=add|sp_sparen_brace=remove|sp_sparen_brace=force|sp_sparen_brace=not_defined
+ChoicesRegex=sp_sparen_brace\s*=\s*ignore|sp_sparen_brace\s*=\s*add|sp_sparen_brace\s*=\s*remove|sp_sparen_brace\s*=\s*force|sp_sparen_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sparen Brace|Add Sp Sparen Brace|Remove Sp Sparen Brace|Force Sp Sparen Brace"
 ValueDefault=ignore
 
@@ -880,7 +975,8 @@ Category=1
 Description="<html>Add or remove space between 'do' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_do_brace_open\s*=\s*ignore|sp_do_brace_open\s*=\s*add|sp_do_brace_open\s*=\s*remove|sp_do_brace_open\s*=\s*force|sp_do_brace_open\s*=\s*not_defined
+Choices=sp_do_brace_open=ignore|sp_do_brace_open=add|sp_do_brace_open=remove|sp_do_brace_open=force|sp_do_brace_open=not_defined
+ChoicesRegex=sp_do_brace_open\s*=\s*ignore|sp_do_brace_open\s*=\s*add|sp_do_brace_open\s*=\s*remove|sp_do_brace_open\s*=\s*force|sp_do_brace_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Do Brace Open|Add Sp Do Brace Open|Remove Sp Do Brace Open|Force Sp Do Brace Open"
 ValueDefault=ignore
 
@@ -889,7 +985,8 @@ Category=1
 Description="<html>Add or remove space between '}' and 'while'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_close_while\s*=\s*ignore|sp_brace_close_while\s*=\s*add|sp_brace_close_while\s*=\s*remove|sp_brace_close_while\s*=\s*force|sp_brace_close_while\s*=\s*not_defined
+Choices=sp_brace_close_while=ignore|sp_brace_close_while=add|sp_brace_close_while=remove|sp_brace_close_while=force|sp_brace_close_while=not_defined
+ChoicesRegex=sp_brace_close_while\s*=\s*ignore|sp_brace_close_while\s*=\s*add|sp_brace_close_while\s*=\s*remove|sp_brace_close_while\s*=\s*force|sp_brace_close_while\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Close While|Add Sp Brace Close While|Remove Sp Brace Close While|Force Sp Brace Close While"
 ValueDefault=ignore
 
@@ -898,7 +995,8 @@ Category=1
 Description="<html>Add or remove space between 'while' and '('. Overrides sp_before_sparen.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_while_paren_open\s*=\s*ignore|sp_while_paren_open\s*=\s*add|sp_while_paren_open\s*=\s*remove|sp_while_paren_open\s*=\s*force|sp_while_paren_open\s*=\s*not_defined
+Choices=sp_while_paren_open=ignore|sp_while_paren_open=add|sp_while_paren_open=remove|sp_while_paren_open=force|sp_while_paren_open=not_defined
+ChoicesRegex=sp_while_paren_open\s*=\s*ignore|sp_while_paren_open\s*=\s*add|sp_while_paren_open\s*=\s*remove|sp_while_paren_open\s*=\s*force|sp_while_paren_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp While Paren Open|Add Sp While Paren Open|Remove Sp While Paren Open|Force Sp While Paren Open"
 ValueDefault=ignore
 
@@ -907,7 +1005,8 @@ Category=1
 Description="<html>(D) Add or remove space between 'invariant' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_invariant_paren\s*=\s*ignore|sp_invariant_paren\s*=\s*add|sp_invariant_paren\s*=\s*remove|sp_invariant_paren\s*=\s*force|sp_invariant_paren\s*=\s*not_defined
+Choices=sp_invariant_paren=ignore|sp_invariant_paren=add|sp_invariant_paren=remove|sp_invariant_paren=force|sp_invariant_paren=not_defined
+ChoicesRegex=sp_invariant_paren\s*=\s*ignore|sp_invariant_paren\s*=\s*add|sp_invariant_paren\s*=\s*remove|sp_invariant_paren\s*=\s*force|sp_invariant_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Invariant Paren|Add Sp Invariant Paren|Remove Sp Invariant Paren|Force Sp Invariant Paren"
 ValueDefault=ignore
 
@@ -916,7 +1015,8 @@ Category=1
 Description="<html>(D) Add or remove space after the ')' in 'invariant (C) c'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_invariant_paren\s*=\s*ignore|sp_after_invariant_paren\s*=\s*add|sp_after_invariant_paren\s*=\s*remove|sp_after_invariant_paren\s*=\s*force|sp_after_invariant_paren\s*=\s*not_defined
+Choices=sp_after_invariant_paren=ignore|sp_after_invariant_paren=add|sp_after_invariant_paren=remove|sp_after_invariant_paren=force|sp_after_invariant_paren=not_defined
+ChoicesRegex=sp_after_invariant_paren\s*=\s*ignore|sp_after_invariant_paren\s*=\s*add|sp_after_invariant_paren\s*=\s*remove|sp_after_invariant_paren\s*=\s*force|sp_after_invariant_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Invariant Paren|Add Sp After Invariant Paren|Remove Sp After Invariant Paren|Force Sp After Invariant Paren"
 ValueDefault=ignore
 
@@ -925,7 +1025,8 @@ Category=1
 Description="<html>Add or remove space before empty statement ';' on 'if', 'for' and 'while'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_special_semi\s*=\s*ignore|sp_special_semi\s*=\s*add|sp_special_semi\s*=\s*remove|sp_special_semi\s*=\s*force|sp_special_semi\s*=\s*not_defined
+Choices=sp_special_semi=ignore|sp_special_semi=add|sp_special_semi=remove|sp_special_semi=force|sp_special_semi=not_defined
+ChoicesRegex=sp_special_semi\s*=\s*ignore|sp_special_semi\s*=\s*add|sp_special_semi\s*=\s*remove|sp_special_semi\s*=\s*force|sp_special_semi\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Special Semi|Add Sp Special Semi|Remove Sp Special Semi|Force Sp Special Semi"
 ValueDefault=ignore
 
@@ -934,7 +1035,8 @@ Category=1
 Description="<html>Add or remove space before ';'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_semi\s*=\s*ignore|sp_before_semi\s*=\s*add|sp_before_semi\s*=\s*remove|sp_before_semi\s*=\s*force|sp_before_semi\s*=\s*not_defined
+Choices=sp_before_semi=ignore|sp_before_semi=add|sp_before_semi=remove|sp_before_semi=force|sp_before_semi=not_defined
+ChoicesRegex=sp_before_semi\s*=\s*ignore|sp_before_semi\s*=\s*add|sp_before_semi\s*=\s*remove|sp_before_semi\s*=\s*force|sp_before_semi\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Semi|Add Sp Before Semi|Remove Sp Before Semi|Force Sp Before Semi"
 ValueDefault=remove
 
@@ -943,7 +1045,8 @@ Category=1
 Description="<html>Add or remove space before ';' in non-empty 'for' statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_semi_for\s*=\s*ignore|sp_before_semi_for\s*=\s*add|sp_before_semi_for\s*=\s*remove|sp_before_semi_for\s*=\s*force|sp_before_semi_for\s*=\s*not_defined
+Choices=sp_before_semi_for=ignore|sp_before_semi_for=add|sp_before_semi_for=remove|sp_before_semi_for=force|sp_before_semi_for=not_defined
+ChoicesRegex=sp_before_semi_for\s*=\s*ignore|sp_before_semi_for\s*=\s*add|sp_before_semi_for\s*=\s*remove|sp_before_semi_for\s*=\s*force|sp_before_semi_for\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Semi For|Add Sp Before Semi For|Remove Sp Before Semi For|Force Sp Before Semi For"
 ValueDefault=ignore
 
@@ -952,7 +1055,8 @@ Category=1
 Description="<html>Add or remove space before a semicolon of an empty left part of a for<br/>statement, as in 'for ( &lt;here&gt; ; ; )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_semi_for_empty\s*=\s*ignore|sp_before_semi_for_empty\s*=\s*add|sp_before_semi_for_empty\s*=\s*remove|sp_before_semi_for_empty\s*=\s*force|sp_before_semi_for_empty\s*=\s*not_defined
+Choices=sp_before_semi_for_empty=ignore|sp_before_semi_for_empty=add|sp_before_semi_for_empty=remove|sp_before_semi_for_empty=force|sp_before_semi_for_empty=not_defined
+ChoicesRegex=sp_before_semi_for_empty\s*=\s*ignore|sp_before_semi_for_empty\s*=\s*add|sp_before_semi_for_empty\s*=\s*remove|sp_before_semi_for_empty\s*=\s*force|sp_before_semi_for_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Semi For Empty|Add Sp Before Semi For Empty|Remove Sp Before Semi For Empty|Force Sp Before Semi For Empty"
 ValueDefault=ignore
 
@@ -961,7 +1065,8 @@ Category=1
 Description="<html>Add or remove space between the semicolons of an empty middle part of a for<br/>statement, as in 'for ( ; &lt;here&gt; ; )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_semi_for_empty\s*=\s*ignore|sp_between_semi_for_empty\s*=\s*add|sp_between_semi_for_empty\s*=\s*remove|sp_between_semi_for_empty\s*=\s*force|sp_between_semi_for_empty\s*=\s*not_defined
+Choices=sp_between_semi_for_empty=ignore|sp_between_semi_for_empty=add|sp_between_semi_for_empty=remove|sp_between_semi_for_empty=force|sp_between_semi_for_empty=not_defined
+ChoicesRegex=sp_between_semi_for_empty\s*=\s*ignore|sp_between_semi_for_empty\s*=\s*add|sp_between_semi_for_empty\s*=\s*remove|sp_between_semi_for_empty\s*=\s*force|sp_between_semi_for_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between Semi For Empty|Add Sp Between Semi For Empty|Remove Sp Between Semi For Empty|Force Sp Between Semi For Empty"
 ValueDefault=ignore
 
@@ -970,7 +1075,8 @@ Category=1
 Description="<html>Add or remove space after ';', except when followed by a comment.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_semi\s*=\s*ignore|sp_after_semi\s*=\s*add|sp_after_semi\s*=\s*remove|sp_after_semi\s*=\s*force|sp_after_semi\s*=\s*not_defined
+Choices=sp_after_semi=ignore|sp_after_semi=add|sp_after_semi=remove|sp_after_semi=force|sp_after_semi=not_defined
+ChoicesRegex=sp_after_semi\s*=\s*ignore|sp_after_semi\s*=\s*add|sp_after_semi\s*=\s*remove|sp_after_semi\s*=\s*force|sp_after_semi\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Semi|Add Sp After Semi|Remove Sp After Semi|Force Sp After Semi"
 ValueDefault=add
 
@@ -979,7 +1085,8 @@ Category=1
 Description="<html>Add or remove space after ';' in non-empty 'for' statements.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_semi_for\s*=\s*ignore|sp_after_semi_for\s*=\s*add|sp_after_semi_for\s*=\s*remove|sp_after_semi_for\s*=\s*force|sp_after_semi_for\s*=\s*not_defined
+Choices=sp_after_semi_for=ignore|sp_after_semi_for=add|sp_after_semi_for=remove|sp_after_semi_for=force|sp_after_semi_for=not_defined
+ChoicesRegex=sp_after_semi_for\s*=\s*ignore|sp_after_semi_for\s*=\s*add|sp_after_semi_for\s*=\s*remove|sp_after_semi_for\s*=\s*force|sp_after_semi_for\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Semi For|Add Sp After Semi For|Remove Sp After Semi For|Force Sp After Semi For"
 ValueDefault=force
 
@@ -988,7 +1095,8 @@ Category=1
 Description="<html>Add or remove space after the final semicolon of an empty part of a for<br/>statement, as in 'for ( ; ; &lt;here&gt; )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_semi_for_empty\s*=\s*ignore|sp_after_semi_for_empty\s*=\s*add|sp_after_semi_for_empty\s*=\s*remove|sp_after_semi_for_empty\s*=\s*force|sp_after_semi_for_empty\s*=\s*not_defined
+Choices=sp_after_semi_for_empty=ignore|sp_after_semi_for_empty=add|sp_after_semi_for_empty=remove|sp_after_semi_for_empty=force|sp_after_semi_for_empty=not_defined
+ChoicesRegex=sp_after_semi_for_empty\s*=\s*ignore|sp_after_semi_for_empty\s*=\s*add|sp_after_semi_for_empty\s*=\s*remove|sp_after_semi_for_empty\s*=\s*force|sp_after_semi_for_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Semi For Empty|Add Sp After Semi For Empty|Remove Sp After Semi For Empty|Force Sp After Semi For Empty"
 ValueDefault=ignore
 
@@ -997,7 +1105,8 @@ Category=1
 Description="<html>Add or remove space before '[' (except '[]').</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_square\s*=\s*ignore|sp_before_square\s*=\s*add|sp_before_square\s*=\s*remove|sp_before_square\s*=\s*force|sp_before_square\s*=\s*not_defined
+Choices=sp_before_square=ignore|sp_before_square=add|sp_before_square=remove|sp_before_square=force|sp_before_square=not_defined
+ChoicesRegex=sp_before_square\s*=\s*ignore|sp_before_square\s*=\s*add|sp_before_square\s*=\s*remove|sp_before_square\s*=\s*force|sp_before_square\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Square|Add Sp Before Square|Remove Sp Before Square|Force Sp Before Square"
 ValueDefault=ignore
 
@@ -1006,7 +1115,8 @@ Category=1
 Description="<html>Add or remove space before '[' for a variable definition.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_vardef_square\s*=\s*ignore|sp_before_vardef_square\s*=\s*add|sp_before_vardef_square\s*=\s*remove|sp_before_vardef_square\s*=\s*force|sp_before_vardef_square\s*=\s*not_defined
+Choices=sp_before_vardef_square=ignore|sp_before_vardef_square=add|sp_before_vardef_square=remove|sp_before_vardef_square=force|sp_before_vardef_square=not_defined
+ChoicesRegex=sp_before_vardef_square\s*=\s*ignore|sp_before_vardef_square\s*=\s*add|sp_before_vardef_square\s*=\s*remove|sp_before_vardef_square\s*=\s*force|sp_before_vardef_square\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Vardef Square|Add Sp Before Vardef Square|Remove Sp Before Vardef Square|Force Sp Before Vardef Square"
 ValueDefault=remove
 
@@ -1015,7 +1125,8 @@ Category=1
 Description="<html>Add or remove space before '[' for asm block.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_square_asm_block\s*=\s*ignore|sp_before_square_asm_block\s*=\s*add|sp_before_square_asm_block\s*=\s*remove|sp_before_square_asm_block\s*=\s*force|sp_before_square_asm_block\s*=\s*not_defined
+Choices=sp_before_square_asm_block=ignore|sp_before_square_asm_block=add|sp_before_square_asm_block=remove|sp_before_square_asm_block=force|sp_before_square_asm_block=not_defined
+ChoicesRegex=sp_before_square_asm_block\s*=\s*ignore|sp_before_square_asm_block\s*=\s*add|sp_before_square_asm_block\s*=\s*remove|sp_before_square_asm_block\s*=\s*force|sp_before_square_asm_block\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Square Asm Block|Add Sp Before Square Asm Block|Remove Sp Before Square Asm Block|Force Sp Before Square Asm Block"
 ValueDefault=ignore
 
@@ -1024,7 +1135,8 @@ Category=1
 Description="<html>Add or remove space before '[]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_squares\s*=\s*ignore|sp_before_squares\s*=\s*add|sp_before_squares\s*=\s*remove|sp_before_squares\s*=\s*force|sp_before_squares\s*=\s*not_defined
+Choices=sp_before_squares=ignore|sp_before_squares=add|sp_before_squares=remove|sp_before_squares=force|sp_before_squares=not_defined
+ChoicesRegex=sp_before_squares\s*=\s*ignore|sp_before_squares\s*=\s*add|sp_before_squares\s*=\s*remove|sp_before_squares\s*=\s*force|sp_before_squares\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Squares|Add Sp Before Squares|Remove Sp Before Squares|Force Sp Before Squares"
 ValueDefault=ignore
 
@@ -1033,7 +1145,8 @@ Category=1
 Description="<html>Add or remove space before C++17 structured bindings.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_before_struct_binding\s*=\s*ignore|sp_cpp_before_struct_binding\s*=\s*add|sp_cpp_before_struct_binding\s*=\s*remove|sp_cpp_before_struct_binding\s*=\s*force|sp_cpp_before_struct_binding\s*=\s*not_defined
+Choices=sp_cpp_before_struct_binding=ignore|sp_cpp_before_struct_binding=add|sp_cpp_before_struct_binding=remove|sp_cpp_before_struct_binding=force|sp_cpp_before_struct_binding=not_defined
+ChoicesRegex=sp_cpp_before_struct_binding\s*=\s*ignore|sp_cpp_before_struct_binding\s*=\s*add|sp_cpp_before_struct_binding\s*=\s*remove|sp_cpp_before_struct_binding\s*=\s*force|sp_cpp_before_struct_binding\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Before Struct Binding|Add Sp Cpp Before Struct Binding|Remove Sp Cpp Before Struct Binding|Force Sp Cpp Before Struct Binding"
 ValueDefault=ignore
 
@@ -1042,7 +1155,8 @@ Category=1
 Description="<html>Add or remove space inside a non-empty '[' and ']'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_square\s*=\s*ignore|sp_inside_square\s*=\s*add|sp_inside_square\s*=\s*remove|sp_inside_square\s*=\s*force|sp_inside_square\s*=\s*not_defined
+Choices=sp_inside_square=ignore|sp_inside_square=add|sp_inside_square=remove|sp_inside_square=force|sp_inside_square=not_defined
+ChoicesRegex=sp_inside_square\s*=\s*ignore|sp_inside_square\s*=\s*add|sp_inside_square\s*=\s*remove|sp_inside_square\s*=\s*force|sp_inside_square\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Square|Add Sp Inside Square|Remove Sp Inside Square|Force Sp Inside Square"
 ValueDefault=ignore
 
@@ -1051,7 +1165,8 @@ Category=1
 Description="<html>Add or remove space inside '[]'.<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_square_empty\s*=\s*ignore|sp_inside_square_empty\s*=\s*add|sp_inside_square_empty\s*=\s*remove|sp_inside_square_empty\s*=\s*force|sp_inside_square_empty\s*=\s*not_defined
+Choices=sp_inside_square_empty=ignore|sp_inside_square_empty=add|sp_inside_square_empty=remove|sp_inside_square_empty=force|sp_inside_square_empty=not_defined
+ChoicesRegex=sp_inside_square_empty\s*=\s*ignore|sp_inside_square_empty\s*=\s*add|sp_inside_square_empty\s*=\s*remove|sp_inside_square_empty\s*=\s*force|sp_inside_square_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Square Empty|Add Sp Inside Square Empty|Remove Sp Inside Square Empty|Force Sp Inside Square Empty"
 ValueDefault=ignore
 
@@ -1060,7 +1175,8 @@ Category=1
 Description="<html>(OC) Add or remove space inside a non-empty Objective-C boxed array '@[' and<br/>']'. If set to ignore, sp_inside_square is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_square_oc_array\s*=\s*ignore|sp_inside_square_oc_array\s*=\s*add|sp_inside_square_oc_array\s*=\s*remove|sp_inside_square_oc_array\s*=\s*force|sp_inside_square_oc_array\s*=\s*not_defined
+Choices=sp_inside_square_oc_array=ignore|sp_inside_square_oc_array=add|sp_inside_square_oc_array=remove|sp_inside_square_oc_array=force|sp_inside_square_oc_array=not_defined
+ChoicesRegex=sp_inside_square_oc_array\s*=\s*ignore|sp_inside_square_oc_array\s*=\s*add|sp_inside_square_oc_array\s*=\s*remove|sp_inside_square_oc_array\s*=\s*force|sp_inside_square_oc_array\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Square Oc Array|Add Sp Inside Square Oc Array|Remove Sp Inside Square Oc Array|Force Sp Inside Square Oc Array"
 ValueDefault=ignore
 
@@ -1069,7 +1185,8 @@ Category=1
 Description="<html>Add or remove space after ',', i.e. 'a,b' vs. 'a, b'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_comma\s*=\s*ignore|sp_after_comma\s*=\s*add|sp_after_comma\s*=\s*remove|sp_after_comma\s*=\s*force|sp_after_comma\s*=\s*not_defined
+Choices=sp_after_comma=ignore|sp_after_comma=add|sp_after_comma=remove|sp_after_comma=force|sp_after_comma=not_defined
+ChoicesRegex=sp_after_comma\s*=\s*ignore|sp_after_comma\s*=\s*add|sp_after_comma\s*=\s*remove|sp_after_comma\s*=\s*force|sp_after_comma\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Comma|Add Sp After Comma|Remove Sp After Comma|Force Sp After Comma"
 ValueDefault=ignore
 
@@ -1078,7 +1195,8 @@ Category=1
 Description="<html>Add or remove space before ',', i.e. 'a,b' vs. 'a ,b'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_comma\s*=\s*ignore|sp_before_comma\s*=\s*add|sp_before_comma\s*=\s*remove|sp_before_comma\s*=\s*force|sp_before_comma\s*=\s*not_defined
+Choices=sp_before_comma=ignore|sp_before_comma=add|sp_before_comma=remove|sp_before_comma=force|sp_before_comma=not_defined
+ChoicesRegex=sp_before_comma\s*=\s*ignore|sp_before_comma\s*=\s*add|sp_before_comma\s*=\s*remove|sp_before_comma\s*=\s*force|sp_before_comma\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Comma|Add Sp Before Comma|Remove Sp Before Comma|Force Sp Before Comma"
 ValueDefault=remove
 
@@ -1087,7 +1205,8 @@ Category=1
 Description="<html>(C#, Vala) Add or remove space between ',' and ']' in multidimensional array type<br/>like 'int[,,]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_mdatype_commas\s*=\s*ignore|sp_after_mdatype_commas\s*=\s*add|sp_after_mdatype_commas\s*=\s*remove|sp_after_mdatype_commas\s*=\s*force|sp_after_mdatype_commas\s*=\s*not_defined
+Choices=sp_after_mdatype_commas=ignore|sp_after_mdatype_commas=add|sp_after_mdatype_commas=remove|sp_after_mdatype_commas=force|sp_after_mdatype_commas=not_defined
+ChoicesRegex=sp_after_mdatype_commas\s*=\s*ignore|sp_after_mdatype_commas\s*=\s*add|sp_after_mdatype_commas\s*=\s*remove|sp_after_mdatype_commas\s*=\s*force|sp_after_mdatype_commas\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Mdatype Commas|Add Sp After Mdatype Commas|Remove Sp After Mdatype Commas|Force Sp After Mdatype Commas"
 ValueDefault=ignore
 
@@ -1096,7 +1215,8 @@ Category=1
 Description="<html>(C#, Vala) Add or remove space between '[' and ',' in multidimensional array type<br/>like 'int[,,]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_mdatype_commas\s*=\s*ignore|sp_before_mdatype_commas\s*=\s*add|sp_before_mdatype_commas\s*=\s*remove|sp_before_mdatype_commas\s*=\s*force|sp_before_mdatype_commas\s*=\s*not_defined
+Choices=sp_before_mdatype_commas=ignore|sp_before_mdatype_commas=add|sp_before_mdatype_commas=remove|sp_before_mdatype_commas=force|sp_before_mdatype_commas=not_defined
+ChoicesRegex=sp_before_mdatype_commas\s*=\s*ignore|sp_before_mdatype_commas\s*=\s*add|sp_before_mdatype_commas\s*=\s*remove|sp_before_mdatype_commas\s*=\s*force|sp_before_mdatype_commas\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Mdatype Commas|Add Sp Before Mdatype Commas|Remove Sp Before Mdatype Commas|Force Sp Before Mdatype Commas"
 ValueDefault=ignore
 
@@ -1105,7 +1225,8 @@ Category=1
 Description="<html>(C#, Vala) Add or remove space between ',' in multidimensional array type<br/>like 'int[,,]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_mdatype_commas\s*=\s*ignore|sp_between_mdatype_commas\s*=\s*add|sp_between_mdatype_commas\s*=\s*remove|sp_between_mdatype_commas\s*=\s*force|sp_between_mdatype_commas\s*=\s*not_defined
+Choices=sp_between_mdatype_commas=ignore|sp_between_mdatype_commas=add|sp_between_mdatype_commas=remove|sp_between_mdatype_commas=force|sp_between_mdatype_commas=not_defined
+ChoicesRegex=sp_between_mdatype_commas\s*=\s*ignore|sp_between_mdatype_commas\s*=\s*add|sp_between_mdatype_commas\s*=\s*remove|sp_between_mdatype_commas\s*=\s*force|sp_between_mdatype_commas\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between Mdatype Commas|Add Sp Between Mdatype Commas|Remove Sp Between Mdatype Commas|Force Sp Between Mdatype Commas"
 ValueDefault=ignore
 
@@ -1114,7 +1235,8 @@ Category=1
 Description="<html>Add or remove space between an open parenthesis and comma,<br/>i.e. '(,' vs. '( ,'.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_comma\s*=\s*ignore|sp_paren_comma\s*=\s*add|sp_paren_comma\s*=\s*remove|sp_paren_comma\s*=\s*force|sp_paren_comma\s*=\s*not_defined
+Choices=sp_paren_comma=ignore|sp_paren_comma=add|sp_paren_comma=remove|sp_paren_comma=force|sp_paren_comma=not_defined
+ChoicesRegex=sp_paren_comma\s*=\s*ignore|sp_paren_comma\s*=\s*add|sp_paren_comma\s*=\s*remove|sp_paren_comma\s*=\s*force|sp_paren_comma\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Comma|Add Sp Paren Comma|Remove Sp Paren Comma|Force Sp Paren Comma"
 ValueDefault=force
 
@@ -1123,7 +1245,8 @@ Category=1
 Description="<html>Add or remove space between a type and ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_type_colon\s*=\s*ignore|sp_type_colon\s*=\s*add|sp_type_colon\s*=\s*remove|sp_type_colon\s*=\s*force|sp_type_colon\s*=\s*not_defined
+Choices=sp_type_colon=ignore|sp_type_colon=add|sp_type_colon=remove|sp_type_colon=force|sp_type_colon=not_defined
+ChoicesRegex=sp_type_colon\s*=\s*ignore|sp_type_colon\s*=\s*add|sp_type_colon\s*=\s*remove|sp_type_colon\s*=\s*force|sp_type_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Type Colon|Add Sp Type Colon|Remove Sp Type Colon|Force Sp Type Colon"
 ValueDefault=ignore
 
@@ -1132,7 +1255,8 @@ Category=1
 Description="<html>Add or remove space after the variadic '...' when preceded by a<br/>non-punctuator.<br/>The value REMOVE will be overridden with FORCE</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ellipsis\s*=\s*ignore|sp_after_ellipsis\s*=\s*add|sp_after_ellipsis\s*=\s*remove|sp_after_ellipsis\s*=\s*force|sp_after_ellipsis\s*=\s*not_defined
+Choices=sp_after_ellipsis=ignore|sp_after_ellipsis=add|sp_after_ellipsis=remove|sp_after_ellipsis=force|sp_after_ellipsis=not_defined
+ChoicesRegex=sp_after_ellipsis\s*=\s*ignore|sp_after_ellipsis\s*=\s*add|sp_after_ellipsis\s*=\s*remove|sp_after_ellipsis\s*=\s*force|sp_after_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ellipsis|Add Sp After Ellipsis|Remove Sp After Ellipsis|Force Sp After Ellipsis"
 ValueDefault=ignore
 
@@ -1141,7 +1265,8 @@ Category=1
 Description="<html>Add or remove space before the variadic '...' when preceded by a<br/>non-punctuator.<br/>The value REMOVE will be overridden with FORCE</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_ellipsis\s*=\s*ignore|sp_before_ellipsis\s*=\s*add|sp_before_ellipsis\s*=\s*remove|sp_before_ellipsis\s*=\s*force|sp_before_ellipsis\s*=\s*not_defined
+Choices=sp_before_ellipsis=ignore|sp_before_ellipsis=add|sp_before_ellipsis=remove|sp_before_ellipsis=force|sp_before_ellipsis=not_defined
+ChoicesRegex=sp_before_ellipsis\s*=\s*ignore|sp_before_ellipsis\s*=\s*add|sp_before_ellipsis\s*=\s*remove|sp_before_ellipsis\s*=\s*force|sp_before_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Ellipsis|Add Sp Before Ellipsis|Remove Sp Before Ellipsis|Force Sp Before Ellipsis"
 ValueDefault=ignore
 
@@ -1150,7 +1275,8 @@ Category=1
 Description="<html>Add or remove space between a type and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_type_ellipsis\s*=\s*ignore|sp_type_ellipsis\s*=\s*add|sp_type_ellipsis\s*=\s*remove|sp_type_ellipsis\s*=\s*force|sp_type_ellipsis\s*=\s*not_defined
+Choices=sp_type_ellipsis=ignore|sp_type_ellipsis=add|sp_type_ellipsis=remove|sp_type_ellipsis=force|sp_type_ellipsis=not_defined
+ChoicesRegex=sp_type_ellipsis\s*=\s*ignore|sp_type_ellipsis\s*=\s*add|sp_type_ellipsis\s*=\s*remove|sp_type_ellipsis\s*=\s*force|sp_type_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Type Ellipsis|Add Sp Type Ellipsis|Remove Sp Type Ellipsis|Force Sp Type Ellipsis"
 ValueDefault=ignore
 
@@ -1159,7 +1285,8 @@ Category=1
 Description="<html>Add or remove space between a '*' and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ptr_type_ellipsis\s*=\s*ignore|sp_ptr_type_ellipsis\s*=\s*add|sp_ptr_type_ellipsis\s*=\s*remove|sp_ptr_type_ellipsis\s*=\s*force|sp_ptr_type_ellipsis\s*=\s*not_defined
+Choices=sp_ptr_type_ellipsis=ignore|sp_ptr_type_ellipsis=add|sp_ptr_type_ellipsis=remove|sp_ptr_type_ellipsis=force|sp_ptr_type_ellipsis=not_defined
+ChoicesRegex=sp_ptr_type_ellipsis\s*=\s*ignore|sp_ptr_type_ellipsis\s*=\s*add|sp_ptr_type_ellipsis\s*=\s*remove|sp_ptr_type_ellipsis\s*=\s*force|sp_ptr_type_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ptr Type Ellipsis|Add Sp Ptr Type Ellipsis|Remove Sp Ptr Type Ellipsis|Force Sp Ptr Type Ellipsis"
 ValueDefault=ignore
 
@@ -1168,7 +1295,8 @@ Category=1
 Description="<html>Add or remove space between ')' and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_ellipsis\s*=\s*ignore|sp_paren_ellipsis\s*=\s*add|sp_paren_ellipsis\s*=\s*remove|sp_paren_ellipsis\s*=\s*force|sp_paren_ellipsis\s*=\s*not_defined
+Choices=sp_paren_ellipsis=ignore|sp_paren_ellipsis=add|sp_paren_ellipsis=remove|sp_paren_ellipsis=force|sp_paren_ellipsis=not_defined
+ChoicesRegex=sp_paren_ellipsis\s*=\s*ignore|sp_paren_ellipsis\s*=\s*add|sp_paren_ellipsis\s*=\s*remove|sp_paren_ellipsis\s*=\s*force|sp_paren_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Ellipsis|Add Sp Paren Ellipsis|Remove Sp Paren Ellipsis|Force Sp Paren Ellipsis"
 ValueDefault=ignore
 
@@ -1177,7 +1305,8 @@ Category=1
 Description="<html>Add or remove space between '&amp;&amp;' and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_byref_ellipsis\s*=\s*ignore|sp_byref_ellipsis\s*=\s*add|sp_byref_ellipsis\s*=\s*remove|sp_byref_ellipsis\s*=\s*force|sp_byref_ellipsis\s*=\s*not_defined
+Choices=sp_byref_ellipsis=ignore|sp_byref_ellipsis=add|sp_byref_ellipsis=remove|sp_byref_ellipsis=force|sp_byref_ellipsis=not_defined
+ChoicesRegex=sp_byref_ellipsis\s*=\s*ignore|sp_byref_ellipsis\s*=\s*add|sp_byref_ellipsis\s*=\s*remove|sp_byref_ellipsis\s*=\s*force|sp_byref_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Byref Ellipsis|Add Sp Byref Ellipsis|Remove Sp Byref Ellipsis|Force Sp Byref Ellipsis"
 ValueDefault=ignore
 
@@ -1186,7 +1315,8 @@ Category=1
 Description="<html>Add or remove space between ')' and a qualifier such as 'const'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_qualifier\s*=\s*ignore|sp_paren_qualifier\s*=\s*add|sp_paren_qualifier\s*=\s*remove|sp_paren_qualifier\s*=\s*force|sp_paren_qualifier\s*=\s*not_defined
+Choices=sp_paren_qualifier=ignore|sp_paren_qualifier=add|sp_paren_qualifier=remove|sp_paren_qualifier=force|sp_paren_qualifier=not_defined
+ChoicesRegex=sp_paren_qualifier\s*=\s*ignore|sp_paren_qualifier\s*=\s*add|sp_paren_qualifier\s*=\s*remove|sp_paren_qualifier\s*=\s*force|sp_paren_qualifier\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Qualifier|Add Sp Paren Qualifier|Remove Sp Paren Qualifier|Force Sp Paren Qualifier"
 ValueDefault=ignore
 
@@ -1195,7 +1325,8 @@ Category=1
 Description="<html>Add or remove space between ')' and 'noexcept'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_noexcept\s*=\s*ignore|sp_paren_noexcept\s*=\s*add|sp_paren_noexcept\s*=\s*remove|sp_paren_noexcept\s*=\s*force|sp_paren_noexcept\s*=\s*not_defined
+Choices=sp_paren_noexcept=ignore|sp_paren_noexcept=add|sp_paren_noexcept=remove|sp_paren_noexcept=force|sp_paren_noexcept=not_defined
+ChoicesRegex=sp_paren_noexcept\s*=\s*ignore|sp_paren_noexcept\s*=\s*add|sp_paren_noexcept\s*=\s*remove|sp_paren_noexcept\s*=\s*force|sp_paren_noexcept\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Noexcept|Add Sp Paren Noexcept|Remove Sp Paren Noexcept|Force Sp Paren Noexcept"
 ValueDefault=ignore
 
@@ -1204,7 +1335,8 @@ Category=1
 Description="<html>Add or remove space after class ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_class_colon\s*=\s*ignore|sp_after_class_colon\s*=\s*add|sp_after_class_colon\s*=\s*remove|sp_after_class_colon\s*=\s*force|sp_after_class_colon\s*=\s*not_defined
+Choices=sp_after_class_colon=ignore|sp_after_class_colon=add|sp_after_class_colon=remove|sp_after_class_colon=force|sp_after_class_colon=not_defined
+ChoicesRegex=sp_after_class_colon\s*=\s*ignore|sp_after_class_colon\s*=\s*add|sp_after_class_colon\s*=\s*remove|sp_after_class_colon\s*=\s*force|sp_after_class_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Class Colon|Add Sp After Class Colon|Remove Sp After Class Colon|Force Sp After Class Colon"
 ValueDefault=ignore
 
@@ -1213,7 +1345,8 @@ Category=1
 Description="<html>Add or remove space before class ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_class_colon\s*=\s*ignore|sp_before_class_colon\s*=\s*add|sp_before_class_colon\s*=\s*remove|sp_before_class_colon\s*=\s*force|sp_before_class_colon\s*=\s*not_defined
+Choices=sp_before_class_colon=ignore|sp_before_class_colon=add|sp_before_class_colon=remove|sp_before_class_colon=force|sp_before_class_colon=not_defined
+ChoicesRegex=sp_before_class_colon\s*=\s*ignore|sp_before_class_colon\s*=\s*add|sp_before_class_colon\s*=\s*remove|sp_before_class_colon\s*=\s*force|sp_before_class_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Class Colon|Add Sp Before Class Colon|Remove Sp Before Class Colon|Force Sp Before Class Colon"
 ValueDefault=ignore
 
@@ -1222,7 +1355,8 @@ Category=1
 Description="<html>Add or remove space after class constructor ':'.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_constr_colon\s*=\s*ignore|sp_after_constr_colon\s*=\s*add|sp_after_constr_colon\s*=\s*remove|sp_after_constr_colon\s*=\s*force|sp_after_constr_colon\s*=\s*not_defined
+Choices=sp_after_constr_colon=ignore|sp_after_constr_colon=add|sp_after_constr_colon=remove|sp_after_constr_colon=force|sp_after_constr_colon=not_defined
+ChoicesRegex=sp_after_constr_colon\s*=\s*ignore|sp_after_constr_colon\s*=\s*add|sp_after_constr_colon\s*=\s*remove|sp_after_constr_colon\s*=\s*force|sp_after_constr_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Constr Colon|Add Sp After Constr Colon|Remove Sp After Constr Colon|Force Sp After Constr Colon"
 ValueDefault=add
 
@@ -1231,7 +1365,8 @@ Category=1
 Description="<html>Add or remove space before class constructor ':'.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_constr_colon\s*=\s*ignore|sp_before_constr_colon\s*=\s*add|sp_before_constr_colon\s*=\s*remove|sp_before_constr_colon\s*=\s*force|sp_before_constr_colon\s*=\s*not_defined
+Choices=sp_before_constr_colon=ignore|sp_before_constr_colon=add|sp_before_constr_colon=remove|sp_before_constr_colon=force|sp_before_constr_colon=not_defined
+ChoicesRegex=sp_before_constr_colon\s*=\s*ignore|sp_before_constr_colon\s*=\s*add|sp_before_constr_colon\s*=\s*remove|sp_before_constr_colon\s*=\s*force|sp_before_constr_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Constr Colon|Add Sp Before Constr Colon|Remove Sp Before Constr Colon|Force Sp Before Constr Colon"
 ValueDefault=add
 
@@ -1240,7 +1375,8 @@ Category=1
 Description="<html>Add or remove space before case ':'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_case_colon\s*=\s*ignore|sp_before_case_colon\s*=\s*add|sp_before_case_colon\s*=\s*remove|sp_before_case_colon\s*=\s*force|sp_before_case_colon\s*=\s*not_defined
+Choices=sp_before_case_colon=ignore|sp_before_case_colon=add|sp_before_case_colon=remove|sp_before_case_colon=force|sp_before_case_colon=not_defined
+ChoicesRegex=sp_before_case_colon\s*=\s*ignore|sp_before_case_colon\s*=\s*add|sp_before_case_colon\s*=\s*remove|sp_before_case_colon\s*=\s*force|sp_before_case_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Case Colon|Add Sp Before Case Colon|Remove Sp Before Case Colon|Force Sp Before Case Colon"
 ValueDefault=remove
 
@@ -1249,7 +1385,8 @@ Category=1
 Description="<html>Add or remove space between 'operator' and operator sign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_operator\s*=\s*ignore|sp_after_operator\s*=\s*add|sp_after_operator\s*=\s*remove|sp_after_operator\s*=\s*force|sp_after_operator\s*=\s*not_defined
+Choices=sp_after_operator=ignore|sp_after_operator=add|sp_after_operator=remove|sp_after_operator=force|sp_after_operator=not_defined
+ChoicesRegex=sp_after_operator\s*=\s*ignore|sp_after_operator\s*=\s*add|sp_after_operator\s*=\s*remove|sp_after_operator\s*=\s*force|sp_after_operator\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Operator|Add Sp After Operator|Remove Sp After Operator|Force Sp After Operator"
 ValueDefault=ignore
 
@@ -1258,7 +1395,8 @@ Category=1
 Description="<html>Add or remove space between the operator symbol and the open parenthesis, as<br/>in 'operator ++('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_operator_sym\s*=\s*ignore|sp_after_operator_sym\s*=\s*add|sp_after_operator_sym\s*=\s*remove|sp_after_operator_sym\s*=\s*force|sp_after_operator_sym\s*=\s*not_defined
+Choices=sp_after_operator_sym=ignore|sp_after_operator_sym=add|sp_after_operator_sym=remove|sp_after_operator_sym=force|sp_after_operator_sym=not_defined
+ChoicesRegex=sp_after_operator_sym\s*=\s*ignore|sp_after_operator_sym\s*=\s*add|sp_after_operator_sym\s*=\s*remove|sp_after_operator_sym\s*=\s*force|sp_after_operator_sym\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Operator Sym|Add Sp After Operator Sym|Remove Sp After Operator Sym|Force Sp After Operator Sym"
 ValueDefault=ignore
 
@@ -1267,7 +1405,8 @@ Category=1
 Description="<html>Overrides sp_after_operator_sym when the operator has no arguments, as in<br/>'operator *()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_operator_sym_empty\s*=\s*ignore|sp_after_operator_sym_empty\s*=\s*add|sp_after_operator_sym_empty\s*=\s*remove|sp_after_operator_sym_empty\s*=\s*force|sp_after_operator_sym_empty\s*=\s*not_defined
+Choices=sp_after_operator_sym_empty=ignore|sp_after_operator_sym_empty=add|sp_after_operator_sym_empty=remove|sp_after_operator_sym_empty=force|sp_after_operator_sym_empty=not_defined
+ChoicesRegex=sp_after_operator_sym_empty\s*=\s*ignore|sp_after_operator_sym_empty\s*=\s*add|sp_after_operator_sym_empty\s*=\s*remove|sp_after_operator_sym_empty\s*=\s*force|sp_after_operator_sym_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Operator Sym Empty|Add Sp After Operator Sym Empty|Remove Sp After Operator Sym Empty|Force Sp After Operator Sym Empty"
 ValueDefault=ignore
 
@@ -1276,7 +1415,8 @@ Category=1
 Description="<html>Add or remove space after C/D cast, i.e. 'cast(int)a' vs. 'cast(int) a' or<br/>'(int)a' vs. '(int) a'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_cast\s*=\s*ignore|sp_after_cast\s*=\s*add|sp_after_cast\s*=\s*remove|sp_after_cast\s*=\s*force|sp_after_cast\s*=\s*not_defined
+Choices=sp_after_cast=ignore|sp_after_cast=add|sp_after_cast=remove|sp_after_cast=force|sp_after_cast=not_defined
+ChoicesRegex=sp_after_cast\s*=\s*ignore|sp_after_cast\s*=\s*add|sp_after_cast\s*=\s*remove|sp_after_cast\s*=\s*force|sp_after_cast\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Cast|Add Sp After Cast|Remove Sp After Cast|Force Sp After Cast"
 ValueDefault=ignore
 
@@ -1285,7 +1425,8 @@ Category=1
 Description="<html>Add or remove spaces inside cast parentheses.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_paren_cast\s*=\s*ignore|sp_inside_paren_cast\s*=\s*add|sp_inside_paren_cast\s*=\s*remove|sp_inside_paren_cast\s*=\s*force|sp_inside_paren_cast\s*=\s*not_defined
+Choices=sp_inside_paren_cast=ignore|sp_inside_paren_cast=add|sp_inside_paren_cast=remove|sp_inside_paren_cast=force|sp_inside_paren_cast=not_defined
+ChoicesRegex=sp_inside_paren_cast\s*=\s*ignore|sp_inside_paren_cast\s*=\s*add|sp_inside_paren_cast\s*=\s*remove|sp_inside_paren_cast\s*=\s*force|sp_inside_paren_cast\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Paren Cast|Add Sp Inside Paren Cast|Remove Sp Inside Paren Cast|Force Sp Inside Paren Cast"
 ValueDefault=ignore
 
@@ -1294,7 +1435,8 @@ Category=1
 Description="<html>Add or remove space between the type and open parenthesis in a C++ cast,<br/>i.e. 'int(exp)' vs. 'int (exp)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_cast_paren\s*=\s*ignore|sp_cpp_cast_paren\s*=\s*add|sp_cpp_cast_paren\s*=\s*remove|sp_cpp_cast_paren\s*=\s*force|sp_cpp_cast_paren\s*=\s*not_defined
+Choices=sp_cpp_cast_paren=ignore|sp_cpp_cast_paren=add|sp_cpp_cast_paren=remove|sp_cpp_cast_paren=force|sp_cpp_cast_paren=not_defined
+ChoicesRegex=sp_cpp_cast_paren\s*=\s*ignore|sp_cpp_cast_paren\s*=\s*add|sp_cpp_cast_paren\s*=\s*remove|sp_cpp_cast_paren\s*=\s*force|sp_cpp_cast_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Cast Paren|Add Sp Cpp Cast Paren|Remove Sp Cpp Cast Paren|Force Sp Cpp Cast Paren"
 ValueDefault=ignore
 
@@ -1303,7 +1445,8 @@ Category=1
 Description="<html>Add or remove space between 'sizeof' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sizeof_paren\s*=\s*ignore|sp_sizeof_paren\s*=\s*add|sp_sizeof_paren\s*=\s*remove|sp_sizeof_paren\s*=\s*force|sp_sizeof_paren\s*=\s*not_defined
+Choices=sp_sizeof_paren=ignore|sp_sizeof_paren=add|sp_sizeof_paren=remove|sp_sizeof_paren=force|sp_sizeof_paren=not_defined
+ChoicesRegex=sp_sizeof_paren\s*=\s*ignore|sp_sizeof_paren\s*=\s*add|sp_sizeof_paren\s*=\s*remove|sp_sizeof_paren\s*=\s*force|sp_sizeof_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sizeof Paren|Add Sp Sizeof Paren|Remove Sp Sizeof Paren|Force Sp Sizeof Paren"
 ValueDefault=ignore
 
@@ -1312,7 +1455,8 @@ Category=1
 Description="<html>Add or remove space between 'sizeof' and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sizeof_ellipsis\s*=\s*ignore|sp_sizeof_ellipsis\s*=\s*add|sp_sizeof_ellipsis\s*=\s*remove|sp_sizeof_ellipsis\s*=\s*force|sp_sizeof_ellipsis\s*=\s*not_defined
+Choices=sp_sizeof_ellipsis=ignore|sp_sizeof_ellipsis=add|sp_sizeof_ellipsis=remove|sp_sizeof_ellipsis=force|sp_sizeof_ellipsis=not_defined
+ChoicesRegex=sp_sizeof_ellipsis\s*=\s*ignore|sp_sizeof_ellipsis\s*=\s*add|sp_sizeof_ellipsis\s*=\s*remove|sp_sizeof_ellipsis\s*=\s*force|sp_sizeof_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sizeof Ellipsis|Add Sp Sizeof Ellipsis|Remove Sp Sizeof Ellipsis|Force Sp Sizeof Ellipsis"
 ValueDefault=ignore
 
@@ -1321,7 +1465,8 @@ Category=1
 Description="<html>Add or remove space between 'sizeof...' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sizeof_ellipsis_paren\s*=\s*ignore|sp_sizeof_ellipsis_paren\s*=\s*add|sp_sizeof_ellipsis_paren\s*=\s*remove|sp_sizeof_ellipsis_paren\s*=\s*force|sp_sizeof_ellipsis_paren\s*=\s*not_defined
+Choices=sp_sizeof_ellipsis_paren=ignore|sp_sizeof_ellipsis_paren=add|sp_sizeof_ellipsis_paren=remove|sp_sizeof_ellipsis_paren=force|sp_sizeof_ellipsis_paren=not_defined
+ChoicesRegex=sp_sizeof_ellipsis_paren\s*=\s*ignore|sp_sizeof_ellipsis_paren\s*=\s*add|sp_sizeof_ellipsis_paren\s*=\s*remove|sp_sizeof_ellipsis_paren\s*=\s*force|sp_sizeof_ellipsis_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sizeof Ellipsis Paren|Add Sp Sizeof Ellipsis Paren|Remove Sp Sizeof Ellipsis Paren|Force Sp Sizeof Ellipsis Paren"
 ValueDefault=ignore
 
@@ -1330,7 +1475,8 @@ Category=1
 Description="<html>Add or remove space between '...' and a parameter pack.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ellipsis_parameter_pack\s*=\s*ignore|sp_ellipsis_parameter_pack\s*=\s*add|sp_ellipsis_parameter_pack\s*=\s*remove|sp_ellipsis_parameter_pack\s*=\s*force|sp_ellipsis_parameter_pack\s*=\s*not_defined
+Choices=sp_ellipsis_parameter_pack=ignore|sp_ellipsis_parameter_pack=add|sp_ellipsis_parameter_pack=remove|sp_ellipsis_parameter_pack=force|sp_ellipsis_parameter_pack=not_defined
+ChoicesRegex=sp_ellipsis_parameter_pack\s*=\s*ignore|sp_ellipsis_parameter_pack\s*=\s*add|sp_ellipsis_parameter_pack\s*=\s*remove|sp_ellipsis_parameter_pack\s*=\s*force|sp_ellipsis_parameter_pack\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ellipsis Parameter Pack|Add Sp Ellipsis Parameter Pack|Remove Sp Ellipsis Parameter Pack|Force Sp Ellipsis Parameter Pack"
 ValueDefault=ignore
 
@@ -1339,7 +1485,8 @@ Category=1
 Description="<html>Add or remove space between a parameter pack and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_parameter_pack_ellipsis\s*=\s*ignore|sp_parameter_pack_ellipsis\s*=\s*add|sp_parameter_pack_ellipsis\s*=\s*remove|sp_parameter_pack_ellipsis\s*=\s*force|sp_parameter_pack_ellipsis\s*=\s*not_defined
+Choices=sp_parameter_pack_ellipsis=ignore|sp_parameter_pack_ellipsis=add|sp_parameter_pack_ellipsis=remove|sp_parameter_pack_ellipsis=force|sp_parameter_pack_ellipsis=not_defined
+ChoicesRegex=sp_parameter_pack_ellipsis\s*=\s*ignore|sp_parameter_pack_ellipsis\s*=\s*add|sp_parameter_pack_ellipsis\s*=\s*remove|sp_parameter_pack_ellipsis\s*=\s*force|sp_parameter_pack_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Parameter Pack Ellipsis|Add Sp Parameter Pack Ellipsis|Remove Sp Parameter Pack Ellipsis|Force Sp Parameter Pack Ellipsis"
 ValueDefault=ignore
 
@@ -1348,7 +1495,8 @@ Category=1
 Description="<html>Add or remove space between 'decltype' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_decltype_paren\s*=\s*ignore|sp_decltype_paren\s*=\s*add|sp_decltype_paren\s*=\s*remove|sp_decltype_paren\s*=\s*force|sp_decltype_paren\s*=\s*not_defined
+Choices=sp_decltype_paren=ignore|sp_decltype_paren=add|sp_decltype_paren=remove|sp_decltype_paren=force|sp_decltype_paren=not_defined
+ChoicesRegex=sp_decltype_paren\s*=\s*ignore|sp_decltype_paren\s*=\s*add|sp_decltype_paren\s*=\s*remove|sp_decltype_paren\s*=\s*force|sp_decltype_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Decltype Paren|Add Sp Decltype Paren|Remove Sp Decltype Paren|Force Sp Decltype Paren"
 ValueDefault=ignore
 
@@ -1357,7 +1505,8 @@ Category=1
 Description="<html>(Pawn) Add or remove space after the tag keyword.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_tag\s*=\s*ignore|sp_after_tag\s*=\s*add|sp_after_tag\s*=\s*remove|sp_after_tag\s*=\s*force|sp_after_tag\s*=\s*not_defined
+Choices=sp_after_tag=ignore|sp_after_tag=add|sp_after_tag=remove|sp_after_tag=force|sp_after_tag=not_defined
+ChoicesRegex=sp_after_tag\s*=\s*ignore|sp_after_tag\s*=\s*add|sp_after_tag\s*=\s*remove|sp_after_tag\s*=\s*force|sp_after_tag\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Tag|Add Sp After Tag|Remove Sp After Tag|Force Sp After Tag"
 ValueDefault=ignore
 
@@ -1366,7 +1515,8 @@ Category=1
 Description="<html>Add or remove space inside enum '{' and '}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces_enum\s*=\s*ignore|sp_inside_braces_enum\s*=\s*add|sp_inside_braces_enum\s*=\s*remove|sp_inside_braces_enum\s*=\s*force|sp_inside_braces_enum\s*=\s*not_defined
+Choices=sp_inside_braces_enum=ignore|sp_inside_braces_enum=add|sp_inside_braces_enum=remove|sp_inside_braces_enum=force|sp_inside_braces_enum=not_defined
+ChoicesRegex=sp_inside_braces_enum\s*=\s*ignore|sp_inside_braces_enum\s*=\s*add|sp_inside_braces_enum\s*=\s*remove|sp_inside_braces_enum\s*=\s*force|sp_inside_braces_enum\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces Enum|Add Sp Inside Braces Enum|Remove Sp Inside Braces Enum|Force Sp Inside Braces Enum"
 ValueDefault=ignore
 
@@ -1375,7 +1525,8 @@ Category=1
 Description="<html>Add or remove space inside struct/union '{' and '}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces_struct\s*=\s*ignore|sp_inside_braces_struct\s*=\s*add|sp_inside_braces_struct\s*=\s*remove|sp_inside_braces_struct\s*=\s*force|sp_inside_braces_struct\s*=\s*not_defined
+Choices=sp_inside_braces_struct=ignore|sp_inside_braces_struct=add|sp_inside_braces_struct=remove|sp_inside_braces_struct=force|sp_inside_braces_struct=not_defined
+ChoicesRegex=sp_inside_braces_struct\s*=\s*ignore|sp_inside_braces_struct\s*=\s*add|sp_inside_braces_struct\s*=\s*remove|sp_inside_braces_struct\s*=\s*force|sp_inside_braces_struct\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces Struct|Add Sp Inside Braces Struct|Remove Sp Inside Braces Struct|Force Sp Inside Braces Struct"
 ValueDefault=ignore
 
@@ -1384,7 +1535,8 @@ Category=1
 Description="<html>(OC) Add or remove space inside Objective-C boxed dictionary '{' and '}'</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces_oc_dict\s*=\s*ignore|sp_inside_braces_oc_dict\s*=\s*add|sp_inside_braces_oc_dict\s*=\s*remove|sp_inside_braces_oc_dict\s*=\s*force|sp_inside_braces_oc_dict\s*=\s*not_defined
+Choices=sp_inside_braces_oc_dict=ignore|sp_inside_braces_oc_dict=add|sp_inside_braces_oc_dict=remove|sp_inside_braces_oc_dict=force|sp_inside_braces_oc_dict=not_defined
+ChoicesRegex=sp_inside_braces_oc_dict\s*=\s*ignore|sp_inside_braces_oc_dict\s*=\s*add|sp_inside_braces_oc_dict\s*=\s*remove|sp_inside_braces_oc_dict\s*=\s*force|sp_inside_braces_oc_dict\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces Oc Dict|Add Sp Inside Braces Oc Dict|Remove Sp Inside Braces Oc Dict|Force Sp Inside Braces Oc Dict"
 ValueDefault=ignore
 
@@ -1393,7 +1545,8 @@ Category=1
 Description="<html>Add or remove space after open brace in an unnamed temporary<br/>direct-list-initialization<br/>if statement is a brace_init_lst<br/>works only if sp_brace_brace is set to ignore.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_type_brace_init_lst_open\s*=\s*ignore|sp_after_type_brace_init_lst_open\s*=\s*add|sp_after_type_brace_init_lst_open\s*=\s*remove|sp_after_type_brace_init_lst_open\s*=\s*force|sp_after_type_brace_init_lst_open\s*=\s*not_defined
+Choices=sp_after_type_brace_init_lst_open=ignore|sp_after_type_brace_init_lst_open=add|sp_after_type_brace_init_lst_open=remove|sp_after_type_brace_init_lst_open=force|sp_after_type_brace_init_lst_open=not_defined
+ChoicesRegex=sp_after_type_brace_init_lst_open\s*=\s*ignore|sp_after_type_brace_init_lst_open\s*=\s*add|sp_after_type_brace_init_lst_open\s*=\s*remove|sp_after_type_brace_init_lst_open\s*=\s*force|sp_after_type_brace_init_lst_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Type Brace Init Lst Open|Add Sp After Type Brace Init Lst Open|Remove Sp After Type Brace Init Lst Open|Force Sp After Type Brace Init Lst Open"
 ValueDefault=ignore
 
@@ -1402,7 +1555,8 @@ Category=1
 Description="<html>Add or remove space before close brace in an unnamed temporary<br/>direct-list-initialization<br/>if statement is a brace_init_lst<br/>works only if sp_brace_brace is set to ignore.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_type_brace_init_lst_close\s*=\s*ignore|sp_before_type_brace_init_lst_close\s*=\s*add|sp_before_type_brace_init_lst_close\s*=\s*remove|sp_before_type_brace_init_lst_close\s*=\s*force|sp_before_type_brace_init_lst_close\s*=\s*not_defined
+Choices=sp_before_type_brace_init_lst_close=ignore|sp_before_type_brace_init_lst_close=add|sp_before_type_brace_init_lst_close=remove|sp_before_type_brace_init_lst_close=force|sp_before_type_brace_init_lst_close=not_defined
+ChoicesRegex=sp_before_type_brace_init_lst_close\s*=\s*ignore|sp_before_type_brace_init_lst_close\s*=\s*add|sp_before_type_brace_init_lst_close\s*=\s*remove|sp_before_type_brace_init_lst_close\s*=\s*force|sp_before_type_brace_init_lst_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Type Brace Init Lst Close|Add Sp Before Type Brace Init Lst Close|Remove Sp Before Type Brace Init Lst Close|Force Sp Before Type Brace Init Lst Close"
 ValueDefault=ignore
 
@@ -1411,7 +1565,8 @@ Category=1
 Description="<html>Add or remove space inside an unnamed temporary direct-list-initialization<br/>if statement is a brace_init_lst<br/>works only if sp_brace_brace is set to ignore<br/>works only if sp_before_type_brace_init_lst_close is set to ignore.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_type_brace_init_lst\s*=\s*ignore|sp_inside_type_brace_init_lst\s*=\s*add|sp_inside_type_brace_init_lst\s*=\s*remove|sp_inside_type_brace_init_lst\s*=\s*force|sp_inside_type_brace_init_lst\s*=\s*not_defined
+Choices=sp_inside_type_brace_init_lst=ignore|sp_inside_type_brace_init_lst=add|sp_inside_type_brace_init_lst=remove|sp_inside_type_brace_init_lst=force|sp_inside_type_brace_init_lst=not_defined
+ChoicesRegex=sp_inside_type_brace_init_lst\s*=\s*ignore|sp_inside_type_brace_init_lst\s*=\s*add|sp_inside_type_brace_init_lst\s*=\s*remove|sp_inside_type_brace_init_lst\s*=\s*force|sp_inside_type_brace_init_lst\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Type Brace Init Lst|Add Sp Inside Type Brace Init Lst|Remove Sp Inside Type Brace Init Lst|Force Sp Inside Type Brace Init Lst"
 ValueDefault=ignore
 
@@ -1420,7 +1575,8 @@ Category=1
 Description="<html>Add or remove space inside '{' and '}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces\s*=\s*ignore|sp_inside_braces\s*=\s*add|sp_inside_braces\s*=\s*remove|sp_inside_braces\s*=\s*force|sp_inside_braces\s*=\s*not_defined
+Choices=sp_inside_braces=ignore|sp_inside_braces=add|sp_inside_braces=remove|sp_inside_braces=force|sp_inside_braces=not_defined
+ChoicesRegex=sp_inside_braces\s*=\s*ignore|sp_inside_braces\s*=\s*add|sp_inside_braces\s*=\s*remove|sp_inside_braces\s*=\s*force|sp_inside_braces\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces|Add Sp Inside Braces|Remove Sp Inside Braces|Force Sp Inside Braces"
 ValueDefault=ignore
 
@@ -1429,7 +1585,8 @@ Category=1
 Description="<html>Add or remove space inside '{}'.<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces_empty\s*=\s*ignore|sp_inside_braces_empty\s*=\s*add|sp_inside_braces_empty\s*=\s*remove|sp_inside_braces_empty\s*=\s*force|sp_inside_braces_empty\s*=\s*not_defined
+Choices=sp_inside_braces_empty=ignore|sp_inside_braces_empty=add|sp_inside_braces_empty=remove|sp_inside_braces_empty=force|sp_inside_braces_empty=not_defined
+ChoicesRegex=sp_inside_braces_empty\s*=\s*ignore|sp_inside_braces_empty\s*=\s*add|sp_inside_braces_empty\s*=\s*remove|sp_inside_braces_empty\s*=\s*force|sp_inside_braces_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces Empty|Add Sp Inside Braces Empty|Remove Sp Inside Braces Empty|Force Sp Inside Braces Empty"
 ValueDefault=ignore
 
@@ -1438,7 +1595,8 @@ Category=1
 Description="<html>Add or remove space around trailing return operator '-&gt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_trailing_return\s*=\s*ignore|sp_trailing_return\s*=\s*add|sp_trailing_return\s*=\s*remove|sp_trailing_return\s*=\s*force|sp_trailing_return\s*=\s*not_defined
+Choices=sp_trailing_return=ignore|sp_trailing_return=add|sp_trailing_return=remove|sp_trailing_return=force|sp_trailing_return=not_defined
+ChoicesRegex=sp_trailing_return\s*=\s*ignore|sp_trailing_return\s*=\s*add|sp_trailing_return\s*=\s*remove|sp_trailing_return\s*=\s*force|sp_trailing_return\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Trailing Return|Add Sp Trailing Return|Remove Sp Trailing Return|Force Sp Trailing Return"
 ValueDefault=ignore
 
@@ -1447,7 +1605,8 @@ Category=1
 Description="<html>Add or remove space between return type and function name. A minimum of 1<br/>is forced except for pointer return types.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_type_func\s*=\s*ignore|sp_type_func\s*=\s*add|sp_type_func\s*=\s*remove|sp_type_func\s*=\s*force|sp_type_func\s*=\s*not_defined
+Choices=sp_type_func=ignore|sp_type_func=add|sp_type_func=remove|sp_type_func=force|sp_type_func=not_defined
+ChoicesRegex=sp_type_func\s*=\s*ignore|sp_type_func\s*=\s*add|sp_type_func\s*=\s*remove|sp_type_func\s*=\s*force|sp_type_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Type Func|Add Sp Type Func|Remove Sp Type Func|Force Sp Type Func"
 ValueDefault=ignore
 
@@ -1456,7 +1615,8 @@ Category=1
 Description="<html>Add or remove space between type and open brace of an unnamed temporary<br/>direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_type_brace_init_lst\s*=\s*ignore|sp_type_brace_init_lst\s*=\s*add|sp_type_brace_init_lst\s*=\s*remove|sp_type_brace_init_lst\s*=\s*force|sp_type_brace_init_lst\s*=\s*not_defined
+Choices=sp_type_brace_init_lst=ignore|sp_type_brace_init_lst=add|sp_type_brace_init_lst=remove|sp_type_brace_init_lst=force|sp_type_brace_init_lst=not_defined
+ChoicesRegex=sp_type_brace_init_lst\s*=\s*ignore|sp_type_brace_init_lst\s*=\s*add|sp_type_brace_init_lst\s*=\s*remove|sp_type_brace_init_lst\s*=\s*force|sp_type_brace_init_lst\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Type Brace Init Lst|Add Sp Type Brace Init Lst|Remove Sp Type Brace Init Lst|Force Sp Type Brace Init Lst"
 ValueDefault=ignore
 
@@ -1465,7 +1625,8 @@ Category=1
 Description="<html>Add or remove space between function name and '(' on function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_proto_paren\s*=\s*ignore|sp_func_proto_paren\s*=\s*add|sp_func_proto_paren\s*=\s*remove|sp_func_proto_paren\s*=\s*force|sp_func_proto_paren\s*=\s*not_defined
+Choices=sp_func_proto_paren=ignore|sp_func_proto_paren=add|sp_func_proto_paren=remove|sp_func_proto_paren=force|sp_func_proto_paren=not_defined
+ChoicesRegex=sp_func_proto_paren\s*=\s*ignore|sp_func_proto_paren\s*=\s*add|sp_func_proto_paren\s*=\s*remove|sp_func_proto_paren\s*=\s*force|sp_func_proto_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Proto Paren|Add Sp Func Proto Paren|Remove Sp Func Proto Paren|Force Sp Func Proto Paren"
 ValueDefault=ignore
 
@@ -1474,7 +1635,8 @@ Category=1
 Description="<html>Add or remove space between function name and '()' on function declaration<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_proto_paren_empty\s*=\s*ignore|sp_func_proto_paren_empty\s*=\s*add|sp_func_proto_paren_empty\s*=\s*remove|sp_func_proto_paren_empty\s*=\s*force|sp_func_proto_paren_empty\s*=\s*not_defined
+Choices=sp_func_proto_paren_empty=ignore|sp_func_proto_paren_empty=add|sp_func_proto_paren_empty=remove|sp_func_proto_paren_empty=force|sp_func_proto_paren_empty=not_defined
+ChoicesRegex=sp_func_proto_paren_empty\s*=\s*ignore|sp_func_proto_paren_empty\s*=\s*add|sp_func_proto_paren_empty\s*=\s*remove|sp_func_proto_paren_empty\s*=\s*force|sp_func_proto_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Proto Paren Empty|Add Sp Func Proto Paren Empty|Remove Sp Func Proto Paren Empty|Force Sp Func Proto Paren Empty"
 ValueDefault=ignore
 
@@ -1483,7 +1645,8 @@ Category=1
 Description="<html>Add or remove space between function name and '(' with a typedef specifier.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_type_paren\s*=\s*ignore|sp_func_type_paren\s*=\s*add|sp_func_type_paren\s*=\s*remove|sp_func_type_paren\s*=\s*force|sp_func_type_paren\s*=\s*not_defined
+Choices=sp_func_type_paren=ignore|sp_func_type_paren=add|sp_func_type_paren=remove|sp_func_type_paren=force|sp_func_type_paren=not_defined
+ChoicesRegex=sp_func_type_paren\s*=\s*ignore|sp_func_type_paren\s*=\s*add|sp_func_type_paren\s*=\s*remove|sp_func_type_paren\s*=\s*force|sp_func_type_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Type Paren|Add Sp Func Type Paren|Remove Sp Func Type Paren|Force Sp Func Type Paren"
 ValueDefault=ignore
 
@@ -1492,7 +1655,8 @@ Category=1
 Description="<html>Add or remove space between alias name and '(' of a non-pointer function type typedef.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_def_paren\s*=\s*ignore|sp_func_def_paren\s*=\s*add|sp_func_def_paren\s*=\s*remove|sp_func_def_paren\s*=\s*force|sp_func_def_paren\s*=\s*not_defined
+Choices=sp_func_def_paren=ignore|sp_func_def_paren=add|sp_func_def_paren=remove|sp_func_def_paren=force|sp_func_def_paren=not_defined
+ChoicesRegex=sp_func_def_paren\s*=\s*ignore|sp_func_def_paren\s*=\s*add|sp_func_def_paren\s*=\s*remove|sp_func_def_paren\s*=\s*force|sp_func_def_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Def Paren|Add Sp Func Def Paren|Remove Sp Func Def Paren|Force Sp Func Def Paren"
 ValueDefault=ignore
 
@@ -1501,7 +1665,8 @@ Category=1
 Description="<html>Add or remove space between function name and '()' on function definition<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_def_paren_empty\s*=\s*ignore|sp_func_def_paren_empty\s*=\s*add|sp_func_def_paren_empty\s*=\s*remove|sp_func_def_paren_empty\s*=\s*force|sp_func_def_paren_empty\s*=\s*not_defined
+Choices=sp_func_def_paren_empty=ignore|sp_func_def_paren_empty=add|sp_func_def_paren_empty=remove|sp_func_def_paren_empty=force|sp_func_def_paren_empty=not_defined
+ChoicesRegex=sp_func_def_paren_empty\s*=\s*ignore|sp_func_def_paren_empty\s*=\s*add|sp_func_def_paren_empty\s*=\s*remove|sp_func_def_paren_empty\s*=\s*force|sp_func_def_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Def Paren Empty|Add Sp Func Def Paren Empty|Remove Sp Func Def Paren Empty|Force Sp Func Def Paren Empty"
 ValueDefault=ignore
 
@@ -1510,7 +1675,8 @@ Category=1
 Description="<html>Add or remove space inside empty function '()'.<br/>Overrides sp_after_angle unless use_sp_after_angle_always is set to true.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_fparens\s*=\s*ignore|sp_inside_fparens\s*=\s*add|sp_inside_fparens\s*=\s*remove|sp_inside_fparens\s*=\s*force|sp_inside_fparens\s*=\s*not_defined
+Choices=sp_inside_fparens=ignore|sp_inside_fparens=add|sp_inside_fparens=remove|sp_inside_fparens=force|sp_inside_fparens=not_defined
+ChoicesRegex=sp_inside_fparens\s*=\s*ignore|sp_inside_fparens\s*=\s*add|sp_inside_fparens\s*=\s*remove|sp_inside_fparens\s*=\s*force|sp_inside_fparens\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Fparens|Add Sp Inside Fparens|Remove Sp Inside Fparens|Force Sp Inside Fparens"
 ValueDefault=ignore
 
@@ -1519,7 +1685,8 @@ Category=1
 Description="<html>Add or remove space inside function '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_fparen\s*=\s*ignore|sp_inside_fparen\s*=\s*add|sp_inside_fparen\s*=\s*remove|sp_inside_fparen\s*=\s*force|sp_inside_fparen\s*=\s*not_defined
+Choices=sp_inside_fparen=ignore|sp_inside_fparen=add|sp_inside_fparen=remove|sp_inside_fparen=force|sp_inside_fparen=not_defined
+ChoicesRegex=sp_inside_fparen\s*=\s*ignore|sp_inside_fparen\s*=\s*add|sp_inside_fparen\s*=\s*remove|sp_inside_fparen\s*=\s*force|sp_inside_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Fparen|Add Sp Inside Fparen|Remove Sp Inside Fparen|Force Sp Inside Fparen"
 ValueDefault=ignore
 
@@ -1528,7 +1695,8 @@ Category=1
 Description="<html>Add or remove space inside user functor '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_user_inside_rparen\s*=\s*ignore|sp_func_call_user_inside_rparen\s*=\s*add|sp_func_call_user_inside_rparen\s*=\s*remove|sp_func_call_user_inside_rparen\s*=\s*force|sp_func_call_user_inside_rparen\s*=\s*not_defined
+Choices=sp_func_call_user_inside_rparen=ignore|sp_func_call_user_inside_rparen=add|sp_func_call_user_inside_rparen=remove|sp_func_call_user_inside_rparen=force|sp_func_call_user_inside_rparen=not_defined
+ChoicesRegex=sp_func_call_user_inside_rparen\s*=\s*ignore|sp_func_call_user_inside_rparen\s*=\s*add|sp_func_call_user_inside_rparen\s*=\s*remove|sp_func_call_user_inside_rparen\s*=\s*force|sp_func_call_user_inside_rparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call User Inside Rparen|Add Sp Func Call User Inside Rparen|Remove Sp Func Call User Inside Rparen|Force Sp Func Call User Inside Rparen"
 ValueDefault=ignore
 
@@ -1537,7 +1705,8 @@ Category=1
 Description="<html>Add or remove space inside empty functor '()'.<br/>Overrides sp_after_angle unless use_sp_after_angle_always is set to true.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_rparens\s*=\s*ignore|sp_inside_rparens\s*=\s*add|sp_inside_rparens\s*=\s*remove|sp_inside_rparens\s*=\s*force|sp_inside_rparens\s*=\s*not_defined
+Choices=sp_inside_rparens=ignore|sp_inside_rparens=add|sp_inside_rparens=remove|sp_inside_rparens=force|sp_inside_rparens=not_defined
+ChoicesRegex=sp_inside_rparens\s*=\s*ignore|sp_inside_rparens\s*=\s*add|sp_inside_rparens\s*=\s*remove|sp_inside_rparens\s*=\s*force|sp_inside_rparens\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Rparens|Add Sp Inside Rparens|Remove Sp Inside Rparens|Force Sp Inside Rparens"
 ValueDefault=ignore
 
@@ -1546,7 +1715,8 @@ Category=1
 Description="<html>Add or remove space inside functor '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_rparen\s*=\s*ignore|sp_inside_rparen\s*=\s*add|sp_inside_rparen\s*=\s*remove|sp_inside_rparen\s*=\s*force|sp_inside_rparen\s*=\s*not_defined
+Choices=sp_inside_rparen=ignore|sp_inside_rparen=add|sp_inside_rparen=remove|sp_inside_rparen=force|sp_inside_rparen=not_defined
+ChoicesRegex=sp_inside_rparen\s*=\s*ignore|sp_inside_rparen\s*=\s*add|sp_inside_rparen\s*=\s*remove|sp_inside_rparen\s*=\s*force|sp_inside_rparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Rparen|Add Sp Inside Rparen|Remove Sp Inside Rparen|Force Sp Inside Rparen"
 ValueDefault=ignore
 
@@ -1555,7 +1725,8 @@ Category=1
 Description="<html>Add or remove space inside the first parentheses in a function type, as in<br/>'void (*x)(...)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_tparen\s*=\s*ignore|sp_inside_tparen\s*=\s*add|sp_inside_tparen\s*=\s*remove|sp_inside_tparen\s*=\s*force|sp_inside_tparen\s*=\s*not_defined
+Choices=sp_inside_tparen=ignore|sp_inside_tparen=add|sp_inside_tparen=remove|sp_inside_tparen=force|sp_inside_tparen=not_defined
+ChoicesRegex=sp_inside_tparen\s*=\s*ignore|sp_inside_tparen\s*=\s*add|sp_inside_tparen\s*=\s*remove|sp_inside_tparen\s*=\s*force|sp_inside_tparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Tparen|Add Sp Inside Tparen|Remove Sp Inside Tparen|Force Sp Inside Tparen"
 ValueDefault=ignore
 
@@ -1564,7 +1735,8 @@ Category=1
 Description="<html>Add or remove space between the ')' and '(' in a function type, as in<br/>'void (*x)(...)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_tparen_close\s*=\s*ignore|sp_after_tparen_close\s*=\s*add|sp_after_tparen_close\s*=\s*remove|sp_after_tparen_close\s*=\s*force|sp_after_tparen_close\s*=\s*not_defined
+Choices=sp_after_tparen_close=ignore|sp_after_tparen_close=add|sp_after_tparen_close=remove|sp_after_tparen_close=force|sp_after_tparen_close=not_defined
+ChoicesRegex=sp_after_tparen_close\s*=\s*ignore|sp_after_tparen_close\s*=\s*add|sp_after_tparen_close\s*=\s*remove|sp_after_tparen_close\s*=\s*force|sp_after_tparen_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Tparen Close|Add Sp After Tparen Close|Remove Sp After Tparen Close|Force Sp After Tparen Close"
 ValueDefault=ignore
 
@@ -1573,7 +1745,8 @@ Category=1
 Description="<html>Add or remove space between ']' and '(' when part of a function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_square_fparen\s*=\s*ignore|sp_square_fparen\s*=\s*add|sp_square_fparen\s*=\s*remove|sp_square_fparen\s*=\s*force|sp_square_fparen\s*=\s*not_defined
+Choices=sp_square_fparen=ignore|sp_square_fparen=add|sp_square_fparen=remove|sp_square_fparen=force|sp_square_fparen=not_defined
+ChoicesRegex=sp_square_fparen\s*=\s*ignore|sp_square_fparen\s*=\s*add|sp_square_fparen\s*=\s*remove|sp_square_fparen\s*=\s*force|sp_square_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Square Fparen|Add Sp Square Fparen|Remove Sp Square Fparen|Force Sp Square Fparen"
 ValueDefault=ignore
 
@@ -1582,7 +1755,8 @@ Category=1
 Description="<html>Add or remove space between ')' and '{' of function.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_fparen_brace\s*=\s*ignore|sp_fparen_brace\s*=\s*add|sp_fparen_brace\s*=\s*remove|sp_fparen_brace\s*=\s*force|sp_fparen_brace\s*=\s*not_defined
+Choices=sp_fparen_brace=ignore|sp_fparen_brace=add|sp_fparen_brace=remove|sp_fparen_brace=force|sp_fparen_brace=not_defined
+ChoicesRegex=sp_fparen_brace\s*=\s*ignore|sp_fparen_brace\s*=\s*add|sp_fparen_brace\s*=\s*remove|sp_fparen_brace\s*=\s*force|sp_fparen_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Fparen Brace|Add Sp Fparen Brace|Remove Sp Fparen Brace|Force Sp Fparen Brace"
 ValueDefault=ignore
 
@@ -1591,7 +1765,8 @@ Category=1
 Description="<html>Add or remove space between ')' and '{' of a function call in object<br/>initialization.<br/><br/>Overrides sp_fparen_brace.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_fparen_brace_initializer\s*=\s*ignore|sp_fparen_brace_initializer\s*=\s*add|sp_fparen_brace_initializer\s*=\s*remove|sp_fparen_brace_initializer\s*=\s*force|sp_fparen_brace_initializer\s*=\s*not_defined
+Choices=sp_fparen_brace_initializer=ignore|sp_fparen_brace_initializer=add|sp_fparen_brace_initializer=remove|sp_fparen_brace_initializer=force|sp_fparen_brace_initializer=not_defined
+ChoicesRegex=sp_fparen_brace_initializer\s*=\s*ignore|sp_fparen_brace_initializer\s*=\s*add|sp_fparen_brace_initializer\s*=\s*remove|sp_fparen_brace_initializer\s*=\s*force|sp_fparen_brace_initializer\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Fparen Brace Initializer|Add Sp Fparen Brace Initializer|Remove Sp Fparen Brace Initializer|Force Sp Fparen Brace Initializer"
 ValueDefault=ignore
 
@@ -1600,7 +1775,8 @@ Category=1
 Description="<html>(Java) Add or remove space between ')' and '{{' of double brace initializer.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_fparen_dbrace\s*=\s*ignore|sp_fparen_dbrace\s*=\s*add|sp_fparen_dbrace\s*=\s*remove|sp_fparen_dbrace\s*=\s*force|sp_fparen_dbrace\s*=\s*not_defined
+Choices=sp_fparen_dbrace=ignore|sp_fparen_dbrace=add|sp_fparen_dbrace=remove|sp_fparen_dbrace=force|sp_fparen_dbrace=not_defined
+ChoicesRegex=sp_fparen_dbrace\s*=\s*ignore|sp_fparen_dbrace\s*=\s*add|sp_fparen_dbrace\s*=\s*remove|sp_fparen_dbrace\s*=\s*force|sp_fparen_dbrace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Fparen Dbrace|Add Sp Fparen Dbrace|Remove Sp Fparen Dbrace|Force Sp Fparen Dbrace"
 ValueDefault=ignore
 
@@ -1609,7 +1785,8 @@ Category=1
 Description="<html>Add or remove space between function name and '(' on function calls.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_paren\s*=\s*ignore|sp_func_call_paren\s*=\s*add|sp_func_call_paren\s*=\s*remove|sp_func_call_paren\s*=\s*force|sp_func_call_paren\s*=\s*not_defined
+Choices=sp_func_call_paren=ignore|sp_func_call_paren=add|sp_func_call_paren=remove|sp_func_call_paren=force|sp_func_call_paren=not_defined
+ChoicesRegex=sp_func_call_paren\s*=\s*ignore|sp_func_call_paren\s*=\s*add|sp_func_call_paren\s*=\s*remove|sp_func_call_paren\s*=\s*force|sp_func_call_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call Paren|Add Sp Func Call Paren|Remove Sp Func Call Paren|Force Sp Func Call Paren"
 ValueDefault=ignore
 
@@ -1618,7 +1795,8 @@ Category=1
 Description="<html>Add or remove space between function name and '()' on function calls without<br/>parameters. If set to ignore (the default), sp_func_call_paren is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_paren_empty\s*=\s*ignore|sp_func_call_paren_empty\s*=\s*add|sp_func_call_paren_empty\s*=\s*remove|sp_func_call_paren_empty\s*=\s*force|sp_func_call_paren_empty\s*=\s*not_defined
+Choices=sp_func_call_paren_empty=ignore|sp_func_call_paren_empty=add|sp_func_call_paren_empty=remove|sp_func_call_paren_empty=force|sp_func_call_paren_empty=not_defined
+ChoicesRegex=sp_func_call_paren_empty\s*=\s*ignore|sp_func_call_paren_empty\s*=\s*add|sp_func_call_paren_empty\s*=\s*remove|sp_func_call_paren_empty\s*=\s*force|sp_func_call_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call Paren Empty|Add Sp Func Call Paren Empty|Remove Sp Func Call Paren Empty|Force Sp Func Call Paren Empty"
 ValueDefault=ignore
 
@@ -1627,7 +1805,8 @@ Category=1
 Description="<html>Add or remove space between the user function name and '(' on function<br/>calls. You need to set a keyword to be a user function in the config file,<br/>like:<br/>  set func_call_user tr _ i18n</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_user_paren\s*=\s*ignore|sp_func_call_user_paren\s*=\s*add|sp_func_call_user_paren\s*=\s*remove|sp_func_call_user_paren\s*=\s*force|sp_func_call_user_paren\s*=\s*not_defined
+Choices=sp_func_call_user_paren=ignore|sp_func_call_user_paren=add|sp_func_call_user_paren=remove|sp_func_call_user_paren=force|sp_func_call_user_paren=not_defined
+ChoicesRegex=sp_func_call_user_paren\s*=\s*ignore|sp_func_call_user_paren\s*=\s*add|sp_func_call_user_paren\s*=\s*remove|sp_func_call_user_paren\s*=\s*force|sp_func_call_user_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call User Paren|Add Sp Func Call User Paren|Remove Sp Func Call User Paren|Force Sp Func Call User Paren"
 ValueDefault=ignore
 
@@ -1636,7 +1815,8 @@ Category=1
 Description="<html>Add or remove space inside user function '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_user_inside_fparen\s*=\s*ignore|sp_func_call_user_inside_fparen\s*=\s*add|sp_func_call_user_inside_fparen\s*=\s*remove|sp_func_call_user_inside_fparen\s*=\s*force|sp_func_call_user_inside_fparen\s*=\s*not_defined
+Choices=sp_func_call_user_inside_fparen=ignore|sp_func_call_user_inside_fparen=add|sp_func_call_user_inside_fparen=remove|sp_func_call_user_inside_fparen=force|sp_func_call_user_inside_fparen=not_defined
+ChoicesRegex=sp_func_call_user_inside_fparen\s*=\s*ignore|sp_func_call_user_inside_fparen\s*=\s*add|sp_func_call_user_inside_fparen\s*=\s*remove|sp_func_call_user_inside_fparen\s*=\s*force|sp_func_call_user_inside_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call User Inside Fparen|Add Sp Func Call User Inside Fparen|Remove Sp Func Call User Inside Fparen|Force Sp Func Call User Inside Fparen"
 ValueDefault=ignore
 
@@ -1645,7 +1825,8 @@ Category=1
 Description="<html>Add or remove space between nested parentheses with user functions,<br/>i.e. '((' vs. '( ('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_user_paren_paren\s*=\s*ignore|sp_func_call_user_paren_paren\s*=\s*add|sp_func_call_user_paren_paren\s*=\s*remove|sp_func_call_user_paren_paren\s*=\s*force|sp_func_call_user_paren_paren\s*=\s*not_defined
+Choices=sp_func_call_user_paren_paren=ignore|sp_func_call_user_paren_paren=add|sp_func_call_user_paren_paren=remove|sp_func_call_user_paren_paren=force|sp_func_call_user_paren_paren=not_defined
+ChoicesRegex=sp_func_call_user_paren_paren\s*=\s*ignore|sp_func_call_user_paren_paren\s*=\s*add|sp_func_call_user_paren_paren\s*=\s*remove|sp_func_call_user_paren_paren\s*=\s*force|sp_func_call_user_paren_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call User Paren Paren|Add Sp Func Call User Paren Paren|Remove Sp Func Call User Paren Paren|Force Sp Func Call User Paren Paren"
 ValueDefault=ignore
 
@@ -1654,7 +1835,8 @@ Category=1
 Description="<html>Add or remove space between a constructor/destructor and the open<br/>parenthesis.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_class_paren\s*=\s*ignore|sp_func_class_paren\s*=\s*add|sp_func_class_paren\s*=\s*remove|sp_func_class_paren\s*=\s*force|sp_func_class_paren\s*=\s*not_defined
+Choices=sp_func_class_paren=ignore|sp_func_class_paren=add|sp_func_class_paren=remove|sp_func_class_paren=force|sp_func_class_paren=not_defined
+ChoicesRegex=sp_func_class_paren\s*=\s*ignore|sp_func_class_paren\s*=\s*add|sp_func_class_paren\s*=\s*remove|sp_func_class_paren\s*=\s*force|sp_func_class_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Class Paren|Add Sp Func Class Paren|Remove Sp Func Class Paren|Force Sp Func Class Paren"
 ValueDefault=ignore
 
@@ -1663,7 +1845,8 @@ Category=1
 Description="<html>Add or remove space between a constructor without parameters or destructor<br/>and '()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_class_paren_empty\s*=\s*ignore|sp_func_class_paren_empty\s*=\s*add|sp_func_class_paren_empty\s*=\s*remove|sp_func_class_paren_empty\s*=\s*force|sp_func_class_paren_empty\s*=\s*not_defined
+Choices=sp_func_class_paren_empty=ignore|sp_func_class_paren_empty=add|sp_func_class_paren_empty=remove|sp_func_class_paren_empty=force|sp_func_class_paren_empty=not_defined
+ChoicesRegex=sp_func_class_paren_empty\s*=\s*ignore|sp_func_class_paren_empty\s*=\s*add|sp_func_class_paren_empty\s*=\s*remove|sp_func_class_paren_empty\s*=\s*force|sp_func_class_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Class Paren Empty|Add Sp Func Class Paren Empty|Remove Sp Func Class Paren Empty|Force Sp Func Class Paren Empty"
 ValueDefault=ignore
 
@@ -1672,7 +1855,8 @@ Category=1
 Description="<html>Add or remove space after 'return'.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_return\s*=\s*ignore|sp_return\s*=\s*add|sp_return\s*=\s*remove|sp_return\s*=\s*force|sp_return\s*=\s*not_defined
+Choices=sp_return=ignore|sp_return=add|sp_return=remove|sp_return=force|sp_return=not_defined
+ChoicesRegex=sp_return\s*=\s*ignore|sp_return\s*=\s*add|sp_return\s*=\s*remove|sp_return\s*=\s*force|sp_return\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Return|Add Sp Return|Remove Sp Return|Force Sp Return"
 ValueDefault=force
 
@@ -1681,7 +1865,8 @@ Category=1
 Description="<html>Add or remove space between 'return' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_return_paren\s*=\s*ignore|sp_return_paren\s*=\s*add|sp_return_paren\s*=\s*remove|sp_return_paren\s*=\s*force|sp_return_paren\s*=\s*not_defined
+Choices=sp_return_paren=ignore|sp_return_paren=add|sp_return_paren=remove|sp_return_paren=force|sp_return_paren=not_defined
+ChoicesRegex=sp_return_paren\s*=\s*ignore|sp_return_paren\s*=\s*add|sp_return_paren\s*=\s*remove|sp_return_paren\s*=\s*force|sp_return_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Return Paren|Add Sp Return Paren|Remove Sp Return Paren|Force Sp Return Paren"
 ValueDefault=ignore
 
@@ -1690,7 +1875,8 @@ Category=1
 Description="<html>Add or remove space between 'return' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_return_brace\s*=\s*ignore|sp_return_brace\s*=\s*add|sp_return_brace\s*=\s*remove|sp_return_brace\s*=\s*force|sp_return_brace\s*=\s*not_defined
+Choices=sp_return_brace=ignore|sp_return_brace=add|sp_return_brace=remove|sp_return_brace=force|sp_return_brace=not_defined
+ChoicesRegex=sp_return_brace\s*=\s*ignore|sp_return_brace\s*=\s*add|sp_return_brace\s*=\s*remove|sp_return_brace\s*=\s*force|sp_return_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Return Brace|Add Sp Return Brace|Remove Sp Return Brace|Force Sp Return Brace"
 ValueDefault=ignore
 
@@ -1699,7 +1885,8 @@ Category=1
 Description="<html>Add or remove space between '__attribute__' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_attribute_paren\s*=\s*ignore|sp_attribute_paren\s*=\s*add|sp_attribute_paren\s*=\s*remove|sp_attribute_paren\s*=\s*force|sp_attribute_paren\s*=\s*not_defined
+Choices=sp_attribute_paren=ignore|sp_attribute_paren=add|sp_attribute_paren=remove|sp_attribute_paren=force|sp_attribute_paren=not_defined
+ChoicesRegex=sp_attribute_paren\s*=\s*ignore|sp_attribute_paren\s*=\s*add|sp_attribute_paren\s*=\s*remove|sp_attribute_paren\s*=\s*force|sp_attribute_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Attribute Paren|Add Sp Attribute Paren|Remove Sp Attribute Paren|Force Sp Attribute Paren"
 ValueDefault=ignore
 
@@ -1708,7 +1895,8 @@ Category=1
 Description="<html>Add or remove space between 'defined' and '(' in '#if defined (FOO)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_defined_paren\s*=\s*ignore|sp_defined_paren\s*=\s*add|sp_defined_paren\s*=\s*remove|sp_defined_paren\s*=\s*force|sp_defined_paren\s*=\s*not_defined
+Choices=sp_defined_paren=ignore|sp_defined_paren=add|sp_defined_paren=remove|sp_defined_paren=force|sp_defined_paren=not_defined
+ChoicesRegex=sp_defined_paren\s*=\s*ignore|sp_defined_paren\s*=\s*add|sp_defined_paren\s*=\s*remove|sp_defined_paren\s*=\s*force|sp_defined_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Defined Paren|Add Sp Defined Paren|Remove Sp Defined Paren|Force Sp Defined Paren"
 ValueDefault=ignore
 
@@ -1717,7 +1905,8 @@ Category=1
 Description="<html>Add or remove space between 'throw' and '(' in 'throw (something)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_throw_paren\s*=\s*ignore|sp_throw_paren\s*=\s*add|sp_throw_paren\s*=\s*remove|sp_throw_paren\s*=\s*force|sp_throw_paren\s*=\s*not_defined
+Choices=sp_throw_paren=ignore|sp_throw_paren=add|sp_throw_paren=remove|sp_throw_paren=force|sp_throw_paren=not_defined
+ChoicesRegex=sp_throw_paren\s*=\s*ignore|sp_throw_paren\s*=\s*add|sp_throw_paren\s*=\s*remove|sp_throw_paren\s*=\s*force|sp_throw_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Throw Paren|Add Sp Throw Paren|Remove Sp Throw Paren|Force Sp Throw Paren"
 ValueDefault=ignore
 
@@ -1726,7 +1915,8 @@ Category=1
 Description="<html>Add or remove space between 'throw' and anything other than '(' as in<br/>'@throw [...];'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_throw\s*=\s*ignore|sp_after_throw\s*=\s*add|sp_after_throw\s*=\s*remove|sp_after_throw\s*=\s*force|sp_after_throw\s*=\s*not_defined
+Choices=sp_after_throw=ignore|sp_after_throw=add|sp_after_throw=remove|sp_after_throw=force|sp_after_throw=not_defined
+ChoicesRegex=sp_after_throw\s*=\s*ignore|sp_after_throw\s*=\s*add|sp_after_throw\s*=\s*remove|sp_after_throw\s*=\s*force|sp_after_throw\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Throw|Add Sp After Throw|Remove Sp After Throw|Force Sp After Throw"
 ValueDefault=ignore
 
@@ -1735,7 +1925,8 @@ Category=1
 Description="<html>Add or remove space between 'catch' and '(' in 'catch (something) { }'.<br/>If set to ignore, sp_before_sparen is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_catch_paren\s*=\s*ignore|sp_catch_paren\s*=\s*add|sp_catch_paren\s*=\s*remove|sp_catch_paren\s*=\s*force|sp_catch_paren\s*=\s*not_defined
+Choices=sp_catch_paren=ignore|sp_catch_paren=add|sp_catch_paren=remove|sp_catch_paren=force|sp_catch_paren=not_defined
+ChoicesRegex=sp_catch_paren\s*=\s*ignore|sp_catch_paren\s*=\s*add|sp_catch_paren\s*=\s*remove|sp_catch_paren\s*=\s*force|sp_catch_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Catch Paren|Add Sp Catch Paren|Remove Sp Catch Paren|Force Sp Catch Paren"
 ValueDefault=ignore
 
@@ -1744,7 +1935,8 @@ Category=1
 Description="<html>(OC) Add or remove space between '@catch' and '('<br/>in '@catch (something) { }'. If set to ignore, sp_catch_paren is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_oc_catch_paren\s*=\s*ignore|sp_oc_catch_paren\s*=\s*add|sp_oc_catch_paren\s*=\s*remove|sp_oc_catch_paren\s*=\s*force|sp_oc_catch_paren\s*=\s*not_defined
+Choices=sp_oc_catch_paren=ignore|sp_oc_catch_paren=add|sp_oc_catch_paren=remove|sp_oc_catch_paren=force|sp_oc_catch_paren=not_defined
+ChoicesRegex=sp_oc_catch_paren\s*=\s*ignore|sp_oc_catch_paren\s*=\s*add|sp_oc_catch_paren\s*=\s*remove|sp_oc_catch_paren\s*=\s*force|sp_oc_catch_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Oc Catch Paren|Add Sp Oc Catch Paren|Remove Sp Oc Catch Paren|Force Sp Oc Catch Paren"
 ValueDefault=ignore
 
@@ -1753,7 +1945,8 @@ Category=1
 Description="<html>(OC) Add or remove space before Objective-C protocol list<br/>as in '@protocol Protocol&lt;here&gt;&lt;Protocol_A&gt;' or '@interface MyClass : NSObject&lt;here&gt;&lt;MyProtocol&gt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_oc_proto_list\s*=\s*ignore|sp_before_oc_proto_list\s*=\s*add|sp_before_oc_proto_list\s*=\s*remove|sp_before_oc_proto_list\s*=\s*force|sp_before_oc_proto_list\s*=\s*not_defined
+Choices=sp_before_oc_proto_list=ignore|sp_before_oc_proto_list=add|sp_before_oc_proto_list=remove|sp_before_oc_proto_list=force|sp_before_oc_proto_list=not_defined
+ChoicesRegex=sp_before_oc_proto_list\s*=\s*ignore|sp_before_oc_proto_list\s*=\s*add|sp_before_oc_proto_list\s*=\s*remove|sp_before_oc_proto_list\s*=\s*force|sp_before_oc_proto_list\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Oc Proto List|Add Sp Before Oc Proto List|Remove Sp Before Oc Proto List|Force Sp Before Oc Proto List"
 ValueDefault=ignore
 
@@ -1762,7 +1955,8 @@ Category=1
 Description="<html>(OC) Add or remove space between class name and '('<br/>in '@interface className(categoryName)&lt;ProtocolName&gt;:BaseClass'</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_oc_classname_paren\s*=\s*ignore|sp_oc_classname_paren\s*=\s*add|sp_oc_classname_paren\s*=\s*remove|sp_oc_classname_paren\s*=\s*force|sp_oc_classname_paren\s*=\s*not_defined
+Choices=sp_oc_classname_paren=ignore|sp_oc_classname_paren=add|sp_oc_classname_paren=remove|sp_oc_classname_paren=force|sp_oc_classname_paren=not_defined
+ChoicesRegex=sp_oc_classname_paren\s*=\s*ignore|sp_oc_classname_paren\s*=\s*add|sp_oc_classname_paren\s*=\s*remove|sp_oc_classname_paren\s*=\s*force|sp_oc_classname_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Oc Classname Paren|Add Sp Oc Classname Paren|Remove Sp Oc Classname Paren|Force Sp Oc Classname Paren"
 ValueDefault=ignore
 
@@ -1771,7 +1965,8 @@ Category=1
 Description="<html>(D) Add or remove space between 'version' and '('<br/>in 'version (something) { }'. If set to ignore, sp_before_sparen is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_version_paren\s*=\s*ignore|sp_version_paren\s*=\s*add|sp_version_paren\s*=\s*remove|sp_version_paren\s*=\s*force|sp_version_paren\s*=\s*not_defined
+Choices=sp_version_paren=ignore|sp_version_paren=add|sp_version_paren=remove|sp_version_paren=force|sp_version_paren=not_defined
+ChoicesRegex=sp_version_paren\s*=\s*ignore|sp_version_paren\s*=\s*add|sp_version_paren\s*=\s*remove|sp_version_paren\s*=\s*force|sp_version_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Version Paren|Add Sp Version Paren|Remove Sp Version Paren|Force Sp Version Paren"
 ValueDefault=ignore
 
@@ -1780,7 +1975,8 @@ Category=1
 Description="<html>(D) Add or remove space between 'scope' and '('<br/>in 'scope (something) { }'. If set to ignore, sp_before_sparen is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_scope_paren\s*=\s*ignore|sp_scope_paren\s*=\s*add|sp_scope_paren\s*=\s*remove|sp_scope_paren\s*=\s*force|sp_scope_paren\s*=\s*not_defined
+Choices=sp_scope_paren=ignore|sp_scope_paren=add|sp_scope_paren=remove|sp_scope_paren=force|sp_scope_paren=not_defined
+ChoicesRegex=sp_scope_paren\s*=\s*ignore|sp_scope_paren\s*=\s*add|sp_scope_paren\s*=\s*remove|sp_scope_paren\s*=\s*force|sp_scope_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Scope Paren|Add Sp Scope Paren|Remove Sp Scope Paren|Force Sp Scope Paren"
 ValueDefault=ignore
 
@@ -1789,7 +1985,8 @@ Category=1
 Description="<html>Add or remove space between 'super' and '(' in 'super (something)'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_super_paren\s*=\s*ignore|sp_super_paren\s*=\s*add|sp_super_paren\s*=\s*remove|sp_super_paren\s*=\s*force|sp_super_paren\s*=\s*not_defined
+Choices=sp_super_paren=ignore|sp_super_paren=add|sp_super_paren=remove|sp_super_paren=force|sp_super_paren=not_defined
+ChoicesRegex=sp_super_paren\s*=\s*ignore|sp_super_paren\s*=\s*add|sp_super_paren\s*=\s*remove|sp_super_paren\s*=\s*force|sp_super_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Super Paren|Add Sp Super Paren|Remove Sp Super Paren|Force Sp Super Paren"
 ValueDefault=remove
 
@@ -1798,7 +1995,8 @@ Category=1
 Description="<html>Add or remove space between 'this' and '(' in 'this (something)'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_this_paren\s*=\s*ignore|sp_this_paren\s*=\s*add|sp_this_paren\s*=\s*remove|sp_this_paren\s*=\s*force|sp_this_paren\s*=\s*not_defined
+Choices=sp_this_paren=ignore|sp_this_paren=add|sp_this_paren=remove|sp_this_paren=force|sp_this_paren=not_defined
+ChoicesRegex=sp_this_paren\s*=\s*ignore|sp_this_paren\s*=\s*add|sp_this_paren\s*=\s*remove|sp_this_paren\s*=\s*force|sp_this_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp This Paren|Add Sp This Paren|Remove Sp This Paren|Force Sp This Paren"
 ValueDefault=remove
 
@@ -1807,7 +2005,8 @@ Category=1
 Description="<html>Add or remove space between a macro name and its definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_macro\s*=\s*ignore|sp_macro\s*=\s*add|sp_macro\s*=\s*remove|sp_macro\s*=\s*force|sp_macro\s*=\s*not_defined
+Choices=sp_macro=ignore|sp_macro=add|sp_macro=remove|sp_macro=force|sp_macro=not_defined
+ChoicesRegex=sp_macro\s*=\s*ignore|sp_macro\s*=\s*add|sp_macro\s*=\s*remove|sp_macro\s*=\s*force|sp_macro\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Macro|Add Sp Macro|Remove Sp Macro|Force Sp Macro"
 ValueDefault=ignore
 
@@ -1816,7 +2015,8 @@ Category=1
 Description="<html>Add or remove space between a macro function ')' and its definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_macro_func\s*=\s*ignore|sp_macro_func\s*=\s*add|sp_macro_func\s*=\s*remove|sp_macro_func\s*=\s*force|sp_macro_func\s*=\s*not_defined
+Choices=sp_macro_func=ignore|sp_macro_func=add|sp_macro_func=remove|sp_macro_func=force|sp_macro_func=not_defined
+ChoicesRegex=sp_macro_func\s*=\s*ignore|sp_macro_func\s*=\s*add|sp_macro_func\s*=\s*remove|sp_macro_func\s*=\s*force|sp_macro_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Macro Func|Add Sp Macro Func|Remove Sp Macro Func|Force Sp Macro Func"
 ValueDefault=ignore
 
@@ -1825,7 +2025,8 @@ Category=1
 Description="<html>Add or remove space between 'else' and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_else_brace\s*=\s*ignore|sp_else_brace\s*=\s*add|sp_else_brace\s*=\s*remove|sp_else_brace\s*=\s*force|sp_else_brace\s*=\s*not_defined
+Choices=sp_else_brace=ignore|sp_else_brace=add|sp_else_brace=remove|sp_else_brace=force|sp_else_brace=not_defined
+ChoicesRegex=sp_else_brace\s*=\s*ignore|sp_else_brace\s*=\s*add|sp_else_brace\s*=\s*remove|sp_else_brace\s*=\s*force|sp_else_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Else Brace|Add Sp Else Brace|Remove Sp Else Brace|Force Sp Else Brace"
 ValueDefault=ignore
 
@@ -1834,7 +2035,8 @@ Category=1
 Description="<html>Add or remove space between '}' and 'else' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_else\s*=\s*ignore|sp_brace_else\s*=\s*add|sp_brace_else\s*=\s*remove|sp_brace_else\s*=\s*force|sp_brace_else\s*=\s*not_defined
+Choices=sp_brace_else=ignore|sp_brace_else=add|sp_brace_else=remove|sp_brace_else=force|sp_brace_else=not_defined
+ChoicesRegex=sp_brace_else\s*=\s*ignore|sp_brace_else\s*=\s*add|sp_brace_else\s*=\s*remove|sp_brace_else\s*=\s*force|sp_brace_else\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Else|Add Sp Brace Else|Remove Sp Brace Else|Force Sp Brace Else"
 ValueDefault=ignore
 
@@ -1843,7 +2045,8 @@ Category=1
 Description="<html>Add or remove space between '}' and the name of a typedef on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_typedef\s*=\s*ignore|sp_brace_typedef\s*=\s*add|sp_brace_typedef\s*=\s*remove|sp_brace_typedef\s*=\s*force|sp_brace_typedef\s*=\s*not_defined
+Choices=sp_brace_typedef=ignore|sp_brace_typedef=add|sp_brace_typedef=remove|sp_brace_typedef=force|sp_brace_typedef=not_defined
+ChoicesRegex=sp_brace_typedef\s*=\s*ignore|sp_brace_typedef\s*=\s*add|sp_brace_typedef\s*=\s*remove|sp_brace_typedef\s*=\s*force|sp_brace_typedef\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Typedef|Add Sp Brace Typedef|Remove Sp Brace Typedef|Force Sp Brace Typedef"
 ValueDefault=ignore
 
@@ -1852,7 +2055,8 @@ Category=1
 Description="<html>Add or remove space before the '{' of a 'catch' statement, if the '{' and<br/>'catch' are on the same line, as in 'catch (decl) &lt;here&gt; {'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_catch_brace\s*=\s*ignore|sp_catch_brace\s*=\s*add|sp_catch_brace\s*=\s*remove|sp_catch_brace\s*=\s*force|sp_catch_brace\s*=\s*not_defined
+Choices=sp_catch_brace=ignore|sp_catch_brace=add|sp_catch_brace=remove|sp_catch_brace=force|sp_catch_brace=not_defined
+ChoicesRegex=sp_catch_brace\s*=\s*ignore|sp_catch_brace\s*=\s*add|sp_catch_brace\s*=\s*remove|sp_catch_brace\s*=\s*force|sp_catch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Catch Brace|Add Sp Catch Brace|Remove Sp Catch Brace|Force Sp Catch Brace"
 ValueDefault=ignore
 
@@ -1861,7 +2065,8 @@ Category=1
 Description="<html>(OC) Add or remove space before the '{' of a '@catch' statement, if the '{'<br/>and '@catch' are on the same line, as in '@catch (decl) &lt;here&gt; {'.<br/>If set to ignore, sp_catch_brace is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_oc_catch_brace\s*=\s*ignore|sp_oc_catch_brace\s*=\s*add|sp_oc_catch_brace\s*=\s*remove|sp_oc_catch_brace\s*=\s*force|sp_oc_catch_brace\s*=\s*not_defined
+Choices=sp_oc_catch_brace=ignore|sp_oc_catch_brace=add|sp_oc_catch_brace=remove|sp_oc_catch_brace=force|sp_oc_catch_brace=not_defined
+ChoicesRegex=sp_oc_catch_brace\s*=\s*ignore|sp_oc_catch_brace\s*=\s*add|sp_oc_catch_brace\s*=\s*remove|sp_oc_catch_brace\s*=\s*force|sp_oc_catch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Oc Catch Brace|Add Sp Oc Catch Brace|Remove Sp Oc Catch Brace|Force Sp Oc Catch Brace"
 ValueDefault=ignore
 
@@ -1870,7 +2075,8 @@ Category=1
 Description="<html>Add or remove space between '}' and 'catch' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_catch\s*=\s*ignore|sp_brace_catch\s*=\s*add|sp_brace_catch\s*=\s*remove|sp_brace_catch\s*=\s*force|sp_brace_catch\s*=\s*not_defined
+Choices=sp_brace_catch=ignore|sp_brace_catch=add|sp_brace_catch=remove|sp_brace_catch=force|sp_brace_catch=not_defined
+ChoicesRegex=sp_brace_catch\s*=\s*ignore|sp_brace_catch\s*=\s*add|sp_brace_catch\s*=\s*remove|sp_brace_catch\s*=\s*force|sp_brace_catch\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Catch|Add Sp Brace Catch|Remove Sp Brace Catch|Force Sp Brace Catch"
 ValueDefault=ignore
 
@@ -1879,7 +2085,8 @@ Category=1
 Description="<html>(OC) Add or remove space between '}' and '@catch' if on the same line.<br/>If set to ignore, sp_brace_catch is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_oc_brace_catch\s*=\s*ignore|sp_oc_brace_catch\s*=\s*add|sp_oc_brace_catch\s*=\s*remove|sp_oc_brace_catch\s*=\s*force|sp_oc_brace_catch\s*=\s*not_defined
+Choices=sp_oc_brace_catch=ignore|sp_oc_brace_catch=add|sp_oc_brace_catch=remove|sp_oc_brace_catch=force|sp_oc_brace_catch=not_defined
+ChoicesRegex=sp_oc_brace_catch\s*=\s*ignore|sp_oc_brace_catch\s*=\s*add|sp_oc_brace_catch\s*=\s*remove|sp_oc_brace_catch\s*=\s*force|sp_oc_brace_catch\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Oc Brace Catch|Add Sp Oc Brace Catch|Remove Sp Oc Brace Catch|Force Sp Oc Brace Catch"
 ValueDefault=ignore
 
@@ -1888,7 +2095,8 @@ Category=1
 Description="<html>Add or remove space between 'finally' and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_finally_brace\s*=\s*ignore|sp_finally_brace\s*=\s*add|sp_finally_brace\s*=\s*remove|sp_finally_brace\s*=\s*force|sp_finally_brace\s*=\s*not_defined
+Choices=sp_finally_brace=ignore|sp_finally_brace=add|sp_finally_brace=remove|sp_finally_brace=force|sp_finally_brace=not_defined
+ChoicesRegex=sp_finally_brace\s*=\s*ignore|sp_finally_brace\s*=\s*add|sp_finally_brace\s*=\s*remove|sp_finally_brace\s*=\s*force|sp_finally_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Finally Brace|Add Sp Finally Brace|Remove Sp Finally Brace|Force Sp Finally Brace"
 ValueDefault=ignore
 
@@ -1897,7 +2105,8 @@ Category=1
 Description="<html>Add or remove space between '}' and 'finally' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_finally\s*=\s*ignore|sp_brace_finally\s*=\s*add|sp_brace_finally\s*=\s*remove|sp_brace_finally\s*=\s*force|sp_brace_finally\s*=\s*not_defined
+Choices=sp_brace_finally=ignore|sp_brace_finally=add|sp_brace_finally=remove|sp_brace_finally=force|sp_brace_finally=not_defined
+ChoicesRegex=sp_brace_finally\s*=\s*ignore|sp_brace_finally\s*=\s*add|sp_brace_finally\s*=\s*remove|sp_brace_finally\s*=\s*force|sp_brace_finally\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Finally|Add Sp Brace Finally|Remove Sp Brace Finally|Force Sp Brace Finally"
 ValueDefault=ignore
 
@@ -1906,7 +2115,8 @@ Category=1
 Description="<html>Add or remove space between 'try' and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_try_brace\s*=\s*ignore|sp_try_brace\s*=\s*add|sp_try_brace\s*=\s*remove|sp_try_brace\s*=\s*force|sp_try_brace\s*=\s*not_defined
+Choices=sp_try_brace=ignore|sp_try_brace=add|sp_try_brace=remove|sp_try_brace=force|sp_try_brace=not_defined
+ChoicesRegex=sp_try_brace\s*=\s*ignore|sp_try_brace\s*=\s*add|sp_try_brace\s*=\s*remove|sp_try_brace\s*=\s*force|sp_try_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Try Brace|Add Sp Try Brace|Remove Sp Try Brace|Force Sp Try Brace"
 ValueDefault=ignore
 
@@ -1915,7 +2125,8 @@ Category=1
 Description="<html>Add or remove space between get/set and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_getset_brace\s*=\s*ignore|sp_getset_brace\s*=\s*add|sp_getset_brace\s*=\s*remove|sp_getset_brace\s*=\s*force|sp_getset_brace\s*=\s*not_defined
+Choices=sp_getset_brace=ignore|sp_getset_brace=add|sp_getset_brace=remove|sp_getset_brace=force|sp_getset_brace=not_defined
+ChoicesRegex=sp_getset_brace\s*=\s*ignore|sp_getset_brace\s*=\s*add|sp_getset_brace\s*=\s*remove|sp_getset_brace\s*=\s*force|sp_getset_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Getset Brace|Add Sp Getset Brace|Remove Sp Getset Brace|Force Sp Getset Brace"
 ValueDefault=ignore
 
@@ -1924,7 +2135,8 @@ Category=1
 Description="<html>Add or remove space between a variable and '{' for C++ uniform<br/>initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_word_brace_init_lst\s*=\s*ignore|sp_word_brace_init_lst\s*=\s*add|sp_word_brace_init_lst\s*=\s*remove|sp_word_brace_init_lst\s*=\s*force|sp_word_brace_init_lst\s*=\s*not_defined
+Choices=sp_word_brace_init_lst=ignore|sp_word_brace_init_lst=add|sp_word_brace_init_lst=remove|sp_word_brace_init_lst=force|sp_word_brace_init_lst=not_defined
+ChoicesRegex=sp_word_brace_init_lst\s*=\s*ignore|sp_word_brace_init_lst\s*=\s*add|sp_word_brace_init_lst\s*=\s*remove|sp_word_brace_init_lst\s*=\s*force|sp_word_brace_init_lst\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Word Brace Init Lst|Add Sp Word Brace Init Lst|Remove Sp Word Brace Init Lst|Force Sp Word Brace Init Lst"
 ValueDefault=ignore
 
@@ -1933,7 +2145,8 @@ Category=1
 Description="<html>Add or remove space between a variable and '{' for a namespace.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_word_brace_ns\s*=\s*ignore|sp_word_brace_ns\s*=\s*add|sp_word_brace_ns\s*=\s*remove|sp_word_brace_ns\s*=\s*force|sp_word_brace_ns\s*=\s*not_defined
+Choices=sp_word_brace_ns=ignore|sp_word_brace_ns=add|sp_word_brace_ns=remove|sp_word_brace_ns=force|sp_word_brace_ns=not_defined
+ChoicesRegex=sp_word_brace_ns\s*=\s*ignore|sp_word_brace_ns\s*=\s*add|sp_word_brace_ns\s*=\s*remove|sp_word_brace_ns\s*=\s*force|sp_word_brace_ns\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Word Brace Ns|Add Sp Word Brace Ns|Remove Sp Word Brace Ns|Force Sp Word Brace Ns"
 ValueDefault=add
 
@@ -1942,7 +2155,8 @@ Category=1
 Description="<html>Add or remove space before the '::' operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_dc\s*=\s*ignore|sp_before_dc\s*=\s*add|sp_before_dc\s*=\s*remove|sp_before_dc\s*=\s*force|sp_before_dc\s*=\s*not_defined
+Choices=sp_before_dc=ignore|sp_before_dc=add|sp_before_dc=remove|sp_before_dc=force|sp_before_dc=not_defined
+ChoicesRegex=sp_before_dc\s*=\s*ignore|sp_before_dc\s*=\s*add|sp_before_dc\s*=\s*remove|sp_before_dc\s*=\s*force|sp_before_dc\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Dc|Add Sp Before Dc|Remove Sp Before Dc|Force Sp Before Dc"
 ValueDefault=ignore
 
@@ -1951,7 +2165,8 @@ Category=1
 Description="<html>Add or remove space after the '::' operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_dc\s*=\s*ignore|sp_after_dc\s*=\s*add|sp_after_dc\s*=\s*remove|sp_after_dc\s*=\s*force|sp_after_dc\s*=\s*not_defined
+Choices=sp_after_dc=ignore|sp_after_dc=add|sp_after_dc=remove|sp_after_dc=force|sp_after_dc=not_defined
+ChoicesRegex=sp_after_dc\s*=\s*ignore|sp_after_dc\s*=\s*add|sp_after_dc\s*=\s*remove|sp_after_dc\s*=\s*force|sp_after_dc\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Dc|Add Sp After Dc|Remove Sp After Dc|Force Sp After Dc"
 ValueDefault=ignore
 
@@ -1960,7 +2175,8 @@ Category=1
 Description="<html>(D) Add or remove around the D named array initializer ':' operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_d_array_colon\s*=\s*ignore|sp_d_array_colon\s*=\s*add|sp_d_array_colon\s*=\s*remove|sp_d_array_colon\s*=\s*force|sp_d_array_colon\s*=\s*not_defined
+Choices=sp_d_array_colon=ignore|sp_d_array_colon=add|sp_d_array_colon=remove|sp_d_array_colon=force|sp_d_array_colon=not_defined
+ChoicesRegex=sp_d_array_colon\s*=\s*ignore|sp_d_array_colon\s*=\s*add|sp_d_array_colon\s*=\s*remove|sp_d_array_colon\s*=\s*force|sp_d_array_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp D Array Colon|Add Sp D Array Colon|Remove Sp D Array Colon|Force Sp D Array Colon"
 ValueDefault=ignore
 
@@ -1969,7 +2185,8 @@ Category=1
 Description="<html>Add or remove space after the '!' (not) unary operator.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_not\s*=\s*ignore|sp_not\s*=\s*add|sp_not\s*=\s*remove|sp_not\s*=\s*force|sp_not\s*=\s*not_defined
+Choices=sp_not=ignore|sp_not=add|sp_not=remove|sp_not=force|sp_not=not_defined
+ChoicesRegex=sp_not\s*=\s*ignore|sp_not\s*=\s*add|sp_not\s*=\s*remove|sp_not\s*=\s*force|sp_not\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Not|Add Sp Not|Remove Sp Not|Force Sp Not"
 ValueDefault=remove
 
@@ -1978,7 +2195,8 @@ Category=1
 Description="<html>Add or remove space between two '!' (not) unary operators.<br/>If set to ignore, sp_not will be used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_not_not\s*=\s*ignore|sp_not_not\s*=\s*add|sp_not_not\s*=\s*remove|sp_not_not\s*=\s*force|sp_not_not\s*=\s*not_defined
+Choices=sp_not_not=ignore|sp_not_not=add|sp_not_not=remove|sp_not_not=force|sp_not_not=not_defined
+ChoicesRegex=sp_not_not\s*=\s*ignore|sp_not_not\s*=\s*add|sp_not_not\s*=\s*remove|sp_not_not\s*=\s*force|sp_not_not\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Not Not|Add Sp Not Not|Remove Sp Not Not|Force Sp Not Not"
 ValueDefault=ignore
 
@@ -1987,7 +2205,8 @@ Category=1
 Description="<html>Add or remove space after the '~' (invert) unary operator.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inv\s*=\s*ignore|sp_inv\s*=\s*add|sp_inv\s*=\s*remove|sp_inv\s*=\s*force|sp_inv\s*=\s*not_defined
+Choices=sp_inv=ignore|sp_inv=add|sp_inv=remove|sp_inv=force|sp_inv=not_defined
+ChoicesRegex=sp_inv\s*=\s*ignore|sp_inv\s*=\s*add|sp_inv\s*=\s*remove|sp_inv\s*=\s*force|sp_inv\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inv|Add Sp Inv|Remove Sp Inv|Force Sp Inv"
 ValueDefault=remove
 
@@ -1996,7 +2215,8 @@ Category=1
 Description="<html>Add or remove space after the '&amp;' (address-of) unary operator. This does not<br/>affect the spacing after a '&amp;' that is part of a type.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_addr\s*=\s*ignore|sp_addr\s*=\s*add|sp_addr\s*=\s*remove|sp_addr\s*=\s*force|sp_addr\s*=\s*not_defined
+Choices=sp_addr=ignore|sp_addr=add|sp_addr=remove|sp_addr=force|sp_addr=not_defined
+ChoicesRegex=sp_addr\s*=\s*ignore|sp_addr\s*=\s*add|sp_addr\s*=\s*remove|sp_addr\s*=\s*force|sp_addr\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Addr|Add Sp Addr|Remove Sp Addr|Force Sp Addr"
 ValueDefault=remove
 
@@ -2005,7 +2225,8 @@ Category=1
 Description="<html>Add or remove space around the '.' or '-&gt;' operators.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_member\s*=\s*ignore|sp_member\s*=\s*add|sp_member\s*=\s*remove|sp_member\s*=\s*force|sp_member\s*=\s*not_defined
+Choices=sp_member=ignore|sp_member=add|sp_member=remove|sp_member=force|sp_member=not_defined
+ChoicesRegex=sp_member\s*=\s*ignore|sp_member\s*=\s*add|sp_member\s*=\s*remove|sp_member\s*=\s*force|sp_member\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Member|Add Sp Member|Remove Sp Member|Force Sp Member"
 ValueDefault=remove
 
@@ -2014,7 +2235,8 @@ Category=1
 Description="<html>Add or remove space after the '*' (dereference) unary operator. This does<br/>not affect the spacing after a '*' that is part of a type.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_deref\s*=\s*ignore|sp_deref\s*=\s*add|sp_deref\s*=\s*remove|sp_deref\s*=\s*force|sp_deref\s*=\s*not_defined
+Choices=sp_deref=ignore|sp_deref=add|sp_deref=remove|sp_deref=force|sp_deref=not_defined
+ChoicesRegex=sp_deref\s*=\s*ignore|sp_deref\s*=\s*add|sp_deref\s*=\s*remove|sp_deref\s*=\s*force|sp_deref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Deref|Add Sp Deref|Remove Sp Deref|Force Sp Deref"
 ValueDefault=remove
 
@@ -2023,7 +2245,8 @@ Category=1
 Description="<html>Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sign\s*=\s*ignore|sp_sign\s*=\s*add|sp_sign\s*=\s*remove|sp_sign\s*=\s*force|sp_sign\s*=\s*not_defined
+Choices=sp_sign=ignore|sp_sign=add|sp_sign=remove|sp_sign=force|sp_sign=not_defined
+ChoicesRegex=sp_sign\s*=\s*ignore|sp_sign\s*=\s*add|sp_sign\s*=\s*remove|sp_sign\s*=\s*force|sp_sign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sign|Add Sp Sign|Remove Sp Sign|Force Sp Sign"
 ValueDefault=remove
 
@@ -2032,7 +2255,8 @@ Category=1
 Description="<html>Add or remove space between '++' and '--' the word to which it is being<br/>applied, as in '(--x)' or 'y++;'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_incdec\s*=\s*ignore|sp_incdec\s*=\s*add|sp_incdec\s*=\s*remove|sp_incdec\s*=\s*force|sp_incdec\s*=\s*not_defined
+Choices=sp_incdec=ignore|sp_incdec=add|sp_incdec=remove|sp_incdec=force|sp_incdec=not_defined
+ChoicesRegex=sp_incdec\s*=\s*ignore|sp_incdec\s*=\s*add|sp_incdec\s*=\s*remove|sp_incdec\s*=\s*force|sp_incdec\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Incdec|Add Sp Incdec|Remove Sp Incdec|Force Sp Incdec"
 ValueDefault=remove
 
@@ -2041,7 +2265,8 @@ Category=1
 Description="<html>Add or remove space before a backslash-newline at the end of a line.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_nl_cont\s*=\s*ignore|sp_before_nl_cont\s*=\s*add|sp_before_nl_cont\s*=\s*remove|sp_before_nl_cont\s*=\s*force|sp_before_nl_cont\s*=\s*not_defined
+Choices=sp_before_nl_cont=ignore|sp_before_nl_cont=add|sp_before_nl_cont=remove|sp_before_nl_cont=force|sp_before_nl_cont=not_defined
+ChoicesRegex=sp_before_nl_cont\s*=\s*ignore|sp_before_nl_cont\s*=\s*add|sp_before_nl_cont\s*=\s*remove|sp_before_nl_cont\s*=\s*force|sp_before_nl_cont\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Nl Cont|Add Sp Before Nl Cont|Remove Sp Before Nl Cont|Force Sp Before Nl Cont"
 ValueDefault=add
 
@@ -2050,7 +2275,8 @@ Category=1
 Description="<html>(OC) Add or remove space after the scope '+' or '-', as in '-(void) foo;'<br/>or '+(int) bar;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_scope\s*=\s*ignore|sp_after_oc_scope\s*=\s*add|sp_after_oc_scope\s*=\s*remove|sp_after_oc_scope\s*=\s*force|sp_after_oc_scope\s*=\s*not_defined
+Choices=sp_after_oc_scope=ignore|sp_after_oc_scope=add|sp_after_oc_scope=remove|sp_after_oc_scope=force|sp_after_oc_scope=not_defined
+ChoicesRegex=sp_after_oc_scope\s*=\s*ignore|sp_after_oc_scope\s*=\s*add|sp_after_oc_scope\s*=\s*remove|sp_after_oc_scope\s*=\s*force|sp_after_oc_scope\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Scope|Add Sp After Oc Scope|Remove Sp After Oc Scope|Force Sp After Oc Scope"
 ValueDefault=ignore
 
@@ -2059,7 +2285,8 @@ Category=1
 Description="<html>(OC) Add or remove space after the colon in message specs,<br/>i.e. '-(int) f:(int) x;' vs. '-(int) f: (int) x;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_colon\s*=\s*ignore|sp_after_oc_colon\s*=\s*add|sp_after_oc_colon\s*=\s*remove|sp_after_oc_colon\s*=\s*force|sp_after_oc_colon\s*=\s*not_defined
+Choices=sp_after_oc_colon=ignore|sp_after_oc_colon=add|sp_after_oc_colon=remove|sp_after_oc_colon=force|sp_after_oc_colon=not_defined
+ChoicesRegex=sp_after_oc_colon\s*=\s*ignore|sp_after_oc_colon\s*=\s*add|sp_after_oc_colon\s*=\s*remove|sp_after_oc_colon\s*=\s*force|sp_after_oc_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Colon|Add Sp After Oc Colon|Remove Sp After Oc Colon|Force Sp After Oc Colon"
 ValueDefault=ignore
 
@@ -2068,7 +2295,8 @@ Category=1
 Description="<html>(OC) Add or remove space before the colon in message specs,<br/>i.e. '-(int) f: (int) x;' vs. '-(int) f : (int) x;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_oc_colon\s*=\s*ignore|sp_before_oc_colon\s*=\s*add|sp_before_oc_colon\s*=\s*remove|sp_before_oc_colon\s*=\s*force|sp_before_oc_colon\s*=\s*not_defined
+Choices=sp_before_oc_colon=ignore|sp_before_oc_colon=add|sp_before_oc_colon=remove|sp_before_oc_colon=force|sp_before_oc_colon=not_defined
+ChoicesRegex=sp_before_oc_colon\s*=\s*ignore|sp_before_oc_colon\s*=\s*add|sp_before_oc_colon\s*=\s*remove|sp_before_oc_colon\s*=\s*force|sp_before_oc_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Oc Colon|Add Sp Before Oc Colon|Remove Sp Before Oc Colon|Force Sp Before Oc Colon"
 ValueDefault=ignore
 
@@ -2077,7 +2305,8 @@ Category=1
 Description="<html>(OC) Add or remove space after the colon in immutable dictionary expression<br/>'NSDictionary *test = @{@"foo" :@"bar"};'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_dict_colon\s*=\s*ignore|sp_after_oc_dict_colon\s*=\s*add|sp_after_oc_dict_colon\s*=\s*remove|sp_after_oc_dict_colon\s*=\s*force|sp_after_oc_dict_colon\s*=\s*not_defined
+Choices=sp_after_oc_dict_colon=ignore|sp_after_oc_dict_colon=add|sp_after_oc_dict_colon=remove|sp_after_oc_dict_colon=force|sp_after_oc_dict_colon=not_defined
+ChoicesRegex=sp_after_oc_dict_colon\s*=\s*ignore|sp_after_oc_dict_colon\s*=\s*add|sp_after_oc_dict_colon\s*=\s*remove|sp_after_oc_dict_colon\s*=\s*force|sp_after_oc_dict_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Dict Colon|Add Sp After Oc Dict Colon|Remove Sp After Oc Dict Colon|Force Sp After Oc Dict Colon"
 ValueDefault=ignore
 
@@ -2086,7 +2315,8 @@ Category=1
 Description="<html>(OC) Add or remove space before the colon in immutable dictionary expression<br/>'NSDictionary *test = @{@"foo" :@"bar"};'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_oc_dict_colon\s*=\s*ignore|sp_before_oc_dict_colon\s*=\s*add|sp_before_oc_dict_colon\s*=\s*remove|sp_before_oc_dict_colon\s*=\s*force|sp_before_oc_dict_colon\s*=\s*not_defined
+Choices=sp_before_oc_dict_colon=ignore|sp_before_oc_dict_colon=add|sp_before_oc_dict_colon=remove|sp_before_oc_dict_colon=force|sp_before_oc_dict_colon=not_defined
+ChoicesRegex=sp_before_oc_dict_colon\s*=\s*ignore|sp_before_oc_dict_colon\s*=\s*add|sp_before_oc_dict_colon\s*=\s*remove|sp_before_oc_dict_colon\s*=\s*force|sp_before_oc_dict_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Oc Dict Colon|Add Sp Before Oc Dict Colon|Remove Sp Before Oc Dict Colon|Force Sp Before Oc Dict Colon"
 ValueDefault=ignore
 
@@ -2095,7 +2325,8 @@ Category=1
 Description="<html>(OC) Add or remove space after the colon in message specs,<br/>i.e. '[object setValue:1];' vs. '[object setValue: 1];'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_send_oc_colon\s*=\s*ignore|sp_after_send_oc_colon\s*=\s*add|sp_after_send_oc_colon\s*=\s*remove|sp_after_send_oc_colon\s*=\s*force|sp_after_send_oc_colon\s*=\s*not_defined
+Choices=sp_after_send_oc_colon=ignore|sp_after_send_oc_colon=add|sp_after_send_oc_colon=remove|sp_after_send_oc_colon=force|sp_after_send_oc_colon=not_defined
+ChoicesRegex=sp_after_send_oc_colon\s*=\s*ignore|sp_after_send_oc_colon\s*=\s*add|sp_after_send_oc_colon\s*=\s*remove|sp_after_send_oc_colon\s*=\s*force|sp_after_send_oc_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Send Oc Colon|Add Sp After Send Oc Colon|Remove Sp After Send Oc Colon|Force Sp After Send Oc Colon"
 ValueDefault=ignore
 
@@ -2104,7 +2335,8 @@ Category=1
 Description="<html>(OC) Add or remove space before the colon in message specs,<br/>i.e. '[object setValue:1];' vs. '[object setValue :1];'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_send_oc_colon\s*=\s*ignore|sp_before_send_oc_colon\s*=\s*add|sp_before_send_oc_colon\s*=\s*remove|sp_before_send_oc_colon\s*=\s*force|sp_before_send_oc_colon\s*=\s*not_defined
+Choices=sp_before_send_oc_colon=ignore|sp_before_send_oc_colon=add|sp_before_send_oc_colon=remove|sp_before_send_oc_colon=force|sp_before_send_oc_colon=not_defined
+ChoicesRegex=sp_before_send_oc_colon\s*=\s*ignore|sp_before_send_oc_colon\s*=\s*add|sp_before_send_oc_colon\s*=\s*remove|sp_before_send_oc_colon\s*=\s*force|sp_before_send_oc_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Send Oc Colon|Add Sp Before Send Oc Colon|Remove Sp Before Send Oc Colon|Force Sp Before Send Oc Colon"
 ValueDefault=ignore
 
@@ -2113,7 +2345,8 @@ Category=1
 Description="<html>(OC) Add or remove space after the (type) in message specs,<br/>i.e. '-(int)f: (int) x;' vs. '-(int)f: (int)x;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_type\s*=\s*ignore|sp_after_oc_type\s*=\s*add|sp_after_oc_type\s*=\s*remove|sp_after_oc_type\s*=\s*force|sp_after_oc_type\s*=\s*not_defined
+Choices=sp_after_oc_type=ignore|sp_after_oc_type=add|sp_after_oc_type=remove|sp_after_oc_type=force|sp_after_oc_type=not_defined
+ChoicesRegex=sp_after_oc_type\s*=\s*ignore|sp_after_oc_type\s*=\s*add|sp_after_oc_type\s*=\s*remove|sp_after_oc_type\s*=\s*force|sp_after_oc_type\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Type|Add Sp After Oc Type|Remove Sp After Oc Type|Force Sp After Oc Type"
 ValueDefault=ignore
 
@@ -2122,7 +2355,8 @@ Category=1
 Description="<html>(OC) Add or remove space after the first (type) in message specs,<br/>i.e. '-(int) f:(int)x;' vs. '-(int)f:(int)x;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_return_type\s*=\s*ignore|sp_after_oc_return_type\s*=\s*add|sp_after_oc_return_type\s*=\s*remove|sp_after_oc_return_type\s*=\s*force|sp_after_oc_return_type\s*=\s*not_defined
+Choices=sp_after_oc_return_type=ignore|sp_after_oc_return_type=add|sp_after_oc_return_type=remove|sp_after_oc_return_type=force|sp_after_oc_return_type=not_defined
+ChoicesRegex=sp_after_oc_return_type\s*=\s*ignore|sp_after_oc_return_type\s*=\s*add|sp_after_oc_return_type\s*=\s*remove|sp_after_oc_return_type\s*=\s*force|sp_after_oc_return_type\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Return Type|Add Sp After Oc Return Type|Remove Sp After Oc Return Type|Force Sp After Oc Return Type"
 ValueDefault=ignore
 
@@ -2131,7 +2365,8 @@ Category=1
 Description="<html>(OC) Add or remove space between '@selector' and '(',<br/>i.e. '@selector(msgName)' vs. '@selector (msgName)'.<br/>Also applies to '@protocol()' constructs.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_at_sel\s*=\s*ignore|sp_after_oc_at_sel\s*=\s*add|sp_after_oc_at_sel\s*=\s*remove|sp_after_oc_at_sel\s*=\s*force|sp_after_oc_at_sel\s*=\s*not_defined
+Choices=sp_after_oc_at_sel=ignore|sp_after_oc_at_sel=add|sp_after_oc_at_sel=remove|sp_after_oc_at_sel=force|sp_after_oc_at_sel=not_defined
+ChoicesRegex=sp_after_oc_at_sel\s*=\s*ignore|sp_after_oc_at_sel\s*=\s*add|sp_after_oc_at_sel\s*=\s*remove|sp_after_oc_at_sel\s*=\s*force|sp_after_oc_at_sel\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc At Sel|Add Sp After Oc At Sel|Remove Sp After Oc At Sel|Force Sp After Oc At Sel"
 ValueDefault=ignore
 
@@ -2140,7 +2375,8 @@ Category=1
 Description="<html>(OC) Add or remove space between '@selector(x)' and the following word,<br/>i.e. '@selector(foo) a:' vs. '@selector(foo)a:'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_at_sel_parens\s*=\s*ignore|sp_after_oc_at_sel_parens\s*=\s*add|sp_after_oc_at_sel_parens\s*=\s*remove|sp_after_oc_at_sel_parens\s*=\s*force|sp_after_oc_at_sel_parens\s*=\s*not_defined
+Choices=sp_after_oc_at_sel_parens=ignore|sp_after_oc_at_sel_parens=add|sp_after_oc_at_sel_parens=remove|sp_after_oc_at_sel_parens=force|sp_after_oc_at_sel_parens=not_defined
+ChoicesRegex=sp_after_oc_at_sel_parens\s*=\s*ignore|sp_after_oc_at_sel_parens\s*=\s*add|sp_after_oc_at_sel_parens\s*=\s*remove|sp_after_oc_at_sel_parens\s*=\s*force|sp_after_oc_at_sel_parens\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc At Sel Parens|Add Sp After Oc At Sel Parens|Remove Sp After Oc At Sel Parens|Force Sp After Oc At Sel Parens"
 ValueDefault=ignore
 
@@ -2149,7 +2385,8 @@ Category=1
 Description="<html>(OC) Add or remove space inside '@selector' parentheses,<br/>i.e. '@selector(foo)' vs. '@selector( foo )'.<br/>Also applies to '@protocol()' constructs.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_oc_at_sel_parens\s*=\s*ignore|sp_inside_oc_at_sel_parens\s*=\s*add|sp_inside_oc_at_sel_parens\s*=\s*remove|sp_inside_oc_at_sel_parens\s*=\s*force|sp_inside_oc_at_sel_parens\s*=\s*not_defined
+Choices=sp_inside_oc_at_sel_parens=ignore|sp_inside_oc_at_sel_parens=add|sp_inside_oc_at_sel_parens=remove|sp_inside_oc_at_sel_parens=force|sp_inside_oc_at_sel_parens=not_defined
+ChoicesRegex=sp_inside_oc_at_sel_parens\s*=\s*ignore|sp_inside_oc_at_sel_parens\s*=\s*add|sp_inside_oc_at_sel_parens\s*=\s*remove|sp_inside_oc_at_sel_parens\s*=\s*force|sp_inside_oc_at_sel_parens\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Oc At Sel Parens|Add Sp Inside Oc At Sel Parens|Remove Sp Inside Oc At Sel Parens|Force Sp Inside Oc At Sel Parens"
 ValueDefault=ignore
 
@@ -2158,7 +2395,8 @@ Category=1
 Description="<html>(OC) Add or remove space before a block pointer caret,<br/>i.e. '^int (int arg){...}' vs. ' ^int (int arg){...}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_oc_block_caret\s*=\s*ignore|sp_before_oc_block_caret\s*=\s*add|sp_before_oc_block_caret\s*=\s*remove|sp_before_oc_block_caret\s*=\s*force|sp_before_oc_block_caret\s*=\s*not_defined
+Choices=sp_before_oc_block_caret=ignore|sp_before_oc_block_caret=add|sp_before_oc_block_caret=remove|sp_before_oc_block_caret=force|sp_before_oc_block_caret=not_defined
+ChoicesRegex=sp_before_oc_block_caret\s*=\s*ignore|sp_before_oc_block_caret\s*=\s*add|sp_before_oc_block_caret\s*=\s*remove|sp_before_oc_block_caret\s*=\s*force|sp_before_oc_block_caret\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Oc Block Caret|Add Sp Before Oc Block Caret|Remove Sp Before Oc Block Caret|Force Sp Before Oc Block Caret"
 ValueDefault=ignore
 
@@ -2167,7 +2405,8 @@ Category=1
 Description="<html>(OC) Add or remove space after a block pointer caret,<br/>i.e. '^int (int arg){...}' vs. '^ int (int arg){...}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_block_caret\s*=\s*ignore|sp_after_oc_block_caret\s*=\s*add|sp_after_oc_block_caret\s*=\s*remove|sp_after_oc_block_caret\s*=\s*force|sp_after_oc_block_caret\s*=\s*not_defined
+Choices=sp_after_oc_block_caret=ignore|sp_after_oc_block_caret=add|sp_after_oc_block_caret=remove|sp_after_oc_block_caret=force|sp_after_oc_block_caret=not_defined
+ChoicesRegex=sp_after_oc_block_caret\s*=\s*ignore|sp_after_oc_block_caret\s*=\s*add|sp_after_oc_block_caret\s*=\s*remove|sp_after_oc_block_caret\s*=\s*force|sp_after_oc_block_caret\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Block Caret|Add Sp After Oc Block Caret|Remove Sp After Oc Block Caret|Force Sp After Oc Block Caret"
 ValueDefault=ignore
 
@@ -2176,7 +2415,8 @@ Category=1
 Description="<html>(OC) Add or remove space between the receiver and selector in a message,<br/>as in '[receiver selector ...]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_msg_receiver\s*=\s*ignore|sp_after_oc_msg_receiver\s*=\s*add|sp_after_oc_msg_receiver\s*=\s*remove|sp_after_oc_msg_receiver\s*=\s*force|sp_after_oc_msg_receiver\s*=\s*not_defined
+Choices=sp_after_oc_msg_receiver=ignore|sp_after_oc_msg_receiver=add|sp_after_oc_msg_receiver=remove|sp_after_oc_msg_receiver=force|sp_after_oc_msg_receiver=not_defined
+ChoicesRegex=sp_after_oc_msg_receiver\s*=\s*ignore|sp_after_oc_msg_receiver\s*=\s*add|sp_after_oc_msg_receiver\s*=\s*remove|sp_after_oc_msg_receiver\s*=\s*force|sp_after_oc_msg_receiver\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Msg Receiver|Add Sp After Oc Msg Receiver|Remove Sp After Oc Msg Receiver|Force Sp After Oc Msg Receiver"
 ValueDefault=ignore
 
@@ -2185,7 +2425,8 @@ Category=1
 Description="<html>(OC) Add or remove space after '@property'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_property\s*=\s*ignore|sp_after_oc_property\s*=\s*add|sp_after_oc_property\s*=\s*remove|sp_after_oc_property\s*=\s*force|sp_after_oc_property\s*=\s*not_defined
+Choices=sp_after_oc_property=ignore|sp_after_oc_property=add|sp_after_oc_property=remove|sp_after_oc_property=force|sp_after_oc_property=not_defined
+ChoicesRegex=sp_after_oc_property\s*=\s*ignore|sp_after_oc_property\s*=\s*add|sp_after_oc_property\s*=\s*remove|sp_after_oc_property\s*=\s*force|sp_after_oc_property\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Property|Add Sp After Oc Property|Remove Sp After Oc Property|Force Sp After Oc Property"
 ValueDefault=ignore
 
@@ -2194,7 +2435,8 @@ Category=1
 Description="<html>(OC) Add or remove space between '@synchronized' and the open parenthesis,<br/>i.e. '@synchronized(foo)' vs. '@synchronized (foo)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_synchronized\s*=\s*ignore|sp_after_oc_synchronized\s*=\s*add|sp_after_oc_synchronized\s*=\s*remove|sp_after_oc_synchronized\s*=\s*force|sp_after_oc_synchronized\s*=\s*not_defined
+Choices=sp_after_oc_synchronized=ignore|sp_after_oc_synchronized=add|sp_after_oc_synchronized=remove|sp_after_oc_synchronized=force|sp_after_oc_synchronized=not_defined
+ChoicesRegex=sp_after_oc_synchronized\s*=\s*ignore|sp_after_oc_synchronized\s*=\s*add|sp_after_oc_synchronized\s*=\s*remove|sp_after_oc_synchronized\s*=\s*force|sp_after_oc_synchronized\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Synchronized|Add Sp After Oc Synchronized|Remove Sp After Oc Synchronized|Force Sp After Oc Synchronized"
 ValueDefault=ignore
 
@@ -2203,7 +2445,8 @@ Category=1
 Description="<html>Add or remove space around the ':' in 'b ? t : f'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_colon\s*=\s*ignore|sp_cond_colon\s*=\s*add|sp_cond_colon\s*=\s*remove|sp_cond_colon\s*=\s*force|sp_cond_colon\s*=\s*not_defined
+Choices=sp_cond_colon=ignore|sp_cond_colon=add|sp_cond_colon=remove|sp_cond_colon=force|sp_cond_colon=not_defined
+ChoicesRegex=sp_cond_colon\s*=\s*ignore|sp_cond_colon\s*=\s*add|sp_cond_colon\s*=\s*remove|sp_cond_colon\s*=\s*force|sp_cond_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Colon|Add Sp Cond Colon|Remove Sp Cond Colon|Force Sp Cond Colon"
 ValueDefault=ignore
 
@@ -2212,7 +2455,8 @@ Category=1
 Description="<html>Add or remove space before the ':' in 'b ? t : f'.<br/><br/>Overrides sp_cond_colon.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_colon_before\s*=\s*ignore|sp_cond_colon_before\s*=\s*add|sp_cond_colon_before\s*=\s*remove|sp_cond_colon_before\s*=\s*force|sp_cond_colon_before\s*=\s*not_defined
+Choices=sp_cond_colon_before=ignore|sp_cond_colon_before=add|sp_cond_colon_before=remove|sp_cond_colon_before=force|sp_cond_colon_before=not_defined
+ChoicesRegex=sp_cond_colon_before\s*=\s*ignore|sp_cond_colon_before\s*=\s*add|sp_cond_colon_before\s*=\s*remove|sp_cond_colon_before\s*=\s*force|sp_cond_colon_before\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Colon Before|Add Sp Cond Colon Before|Remove Sp Cond Colon Before|Force Sp Cond Colon Before"
 ValueDefault=ignore
 
@@ -2221,7 +2465,8 @@ Category=1
 Description="<html>Add or remove space after the ':' in 'b ? t : f'.<br/><br/>Overrides sp_cond_colon.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_colon_after\s*=\s*ignore|sp_cond_colon_after\s*=\s*add|sp_cond_colon_after\s*=\s*remove|sp_cond_colon_after\s*=\s*force|sp_cond_colon_after\s*=\s*not_defined
+Choices=sp_cond_colon_after=ignore|sp_cond_colon_after=add|sp_cond_colon_after=remove|sp_cond_colon_after=force|sp_cond_colon_after=not_defined
+ChoicesRegex=sp_cond_colon_after\s*=\s*ignore|sp_cond_colon_after\s*=\s*add|sp_cond_colon_after\s*=\s*remove|sp_cond_colon_after\s*=\s*force|sp_cond_colon_after\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Colon After|Add Sp Cond Colon After|Remove Sp Cond Colon After|Force Sp Cond Colon After"
 ValueDefault=ignore
 
@@ -2230,7 +2475,8 @@ Category=1
 Description="<html>Add or remove space around the '?' in 'b ? t : f'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_question\s*=\s*ignore|sp_cond_question\s*=\s*add|sp_cond_question\s*=\s*remove|sp_cond_question\s*=\s*force|sp_cond_question\s*=\s*not_defined
+Choices=sp_cond_question=ignore|sp_cond_question=add|sp_cond_question=remove|sp_cond_question=force|sp_cond_question=not_defined
+ChoicesRegex=sp_cond_question\s*=\s*ignore|sp_cond_question\s*=\s*add|sp_cond_question\s*=\s*remove|sp_cond_question\s*=\s*force|sp_cond_question\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Question|Add Sp Cond Question|Remove Sp Cond Question|Force Sp Cond Question"
 ValueDefault=ignore
 
@@ -2239,7 +2485,8 @@ Category=1
 Description="<html>Add or remove space before the '?' in 'b ? t : f'.<br/><br/>Overrides sp_cond_question.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_question_before\s*=\s*ignore|sp_cond_question_before\s*=\s*add|sp_cond_question_before\s*=\s*remove|sp_cond_question_before\s*=\s*force|sp_cond_question_before\s*=\s*not_defined
+Choices=sp_cond_question_before=ignore|sp_cond_question_before=add|sp_cond_question_before=remove|sp_cond_question_before=force|sp_cond_question_before=not_defined
+ChoicesRegex=sp_cond_question_before\s*=\s*ignore|sp_cond_question_before\s*=\s*add|sp_cond_question_before\s*=\s*remove|sp_cond_question_before\s*=\s*force|sp_cond_question_before\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Question Before|Add Sp Cond Question Before|Remove Sp Cond Question Before|Force Sp Cond Question Before"
 ValueDefault=ignore
 
@@ -2248,7 +2495,8 @@ Category=1
 Description="<html>Add or remove space after the '?' in 'b ? t : f'.<br/><br/>Overrides sp_cond_question.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_question_after\s*=\s*ignore|sp_cond_question_after\s*=\s*add|sp_cond_question_after\s*=\s*remove|sp_cond_question_after\s*=\s*force|sp_cond_question_after\s*=\s*not_defined
+Choices=sp_cond_question_after=ignore|sp_cond_question_after=add|sp_cond_question_after=remove|sp_cond_question_after=force|sp_cond_question_after=not_defined
+ChoicesRegex=sp_cond_question_after\s*=\s*ignore|sp_cond_question_after\s*=\s*add|sp_cond_question_after\s*=\s*remove|sp_cond_question_after\s*=\s*force|sp_cond_question_after\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Question After|Add Sp Cond Question After|Remove Sp Cond Question After|Force Sp Cond Question After"
 ValueDefault=ignore
 
@@ -2257,7 +2505,8 @@ Category=1
 Description="<html>In the abbreviated ternary form '(a ?: b)', add or remove space between '?'<br/>and ':'.<br/><br/>Overrides all other sp_cond_* options.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_ternary_short\s*=\s*ignore|sp_cond_ternary_short\s*=\s*add|sp_cond_ternary_short\s*=\s*remove|sp_cond_ternary_short\s*=\s*force|sp_cond_ternary_short\s*=\s*not_defined
+Choices=sp_cond_ternary_short=ignore|sp_cond_ternary_short=add|sp_cond_ternary_short=remove|sp_cond_ternary_short=force|sp_cond_ternary_short=not_defined
+ChoicesRegex=sp_cond_ternary_short\s*=\s*ignore|sp_cond_ternary_short\s*=\s*add|sp_cond_ternary_short\s*=\s*remove|sp_cond_ternary_short\s*=\s*force|sp_cond_ternary_short\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Ternary Short|Add Sp Cond Ternary Short|Remove Sp Cond Ternary Short|Force Sp Cond Ternary Short"
 ValueDefault=ignore
 
@@ -2266,7 +2515,8 @@ Category=1
 Description="<html>Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make<br/>sense here.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_case_label\s*=\s*ignore|sp_case_label\s*=\s*add|sp_case_label\s*=\s*remove|sp_case_label\s*=\s*force|sp_case_label\s*=\s*not_defined
+Choices=sp_case_label=ignore|sp_case_label=add|sp_case_label=remove|sp_case_label=force|sp_case_label=not_defined
+ChoicesRegex=sp_case_label\s*=\s*ignore|sp_case_label\s*=\s*add|sp_case_label\s*=\s*remove|sp_case_label\s*=\s*force|sp_case_label\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Case Label|Add Sp Case Label|Remove Sp Case Label|Force Sp Case Label"
 ValueDefault=ignore
 
@@ -2275,7 +2525,8 @@ Category=1
 Description="<html>(D) Add or remove space around the D '..' operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_range\s*=\s*ignore|sp_range\s*=\s*add|sp_range\s*=\s*remove|sp_range\s*=\s*force|sp_range\s*=\s*not_defined
+Choices=sp_range=ignore|sp_range=add|sp_range=remove|sp_range=force|sp_range=not_defined
+ChoicesRegex=sp_range\s*=\s*ignore|sp_range\s*=\s*add|sp_range\s*=\s*remove|sp_range\s*=\s*force|sp_range\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Range|Add Sp Range|Remove Sp Range|Force Sp Range"
 ValueDefault=ignore
 
@@ -2284,7 +2535,8 @@ Category=1
 Description="<html>Add or remove space after ':' in a Java/C++11 range-based 'for',<br/>as in 'for (Type var : &lt;here&gt; expr)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_for_colon\s*=\s*ignore|sp_after_for_colon\s*=\s*add|sp_after_for_colon\s*=\s*remove|sp_after_for_colon\s*=\s*force|sp_after_for_colon\s*=\s*not_defined
+Choices=sp_after_for_colon=ignore|sp_after_for_colon=add|sp_after_for_colon=remove|sp_after_for_colon=force|sp_after_for_colon=not_defined
+ChoicesRegex=sp_after_for_colon\s*=\s*ignore|sp_after_for_colon\s*=\s*add|sp_after_for_colon\s*=\s*remove|sp_after_for_colon\s*=\s*force|sp_after_for_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After For Colon|Add Sp After For Colon|Remove Sp After For Colon|Force Sp After For Colon"
 ValueDefault=ignore
 
@@ -2293,7 +2545,8 @@ Category=1
 Description="<html>Add or remove space before ':' in a Java/C++11 range-based 'for',<br/>as in 'for (Type var &lt;here&gt; : expr)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_for_colon\s*=\s*ignore|sp_before_for_colon\s*=\s*add|sp_before_for_colon\s*=\s*remove|sp_before_for_colon\s*=\s*force|sp_before_for_colon\s*=\s*not_defined
+Choices=sp_before_for_colon=ignore|sp_before_for_colon=add|sp_before_for_colon=remove|sp_before_for_colon=force|sp_before_for_colon=not_defined
+ChoicesRegex=sp_before_for_colon\s*=\s*ignore|sp_before_for_colon\s*=\s*add|sp_before_for_colon\s*=\s*remove|sp_before_for_colon\s*=\s*force|sp_before_for_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before For Colon|Add Sp Before For Colon|Remove Sp Before For Colon|Force Sp Before For Colon"
 ValueDefault=ignore
 
@@ -2302,7 +2555,8 @@ Category=1
 Description="<html>(D) Add or remove space between 'extern' and '(' as in 'extern &lt;here&gt; (C)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_extern_paren\s*=\s*ignore|sp_extern_paren\s*=\s*add|sp_extern_paren\s*=\s*remove|sp_extern_paren\s*=\s*force|sp_extern_paren\s*=\s*not_defined
+Choices=sp_extern_paren=ignore|sp_extern_paren=add|sp_extern_paren=remove|sp_extern_paren=force|sp_extern_paren=not_defined
+ChoicesRegex=sp_extern_paren\s*=\s*ignore|sp_extern_paren\s*=\s*add|sp_extern_paren\s*=\s*remove|sp_extern_paren\s*=\s*force|sp_extern_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Extern Paren|Add Sp Extern Paren|Remove Sp Extern Paren|Force Sp Extern Paren"
 ValueDefault=ignore
 
@@ -2311,7 +2565,8 @@ Category=1
 Description="<html>Add or remove space after the opening of a C++ comment, as in '// &lt;here&gt; A'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cmt_cpp_start\s*=\s*ignore|sp_cmt_cpp_start\s*=\s*add|sp_cmt_cpp_start\s*=\s*remove|sp_cmt_cpp_start\s*=\s*force|sp_cmt_cpp_start\s*=\s*not_defined
+Choices=sp_cmt_cpp_start=ignore|sp_cmt_cpp_start=add|sp_cmt_cpp_start=remove|sp_cmt_cpp_start=force|sp_cmt_cpp_start=not_defined
+ChoicesRegex=sp_cmt_cpp_start\s*=\s*ignore|sp_cmt_cpp_start\s*=\s*add|sp_cmt_cpp_start\s*=\s*remove|sp_cmt_cpp_start\s*=\s*force|sp_cmt_cpp_start\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cmt Cpp Start|Add Sp Cmt Cpp Start|Remove Sp Cmt Cpp Start|Force Sp Cmt Cpp Start"
 ValueDefault=ignore
 
@@ -2320,7 +2575,8 @@ Category=1
 Description="<html>remove space after the '//' and the pvs command '-V1234',<br/>only works with sp_cmt_cpp_start set to add or force.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_cmt_cpp_pvs\s*=\s*true|sp_cmt_cpp_pvs\s*=\s*false
+TrueFalse=sp_cmt_cpp_pvs=true|sp_cmt_cpp_pvs=false
+TrueFalseRegex=sp_cmt_cpp_pvs\s*=\s*true|sp_cmt_cpp_pvs\s*=\s*false
 ValueDefault=false
 
 [Sp Cmt Cpp Lint]
@@ -2328,7 +2584,8 @@ Category=1
 Description="<html>remove space after the '//' and the command 'lint',<br/>only works with sp_cmt_cpp_start set to add or force.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_cmt_cpp_lint\s*=\s*true|sp_cmt_cpp_lint\s*=\s*false
+TrueFalse=sp_cmt_cpp_lint=true|sp_cmt_cpp_lint=false
+TrueFalseRegex=sp_cmt_cpp_lint\s*=\s*true|sp_cmt_cpp_lint\s*=\s*false
 ValueDefault=false
 
 [Sp Cmt Cpp Region]
@@ -2336,7 +2593,8 @@ Category=1
 Description="<html>Add or remove space in a C++ region marker comment, as in '// &lt;here&gt; BEGIN'.<br/>A region marker is defined as a comment which is not preceded by other text<br/>(i.e. the comment is the first non-whitespace on the line), and which starts<br/>with either 'BEGIN' or 'END'.<br/><br/>Overrides sp_cmt_cpp_start.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cmt_cpp_region\s*=\s*ignore|sp_cmt_cpp_region\s*=\s*add|sp_cmt_cpp_region\s*=\s*remove|sp_cmt_cpp_region\s*=\s*force|sp_cmt_cpp_region\s*=\s*not_defined
+Choices=sp_cmt_cpp_region=ignore|sp_cmt_cpp_region=add|sp_cmt_cpp_region=remove|sp_cmt_cpp_region=force|sp_cmt_cpp_region=not_defined
+ChoicesRegex=sp_cmt_cpp_region\s*=\s*ignore|sp_cmt_cpp_region\s*=\s*add|sp_cmt_cpp_region\s*=\s*remove|sp_cmt_cpp_region\s*=\s*force|sp_cmt_cpp_region\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cmt Cpp Region|Add Sp Cmt Cpp Region|Remove Sp Cmt Cpp Region|Force Sp Cmt Cpp Region"
 ValueDefault=ignore
 
@@ -2345,7 +2603,8 @@ Category=1
 Description="<html>If true, space added with sp_cmt_cpp_start will be added after Doxygen<br/>sequences like '///', '///&lt;', '//!' and '//!&lt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_cmt_cpp_doxygen\s*=\s*true|sp_cmt_cpp_doxygen\s*=\s*false
+TrueFalse=sp_cmt_cpp_doxygen=true|sp_cmt_cpp_doxygen=false
+TrueFalseRegex=sp_cmt_cpp_doxygen\s*=\s*true|sp_cmt_cpp_doxygen\s*=\s*false
 ValueDefault=false
 
 [Sp Cmt Cpp Qttr]
@@ -2353,7 +2612,8 @@ Category=1
 Description="<html>If true, space added with sp_cmt_cpp_start will be added after Qt translator<br/>or meta-data comments like '//:', '//=', and '//~'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_cmt_cpp_qttr\s*=\s*true|sp_cmt_cpp_qttr\s*=\s*false
+TrueFalse=sp_cmt_cpp_qttr=true|sp_cmt_cpp_qttr=false
+TrueFalseRegex=sp_cmt_cpp_qttr\s*=\s*true|sp_cmt_cpp_qttr\s*=\s*false
 ValueDefault=false
 
 [Sp Endif Cmt]
@@ -2361,7 +2621,8 @@ Category=1
 Description="<html>Add or remove space between #else or #endif and a trailing comment.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_endif_cmt\s*=\s*ignore|sp_endif_cmt\s*=\s*add|sp_endif_cmt\s*=\s*remove|sp_endif_cmt\s*=\s*force|sp_endif_cmt\s*=\s*not_defined
+Choices=sp_endif_cmt=ignore|sp_endif_cmt=add|sp_endif_cmt=remove|sp_endif_cmt=force|sp_endif_cmt=not_defined
+ChoicesRegex=sp_endif_cmt\s*=\s*ignore|sp_endif_cmt\s*=\s*add|sp_endif_cmt\s*=\s*remove|sp_endif_cmt\s*=\s*force|sp_endif_cmt\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Endif Cmt|Add Sp Endif Cmt|Remove Sp Endif Cmt|Force Sp Endif Cmt"
 ValueDefault=ignore
 
@@ -2370,7 +2631,8 @@ Category=1
 Description="<html>Add or remove space after 'new', 'delete' and 'delete[]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_new\s*=\s*ignore|sp_after_new\s*=\s*add|sp_after_new\s*=\s*remove|sp_after_new\s*=\s*force|sp_after_new\s*=\s*not_defined
+Choices=sp_after_new=ignore|sp_after_new=add|sp_after_new=remove|sp_after_new=force|sp_after_new=not_defined
+ChoicesRegex=sp_after_new\s*=\s*ignore|sp_after_new\s*=\s*add|sp_after_new\s*=\s*remove|sp_after_new\s*=\s*force|sp_after_new\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After New|Add Sp After New|Remove Sp After New|Force Sp After New"
 ValueDefault=ignore
 
@@ -2379,7 +2641,8 @@ Category=1
 Description="<html>Add or remove space between 'new' and '(' in 'new()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_new_paren\s*=\s*ignore|sp_between_new_paren\s*=\s*add|sp_between_new_paren\s*=\s*remove|sp_between_new_paren\s*=\s*force|sp_between_new_paren\s*=\s*not_defined
+Choices=sp_between_new_paren=ignore|sp_between_new_paren=add|sp_between_new_paren=remove|sp_between_new_paren=force|sp_between_new_paren=not_defined
+ChoicesRegex=sp_between_new_paren\s*=\s*ignore|sp_between_new_paren\s*=\s*add|sp_between_new_paren\s*=\s*remove|sp_between_new_paren\s*=\s*force|sp_between_new_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between New Paren|Add Sp Between New Paren|Remove Sp Between New Paren|Force Sp Between New Paren"
 ValueDefault=ignore
 
@@ -2388,7 +2651,8 @@ Category=1
 Description="<html>Add or remove space between ')' and type in 'new(foo) BAR'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_newop_paren\s*=\s*ignore|sp_after_newop_paren\s*=\s*add|sp_after_newop_paren\s*=\s*remove|sp_after_newop_paren\s*=\s*force|sp_after_newop_paren\s*=\s*not_defined
+Choices=sp_after_newop_paren=ignore|sp_after_newop_paren=add|sp_after_newop_paren=remove|sp_after_newop_paren=force|sp_after_newop_paren=not_defined
+ChoicesRegex=sp_after_newop_paren\s*=\s*ignore|sp_after_newop_paren\s*=\s*add|sp_after_newop_paren\s*=\s*remove|sp_after_newop_paren\s*=\s*force|sp_after_newop_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Newop Paren|Add Sp After Newop Paren|Remove Sp After Newop Paren|Force Sp After Newop Paren"
 ValueDefault=ignore
 
@@ -2397,7 +2661,8 @@ Category=1
 Description="<html>Add or remove space inside parentheses of the new operator<br/>as in 'new(foo) BAR'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_newop_paren\s*=\s*ignore|sp_inside_newop_paren\s*=\s*add|sp_inside_newop_paren\s*=\s*remove|sp_inside_newop_paren\s*=\s*force|sp_inside_newop_paren\s*=\s*not_defined
+Choices=sp_inside_newop_paren=ignore|sp_inside_newop_paren=add|sp_inside_newop_paren=remove|sp_inside_newop_paren=force|sp_inside_newop_paren=not_defined
+ChoicesRegex=sp_inside_newop_paren\s*=\s*ignore|sp_inside_newop_paren\s*=\s*add|sp_inside_newop_paren\s*=\s*remove|sp_inside_newop_paren\s*=\s*force|sp_inside_newop_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Newop Paren|Add Sp Inside Newop Paren|Remove Sp Inside Newop Paren|Force Sp Inside Newop Paren"
 ValueDefault=ignore
 
@@ -2406,7 +2671,8 @@ Category=1
 Description="<html>Add or remove space after the open parenthesis of the new operator,<br/>as in 'new(foo) BAR'.<br/><br/>Overrides sp_inside_newop_paren.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_newop_paren_open\s*=\s*ignore|sp_inside_newop_paren_open\s*=\s*add|sp_inside_newop_paren_open\s*=\s*remove|sp_inside_newop_paren_open\s*=\s*force|sp_inside_newop_paren_open\s*=\s*not_defined
+Choices=sp_inside_newop_paren_open=ignore|sp_inside_newop_paren_open=add|sp_inside_newop_paren_open=remove|sp_inside_newop_paren_open=force|sp_inside_newop_paren_open=not_defined
+ChoicesRegex=sp_inside_newop_paren_open\s*=\s*ignore|sp_inside_newop_paren_open\s*=\s*add|sp_inside_newop_paren_open\s*=\s*remove|sp_inside_newop_paren_open\s*=\s*force|sp_inside_newop_paren_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Newop Paren Open|Add Sp Inside Newop Paren Open|Remove Sp Inside Newop Paren Open|Force Sp Inside Newop Paren Open"
 ValueDefault=ignore
 
@@ -2415,7 +2681,8 @@ Category=1
 Description="<html>Add or remove space before the close parenthesis of the new operator,<br/>as in 'new(foo) BAR'.<br/><br/>Overrides sp_inside_newop_paren.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_newop_paren_close\s*=\s*ignore|sp_inside_newop_paren_close\s*=\s*add|sp_inside_newop_paren_close\s*=\s*remove|sp_inside_newop_paren_close\s*=\s*force|sp_inside_newop_paren_close\s*=\s*not_defined
+Choices=sp_inside_newop_paren_close=ignore|sp_inside_newop_paren_close=add|sp_inside_newop_paren_close=remove|sp_inside_newop_paren_close=force|sp_inside_newop_paren_close=not_defined
+ChoicesRegex=sp_inside_newop_paren_close\s*=\s*ignore|sp_inside_newop_paren_close\s*=\s*add|sp_inside_newop_paren_close\s*=\s*remove|sp_inside_newop_paren_close\s*=\s*force|sp_inside_newop_paren_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Newop Paren Close|Add Sp Inside Newop Paren Close|Remove Sp Inside Newop Paren Close|Force Sp Inside Newop Paren Close"
 ValueDefault=ignore
 
@@ -2424,7 +2691,8 @@ Category=1
 Description="<html>Add or remove space before a trailing comment.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_tr_cmt\s*=\s*ignore|sp_before_tr_cmt\s*=\s*add|sp_before_tr_cmt\s*=\s*remove|sp_before_tr_cmt\s*=\s*force|sp_before_tr_cmt\s*=\s*not_defined
+Choices=sp_before_tr_cmt=ignore|sp_before_tr_cmt=add|sp_before_tr_cmt=remove|sp_before_tr_cmt=force|sp_before_tr_cmt=not_defined
+ChoicesRegex=sp_before_tr_cmt\s*=\s*ignore|sp_before_tr_cmt\s*=\s*add|sp_before_tr_cmt\s*=\s*remove|sp_before_tr_cmt\s*=\s*force|sp_before_tr_cmt\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Tr Cmt|Add Sp Before Tr Cmt|Remove Sp Before Tr Cmt|Force Sp Before Tr Cmt"
 ValueDefault=ignore
 
@@ -2433,7 +2701,8 @@ Category=1
 Description="<html>Number of spaces before a trailing comment.</html>"
 Enabled=false
 EditorType=numeric
-CallName="sp_num_before_tr_cmt\s*=\s*"
+CallName="sp_num_before_tr_cmt="
+CallNameRegex="sp_num_before_tr_cmt\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2443,7 +2712,8 @@ Category=1
 Description="<html>Add or remove space before an embedded comment.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_emb_cmt\s*=\s*ignore|sp_before_emb_cmt\s*=\s*add|sp_before_emb_cmt\s*=\s*remove|sp_before_emb_cmt\s*=\s*force|sp_before_emb_cmt\s*=\s*not_defined
+Choices=sp_before_emb_cmt=ignore|sp_before_emb_cmt=add|sp_before_emb_cmt=remove|sp_before_emb_cmt=force|sp_before_emb_cmt=not_defined
+ChoicesRegex=sp_before_emb_cmt\s*=\s*ignore|sp_before_emb_cmt\s*=\s*add|sp_before_emb_cmt\s*=\s*remove|sp_before_emb_cmt\s*=\s*force|sp_before_emb_cmt\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Emb Cmt|Add Sp Before Emb Cmt|Remove Sp Before Emb Cmt|Force Sp Before Emb Cmt"
 ValueDefault=force
 
@@ -2452,7 +2722,8 @@ Category=1
 Description="<html>Number of spaces before an embedded comment.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="sp_num_before_emb_cmt\s*=\s*"
+CallName="sp_num_before_emb_cmt="
+CallNameRegex="sp_num_before_emb_cmt\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -2462,7 +2733,8 @@ Category=1
 Description="<html>Add or remove space after an embedded comment.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_emb_cmt\s*=\s*ignore|sp_after_emb_cmt\s*=\s*add|sp_after_emb_cmt\s*=\s*remove|sp_after_emb_cmt\s*=\s*force|sp_after_emb_cmt\s*=\s*not_defined
+Choices=sp_after_emb_cmt=ignore|sp_after_emb_cmt=add|sp_after_emb_cmt=remove|sp_after_emb_cmt=force|sp_after_emb_cmt=not_defined
+ChoicesRegex=sp_after_emb_cmt\s*=\s*ignore|sp_after_emb_cmt\s*=\s*add|sp_after_emb_cmt\s*=\s*remove|sp_after_emb_cmt\s*=\s*force|sp_after_emb_cmt\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Emb Cmt|Add Sp After Emb Cmt|Remove Sp After Emb Cmt|Force Sp After Emb Cmt"
 ValueDefault=force
 
@@ -2471,7 +2743,8 @@ Category=1
 Description="<html>Number of spaces after an embedded comment.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="sp_num_after_emb_cmt\s*=\s*"
+CallName="sp_num_after_emb_cmt="
+CallNameRegex="sp_num_after_emb_cmt\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -2481,7 +2754,8 @@ Category=1
 Description="<html>(Java) Add or remove space between an annotation and the open parenthesis.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_annotation_paren\s*=\s*ignore|sp_annotation_paren\s*=\s*add|sp_annotation_paren\s*=\s*remove|sp_annotation_paren\s*=\s*force|sp_annotation_paren\s*=\s*not_defined
+Choices=sp_annotation_paren=ignore|sp_annotation_paren=add|sp_annotation_paren=remove|sp_annotation_paren=force|sp_annotation_paren=not_defined
+ChoicesRegex=sp_annotation_paren\s*=\s*ignore|sp_annotation_paren\s*=\s*add|sp_annotation_paren\s*=\s*remove|sp_annotation_paren\s*=\s*force|sp_annotation_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Annotation Paren|Add Sp Annotation Paren|Remove Sp Annotation Paren|Force Sp Annotation Paren"
 ValueDefault=ignore
 
@@ -2490,7 +2764,8 @@ Category=1
 Description="<html>If true, vbrace tokens are dropped to the previous token and skipped.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_skip_vbrace_tokens\s*=\s*true|sp_skip_vbrace_tokens\s*=\s*false
+TrueFalse=sp_skip_vbrace_tokens=true|sp_skip_vbrace_tokens=false
+TrueFalseRegex=sp_skip_vbrace_tokens\s*=\s*true|sp_skip_vbrace_tokens\s*=\s*false
 ValueDefault=false
 
 [Sp After Noexcept]
@@ -2498,7 +2773,8 @@ Category=1
 Description="<html>Add or remove space after 'noexcept'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_noexcept\s*=\s*ignore|sp_after_noexcept\s*=\s*add|sp_after_noexcept\s*=\s*remove|sp_after_noexcept\s*=\s*force|sp_after_noexcept\s*=\s*not_defined
+Choices=sp_after_noexcept=ignore|sp_after_noexcept=add|sp_after_noexcept=remove|sp_after_noexcept=force|sp_after_noexcept=not_defined
+ChoicesRegex=sp_after_noexcept\s*=\s*ignore|sp_after_noexcept\s*=\s*add|sp_after_noexcept\s*=\s*remove|sp_after_noexcept\s*=\s*force|sp_after_noexcept\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Noexcept|Add Sp After Noexcept|Remove Sp After Noexcept|Force Sp After Noexcept"
 ValueDefault=ignore
 
@@ -2507,7 +2783,8 @@ Category=1
 Description="<html>Add or remove space after '_'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_vala_after_translation\s*=\s*ignore|sp_vala_after_translation\s*=\s*add|sp_vala_after_translation\s*=\s*remove|sp_vala_after_translation\s*=\s*force|sp_vala_after_translation\s*=\s*not_defined
+Choices=sp_vala_after_translation=ignore|sp_vala_after_translation=add|sp_vala_after_translation=remove|sp_vala_after_translation=force|sp_vala_after_translation=not_defined
+ChoicesRegex=sp_vala_after_translation\s*=\s*ignore|sp_vala_after_translation\s*=\s*add|sp_vala_after_translation\s*=\s*remove|sp_vala_after_translation\s*=\s*force|sp_vala_after_translation\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Vala After Translation|Add Sp Vala After Translation|Remove Sp Vala After Translation|Force Sp Vala After Translation"
 ValueDefault=ignore
 
@@ -2516,7 +2793,8 @@ Category=1
 Description="<html>Add or remove space before a bit colon ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_bit_colon\s*=\s*ignore|sp_before_bit_colon\s*=\s*add|sp_before_bit_colon\s*=\s*remove|sp_before_bit_colon\s*=\s*force|sp_before_bit_colon\s*=\s*not_defined
+Choices=sp_before_bit_colon=ignore|sp_before_bit_colon=add|sp_before_bit_colon=remove|sp_before_bit_colon=force|sp_before_bit_colon=not_defined
+ChoicesRegex=sp_before_bit_colon\s*=\s*ignore|sp_before_bit_colon\s*=\s*add|sp_before_bit_colon\s*=\s*remove|sp_before_bit_colon\s*=\s*force|sp_before_bit_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Bit Colon|Add Sp Before Bit Colon|Remove Sp Before Bit Colon|Force Sp Before Bit Colon"
 ValueDefault=ignore
 
@@ -2525,7 +2803,8 @@ Category=1
 Description="<html>Add or remove space after a bit colon ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_bit_colon\s*=\s*ignore|sp_after_bit_colon\s*=\s*add|sp_after_bit_colon\s*=\s*remove|sp_after_bit_colon\s*=\s*force|sp_after_bit_colon\s*=\s*not_defined
+Choices=sp_after_bit_colon=ignore|sp_after_bit_colon=add|sp_after_bit_colon=remove|sp_after_bit_colon=force|sp_after_bit_colon=not_defined
+ChoicesRegex=sp_after_bit_colon\s*=\s*ignore|sp_after_bit_colon\s*=\s*add|sp_after_bit_colon\s*=\s*remove|sp_after_bit_colon\s*=\s*force|sp_after_bit_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Bit Colon|Add Sp After Bit Colon|Remove Sp After Bit Colon|Force Sp After Bit Colon"
 ValueDefault=ignore
 
@@ -2534,7 +2813,8 @@ Category=1
 Description="<html>If true, a &lt;TAB&gt; is inserted after #define.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=force_tab_after_define\s*=\s*true|force_tab_after_define\s*=\s*false
+TrueFalse=force_tab_after_define=true|force_tab_after_define=false
+TrueFalseRegex=force_tab_after_define\s*=\s*true|force_tab_after_define\s*=\s*false
 ValueDefault=false
 
 [Indent Columns]
@@ -2542,7 +2822,8 @@ Category=2
 Description="<html>The number of columns to indent per level. Usually 2, 3, 4, or 8.<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_columns\s*=\s*"
+CallName="indent_columns="
+CallNameRegex="indent_columns\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=8
@@ -2552,7 +2833,8 @@ Category=2
 Description="<html>Whether to ignore indent for the first continuation line. Subsequent<br/>continuation lines will still be indented to match the first.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_first_continue\s*=\s*true|indent_ignore_first_continue\s*=\s*false
+TrueFalse=indent_ignore_first_continue=true|indent_ignore_first_continue=false
+TrueFalseRegex=indent_ignore_first_continue\s*=\s*true|indent_ignore_first_continue\s*=\s*false
 ValueDefault=false
 
 [Indent Continue]
@@ -2560,7 +2842,8 @@ Category=2
 Description="<html>The continuation indent. If non-zero, this overrides the indent of '(', '['<br/>and '=' continuation indents. Negative values are OK; negative value is<br/>absolute and not increased for each '(' or '[' level.<br/><br/>For FreeBSD, this is set to 4.<br/>Requires indent_ignore_first_continue=false.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_continue\s*=\s*"
+CallName="indent_continue="
+CallNameRegex="indent_continue\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -2570,7 +2853,8 @@ Category=2
 Description="<html>The continuation indent, only for class header line(s). If non-zero, this<br/>overrides the indent of 'class' continuation indents.<br/>Requires indent_ignore_first_continue=false.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_continue_class_head\s*=\s*"
+CallName="indent_continue_class_head="
+CallNameRegex="indent_continue_class_head\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2580,7 +2864,8 @@ Category=2
 Description="<html>Whether to indent empty lines (i.e. lines which contain only spaces before<br/>the newline character).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_single_newlines\s*=\s*true|indent_single_newlines\s*=\s*false
+TrueFalse=indent_single_newlines=true|indent_single_newlines=false
+TrueFalseRegex=indent_single_newlines\s*=\s*true|indent_single_newlines\s*=\s*false
 ValueDefault=false
 
 [Indent Param]
@@ -2588,7 +2873,8 @@ Category=2
 Description="<html>The continuation indent for func_*_param if they are true. If non-zero, this<br/>overrides the indent.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_param\s*=\s*"
+CallName="indent_param="
+CallNameRegex="indent_param\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2598,7 +2884,8 @@ Category=2
 Description="<html>How to use tabs when indenting code.<br/><br/>0: Spaces only<br/>1: Indent with tabs to brace level, align with spaces (default)<br/>2: Indent and align with tabs, using spaces when not on a tabstop<br/><br/>Default: 1</html>"
 Enabled=true
 EditorType=multiple
-Choices="indent_with_tabs\s*=\s*0|indent_with_tabs\s*=\s*1|indent_with_tabs\s*=\s*2"
+Choices="indent_with_tabs=0|indent_with_tabs=1|indent_with_tabs=2"
+ChoicesRegex="indent_with_tabs\s*=\s*0|indent_with_tabs\s*=\s*1|indent_with_tabs\s*=\s*2"
 ChoicesReadable="Spaces only|Indent with tabs, align with spaces|Indent and align with tabs"
 ValueDefault=1
 
@@ -2607,7 +2894,8 @@ Category=2
 Description="<html>Whether to indent comments that are not at a brace level with tabs on a<br/>tabstop. Requires indent_with_tabs=2. If false, will use spaces.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cmt_with_tabs\s*=\s*true|indent_cmt_with_tabs\s*=\s*false
+TrueFalse=indent_cmt_with_tabs=true|indent_cmt_with_tabs=false
+TrueFalseRegex=indent_cmt_with_tabs\s*=\s*true|indent_cmt_with_tabs\s*=\s*false
 ValueDefault=false
 
 [Indent Align String]
@@ -2615,7 +2903,8 @@ Category=2
 Description="<html>Whether to indent strings broken by '\' so that they line up.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_align_string\s*=\s*true|indent_align_string\s*=\s*false
+TrueFalse=indent_align_string=true|indent_align_string=false
+TrueFalseRegex=indent_align_string\s*=\s*true|indent_align_string\s*=\s*false
 ValueDefault=false
 
 [Indent Xml String]
@@ -2623,7 +2912,8 @@ Category=2
 Description="<html>The number of spaces to indent multi-line XML strings.<br/>Requires indent_align_string=true.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_xml_string\s*=\s*"
+CallName="indent_xml_string="
+CallNameRegex="indent_xml_string\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2633,7 +2923,8 @@ Category=2
 Description="<html>Spaces to indent '{' from level.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_brace\s*=\s*"
+CallName="indent_brace="
+CallNameRegex="indent_brace\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2643,7 +2934,8 @@ Category=2
 Description="<html>Whether braces are indented to the body level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_braces\s*=\s*true|indent_braces\s*=\s*false
+TrueFalse=indent_braces=true|indent_braces=false
+TrueFalseRegex=indent_braces\s*=\s*true|indent_braces\s*=\s*false
 ValueDefault=false
 
 [Indent Braces No Func]
@@ -2651,7 +2943,8 @@ Category=2
 Description="<html>Whether to disable indenting function braces if indent_braces=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_braces_no_func\s*=\s*true|indent_braces_no_func\s*=\s*false
+TrueFalse=indent_braces_no_func=true|indent_braces_no_func=false
+TrueFalseRegex=indent_braces_no_func\s*=\s*true|indent_braces_no_func\s*=\s*false
 ValueDefault=false
 
 [Indent Braces No Class]
@@ -2659,7 +2952,8 @@ Category=2
 Description="<html>Whether to disable indenting class braces if indent_braces=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_braces_no_class\s*=\s*true|indent_braces_no_class\s*=\s*false
+TrueFalse=indent_braces_no_class=true|indent_braces_no_class=false
+TrueFalseRegex=indent_braces_no_class\s*=\s*true|indent_braces_no_class\s*=\s*false
 ValueDefault=false
 
 [Indent Braces No Struct]
@@ -2667,7 +2961,8 @@ Category=2
 Description="<html>Whether to disable indenting struct braces if indent_braces=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_braces_no_struct\s*=\s*true|indent_braces_no_struct\s*=\s*false
+TrueFalse=indent_braces_no_struct=true|indent_braces_no_struct=false
+TrueFalseRegex=indent_braces_no_struct\s*=\s*true|indent_braces_no_struct\s*=\s*false
 ValueDefault=false
 
 [Indent Brace Parent]
@@ -2675,7 +2970,8 @@ Category=2
 Description="<html>Whether to indent based on the size of the brace parent,<br/>i.e. 'if' =&gt; 3 spaces, 'for' =&gt; 4 spaces, etc.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_brace_parent\s*=\s*true|indent_brace_parent\s*=\s*false
+TrueFalse=indent_brace_parent=true|indent_brace_parent=false
+TrueFalseRegex=indent_brace_parent\s*=\s*true|indent_brace_parent\s*=\s*false
 ValueDefault=false
 
 [Indent Paren Open Brace]
@@ -2683,7 +2979,8 @@ Category=2
 Description="<html>Whether to indent based on the open parenthesis instead of the open brace<br/>in '({\n'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_open_brace\s*=\s*true|indent_paren_open_brace\s*=\s*false
+TrueFalse=indent_paren_open_brace=true|indent_paren_open_brace=false
+TrueFalseRegex=indent_paren_open_brace\s*=\s*true|indent_paren_open_brace\s*=\s*false
 ValueDefault=false
 
 [Indent Cs Delegate Brace]
@@ -2691,7 +2988,8 @@ Category=2
 Description="<html>(C#) Whether to indent the brace of a C# delegate by another level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cs_delegate_brace\s*=\s*true|indent_cs_delegate_brace\s*=\s*false
+TrueFalse=indent_cs_delegate_brace=true|indent_cs_delegate_brace=false
+TrueFalseRegex=indent_cs_delegate_brace\s*=\s*true|indent_cs_delegate_brace\s*=\s*false
 ValueDefault=false
 
 [Indent Cs Delegate Body]
@@ -2699,7 +2997,8 @@ Category=2
 Description="<html>(C#) Whether to indent a C# delegate (to handle delegates with no brace) by<br/>another level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cs_delegate_body\s*=\s*true|indent_cs_delegate_body\s*=\s*false
+TrueFalse=indent_cs_delegate_body=true|indent_cs_delegate_body=false
+TrueFalseRegex=indent_cs_delegate_body\s*=\s*true|indent_cs_delegate_body\s*=\s*false
 ValueDefault=false
 
 [Indent Namespace]
@@ -2707,7 +3006,8 @@ Category=2
 Description="<html>Whether to indent the body of a 'namespace'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_namespace\s*=\s*true|indent_namespace\s*=\s*false
+TrueFalse=indent_namespace=true|indent_namespace=false
+TrueFalseRegex=indent_namespace\s*=\s*true|indent_namespace\s*=\s*false
 ValueDefault=false
 
 [Indent Namespace Single Indent]
@@ -2715,7 +3015,8 @@ Category=2
 Description="<html>Whether to indent only the first namespace, and not any nested namespaces.<br/>Requires indent_namespace=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_namespace_single_indent\s*=\s*true|indent_namespace_single_indent\s*=\s*false
+TrueFalse=indent_namespace_single_indent=true|indent_namespace_single_indent=false
+TrueFalseRegex=indent_namespace_single_indent\s*=\s*true|indent_namespace_single_indent\s*=\s*false
 ValueDefault=false
 
 [Indent Namespace Level]
@@ -2723,7 +3024,8 @@ Category=2
 Description="<html>The number of spaces to indent a namespace block.<br/>If set to zero, use the value indent_columns</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_namespace_level\s*=\s*"
+CallName="indent_namespace_level="
+CallNameRegex="indent_namespace_level\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2733,7 +3035,8 @@ Category=2
 Description="<html>If the body of the namespace is longer than this number, it won't be<br/>indented. Requires indent_namespace=true. 0 means no limit.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_namespace_limit\s*=\s*"
+CallName="indent_namespace_limit="
+CallNameRegex="indent_namespace_limit\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -2743,7 +3046,8 @@ Category=2
 Description="<html>Whether to indent only in inner namespaces (nested in other namespaces).<br/>Requires indent_namespace=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_namespace_inner_only\s*=\s*true|indent_namespace_inner_only\s*=\s*false
+TrueFalse=indent_namespace_inner_only=true|indent_namespace_inner_only=false
+TrueFalseRegex=indent_namespace_inner_only\s*=\s*true|indent_namespace_inner_only\s*=\s*false
 ValueDefault=false
 
 [Indent Extern]
@@ -2751,7 +3055,8 @@ Category=2
 Description="<html>Whether the 'extern "C"' body is indented.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_extern\s*=\s*true|indent_extern\s*=\s*false
+TrueFalse=indent_extern=true|indent_extern=false
+TrueFalseRegex=indent_extern\s*=\s*true|indent_extern\s*=\s*false
 ValueDefault=false
 
 [Indent Class]
@@ -2759,7 +3064,8 @@ Category=2
 Description="<html>Whether the 'class' body is indented.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_class\s*=\s*true|indent_class\s*=\s*false
+TrueFalse=indent_class=true|indent_class=false
+TrueFalseRegex=indent_class\s*=\s*true|indent_class\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Before Class Colon]
@@ -2767,7 +3073,8 @@ Category=2
 Description="<html>Whether to ignore indent for the leading base class colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_before_class_colon\s*=\s*true|indent_ignore_before_class_colon\s*=\s*false
+TrueFalse=indent_ignore_before_class_colon=true|indent_ignore_before_class_colon=false
+TrueFalseRegex=indent_ignore_before_class_colon\s*=\s*true|indent_ignore_before_class_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Before Class Colon]
@@ -2775,7 +3082,8 @@ Category=2
 Description="<html>Additional indent before the leading base class colon.<br/>Negative values decrease indent down to the first column.<br/>Requires indent_ignore_before_class_colon=false and a newline break before<br/>the colon (see pos_class_colon and nl_class_colon)</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_before_class_colon\s*=\s*"
+CallName="indent_before_class_colon="
+CallNameRegex="indent_before_class_colon\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -2785,7 +3093,8 @@ Category=2
 Description="<html>Whether to indent the stuff after a leading base class colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_class_colon\s*=\s*true|indent_class_colon\s*=\s*false
+TrueFalse=indent_class_colon=true|indent_class_colon=false
+TrueFalseRegex=indent_class_colon\s*=\s*true|indent_class_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Class On Colon]
@@ -2793,7 +3102,8 @@ Category=2
 Description="<html>Whether to indent based on a class colon instead of the stuff after the<br/>colon. Requires indent_class_colon=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_class_on_colon\s*=\s*true|indent_class_on_colon\s*=\s*false
+TrueFalse=indent_class_on_colon=true|indent_class_on_colon=false
+TrueFalseRegex=indent_class_on_colon\s*=\s*true|indent_class_on_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Before Constr Colon]
@@ -2801,7 +3111,8 @@ Category=2
 Description="<html>Whether to ignore indent for a leading class initializer colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_before_constr_colon\s*=\s*true|indent_ignore_before_constr_colon\s*=\s*false
+TrueFalse=indent_ignore_before_constr_colon=true|indent_ignore_before_constr_colon=false
+TrueFalseRegex=indent_ignore_before_constr_colon\s*=\s*true|indent_ignore_before_constr_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Constr Colon]
@@ -2809,7 +3120,8 @@ Category=2
 Description="<html>Whether to indent the stuff after a leading class initializer colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_constr_colon\s*=\s*true|indent_constr_colon\s*=\s*false
+TrueFalse=indent_constr_colon=true|indent_constr_colon=false
+TrueFalseRegex=indent_constr_colon\s*=\s*true|indent_constr_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Ctor Init Leading]
@@ -2817,7 +3129,8 @@ Category=2
 Description="<html>Virtual indent from the ':' for leading member initializers.<br/><br/>Default: 2</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_ctor_init_leading\s*=\s*"
+CallName="indent_ctor_init_leading="
+CallNameRegex="indent_ctor_init_leading\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=2
@@ -2827,7 +3140,8 @@ Category=2
 Description="<html>Virtual indent from the ':' for following member initializers.<br/><br/>Default: 2</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_ctor_init_following\s*=\s*"
+CallName="indent_ctor_init_following="
+CallNameRegex="indent_ctor_init_following\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=2
@@ -2837,7 +3151,8 @@ Category=2
 Description="<html>Additional indent for constructor initializer list.<br/>Negative values decrease indent down to the first column.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_ctor_init\s*=\s*"
+CallName="indent_ctor_init="
+CallNameRegex="indent_ctor_init\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -2847,7 +3162,8 @@ Category=2
 Description="<html>Whether to indent 'if' following 'else' as a new block under the 'else'.<br/>If false, 'else\nif' is treated as 'else if' for indenting purposes.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_else_if\s*=\s*true|indent_else_if\s*=\s*false
+TrueFalse=indent_else_if=true|indent_else_if=false
+TrueFalseRegex=indent_else_if\s*=\s*true|indent_else_if\s*=\s*false
 ValueDefault=false
 
 [Indent Var Def Blk]
@@ -2855,7 +3171,8 @@ Category=2
 Description="<html>Amount to indent variable declarations after a open brace.<br/><br/> &lt;0: Relative<br/>&gt;=0: Absolute</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_var_def_blk\s*=\s*"
+CallName="indent_var_def_blk="
+CallNameRegex="indent_var_def_blk\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -2865,7 +3182,8 @@ Category=2
 Description="<html>Whether to indent continued variable declarations instead of aligning.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_var_def_cont\s*=\s*true|indent_var_def_cont\s*=\s*false
+TrueFalse=indent_var_def_cont=true|indent_var_def_cont=false
+TrueFalseRegex=indent_var_def_cont\s*=\s*true|indent_var_def_cont\s*=\s*false
 ValueDefault=false
 
 [Indent Shift]
@@ -2873,7 +3191,8 @@ Category=2
 Description="<html>How to indent continued shift expressions ('&lt;&lt;' and '&gt;&gt;').<br/>Set align_left_shift=false when using this.<br/> 0: Align shift operators instead of indenting them (default)<br/> 1: Indent by one level<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_shift\s*=\s*"
+CallName="indent_shift="
+CallNameRegex="indent_shift\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=0
@@ -2883,7 +3202,8 @@ Category=2
 Description="<html>Whether to force indentation of function definitions to start in column 1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_def_force_col1\s*=\s*true|indent_func_def_force_col1\s*=\s*false
+TrueFalse=indent_func_def_force_col1=true|indent_func_def_force_col1=false
+TrueFalseRegex=indent_func_def_force_col1\s*=\s*true|indent_func_def_force_col1\s*=\s*false
 ValueDefault=false
 
 [Indent Func Call Param]
@@ -2891,7 +3211,8 @@ Category=2
 Description="<html>Whether to indent continued function call parameters one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_call_param\s*=\s*true|indent_func_call_param\s*=\s*false
+TrueFalse=indent_func_call_param=true|indent_func_call_param=false
+TrueFalseRegex=indent_func_call_param\s*=\s*true|indent_func_call_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Def Param]
@@ -2899,7 +3220,8 @@ Category=2
 Description="<html>Whether to indent continued function definition parameters one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_def_param\s*=\s*true|indent_func_def_param\s*=\s*false
+TrueFalse=indent_func_def_param=true|indent_func_def_param=false
+TrueFalseRegex=indent_func_def_param\s*=\s*true|indent_func_def_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Def Param Paren Pos Threshold]
@@ -2907,7 +3229,8 @@ Category=2
 Description="<html>for function definitions, only if indent_func_def_param is false<br/>Allows to align params when appropriate and indent them when not<br/>behave as if it was true if paren position is more than this value<br/>if paren position is more than the option value</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_func_def_param_paren_pos_threshold\s*=\s*"
+CallName="indent_func_def_param_paren_pos_threshold="
+CallNameRegex="indent_func_def_param_paren_pos_threshold\s*=\s*"
 MinVal=0
 MaxVal=160
 ValueDefault=0
@@ -2917,7 +3240,8 @@ Category=2
 Description="<html>Whether to indent continued function call prototype one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_proto_param\s*=\s*true|indent_func_proto_param\s*=\s*false
+TrueFalse=indent_func_proto_param=true|indent_func_proto_param=false
+TrueFalseRegex=indent_func_proto_param\s*=\s*true|indent_func_proto_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Class Param]
@@ -2925,7 +3249,8 @@ Category=2
 Description="<html>Whether to indent continued function call declaration one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_class_param\s*=\s*true|indent_func_class_param\s*=\s*false
+TrueFalse=indent_func_class_param=true|indent_func_class_param=false
+TrueFalseRegex=indent_func_class_param\s*=\s*true|indent_func_class_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Ctor Var Param]
@@ -2933,7 +3258,8 @@ Category=2
 Description="<html>Whether to indent continued class variable constructors one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_ctor_var_param\s*=\s*true|indent_func_ctor_var_param\s*=\s*false
+TrueFalse=indent_func_ctor_var_param=true|indent_func_ctor_var_param=false
+TrueFalseRegex=indent_func_ctor_var_param\s*=\s*true|indent_func_ctor_var_param\s*=\s*false
 ValueDefault=false
 
 [Indent Template Param]
@@ -2941,7 +3267,8 @@ Category=2
 Description="<html>Whether to indent continued template parameter list one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_template_param\s*=\s*true|indent_template_param\s*=\s*false
+TrueFalse=indent_template_param=true|indent_template_param=false
+TrueFalseRegex=indent_template_param\s*=\s*true|indent_template_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Param Double]
@@ -2949,7 +3276,8 @@ Category=2
 Description="<html>Double the indent for indent_func_xxx_param options.<br/>Use both values of the options indent_columns and indent_param.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_param_double\s*=\s*true|indent_func_param_double\s*=\s*false
+TrueFalse=indent_func_param_double=true|indent_func_param_double=false
+TrueFalseRegex=indent_func_param_double\s*=\s*true|indent_func_param_double\s*=\s*false
 ValueDefault=false
 
 [Indent Func Const]
@@ -2957,7 +3285,8 @@ Category=2
 Description="<html>Indentation column for standalone 'const' qualifier on a function<br/>prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_func_const\s*=\s*"
+CallName="indent_func_const="
+CallNameRegex="indent_func_const\s*=\s*"
 MinVal=0
 MaxVal=69
 ValueDefault=0
@@ -2967,7 +3296,8 @@ Category=2
 Description="<html>Indentation column for standalone 'throw' qualifier on a function<br/>prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_func_throw\s*=\s*"
+CallName="indent_func_throw="
+CallNameRegex="indent_func_throw\s*=\s*"
 MinVal=0
 MaxVal=41
 ValueDefault=0
@@ -2977,7 +3307,8 @@ Category=2
 Description="<html>How to indent within a macro followed by a brace on the same line<br/>This allows reducing the indent in macros that have (for example)<br/>`do { ... } while (0)` blocks bracketing them.<br/><br/>true:  add an indent for the brace on the same line as the macro<br/>false: do not add an indent for the brace on the same line as the macro<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_macro_brace\s*=\s*true|indent_macro_brace\s*=\s*false
+TrueFalse=indent_macro_brace=true|indent_macro_brace=false
+TrueFalseRegex=indent_macro_brace\s*=\s*true|indent_macro_brace\s*=\s*false
 ValueDefault=true
 
 [Indent Member]
@@ -2985,7 +3316,8 @@ Category=2
 Description="<html>The number of spaces to indent a continued '-&gt;' or '.'.<br/>Usually set to 0, 1, or indent_columns.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_member\s*=\s*"
+CallName="indent_member="
+CallNameRegex="indent_member\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2995,7 +3327,8 @@ Category=2
 Description="<html>Whether lines broken at '.' or '-&gt;' should be indented by a single indent.<br/>The indent_member option will not be effective if this is set to true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_member_single\s*=\s*true|indent_member_single\s*=\s*false
+TrueFalse=indent_member_single=true|indent_member_single=false
+TrueFalseRegex=indent_member_single\s*=\s*true|indent_member_single\s*=\s*false
 ValueDefault=false
 
 [Indent Single Line Comments Before]
@@ -3003,7 +3336,8 @@ Category=2
 Description="<html>Spaces to indent single line ('//') comments on lines before code.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_single_line_comments_before\s*=\s*"
+CallName="indent_single_line_comments_before="
+CallNameRegex="indent_single_line_comments_before\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3013,7 +3347,8 @@ Category=2
 Description="<html>Spaces to indent single line ('//') comments on lines after code.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_single_line_comments_after\s*=\s*"
+CallName="indent_single_line_comments_after="
+CallNameRegex="indent_single_line_comments_after\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3023,7 +3358,8 @@ Category=2
 Description="<html>When opening a paren for a control statement (if, for, while, etc), increase<br/>the indent level by this value. Negative values decrease the indent level.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_sparen_extra\s*=\s*"
+CallName="indent_sparen_extra="
+CallNameRegex="indent_sparen_extra\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -3033,7 +3369,8 @@ Category=2
 Description="<html>Whether to indent trailing single line ('//') comments relative to the code<br/>instead of trying to keep the same absolute column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_relative_single_line_comments\s*=\s*true|indent_relative_single_line_comments\s*=\s*false
+TrueFalse=indent_relative_single_line_comments=true|indent_relative_single_line_comments=false
+TrueFalseRegex=indent_relative_single_line_comments\s*=\s*true|indent_relative_single_line_comments\s*=\s*false
 ValueDefault=false
 
 [Indent Switch Case]
@@ -3041,7 +3378,8 @@ Category=2
 Description="<html>Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.<br/>It might be wise to choose the same value for the option indent_case_brace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_switch_case\s*=\s*"
+CallName="indent_switch_case="
+CallNameRegex="indent_switch_case\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3051,7 +3389,8 @@ Category=2
 Description="<html>Spaces to indent the body of a 'switch' before any 'case'.<br/>Usually the same as indent_columns or indent_switch_case.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_switch_body\s*=\s*"
+CallName="indent_switch_body="
+CallNameRegex="indent_switch_body\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3061,7 +3400,8 @@ Category=2
 Description="<html>Whether to ignore indent for '{' following 'case'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_case_brace\s*=\s*true|indent_ignore_case_brace\s*=\s*false
+TrueFalse=indent_ignore_case_brace=true|indent_ignore_case_brace=false
+TrueFalseRegex=indent_ignore_case_brace\s*=\s*true|indent_ignore_case_brace\s*=\s*false
 ValueDefault=false
 
 [Indent Case Brace]
@@ -3069,7 +3409,8 @@ Category=2
 Description="<html>Spaces to indent '{' from 'case'. By default, the brace will appear under<br/>the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.<br/>It might be wise to choose the same value for the option indent_switch_case.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_case_brace\s*=\s*"
+CallName="indent_case_brace="
+CallNameRegex="indent_case_brace\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -3079,7 +3420,8 @@ Category=2
 Description="<html>indent 'break' with 'case' from 'switch'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_switch_break_with_case\s*=\s*true|indent_switch_break_with_case\s*=\s*false
+TrueFalse=indent_switch_break_with_case=true|indent_switch_break_with_case=false
+TrueFalseRegex=indent_switch_break_with_case\s*=\s*true|indent_switch_break_with_case\s*=\s*false
 ValueDefault=false
 
 [Indent Switch Pp]
@@ -3087,7 +3429,8 @@ Category=2
 Description="<html>Whether to indent preprocessor statements inside of switch statements.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_switch_pp\s*=\s*true|indent_switch_pp\s*=\s*false
+TrueFalse=indent_switch_pp=true|indent_switch_pp=false
+TrueFalseRegex=indent_switch_pp\s*=\s*true|indent_switch_pp\s*=\s*false
 ValueDefault=true
 
 [Indent Case Shift]
@@ -3095,7 +3438,8 @@ Category=2
 Description="<html>Spaces to shift the 'case' line, without affecting any other lines.<br/>Usually 0.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_case_shift\s*=\s*"
+CallName="indent_case_shift="
+CallNameRegex="indent_case_shift\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3105,7 +3449,8 @@ Category=2
 Description="<html>Whether to align comments before 'case' with the 'case'.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_case_comment\s*=\s*true|indent_case_comment\s*=\s*false
+TrueFalse=indent_case_comment=true|indent_case_comment=false
+TrueFalseRegex=indent_case_comment\s*=\s*true|indent_case_comment\s*=\s*false
 ValueDefault=true
 
 [Indent Comment]
@@ -3113,7 +3458,8 @@ Category=2
 Description="<html>Whether to indent comments not found in first column.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_comment\s*=\s*true|indent_comment\s*=\s*false
+TrueFalse=indent_comment=true|indent_comment=false
+TrueFalseRegex=indent_comment\s*=\s*true|indent_comment\s*=\s*false
 ValueDefault=true
 
 [Indent Col1 Comment]
@@ -3121,7 +3467,8 @@ Category=2
 Description="<html>Whether to indent comments found in first column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_col1_comment\s*=\s*true|indent_col1_comment\s*=\s*false
+TrueFalse=indent_col1_comment=true|indent_col1_comment=false
+TrueFalseRegex=indent_col1_comment\s*=\s*true|indent_col1_comment\s*=\s*false
 ValueDefault=false
 
 [Indent Col1 Multi String Literal]
@@ -3129,7 +3476,8 @@ Category=2
 Description="<html>Whether to indent multi string literal in first column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_col1_multi_string_literal\s*=\s*true|indent_col1_multi_string_literal\s*=\s*false
+TrueFalse=indent_col1_multi_string_literal=true|indent_col1_multi_string_literal=false
+TrueFalseRegex=indent_col1_multi_string_literal\s*=\s*true|indent_col1_multi_string_literal\s*=\s*false
 ValueDefault=false
 
 [Indent Comment Align Thresh]
@@ -3137,7 +3485,8 @@ Category=2
 Description="<html>Align comments on adjacent lines that are this many columns apart or less.<br/><br/>Default: 3</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_comment_align_thresh\s*=\s*"
+CallName="indent_comment_align_thresh="
+CallNameRegex="indent_comment_align_thresh\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=3
@@ -3147,7 +3496,8 @@ Category=2
 Description="<html>Whether to ignore indent for goto labels.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_label\s*=\s*true|indent_ignore_label\s*=\s*false
+TrueFalse=indent_ignore_label=true|indent_ignore_label=false
+TrueFalseRegex=indent_ignore_label\s*=\s*true|indent_ignore_label\s*=\s*false
 ValueDefault=false
 
 [Indent Label]
@@ -3155,7 +3505,8 @@ Category=2
 Description="<html>How to indent goto labels. Requires indent_ignore_label=false.<br/><br/> &gt;0: Absolute column where 1 is the leftmost column<br/>&lt;=0: Subtract from brace indent<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_label\s*=\s*"
+CallName="indent_label="
+CallNameRegex="indent_label\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=1
@@ -3165,7 +3516,8 @@ Category=2
 Description="<html>How to indent access specifiers that are followed by a<br/>colon.<br/><br/> &gt;0: Absolute column where 1 is the leftmost column<br/>&lt;=0: Subtract from brace indent<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_access_spec\s*=\s*"
+CallName="indent_access_spec="
+CallNameRegex="indent_access_spec\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=1
@@ -3175,7 +3527,8 @@ Category=2
 Description="<html>Whether to indent the code after an access specifier by one level.<br/>If true, this option forces 'indent_access_spec=0'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_access_spec_body\s*=\s*true|indent_access_spec_body\s*=\s*false
+TrueFalse=indent_access_spec_body=true|indent_access_spec_body=false
+TrueFalseRegex=indent_access_spec_body\s*=\s*true|indent_access_spec_body\s*=\s*false
 ValueDefault=false
 
 [Indent Paren Nl]
@@ -3183,7 +3536,8 @@ Category=2
 Description="<html>If an open parenthesis is followed by a newline, whether to indent the next<br/>line so that it lines up after the open parenthesis (not recommended).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_nl\s*=\s*true|indent_paren_nl\s*=\s*false
+TrueFalse=indent_paren_nl=true|indent_paren_nl=false
+TrueFalseRegex=indent_paren_nl\s*=\s*true|indent_paren_nl\s*=\s*false
 ValueDefault=false
 
 [Indent Paren Close]
@@ -3191,7 +3545,8 @@ Category=2
 Description="<html>How to indent a close parenthesis after a newline.<br/><br/> 0: Indent to body level (default)<br/> 1: Align under the open parenthesis<br/> 2: Indent to the brace level<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_paren_close\s*=\s*"
+CallName="indent_paren_close="
+CallNameRegex="indent_paren_close\s*=\s*"
 MinVal=-1
 MaxVal=2
 ValueDefault=0
@@ -3201,7 +3556,8 @@ Category=2
 Description="<html>Whether to indent the open parenthesis of a function definition,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_after_func_def\s*=\s*true|indent_paren_after_func_def\s*=\s*false
+TrueFalse=indent_paren_after_func_def=true|indent_paren_after_func_def=false
+TrueFalseRegex=indent_paren_after_func_def\s*=\s*true|indent_paren_after_func_def\s*=\s*false
 ValueDefault=false
 
 [Indent Paren After Func Decl]
@@ -3209,7 +3565,8 @@ Category=2
 Description="<html>Whether to indent the open parenthesis of a function declaration,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_after_func_decl\s*=\s*true|indent_paren_after_func_decl\s*=\s*false
+TrueFalse=indent_paren_after_func_decl=true|indent_paren_after_func_decl=false
+TrueFalseRegex=indent_paren_after_func_decl\s*=\s*true|indent_paren_after_func_decl\s*=\s*false
 ValueDefault=false
 
 [Indent Paren After Func Call]
@@ -3217,7 +3574,8 @@ Category=2
 Description="<html>Whether to indent the open parenthesis of a function call,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_after_func_call\s*=\s*true|indent_paren_after_func_call\s*=\s*false
+TrueFalse=indent_paren_after_func_call=true|indent_paren_after_func_call=false
+TrueFalseRegex=indent_paren_after_func_call\s*=\s*true|indent_paren_after_func_call\s*=\s*false
 ValueDefault=false
 
 [Indent Comma Brace]
@@ -3225,7 +3583,8 @@ Category=2
 Description="<html>How to indent a comma when inside braces.<br/> 0: Indent by one level (default)<br/> 1: Align under the open brace<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_comma_brace\s*=\s*"
+CallName="indent_comma_brace="
+CallNameRegex="indent_comma_brace\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=0
@@ -3235,7 +3594,8 @@ Category=2
 Description="<html>How to indent a comma when inside parentheses.<br/> 0: Indent by one level (default)<br/> 1: Align under the open parenthesis<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_comma_paren\s*=\s*"
+CallName="indent_comma_paren="
+CallNameRegex="indent_comma_paren\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=0
@@ -3245,7 +3605,8 @@ Category=2
 Description="<html>How to indent a Boolean operator when inside parentheses.<br/> 0: Indent by one level (default)<br/> 1: Align under the open parenthesis<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_bool_paren\s*=\s*"
+CallName="indent_bool_paren="
+CallNameRegex="indent_bool_paren\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=0
@@ -3255,7 +3616,8 @@ Category=2
 Description="<html>Whether to ignore the indentation of a Boolean operator when outside<br/>parentheses.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_bool\s*=\s*true|indent_ignore_bool\s*=\s*false
+TrueFalse=indent_ignore_bool=true|indent_ignore_bool=false
+TrueFalseRegex=indent_ignore_bool\s*=\s*true|indent_ignore_bool\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Arith]
@@ -3263,7 +3625,8 @@ Category=2
 Description="<html>Whether to ignore the indentation of an arithmetic operator.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_arith\s*=\s*true|indent_ignore_arith\s*=\s*false
+TrueFalse=indent_ignore_arith=true|indent_ignore_arith=false
+TrueFalseRegex=indent_ignore_arith\s*=\s*true|indent_ignore_arith\s*=\s*false
 ValueDefault=false
 
 [Indent Semicolon For Paren]
@@ -3271,7 +3634,8 @@ Category=2
 Description="<html>Whether to indent a semicolon when inside a for parenthesis.<br/>If true, aligns under the open for parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_semicolon_for_paren\s*=\s*true|indent_semicolon_for_paren\s*=\s*false
+TrueFalse=indent_semicolon_for_paren=true|indent_semicolon_for_paren=false
+TrueFalseRegex=indent_semicolon_for_paren\s*=\s*true|indent_semicolon_for_paren\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Semicolon]
@@ -3279,7 +3643,8 @@ Category=2
 Description="<html>Whether to ignore the indentation of a semicolon outside of a 'for'<br/>statement.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_semicolon\s*=\s*true|indent_ignore_semicolon\s*=\s*false
+TrueFalse=indent_ignore_semicolon=true|indent_ignore_semicolon=false
+TrueFalseRegex=indent_ignore_semicolon\s*=\s*true|indent_ignore_semicolon\s*=\s*false
 ValueDefault=false
 
 [Indent First Bool Expr]
@@ -3287,7 +3652,8 @@ Category=2
 Description="<html>Whether to align the first expression to following ones<br/>if indent_bool_paren=1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_first_bool_expr\s*=\s*true|indent_first_bool_expr\s*=\s*false
+TrueFalse=indent_first_bool_expr=true|indent_first_bool_expr=false
+TrueFalseRegex=indent_first_bool_expr\s*=\s*true|indent_first_bool_expr\s*=\s*false
 ValueDefault=false
 
 [Indent First For Expr]
@@ -3295,7 +3661,8 @@ Category=2
 Description="<html>Whether to align the first expression to following ones<br/>if indent_semicolon_for_paren=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_first_for_expr\s*=\s*true|indent_first_for_expr\s*=\s*false
+TrueFalse=indent_first_for_expr=true|indent_first_for_expr=false
+TrueFalseRegex=indent_first_for_expr\s*=\s*true|indent_first_for_expr\s*=\s*false
 ValueDefault=false
 
 [Indent Square Nl]
@@ -3303,7 +3670,8 @@ Category=2
 Description="<html>If an open square is followed by a newline, whether to indent the next line<br/>so that it lines up after the open square (not recommended).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_square_nl\s*=\s*true|indent_square_nl\s*=\s*false
+TrueFalse=indent_square_nl=true|indent_square_nl=false
+TrueFalseRegex=indent_square_nl\s*=\s*true|indent_square_nl\s*=\s*false
 ValueDefault=false
 
 [Indent Preserve Sql]
@@ -3311,7 +3679,8 @@ Category=2
 Description="<html>(ESQL/C) Whether to preserve the relative indent of 'EXEC SQL' bodies.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_preserve_sql\s*=\s*true|indent_preserve_sql\s*=\s*false
+TrueFalse=indent_preserve_sql=true|indent_preserve_sql=false
+TrueFalseRegex=indent_preserve_sql\s*=\s*true|indent_preserve_sql\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Assign]
@@ -3319,7 +3688,8 @@ Category=2
 Description="<html>Whether to ignore the indentation of an assignment operator.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_assign\s*=\s*true|indent_ignore_assign\s*=\s*false
+TrueFalse=indent_ignore_assign=true|indent_ignore_assign=false
+TrueFalseRegex=indent_ignore_assign\s*=\s*true|indent_ignore_assign\s*=\s*false
 ValueDefault=false
 
 [Indent Align Assign]
@@ -3327,7 +3697,8 @@ Category=2
 Description="<html>Whether to align continued statements at the '='. If false or if the '=' is<br/>followed by a newline, the next line is indent one tab.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_align_assign\s*=\s*true|indent_align_assign\s*=\s*false
+TrueFalse=indent_align_assign=true|indent_align_assign=false
+TrueFalseRegex=indent_align_assign\s*=\s*true|indent_align_assign\s*=\s*false
 ValueDefault=true
 
 [Indent Off After Assign]
@@ -3335,7 +3706,8 @@ Category=2
 Description="<html>If true, the indentation of the chunks after a '=' sequence will be set at<br/>LHS token indentation column before '='.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_off_after_assign\s*=\s*true|indent_off_after_assign\s*=\s*false
+TrueFalse=indent_off_after_assign=true|indent_off_after_assign=false
+TrueFalseRegex=indent_off_after_assign\s*=\s*true|indent_off_after_assign\s*=\s*false
 ValueDefault=false
 
 [Indent Align Paren]
@@ -3343,7 +3715,8 @@ Category=2
 Description="<html>Whether to align continued statements at the '('. If false or the '(' is<br/>followed by a newline, the next line indent is one tab.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_align_paren\s*=\s*true|indent_align_paren\s*=\s*false
+TrueFalse=indent_align_paren=true|indent_align_paren=false
+TrueFalseRegex=indent_align_paren\s*=\s*true|indent_align_paren\s*=\s*false
 ValueDefault=true
 
 [Indent Oc Inside Msg Sel]
@@ -3351,7 +3724,8 @@ Category=2
 Description="<html>(OC) Whether to indent Objective-C code inside message selectors.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_inside_msg_sel\s*=\s*true|indent_oc_inside_msg_sel\s*=\s*false
+TrueFalse=indent_oc_inside_msg_sel=true|indent_oc_inside_msg_sel=false
+TrueFalseRegex=indent_oc_inside_msg_sel\s*=\s*true|indent_oc_inside_msg_sel\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block]
@@ -3359,7 +3733,8 @@ Category=2
 Description="<html>(OC) Whether to indent Objective-C blocks at brace level instead of usual<br/>rules.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block\s*=\s*true|indent_oc_block\s*=\s*false
+TrueFalse=indent_oc_block=true|indent_oc_block=false
+TrueFalseRegex=indent_oc_block\s*=\s*true|indent_oc_block\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg]
@@ -3367,7 +3742,8 @@ Category=2
 Description="<html>(OC) Indent for Objective-C blocks in a message relative to the parameter<br/>name.<br/><br/>=0: Use indent_oc_block rules<br/>&gt;0: Use specified number of spaces to indent</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_oc_block_msg\s*=\s*"
+CallName="indent_oc_block_msg="
+CallNameRegex="indent_oc_block_msg\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3377,7 +3753,8 @@ Category=2
 Description="<html>(OC) Minimum indent for subsequent parameters</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_oc_msg_colon\s*=\s*"
+CallName="indent_oc_msg_colon="
+CallNameRegex="indent_oc_msg_colon\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -3387,7 +3764,8 @@ Category=2
 Description="<html>(OC) Whether to prioritize aligning with initial colon (and stripping spaces<br/>from lines, if necessary).<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_msg_prioritize_first_colon\s*=\s*true|indent_oc_msg_prioritize_first_colon\s*=\s*false
+TrueFalse=indent_oc_msg_prioritize_first_colon=true|indent_oc_msg_prioritize_first_colon=false
+TrueFalseRegex=indent_oc_msg_prioritize_first_colon\s*=\s*true|indent_oc_msg_prioritize_first_colon\s*=\s*false
 ValueDefault=true
 
 [Indent Oc Block Msg Xcode Style]
@@ -3395,7 +3773,8 @@ Category=2
 Description="<html>(OC) Whether to indent blocks the way that Xcode does by default<br/>(from the keyword if the parameter is on its own line; otherwise, from the<br/>previous indentation level). Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_xcode_style\s*=\s*true|indent_oc_block_msg_xcode_style\s*=\s*false
+TrueFalse=indent_oc_block_msg_xcode_style=true|indent_oc_block_msg_xcode_style=false
+TrueFalseRegex=indent_oc_block_msg_xcode_style\s*=\s*true|indent_oc_block_msg_xcode_style\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg From Keyword]
@@ -3403,7 +3782,8 @@ Category=2
 Description="<html>(OC) Whether to indent blocks from where the brace is, relative to a<br/>message keyword. Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_from_keyword\s*=\s*true|indent_oc_block_msg_from_keyword\s*=\s*false
+TrueFalse=indent_oc_block_msg_from_keyword=true|indent_oc_block_msg_from_keyword=false
+TrueFalseRegex=indent_oc_block_msg_from_keyword\s*=\s*true|indent_oc_block_msg_from_keyword\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg From Colon]
@@ -3411,7 +3791,8 @@ Category=2
 Description="<html>(OC) Whether to indent blocks from where the brace is, relative to a message<br/>colon. Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_from_colon\s*=\s*true|indent_oc_block_msg_from_colon\s*=\s*false
+TrueFalse=indent_oc_block_msg_from_colon=true|indent_oc_block_msg_from_colon=false
+TrueFalseRegex=indent_oc_block_msg_from_colon\s*=\s*true|indent_oc_block_msg_from_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg From Caret]
@@ -3419,7 +3800,8 @@ Category=2
 Description="<html>(OC) Whether to indent blocks from where the block caret is.<br/>Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_from_caret\s*=\s*true|indent_oc_block_msg_from_caret\s*=\s*false
+TrueFalse=indent_oc_block_msg_from_caret=true|indent_oc_block_msg_from_caret=false
+TrueFalseRegex=indent_oc_block_msg_from_caret\s*=\s*true|indent_oc_block_msg_from_caret\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg From Brace]
@@ -3427,7 +3809,8 @@ Category=2
 Description="<html>(OC) Whether to indent blocks from where the brace caret is.<br/>Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_from_brace\s*=\s*true|indent_oc_block_msg_from_brace\s*=\s*false
+TrueFalse=indent_oc_block_msg_from_brace=true|indent_oc_block_msg_from_brace=false
+TrueFalseRegex=indent_oc_block_msg_from_brace\s*=\s*true|indent_oc_block_msg_from_brace\s*=\s*false
 ValueDefault=false
 
 [Indent Min Vbrace Open]
@@ -3435,7 +3818,8 @@ Category=2
 Description="<html>When indenting after virtual brace open and newline add further spaces to<br/>reach this minimum indent.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_min_vbrace_open\s*=\s*"
+CallName="indent_min_vbrace_open="
+CallNameRegex="indent_min_vbrace_open\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3445,7 +3829,8 @@ Category=2
 Description="<html>Whether to add further spaces after regular indent to reach next tabstop<br/>when indenting after virtual brace open and newline.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_vbrace_open_on_tabstop\s*=\s*true|indent_vbrace_open_on_tabstop\s*=\s*false
+TrueFalse=indent_vbrace_open_on_tabstop=true|indent_vbrace_open_on_tabstop=false
+TrueFalseRegex=indent_vbrace_open_on_tabstop\s*=\s*true|indent_vbrace_open_on_tabstop\s*=\s*false
 ValueDefault=false
 
 [Indent Token After Brace]
@@ -3453,7 +3838,8 @@ Category=2
 Description="<html>How to indent after a brace followed by another token (not a newline).<br/>true:  indent all contained lines to match the token<br/>false: indent all contained lines to match the brace<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_token_after_brace\s*=\s*true|indent_token_after_brace\s*=\s*false
+TrueFalse=indent_token_after_brace=true|indent_token_after_brace=false
+TrueFalseRegex=indent_token_after_brace\s*=\s*true|indent_token_after_brace\s*=\s*false
 ValueDefault=true
 
 [Indent Cpp Lambda Body]
@@ -3461,7 +3847,8 @@ Category=2
 Description="<html>Whether to indent the body of a C++11 lambda.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cpp_lambda_body\s*=\s*true|indent_cpp_lambda_body\s*=\s*false
+TrueFalse=indent_cpp_lambda_body=true|indent_cpp_lambda_body=false
+TrueFalseRegex=indent_cpp_lambda_body\s*=\s*true|indent_cpp_lambda_body\s*=\s*false
 ValueDefault=false
 
 [Indent Compound Literal Return]
@@ -3469,7 +3856,8 @@ Category=2
 Description="<html>How to indent compound literals that are being returned.<br/>true: add both the indent from return &amp; the compound literal open brace<br/>      (i.e. 2 indent levels)<br/>false: only indent 1 level, don't add the indent for the open brace, only<br/>       add the indent for the return.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_compound_literal_return\s*=\s*true|indent_compound_literal_return\s*=\s*false
+TrueFalse=indent_compound_literal_return=true|indent_compound_literal_return=false
+TrueFalseRegex=indent_compound_literal_return\s*=\s*true|indent_compound_literal_return\s*=\s*false
 ValueDefault=true
 
 [Indent Using Block]
@@ -3477,7 +3865,8 @@ Category=2
 Description="<html>(C#) Whether to indent a 'using' block if no braces are used.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_using_block\s*=\s*true|indent_using_block\s*=\s*false
+TrueFalse=indent_using_block=true|indent_using_block=false
+TrueFalseRegex=indent_using_block\s*=\s*true|indent_using_block\s*=\s*false
 ValueDefault=true
 
 [Indent Ternary Operator]
@@ -3485,7 +3874,8 @@ Category=2
 Description="<html>How to indent the continuation of ternary operator.<br/><br/>0: Off (default)<br/>1: When the `if_false` is a continuation, indent it under the `if_true` branch<br/>2: When the `:` is a continuation, indent it under `?`</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_ternary_operator\s*=\s*"
+CallName="indent_ternary_operator="
+CallNameRegex="indent_ternary_operator\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -3495,7 +3885,8 @@ Category=2
 Description="<html>Whether to indent the statements inside ternary operator.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_inside_ternary_operator\s*=\s*true|indent_inside_ternary_operator\s*=\s*false
+TrueFalse=indent_inside_ternary_operator=true|indent_inside_ternary_operator=false
+TrueFalseRegex=indent_inside_ternary_operator\s*=\s*true|indent_inside_ternary_operator\s*=\s*false
 ValueDefault=false
 
 [Indent Off After Return]
@@ -3503,7 +3894,8 @@ Category=2
 Description="<html>If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_off_after_return\s*=\s*true|indent_off_after_return\s*=\s*false
+TrueFalse=indent_off_after_return=true|indent_off_after_return=false
+TrueFalseRegex=indent_off_after_return\s*=\s*true|indent_off_after_return\s*=\s*false
 ValueDefault=false
 
 [Indent Off After Return New]
@@ -3511,7 +3903,8 @@ Category=2
 Description="<html>If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_off_after_return_new\s*=\s*true|indent_off_after_return_new\s*=\s*false
+TrueFalse=indent_off_after_return_new=true|indent_off_after_return_new=false
+TrueFalseRegex=indent_off_after_return_new\s*=\s*true|indent_off_after_return_new\s*=\s*false
 ValueDefault=false
 
 [Indent Single After Return]
@@ -3519,7 +3912,8 @@ Category=2
 Description="<html>If true, the tokens after return are indented with regular single indentation. By default (false) the indentation is after the return token.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_single_after_return\s*=\s*true|indent_single_after_return\s*=\s*false
+TrueFalse=indent_single_after_return=true|indent_single_after_return=false
+TrueFalseRegex=indent_single_after_return\s*=\s*true|indent_single_after_return\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Asm Block]
@@ -3527,7 +3921,8 @@ Category=2
 Description="<html>Whether to ignore indent and alignment for 'asm' blocks (i.e. assume they<br/>have their own indentation).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_asm_block\s*=\s*true|indent_ignore_asm_block\s*=\s*false
+TrueFalse=indent_ignore_asm_block=true|indent_ignore_asm_block=false
+TrueFalseRegex=indent_ignore_asm_block\s*=\s*true|indent_ignore_asm_block\s*=\s*false
 ValueDefault=false
 
 [Donot Indent Func Def Close Paren]
@@ -3535,7 +3930,8 @@ Category=2
 Description="<html>Don't indent the close parenthesis of a function definition,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=donot_indent_func_def_close_paren\s*=\s*true|donot_indent_func_def_close_paren\s*=\s*false
+TrueFalse=donot_indent_func_def_close_paren=true|donot_indent_func_def_close_paren=false
+TrueFalseRegex=donot_indent_func_def_close_paren\s*=\s*true|donot_indent_func_def_close_paren\s*=\s*false
 ValueDefault=false
 
 [Nl Collapse Empty Body]
@@ -3543,7 +3939,8 @@ Category=3
 Description="<html>Whether to collapse empty blocks between '{' and '}' except for functions.<br/>Use nl_collapse_empty_body_functions to specify how empty function braces<br/>should be formatted.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_collapse_empty_body\s*=\s*true|nl_collapse_empty_body\s*=\s*false
+TrueFalse=nl_collapse_empty_body=true|nl_collapse_empty_body=false
+TrueFalseRegex=nl_collapse_empty_body\s*=\s*true|nl_collapse_empty_body\s*=\s*false
 ValueDefault=false
 
 [Nl Collapse Empty Body Functions]
@@ -3551,7 +3948,8 @@ Category=3
 Description="<html>Whether to collapse empty blocks between '{' and '}' for functions only.<br/>If true, overrides nl_inside_empty_func.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_collapse_empty_body_functions\s*=\s*true|nl_collapse_empty_body_functions\s*=\s*false
+TrueFalse=nl_collapse_empty_body_functions=true|nl_collapse_empty_body_functions=false
+TrueFalseRegex=nl_collapse_empty_body_functions\s*=\s*true|nl_collapse_empty_body_functions\s*=\s*false
 ValueDefault=false
 
 [Nl Assign Leave One Liners]
@@ -3559,7 +3957,8 @@ Category=3
 Description="<html>Don't split one-line braced assignments, as in 'foo_t f = { 1, 2 };'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_assign_leave_one_liners\s*=\s*true|nl_assign_leave_one_liners\s*=\s*false
+TrueFalse=nl_assign_leave_one_liners=true|nl_assign_leave_one_liners=false
+TrueFalseRegex=nl_assign_leave_one_liners\s*=\s*true|nl_assign_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Class Leave One Liners]
@@ -3567,7 +3966,8 @@ Category=3
 Description="<html>Don't split one-line braced statements inside a 'class xx { }' body.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_class_leave_one_liners\s*=\s*true|nl_class_leave_one_liners\s*=\s*false
+TrueFalse=nl_class_leave_one_liners=true|nl_class_leave_one_liners=false
+TrueFalseRegex=nl_class_leave_one_liners\s*=\s*true|nl_class_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Enum Leave One Liners]
@@ -3575,7 +3975,8 @@ Category=3
 Description="<html>Don't split one-line enums, as in 'enum foo { BAR = 15 };'</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_enum_leave_one_liners\s*=\s*true|nl_enum_leave_one_liners\s*=\s*false
+TrueFalse=nl_enum_leave_one_liners=true|nl_enum_leave_one_liners=false
+TrueFalseRegex=nl_enum_leave_one_liners\s*=\s*true|nl_enum_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Getset Leave One Liners]
@@ -3583,7 +3984,8 @@ Category=3
 Description="<html>Don't split one-line get or set functions.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_getset_leave_one_liners\s*=\s*true|nl_getset_leave_one_liners\s*=\s*false
+TrueFalse=nl_getset_leave_one_liners=true|nl_getset_leave_one_liners=false
+TrueFalseRegex=nl_getset_leave_one_liners\s*=\s*true|nl_getset_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Cs Property Leave One Liners]
@@ -3591,7 +3993,8 @@ Category=3
 Description="<html>(C#) Don't split one-line property get or set functions.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_cs_property_leave_one_liners\s*=\s*true|nl_cs_property_leave_one_liners\s*=\s*false
+TrueFalse=nl_cs_property_leave_one_liners=true|nl_cs_property_leave_one_liners=false
+TrueFalseRegex=nl_cs_property_leave_one_liners\s*=\s*true|nl_cs_property_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Func Leave One Liners]
@@ -3599,7 +4002,8 @@ Category=3
 Description="<html>Don't split one-line function definitions, as in 'int foo() { return 0; }'.<br/>might modify nl_func_type_name</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_leave_one_liners\s*=\s*true|nl_func_leave_one_liners\s*=\s*false
+TrueFalse=nl_func_leave_one_liners=true|nl_func_leave_one_liners=false
+TrueFalseRegex=nl_func_leave_one_liners\s*=\s*true|nl_func_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Cpp Lambda Leave One Liners]
@@ -3607,7 +4011,8 @@ Category=3
 Description="<html>Don't split one-line C++11 lambdas, as in '[]() { return 0; }'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_cpp_lambda_leave_one_liners\s*=\s*true|nl_cpp_lambda_leave_one_liners\s*=\s*false
+TrueFalse=nl_cpp_lambda_leave_one_liners=true|nl_cpp_lambda_leave_one_liners=false
+TrueFalseRegex=nl_cpp_lambda_leave_one_liners\s*=\s*true|nl_cpp_lambda_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl If Leave One Liners]
@@ -3615,7 +4020,8 @@ Category=3
 Description="<html>Don't split one-line if/else statements, as in 'if(...) b++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_if_leave_one_liners\s*=\s*true|nl_if_leave_one_liners\s*=\s*false
+TrueFalse=nl_if_leave_one_liners=true|nl_if_leave_one_liners=false
+TrueFalseRegex=nl_if_leave_one_liners\s*=\s*true|nl_if_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl While Leave One Liners]
@@ -3623,7 +4029,8 @@ Category=3
 Description="<html>Don't split one-line while statements, as in 'while(...) b++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_while_leave_one_liners\s*=\s*true|nl_while_leave_one_liners\s*=\s*false
+TrueFalse=nl_while_leave_one_liners=true|nl_while_leave_one_liners=false
+TrueFalseRegex=nl_while_leave_one_liners\s*=\s*true|nl_while_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Do Leave One Liners]
@@ -3631,7 +4038,8 @@ Category=3
 Description="<html>Don't split one-line do statements, as in 'do { b++; } while(...);'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_do_leave_one_liners\s*=\s*true|nl_do_leave_one_liners\s*=\s*false
+TrueFalse=nl_do_leave_one_liners=true|nl_do_leave_one_liners=false
+TrueFalseRegex=nl_do_leave_one_liners\s*=\s*true|nl_do_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl For Leave One Liners]
@@ -3639,7 +4047,8 @@ Category=3
 Description="<html>Don't split one-line for statements, as in 'for(...) b++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_for_leave_one_liners\s*=\s*true|nl_for_leave_one_liners\s*=\s*false
+TrueFalse=nl_for_leave_one_liners=true|nl_for_leave_one_liners=false
+TrueFalseRegex=nl_for_leave_one_liners\s*=\s*true|nl_for_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Oc Msg Leave One Liner]
@@ -3647,7 +4056,8 @@ Category=3
 Description="<html>(OC) Don't split one-line Objective-C messages.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_oc_msg_leave_one_liner\s*=\s*true|nl_oc_msg_leave_one_liner\s*=\s*false
+TrueFalse=nl_oc_msg_leave_one_liner=true|nl_oc_msg_leave_one_liner=false
+TrueFalseRegex=nl_oc_msg_leave_one_liner\s*=\s*true|nl_oc_msg_leave_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Oc Mdef Brace]
@@ -3655,7 +4065,8 @@ Category=3
 Description="<html>(OC) Add or remove newline between method declaration and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_mdef_brace\s*=\s*ignore|nl_oc_mdef_brace\s*=\s*add|nl_oc_mdef_brace\s*=\s*remove|nl_oc_mdef_brace\s*=\s*force|nl_oc_mdef_brace\s*=\s*not_defined
+Choices=nl_oc_mdef_brace=ignore|nl_oc_mdef_brace=add|nl_oc_mdef_brace=remove|nl_oc_mdef_brace=force|nl_oc_mdef_brace=not_defined
+ChoicesRegex=nl_oc_mdef_brace\s*=\s*ignore|nl_oc_mdef_brace\s*=\s*add|nl_oc_mdef_brace\s*=\s*remove|nl_oc_mdef_brace\s*=\s*force|nl_oc_mdef_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Mdef Brace|Add Nl Oc Mdef Brace|Remove Nl Oc Mdef Brace|Force Nl Oc Mdef Brace"
 ValueDefault=ignore
 
@@ -3664,7 +4075,8 @@ Category=3
 Description="<html>(OC) Add or remove newline between Objective-C block signature and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_block_brace\s*=\s*ignore|nl_oc_block_brace\s*=\s*add|nl_oc_block_brace\s*=\s*remove|nl_oc_block_brace\s*=\s*force|nl_oc_block_brace\s*=\s*not_defined
+Choices=nl_oc_block_brace=ignore|nl_oc_block_brace=add|nl_oc_block_brace=remove|nl_oc_block_brace=force|nl_oc_block_brace=not_defined
+ChoicesRegex=nl_oc_block_brace\s*=\s*ignore|nl_oc_block_brace\s*=\s*add|nl_oc_block_brace\s*=\s*remove|nl_oc_block_brace\s*=\s*force|nl_oc_block_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Block Brace|Add Nl Oc Block Brace|Remove Nl Oc Block Brace|Force Nl Oc Block Brace"
 ValueDefault=ignore
 
@@ -3673,7 +4085,8 @@ Category=3
 Description="<html>(OC) Add or remove blank line before '@interface' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_before_interface\s*=\s*ignore|nl_oc_before_interface\s*=\s*add|nl_oc_before_interface\s*=\s*remove|nl_oc_before_interface\s*=\s*force|nl_oc_before_interface\s*=\s*not_defined
+Choices=nl_oc_before_interface=ignore|nl_oc_before_interface=add|nl_oc_before_interface=remove|nl_oc_before_interface=force|nl_oc_before_interface=not_defined
+ChoicesRegex=nl_oc_before_interface\s*=\s*ignore|nl_oc_before_interface\s*=\s*add|nl_oc_before_interface\s*=\s*remove|nl_oc_before_interface\s*=\s*force|nl_oc_before_interface\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Before Interface|Add Nl Oc Before Interface|Remove Nl Oc Before Interface|Force Nl Oc Before Interface"
 ValueDefault=ignore
 
@@ -3682,7 +4095,8 @@ Category=3
 Description="<html>(OC) Add or remove blank line before '@implementation' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_before_implementation\s*=\s*ignore|nl_oc_before_implementation\s*=\s*add|nl_oc_before_implementation\s*=\s*remove|nl_oc_before_implementation\s*=\s*force|nl_oc_before_implementation\s*=\s*not_defined
+Choices=nl_oc_before_implementation=ignore|nl_oc_before_implementation=add|nl_oc_before_implementation=remove|nl_oc_before_implementation=force|nl_oc_before_implementation=not_defined
+ChoicesRegex=nl_oc_before_implementation\s*=\s*ignore|nl_oc_before_implementation\s*=\s*add|nl_oc_before_implementation\s*=\s*remove|nl_oc_before_implementation\s*=\s*force|nl_oc_before_implementation\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Before Implementation|Add Nl Oc Before Implementation|Remove Nl Oc Before Implementation|Force Nl Oc Before Implementation"
 ValueDefault=ignore
 
@@ -3691,7 +4105,8 @@ Category=3
 Description="<html>(OC) Add or remove blank line before '@end' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_before_end\s*=\s*ignore|nl_oc_before_end\s*=\s*add|nl_oc_before_end\s*=\s*remove|nl_oc_before_end\s*=\s*force|nl_oc_before_end\s*=\s*not_defined
+Choices=nl_oc_before_end=ignore|nl_oc_before_end=add|nl_oc_before_end=remove|nl_oc_before_end=force|nl_oc_before_end=not_defined
+ChoicesRegex=nl_oc_before_end\s*=\s*ignore|nl_oc_before_end\s*=\s*add|nl_oc_before_end\s*=\s*remove|nl_oc_before_end\s*=\s*force|nl_oc_before_end\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Before End|Add Nl Oc Before End|Remove Nl Oc Before End|Force Nl Oc Before End"
 ValueDefault=ignore
 
@@ -3700,7 +4115,8 @@ Category=3
 Description="<html>(OC) Add or remove newline between '@interface' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_interface_brace\s*=\s*ignore|nl_oc_interface_brace\s*=\s*add|nl_oc_interface_brace\s*=\s*remove|nl_oc_interface_brace\s*=\s*force|nl_oc_interface_brace\s*=\s*not_defined
+Choices=nl_oc_interface_brace=ignore|nl_oc_interface_brace=add|nl_oc_interface_brace=remove|nl_oc_interface_brace=force|nl_oc_interface_brace=not_defined
+ChoicesRegex=nl_oc_interface_brace\s*=\s*ignore|nl_oc_interface_brace\s*=\s*add|nl_oc_interface_brace\s*=\s*remove|nl_oc_interface_brace\s*=\s*force|nl_oc_interface_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Interface Brace|Add Nl Oc Interface Brace|Remove Nl Oc Interface Brace|Force Nl Oc Interface Brace"
 ValueDefault=ignore
 
@@ -3709,7 +4125,8 @@ Category=3
 Description="<html>(OC) Add or remove newline between '@implementation' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_implementation_brace\s*=\s*ignore|nl_oc_implementation_brace\s*=\s*add|nl_oc_implementation_brace\s*=\s*remove|nl_oc_implementation_brace\s*=\s*force|nl_oc_implementation_brace\s*=\s*not_defined
+Choices=nl_oc_implementation_brace=ignore|nl_oc_implementation_brace=add|nl_oc_implementation_brace=remove|nl_oc_implementation_brace=force|nl_oc_implementation_brace=not_defined
+ChoicesRegex=nl_oc_implementation_brace\s*=\s*ignore|nl_oc_implementation_brace\s*=\s*add|nl_oc_implementation_brace\s*=\s*remove|nl_oc_implementation_brace\s*=\s*force|nl_oc_implementation_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Implementation Brace|Add Nl Oc Implementation Brace|Remove Nl Oc Implementation Brace|Force Nl Oc Implementation Brace"
 ValueDefault=ignore
 
@@ -3718,7 +4135,8 @@ Category=3
 Description="<html>Add or remove newlines at the start of the file.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_start_of_file\s*=\s*ignore|nl_start_of_file\s*=\s*add|nl_start_of_file\s*=\s*remove|nl_start_of_file\s*=\s*force|nl_start_of_file\s*=\s*not_defined
+Choices=nl_start_of_file=ignore|nl_start_of_file=add|nl_start_of_file=remove|nl_start_of_file=force|nl_start_of_file=not_defined
+ChoicesRegex=nl_start_of_file\s*=\s*ignore|nl_start_of_file\s*=\s*add|nl_start_of_file\s*=\s*remove|nl_start_of_file\s*=\s*force|nl_start_of_file\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Start Of File|Add Nl Start Of File|Remove Nl Start Of File|Force Nl Start Of File"
 ValueDefault=ignore
 
@@ -3727,7 +4145,8 @@ Category=3
 Description="<html>The minimum number of newlines at the start of the file (only used if<br/>nl_start_of_file is 'add' or 'force').</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_start_of_file_min\s*=\s*"
+CallName="nl_start_of_file_min="
+CallNameRegex="nl_start_of_file_min\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3737,7 +4156,8 @@ Category=3
 Description="<html>Add or remove newline at the end of the file.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_end_of_file\s*=\s*ignore|nl_end_of_file\s*=\s*add|nl_end_of_file\s*=\s*remove|nl_end_of_file\s*=\s*force|nl_end_of_file\s*=\s*not_defined
+Choices=nl_end_of_file=ignore|nl_end_of_file=add|nl_end_of_file=remove|nl_end_of_file=force|nl_end_of_file=not_defined
+ChoicesRegex=nl_end_of_file\s*=\s*ignore|nl_end_of_file\s*=\s*add|nl_end_of_file\s*=\s*remove|nl_end_of_file\s*=\s*force|nl_end_of_file\s*=\s*not_defined
 ChoicesReadable="Ignore Nl End Of File|Add Nl End Of File|Remove Nl End Of File|Force Nl End Of File"
 ValueDefault=ignore
 
@@ -3746,7 +4166,8 @@ Category=3
 Description="<html>The minimum number of newlines at the end of the file (only used if<br/>nl_end_of_file is 'add' or 'force').</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_end_of_file_min\s*=\s*"
+CallName="nl_end_of_file_min="
+CallNameRegex="nl_end_of_file_min\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3756,7 +4177,8 @@ Category=3
 Description="<html>Add or remove newline between '=' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_assign_brace\s*=\s*ignore|nl_assign_brace\s*=\s*add|nl_assign_brace\s*=\s*remove|nl_assign_brace\s*=\s*force|nl_assign_brace\s*=\s*not_defined
+Choices=nl_assign_brace=ignore|nl_assign_brace=add|nl_assign_brace=remove|nl_assign_brace=force|nl_assign_brace=not_defined
+ChoicesRegex=nl_assign_brace\s*=\s*ignore|nl_assign_brace\s*=\s*add|nl_assign_brace\s*=\s*remove|nl_assign_brace\s*=\s*force|nl_assign_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Assign Brace|Add Nl Assign Brace|Remove Nl Assign Brace|Force Nl Assign Brace"
 ValueDefault=ignore
 
@@ -3765,7 +4187,8 @@ Category=3
 Description="<html>(D) Add or remove newline between '=' and '['.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_assign_square\s*=\s*ignore|nl_assign_square\s*=\s*add|nl_assign_square\s*=\s*remove|nl_assign_square\s*=\s*force|nl_assign_square\s*=\s*not_defined
+Choices=nl_assign_square=ignore|nl_assign_square=add|nl_assign_square=remove|nl_assign_square=force|nl_assign_square=not_defined
+ChoicesRegex=nl_assign_square\s*=\s*ignore|nl_assign_square\s*=\s*add|nl_assign_square\s*=\s*remove|nl_assign_square\s*=\s*force|nl_assign_square\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Assign Square|Add Nl Assign Square|Remove Nl Assign Square|Force Nl Assign Square"
 ValueDefault=ignore
 
@@ -3774,7 +4197,8 @@ Category=3
 Description="<html>Add or remove newline between '[]' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_tsquare_brace\s*=\s*ignore|nl_tsquare_brace\s*=\s*add|nl_tsquare_brace\s*=\s*remove|nl_tsquare_brace\s*=\s*force|nl_tsquare_brace\s*=\s*not_defined
+Choices=nl_tsquare_brace=ignore|nl_tsquare_brace=add|nl_tsquare_brace=remove|nl_tsquare_brace=force|nl_tsquare_brace=not_defined
+ChoicesRegex=nl_tsquare_brace\s*=\s*ignore|nl_tsquare_brace\s*=\s*add|nl_tsquare_brace\s*=\s*remove|nl_tsquare_brace\s*=\s*force|nl_tsquare_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Tsquare Brace|Add Nl Tsquare Brace|Remove Nl Tsquare Brace|Force Nl Tsquare Brace"
 ValueDefault=ignore
 
@@ -3783,7 +4207,8 @@ Category=3
 Description="<html>(D) Add or remove newline after '= ['. Will also affect the newline before<br/>the ']'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_square_assign\s*=\s*ignore|nl_after_square_assign\s*=\s*add|nl_after_square_assign\s*=\s*remove|nl_after_square_assign\s*=\s*force|nl_after_square_assign\s*=\s*not_defined
+Choices=nl_after_square_assign=ignore|nl_after_square_assign=add|nl_after_square_assign=remove|nl_after_square_assign=force|nl_after_square_assign=not_defined
+ChoicesRegex=nl_after_square_assign\s*=\s*ignore|nl_after_square_assign\s*=\s*add|nl_after_square_assign\s*=\s*remove|nl_after_square_assign\s*=\s*force|nl_after_square_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Square Assign|Add Nl After Square Assign|Remove Nl After Square Assign|Force Nl After Square Assign"
 ValueDefault=ignore
 
@@ -3792,7 +4217,8 @@ Category=3
 Description="<html>Add or remove newline between a function call's ')' and '{', as in<br/>'list_for_each(item, &amp;list) { }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_fcall_brace\s*=\s*ignore|nl_fcall_brace\s*=\s*add|nl_fcall_brace\s*=\s*remove|nl_fcall_brace\s*=\s*force|nl_fcall_brace\s*=\s*not_defined
+Choices=nl_fcall_brace=ignore|nl_fcall_brace=add|nl_fcall_brace=remove|nl_fcall_brace=force|nl_fcall_brace=not_defined
+ChoicesRegex=nl_fcall_brace\s*=\s*ignore|nl_fcall_brace\s*=\s*add|nl_fcall_brace\s*=\s*remove|nl_fcall_brace\s*=\s*force|nl_fcall_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Fcall Brace|Add Nl Fcall Brace|Remove Nl Fcall Brace|Force Nl Fcall Brace"
 ValueDefault=ignore
 
@@ -3801,7 +4227,8 @@ Category=3
 Description="<html>Add or remove newline between 'enum' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_brace\s*=\s*ignore|nl_enum_brace\s*=\s*add|nl_enum_brace\s*=\s*remove|nl_enum_brace\s*=\s*force|nl_enum_brace\s*=\s*not_defined
+Choices=nl_enum_brace=ignore|nl_enum_brace=add|nl_enum_brace=remove|nl_enum_brace=force|nl_enum_brace=not_defined
+ChoicesRegex=nl_enum_brace\s*=\s*ignore|nl_enum_brace\s*=\s*add|nl_enum_brace\s*=\s*remove|nl_enum_brace\s*=\s*force|nl_enum_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Brace|Add Nl Enum Brace|Remove Nl Enum Brace|Force Nl Enum Brace"
 ValueDefault=ignore
 
@@ -3810,7 +4237,8 @@ Category=3
 Description="<html>Add or remove newline between 'enum' and 'class'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_class\s*=\s*ignore|nl_enum_class\s*=\s*add|nl_enum_class\s*=\s*remove|nl_enum_class\s*=\s*force|nl_enum_class\s*=\s*not_defined
+Choices=nl_enum_class=ignore|nl_enum_class=add|nl_enum_class=remove|nl_enum_class=force|nl_enum_class=not_defined
+ChoicesRegex=nl_enum_class\s*=\s*ignore|nl_enum_class\s*=\s*add|nl_enum_class\s*=\s*remove|nl_enum_class\s*=\s*force|nl_enum_class\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Class|Add Nl Enum Class|Remove Nl Enum Class|Force Nl Enum Class"
 ValueDefault=ignore
 
@@ -3819,7 +4247,8 @@ Category=3
 Description="<html>Add or remove newline between 'enum class' and the identifier.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_class_identifier\s*=\s*ignore|nl_enum_class_identifier\s*=\s*add|nl_enum_class_identifier\s*=\s*remove|nl_enum_class_identifier\s*=\s*force|nl_enum_class_identifier\s*=\s*not_defined
+Choices=nl_enum_class_identifier=ignore|nl_enum_class_identifier=add|nl_enum_class_identifier=remove|nl_enum_class_identifier=force|nl_enum_class_identifier=not_defined
+ChoicesRegex=nl_enum_class_identifier\s*=\s*ignore|nl_enum_class_identifier\s*=\s*add|nl_enum_class_identifier\s*=\s*remove|nl_enum_class_identifier\s*=\s*force|nl_enum_class_identifier\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Class Identifier|Add Nl Enum Class Identifier|Remove Nl Enum Class Identifier|Force Nl Enum Class Identifier"
 ValueDefault=ignore
 
@@ -3828,7 +4257,8 @@ Category=3
 Description="<html>Add or remove newline between 'enum class' type and ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_identifier_colon\s*=\s*ignore|nl_enum_identifier_colon\s*=\s*add|nl_enum_identifier_colon\s*=\s*remove|nl_enum_identifier_colon\s*=\s*force|nl_enum_identifier_colon\s*=\s*not_defined
+Choices=nl_enum_identifier_colon=ignore|nl_enum_identifier_colon=add|nl_enum_identifier_colon=remove|nl_enum_identifier_colon=force|nl_enum_identifier_colon=not_defined
+ChoicesRegex=nl_enum_identifier_colon\s*=\s*ignore|nl_enum_identifier_colon\s*=\s*add|nl_enum_identifier_colon\s*=\s*remove|nl_enum_identifier_colon\s*=\s*force|nl_enum_identifier_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Identifier Colon|Add Nl Enum Identifier Colon|Remove Nl Enum Identifier Colon|Force Nl Enum Identifier Colon"
 ValueDefault=ignore
 
@@ -3837,7 +4267,8 @@ Category=3
 Description="<html>Add or remove newline between 'enum class identifier :' and type.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_colon_type\s*=\s*ignore|nl_enum_colon_type\s*=\s*add|nl_enum_colon_type\s*=\s*remove|nl_enum_colon_type\s*=\s*force|nl_enum_colon_type\s*=\s*not_defined
+Choices=nl_enum_colon_type=ignore|nl_enum_colon_type=add|nl_enum_colon_type=remove|nl_enum_colon_type=force|nl_enum_colon_type=not_defined
+ChoicesRegex=nl_enum_colon_type\s*=\s*ignore|nl_enum_colon_type\s*=\s*add|nl_enum_colon_type\s*=\s*remove|nl_enum_colon_type\s*=\s*force|nl_enum_colon_type\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Colon Type|Add Nl Enum Colon Type|Remove Nl Enum Colon Type|Force Nl Enum Colon Type"
 ValueDefault=ignore
 
@@ -3846,7 +4277,8 @@ Category=3
 Description="<html>Add or remove newline between 'struct and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_struct_brace\s*=\s*ignore|nl_struct_brace\s*=\s*add|nl_struct_brace\s*=\s*remove|nl_struct_brace\s*=\s*force|nl_struct_brace\s*=\s*not_defined
+Choices=nl_struct_brace=ignore|nl_struct_brace=add|nl_struct_brace=remove|nl_struct_brace=force|nl_struct_brace=not_defined
+ChoicesRegex=nl_struct_brace\s*=\s*ignore|nl_struct_brace\s*=\s*add|nl_struct_brace\s*=\s*remove|nl_struct_brace\s*=\s*force|nl_struct_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Struct Brace|Add Nl Struct Brace|Remove Nl Struct Brace|Force Nl Struct Brace"
 ValueDefault=ignore
 
@@ -3855,7 +4287,8 @@ Category=3
 Description="<html>Add or remove newline between 'union' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_union_brace\s*=\s*ignore|nl_union_brace\s*=\s*add|nl_union_brace\s*=\s*remove|nl_union_brace\s*=\s*force|nl_union_brace\s*=\s*not_defined
+Choices=nl_union_brace=ignore|nl_union_brace=add|nl_union_brace=remove|nl_union_brace=force|nl_union_brace=not_defined
+ChoicesRegex=nl_union_brace\s*=\s*ignore|nl_union_brace\s*=\s*add|nl_union_brace\s*=\s*remove|nl_union_brace\s*=\s*force|nl_union_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Union Brace|Add Nl Union Brace|Remove Nl Union Brace|Force Nl Union Brace"
 ValueDefault=ignore
 
@@ -3864,7 +4297,8 @@ Category=3
 Description="<html>Add or remove newline between 'if' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_if_brace\s*=\s*ignore|nl_if_brace\s*=\s*add|nl_if_brace\s*=\s*remove|nl_if_brace\s*=\s*force|nl_if_brace\s*=\s*not_defined
+Choices=nl_if_brace=ignore|nl_if_brace=add|nl_if_brace=remove|nl_if_brace=force|nl_if_brace=not_defined
+ChoicesRegex=nl_if_brace\s*=\s*ignore|nl_if_brace\s*=\s*add|nl_if_brace\s*=\s*remove|nl_if_brace\s*=\s*force|nl_if_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl If Brace|Add Nl If Brace|Remove Nl If Brace|Force Nl If Brace"
 ValueDefault=ignore
 
@@ -3873,7 +4307,8 @@ Category=3
 Description="<html>Add or remove newline between '}' and 'else'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_else\s*=\s*ignore|nl_brace_else\s*=\s*add|nl_brace_else\s*=\s*remove|nl_brace_else\s*=\s*force|nl_brace_else\s*=\s*not_defined
+Choices=nl_brace_else=ignore|nl_brace_else=add|nl_brace_else=remove|nl_brace_else=force|nl_brace_else=not_defined
+ChoicesRegex=nl_brace_else\s*=\s*ignore|nl_brace_else\s*=\s*add|nl_brace_else\s*=\s*remove|nl_brace_else\s*=\s*force|nl_brace_else\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Else|Add Nl Brace Else|Remove Nl Brace Else|Force Nl Brace Else"
 ValueDefault=ignore
 
@@ -3882,7 +4317,8 @@ Category=3
 Description="<html>Add or remove newline between 'else if' and '{'. If set to ignore,<br/>nl_if_brace is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_elseif_brace\s*=\s*ignore|nl_elseif_brace\s*=\s*add|nl_elseif_brace\s*=\s*remove|nl_elseif_brace\s*=\s*force|nl_elseif_brace\s*=\s*not_defined
+Choices=nl_elseif_brace=ignore|nl_elseif_brace=add|nl_elseif_brace=remove|nl_elseif_brace=force|nl_elseif_brace=not_defined
+ChoicesRegex=nl_elseif_brace\s*=\s*ignore|nl_elseif_brace\s*=\s*add|nl_elseif_brace\s*=\s*remove|nl_elseif_brace\s*=\s*force|nl_elseif_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Elseif Brace|Add Nl Elseif Brace|Remove Nl Elseif Brace|Force Nl Elseif Brace"
 ValueDefault=ignore
 
@@ -3891,7 +4327,8 @@ Category=3
 Description="<html>Add or remove newline between 'else' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_else_brace\s*=\s*ignore|nl_else_brace\s*=\s*add|nl_else_brace\s*=\s*remove|nl_else_brace\s*=\s*force|nl_else_brace\s*=\s*not_defined
+Choices=nl_else_brace=ignore|nl_else_brace=add|nl_else_brace=remove|nl_else_brace=force|nl_else_brace=not_defined
+ChoicesRegex=nl_else_brace\s*=\s*ignore|nl_else_brace\s*=\s*add|nl_else_brace\s*=\s*remove|nl_else_brace\s*=\s*force|nl_else_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Else Brace|Add Nl Else Brace|Remove Nl Else Brace|Force Nl Else Brace"
 ValueDefault=ignore
 
@@ -3900,7 +4337,8 @@ Category=3
 Description="<html>Add or remove newline between 'else' and 'if'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_else_if\s*=\s*ignore|nl_else_if\s*=\s*add|nl_else_if\s*=\s*remove|nl_else_if\s*=\s*force|nl_else_if\s*=\s*not_defined
+Choices=nl_else_if=ignore|nl_else_if=add|nl_else_if=remove|nl_else_if=force|nl_else_if=not_defined
+ChoicesRegex=nl_else_if\s*=\s*ignore|nl_else_if\s*=\s*add|nl_else_if\s*=\s*remove|nl_else_if\s*=\s*force|nl_else_if\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Else If|Add Nl Else If|Remove Nl Else If|Force Nl Else If"
 ValueDefault=ignore
 
@@ -3909,7 +4347,8 @@ Category=3
 Description="<html>Add or remove newline before '{' opening brace</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_opening_brace_func_class_def\s*=\s*ignore|nl_before_opening_brace_func_class_def\s*=\s*add|nl_before_opening_brace_func_class_def\s*=\s*remove|nl_before_opening_brace_func_class_def\s*=\s*force|nl_before_opening_brace_func_class_def\s*=\s*not_defined
+Choices=nl_before_opening_brace_func_class_def=ignore|nl_before_opening_brace_func_class_def=add|nl_before_opening_brace_func_class_def=remove|nl_before_opening_brace_func_class_def=force|nl_before_opening_brace_func_class_def=not_defined
+ChoicesRegex=nl_before_opening_brace_func_class_def\s*=\s*ignore|nl_before_opening_brace_func_class_def\s*=\s*add|nl_before_opening_brace_func_class_def\s*=\s*remove|nl_before_opening_brace_func_class_def\s*=\s*force|nl_before_opening_brace_func_class_def\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Opening Brace Func Class Def|Add Nl Before Opening Brace Func Class Def|Remove Nl Before Opening Brace Func Class Def|Force Nl Before Opening Brace Func Class Def"
 ValueDefault=ignore
 
@@ -3918,7 +4357,8 @@ Category=3
 Description="<html>Add or remove newline before 'if'/'else if' closing parenthesis.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_if_closing_paren\s*=\s*ignore|nl_before_if_closing_paren\s*=\s*add|nl_before_if_closing_paren\s*=\s*remove|nl_before_if_closing_paren\s*=\s*force|nl_before_if_closing_paren\s*=\s*not_defined
+Choices=nl_before_if_closing_paren=ignore|nl_before_if_closing_paren=add|nl_before_if_closing_paren=remove|nl_before_if_closing_paren=force|nl_before_if_closing_paren=not_defined
+ChoicesRegex=nl_before_if_closing_paren\s*=\s*ignore|nl_before_if_closing_paren\s*=\s*add|nl_before_if_closing_paren\s*=\s*remove|nl_before_if_closing_paren\s*=\s*force|nl_before_if_closing_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before If Closing Paren|Add Nl Before If Closing Paren|Remove Nl Before If Closing Paren|Force Nl Before If Closing Paren"
 ValueDefault=ignore
 
@@ -3927,7 +4367,8 @@ Category=3
 Description="<html>Add or remove newline between '}' and 'finally'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_finally\s*=\s*ignore|nl_brace_finally\s*=\s*add|nl_brace_finally\s*=\s*remove|nl_brace_finally\s*=\s*force|nl_brace_finally\s*=\s*not_defined
+Choices=nl_brace_finally=ignore|nl_brace_finally=add|nl_brace_finally=remove|nl_brace_finally=force|nl_brace_finally=not_defined
+ChoicesRegex=nl_brace_finally\s*=\s*ignore|nl_brace_finally\s*=\s*add|nl_brace_finally\s*=\s*remove|nl_brace_finally\s*=\s*force|nl_brace_finally\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Finally|Add Nl Brace Finally|Remove Nl Brace Finally|Force Nl Brace Finally"
 ValueDefault=ignore
 
@@ -3936,7 +4377,8 @@ Category=3
 Description="<html>Add or remove newline between 'finally' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_finally_brace\s*=\s*ignore|nl_finally_brace\s*=\s*add|nl_finally_brace\s*=\s*remove|nl_finally_brace\s*=\s*force|nl_finally_brace\s*=\s*not_defined
+Choices=nl_finally_brace=ignore|nl_finally_brace=add|nl_finally_brace=remove|nl_finally_brace=force|nl_finally_brace=not_defined
+ChoicesRegex=nl_finally_brace\s*=\s*ignore|nl_finally_brace\s*=\s*add|nl_finally_brace\s*=\s*remove|nl_finally_brace\s*=\s*force|nl_finally_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Finally Brace|Add Nl Finally Brace|Remove Nl Finally Brace|Force Nl Finally Brace"
 ValueDefault=ignore
 
@@ -3945,7 +4387,8 @@ Category=3
 Description="<html>Add or remove newline between 'try' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_try_brace\s*=\s*ignore|nl_try_brace\s*=\s*add|nl_try_brace\s*=\s*remove|nl_try_brace\s*=\s*force|nl_try_brace\s*=\s*not_defined
+Choices=nl_try_brace=ignore|nl_try_brace=add|nl_try_brace=remove|nl_try_brace=force|nl_try_brace=not_defined
+ChoicesRegex=nl_try_brace\s*=\s*ignore|nl_try_brace\s*=\s*add|nl_try_brace\s*=\s*remove|nl_try_brace\s*=\s*force|nl_try_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Try Brace|Add Nl Try Brace|Remove Nl Try Brace|Force Nl Try Brace"
 ValueDefault=ignore
 
@@ -3954,7 +4397,8 @@ Category=3
 Description="<html>Add or remove newline between get/set and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_getset_brace\s*=\s*ignore|nl_getset_brace\s*=\s*add|nl_getset_brace\s*=\s*remove|nl_getset_brace\s*=\s*force|nl_getset_brace\s*=\s*not_defined
+Choices=nl_getset_brace=ignore|nl_getset_brace=add|nl_getset_brace=remove|nl_getset_brace=force|nl_getset_brace=not_defined
+ChoicesRegex=nl_getset_brace\s*=\s*ignore|nl_getset_brace\s*=\s*add|nl_getset_brace\s*=\s*remove|nl_getset_brace\s*=\s*force|nl_getset_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Getset Brace|Add Nl Getset Brace|Remove Nl Getset Brace|Force Nl Getset Brace"
 ValueDefault=ignore
 
@@ -3963,7 +4407,8 @@ Category=3
 Description="<html>Add or remove newline between 'for' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_for_brace\s*=\s*ignore|nl_for_brace\s*=\s*add|nl_for_brace\s*=\s*remove|nl_for_brace\s*=\s*force|nl_for_brace\s*=\s*not_defined
+Choices=nl_for_brace=ignore|nl_for_brace=add|nl_for_brace=remove|nl_for_brace=force|nl_for_brace=not_defined
+ChoicesRegex=nl_for_brace\s*=\s*ignore|nl_for_brace\s*=\s*add|nl_for_brace\s*=\s*remove|nl_for_brace\s*=\s*force|nl_for_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl For Brace|Add Nl For Brace|Remove Nl For Brace|Force Nl For Brace"
 ValueDefault=ignore
 
@@ -3972,7 +4417,8 @@ Category=3
 Description="<html>Add or remove newline before the '{' of a 'catch' statement, as in<br/>'catch (decl) &lt;here&gt; {'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_catch_brace\s*=\s*ignore|nl_catch_brace\s*=\s*add|nl_catch_brace\s*=\s*remove|nl_catch_brace\s*=\s*force|nl_catch_brace\s*=\s*not_defined
+Choices=nl_catch_brace=ignore|nl_catch_brace=add|nl_catch_brace=remove|nl_catch_brace=force|nl_catch_brace=not_defined
+ChoicesRegex=nl_catch_brace\s*=\s*ignore|nl_catch_brace\s*=\s*add|nl_catch_brace\s*=\s*remove|nl_catch_brace\s*=\s*force|nl_catch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Catch Brace|Add Nl Catch Brace|Remove Nl Catch Brace|Force Nl Catch Brace"
 ValueDefault=ignore
 
@@ -3981,7 +4427,8 @@ Category=3
 Description="<html>(OC) Add or remove newline before the '{' of a '@catch' statement, as in<br/>'@catch (decl) &lt;here&gt; {'. If set to ignore, nl_catch_brace is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_catch_brace\s*=\s*ignore|nl_oc_catch_brace\s*=\s*add|nl_oc_catch_brace\s*=\s*remove|nl_oc_catch_brace\s*=\s*force|nl_oc_catch_brace\s*=\s*not_defined
+Choices=nl_oc_catch_brace=ignore|nl_oc_catch_brace=add|nl_oc_catch_brace=remove|nl_oc_catch_brace=force|nl_oc_catch_brace=not_defined
+ChoicesRegex=nl_oc_catch_brace\s*=\s*ignore|nl_oc_catch_brace\s*=\s*add|nl_oc_catch_brace\s*=\s*remove|nl_oc_catch_brace\s*=\s*force|nl_oc_catch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Catch Brace|Add Nl Oc Catch Brace|Remove Nl Oc Catch Brace|Force Nl Oc Catch Brace"
 ValueDefault=ignore
 
@@ -3990,7 +4437,8 @@ Category=3
 Description="<html>Add or remove newline between '}' and 'catch'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_catch\s*=\s*ignore|nl_brace_catch\s*=\s*add|nl_brace_catch\s*=\s*remove|nl_brace_catch\s*=\s*force|nl_brace_catch\s*=\s*not_defined
+Choices=nl_brace_catch=ignore|nl_brace_catch=add|nl_brace_catch=remove|nl_brace_catch=force|nl_brace_catch=not_defined
+ChoicesRegex=nl_brace_catch\s*=\s*ignore|nl_brace_catch\s*=\s*add|nl_brace_catch\s*=\s*remove|nl_brace_catch\s*=\s*force|nl_brace_catch\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Catch|Add Nl Brace Catch|Remove Nl Brace Catch|Force Nl Brace Catch"
 ValueDefault=ignore
 
@@ -3999,7 +4447,8 @@ Category=3
 Description="<html>(OC) Add or remove newline between '}' and '@catch'. If set to ignore,<br/>nl_brace_catch is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_brace_catch\s*=\s*ignore|nl_oc_brace_catch\s*=\s*add|nl_oc_brace_catch\s*=\s*remove|nl_oc_brace_catch\s*=\s*force|nl_oc_brace_catch\s*=\s*not_defined
+Choices=nl_oc_brace_catch=ignore|nl_oc_brace_catch=add|nl_oc_brace_catch=remove|nl_oc_brace_catch=force|nl_oc_brace_catch=not_defined
+ChoicesRegex=nl_oc_brace_catch\s*=\s*ignore|nl_oc_brace_catch\s*=\s*add|nl_oc_brace_catch\s*=\s*remove|nl_oc_brace_catch\s*=\s*force|nl_oc_brace_catch\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Brace Catch|Add Nl Oc Brace Catch|Remove Nl Oc Brace Catch|Force Nl Oc Brace Catch"
 ValueDefault=ignore
 
@@ -4008,7 +4457,8 @@ Category=3
 Description="<html>Add or remove newline between '}' and ']'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_square\s*=\s*ignore|nl_brace_square\s*=\s*add|nl_brace_square\s*=\s*remove|nl_brace_square\s*=\s*force|nl_brace_square\s*=\s*not_defined
+Choices=nl_brace_square=ignore|nl_brace_square=add|nl_brace_square=remove|nl_brace_square=force|nl_brace_square=not_defined
+ChoicesRegex=nl_brace_square\s*=\s*ignore|nl_brace_square\s*=\s*add|nl_brace_square\s*=\s*remove|nl_brace_square\s*=\s*force|nl_brace_square\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Square|Add Nl Brace Square|Remove Nl Brace Square|Force Nl Brace Square"
 ValueDefault=ignore
 
@@ -4017,7 +4467,8 @@ Category=3
 Description="<html>Add or remove newline between '}' and ')' in a function invocation.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_fparen\s*=\s*ignore|nl_brace_fparen\s*=\s*add|nl_brace_fparen\s*=\s*remove|nl_brace_fparen\s*=\s*force|nl_brace_fparen\s*=\s*not_defined
+Choices=nl_brace_fparen=ignore|nl_brace_fparen=add|nl_brace_fparen=remove|nl_brace_fparen=force|nl_brace_fparen=not_defined
+ChoicesRegex=nl_brace_fparen\s*=\s*ignore|nl_brace_fparen\s*=\s*add|nl_brace_fparen\s*=\s*remove|nl_brace_fparen\s*=\s*force|nl_brace_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Fparen|Add Nl Brace Fparen|Remove Nl Brace Fparen|Force Nl Brace Fparen"
 ValueDefault=ignore
 
@@ -4026,7 +4477,8 @@ Category=3
 Description="<html>Add or remove newline between 'while' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_while_brace\s*=\s*ignore|nl_while_brace\s*=\s*add|nl_while_brace\s*=\s*remove|nl_while_brace\s*=\s*force|nl_while_brace\s*=\s*not_defined
+Choices=nl_while_brace=ignore|nl_while_brace=add|nl_while_brace=remove|nl_while_brace=force|nl_while_brace=not_defined
+ChoicesRegex=nl_while_brace\s*=\s*ignore|nl_while_brace\s*=\s*add|nl_while_brace\s*=\s*remove|nl_while_brace\s*=\s*force|nl_while_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl While Brace|Add Nl While Brace|Remove Nl While Brace|Force Nl While Brace"
 ValueDefault=ignore
 
@@ -4035,7 +4487,8 @@ Category=3
 Description="<html>(D) Add or remove newline between 'scope (x)' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_scope_brace\s*=\s*ignore|nl_scope_brace\s*=\s*add|nl_scope_brace\s*=\s*remove|nl_scope_brace\s*=\s*force|nl_scope_brace\s*=\s*not_defined
+Choices=nl_scope_brace=ignore|nl_scope_brace=add|nl_scope_brace=remove|nl_scope_brace=force|nl_scope_brace=not_defined
+ChoicesRegex=nl_scope_brace\s*=\s*ignore|nl_scope_brace\s*=\s*add|nl_scope_brace\s*=\s*remove|nl_scope_brace\s*=\s*force|nl_scope_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Scope Brace|Add Nl Scope Brace|Remove Nl Scope Brace|Force Nl Scope Brace"
 ValueDefault=ignore
 
@@ -4044,7 +4497,8 @@ Category=3
 Description="<html>(D) Add or remove newline between 'unittest' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_unittest_brace\s*=\s*ignore|nl_unittest_brace\s*=\s*add|nl_unittest_brace\s*=\s*remove|nl_unittest_brace\s*=\s*force|nl_unittest_brace\s*=\s*not_defined
+Choices=nl_unittest_brace=ignore|nl_unittest_brace=add|nl_unittest_brace=remove|nl_unittest_brace=force|nl_unittest_brace=not_defined
+ChoicesRegex=nl_unittest_brace\s*=\s*ignore|nl_unittest_brace\s*=\s*add|nl_unittest_brace\s*=\s*remove|nl_unittest_brace\s*=\s*force|nl_unittest_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Unittest Brace|Add Nl Unittest Brace|Remove Nl Unittest Brace|Force Nl Unittest Brace"
 ValueDefault=ignore
 
@@ -4053,7 +4507,8 @@ Category=3
 Description="<html>(D) Add or remove newline between 'version (x)' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_version_brace\s*=\s*ignore|nl_version_brace\s*=\s*add|nl_version_brace\s*=\s*remove|nl_version_brace\s*=\s*force|nl_version_brace\s*=\s*not_defined
+Choices=nl_version_brace=ignore|nl_version_brace=add|nl_version_brace=remove|nl_version_brace=force|nl_version_brace=not_defined
+ChoicesRegex=nl_version_brace\s*=\s*ignore|nl_version_brace\s*=\s*add|nl_version_brace\s*=\s*remove|nl_version_brace\s*=\s*force|nl_version_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Version Brace|Add Nl Version Brace|Remove Nl Version Brace|Force Nl Version Brace"
 ValueDefault=ignore
 
@@ -4062,7 +4517,8 @@ Category=3
 Description="<html>(C#) Add or remove newline between 'using' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_using_brace\s*=\s*ignore|nl_using_brace\s*=\s*add|nl_using_brace\s*=\s*remove|nl_using_brace\s*=\s*force|nl_using_brace\s*=\s*not_defined
+Choices=nl_using_brace=ignore|nl_using_brace=add|nl_using_brace=remove|nl_using_brace=force|nl_using_brace=not_defined
+ChoicesRegex=nl_using_brace\s*=\s*ignore|nl_using_brace\s*=\s*add|nl_using_brace\s*=\s*remove|nl_using_brace\s*=\s*force|nl_using_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Using Brace|Add Nl Using Brace|Remove Nl Using Brace|Force Nl Using Brace"
 ValueDefault=ignore
 
@@ -4071,7 +4527,8 @@ Category=3
 Description="<html>Add or remove newline between two open or close braces. Due to general<br/>newline/brace handling, REMOVE may not work.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_brace\s*=\s*ignore|nl_brace_brace\s*=\s*add|nl_brace_brace\s*=\s*remove|nl_brace_brace\s*=\s*force|nl_brace_brace\s*=\s*not_defined
+Choices=nl_brace_brace=ignore|nl_brace_brace=add|nl_brace_brace=remove|nl_brace_brace=force|nl_brace_brace=not_defined
+ChoicesRegex=nl_brace_brace\s*=\s*ignore|nl_brace_brace\s*=\s*add|nl_brace_brace\s*=\s*remove|nl_brace_brace\s*=\s*force|nl_brace_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Brace|Add Nl Brace Brace|Remove Nl Brace Brace|Force Nl Brace Brace"
 ValueDefault=ignore
 
@@ -4080,7 +4537,8 @@ Category=3
 Description="<html>Add or remove newline between 'do' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_do_brace\s*=\s*ignore|nl_do_brace\s*=\s*add|nl_do_brace\s*=\s*remove|nl_do_brace\s*=\s*force|nl_do_brace\s*=\s*not_defined
+Choices=nl_do_brace=ignore|nl_do_brace=add|nl_do_brace=remove|nl_do_brace=force|nl_do_brace=not_defined
+ChoicesRegex=nl_do_brace\s*=\s*ignore|nl_do_brace\s*=\s*add|nl_do_brace\s*=\s*remove|nl_do_brace\s*=\s*force|nl_do_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Do Brace|Add Nl Do Brace|Remove Nl Do Brace|Force Nl Do Brace"
 ValueDefault=ignore
 
@@ -4089,7 +4547,8 @@ Category=3
 Description="<html>Add or remove newline between '}' and 'while' of 'do' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_while\s*=\s*ignore|nl_brace_while\s*=\s*add|nl_brace_while\s*=\s*remove|nl_brace_while\s*=\s*force|nl_brace_while\s*=\s*not_defined
+Choices=nl_brace_while=ignore|nl_brace_while=add|nl_brace_while=remove|nl_brace_while=force|nl_brace_while=not_defined
+ChoicesRegex=nl_brace_while\s*=\s*ignore|nl_brace_while\s*=\s*add|nl_brace_while\s*=\s*remove|nl_brace_while\s*=\s*force|nl_brace_while\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace While|Add Nl Brace While|Remove Nl Brace While|Force Nl Brace While"
 ValueDefault=ignore
 
@@ -4098,7 +4557,8 @@ Category=3
 Description="<html>Add or remove newline between 'switch' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_switch_brace\s*=\s*ignore|nl_switch_brace\s*=\s*add|nl_switch_brace\s*=\s*remove|nl_switch_brace\s*=\s*force|nl_switch_brace\s*=\s*not_defined
+Choices=nl_switch_brace=ignore|nl_switch_brace=add|nl_switch_brace=remove|nl_switch_brace=force|nl_switch_brace=not_defined
+ChoicesRegex=nl_switch_brace\s*=\s*ignore|nl_switch_brace\s*=\s*add|nl_switch_brace\s*=\s*remove|nl_switch_brace\s*=\s*force|nl_switch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Switch Brace|Add Nl Switch Brace|Remove Nl Switch Brace|Force Nl Switch Brace"
 ValueDefault=ignore
 
@@ -4107,7 +4567,8 @@ Category=3
 Description="<html>Add or remove newline between 'synchronized' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_synchronized_brace\s*=\s*ignore|nl_synchronized_brace\s*=\s*add|nl_synchronized_brace\s*=\s*remove|nl_synchronized_brace\s*=\s*force|nl_synchronized_brace\s*=\s*not_defined
+Choices=nl_synchronized_brace=ignore|nl_synchronized_brace=add|nl_synchronized_brace=remove|nl_synchronized_brace=force|nl_synchronized_brace=not_defined
+ChoicesRegex=nl_synchronized_brace\s*=\s*ignore|nl_synchronized_brace\s*=\s*add|nl_synchronized_brace\s*=\s*remove|nl_synchronized_brace\s*=\s*force|nl_synchronized_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Synchronized Brace|Add Nl Synchronized Brace|Remove Nl Synchronized Brace|Force Nl Synchronized Brace"
 ValueDefault=ignore
 
@@ -4116,7 +4577,8 @@ Category=3
 Description="<html>Add a newline between ')' and '{' if the ')' is on a different line than the<br/>if/for/etc.<br/><br/>Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch and<br/>nl_catch_brace.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_multi_line_cond\s*=\s*true|nl_multi_line_cond\s*=\s*false
+TrueFalse=nl_multi_line_cond=true|nl_multi_line_cond=false
+TrueFalseRegex=nl_multi_line_cond\s*=\s*true|nl_multi_line_cond\s*=\s*false
 ValueDefault=false
 
 [Nl Multi Line Sparen Open]
@@ -4124,7 +4586,8 @@ Category=3
 Description="<html>Add a newline after '(' if an if/for/while/switch condition spans multiple<br/>lines</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_multi_line_sparen_open\s*=\s*ignore|nl_multi_line_sparen_open\s*=\s*add|nl_multi_line_sparen_open\s*=\s*remove|nl_multi_line_sparen_open\s*=\s*force|nl_multi_line_sparen_open\s*=\s*not_defined
+Choices=nl_multi_line_sparen_open=ignore|nl_multi_line_sparen_open=add|nl_multi_line_sparen_open=remove|nl_multi_line_sparen_open=force|nl_multi_line_sparen_open=not_defined
+ChoicesRegex=nl_multi_line_sparen_open\s*=\s*ignore|nl_multi_line_sparen_open\s*=\s*add|nl_multi_line_sparen_open\s*=\s*remove|nl_multi_line_sparen_open\s*=\s*force|nl_multi_line_sparen_open\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Multi Line Sparen Open|Add Nl Multi Line Sparen Open|Remove Nl Multi Line Sparen Open|Force Nl Multi Line Sparen Open"
 ValueDefault=ignore
 
@@ -4133,7 +4596,8 @@ Category=3
 Description="<html>Add a newline before ')' if an if/for/while/switch condition spans multiple<br/>lines. Overrides nl_before_if_closing_paren if both are specified.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_multi_line_sparen_close\s*=\s*ignore|nl_multi_line_sparen_close\s*=\s*add|nl_multi_line_sparen_close\s*=\s*remove|nl_multi_line_sparen_close\s*=\s*force|nl_multi_line_sparen_close\s*=\s*not_defined
+Choices=nl_multi_line_sparen_close=ignore|nl_multi_line_sparen_close=add|nl_multi_line_sparen_close=remove|nl_multi_line_sparen_close=force|nl_multi_line_sparen_close=not_defined
+ChoicesRegex=nl_multi_line_sparen_close\s*=\s*ignore|nl_multi_line_sparen_close\s*=\s*add|nl_multi_line_sparen_close\s*=\s*remove|nl_multi_line_sparen_close\s*=\s*force|nl_multi_line_sparen_close\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Multi Line Sparen Close|Add Nl Multi Line Sparen Close|Remove Nl Multi Line Sparen Close|Force Nl Multi Line Sparen Close"
 ValueDefault=ignore
 
@@ -4142,7 +4606,8 @@ Category=3
 Description="<html>Force a newline in a define after the macro name for multi-line defines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_multi_line_define\s*=\s*true|nl_multi_line_define\s*=\s*false
+TrueFalse=nl_multi_line_define=true|nl_multi_line_define=false
+TrueFalseRegex=nl_multi_line_define\s*=\s*true|nl_multi_line_define\s*=\s*false
 ValueDefault=false
 
 [Nl Before Case]
@@ -4150,7 +4615,8 @@ Category=3
 Description="<html>Whether to add a newline before 'case', and a blank line before a 'case'<br/>statement that follows a ';' or '}'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_before_case\s*=\s*true|nl_before_case\s*=\s*false
+TrueFalse=nl_before_case=true|nl_before_case=false
+TrueFalseRegex=nl_before_case\s*=\s*true|nl_before_case\s*=\s*false
 ValueDefault=false
 
 [Nl After Case]
@@ -4158,7 +4624,8 @@ Category=3
 Description="<html>Whether to add a newline after a 'case' statement.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_case\s*=\s*true|nl_after_case\s*=\s*false
+TrueFalse=nl_after_case=true|nl_after_case=false
+TrueFalseRegex=nl_after_case\s*=\s*true|nl_after_case\s*=\s*false
 ValueDefault=false
 
 [Nl Case Colon Brace]
@@ -4166,7 +4633,8 @@ Category=3
 Description="<html>Add or remove newline between a case ':' and '{'.<br/><br/>Overrides nl_after_case.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_case_colon_brace\s*=\s*ignore|nl_case_colon_brace\s*=\s*add|nl_case_colon_brace\s*=\s*remove|nl_case_colon_brace\s*=\s*force|nl_case_colon_brace\s*=\s*not_defined
+Choices=nl_case_colon_brace=ignore|nl_case_colon_brace=add|nl_case_colon_brace=remove|nl_case_colon_brace=force|nl_case_colon_brace=not_defined
+ChoicesRegex=nl_case_colon_brace\s*=\s*ignore|nl_case_colon_brace\s*=\s*add|nl_case_colon_brace\s*=\s*remove|nl_case_colon_brace\s*=\s*force|nl_case_colon_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Case Colon Brace|Add Nl Case Colon Brace|Remove Nl Case Colon Brace|Force Nl Case Colon Brace"
 ValueDefault=ignore
 
@@ -4175,7 +4643,8 @@ Category=3
 Description="<html>Add or remove newline between ')' and 'throw'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_throw\s*=\s*ignore|nl_before_throw\s*=\s*add|nl_before_throw\s*=\s*remove|nl_before_throw\s*=\s*force|nl_before_throw\s*=\s*not_defined
+Choices=nl_before_throw=ignore|nl_before_throw=add|nl_before_throw=remove|nl_before_throw=force|nl_before_throw=not_defined
+ChoicesRegex=nl_before_throw\s*=\s*ignore|nl_before_throw\s*=\s*add|nl_before_throw\s*=\s*remove|nl_before_throw\s*=\s*force|nl_before_throw\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Throw|Add Nl Before Throw|Remove Nl Before Throw|Force Nl Before Throw"
 ValueDefault=ignore
 
@@ -4184,7 +4653,8 @@ Category=3
 Description="<html>Add or remove newline between 'namespace' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_namespace_brace\s*=\s*ignore|nl_namespace_brace\s*=\s*add|nl_namespace_brace\s*=\s*remove|nl_namespace_brace\s*=\s*force|nl_namespace_brace\s*=\s*not_defined
+Choices=nl_namespace_brace=ignore|nl_namespace_brace=add|nl_namespace_brace=remove|nl_namespace_brace=force|nl_namespace_brace=not_defined
+ChoicesRegex=nl_namespace_brace\s*=\s*ignore|nl_namespace_brace\s*=\s*add|nl_namespace_brace\s*=\s*remove|nl_namespace_brace\s*=\s*force|nl_namespace_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Namespace Brace|Add Nl Namespace Brace|Remove Nl Namespace Brace|Force Nl Namespace Brace"
 ValueDefault=ignore
 
@@ -4193,7 +4663,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template class.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class\s*=\s*ignore|nl_template_class\s*=\s*add|nl_template_class\s*=\s*remove|nl_template_class\s*=\s*force|nl_template_class\s*=\s*not_defined
+Choices=nl_template_class=ignore|nl_template_class=add|nl_template_class=remove|nl_template_class=force|nl_template_class=not_defined
+ChoicesRegex=nl_template_class\s*=\s*ignore|nl_template_class\s*=\s*add|nl_template_class\s*=\s*remove|nl_template_class\s*=\s*force|nl_template_class\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class|Add Nl Template Class|Remove Nl Template Class|Force Nl Template Class"
 ValueDefault=ignore
 
@@ -4202,7 +4673,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template class declaration.<br/><br/>Overrides nl_template_class.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class_decl\s*=\s*ignore|nl_template_class_decl\s*=\s*add|nl_template_class_decl\s*=\s*remove|nl_template_class_decl\s*=\s*force|nl_template_class_decl\s*=\s*not_defined
+Choices=nl_template_class_decl=ignore|nl_template_class_decl=add|nl_template_class_decl=remove|nl_template_class_decl=force|nl_template_class_decl=not_defined
+ChoicesRegex=nl_template_class_decl\s*=\s*ignore|nl_template_class_decl\s*=\s*add|nl_template_class_decl\s*=\s*remove|nl_template_class_decl\s*=\s*force|nl_template_class_decl\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class Decl|Add Nl Template Class Decl|Remove Nl Template Class Decl|Force Nl Template Class Decl"
 ValueDefault=ignore
 
@@ -4211,7 +4683,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized class declaration.<br/><br/>Overrides nl_template_class_decl.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class_decl_special\s*=\s*ignore|nl_template_class_decl_special\s*=\s*add|nl_template_class_decl_special\s*=\s*remove|nl_template_class_decl_special\s*=\s*force|nl_template_class_decl_special\s*=\s*not_defined
+Choices=nl_template_class_decl_special=ignore|nl_template_class_decl_special=add|nl_template_class_decl_special=remove|nl_template_class_decl_special=force|nl_template_class_decl_special=not_defined
+ChoicesRegex=nl_template_class_decl_special\s*=\s*ignore|nl_template_class_decl_special\s*=\s*add|nl_template_class_decl_special\s*=\s*remove|nl_template_class_decl_special\s*=\s*force|nl_template_class_decl_special\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class Decl Special|Add Nl Template Class Decl Special|Remove Nl Template Class Decl Special|Force Nl Template Class Decl Special"
 ValueDefault=ignore
 
@@ -4220,7 +4693,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template class definition.<br/><br/>Overrides nl_template_class.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class_def\s*=\s*ignore|nl_template_class_def\s*=\s*add|nl_template_class_def\s*=\s*remove|nl_template_class_def\s*=\s*force|nl_template_class_def\s*=\s*not_defined
+Choices=nl_template_class_def=ignore|nl_template_class_def=add|nl_template_class_def=remove|nl_template_class_def=force|nl_template_class_def=not_defined
+ChoicesRegex=nl_template_class_def\s*=\s*ignore|nl_template_class_def\s*=\s*add|nl_template_class_def\s*=\s*remove|nl_template_class_def\s*=\s*force|nl_template_class_def\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class Def|Add Nl Template Class Def|Remove Nl Template Class Def|Force Nl Template Class Def"
 ValueDefault=ignore
 
@@ -4229,7 +4703,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized class definition.<br/><br/>Overrides nl_template_class_def.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class_def_special\s*=\s*ignore|nl_template_class_def_special\s*=\s*add|nl_template_class_def_special\s*=\s*remove|nl_template_class_def_special\s*=\s*force|nl_template_class_def_special\s*=\s*not_defined
+Choices=nl_template_class_def_special=ignore|nl_template_class_def_special=add|nl_template_class_def_special=remove|nl_template_class_def_special=force|nl_template_class_def_special=not_defined
+ChoicesRegex=nl_template_class_def_special\s*=\s*ignore|nl_template_class_def_special\s*=\s*add|nl_template_class_def_special\s*=\s*remove|nl_template_class_def_special\s*=\s*force|nl_template_class_def_special\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class Def Special|Add Nl Template Class Def Special|Remove Nl Template Class Def Special|Force Nl Template Class Def Special"
 ValueDefault=ignore
 
@@ -4238,7 +4713,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template function.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func\s*=\s*ignore|nl_template_func\s*=\s*add|nl_template_func\s*=\s*remove|nl_template_func\s*=\s*force|nl_template_func\s*=\s*not_defined
+Choices=nl_template_func=ignore|nl_template_func=add|nl_template_func=remove|nl_template_func=force|nl_template_func=not_defined
+ChoicesRegex=nl_template_func\s*=\s*ignore|nl_template_func\s*=\s*add|nl_template_func\s*=\s*remove|nl_template_func\s*=\s*force|nl_template_func\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func|Add Nl Template Func|Remove Nl Template Func|Force Nl Template Func"
 ValueDefault=ignore
 
@@ -4247,7 +4723,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template function<br/>declaration.<br/><br/>Overrides nl_template_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func_decl\s*=\s*ignore|nl_template_func_decl\s*=\s*add|nl_template_func_decl\s*=\s*remove|nl_template_func_decl\s*=\s*force|nl_template_func_decl\s*=\s*not_defined
+Choices=nl_template_func_decl=ignore|nl_template_func_decl=add|nl_template_func_decl=remove|nl_template_func_decl=force|nl_template_func_decl=not_defined
+ChoicesRegex=nl_template_func_decl\s*=\s*ignore|nl_template_func_decl\s*=\s*add|nl_template_func_decl\s*=\s*remove|nl_template_func_decl\s*=\s*force|nl_template_func_decl\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func Decl|Add Nl Template Func Decl|Remove Nl Template Func Decl|Force Nl Template Func Decl"
 ValueDefault=ignore
 
@@ -4256,7 +4733,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized function<br/>declaration.<br/><br/>Overrides nl_template_func_decl.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func_decl_special\s*=\s*ignore|nl_template_func_decl_special\s*=\s*add|nl_template_func_decl_special\s*=\s*remove|nl_template_func_decl_special\s*=\s*force|nl_template_func_decl_special\s*=\s*not_defined
+Choices=nl_template_func_decl_special=ignore|nl_template_func_decl_special=add|nl_template_func_decl_special=remove|nl_template_func_decl_special=force|nl_template_func_decl_special=not_defined
+ChoicesRegex=nl_template_func_decl_special\s*=\s*ignore|nl_template_func_decl_special\s*=\s*add|nl_template_func_decl_special\s*=\s*remove|nl_template_func_decl_special\s*=\s*force|nl_template_func_decl_special\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func Decl Special|Add Nl Template Func Decl Special|Remove Nl Template Func Decl Special|Force Nl Template Func Decl Special"
 ValueDefault=ignore
 
@@ -4265,7 +4743,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template function<br/>definition.<br/><br/>Overrides nl_template_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func_def\s*=\s*ignore|nl_template_func_def\s*=\s*add|nl_template_func_def\s*=\s*remove|nl_template_func_def\s*=\s*force|nl_template_func_def\s*=\s*not_defined
+Choices=nl_template_func_def=ignore|nl_template_func_def=add|nl_template_func_def=remove|nl_template_func_def=force|nl_template_func_def=not_defined
+ChoicesRegex=nl_template_func_def\s*=\s*ignore|nl_template_func_def\s*=\s*add|nl_template_func_def\s*=\s*remove|nl_template_func_def\s*=\s*force|nl_template_func_def\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func Def|Add Nl Template Func Def|Remove Nl Template Func Def|Force Nl Template Func Def"
 ValueDefault=ignore
 
@@ -4274,7 +4753,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized function<br/>definition.<br/><br/>Overrides nl_template_func_def.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func_def_special\s*=\s*ignore|nl_template_func_def_special\s*=\s*add|nl_template_func_def_special\s*=\s*remove|nl_template_func_def_special\s*=\s*force|nl_template_func_def_special\s*=\s*not_defined
+Choices=nl_template_func_def_special=ignore|nl_template_func_def_special=add|nl_template_func_def_special=remove|nl_template_func_def_special=force|nl_template_func_def_special=not_defined
+ChoicesRegex=nl_template_func_def_special\s*=\s*ignore|nl_template_func_def_special\s*=\s*add|nl_template_func_def_special\s*=\s*remove|nl_template_func_def_special\s*=\s*force|nl_template_func_def_special\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func Def Special|Add Nl Template Func Def Special|Remove Nl Template Func Def Special|Force Nl Template Func Def Special"
 ValueDefault=ignore
 
@@ -4283,7 +4763,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template variable.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_var\s*=\s*ignore|nl_template_var\s*=\s*add|nl_template_var\s*=\s*remove|nl_template_var\s*=\s*force|nl_template_var\s*=\s*not_defined
+Choices=nl_template_var=ignore|nl_template_var=add|nl_template_var=remove|nl_template_var=force|nl_template_var=not_defined
+ChoicesRegex=nl_template_var\s*=\s*ignore|nl_template_var\s*=\s*add|nl_template_var\s*=\s*remove|nl_template_var\s*=\s*force|nl_template_var\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Var|Add Nl Template Var|Remove Nl Template Var|Force Nl Template Var"
 ValueDefault=ignore
 
@@ -4292,7 +4773,8 @@ Category=3
 Description="<html>Add or remove newline between 'template&lt;...&gt;' and 'using' of a templated<br/>type alias.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_using\s*=\s*ignore|nl_template_using\s*=\s*add|nl_template_using\s*=\s*remove|nl_template_using\s*=\s*force|nl_template_using\s*=\s*not_defined
+Choices=nl_template_using=ignore|nl_template_using=add|nl_template_using=remove|nl_template_using=force|nl_template_using=not_defined
+ChoicesRegex=nl_template_using\s*=\s*ignore|nl_template_using\s*=\s*add|nl_template_using\s*=\s*remove|nl_template_using\s*=\s*force|nl_template_using\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Using|Add Nl Template Using|Remove Nl Template Using|Force Nl Template Using"
 ValueDefault=ignore
 
@@ -4301,7 +4783,8 @@ Category=3
 Description="<html>Add or remove newline between 'class' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_class_brace\s*=\s*ignore|nl_class_brace\s*=\s*add|nl_class_brace\s*=\s*remove|nl_class_brace\s*=\s*force|nl_class_brace\s*=\s*not_defined
+Choices=nl_class_brace=ignore|nl_class_brace=add|nl_class_brace=remove|nl_class_brace=force|nl_class_brace=not_defined
+ChoicesRegex=nl_class_brace\s*=\s*ignore|nl_class_brace\s*=\s*add|nl_class_brace\s*=\s*remove|nl_class_brace\s*=\s*force|nl_class_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Class Brace|Add Nl Class Brace|Remove Nl Class Brace|Force Nl Class Brace"
 ValueDefault=ignore
 
@@ -4310,7 +4793,8 @@ Category=3
 Description="<html>Add or remove newline before or after (depending on pos_class_comma,<br/>may not be IGNORE) each',' in the base class list.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_class_init_args\s*=\s*ignore|nl_class_init_args\s*=\s*add|nl_class_init_args\s*=\s*remove|nl_class_init_args\s*=\s*force|nl_class_init_args\s*=\s*not_defined
+Choices=nl_class_init_args=ignore|nl_class_init_args=add|nl_class_init_args=remove|nl_class_init_args=force|nl_class_init_args=not_defined
+ChoicesRegex=nl_class_init_args\s*=\s*ignore|nl_class_init_args\s*=\s*add|nl_class_init_args\s*=\s*remove|nl_class_init_args\s*=\s*force|nl_class_init_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Class Init Args|Add Nl Class Init Args|Remove Nl Class Init Args|Force Nl Class Init Args"
 ValueDefault=ignore
 
@@ -4319,7 +4803,8 @@ Category=3
 Description="<html>Add or remove newline after each ',' in the constructor member<br/>initialization. Related to nl_constr_colon, pos_constr_colon and<br/>pos_constr_comma.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_constr_init_args\s*=\s*ignore|nl_constr_init_args\s*=\s*add|nl_constr_init_args\s*=\s*remove|nl_constr_init_args\s*=\s*force|nl_constr_init_args\s*=\s*not_defined
+Choices=nl_constr_init_args=ignore|nl_constr_init_args=add|nl_constr_init_args=remove|nl_constr_init_args=force|nl_constr_init_args=not_defined
+ChoicesRegex=nl_constr_init_args\s*=\s*ignore|nl_constr_init_args\s*=\s*add|nl_constr_init_args\s*=\s*remove|nl_constr_init_args\s*=\s*force|nl_constr_init_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Constr Init Args|Add Nl Constr Init Args|Remove Nl Constr Init Args|Force Nl Constr Init Args"
 ValueDefault=ignore
 
@@ -4328,7 +4813,8 @@ Category=3
 Description="<html>Add or remove newline before first element, after comma, and after last<br/>element, in 'enum'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_own_lines\s*=\s*ignore|nl_enum_own_lines\s*=\s*add|nl_enum_own_lines\s*=\s*remove|nl_enum_own_lines\s*=\s*force|nl_enum_own_lines\s*=\s*not_defined
+Choices=nl_enum_own_lines=ignore|nl_enum_own_lines=add|nl_enum_own_lines=remove|nl_enum_own_lines=force|nl_enum_own_lines=not_defined
+ChoicesRegex=nl_enum_own_lines\s*=\s*ignore|nl_enum_own_lines\s*=\s*add|nl_enum_own_lines\s*=\s*remove|nl_enum_own_lines\s*=\s*force|nl_enum_own_lines\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Own Lines|Add Nl Enum Own Lines|Remove Nl Enum Own Lines|Force Nl Enum Own Lines"
 ValueDefault=ignore
 
@@ -4337,7 +4823,8 @@ Category=3
 Description="<html>Add or remove newline between return type and function name in a function<br/>definition.<br/>might be modified by nl_func_leave_one_liners</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_type_name\s*=\s*ignore|nl_func_type_name\s*=\s*add|nl_func_type_name\s*=\s*remove|nl_func_type_name\s*=\s*force|nl_func_type_name\s*=\s*not_defined
+Choices=nl_func_type_name=ignore|nl_func_type_name=add|nl_func_type_name=remove|nl_func_type_name=force|nl_func_type_name=not_defined
+ChoicesRegex=nl_func_type_name\s*=\s*ignore|nl_func_type_name\s*=\s*add|nl_func_type_name\s*=\s*remove|nl_func_type_name\s*=\s*force|nl_func_type_name\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Type Name|Add Nl Func Type Name|Remove Nl Func Type Name|Force Nl Func Type Name"
 ValueDefault=ignore
 
@@ -4346,7 +4833,8 @@ Category=3
 Description="<html>Add or remove newline between return type and function name inside a class<br/>definition. If set to ignore, nl_func_type_name or nl_func_proto_type_name<br/>is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_type_name_class\s*=\s*ignore|nl_func_type_name_class\s*=\s*add|nl_func_type_name_class\s*=\s*remove|nl_func_type_name_class\s*=\s*force|nl_func_type_name_class\s*=\s*not_defined
+Choices=nl_func_type_name_class=ignore|nl_func_type_name_class=add|nl_func_type_name_class=remove|nl_func_type_name_class=force|nl_func_type_name_class=not_defined
+ChoicesRegex=nl_func_type_name_class\s*=\s*ignore|nl_func_type_name_class\s*=\s*add|nl_func_type_name_class\s*=\s*remove|nl_func_type_name_class\s*=\s*force|nl_func_type_name_class\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Type Name Class|Add Nl Func Type Name Class|Remove Nl Func Type Name Class|Force Nl Func Type Name Class"
 ValueDefault=ignore
 
@@ -4355,7 +4843,8 @@ Category=3
 Description="<html>Add or remove newline between class specification and '::'<br/>in 'void A::f() { }'. Only appears in separate member implementation (does<br/>not appear with in-line implementation).</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_class_scope\s*=\s*ignore|nl_func_class_scope\s*=\s*add|nl_func_class_scope\s*=\s*remove|nl_func_class_scope\s*=\s*force|nl_func_class_scope\s*=\s*not_defined
+Choices=nl_func_class_scope=ignore|nl_func_class_scope=add|nl_func_class_scope=remove|nl_func_class_scope=force|nl_func_class_scope=not_defined
+ChoicesRegex=nl_func_class_scope\s*=\s*ignore|nl_func_class_scope\s*=\s*add|nl_func_class_scope\s*=\s*remove|nl_func_class_scope\s*=\s*force|nl_func_class_scope\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Class Scope|Add Nl Func Class Scope|Remove Nl Func Class Scope|Force Nl Func Class Scope"
 ValueDefault=ignore
 
@@ -4364,7 +4853,8 @@ Category=3
 Description="<html>Add or remove newline between function scope and name, as in<br/>'void A :: &lt;here&gt; f() { }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_scope_name\s*=\s*ignore|nl_func_scope_name\s*=\s*add|nl_func_scope_name\s*=\s*remove|nl_func_scope_name\s*=\s*force|nl_func_scope_name\s*=\s*not_defined
+Choices=nl_func_scope_name=ignore|nl_func_scope_name=add|nl_func_scope_name=remove|nl_func_scope_name=force|nl_func_scope_name=not_defined
+ChoicesRegex=nl_func_scope_name\s*=\s*ignore|nl_func_scope_name\s*=\s*add|nl_func_scope_name\s*=\s*remove|nl_func_scope_name\s*=\s*force|nl_func_scope_name\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Scope Name|Add Nl Func Scope Name|Remove Nl Func Scope Name|Force Nl Func Scope Name"
 ValueDefault=ignore
 
@@ -4373,7 +4863,8 @@ Category=3
 Description="<html>Add or remove newline between return type and function name in a prototype.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_proto_type_name\s*=\s*ignore|nl_func_proto_type_name\s*=\s*add|nl_func_proto_type_name\s*=\s*remove|nl_func_proto_type_name\s*=\s*force|nl_func_proto_type_name\s*=\s*not_defined
+Choices=nl_func_proto_type_name=ignore|nl_func_proto_type_name=add|nl_func_proto_type_name=remove|nl_func_proto_type_name=force|nl_func_proto_type_name=not_defined
+ChoicesRegex=nl_func_proto_type_name\s*=\s*ignore|nl_func_proto_type_name\s*=\s*add|nl_func_proto_type_name\s*=\s*remove|nl_func_proto_type_name\s*=\s*force|nl_func_proto_type_name\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Proto Type Name|Add Nl Func Proto Type Name|Remove Nl Func Proto Type Name|Force Nl Func Proto Type Name"
 ValueDefault=ignore
 
@@ -4382,7 +4873,8 @@ Category=3
 Description="<html>Add or remove newline between a function name and the opening '(' in the<br/>declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_paren\s*=\s*ignore|nl_func_paren\s*=\s*add|nl_func_paren\s*=\s*remove|nl_func_paren\s*=\s*force|nl_func_paren\s*=\s*not_defined
+Choices=nl_func_paren=ignore|nl_func_paren=add|nl_func_paren=remove|nl_func_paren=force|nl_func_paren=not_defined
+ChoicesRegex=nl_func_paren\s*=\s*ignore|nl_func_paren\s*=\s*add|nl_func_paren\s*=\s*remove|nl_func_paren\s*=\s*force|nl_func_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Paren|Add Nl Func Paren|Remove Nl Func Paren|Force Nl Func Paren"
 ValueDefault=ignore
 
@@ -4391,7 +4883,8 @@ Category=3
 Description="<html>Overrides nl_func_paren for functions with no parameters.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_paren_empty\s*=\s*ignore|nl_func_paren_empty\s*=\s*add|nl_func_paren_empty\s*=\s*remove|nl_func_paren_empty\s*=\s*force|nl_func_paren_empty\s*=\s*not_defined
+Choices=nl_func_paren_empty=ignore|nl_func_paren_empty=add|nl_func_paren_empty=remove|nl_func_paren_empty=force|nl_func_paren_empty=not_defined
+ChoicesRegex=nl_func_paren_empty\s*=\s*ignore|nl_func_paren_empty\s*=\s*add|nl_func_paren_empty\s*=\s*remove|nl_func_paren_empty\s*=\s*force|nl_func_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Paren Empty|Add Nl Func Paren Empty|Remove Nl Func Paren Empty|Force Nl Func Paren Empty"
 ValueDefault=ignore
 
@@ -4400,7 +4893,8 @@ Category=3
 Description="<html>Add or remove newline between a function name and the opening '(' in the<br/>definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_paren\s*=\s*ignore|nl_func_def_paren\s*=\s*add|nl_func_def_paren\s*=\s*remove|nl_func_def_paren\s*=\s*force|nl_func_def_paren\s*=\s*not_defined
+Choices=nl_func_def_paren=ignore|nl_func_def_paren=add|nl_func_def_paren=remove|nl_func_def_paren=force|nl_func_def_paren=not_defined
+ChoicesRegex=nl_func_def_paren\s*=\s*ignore|nl_func_def_paren\s*=\s*add|nl_func_def_paren\s*=\s*remove|nl_func_def_paren\s*=\s*force|nl_func_def_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Paren|Add Nl Func Def Paren|Remove Nl Func Def Paren|Force Nl Func Def Paren"
 ValueDefault=ignore
 
@@ -4409,7 +4903,8 @@ Category=3
 Description="<html>Overrides nl_func_def_paren for functions with no parameters.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_paren_empty\s*=\s*ignore|nl_func_def_paren_empty\s*=\s*add|nl_func_def_paren_empty\s*=\s*remove|nl_func_def_paren_empty\s*=\s*force|nl_func_def_paren_empty\s*=\s*not_defined
+Choices=nl_func_def_paren_empty=ignore|nl_func_def_paren_empty=add|nl_func_def_paren_empty=remove|nl_func_def_paren_empty=force|nl_func_def_paren_empty=not_defined
+ChoicesRegex=nl_func_def_paren_empty\s*=\s*ignore|nl_func_def_paren_empty\s*=\s*add|nl_func_def_paren_empty\s*=\s*remove|nl_func_def_paren_empty\s*=\s*force|nl_func_def_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Paren Empty|Add Nl Func Def Paren Empty|Remove Nl Func Def Paren Empty|Force Nl Func Def Paren Empty"
 ValueDefault=ignore
 
@@ -4418,7 +4913,8 @@ Category=3
 Description="<html>Add or remove newline between a function name and the opening '(' in the<br/>call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_paren\s*=\s*ignore|nl_func_call_paren\s*=\s*add|nl_func_call_paren\s*=\s*remove|nl_func_call_paren\s*=\s*force|nl_func_call_paren\s*=\s*not_defined
+Choices=nl_func_call_paren=ignore|nl_func_call_paren=add|nl_func_call_paren=remove|nl_func_call_paren=force|nl_func_call_paren=not_defined
+ChoicesRegex=nl_func_call_paren\s*=\s*ignore|nl_func_call_paren\s*=\s*add|nl_func_call_paren\s*=\s*remove|nl_func_call_paren\s*=\s*force|nl_func_call_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Paren|Add Nl Func Call Paren|Remove Nl Func Call Paren|Force Nl Func Call Paren"
 ValueDefault=ignore
 
@@ -4427,7 +4923,8 @@ Category=3
 Description="<html>Overrides nl_func_call_paren for functions with no parameters.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_paren_empty\s*=\s*ignore|nl_func_call_paren_empty\s*=\s*add|nl_func_call_paren_empty\s*=\s*remove|nl_func_call_paren_empty\s*=\s*force|nl_func_call_paren_empty\s*=\s*not_defined
+Choices=nl_func_call_paren_empty=ignore|nl_func_call_paren_empty=add|nl_func_call_paren_empty=remove|nl_func_call_paren_empty=force|nl_func_call_paren_empty=not_defined
+ChoicesRegex=nl_func_call_paren_empty\s*=\s*ignore|nl_func_call_paren_empty\s*=\s*add|nl_func_call_paren_empty\s*=\s*remove|nl_func_call_paren_empty\s*=\s*force|nl_func_call_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Paren Empty|Add Nl Func Call Paren Empty|Remove Nl Func Call Paren Empty|Force Nl Func Call Paren Empty"
 ValueDefault=ignore
 
@@ -4436,7 +4933,8 @@ Category=3
 Description="<html>Add or remove newline after '(' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_start\s*=\s*ignore|nl_func_decl_start\s*=\s*add|nl_func_decl_start\s*=\s*remove|nl_func_decl_start\s*=\s*force|nl_func_decl_start\s*=\s*not_defined
+Choices=nl_func_decl_start=ignore|nl_func_decl_start=add|nl_func_decl_start=remove|nl_func_decl_start=force|nl_func_decl_start=not_defined
+ChoicesRegex=nl_func_decl_start\s*=\s*ignore|nl_func_decl_start\s*=\s*add|nl_func_decl_start\s*=\s*remove|nl_func_decl_start\s*=\s*force|nl_func_decl_start\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl Start|Add Nl Func Decl Start|Remove Nl Func Decl Start|Force Nl Func Decl Start"
 ValueDefault=ignore
 
@@ -4445,7 +4943,8 @@ Category=3
 Description="<html>Add or remove newline after '(' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_start\s*=\s*ignore|nl_func_def_start\s*=\s*add|nl_func_def_start\s*=\s*remove|nl_func_def_start\s*=\s*force|nl_func_def_start\s*=\s*not_defined
+Choices=nl_func_def_start=ignore|nl_func_def_start=add|nl_func_def_start=remove|nl_func_def_start=force|nl_func_def_start=not_defined
+ChoicesRegex=nl_func_def_start\s*=\s*ignore|nl_func_def_start\s*=\s*add|nl_func_def_start\s*=\s*remove|nl_func_def_start\s*=\s*force|nl_func_def_start\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Start|Add Nl Func Def Start|Remove Nl Func Def Start|Force Nl Func Def Start"
 ValueDefault=ignore
 
@@ -4454,7 +4953,8 @@ Category=3
 Description="<html>Overrides nl_func_decl_start when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_start_single\s*=\s*ignore|nl_func_decl_start_single\s*=\s*add|nl_func_decl_start_single\s*=\s*remove|nl_func_decl_start_single\s*=\s*force|nl_func_decl_start_single\s*=\s*not_defined
+Choices=nl_func_decl_start_single=ignore|nl_func_decl_start_single=add|nl_func_decl_start_single=remove|nl_func_decl_start_single=force|nl_func_decl_start_single=not_defined
+ChoicesRegex=nl_func_decl_start_single\s*=\s*ignore|nl_func_decl_start_single\s*=\s*add|nl_func_decl_start_single\s*=\s*remove|nl_func_decl_start_single\s*=\s*force|nl_func_decl_start_single\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl Start Single|Add Nl Func Decl Start Single|Remove Nl Func Decl Start Single|Force Nl Func Decl Start Single"
 ValueDefault=ignore
 
@@ -4463,7 +4963,8 @@ Category=3
 Description="<html>Overrides nl_func_def_start when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_start_single\s*=\s*ignore|nl_func_def_start_single\s*=\s*add|nl_func_def_start_single\s*=\s*remove|nl_func_def_start_single\s*=\s*force|nl_func_def_start_single\s*=\s*not_defined
+Choices=nl_func_def_start_single=ignore|nl_func_def_start_single=add|nl_func_def_start_single=remove|nl_func_def_start_single=force|nl_func_def_start_single=not_defined
+ChoicesRegex=nl_func_def_start_single\s*=\s*ignore|nl_func_def_start_single\s*=\s*add|nl_func_def_start_single\s*=\s*remove|nl_func_def_start_single\s*=\s*force|nl_func_def_start_single\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Start Single|Add Nl Func Def Start Single|Remove Nl Func Def Start Single|Force Nl Func Def Start Single"
 ValueDefault=ignore
 
@@ -4472,7 +4973,8 @@ Category=3
 Description="<html>Whether to add a newline after '(' in a function declaration if '(' and ')'<br/>are in different lines. If false, nl_func_decl_start is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_decl_start_multi_line\s*=\s*true|nl_func_decl_start_multi_line\s*=\s*false
+TrueFalse=nl_func_decl_start_multi_line=true|nl_func_decl_start_multi_line=false
+TrueFalseRegex=nl_func_decl_start_multi_line\s*=\s*true|nl_func_decl_start_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Def Start Multi Line]
@@ -4480,7 +4982,8 @@ Category=3
 Description="<html>Whether to add a newline after '(' in a function definition if '(' and ')'<br/>are in different lines. If false, nl_func_def_start is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_def_start_multi_line\s*=\s*true|nl_func_def_start_multi_line\s*=\s*false
+TrueFalse=nl_func_def_start_multi_line=true|nl_func_def_start_multi_line=false
+TrueFalseRegex=nl_func_def_start_multi_line\s*=\s*true|nl_func_def_start_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Decl Args]
@@ -4488,7 +4991,8 @@ Category=3
 Description="<html>Add or remove newline after each ',' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_args\s*=\s*ignore|nl_func_decl_args\s*=\s*add|nl_func_decl_args\s*=\s*remove|nl_func_decl_args\s*=\s*force|nl_func_decl_args\s*=\s*not_defined
+Choices=nl_func_decl_args=ignore|nl_func_decl_args=add|nl_func_decl_args=remove|nl_func_decl_args=force|nl_func_decl_args=not_defined
+ChoicesRegex=nl_func_decl_args\s*=\s*ignore|nl_func_decl_args\s*=\s*add|nl_func_decl_args\s*=\s*remove|nl_func_decl_args\s*=\s*force|nl_func_decl_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl Args|Add Nl Func Decl Args|Remove Nl Func Decl Args|Force Nl Func Decl Args"
 ValueDefault=ignore
 
@@ -4497,7 +5001,8 @@ Category=3
 Description="<html>Add or remove newline after each ',' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_args\s*=\s*ignore|nl_func_def_args\s*=\s*add|nl_func_def_args\s*=\s*remove|nl_func_def_args\s*=\s*force|nl_func_def_args\s*=\s*not_defined
+Choices=nl_func_def_args=ignore|nl_func_def_args=add|nl_func_def_args=remove|nl_func_def_args=force|nl_func_def_args=not_defined
+ChoicesRegex=nl_func_def_args\s*=\s*ignore|nl_func_def_args\s*=\s*add|nl_func_def_args\s*=\s*remove|nl_func_def_args\s*=\s*force|nl_func_def_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Args|Add Nl Func Def Args|Remove Nl Func Def Args|Force Nl Func Def Args"
 ValueDefault=ignore
 
@@ -4506,7 +5011,8 @@ Category=3
 Description="<html>Add or remove newline after each ',' in a function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_args\s*=\s*ignore|nl_func_call_args\s*=\s*add|nl_func_call_args\s*=\s*remove|nl_func_call_args\s*=\s*force|nl_func_call_args\s*=\s*not_defined
+Choices=nl_func_call_args=ignore|nl_func_call_args=add|nl_func_call_args=remove|nl_func_call_args=force|nl_func_call_args=not_defined
+ChoicesRegex=nl_func_call_args\s*=\s*ignore|nl_func_call_args\s*=\s*add|nl_func_call_args\s*=\s*remove|nl_func_call_args\s*=\s*force|nl_func_call_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Args|Add Nl Func Call Args|Remove Nl Func Call Args|Force Nl Func Call Args"
 ValueDefault=ignore
 
@@ -4515,7 +5021,8 @@ Category=3
 Description="<html>Whether to add a newline after each ',' in a function declaration if '('<br/>and ')' are in different lines. If false, nl_func_decl_args is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_decl_args_multi_line\s*=\s*true|nl_func_decl_args_multi_line\s*=\s*false
+TrueFalse=nl_func_decl_args_multi_line=true|nl_func_decl_args_multi_line=false
+TrueFalseRegex=nl_func_decl_args_multi_line\s*=\s*true|nl_func_decl_args_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Def Args Multi Line]
@@ -4523,7 +5030,8 @@ Category=3
 Description="<html>Whether to add a newline after each ',' in a function definition if '('<br/>and ')' are in different lines. If false, nl_func_def_args is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_def_args_multi_line\s*=\s*true|nl_func_def_args_multi_line\s*=\s*false
+TrueFalse=nl_func_def_args_multi_line=true|nl_func_def_args_multi_line=false
+TrueFalseRegex=nl_func_def_args_multi_line\s*=\s*true|nl_func_def_args_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Decl End]
@@ -4531,7 +5039,8 @@ Category=3
 Description="<html>Add or remove newline before the ')' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_end\s*=\s*ignore|nl_func_decl_end\s*=\s*add|nl_func_decl_end\s*=\s*remove|nl_func_decl_end\s*=\s*force|nl_func_decl_end\s*=\s*not_defined
+Choices=nl_func_decl_end=ignore|nl_func_decl_end=add|nl_func_decl_end=remove|nl_func_decl_end=force|nl_func_decl_end=not_defined
+ChoicesRegex=nl_func_decl_end\s*=\s*ignore|nl_func_decl_end\s*=\s*add|nl_func_decl_end\s*=\s*remove|nl_func_decl_end\s*=\s*force|nl_func_decl_end\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl End|Add Nl Func Decl End|Remove Nl Func Decl End|Force Nl Func Decl End"
 ValueDefault=ignore
 
@@ -4540,7 +5049,8 @@ Category=3
 Description="<html>Add or remove newline before the ')' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_end\s*=\s*ignore|nl_func_def_end\s*=\s*add|nl_func_def_end\s*=\s*remove|nl_func_def_end\s*=\s*force|nl_func_def_end\s*=\s*not_defined
+Choices=nl_func_def_end=ignore|nl_func_def_end=add|nl_func_def_end=remove|nl_func_def_end=force|nl_func_def_end=not_defined
+ChoicesRegex=nl_func_def_end\s*=\s*ignore|nl_func_def_end\s*=\s*add|nl_func_def_end\s*=\s*remove|nl_func_def_end\s*=\s*force|nl_func_def_end\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def End|Add Nl Func Def End|Remove Nl Func Def End|Force Nl Func Def End"
 ValueDefault=ignore
 
@@ -4549,7 +5059,8 @@ Category=3
 Description="<html>Overrides nl_func_decl_end when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_end_single\s*=\s*ignore|nl_func_decl_end_single\s*=\s*add|nl_func_decl_end_single\s*=\s*remove|nl_func_decl_end_single\s*=\s*force|nl_func_decl_end_single\s*=\s*not_defined
+Choices=nl_func_decl_end_single=ignore|nl_func_decl_end_single=add|nl_func_decl_end_single=remove|nl_func_decl_end_single=force|nl_func_decl_end_single=not_defined
+ChoicesRegex=nl_func_decl_end_single\s*=\s*ignore|nl_func_decl_end_single\s*=\s*add|nl_func_decl_end_single\s*=\s*remove|nl_func_decl_end_single\s*=\s*force|nl_func_decl_end_single\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl End Single|Add Nl Func Decl End Single|Remove Nl Func Decl End Single|Force Nl Func Decl End Single"
 ValueDefault=ignore
 
@@ -4558,7 +5069,8 @@ Category=3
 Description="<html>Overrides nl_func_def_end when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_end_single\s*=\s*ignore|nl_func_def_end_single\s*=\s*add|nl_func_def_end_single\s*=\s*remove|nl_func_def_end_single\s*=\s*force|nl_func_def_end_single\s*=\s*not_defined
+Choices=nl_func_def_end_single=ignore|nl_func_def_end_single=add|nl_func_def_end_single=remove|nl_func_def_end_single=force|nl_func_def_end_single=not_defined
+ChoicesRegex=nl_func_def_end_single\s*=\s*ignore|nl_func_def_end_single\s*=\s*add|nl_func_def_end_single\s*=\s*remove|nl_func_def_end_single\s*=\s*force|nl_func_def_end_single\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def End Single|Add Nl Func Def End Single|Remove Nl Func Def End Single|Force Nl Func Def End Single"
 ValueDefault=ignore
 
@@ -4567,7 +5079,8 @@ Category=3
 Description="<html>Whether to add a newline before ')' in a function declaration if '(' and ')'<br/>are in different lines. If false, nl_func_decl_end is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_decl_end_multi_line\s*=\s*true|nl_func_decl_end_multi_line\s*=\s*false
+TrueFalse=nl_func_decl_end_multi_line=true|nl_func_decl_end_multi_line=false
+TrueFalseRegex=nl_func_decl_end_multi_line\s*=\s*true|nl_func_decl_end_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Def End Multi Line]
@@ -4575,7 +5088,8 @@ Category=3
 Description="<html>Whether to add a newline before ')' in a function definition if '(' and ')'<br/>are in different lines. If false, nl_func_def_end is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_def_end_multi_line\s*=\s*true|nl_func_def_end_multi_line\s*=\s*false
+TrueFalse=nl_func_def_end_multi_line=true|nl_func_def_end_multi_line=false
+TrueFalseRegex=nl_func_def_end_multi_line\s*=\s*true|nl_func_def_end_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Decl Empty]
@@ -4583,7 +5097,8 @@ Category=3
 Description="<html>Add or remove newline between '()' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_empty\s*=\s*ignore|nl_func_decl_empty\s*=\s*add|nl_func_decl_empty\s*=\s*remove|nl_func_decl_empty\s*=\s*force|nl_func_decl_empty\s*=\s*not_defined
+Choices=nl_func_decl_empty=ignore|nl_func_decl_empty=add|nl_func_decl_empty=remove|nl_func_decl_empty=force|nl_func_decl_empty=not_defined
+ChoicesRegex=nl_func_decl_empty\s*=\s*ignore|nl_func_decl_empty\s*=\s*add|nl_func_decl_empty\s*=\s*remove|nl_func_decl_empty\s*=\s*force|nl_func_decl_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl Empty|Add Nl Func Decl Empty|Remove Nl Func Decl Empty|Force Nl Func Decl Empty"
 ValueDefault=ignore
 
@@ -4592,7 +5107,8 @@ Category=3
 Description="<html>Add or remove newline between '()' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_empty\s*=\s*ignore|nl_func_def_empty\s*=\s*add|nl_func_def_empty\s*=\s*remove|nl_func_def_empty\s*=\s*force|nl_func_def_empty\s*=\s*not_defined
+Choices=nl_func_def_empty=ignore|nl_func_def_empty=add|nl_func_def_empty=remove|nl_func_def_empty=force|nl_func_def_empty=not_defined
+ChoicesRegex=nl_func_def_empty\s*=\s*ignore|nl_func_def_empty\s*=\s*add|nl_func_def_empty\s*=\s*remove|nl_func_def_empty\s*=\s*force|nl_func_def_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Empty|Add Nl Func Def Empty|Remove Nl Func Def Empty|Force Nl Func Def Empty"
 ValueDefault=ignore
 
@@ -4601,7 +5117,8 @@ Category=3
 Description="<html>Add or remove newline between '()' in a function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_empty\s*=\s*ignore|nl_func_call_empty\s*=\s*add|nl_func_call_empty\s*=\s*remove|nl_func_call_empty\s*=\s*force|nl_func_call_empty\s*=\s*not_defined
+Choices=nl_func_call_empty=ignore|nl_func_call_empty=add|nl_func_call_empty=remove|nl_func_call_empty=force|nl_func_call_empty=not_defined
+ChoicesRegex=nl_func_call_empty\s*=\s*ignore|nl_func_call_empty\s*=\s*add|nl_func_call_empty\s*=\s*remove|nl_func_call_empty\s*=\s*force|nl_func_call_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Empty|Add Nl Func Call Empty|Remove Nl Func Call Empty|Force Nl Func Call Empty"
 ValueDefault=ignore
 
@@ -4610,7 +5127,8 @@ Category=3
 Description="<html>Whether to add a newline after '(' in a function call,<br/>has preference over nl_func_call_start_multi_line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_start\s*=\s*ignore|nl_func_call_start\s*=\s*add|nl_func_call_start\s*=\s*remove|nl_func_call_start\s*=\s*force|nl_func_call_start\s*=\s*not_defined
+Choices=nl_func_call_start=ignore|nl_func_call_start=add|nl_func_call_start=remove|nl_func_call_start=force|nl_func_call_start=not_defined
+ChoicesRegex=nl_func_call_start\s*=\s*ignore|nl_func_call_start\s*=\s*add|nl_func_call_start\s*=\s*remove|nl_func_call_start\s*=\s*force|nl_func_call_start\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Start|Add Nl Func Call Start|Remove Nl Func Call Start|Force Nl Func Call Start"
 ValueDefault=ignore
 
@@ -4619,7 +5137,8 @@ Category=3
 Description="<html>Whether to add a newline before ')' in a function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_end\s*=\s*ignore|nl_func_call_end\s*=\s*add|nl_func_call_end\s*=\s*remove|nl_func_call_end\s*=\s*force|nl_func_call_end\s*=\s*not_defined
+Choices=nl_func_call_end=ignore|nl_func_call_end=add|nl_func_call_end=remove|nl_func_call_end=force|nl_func_call_end=not_defined
+ChoicesRegex=nl_func_call_end\s*=\s*ignore|nl_func_call_end\s*=\s*add|nl_func_call_end\s*=\s*remove|nl_func_call_end\s*=\s*force|nl_func_call_end\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call End|Add Nl Func Call End|Remove Nl Func Call End|Force Nl Func Call End"
 ValueDefault=ignore
 
@@ -4628,7 +5147,8 @@ Category=3
 Description="<html>Whether to add a newline after '(' in a function call if '(' and ')' are in<br/>different lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_call_start_multi_line\s*=\s*true|nl_func_call_start_multi_line\s*=\s*false
+TrueFalse=nl_func_call_start_multi_line=true|nl_func_call_start_multi_line=false
+TrueFalseRegex=nl_func_call_start_multi_line\s*=\s*true|nl_func_call_start_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Call Args Multi Line]
@@ -4636,7 +5156,8 @@ Category=3
 Description="<html>Whether to add a newline after each ',' in a function call if '(' and ')'<br/>are in different lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_call_args_multi_line\s*=\s*true|nl_func_call_args_multi_line\s*=\s*false
+TrueFalse=nl_func_call_args_multi_line=true|nl_func_call_args_multi_line=false
+TrueFalseRegex=nl_func_call_args_multi_line\s*=\s*true|nl_func_call_args_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Call End Multi Line]
@@ -4644,7 +5165,8 @@ Category=3
 Description="<html>Whether to add a newline before ')' in a function call if '(' and ')' are in<br/>different lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_call_end_multi_line\s*=\s*true|nl_func_call_end_multi_line\s*=\s*false
+TrueFalse=nl_func_call_end_multi_line=true|nl_func_call_end_multi_line=false
+TrueFalseRegex=nl_func_call_end_multi_line\s*=\s*true|nl_func_call_end_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Call Args Multi Line Ignore Closures]
@@ -4652,7 +5174,8 @@ Category=3
 Description="<html>Whether to respect nl_func_call_XXX option in case of closure args.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_call_args_multi_line_ignore_closures\s*=\s*true|nl_func_call_args_multi_line_ignore_closures\s*=\s*false
+TrueFalse=nl_func_call_args_multi_line_ignore_closures=true|nl_func_call_args_multi_line_ignore_closures=false
+TrueFalseRegex=nl_func_call_args_multi_line_ignore_closures\s*=\s*true|nl_func_call_args_multi_line_ignore_closures\s*=\s*false
 ValueDefault=false
 
 [Nl Template Start]
@@ -4660,7 +5183,8 @@ Category=3
 Description="<html>Whether to add a newline after '&lt;' of a template parameter list.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_template_start\s*=\s*true|nl_template_start\s*=\s*false
+TrueFalse=nl_template_start=true|nl_template_start=false
+TrueFalseRegex=nl_template_start\s*=\s*true|nl_template_start\s*=\s*false
 ValueDefault=false
 
 [Nl Template Args]
@@ -4668,7 +5192,8 @@ Category=3
 Description="<html>Whether to add a newline after each ',' in a template parameter list.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_template_args\s*=\s*true|nl_template_args\s*=\s*false
+TrueFalse=nl_template_args=true|nl_template_args=false
+TrueFalseRegex=nl_template_args\s*=\s*true|nl_template_args\s*=\s*false
 ValueDefault=false
 
 [Nl Template End]
@@ -4676,7 +5201,8 @@ Category=3
 Description="<html>Whether to add a newline before '&gt;' of a template parameter list.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_template_end\s*=\s*true|nl_template_end\s*=\s*false
+TrueFalse=nl_template_end=true|nl_template_end=false
+TrueFalseRegex=nl_template_end\s*=\s*true|nl_template_end\s*=\s*false
 ValueDefault=false
 
 [Nl Oc Msg Args]
@@ -4684,7 +5210,8 @@ Category=3
 Description="<html>(OC) Whether to put each Objective-C message parameter on a separate line.<br/>See nl_oc_msg_leave_one_liner.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_oc_msg_args\s*=\s*true|nl_oc_msg_args\s*=\s*false
+TrueFalse=nl_oc_msg_args=true|nl_oc_msg_args=false
+TrueFalseRegex=nl_oc_msg_args\s*=\s*true|nl_oc_msg_args\s*=\s*false
 ValueDefault=false
 
 [Nl Oc Msg Args Min Params]
@@ -4692,7 +5219,8 @@ Category=3
 Description="<html>(OC) Minimum number of Objective-C message parameters before applying nl_oc_msg_args.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_oc_msg_args_min_params\s*=\s*"
+CallName="nl_oc_msg_args_min_params="
+CallNameRegex="nl_oc_msg_args_min_params\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -4702,7 +5230,8 @@ Category=3
 Description="<html>(OC) Max code width of Objective-C message before applying nl_oc_msg_args.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_oc_msg_args_max_code_width\s*=\s*"
+CallName="nl_oc_msg_args_max_code_width="
+CallNameRegex="nl_oc_msg_args_max_code_width\s*=\s*"
 MinVal=0
 MaxVal=10000
 ValueDefault=0
@@ -4712,7 +5241,8 @@ Category=3
 Description="<html>Add or remove newline between function signature and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_fdef_brace\s*=\s*ignore|nl_fdef_brace\s*=\s*add|nl_fdef_brace\s*=\s*remove|nl_fdef_brace\s*=\s*force|nl_fdef_brace\s*=\s*not_defined
+Choices=nl_fdef_brace=ignore|nl_fdef_brace=add|nl_fdef_brace=remove|nl_fdef_brace=force|nl_fdef_brace=not_defined
+ChoicesRegex=nl_fdef_brace\s*=\s*ignore|nl_fdef_brace\s*=\s*add|nl_fdef_brace\s*=\s*remove|nl_fdef_brace\s*=\s*force|nl_fdef_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Fdef Brace|Add Nl Fdef Brace|Remove Nl Fdef Brace|Force Nl Fdef Brace"
 ValueDefault=ignore
 
@@ -4721,7 +5251,8 @@ Category=3
 Description="<html>Add or remove newline between function signature and '{',<br/>if signature ends with ')'. Overrides nl_fdef_brace.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_fdef_brace_cond\s*=\s*ignore|nl_fdef_brace_cond\s*=\s*add|nl_fdef_brace_cond\s*=\s*remove|nl_fdef_brace_cond\s*=\s*force|nl_fdef_brace_cond\s*=\s*not_defined
+Choices=nl_fdef_brace_cond=ignore|nl_fdef_brace_cond=add|nl_fdef_brace_cond=remove|nl_fdef_brace_cond=force|nl_fdef_brace_cond=not_defined
+ChoicesRegex=nl_fdef_brace_cond\s*=\s*ignore|nl_fdef_brace_cond\s*=\s*add|nl_fdef_brace_cond\s*=\s*remove|nl_fdef_brace_cond\s*=\s*force|nl_fdef_brace_cond\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Fdef Brace Cond|Add Nl Fdef Brace Cond|Remove Nl Fdef Brace Cond|Force Nl Fdef Brace Cond"
 ValueDefault=ignore
 
@@ -4730,7 +5261,8 @@ Category=3
 Description="<html>Add or remove newline between C++11 lambda signature and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_cpp_ldef_brace\s*=\s*ignore|nl_cpp_ldef_brace\s*=\s*add|nl_cpp_ldef_brace\s*=\s*remove|nl_cpp_ldef_brace\s*=\s*force|nl_cpp_ldef_brace\s*=\s*not_defined
+Choices=nl_cpp_ldef_brace=ignore|nl_cpp_ldef_brace=add|nl_cpp_ldef_brace=remove|nl_cpp_ldef_brace=force|nl_cpp_ldef_brace=not_defined
+ChoicesRegex=nl_cpp_ldef_brace\s*=\s*ignore|nl_cpp_ldef_brace\s*=\s*add|nl_cpp_ldef_brace\s*=\s*remove|nl_cpp_ldef_brace\s*=\s*force|nl_cpp_ldef_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Cpp Ldef Brace|Add Nl Cpp Ldef Brace|Remove Nl Cpp Ldef Brace|Force Nl Cpp Ldef Brace"
 ValueDefault=ignore
 
@@ -4739,7 +5271,8 @@ Category=3
 Description="<html>Add or remove newline between 'return' and the return expression.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_return_expr\s*=\s*ignore|nl_return_expr\s*=\s*add|nl_return_expr\s*=\s*remove|nl_return_expr\s*=\s*force|nl_return_expr\s*=\s*not_defined
+Choices=nl_return_expr=ignore|nl_return_expr=add|nl_return_expr=remove|nl_return_expr=force|nl_return_expr=not_defined
+ChoicesRegex=nl_return_expr\s*=\s*ignore|nl_return_expr\s*=\s*add|nl_return_expr\s*=\s*remove|nl_return_expr\s*=\s*force|nl_return_expr\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Return Expr|Add Nl Return Expr|Remove Nl Return Expr|Force Nl Return Expr"
 ValueDefault=ignore
 
@@ -4748,7 +5281,8 @@ Category=3
 Description="<html>Add or remove newline between 'throw' and the throw expression.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_throw_expr\s*=\s*ignore|nl_throw_expr\s*=\s*add|nl_throw_expr\s*=\s*remove|nl_throw_expr\s*=\s*force|nl_throw_expr\s*=\s*not_defined
+Choices=nl_throw_expr=ignore|nl_throw_expr=add|nl_throw_expr=remove|nl_throw_expr=force|nl_throw_expr=not_defined
+ChoicesRegex=nl_throw_expr\s*=\s*ignore|nl_throw_expr\s*=\s*add|nl_throw_expr\s*=\s*remove|nl_throw_expr\s*=\s*force|nl_throw_expr\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Throw Expr|Add Nl Throw Expr|Remove Nl Throw Expr|Force Nl Throw Expr"
 ValueDefault=ignore
 
@@ -4757,7 +5291,8 @@ Category=3
 Description="<html>Whether to add a newline after semicolons, except in 'for' statements.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_semicolon\s*=\s*true|nl_after_semicolon\s*=\s*false
+TrueFalse=nl_after_semicolon=true|nl_after_semicolon=false
+TrueFalseRegex=nl_after_semicolon\s*=\s*true|nl_after_semicolon\s*=\s*false
 ValueDefault=false
 
 [Nl Paren Dbrace Open]
@@ -4765,7 +5300,8 @@ Category=3
 Description="<html>(Java) Add or remove newline between the ')' and '{{' of the double brace<br/>initializer.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_paren_dbrace_open\s*=\s*ignore|nl_paren_dbrace_open\s*=\s*add|nl_paren_dbrace_open\s*=\s*remove|nl_paren_dbrace_open\s*=\s*force|nl_paren_dbrace_open\s*=\s*not_defined
+Choices=nl_paren_dbrace_open=ignore|nl_paren_dbrace_open=add|nl_paren_dbrace_open=remove|nl_paren_dbrace_open=force|nl_paren_dbrace_open=not_defined
+ChoicesRegex=nl_paren_dbrace_open\s*=\s*ignore|nl_paren_dbrace_open\s*=\s*add|nl_paren_dbrace_open\s*=\s*remove|nl_paren_dbrace_open\s*=\s*force|nl_paren_dbrace_open\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Paren Dbrace Open|Add Nl Paren Dbrace Open|Remove Nl Paren Dbrace Open|Force Nl Paren Dbrace Open"
 ValueDefault=ignore
 
@@ -4774,7 +5310,8 @@ Category=3
 Description="<html>Whether to add a newline after the type in an unnamed temporary<br/>direct-list-initialization, better:<br/>before a direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_type_brace_init_lst\s*=\s*ignore|nl_type_brace_init_lst\s*=\s*add|nl_type_brace_init_lst\s*=\s*remove|nl_type_brace_init_lst\s*=\s*force|nl_type_brace_init_lst\s*=\s*not_defined
+Choices=nl_type_brace_init_lst=ignore|nl_type_brace_init_lst=add|nl_type_brace_init_lst=remove|nl_type_brace_init_lst=force|nl_type_brace_init_lst=not_defined
+ChoicesRegex=nl_type_brace_init_lst\s*=\s*ignore|nl_type_brace_init_lst\s*=\s*add|nl_type_brace_init_lst\s*=\s*remove|nl_type_brace_init_lst\s*=\s*force|nl_type_brace_init_lst\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Type Brace Init Lst|Add Nl Type Brace Init Lst|Remove Nl Type Brace Init Lst|Force Nl Type Brace Init Lst"
 ValueDefault=ignore
 
@@ -4783,7 +5320,8 @@ Category=3
 Description="<html>Whether to add a newline after the open brace in an unnamed temporary<br/>direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_type_brace_init_lst_open\s*=\s*ignore|nl_type_brace_init_lst_open\s*=\s*add|nl_type_brace_init_lst_open\s*=\s*remove|nl_type_brace_init_lst_open\s*=\s*force|nl_type_brace_init_lst_open\s*=\s*not_defined
+Choices=nl_type_brace_init_lst_open=ignore|nl_type_brace_init_lst_open=add|nl_type_brace_init_lst_open=remove|nl_type_brace_init_lst_open=force|nl_type_brace_init_lst_open=not_defined
+ChoicesRegex=nl_type_brace_init_lst_open\s*=\s*ignore|nl_type_brace_init_lst_open\s*=\s*add|nl_type_brace_init_lst_open\s*=\s*remove|nl_type_brace_init_lst_open\s*=\s*force|nl_type_brace_init_lst_open\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Type Brace Init Lst Open|Add Nl Type Brace Init Lst Open|Remove Nl Type Brace Init Lst Open|Force Nl Type Brace Init Lst Open"
 ValueDefault=ignore
 
@@ -4792,7 +5330,8 @@ Category=3
 Description="<html>Whether to add a newline before the close brace in an unnamed temporary<br/>direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_type_brace_init_lst_close\s*=\s*ignore|nl_type_brace_init_lst_close\s*=\s*add|nl_type_brace_init_lst_close\s*=\s*remove|nl_type_brace_init_lst_close\s*=\s*force|nl_type_brace_init_lst_close\s*=\s*not_defined
+Choices=nl_type_brace_init_lst_close=ignore|nl_type_brace_init_lst_close=add|nl_type_brace_init_lst_close=remove|nl_type_brace_init_lst_close=force|nl_type_brace_init_lst_close=not_defined
+ChoicesRegex=nl_type_brace_init_lst_close\s*=\s*ignore|nl_type_brace_init_lst_close\s*=\s*add|nl_type_brace_init_lst_close\s*=\s*remove|nl_type_brace_init_lst_close\s*=\s*force|nl_type_brace_init_lst_close\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Type Brace Init Lst Close|Add Nl Type Brace Init Lst Close|Remove Nl Type Brace Init Lst Close|Force Nl Type Brace Init Lst Close"
 ValueDefault=ignore
 
@@ -4801,7 +5340,8 @@ Category=3
 Description="<html>Whether to add a newline before '{'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_before_brace_open\s*=\s*true|nl_before_brace_open\s*=\s*false
+TrueFalse=nl_before_brace_open=true|nl_before_brace_open=false
+TrueFalseRegex=nl_before_brace_open\s*=\s*true|nl_before_brace_open\s*=\s*false
 ValueDefault=false
 
 [Nl After Brace Open]
@@ -4809,7 +5349,8 @@ Category=3
 Description="<html>Whether to add a newline after '{'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_brace_open\s*=\s*true|nl_after_brace_open\s*=\s*false
+TrueFalse=nl_after_brace_open=true|nl_after_brace_open=false
+TrueFalseRegex=nl_after_brace_open\s*=\s*true|nl_after_brace_open\s*=\s*false
 ValueDefault=false
 
 [Nl After Brace Open Cmt]
@@ -4817,7 +5358,8 @@ Category=3
 Description="<html>Whether to add a newline between the open brace and a trailing single-line<br/>comment. Requires nl_after_brace_open=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_brace_open_cmt\s*=\s*true|nl_after_brace_open_cmt\s*=\s*false
+TrueFalse=nl_after_brace_open_cmt=true|nl_after_brace_open_cmt=false
+TrueFalseRegex=nl_after_brace_open_cmt\s*=\s*true|nl_after_brace_open_cmt\s*=\s*false
 ValueDefault=false
 
 [Nl After Vbrace Open]
@@ -4825,7 +5367,8 @@ Category=3
 Description="<html>Whether to add a newline after a virtual brace open with a non-empty body.<br/>These occur in un-braced if/while/do/for statement bodies.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_vbrace_open\s*=\s*true|nl_after_vbrace_open\s*=\s*false
+TrueFalse=nl_after_vbrace_open=true|nl_after_vbrace_open=false
+TrueFalseRegex=nl_after_vbrace_open\s*=\s*true|nl_after_vbrace_open\s*=\s*false
 ValueDefault=false
 
 [Nl After Vbrace Open Empty]
@@ -4833,7 +5376,8 @@ Category=3
 Description="<html>Whether to add a newline after a virtual brace open with an empty body.<br/>These occur in un-braced if/while/do/for statement bodies.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_vbrace_open_empty\s*=\s*true|nl_after_vbrace_open_empty\s*=\s*false
+TrueFalse=nl_after_vbrace_open_empty=true|nl_after_vbrace_open_empty=false
+TrueFalseRegex=nl_after_vbrace_open_empty\s*=\s*true|nl_after_vbrace_open_empty\s*=\s*false
 ValueDefault=false
 
 [Nl After Brace Close]
@@ -4841,7 +5385,8 @@ Category=3
 Description="<html>Whether to add a newline after '}'. Does not apply if followed by a<br/>necessary ';'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_brace_close\s*=\s*true|nl_after_brace_close\s*=\s*false
+TrueFalse=nl_after_brace_close=true|nl_after_brace_close=false
+TrueFalseRegex=nl_after_brace_close\s*=\s*true|nl_after_brace_close\s*=\s*false
 ValueDefault=false
 
 [Nl After Vbrace Close]
@@ -4849,7 +5394,8 @@ Category=3
 Description="<html>Whether to add a newline after a virtual brace close,<br/>as in 'if (foo) a++; &lt;here&gt; return;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_vbrace_close\s*=\s*true|nl_after_vbrace_close\s*=\s*false
+TrueFalse=nl_after_vbrace_close=true|nl_after_vbrace_close=false
+TrueFalseRegex=nl_after_vbrace_close\s*=\s*true|nl_after_vbrace_close\s*=\s*false
 ValueDefault=false
 
 [Nl Brace Struct Var]
@@ -4857,7 +5403,8 @@ Category=3
 Description="<html>Add or remove newline between the close brace and identifier,<br/>as in 'struct { int a; } &lt;here&gt; b;'. Affects enumerations, unions and<br/>structures. If set to ignore, uses nl_after_brace_close.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_struct_var\s*=\s*ignore|nl_brace_struct_var\s*=\s*add|nl_brace_struct_var\s*=\s*remove|nl_brace_struct_var\s*=\s*force|nl_brace_struct_var\s*=\s*not_defined
+Choices=nl_brace_struct_var=ignore|nl_brace_struct_var=add|nl_brace_struct_var=remove|nl_brace_struct_var=force|nl_brace_struct_var=not_defined
+ChoicesRegex=nl_brace_struct_var\s*=\s*ignore|nl_brace_struct_var\s*=\s*add|nl_brace_struct_var\s*=\s*remove|nl_brace_struct_var\s*=\s*force|nl_brace_struct_var\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Struct Var|Add Nl Brace Struct Var|Remove Nl Brace Struct Var|Force Nl Brace Struct Var"
 ValueDefault=ignore
 
@@ -4866,7 +5413,8 @@ Category=3
 Description="<html>Whether to alter newlines in '#define' macros.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_define_macro\s*=\s*true|nl_define_macro\s*=\s*false
+TrueFalse=nl_define_macro=true|nl_define_macro=false
+TrueFalseRegex=nl_define_macro\s*=\s*true|nl_define_macro\s*=\s*false
 ValueDefault=false
 
 [Nl Squeeze Paren Close]
@@ -4874,7 +5422,8 @@ Category=3
 Description="<html>Whether to alter newlines between consecutive parenthesis closes. The number<br/>of closing parentheses in a line will depend on respective open parenthesis<br/>lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_squeeze_paren_close\s*=\s*true|nl_squeeze_paren_close\s*=\s*false
+TrueFalse=nl_squeeze_paren_close=true|nl_squeeze_paren_close=false
+TrueFalseRegex=nl_squeeze_paren_close\s*=\s*true|nl_squeeze_paren_close\s*=\s*false
 ValueDefault=false
 
 [Nl Squeeze Ifdef]
@@ -4882,7 +5431,8 @@ Category=3
 Description="<html>Whether to remove blanks after '#ifxx' and '#elxx', or before '#elxx' and<br/>'#endif'. Does not affect top-level #ifdefs.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_squeeze_ifdef\s*=\s*true|nl_squeeze_ifdef\s*=\s*false
+TrueFalse=nl_squeeze_ifdef=true|nl_squeeze_ifdef=false
+TrueFalseRegex=nl_squeeze_ifdef\s*=\s*true|nl_squeeze_ifdef\s*=\s*false
 ValueDefault=false
 
 [Nl Squeeze Ifdef Top Level]
@@ -4890,7 +5440,8 @@ Category=3
 Description="<html>Makes the nl_squeeze_ifdef option affect the top-level #ifdefs as well.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_squeeze_ifdef_top_level\s*=\s*true|nl_squeeze_ifdef_top_level\s*=\s*false
+TrueFalse=nl_squeeze_ifdef_top_level=true|nl_squeeze_ifdef_top_level=false
+TrueFalseRegex=nl_squeeze_ifdef_top_level\s*=\s*true|nl_squeeze_ifdef_top_level\s*=\s*false
 ValueDefault=false
 
 [Nl Before If]
@@ -4898,7 +5449,8 @@ Category=3
 Description="<html>Add or remove blank line before 'if'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_if\s*=\s*ignore|nl_before_if\s*=\s*add|nl_before_if\s*=\s*remove|nl_before_if\s*=\s*force|nl_before_if\s*=\s*not_defined
+Choices=nl_before_if=ignore|nl_before_if=add|nl_before_if=remove|nl_before_if=force|nl_before_if=not_defined
+ChoicesRegex=nl_before_if\s*=\s*ignore|nl_before_if\s*=\s*add|nl_before_if\s*=\s*remove|nl_before_if\s*=\s*force|nl_before_if\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before If|Add Nl Before If|Remove Nl Before If|Force Nl Before If"
 ValueDefault=ignore
 
@@ -4907,7 +5459,8 @@ Category=3
 Description="<html>Add or remove blank line after 'if' statement. Add/Force work only if the<br/>next token is not a closing brace.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_if\s*=\s*ignore|nl_after_if\s*=\s*add|nl_after_if\s*=\s*remove|nl_after_if\s*=\s*force|nl_after_if\s*=\s*not_defined
+Choices=nl_after_if=ignore|nl_after_if=add|nl_after_if=remove|nl_after_if=force|nl_after_if=not_defined
+ChoicesRegex=nl_after_if\s*=\s*ignore|nl_after_if\s*=\s*add|nl_after_if\s*=\s*remove|nl_after_if\s*=\s*force|nl_after_if\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After If|Add Nl After If|Remove Nl After If|Force Nl After If"
 ValueDefault=ignore
 
@@ -4916,7 +5469,8 @@ Category=3
 Description="<html>Add or remove blank line before 'for'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_for\s*=\s*ignore|nl_before_for\s*=\s*add|nl_before_for\s*=\s*remove|nl_before_for\s*=\s*force|nl_before_for\s*=\s*not_defined
+Choices=nl_before_for=ignore|nl_before_for=add|nl_before_for=remove|nl_before_for=force|nl_before_for=not_defined
+ChoicesRegex=nl_before_for\s*=\s*ignore|nl_before_for\s*=\s*add|nl_before_for\s*=\s*remove|nl_before_for\s*=\s*force|nl_before_for\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before For|Add Nl Before For|Remove Nl Before For|Force Nl Before For"
 ValueDefault=ignore
 
@@ -4925,7 +5479,8 @@ Category=3
 Description="<html>Add or remove blank line after 'for' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_for\s*=\s*ignore|nl_after_for\s*=\s*add|nl_after_for\s*=\s*remove|nl_after_for\s*=\s*force|nl_after_for\s*=\s*not_defined
+Choices=nl_after_for=ignore|nl_after_for=add|nl_after_for=remove|nl_after_for=force|nl_after_for=not_defined
+ChoicesRegex=nl_after_for\s*=\s*ignore|nl_after_for\s*=\s*add|nl_after_for\s*=\s*remove|nl_after_for\s*=\s*force|nl_after_for\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After For|Add Nl After For|Remove Nl After For|Force Nl After For"
 ValueDefault=ignore
 
@@ -4934,7 +5489,8 @@ Category=3
 Description="<html>Add or remove blank line before 'while'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_while\s*=\s*ignore|nl_before_while\s*=\s*add|nl_before_while\s*=\s*remove|nl_before_while\s*=\s*force|nl_before_while\s*=\s*not_defined
+Choices=nl_before_while=ignore|nl_before_while=add|nl_before_while=remove|nl_before_while=force|nl_before_while=not_defined
+ChoicesRegex=nl_before_while\s*=\s*ignore|nl_before_while\s*=\s*add|nl_before_while\s*=\s*remove|nl_before_while\s*=\s*force|nl_before_while\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before While|Add Nl Before While|Remove Nl Before While|Force Nl Before While"
 ValueDefault=ignore
 
@@ -4943,7 +5499,8 @@ Category=3
 Description="<html>Add or remove blank line after 'while' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_while\s*=\s*ignore|nl_after_while\s*=\s*add|nl_after_while\s*=\s*remove|nl_after_while\s*=\s*force|nl_after_while\s*=\s*not_defined
+Choices=nl_after_while=ignore|nl_after_while=add|nl_after_while=remove|nl_after_while=force|nl_after_while=not_defined
+ChoicesRegex=nl_after_while\s*=\s*ignore|nl_after_while\s*=\s*add|nl_after_while\s*=\s*remove|nl_after_while\s*=\s*force|nl_after_while\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After While|Add Nl After While|Remove Nl After While|Force Nl After While"
 ValueDefault=ignore
 
@@ -4952,7 +5509,8 @@ Category=3
 Description="<html>Add or remove blank line before 'switch'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_switch\s*=\s*ignore|nl_before_switch\s*=\s*add|nl_before_switch\s*=\s*remove|nl_before_switch\s*=\s*force|nl_before_switch\s*=\s*not_defined
+Choices=nl_before_switch=ignore|nl_before_switch=add|nl_before_switch=remove|nl_before_switch=force|nl_before_switch=not_defined
+ChoicesRegex=nl_before_switch\s*=\s*ignore|nl_before_switch\s*=\s*add|nl_before_switch\s*=\s*remove|nl_before_switch\s*=\s*force|nl_before_switch\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Switch|Add Nl Before Switch|Remove Nl Before Switch|Force Nl Before Switch"
 ValueDefault=ignore
 
@@ -4961,7 +5519,8 @@ Category=3
 Description="<html>Add or remove blank line after 'switch' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_switch\s*=\s*ignore|nl_after_switch\s*=\s*add|nl_after_switch\s*=\s*remove|nl_after_switch\s*=\s*force|nl_after_switch\s*=\s*not_defined
+Choices=nl_after_switch=ignore|nl_after_switch=add|nl_after_switch=remove|nl_after_switch=force|nl_after_switch=not_defined
+ChoicesRegex=nl_after_switch\s*=\s*ignore|nl_after_switch\s*=\s*add|nl_after_switch\s*=\s*remove|nl_after_switch\s*=\s*force|nl_after_switch\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Switch|Add Nl After Switch|Remove Nl After Switch|Force Nl After Switch"
 ValueDefault=ignore
 
@@ -4970,7 +5529,8 @@ Category=3
 Description="<html>Add or remove blank line before 'synchronized'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_synchronized\s*=\s*ignore|nl_before_synchronized\s*=\s*add|nl_before_synchronized\s*=\s*remove|nl_before_synchronized\s*=\s*force|nl_before_synchronized\s*=\s*not_defined
+Choices=nl_before_synchronized=ignore|nl_before_synchronized=add|nl_before_synchronized=remove|nl_before_synchronized=force|nl_before_synchronized=not_defined
+ChoicesRegex=nl_before_synchronized\s*=\s*ignore|nl_before_synchronized\s*=\s*add|nl_before_synchronized\s*=\s*remove|nl_before_synchronized\s*=\s*force|nl_before_synchronized\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Synchronized|Add Nl Before Synchronized|Remove Nl Before Synchronized|Force Nl Before Synchronized"
 ValueDefault=ignore
 
@@ -4979,7 +5539,8 @@ Category=3
 Description="<html>Add or remove blank line after 'synchronized' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_synchronized\s*=\s*ignore|nl_after_synchronized\s*=\s*add|nl_after_synchronized\s*=\s*remove|nl_after_synchronized\s*=\s*force|nl_after_synchronized\s*=\s*not_defined
+Choices=nl_after_synchronized=ignore|nl_after_synchronized=add|nl_after_synchronized=remove|nl_after_synchronized=force|nl_after_synchronized=not_defined
+ChoicesRegex=nl_after_synchronized\s*=\s*ignore|nl_after_synchronized\s*=\s*add|nl_after_synchronized\s*=\s*remove|nl_after_synchronized\s*=\s*force|nl_after_synchronized\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Synchronized|Add Nl After Synchronized|Remove Nl After Synchronized|Force Nl After Synchronized"
 ValueDefault=ignore
 
@@ -4988,7 +5549,8 @@ Category=3
 Description="<html>Add or remove blank line before 'do'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_do\s*=\s*ignore|nl_before_do\s*=\s*add|nl_before_do\s*=\s*remove|nl_before_do\s*=\s*force|nl_before_do\s*=\s*not_defined
+Choices=nl_before_do=ignore|nl_before_do=add|nl_before_do=remove|nl_before_do=force|nl_before_do=not_defined
+ChoicesRegex=nl_before_do\s*=\s*ignore|nl_before_do\s*=\s*add|nl_before_do\s*=\s*remove|nl_before_do\s*=\s*force|nl_before_do\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Do|Add Nl Before Do|Remove Nl Before Do|Force Nl Before Do"
 ValueDefault=ignore
 
@@ -4997,7 +5559,8 @@ Category=3
 Description="<html>Add or remove blank line after 'do/while' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_do\s*=\s*ignore|nl_after_do\s*=\s*add|nl_after_do\s*=\s*remove|nl_after_do\s*=\s*force|nl_after_do\s*=\s*not_defined
+Choices=nl_after_do=ignore|nl_after_do=add|nl_after_do=remove|nl_after_do=force|nl_after_do=not_defined
+ChoicesRegex=nl_after_do\s*=\s*ignore|nl_after_do\s*=\s*add|nl_after_do\s*=\s*remove|nl_after_do\s*=\s*force|nl_after_do\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Do|Add Nl After Do|Remove Nl After Do|Force Nl After Do"
 ValueDefault=ignore
 
@@ -5006,7 +5569,8 @@ Category=3
 Description="<html>Ignore nl_before_{if,for,switch,do,synchronized} if the control<br/>statement is immediately after a case statement.<br/>if nl_before_{if,for,switch,do} is set to remove, this option<br/>does nothing.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_before_ignore_after_case\s*=\s*true|nl_before_ignore_after_case\s*=\s*false
+TrueFalse=nl_before_ignore_after_case=true|nl_before_ignore_after_case=false
+TrueFalseRegex=nl_before_ignore_after_case\s*=\s*true|nl_before_ignore_after_case\s*=\s*false
 ValueDefault=false
 
 [Nl Before Return]
@@ -5014,7 +5578,8 @@ Category=3
 Description="<html>Whether to put a blank line before 'return' statements, unless after an open<br/>brace.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_before_return\s*=\s*true|nl_before_return\s*=\s*false
+TrueFalse=nl_before_return=true|nl_before_return=false
+TrueFalseRegex=nl_before_return\s*=\s*true|nl_before_return\s*=\s*false
 ValueDefault=false
 
 [Nl After Return]
@@ -5022,7 +5587,8 @@ Category=3
 Description="<html>Whether to put a blank line after 'return' statements, unless followed by a<br/>close brace.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_return\s*=\s*true|nl_after_return\s*=\s*false
+TrueFalse=nl_after_return=true|nl_after_return=false
+TrueFalseRegex=nl_after_return\s*=\s*true|nl_after_return\s*=\s*false
 ValueDefault=false
 
 [Nl Before Member]
@@ -5030,7 +5596,8 @@ Category=3
 Description="<html>Whether to put a blank line before a member '.' or '-&gt;' operators.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_member\s*=\s*ignore|nl_before_member\s*=\s*add|nl_before_member\s*=\s*remove|nl_before_member\s*=\s*force|nl_before_member\s*=\s*not_defined
+Choices=nl_before_member=ignore|nl_before_member=add|nl_before_member=remove|nl_before_member=force|nl_before_member=not_defined
+ChoicesRegex=nl_before_member\s*=\s*ignore|nl_before_member\s*=\s*add|nl_before_member\s*=\s*remove|nl_before_member\s*=\s*force|nl_before_member\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Member|Add Nl Before Member|Remove Nl Before Member|Force Nl Before Member"
 ValueDefault=ignore
 
@@ -5039,7 +5606,8 @@ Category=3
 Description="<html>(Java) Whether to put a blank line after a member '.' or '-&gt;' operators.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_member\s*=\s*ignore|nl_after_member\s*=\s*add|nl_after_member\s*=\s*remove|nl_after_member\s*=\s*force|nl_after_member\s*=\s*not_defined
+Choices=nl_after_member=ignore|nl_after_member=add|nl_after_member=remove|nl_after_member=force|nl_after_member=not_defined
+ChoicesRegex=nl_after_member\s*=\s*ignore|nl_after_member\s*=\s*add|nl_after_member\s*=\s*remove|nl_after_member\s*=\s*force|nl_after_member\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Member|Add Nl After Member|Remove Nl After Member|Force Nl After Member"
 ValueDefault=ignore
 
@@ -5048,7 +5616,8 @@ Category=3
 Description="<html>Whether to double-space commented-entries in 'struct'/'union'/'enum'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_ds_struct_enum_cmt\s*=\s*true|nl_ds_struct_enum_cmt\s*=\s*false
+TrueFalse=nl_ds_struct_enum_cmt=true|nl_ds_struct_enum_cmt=false
+TrueFalseRegex=nl_ds_struct_enum_cmt\s*=\s*true|nl_ds_struct_enum_cmt\s*=\s*false
 ValueDefault=false
 
 [Nl Ds Struct Enum Close Brace]
@@ -5056,7 +5625,8 @@ Category=3
 Description="<html>Whether to force a newline before '}' of a 'struct'/'union'/'enum'.<br/>(Lower priority than eat_blanks_before_close_brace.)</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_ds_struct_enum_close_brace\s*=\s*true|nl_ds_struct_enum_close_brace\s*=\s*false
+TrueFalse=nl_ds_struct_enum_close_brace=true|nl_ds_struct_enum_close_brace=false
+TrueFalseRegex=nl_ds_struct_enum_close_brace\s*=\s*true|nl_ds_struct_enum_close_brace\s*=\s*false
 ValueDefault=false
 
 [Nl Class Colon]
@@ -5064,7 +5634,8 @@ Category=3
 Description="<html>Add or remove newline before or after (depending on pos_class_colon) a class<br/>colon, as in 'class Foo &lt;here&gt; : &lt;or here&gt; public Bar'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_class_colon\s*=\s*ignore|nl_class_colon\s*=\s*add|nl_class_colon\s*=\s*remove|nl_class_colon\s*=\s*force|nl_class_colon\s*=\s*not_defined
+Choices=nl_class_colon=ignore|nl_class_colon=add|nl_class_colon=remove|nl_class_colon=force|nl_class_colon=not_defined
+ChoicesRegex=nl_class_colon\s*=\s*ignore|nl_class_colon\s*=\s*add|nl_class_colon\s*=\s*remove|nl_class_colon\s*=\s*force|nl_class_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Class Colon|Add Nl Class Colon|Remove Nl Class Colon|Force Nl Class Colon"
 ValueDefault=ignore
 
@@ -5073,7 +5644,8 @@ Category=3
 Description="<html>Add or remove newline around a class constructor colon. The exact position<br/>depends on nl_constr_init_args, pos_constr_colon and pos_constr_comma.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_constr_colon\s*=\s*ignore|nl_constr_colon\s*=\s*add|nl_constr_colon\s*=\s*remove|nl_constr_colon\s*=\s*force|nl_constr_colon\s*=\s*not_defined
+Choices=nl_constr_colon=ignore|nl_constr_colon=add|nl_constr_colon=remove|nl_constr_colon=force|nl_constr_colon=not_defined
+ChoicesRegex=nl_constr_colon\s*=\s*ignore|nl_constr_colon\s*=\s*add|nl_constr_colon\s*=\s*remove|nl_constr_colon\s*=\s*force|nl_constr_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Constr Colon|Add Nl Constr Colon|Remove Nl Constr Colon|Force Nl Constr Colon"
 ValueDefault=ignore
 
@@ -5082,7 +5654,8 @@ Category=3
 Description="<html>Whether to collapse a two-line namespace, like 'namespace foo\n{ decl; }'<br/>into a single line. If true, prevents other brace newline rules from turning<br/>such code into four lines. If true, it also preserves one-liner namespaces.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_namespace_two_to_one_liner\s*=\s*true|nl_namespace_two_to_one_liner\s*=\s*false
+TrueFalse=nl_namespace_two_to_one_liner=true|nl_namespace_two_to_one_liner=false
+TrueFalseRegex=nl_namespace_two_to_one_liner\s*=\s*true|nl_namespace_two_to_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create If One Liner]
@@ -5090,7 +5663,8 @@ Category=3
 Description="<html>Whether to remove a newline in simple unbraced if statements, turning them<br/>into one-liners, as in 'if(b)\n i++;' =&gt; 'if(b) i++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_if_one_liner\s*=\s*true|nl_create_if_one_liner\s*=\s*false
+TrueFalse=nl_create_if_one_liner=true|nl_create_if_one_liner=false
+TrueFalseRegex=nl_create_if_one_liner\s*=\s*true|nl_create_if_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create For One Liner]
@@ -5098,7 +5672,8 @@ Category=3
 Description="<html>Whether to remove a newline in simple unbraced for statements, turning them<br/>into one-liners, as in 'for (...)\n stmt;' =&gt; 'for (...) stmt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_for_one_liner\s*=\s*true|nl_create_for_one_liner\s*=\s*false
+TrueFalse=nl_create_for_one_liner=true|nl_create_for_one_liner=false
+TrueFalseRegex=nl_create_for_one_liner\s*=\s*true|nl_create_for_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create While One Liner]
@@ -5106,7 +5681,8 @@ Category=3
 Description="<html>Whether to remove a newline in simple unbraced while statements, turning<br/>them into one-liners, as in 'while (expr)\n stmt;' =&gt; 'while (expr) stmt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_while_one_liner\s*=\s*true|nl_create_while_one_liner\s*=\s*false
+TrueFalse=nl_create_while_one_liner=true|nl_create_while_one_liner=false
+TrueFalseRegex=nl_create_while_one_liner\s*=\s*true|nl_create_while_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create Func Def One Liner]
@@ -5114,7 +5690,8 @@ Category=3
 Description="<html>Whether to collapse a function definition whose body (not counting braces)<br/>is only one line so that the entire definition (prototype, braces, body) is<br/>a single line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_func_def_one_liner\s*=\s*true|nl_create_func_def_one_liner\s*=\s*false
+TrueFalse=nl_create_func_def_one_liner=true|nl_create_func_def_one_liner=false
+TrueFalseRegex=nl_create_func_def_one_liner\s*=\s*true|nl_create_func_def_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create List One Liner]
@@ -5122,7 +5699,8 @@ Category=3
 Description="<html>Whether to split one-line simple list definitions into three lines by<br/>adding newlines, as in 'int a[12] = { &lt;here&gt; 0 &lt;here&gt; };'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_list_one_liner\s*=\s*true|nl_create_list_one_liner\s*=\s*false
+TrueFalse=nl_create_list_one_liner=true|nl_create_list_one_liner=false
+TrueFalseRegex=nl_create_list_one_liner\s*=\s*true|nl_create_list_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Split If One Liner]
@@ -5130,7 +5708,8 @@ Category=3
 Description="<html>Whether to split one-line simple unbraced if statements into two lines by<br/>adding a newline, as in 'if(b) &lt;here&gt; i++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_split_if_one_liner\s*=\s*true|nl_split_if_one_liner\s*=\s*false
+TrueFalse=nl_split_if_one_liner=true|nl_split_if_one_liner=false
+TrueFalseRegex=nl_split_if_one_liner\s*=\s*true|nl_split_if_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Split For One Liner]
@@ -5138,7 +5717,8 @@ Category=3
 Description="<html>Whether to split one-line simple unbraced for statements into two lines by<br/>adding a newline, as in 'for (...) &lt;here&gt; stmt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_split_for_one_liner\s*=\s*true|nl_split_for_one_liner\s*=\s*false
+TrueFalse=nl_split_for_one_liner=true|nl_split_for_one_liner=false
+TrueFalseRegex=nl_split_for_one_liner\s*=\s*true|nl_split_for_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Split While One Liner]
@@ -5146,7 +5726,8 @@ Category=3
 Description="<html>Whether to split one-line simple unbraced while statements into two lines by<br/>adding a newline, as in 'while (expr) &lt;here&gt; stmt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_split_while_one_liner\s*=\s*true|nl_split_while_one_liner\s*=\s*false
+TrueFalse=nl_split_while_one_liner=true|nl_split_while_one_liner=false
+TrueFalseRegex=nl_split_while_one_liner\s*=\s*true|nl_split_while_one_liner\s*=\s*false
 ValueDefault=false
 
 [Donot Add Nl Before Cpp Comment]
@@ -5154,7 +5735,8 @@ Category=3
 Description="<html>Don't add a newline before a cpp-comment in a parameter list of a function<br/>call.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=donot_add_nl_before_cpp_comment\s*=\s*true|donot_add_nl_before_cpp_comment\s*=\s*false
+TrueFalse=donot_add_nl_before_cpp_comment=true|donot_add_nl_before_cpp_comment=false
+TrueFalseRegex=donot_add_nl_before_cpp_comment\s*=\s*true|donot_add_nl_before_cpp_comment\s*=\s*false
 ValueDefault=false
 
 [Nl Max]
@@ -5162,7 +5744,8 @@ Category=4
 Description="<html>The maximum number of consecutive newlines (3 = 2 blank lines).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_max\s*=\s*"
+CallName="nl_max="
+CallNameRegex="nl_max\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5172,7 +5755,8 @@ Category=4
 Description="<html>The maximum number of consecutive newlines in a function.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_max_blank_in_func\s*=\s*"
+CallName="nl_max_blank_in_func="
+CallNameRegex="nl_max_blank_in_func\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5182,7 +5766,8 @@ Category=4
 Description="<html>The number of newlines inside an empty function body.<br/>This option overrides eat_blanks_after_open_brace and<br/>eat_blanks_before_close_brace, but is ignored when<br/>nl_collapse_empty_body_functions=true</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_inside_empty_func\s*=\s*"
+CallName="nl_inside_empty_func="
+CallNameRegex="nl_inside_empty_func\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5192,7 +5777,8 @@ Category=4
 Description="<html>The number of newlines before a function prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_func_body_proto\s*=\s*"
+CallName="nl_before_func_body_proto="
+CallNameRegex="nl_before_func_body_proto\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5202,7 +5788,8 @@ Category=4
 Description="<html>The number of newlines before a multi-line function definition. Where<br/>applicable, this option is overridden with eat_blanks_after_open_brace=true</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_func_body_def\s*=\s*"
+CallName="nl_before_func_body_def="
+CallNameRegex="nl_before_func_body_def\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5212,7 +5799,8 @@ Category=4
 Description="<html>The number of newlines before a class constructor/destructor prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_func_class_proto\s*=\s*"
+CallName="nl_before_func_class_proto="
+CallNameRegex="nl_before_func_class_proto\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5222,7 +5810,8 @@ Category=4
 Description="<html>The number of newlines before a class constructor/destructor definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_func_class_def\s*=\s*"
+CallName="nl_before_func_class_def="
+CallNameRegex="nl_before_func_class_def\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5232,7 +5821,8 @@ Category=4
 Description="<html>The number of newlines after a function prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_proto\s*=\s*"
+CallName="nl_after_func_proto="
+CallNameRegex="nl_after_func_proto\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5242,7 +5832,8 @@ Category=4
 Description="<html>The number of newlines after a function prototype, if not followed by<br/>another function prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_proto_group\s*=\s*"
+CallName="nl_after_func_proto_group="
+CallNameRegex="nl_after_func_proto_group\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5252,7 +5843,8 @@ Category=4
 Description="<html>The number of newlines after a class constructor/destructor prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_class_proto\s*=\s*"
+CallName="nl_after_func_class_proto="
+CallNameRegex="nl_after_func_class_proto\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5262,7 +5854,8 @@ Category=4
 Description="<html>The number of newlines after a class constructor/destructor prototype,<br/>if not followed by another constructor/destructor prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_class_proto_group\s*=\s*"
+CallName="nl_after_func_class_proto_group="
+CallNameRegex="nl_after_func_class_proto_group\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5272,7 +5865,8 @@ Category=4
 Description="<html>Whether one-line method definitions inside a class body should be treated<br/>as if they were prototypes for the purposes of adding newlines.<br/><br/>Requires nl_class_leave_one_liners=true. Overrides nl_before_func_body_def<br/>and nl_before_func_class_def for one-liners.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_class_leave_one_liner_groups\s*=\s*true|nl_class_leave_one_liner_groups\s*=\s*false
+TrueFalse=nl_class_leave_one_liner_groups=true|nl_class_leave_one_liner_groups=false
+TrueFalseRegex=nl_class_leave_one_liner_groups\s*=\s*true|nl_class_leave_one_liner_groups\s*=\s*false
 ValueDefault=false
 
 [Nl After Func Body]
@@ -5280,7 +5874,8 @@ Category=4
 Description="<html>The number of newlines after '}' of a multi-line function body.<br/><br/>Overrides nl_min_after_func_body and nl_max_after_func_body.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_body\s*=\s*"
+CallName="nl_after_func_body="
+CallNameRegex="nl_after_func_body\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5290,7 +5885,8 @@ Category=4
 Description="<html>The minimum number of newlines after '}' of a multi-line function body.<br/><br/>Only works when nl_after_func_body is 0.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_min_after_func_body\s*=\s*"
+CallName="nl_min_after_func_body="
+CallNameRegex="nl_min_after_func_body\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5300,7 +5896,8 @@ Category=4
 Description="<html>The maximum number of newlines after '}' of a multi-line function body.<br/><br/>Only works when nl_after_func_body is 0.<br/>Takes precedence over nl_min_after_func_body.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_max_after_func_body\s*=\s*"
+CallName="nl_max_after_func_body="
+CallNameRegex="nl_max_after_func_body\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5310,7 +5907,8 @@ Category=4
 Description="<html>The number of newlines after '}' of a multi-line function body in a class<br/>declaration. Also affects class constructors/destructors.<br/><br/>Overrides nl_after_func_body.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_body_class\s*=\s*"
+CallName="nl_after_func_body_class="
+CallNameRegex="nl_after_func_body_class\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5320,7 +5918,8 @@ Category=4
 Description="<html>The number of newlines after '}' of a single line function body. Also<br/>affects class constructors/destructors.<br/><br/>Overrides nl_after_func_body and nl_after_func_body_class.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_body_one_liner\s*=\s*"
+CallName="nl_after_func_body_one_liner="
+CallNameRegex="nl_after_func_body_one_liner\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5330,7 +5929,8 @@ Category=4
 Description="<html>The number of newlines before a block of typedefs. If nl_after_access_spec<br/>is non-zero, that option takes precedence.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_typedef_blk_start\s*=\s*"
+CallName="nl_typedef_blk_start="
+CallNameRegex="nl_typedef_blk_start\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5340,7 +5940,8 @@ Category=4
 Description="<html>The number of newlines after a block of typedefs.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_typedef_blk_end\s*=\s*"
+CallName="nl_typedef_blk_end="
+CallNameRegex="nl_typedef_blk_end\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5350,7 +5951,8 @@ Category=4
 Description="<html>The maximum number of consecutive newlines within a block of typedefs.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_typedef_blk_in\s*=\s*"
+CallName="nl_typedef_blk_in="
+CallNameRegex="nl_typedef_blk_in\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5360,7 +5962,8 @@ Category=4
 Description="<html>The minimum number of blank lines after a block of variable definitions<br/>at the top of a function body. If any preprocessor directives appear<br/>between the opening brace of the function and the variable block, then<br/>it is considered as not at the top of the function.Newlines are added<br/>before trailing preprocessor directives, if any exist.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_var_def_blk_end_func_top\s*=\s*"
+CallName="nl_var_def_blk_end_func_top="
+CallNameRegex="nl_var_def_blk_end_func_top\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5370,7 +5973,8 @@ Category=4
 Description="<html>The minimum number of empty newlines before a block of variable definitions<br/>not at the top of a function body. If nl_after_access_spec is non-zero,<br/>that option takes precedence. Newlines are not added at the top of the<br/>file or just after an opening brace. Newlines are added above any<br/>preprocessor directives before the block.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_var_def_blk_start\s*=\s*"
+CallName="nl_var_def_blk_start="
+CallNameRegex="nl_var_def_blk_start\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5380,7 +5984,8 @@ Category=4
 Description="<html>The minimum number of empty newlines after a block of variable definitions<br/>not at the top of a function body. Newlines are not added if the block<br/>is at the bottom of the file or just before a preprocessor directive.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_var_def_blk_end\s*=\s*"
+CallName="nl_var_def_blk_end="
+CallNameRegex="nl_var_def_blk_end\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5390,7 +5995,8 @@ Category=4
 Description="<html>The maximum number of consecutive newlines within a block of variable<br/>definitions.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_var_def_blk_in\s*=\s*"
+CallName="nl_var_def_blk_in="
+CallNameRegex="nl_var_def_blk_in\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5400,7 +6006,8 @@ Category=4
 Description="<html>The minimum number of newlines before a multi-line comment.<br/>Doesn't apply if after a brace open or another multi-line comment.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_block_comment\s*=\s*"
+CallName="nl_before_block_comment="
+CallNameRegex="nl_before_block_comment\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5410,7 +6017,8 @@ Category=4
 Description="<html>The minimum number of newlines before a single-line C comment.<br/>Doesn't apply if after a brace open or other single-line C comments.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_c_comment\s*=\s*"
+CallName="nl_before_c_comment="
+CallNameRegex="nl_before_c_comment\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5420,7 +6028,8 @@ Category=4
 Description="<html>The minimum number of newlines before a CPP comment.<br/>Doesn't apply if after a brace open or other CPP comments.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_cpp_comment\s*=\s*"
+CallName="nl_before_cpp_comment="
+CallNameRegex="nl_before_cpp_comment\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5430,7 +6039,8 @@ Category=4
 Description="<html>Whether to force a newline after a multi-line comment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_multiline_comment\s*=\s*true|nl_after_multiline_comment\s*=\s*false
+TrueFalse=nl_after_multiline_comment=true|nl_after_multiline_comment=false
+TrueFalseRegex=nl_after_multiline_comment\s*=\s*true|nl_after_multiline_comment\s*=\s*false
 ValueDefault=false
 
 [Nl After Label Colon]
@@ -5438,7 +6048,8 @@ Category=4
 Description="<html>Whether to force a newline after a label's colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_label_colon\s*=\s*true|nl_after_label_colon\s*=\s*false
+TrueFalse=nl_after_label_colon=true|nl_after_label_colon=false
+TrueFalseRegex=nl_after_label_colon\s*=\s*true|nl_after_label_colon\s*=\s*false
 ValueDefault=false
 
 [Nl Before Struct]
@@ -5446,7 +6057,8 @@ Category=4
 Description="<html>The number of newlines before a struct definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_struct\s*=\s*"
+CallName="nl_before_struct="
+CallNameRegex="nl_before_struct\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5456,7 +6068,8 @@ Category=4
 Description="<html>The number of newlines after '}' or ';' of a struct/enum/union definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_struct\s*=\s*"
+CallName="nl_after_struct="
+CallNameRegex="nl_after_struct\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5466,7 +6079,8 @@ Category=4
 Description="<html>The number of newlines before a class definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_class\s*=\s*"
+CallName="nl_before_class="
+CallNameRegex="nl_before_class\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5476,7 +6090,8 @@ Category=4
 Description="<html>The number of newlines after '}' or ';' of a class definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_class\s*=\s*"
+CallName="nl_after_class="
+CallNameRegex="nl_after_class\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5486,7 +6101,8 @@ Category=4
 Description="<html>The number of newlines before a namespace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_namespace\s*=\s*"
+CallName="nl_before_namespace="
+CallNameRegex="nl_before_namespace\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5496,7 +6112,8 @@ Category=4
 Description="<html>The number of newlines after '{' of a namespace. This also adds newlines<br/>before the matching '}'.<br/><br/>0: Apply eat_blanks_after_open_brace or eat_blanks_before_close_brace if<br/>    applicable, otherwise no change.<br/><br/>Overrides eat_blanks_after_open_brace and eat_blanks_before_close_brace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_inside_namespace\s*=\s*"
+CallName="nl_inside_namespace="
+CallNameRegex="nl_inside_namespace\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5506,7 +6123,8 @@ Category=4
 Description="<html>The number of newlines after '}' of a namespace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_namespace\s*=\s*"
+CallName="nl_after_namespace="
+CallNameRegex="nl_after_namespace\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5516,7 +6134,8 @@ Category=4
 Description="<html>The number of newlines before an access specifier label. This also includes<br/>the Qt-specific 'signals:' and 'slots:'. Will not change the newline count<br/>if after a brace open.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_access_spec\s*=\s*"
+CallName="nl_before_access_spec="
+CallNameRegex="nl_before_access_spec\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5526,7 +6145,8 @@ Category=4
 Description="<html>The number of newlines after an access specifier label. This also includes<br/>the Qt-specific 'signals:' and 'slots:'. Will not change the newline count<br/>if after a brace open.<br/><br/>0: No change (default).<br/><br/>Overrides nl_typedef_blk_start and nl_var_def_blk_start.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_access_spec\s*=\s*"
+CallName="nl_after_access_spec="
+CallNameRegex="nl_after_access_spec\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5536,7 +6156,8 @@ Category=4
 Description="<html>The number of newlines between a function definition and the function<br/>comment, as in '// comment\n &lt;here&gt; void foo() {...}'.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_comment_func_def\s*=\s*"
+CallName="nl_comment_func_def="
+CallNameRegex="nl_comment_func_def\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5546,7 +6167,8 @@ Category=4
 Description="<html>The number of newlines after a try-catch-finally block that isn't followed<br/>by a brace close.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_try_catch_finally\s*=\s*"
+CallName="nl_after_try_catch_finally="
+CallNameRegex="nl_after_try_catch_finally\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5556,7 +6178,8 @@ Category=4
 Description="<html>(C#) The number of newlines before and after a property, indexer or event<br/>declaration.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_around_cs_property\s*=\s*"
+CallName="nl_around_cs_property="
+CallNameRegex="nl_around_cs_property\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5566,7 +6189,8 @@ Category=4
 Description="<html>(C#) The number of newlines between the get/set/add/remove handlers.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_between_get_set\s*=\s*"
+CallName="nl_between_get_set="
+CallNameRegex="nl_between_get_set\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5576,7 +6200,8 @@ Category=4
 Description="<html>(C#) Add or remove newline between property and the '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_property_brace\s*=\s*ignore|nl_property_brace\s*=\s*add|nl_property_brace\s*=\s*remove|nl_property_brace\s*=\s*force|nl_property_brace\s*=\s*not_defined
+Choices=nl_property_brace=ignore|nl_property_brace=add|nl_property_brace=remove|nl_property_brace=force|nl_property_brace=not_defined
+ChoicesRegex=nl_property_brace\s*=\s*ignore|nl_property_brace\s*=\s*add|nl_property_brace\s*=\s*remove|nl_property_brace\s*=\s*force|nl_property_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Property Brace|Add Nl Property Brace|Remove Nl Property Brace|Force Nl Property Brace"
 ValueDefault=ignore
 
@@ -5585,7 +6210,8 @@ Category=4
 Description="<html>Whether to remove blank lines after '{'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=eat_blanks_after_open_brace\s*=\s*true|eat_blanks_after_open_brace\s*=\s*false
+TrueFalse=eat_blanks_after_open_brace=true|eat_blanks_after_open_brace=false
+TrueFalseRegex=eat_blanks_after_open_brace\s*=\s*true|eat_blanks_after_open_brace\s*=\s*false
 ValueDefault=false
 
 [Eat Blanks Before Close Brace]
@@ -5593,7 +6219,8 @@ Category=4
 Description="<html>Whether to remove blank lines before '}'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=eat_blanks_before_close_brace\s*=\s*true|eat_blanks_before_close_brace\s*=\s*false
+TrueFalse=eat_blanks_before_close_brace=true|eat_blanks_before_close_brace=false
+TrueFalseRegex=eat_blanks_before_close_brace\s*=\s*true|eat_blanks_before_close_brace\s*=\s*false
 ValueDefault=false
 
 [Nl Remove Extra Newlines]
@@ -5601,7 +6228,8 @@ Category=4
 Description="<html>How aggressively to remove extra newlines not in preprocessor.<br/><br/>0: No change (default)<br/>1: Remove most newlines not handled by other config<br/>2: Remove all newlines and reformat completely by config</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_remove_extra_newlines\s*=\s*"
+CallName="nl_remove_extra_newlines="
+CallNameRegex="nl_remove_extra_newlines\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -5611,7 +6239,8 @@ Category=4
 Description="<html>(Java) Add or remove newline after an annotation statement. Only affects<br/>annotations that are after a newline.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_annotation\s*=\s*ignore|nl_after_annotation\s*=\s*add|nl_after_annotation\s*=\s*remove|nl_after_annotation\s*=\s*force|nl_after_annotation\s*=\s*not_defined
+Choices=nl_after_annotation=ignore|nl_after_annotation=add|nl_after_annotation=remove|nl_after_annotation=force|nl_after_annotation=not_defined
+ChoicesRegex=nl_after_annotation\s*=\s*ignore|nl_after_annotation\s*=\s*add|nl_after_annotation\s*=\s*remove|nl_after_annotation\s*=\s*force|nl_after_annotation\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Annotation|Add Nl After Annotation|Remove Nl After Annotation|Force Nl After Annotation"
 ValueDefault=ignore
 
@@ -5620,7 +6249,8 @@ Category=4
 Description="<html>(Java) Add or remove newline between two annotations.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_between_annotation\s*=\s*ignore|nl_between_annotation\s*=\s*add|nl_between_annotation\s*=\s*remove|nl_between_annotation\s*=\s*force|nl_between_annotation\s*=\s*not_defined
+Choices=nl_between_annotation=ignore|nl_between_annotation=add|nl_between_annotation=remove|nl_between_annotation=force|nl_between_annotation=not_defined
+ChoicesRegex=nl_between_annotation\s*=\s*ignore|nl_between_annotation\s*=\s*add|nl_between_annotation\s*=\s*remove|nl_between_annotation\s*=\s*force|nl_between_annotation\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Between Annotation|Add Nl Between Annotation|Remove Nl Between Annotation|Force Nl Between Annotation"
 ValueDefault=ignore
 
@@ -5629,7 +6259,8 @@ Category=4
 Description="<html>The number of newlines before a whole-file #ifdef.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_whole_file_ifdef\s*=\s*"
+CallName="nl_before_whole_file_ifdef="
+CallNameRegex="nl_before_whole_file_ifdef\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5639,7 +6270,8 @@ Category=4
 Description="<html>The number of newlines after a whole-file #ifdef.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_whole_file_ifdef\s*=\s*"
+CallName="nl_after_whole_file_ifdef="
+CallNameRegex="nl_after_whole_file_ifdef\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5649,7 +6281,8 @@ Category=4
 Description="<html>The number of newlines before a whole-file #endif.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_whole_file_endif\s*=\s*"
+CallName="nl_before_whole_file_endif="
+CallNameRegex="nl_before_whole_file_endif\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5659,7 +6292,8 @@ Category=4
 Description="<html>The number of newlines after a whole-file #endif.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_whole_file_endif\s*=\s*"
+CallName="nl_after_whole_file_endif="
+CallNameRegex="nl_after_whole_file_endif\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5669,7 +6303,8 @@ Category=5
 Description="<html>The position of arithmetic operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_arith\s*=\s*ignore|pos_arith\s*=\s*break|pos_arith\s*=\s*force|pos_arith\s*=\s*lead|pos_arith\s*=\s*trail|pos_arith\s*=\s*join|pos_arith\s*=\s*lead_break|pos_arith\s*=\s*lead_force|pos_arith\s*=\s*trail_break|pos_arith\s*=\s*trail_force
+Choices=pos_arith=ignore|pos_arith=break|pos_arith=force|pos_arith=lead|pos_arith=trail|pos_arith=join|pos_arith=lead_break|pos_arith=lead_force|pos_arith=trail_break|pos_arith=trail_force
+ChoicesRegex=pos_arith\s*=\s*ignore|pos_arith\s*=\s*break|pos_arith\s*=\s*force|pos_arith\s*=\s*lead|pos_arith\s*=\s*trail|pos_arith\s*=\s*join|pos_arith\s*=\s*lead_break|pos_arith\s*=\s*lead_force|pos_arith\s*=\s*trail_break|pos_arith\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Arith|Break Pos Arith|Force Pos Arith|Lead Pos Arith|Trail Pos Arith|Join Pos Arith|Lead Break Pos Arith|Lead Force Pos Arith|Trail Break Pos Arith|Trail Force Pos Arith"
 ValueDefault=ignore
 
@@ -5678,7 +6313,8 @@ Category=5
 Description="<html>The position of assignment in wrapped expressions. Do not affect '='<br/>followed by '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_assign\s*=\s*ignore|pos_assign\s*=\s*break|pos_assign\s*=\s*force|pos_assign\s*=\s*lead|pos_assign\s*=\s*trail|pos_assign\s*=\s*join|pos_assign\s*=\s*lead_break|pos_assign\s*=\s*lead_force|pos_assign\s*=\s*trail_break|pos_assign\s*=\s*trail_force
+Choices=pos_assign=ignore|pos_assign=break|pos_assign=force|pos_assign=lead|pos_assign=trail|pos_assign=join|pos_assign=lead_break|pos_assign=lead_force|pos_assign=trail_break|pos_assign=trail_force
+ChoicesRegex=pos_assign\s*=\s*ignore|pos_assign\s*=\s*break|pos_assign\s*=\s*force|pos_assign\s*=\s*lead|pos_assign\s*=\s*trail|pos_assign\s*=\s*join|pos_assign\s*=\s*lead_break|pos_assign\s*=\s*lead_force|pos_assign\s*=\s*trail_break|pos_assign\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Assign|Break Pos Assign|Force Pos Assign|Lead Pos Assign|Trail Pos Assign|Join Pos Assign|Lead Break Pos Assign|Lead Force Pos Assign|Trail Break Pos Assign|Trail Force Pos Assign"
 ValueDefault=ignore
 
@@ -5687,7 +6323,8 @@ Category=5
 Description="<html>The position of Boolean operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_bool\s*=\s*ignore|pos_bool\s*=\s*break|pos_bool\s*=\s*force|pos_bool\s*=\s*lead|pos_bool\s*=\s*trail|pos_bool\s*=\s*join|pos_bool\s*=\s*lead_break|pos_bool\s*=\s*lead_force|pos_bool\s*=\s*trail_break|pos_bool\s*=\s*trail_force
+Choices=pos_bool=ignore|pos_bool=break|pos_bool=force|pos_bool=lead|pos_bool=trail|pos_bool=join|pos_bool=lead_break|pos_bool=lead_force|pos_bool=trail_break|pos_bool=trail_force
+ChoicesRegex=pos_bool\s*=\s*ignore|pos_bool\s*=\s*break|pos_bool\s*=\s*force|pos_bool\s*=\s*lead|pos_bool\s*=\s*trail|pos_bool\s*=\s*join|pos_bool\s*=\s*lead_break|pos_bool\s*=\s*lead_force|pos_bool\s*=\s*trail_break|pos_bool\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Bool|Break Pos Bool|Force Pos Bool|Lead Pos Bool|Trail Pos Bool|Join Pos Bool|Lead Break Pos Bool|Lead Force Pos Bool|Trail Break Pos Bool|Trail Force Pos Bool"
 ValueDefault=ignore
 
@@ -5696,7 +6333,8 @@ Category=5
 Description="<html>The position of comparison operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_compare\s*=\s*ignore|pos_compare\s*=\s*break|pos_compare\s*=\s*force|pos_compare\s*=\s*lead|pos_compare\s*=\s*trail|pos_compare\s*=\s*join|pos_compare\s*=\s*lead_break|pos_compare\s*=\s*lead_force|pos_compare\s*=\s*trail_break|pos_compare\s*=\s*trail_force
+Choices=pos_compare=ignore|pos_compare=break|pos_compare=force|pos_compare=lead|pos_compare=trail|pos_compare=join|pos_compare=lead_break|pos_compare=lead_force|pos_compare=trail_break|pos_compare=trail_force
+ChoicesRegex=pos_compare\s*=\s*ignore|pos_compare\s*=\s*break|pos_compare\s*=\s*force|pos_compare\s*=\s*lead|pos_compare\s*=\s*trail|pos_compare\s*=\s*join|pos_compare\s*=\s*lead_break|pos_compare\s*=\s*lead_force|pos_compare\s*=\s*trail_break|pos_compare\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Compare|Break Pos Compare|Force Pos Compare|Lead Pos Compare|Trail Pos Compare|Join Pos Compare|Lead Break Pos Compare|Lead Force Pos Compare|Trail Break Pos Compare|Trail Force Pos Compare"
 ValueDefault=ignore
 
@@ -5705,7 +6343,8 @@ Category=5
 Description="<html>The position of conditional operators, as in the '?' and ':' of<br/>'expr ? stmt : stmt', in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_conditional\s*=\s*ignore|pos_conditional\s*=\s*break|pos_conditional\s*=\s*force|pos_conditional\s*=\s*lead|pos_conditional\s*=\s*trail|pos_conditional\s*=\s*join|pos_conditional\s*=\s*lead_break|pos_conditional\s*=\s*lead_force|pos_conditional\s*=\s*trail_break|pos_conditional\s*=\s*trail_force
+Choices=pos_conditional=ignore|pos_conditional=break|pos_conditional=force|pos_conditional=lead|pos_conditional=trail|pos_conditional=join|pos_conditional=lead_break|pos_conditional=lead_force|pos_conditional=trail_break|pos_conditional=trail_force
+ChoicesRegex=pos_conditional\s*=\s*ignore|pos_conditional\s*=\s*break|pos_conditional\s*=\s*force|pos_conditional\s*=\s*lead|pos_conditional\s*=\s*trail|pos_conditional\s*=\s*join|pos_conditional\s*=\s*lead_break|pos_conditional\s*=\s*lead_force|pos_conditional\s*=\s*trail_break|pos_conditional\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Conditional|Break Pos Conditional|Force Pos Conditional|Lead Pos Conditional|Trail Pos Conditional|Join Pos Conditional|Lead Break Pos Conditional|Lead Force Pos Conditional|Trail Break Pos Conditional|Trail Force Pos Conditional"
 ValueDefault=ignore
 
@@ -5714,7 +6353,8 @@ Category=5
 Description="<html>The position of the comma in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_comma\s*=\s*ignore|pos_comma\s*=\s*break|pos_comma\s*=\s*force|pos_comma\s*=\s*lead|pos_comma\s*=\s*trail|pos_comma\s*=\s*join|pos_comma\s*=\s*lead_break|pos_comma\s*=\s*lead_force|pos_comma\s*=\s*trail_break|pos_comma\s*=\s*trail_force
+Choices=pos_comma=ignore|pos_comma=break|pos_comma=force|pos_comma=lead|pos_comma=trail|pos_comma=join|pos_comma=lead_break|pos_comma=lead_force|pos_comma=trail_break|pos_comma=trail_force
+ChoicesRegex=pos_comma\s*=\s*ignore|pos_comma\s*=\s*break|pos_comma\s*=\s*force|pos_comma\s*=\s*lead|pos_comma\s*=\s*trail|pos_comma\s*=\s*join|pos_comma\s*=\s*lead_break|pos_comma\s*=\s*lead_force|pos_comma\s*=\s*trail_break|pos_comma\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Comma|Break Pos Comma|Force Pos Comma|Lead Pos Comma|Trail Pos Comma|Join Pos Comma|Lead Break Pos Comma|Lead Force Pos Comma|Trail Break Pos Comma|Trail Force Pos Comma"
 ValueDefault=ignore
 
@@ -5723,7 +6363,8 @@ Category=5
 Description="<html>The position of the comma in enum entries.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_enum_comma\s*=\s*ignore|pos_enum_comma\s*=\s*break|pos_enum_comma\s*=\s*force|pos_enum_comma\s*=\s*lead|pos_enum_comma\s*=\s*trail|pos_enum_comma\s*=\s*join|pos_enum_comma\s*=\s*lead_break|pos_enum_comma\s*=\s*lead_force|pos_enum_comma\s*=\s*trail_break|pos_enum_comma\s*=\s*trail_force
+Choices=pos_enum_comma=ignore|pos_enum_comma=break|pos_enum_comma=force|pos_enum_comma=lead|pos_enum_comma=trail|pos_enum_comma=join|pos_enum_comma=lead_break|pos_enum_comma=lead_force|pos_enum_comma=trail_break|pos_enum_comma=trail_force
+ChoicesRegex=pos_enum_comma\s*=\s*ignore|pos_enum_comma\s*=\s*break|pos_enum_comma\s*=\s*force|pos_enum_comma\s*=\s*lead|pos_enum_comma\s*=\s*trail|pos_enum_comma\s*=\s*join|pos_enum_comma\s*=\s*lead_break|pos_enum_comma\s*=\s*lead_force|pos_enum_comma\s*=\s*trail_break|pos_enum_comma\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Enum Comma|Break Pos Enum Comma|Force Pos Enum Comma|Lead Pos Enum Comma|Trail Pos Enum Comma|Join Pos Enum Comma|Lead Break Pos Enum Comma|Lead Force Pos Enum Comma|Trail Break Pos Enum Comma|Trail Force Pos Enum Comma"
 ValueDefault=ignore
 
@@ -5732,7 +6373,8 @@ Category=5
 Description="<html>The position of the comma in the base class list if there is more than one<br/>line. Affects nl_class_init_args.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_class_comma\s*=\s*ignore|pos_class_comma\s*=\s*break|pos_class_comma\s*=\s*force|pos_class_comma\s*=\s*lead|pos_class_comma\s*=\s*trail|pos_class_comma\s*=\s*join|pos_class_comma\s*=\s*lead_break|pos_class_comma\s*=\s*lead_force|pos_class_comma\s*=\s*trail_break|pos_class_comma\s*=\s*trail_force
+Choices=pos_class_comma=ignore|pos_class_comma=break|pos_class_comma=force|pos_class_comma=lead|pos_class_comma=trail|pos_class_comma=join|pos_class_comma=lead_break|pos_class_comma=lead_force|pos_class_comma=trail_break|pos_class_comma=trail_force
+ChoicesRegex=pos_class_comma\s*=\s*ignore|pos_class_comma\s*=\s*break|pos_class_comma\s*=\s*force|pos_class_comma\s*=\s*lead|pos_class_comma\s*=\s*trail|pos_class_comma\s*=\s*join|pos_class_comma\s*=\s*lead_break|pos_class_comma\s*=\s*lead_force|pos_class_comma\s*=\s*trail_break|pos_class_comma\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Class Comma|Break Pos Class Comma|Force Pos Class Comma|Lead Pos Class Comma|Trail Pos Class Comma|Join Pos Class Comma|Lead Break Pos Class Comma|Lead Force Pos Class Comma|Trail Break Pos Class Comma|Trail Force Pos Class Comma"
 ValueDefault=ignore
 
@@ -5741,7 +6383,8 @@ Category=5
 Description="<html>The position of the comma in the constructor initialization list.<br/>Related to nl_constr_colon, nl_constr_init_args and pos_constr_colon.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_constr_comma\s*=\s*ignore|pos_constr_comma\s*=\s*break|pos_constr_comma\s*=\s*force|pos_constr_comma\s*=\s*lead|pos_constr_comma\s*=\s*trail|pos_constr_comma\s*=\s*join|pos_constr_comma\s*=\s*lead_break|pos_constr_comma\s*=\s*lead_force|pos_constr_comma\s*=\s*trail_break|pos_constr_comma\s*=\s*trail_force
+Choices=pos_constr_comma=ignore|pos_constr_comma=break|pos_constr_comma=force|pos_constr_comma=lead|pos_constr_comma=trail|pos_constr_comma=join|pos_constr_comma=lead_break|pos_constr_comma=lead_force|pos_constr_comma=trail_break|pos_constr_comma=trail_force
+ChoicesRegex=pos_constr_comma\s*=\s*ignore|pos_constr_comma\s*=\s*break|pos_constr_comma\s*=\s*force|pos_constr_comma\s*=\s*lead|pos_constr_comma\s*=\s*trail|pos_constr_comma\s*=\s*join|pos_constr_comma\s*=\s*lead_break|pos_constr_comma\s*=\s*lead_force|pos_constr_comma\s*=\s*trail_break|pos_constr_comma\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Constr Comma|Break Pos Constr Comma|Force Pos Constr Comma|Lead Pos Constr Comma|Trail Pos Constr Comma|Join Pos Constr Comma|Lead Break Pos Constr Comma|Lead Force Pos Constr Comma|Trail Break Pos Constr Comma|Trail Force Pos Constr Comma"
 ValueDefault=ignore
 
@@ -5750,7 +6393,8 @@ Category=5
 Description="<html>The position of trailing/leading class colon, between class and base class<br/>list. Affects nl_class_colon.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_class_colon\s*=\s*ignore|pos_class_colon\s*=\s*break|pos_class_colon\s*=\s*force|pos_class_colon\s*=\s*lead|pos_class_colon\s*=\s*trail|pos_class_colon\s*=\s*join|pos_class_colon\s*=\s*lead_break|pos_class_colon\s*=\s*lead_force|pos_class_colon\s*=\s*trail_break|pos_class_colon\s*=\s*trail_force
+Choices=pos_class_colon=ignore|pos_class_colon=break|pos_class_colon=force|pos_class_colon=lead|pos_class_colon=trail|pos_class_colon=join|pos_class_colon=lead_break|pos_class_colon=lead_force|pos_class_colon=trail_break|pos_class_colon=trail_force
+ChoicesRegex=pos_class_colon\s*=\s*ignore|pos_class_colon\s*=\s*break|pos_class_colon\s*=\s*force|pos_class_colon\s*=\s*lead|pos_class_colon\s*=\s*trail|pos_class_colon\s*=\s*join|pos_class_colon\s*=\s*lead_break|pos_class_colon\s*=\s*lead_force|pos_class_colon\s*=\s*trail_break|pos_class_colon\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Class Colon|Break Pos Class Colon|Force Pos Class Colon|Lead Pos Class Colon|Trail Pos Class Colon|Join Pos Class Colon|Lead Break Pos Class Colon|Lead Force Pos Class Colon|Trail Break Pos Class Colon|Trail Force Pos Class Colon"
 ValueDefault=ignore
 
@@ -5759,7 +6403,8 @@ Category=5
 Description="<html>The position of colons between constructor and member initialization.<br/>Related to nl_constr_colon, nl_constr_init_args and pos_constr_comma.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_constr_colon\s*=\s*ignore|pos_constr_colon\s*=\s*break|pos_constr_colon\s*=\s*force|pos_constr_colon\s*=\s*lead|pos_constr_colon\s*=\s*trail|pos_constr_colon\s*=\s*join|pos_constr_colon\s*=\s*lead_break|pos_constr_colon\s*=\s*lead_force|pos_constr_colon\s*=\s*trail_break|pos_constr_colon\s*=\s*trail_force
+Choices=pos_constr_colon=ignore|pos_constr_colon=break|pos_constr_colon=force|pos_constr_colon=lead|pos_constr_colon=trail|pos_constr_colon=join|pos_constr_colon=lead_break|pos_constr_colon=lead_force|pos_constr_colon=trail_break|pos_constr_colon=trail_force
+ChoicesRegex=pos_constr_colon\s*=\s*ignore|pos_constr_colon\s*=\s*break|pos_constr_colon\s*=\s*force|pos_constr_colon\s*=\s*lead|pos_constr_colon\s*=\s*trail|pos_constr_colon\s*=\s*join|pos_constr_colon\s*=\s*lead_break|pos_constr_colon\s*=\s*lead_force|pos_constr_colon\s*=\s*trail_break|pos_constr_colon\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Constr Colon|Break Pos Constr Colon|Force Pos Constr Colon|Lead Pos Constr Colon|Trail Pos Constr Colon|Join Pos Constr Colon|Lead Break Pos Constr Colon|Lead Force Pos Constr Colon|Trail Break Pos Constr Colon|Trail Force Pos Constr Colon"
 ValueDefault=ignore
 
@@ -5768,7 +6413,8 @@ Category=5
 Description="<html>The position of shift operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_shift\s*=\s*ignore|pos_shift\s*=\s*break|pos_shift\s*=\s*force|pos_shift\s*=\s*lead|pos_shift\s*=\s*trail|pos_shift\s*=\s*join|pos_shift\s*=\s*lead_break|pos_shift\s*=\s*lead_force|pos_shift\s*=\s*trail_break|pos_shift\s*=\s*trail_force
+Choices=pos_shift=ignore|pos_shift=break|pos_shift=force|pos_shift=lead|pos_shift=trail|pos_shift=join|pos_shift=lead_break|pos_shift=lead_force|pos_shift=trail_break|pos_shift=trail_force
+ChoicesRegex=pos_shift\s*=\s*ignore|pos_shift\s*=\s*break|pos_shift\s*=\s*force|pos_shift\s*=\s*lead|pos_shift\s*=\s*trail|pos_shift\s*=\s*join|pos_shift\s*=\s*lead_break|pos_shift\s*=\s*lead_force|pos_shift\s*=\s*trail_break|pos_shift\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Shift|Break Pos Shift|Force Pos Shift|Lead Pos Shift|Trail Pos Shift|Join Pos Shift|Lead Break Pos Shift|Lead Force Pos Shift|Trail Break Pos Shift|Trail Force Pos Shift"
 ValueDefault=ignore
 
@@ -5777,7 +6423,8 @@ Category=6
 Description="<html>Try to limit code width to N columns.</html>"
 Enabled=false
 EditorType=numeric
-CallName="code_width\s*=\s*"
+CallName="code_width="
+CallNameRegex="code_width\s*=\s*"
 MinVal=0
 MaxVal=10000
 ValueDefault=0
@@ -5787,7 +6434,8 @@ Category=6
 Description="<html>Whether to fully split long 'for' statements at semi-colons.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=ls_for_split_full\s*=\s*true|ls_for_split_full\s*=\s*false
+TrueFalse=ls_for_split_full=true|ls_for_split_full=false
+TrueFalseRegex=ls_for_split_full\s*=\s*true|ls_for_split_full\s*=\s*false
 ValueDefault=false
 
 [Ls Func Split Full]
@@ -5795,7 +6443,8 @@ Category=6
 Description="<html>Whether to fully split long function prototypes/calls at commas.<br/>The option ls_code_width has priority over the option ls_func_split_full.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=ls_func_split_full\s*=\s*true|ls_func_split_full\s*=\s*false
+TrueFalse=ls_func_split_full=true|ls_func_split_full=false
+TrueFalseRegex=ls_func_split_full\s*=\s*true|ls_func_split_full\s*=\s*false
 ValueDefault=false
 
 [Ls Code Width]
@@ -5803,7 +6452,8 @@ Category=6
 Description="<html>Whether to split lines as close to code_width as possible and ignore some<br/>groupings.<br/>The option ls_code_width has priority over the option ls_func_split_full.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=ls_code_width\s*=\s*true|ls_code_width\s*=\s*false
+TrueFalse=ls_code_width=true|ls_code_width=false
+TrueFalseRegex=ls_code_width\s*=\s*true|ls_code_width\s*=\s*false
 ValueDefault=false
 
 [Align Keep Tabs]
@@ -5811,7 +6461,8 @@ Category=7
 Description="<html>Whether to keep non-indenting tabs.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_keep_tabs\s*=\s*true|align_keep_tabs\s*=\s*false
+TrueFalse=align_keep_tabs=true|align_keep_tabs=false
+TrueFalseRegex=align_keep_tabs\s*=\s*true|align_keep_tabs\s*=\s*false
 ValueDefault=false
 
 [Align With Tabs]
@@ -5819,7 +6470,8 @@ Category=7
 Description="<html>Whether to use tabs for aligning.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_with_tabs\s*=\s*true|align_with_tabs\s*=\s*false
+TrueFalse=align_with_tabs=true|align_with_tabs=false
+TrueFalseRegex=align_with_tabs\s*=\s*true|align_with_tabs\s*=\s*false
 ValueDefault=false
 
 [Align On Tabstop]
@@ -5827,7 +6479,8 @@ Category=7
 Description="<html>Whether to bump out to the next tab when aligning.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_on_tabstop\s*=\s*true|align_on_tabstop\s*=\s*false
+TrueFalse=align_on_tabstop=true|align_on_tabstop=false
+TrueFalseRegex=align_on_tabstop\s*=\s*true|align_on_tabstop\s*=\s*false
 ValueDefault=false
 
 [Align Number Right]
@@ -5835,7 +6488,8 @@ Category=7
 Description="<html>Whether to right-align numbers.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_number_right\s*=\s*true|align_number_right\s*=\s*false
+TrueFalse=align_number_right=true|align_number_right=false
+TrueFalseRegex=align_number_right\s*=\s*true|align_number_right\s*=\s*false
 ValueDefault=false
 
 [Align Keep Extra Space]
@@ -5843,7 +6497,8 @@ Category=7
 Description="<html>Whether to keep whitespace not required for alignment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_keep_extra_space\s*=\s*true|align_keep_extra_space\s*=\s*false
+TrueFalse=align_keep_extra_space=true|align_keep_extra_space=false
+TrueFalseRegex=align_keep_extra_space\s*=\s*true|align_keep_extra_space\s*=\s*false
 ValueDefault=false
 
 [Align Func Params]
@@ -5851,7 +6506,8 @@ Category=7
 Description="<html>Whether to align variable definitions in prototypes and functions.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_func_params\s*=\s*true|align_func_params\s*=\s*false
+TrueFalse=align_func_params=true|align_func_params=false
+TrueFalseRegex=align_func_params\s*=\s*true|align_func_params\s*=\s*false
 ValueDefault=false
 
 [Align Func Params Span]
@@ -5859,7 +6515,8 @@ Category=7
 Description="<html>The span for aligning parameter definitions in function on parameter name.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_params_span\s*=\s*"
+CallName="align_func_params_span="
+CallNameRegex="align_func_params_span\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5869,7 +6526,8 @@ Category=7
 Description="<html>The threshold for aligning function parameter definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_params_thresh\s*=\s*"
+CallName="align_func_params_thresh="
+CallNameRegex="align_func_params_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -5879,7 +6537,8 @@ Category=7
 Description="<html>The gap for aligning function parameter definitions.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_params_gap\s*=\s*"
+CallName="align_func_params_gap="
+CallNameRegex="align_func_params_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5889,7 +6548,8 @@ Category=7
 Description="<html>The span for aligning constructor value.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_constr_value_span\s*=\s*"
+CallName="align_constr_value_span="
+CallNameRegex="align_constr_value_span\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5899,7 +6559,8 @@ Category=7
 Description="<html>The threshold for aligning constructor value.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_constr_value_thresh\s*=\s*"
+CallName="align_constr_value_thresh="
+CallNameRegex="align_constr_value_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -5909,7 +6570,8 @@ Category=7
 Description="<html>The gap for aligning constructor value.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_constr_value_gap\s*=\s*"
+CallName="align_constr_value_gap="
+CallNameRegex="align_constr_value_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5919,7 +6581,8 @@ Category=7
 Description="<html>Whether to align parameters in single-line functions that have the same<br/>name. The function names must already be aligned with each other.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_same_func_call_params\s*=\s*true|align_same_func_call_params\s*=\s*false
+TrueFalse=align_same_func_call_params=true|align_same_func_call_params=false
+TrueFalseRegex=align_same_func_call_params\s*=\s*true|align_same_func_call_params\s*=\s*false
 ValueDefault=false
 
 [Align Same Func Call Params Span]
@@ -5927,7 +6590,8 @@ Category=7
 Description="<html>The span for aligning function-call parameters for single line functions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_same_func_call_params_span\s*=\s*"
+CallName="align_same_func_call_params_span="
+CallNameRegex="align_same_func_call_params_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -5937,7 +6601,8 @@ Category=7
 Description="<html>The threshold for aligning function-call parameters for single line<br/>functions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_same_func_call_params_thresh\s*=\s*"
+CallName="align_same_func_call_params_thresh="
+CallNameRegex="align_same_func_call_params_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -5947,7 +6612,8 @@ Category=7
 Description="<html>The span for aligning variable definitions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_span\s*=\s*"
+CallName="align_var_def_span="
+CallNameRegex="align_var_def_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -5957,7 +6623,8 @@ Category=7
 Description="<html>How to consider (or treat) the '*' in the alignment of variable definitions.<br/><br/>0: Part of the type     'void *   foo;' (default)<br/>1: Part of the variable 'void     *foo;'<br/>2: Dangling             'void    *foo;'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_star_style\s*=\s*"
+CallName="align_var_def_star_style="
+CallNameRegex="align_var_def_star_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -5967,7 +6634,8 @@ Category=7
 Description="<html>How to consider (or treat) the '&amp;' in the alignment of variable definitions.<br/><br/>0: Part of the type     'long &amp;   foo;' (default)<br/>1: Part of the variable 'long     &amp;foo;'<br/>2: Dangling             'long    &amp;foo;'<br/>Dangling: the '&amp;' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_amp_style\s*=\s*"
+CallName="align_var_def_amp_style="
+CallNameRegex="align_var_def_amp_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -5977,7 +6645,8 @@ Category=7
 Description="<html>The threshold for aligning variable definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_thresh\s*=\s*"
+CallName="align_var_def_thresh="
+CallNameRegex="align_var_def_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -5987,7 +6656,8 @@ Category=7
 Description="<html>The gap for aligning variable definitions.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_gap\s*=\s*"
+CallName="align_var_def_gap="
+CallNameRegex="align_var_def_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5997,7 +6667,8 @@ Category=7
 Description="<html>Whether to align the colon in struct bit fields.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_var_def_colon\s*=\s*true|align_var_def_colon\s*=\s*false
+TrueFalse=align_var_def_colon=true|align_var_def_colon=false
+TrueFalseRegex=align_var_def_colon\s*=\s*true|align_var_def_colon\s*=\s*false
 ValueDefault=false
 
 [Align Var Def Colon Gap]
@@ -6005,7 +6676,8 @@ Category=7
 Description="<html>The gap for aligning the colon in struct bit fields.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_colon_gap\s*=\s*"
+CallName="align_var_def_colon_gap="
+CallNameRegex="align_var_def_colon_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6015,7 +6687,8 @@ Category=7
 Description="<html>Whether to align any attribute after the variable name.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_var_def_attribute\s*=\s*true|align_var_def_attribute\s*=\s*false
+TrueFalse=align_var_def_attribute=true|align_var_def_attribute=false
+TrueFalseRegex=align_var_def_attribute\s*=\s*true|align_var_def_attribute\s*=\s*false
 ValueDefault=false
 
 [Align Var Def Inline]
@@ -6023,7 +6696,8 @@ Category=7
 Description="<html>Whether to align inline struct/enum/union variable definitions.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_var_def_inline\s*=\s*true|align_var_def_inline\s*=\s*false
+TrueFalse=align_var_def_inline=true|align_var_def_inline=false
+TrueFalseRegex=align_var_def_inline\s*=\s*true|align_var_def_inline\s*=\s*false
 ValueDefault=false
 
 [Align Assign Span]
@@ -6031,7 +6705,8 @@ Category=7
 Description="<html>The span for aligning on '=' in assignments.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_assign_span\s*=\s*"
+CallName="align_assign_span="
+CallNameRegex="align_assign_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6041,7 +6716,8 @@ Category=7
 Description="<html>The span for aligning on '=' in function prototype modifier.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_assign_func_proto_span\s*=\s*"
+CallName="align_assign_func_proto_span="
+CallNameRegex="align_assign_func_proto_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6051,7 +6727,8 @@ Category=7
 Description="<html>The threshold for aligning on '=' in assignments.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_assign_thresh\s*=\s*"
+CallName="align_assign_thresh="
+CallNameRegex="align_assign_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6061,7 +6738,8 @@ Category=7
 Description="<html>Whether to align on the left most assignment when multiple<br/>definitions are found on the same line.<br/>Depends on 'align_assign_span' and 'align_assign_thresh' settings.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_assign_on_multi_var_defs\s*=\s*true|align_assign_on_multi_var_defs\s*=\s*false
+TrueFalse=align_assign_on_multi_var_defs=true|align_assign_on_multi_var_defs=false
+TrueFalseRegex=align_assign_on_multi_var_defs\s*=\s*true|align_assign_on_multi_var_defs\s*=\s*false
 ValueDefault=false
 
 [Align Braced Init List Span]
@@ -6069,7 +6747,8 @@ Category=7
 Description="<html>The span for aligning on '{' in braced init list.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_braced_init_list_span\s*=\s*"
+CallName="align_braced_init_list_span="
+CallNameRegex="align_braced_init_list_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6079,7 +6758,8 @@ Category=7
 Description="<html>The threshold for aligning on '{' in braced init list.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_braced_init_list_thresh\s*=\s*"
+CallName="align_braced_init_list_thresh="
+CallNameRegex="align_braced_init_list_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6089,7 +6769,8 @@ Category=7
 Description="<html>How to apply align_assign_span to function declaration "assignments", i.e.<br/>'virtual void foo() = 0' or '~foo() = {default|delete}'.<br/><br/>0: Align with other assignments (default)<br/>1: Align with each other, ignoring regular assignments<br/>2: Don't align</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_assign_decl_func\s*=\s*"
+CallName="align_assign_decl_func="
+CallNameRegex="align_assign_decl_func\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6099,7 +6780,8 @@ Category=7
 Description="<html>The span for aligning on '=' in enums.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_enum_equ_span\s*=\s*"
+CallName="align_enum_equ_span="
+CallNameRegex="align_enum_equ_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6109,7 +6791,8 @@ Category=7
 Description="<html>The threshold for aligning on '=' in enums.<br/>Use a negative number for absolute thresholds.<br/><br/>0: no limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_enum_equ_thresh\s*=\s*"
+CallName="align_enum_equ_thresh="
+CallNameRegex="align_enum_equ_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6119,7 +6802,8 @@ Category=7
 Description="<html>The span for aligning class member definitions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_class_span\s*=\s*"
+CallName="align_var_class_span="
+CallNameRegex="align_var_class_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6129,7 +6813,8 @@ Category=7
 Description="<html>The threshold for aligning class member definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_class_thresh\s*=\s*"
+CallName="align_var_class_thresh="
+CallNameRegex="align_var_class_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6139,7 +6824,8 @@ Category=7
 Description="<html>The gap for aligning class member definitions.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_class_gap\s*=\s*"
+CallName="align_var_class_gap="
+CallNameRegex="align_var_class_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6149,7 +6835,8 @@ Category=7
 Description="<html>The span for aligning struct/union member definitions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_struct_span\s*=\s*"
+CallName="align_var_struct_span="
+CallNameRegex="align_var_struct_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6159,7 +6846,8 @@ Category=7
 Description="<html>The threshold for aligning struct/union member definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_struct_thresh\s*=\s*"
+CallName="align_var_struct_thresh="
+CallNameRegex="align_var_struct_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6169,7 +6857,8 @@ Category=7
 Description="<html>The gap for aligning struct/union member definitions.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_struct_gap\s*=\s*"
+CallName="align_var_struct_gap="
+CallNameRegex="align_var_struct_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6179,7 +6868,8 @@ Category=7
 Description="<html>The span for aligning struct initializer values.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_struct_init_span\s*=\s*"
+CallName="align_struct_init_span="
+CallNameRegex="align_struct_init_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6189,7 +6879,8 @@ Category=7
 Description="<html>The span for aligning single-line typedefs.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_span\s*=\s*"
+CallName="align_typedef_span="
+CallNameRegex="align_typedef_span\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6199,7 +6890,8 @@ Category=7
 Description="<html>The minimum space between the type and the synonym of a typedef.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_gap\s*=\s*"
+CallName="align_typedef_gap="
+CallNameRegex="align_typedef_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6209,7 +6901,8 @@ Category=7
 Description="<html>How to align typedef'd functions with other typedefs.<br/><br/>0: Don't mix them at all (default)<br/>1: Align the open parenthesis with the types<br/>2: Align the function type name with the other type names</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_func\s*=\s*"
+CallName="align_typedef_func="
+CallNameRegex="align_typedef_func\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6219,7 +6912,8 @@ Category=7
 Description="<html>How to consider (or treat) the '*' in the alignment of typedefs.<br/><br/>0: Part of the typedef type, 'typedef int * pint;' (default)<br/>1: Part of type name:        'typedef int   *pint;'<br/>2: Dangling:                 'typedef int  *pint;'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_star_style\s*=\s*"
+CallName="align_typedef_star_style="
+CallNameRegex="align_typedef_star_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6229,7 +6923,8 @@ Category=7
 Description="<html>How to consider (or treat) the '&amp;' in the alignment of typedefs.<br/><br/>0: Part of the typedef type, 'typedef int &amp; intref;' (default)<br/>1: Part of type name:        'typedef int   &amp;intref;'<br/>2: Dangling:                 'typedef int  &amp;intref;'<br/>Dangling: the '&amp;' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_amp_style\s*=\s*"
+CallName="align_typedef_amp_style="
+CallNameRegex="align_typedef_amp_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6239,7 +6934,8 @@ Category=7
 Description="<html>The span for aligning comments that end lines.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_right_cmt_span\s*=\s*"
+CallName="align_right_cmt_span="
+CallNameRegex="align_right_cmt_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6249,7 +6945,8 @@ Category=7
 Description="<html>Minimum number of columns between preceding text and a trailing comment in<br/>order for the comment to qualify for being aligned. Must be non-zero to have<br/>an effect.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_right_cmt_gap\s*=\s*"
+CallName="align_right_cmt_gap="
+CallNameRegex="align_right_cmt_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6259,7 +6956,8 @@ Category=7
 Description="<html>If aligning comments, whether to mix with comments after '}' and #endif with<br/>less than three spaces before the comment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_right_cmt_mix\s*=\s*true|align_right_cmt_mix\s*=\s*false
+TrueFalse=align_right_cmt_mix=true|align_right_cmt_mix=false
+TrueFalseRegex=align_right_cmt_mix\s*=\s*true|align_right_cmt_mix\s*=\s*false
 ValueDefault=false
 
 [Align Right Cmt Same Level]
@@ -6267,7 +6965,8 @@ Category=7
 Description="<html>Whether to only align trailing comments that are at the same brace level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_right_cmt_same_level\s*=\s*true|align_right_cmt_same_level\s*=\s*false
+TrueFalse=align_right_cmt_same_level=true|align_right_cmt_same_level=false
+TrueFalseRegex=align_right_cmt_same_level\s*=\s*true|align_right_cmt_same_level\s*=\s*false
 ValueDefault=false
 
 [Align Right Cmt At Col]
@@ -6275,7 +6974,8 @@ Category=7
 Description="<html>Minimum column at which to align trailing comments. Comments which are<br/>aligned beyond this column, but which can be aligned in a lesser column,<br/>may be "pulled in".<br/><br/>0: Ignore (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_right_cmt_at_col\s*=\s*"
+CallName="align_right_cmt_at_col="
+CallNameRegex="align_right_cmt_at_col\s*=\s*"
 MinVal=0
 MaxVal=200
 ValueDefault=0
@@ -6285,7 +6985,8 @@ Category=7
 Description="<html>The span for aligning function prototypes.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_span\s*=\s*"
+CallName="align_func_proto_span="
+CallNameRegex="align_func_proto_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6295,7 +6996,8 @@ Category=7
 Description="<html>Whether to ignore continuation lines when evaluating the number of<br/>new lines for the function prototype alignment's span.<br/><br/>false: continuation lines are part of the newlines count<br/>true:  continuation lines are not counted</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_func_proto_span_ignore_cont_lines\s*=\s*true|align_func_proto_span_ignore_cont_lines\s*=\s*false
+TrueFalse=align_func_proto_span_ignore_cont_lines=true|align_func_proto_span_ignore_cont_lines=false
+TrueFalseRegex=align_func_proto_span_ignore_cont_lines\s*=\s*true|align_func_proto_span_ignore_cont_lines\s*=\s*false
 ValueDefault=false
 
 [Align Func Proto Star Style]
@@ -6303,7 +7005,8 @@ Category=7
 Description="<html>How to consider (or treat) the '*' in the alignment of function prototypes.<br/><br/>0: Part of the type     'void *   foo();' (default)<br/>1: Part of the function 'void     *foo();'<br/>2: Dangling             'void    *foo();'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_star_style\s*=\s*"
+CallName="align_func_proto_star_style="
+CallNameRegex="align_func_proto_star_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6313,7 +7016,8 @@ Category=7
 Description="<html>How to consider (or treat) the '&amp;' in the alignment of function prototypes.<br/><br/>0: Part of the type     'long &amp;   foo();' (default)<br/>1: Part of the function 'long     &amp;foo();'<br/>2: Dangling             'long    &amp;foo();'<br/>Dangling: the '&amp;' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_amp_style\s*=\s*"
+CallName="align_func_proto_amp_style="
+CallNameRegex="align_func_proto_amp_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6323,7 +7027,8 @@ Category=7
 Description="<html>The threshold for aligning function prototypes.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_thresh\s*=\s*"
+CallName="align_func_proto_thresh="
+CallNameRegex="align_func_proto_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6333,7 +7038,8 @@ Category=7
 Description="<html>Minimum gap between the return type and the function name.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_gap\s*=\s*"
+CallName="align_func_proto_gap="
+CallNameRegex="align_func_proto_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6343,7 +7049,8 @@ Category=7
 Description="<html>Whether to align function prototypes on the 'operator' keyword instead of<br/>what follows.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_on_operator\s*=\s*true|align_on_operator\s*=\s*false
+TrueFalse=align_on_operator=true|align_on_operator=false
+TrueFalseRegex=align_on_operator\s*=\s*true|align_on_operator\s*=\s*false
 ValueDefault=false
 
 [Align Mix Var Proto]
@@ -6351,7 +7058,8 @@ Category=7
 Description="<html>Whether to mix aligning prototype and variable declarations. If true,<br/>align_var_def_XXX options are used instead of align_func_proto_XXX options.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_mix_var_proto\s*=\s*true|align_mix_var_proto\s*=\s*false
+TrueFalse=align_mix_var_proto=true|align_mix_var_proto=false
+TrueFalseRegex=align_mix_var_proto\s*=\s*true|align_mix_var_proto\s*=\s*false
 ValueDefault=false
 
 [Align Single Line Func]
@@ -6359,7 +7067,8 @@ Category=7
 Description="<html>Whether to align single-line functions with function prototypes.<br/>Uses align_func_proto_span.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_single_line_func\s*=\s*true|align_single_line_func\s*=\s*false
+TrueFalse=align_single_line_func=true|align_single_line_func=false
+TrueFalseRegex=align_single_line_func\s*=\s*true|align_single_line_func\s*=\s*false
 ValueDefault=false
 
 [Align Single Line Brace]
@@ -6367,7 +7076,8 @@ Category=7
 Description="<html>Whether to align the open brace of single-line functions.<br/>Requires align_single_line_func=true. Uses align_func_proto_span.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_single_line_brace\s*=\s*true|align_single_line_brace\s*=\s*false
+TrueFalse=align_single_line_brace=true|align_single_line_brace=false
+TrueFalseRegex=align_single_line_brace\s*=\s*true|align_single_line_brace\s*=\s*false
 ValueDefault=false
 
 [Align Single Line Brace Gap]
@@ -6375,7 +7085,8 @@ Category=7
 Description="<html>Gap for align_single_line_brace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_single_line_brace_gap\s*=\s*"
+CallName="align_single_line_brace_gap="
+CallNameRegex="align_single_line_brace_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6385,7 +7096,8 @@ Category=7
 Description="<html>(OC) The span for aligning Objective-C message specifications.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_oc_msg_spec_span\s*=\s*"
+CallName="align_oc_msg_spec_span="
+CallNameRegex="align_oc_msg_spec_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6395,7 +7107,8 @@ Category=7
 Description="<html>Whether and how to align backslashes that split a macro onto multiple lines.<br/>This will not work right if the macro contains a multi-line comment.<br/><br/>0: Do nothing (default)<br/>1: Align the backslashes in the column at the end of the longest line<br/>2: Align with the backslash that is farthest to the left, or, if that<br/>   backslash is farther left than the end of the longest line, at the end of<br/>   the longest line<br/>3: Align with the backslash that is farthest to the right</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_nl_cont\s*=\s*"
+CallName="align_nl_cont="
+CallNameRegex="align_nl_cont\s*=\s*"
 MinVal=0
 MaxVal=3
 ValueDefault=0
@@ -6405,7 +7118,8 @@ Category=7
 Description="<html>The minimum number of spaces between the end of a line and its continuation<br/>backslash. Requires align_nl_cont.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_nl_cont_spaces\s*=\s*"
+CallName="align_nl_cont_spaces="
+CallNameRegex="align_nl_cont_spaces\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -6415,7 +7129,8 @@ Category=7
 Description="<html>Whether to align macro functions and variables together.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_pp_define_together\s*=\s*true|align_pp_define_together\s*=\s*false
+TrueFalse=align_pp_define_together=true|align_pp_define_together=false
+TrueFalseRegex=align_pp_define_together\s*=\s*true|align_pp_define_together\s*=\s*false
 ValueDefault=false
 
 [Align Pp Define Span]
@@ -6423,7 +7138,8 @@ Category=7
 Description="<html>The span for aligning on '#define' bodies.<br/><br/>=0: Don't align (default)<br/>&gt;0: Number of lines (including comments) between blocks</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_pp_define_span\s*=\s*"
+CallName="align_pp_define_span="
+CallNameRegex="align_pp_define_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6433,7 +7149,8 @@ Category=7
 Description="<html>The minimum space between label and value of a preprocessor define.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_pp_define_gap\s*=\s*"
+CallName="align_pp_define_gap="
+CallNameRegex="align_pp_define_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6443,7 +7160,8 @@ Category=7
 Description="<html>Whether to align lines that start with '&lt;&lt;' with previous '&lt;&lt;'.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_left_shift\s*=\s*true|align_left_shift\s*=\s*false
+TrueFalse=align_left_shift=true|align_left_shift=false
+TrueFalseRegex=align_left_shift\s*=\s*true|align_left_shift\s*=\s*false
 ValueDefault=true
 
 [Align Eigen Comma Init]
@@ -6451,7 +7169,8 @@ Category=7
 Description="<html>Whether to align comma-separated statements following '&lt;&lt;' (as used to<br/>initialize Eigen matrices).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_eigen_comma_init\s*=\s*true|align_eigen_comma_init\s*=\s*false
+TrueFalse=align_eigen_comma_init=true|align_eigen_comma_init=false
+TrueFalseRegex=align_eigen_comma_init\s*=\s*true|align_eigen_comma_init\s*=\s*false
 ValueDefault=false
 
 [Align Asm Colon]
@@ -6459,7 +7178,8 @@ Category=7
 Description="<html>Whether to align text after 'asm volatile ()' colons.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_asm_colon\s*=\s*true|align_asm_colon\s*=\s*false
+TrueFalse=align_asm_colon=true|align_asm_colon=false
+TrueFalseRegex=align_asm_colon\s*=\s*true|align_asm_colon\s*=\s*false
 ValueDefault=false
 
 [Align Oc Msg Colon Span]
@@ -6467,7 +7187,8 @@ Category=7
 Description="<html>(OC) Span for aligning parameters in an Objective-C message call<br/>on the ':'.<br/><br/>0: Don't align.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_oc_msg_colon_span\s*=\s*"
+CallName="align_oc_msg_colon_span="
+CallNameRegex="align_oc_msg_colon_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6477,7 +7198,8 @@ Category=7
 Description="<html>(OC) Whether to always align with the first parameter, even if it is too<br/>short.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_oc_msg_colon_first\s*=\s*true|align_oc_msg_colon_first\s*=\s*false
+TrueFalse=align_oc_msg_colon_first=true|align_oc_msg_colon_first=false
+TrueFalseRegex=align_oc_msg_colon_first\s*=\s*true|align_oc_msg_colon_first\s*=\s*false
 ValueDefault=false
 
 [Align Oc Decl Colon]
@@ -6485,7 +7207,8 @@ Category=7
 Description="<html>(OC) Whether to align parameters in an Objective-C '+' or '-' declaration<br/>on the ':'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_oc_decl_colon\s*=\s*true|align_oc_decl_colon\s*=\s*false
+TrueFalse=align_oc_decl_colon=true|align_oc_decl_colon=false
+TrueFalseRegex=align_oc_decl_colon\s*=\s*true|align_oc_decl_colon\s*=\s*false
 ValueDefault=false
 
 [Align Oc Msg Colon Xcode Like]
@@ -6493,7 +7216,8 @@ Category=7
 Description="<html>(OC) Whether to not align parameters in an Objectve-C message call if first<br/>colon is not on next line of the message call (the same way Xcode does<br/>alignment)</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_oc_msg_colon_xcode_like\s*=\s*true|align_oc_msg_colon_xcode_like\s*=\s*false
+TrueFalse=align_oc_msg_colon_xcode_like=true|align_oc_msg_colon_xcode_like=false
+TrueFalseRegex=align_oc_msg_colon_xcode_like\s*=\s*true|align_oc_msg_colon_xcode_like\s*=\s*false
 ValueDefault=false
 
 [Cmt Width]
@@ -6501,7 +7225,8 @@ Category=8
 Description="<html>Try to wrap comments at N columns.</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_width\s*=\s*"
+CallName="cmt_width="
+CallNameRegex="cmt_width\s*=\s*"
 MinVal=0
 MaxVal=256
 ValueDefault=0
@@ -6511,7 +7236,8 @@ Category=8
 Description="<html>How to reflow comments.<br/><br/>0: No reflowing (apart from the line wrapping due to cmt_width) (default)<br/>1: No touching at all<br/>2: Full reflow (enable cmt_indent_multi for indent with line wrapping due to cmt_width)</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_reflow_mode\s*=\s*"
+CallName="cmt_reflow_mode="
+CallNameRegex="cmt_reflow_mode\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6520,7 +7246,8 @@ ValueDefault=0
 Category=8
 Description="<html>Path to a file that contains regular expressions describing patterns for<br/>which the end of one line and the beginning of the next will be folded into<br/>the same sentence or paragraph during full comment reflow. The regular<br/>expressions are described using ECMAScript syntax. The syntax for this<br/>specification is as follows, where "..." indicates the custom regular<br/>expression and "n" indicates the nth end_of_prev_line_regex and<br/>beg_of_next_line_regex regular expression pair:<br/><br/>end_of_prev_line_regex[1] = "...$"<br/>beg_of_next_line_regex[1] = "^..."<br/>end_of_prev_line_regex[2] = "...$"<br/>beg_of_next_line_regex[2] = "^..."<br/>            .<br/>            .<br/>            .<br/>end_of_prev_line_regex[n] = "...$"<br/>beg_of_next_line_regex[n] = "^..."<br/><br/>Note that use of this option overrides the default reflow fold regular<br/>expressions, which are internally defined as follows:<br/><br/>end_of_prev_line_regex[1] = "[\w,\]\)]$"<br/>beg_of_next_line_regex[1] = "^[\w,\[\(]"<br/>end_of_prev_line_regex[2] = "\.$"<br/>beg_of_next_line_regex[2] = "^[A-Z]"</html>"
 Enabled=false
-CallName=cmt_reflow_fold_regex_file\s*=\s*
+CallName=cmt_reflow_fold_regex_file=
+CallNameRegex=cmt_reflow_fold_regex_file\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6529,7 +7256,8 @@ Category=8
 Description="<html>Whether to indent wrapped lines to the start of the encompassing paragraph<br/>during full comment reflow (cmt_reflow_mode = 2). Overrides the value<br/>specified by cmt_sp_after_star_cont.<br/><br/>Note that cmt_align_doxygen_javadoc_tags overrides this option for<br/>paragraphs associated with javadoc tags</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_reflow_indent_to_paragraph_start\s*=\s*true|cmt_reflow_indent_to_paragraph_start\s*=\s*false
+TrueFalse=cmt_reflow_indent_to_paragraph_start=true|cmt_reflow_indent_to_paragraph_start=false
+TrueFalseRegex=cmt_reflow_indent_to_paragraph_start\s*=\s*true|cmt_reflow_indent_to_paragraph_start\s*=\s*false
 ValueDefault=false
 
 [Cmt Convert Tab To Spaces]
@@ -6537,7 +7265,8 @@ Category=8
 Description="<html>Whether to convert all tabs to spaces in comments. If false, tabs in<br/>comments are left alone, unless used for indenting.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_convert_tab_to_spaces\s*=\s*true|cmt_convert_tab_to_spaces\s*=\s*false
+TrueFalse=cmt_convert_tab_to_spaces=true|cmt_convert_tab_to_spaces=false
+TrueFalseRegex=cmt_convert_tab_to_spaces\s*=\s*true|cmt_convert_tab_to_spaces\s*=\s*false
 ValueDefault=false
 
 [Cmt Indent Multi]
@@ -6545,7 +7274,8 @@ Category=8
 Description="<html>Whether to apply changes to multi-line comments, including cmt_width,<br/>keyword substitution and leading chars.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_indent_multi\s*=\s*true|cmt_indent_multi\s*=\s*false
+TrueFalse=cmt_indent_multi=true|cmt_indent_multi=false
+TrueFalseRegex=cmt_indent_multi\s*=\s*true|cmt_indent_multi\s*=\s*false
 ValueDefault=true
 
 [Cmt Align Doxygen Javadoc Tags]
@@ -6553,7 +7283,8 @@ Category=8
 Description="<html>Whether to align doxygen javadoc-style tags ('@param', '@return', etc.)<br/>and corresponding fields such that groups of consecutive block tags,<br/>parameter names, and descriptions align with one another. Overrides that<br/>which is specified by the cmt_sp_after_star_cont. If cmt_width &gt; 0, it may<br/>be necessary to enable cmt_indent_multi and set cmt_reflow_mode = 2<br/>in order to achieve the desired alignment for line-wrapping.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_align_doxygen_javadoc_tags\s*=\s*true|cmt_align_doxygen_javadoc_tags\s*=\s*false
+TrueFalse=cmt_align_doxygen_javadoc_tags=true|cmt_align_doxygen_javadoc_tags=false
+TrueFalseRegex=cmt_align_doxygen_javadoc_tags\s*=\s*true|cmt_align_doxygen_javadoc_tags\s*=\s*false
 ValueDefault=false
 
 [Cmt Sp Before Doxygen Javadoc Tags]
@@ -6561,7 +7292,8 @@ Category=8
 Description="<html>The number of spaces to insert after the star and before doxygen<br/>javadoc-style tags (@param, @return, etc). Requires enabling<br/>cmt_align_doxygen_javadoc_tags. Overrides that which is specified by the<br/>cmt_sp_after_star_cont.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_sp_before_doxygen_javadoc_tags\s*=\s*"
+CallName="cmt_sp_before_doxygen_javadoc_tags="
+CallNameRegex="cmt_sp_before_doxygen_javadoc_tags\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -6571,7 +7303,8 @@ Category=8
 Description="<html>Whether to change trailing, single-line c-comments into cpp-comments.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_trailing_single_line_c_to_cpp\s*=\s*true|cmt_trailing_single_line_c_to_cpp\s*=\s*false
+TrueFalse=cmt_trailing_single_line_c_to_cpp=true|cmt_trailing_single_line_c_to_cpp=false
+TrueFalseRegex=cmt_trailing_single_line_c_to_cpp\s*=\s*true|cmt_trailing_single_line_c_to_cpp\s*=\s*false
 ValueDefault=false
 
 [Cmt C Group]
@@ -6579,7 +7312,8 @@ Category=8
 Description="<html>Whether to group c-comments that look like they are in a block.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_c_group\s*=\s*true|cmt_c_group\s*=\s*false
+TrueFalse=cmt_c_group=true|cmt_c_group=false
+TrueFalseRegex=cmt_c_group\s*=\s*true|cmt_c_group\s*=\s*false
 ValueDefault=false
 
 [Cmt C Nl Start]
@@ -6587,7 +7321,8 @@ Category=8
 Description="<html>Whether to put an empty '/*' on the first line of the combined c-comment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_c_nl_start\s*=\s*true|cmt_c_nl_start\s*=\s*false
+TrueFalse=cmt_c_nl_start=true|cmt_c_nl_start=false
+TrueFalseRegex=cmt_c_nl_start\s*=\s*true|cmt_c_nl_start\s*=\s*false
 ValueDefault=false
 
 [Cmt C Nl End]
@@ -6595,7 +7330,8 @@ Category=8
 Description="<html>Whether to add a newline before the closing '*/' of the combined c-comment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_c_nl_end\s*=\s*true|cmt_c_nl_end\s*=\s*false
+TrueFalse=cmt_c_nl_end=true|cmt_c_nl_end=false
+TrueFalseRegex=cmt_c_nl_end\s*=\s*true|cmt_c_nl_end\s*=\s*false
 ValueDefault=false
 
 [Cmt Cpp To C]
@@ -6603,7 +7339,8 @@ Category=8
 Description="<html>Whether to change cpp-comments into c-comments.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_cpp_to_c\s*=\s*true|cmt_cpp_to_c\s*=\s*false
+TrueFalse=cmt_cpp_to_c=true|cmt_cpp_to_c=false
+TrueFalseRegex=cmt_cpp_to_c\s*=\s*true|cmt_cpp_to_c\s*=\s*false
 ValueDefault=false
 
 [Cmt Cpp Group]
@@ -6611,7 +7348,8 @@ Category=8
 Description="<html>Whether to group cpp-comments that look like they are in a block. Only<br/>meaningful if cmt_cpp_to_c=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_cpp_group\s*=\s*true|cmt_cpp_group\s*=\s*false
+TrueFalse=cmt_cpp_group=true|cmt_cpp_group=false
+TrueFalseRegex=cmt_cpp_group\s*=\s*true|cmt_cpp_group\s*=\s*false
 ValueDefault=false
 
 [Cmt Cpp Nl Start]
@@ -6619,7 +7357,8 @@ Category=8
 Description="<html>Whether to put an empty '/*' on the first line of the combined cpp-comment<br/>when converting to a c-comment.<br/><br/>Requires cmt_cpp_to_c=true and cmt_cpp_group=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_cpp_nl_start\s*=\s*true|cmt_cpp_nl_start\s*=\s*false
+TrueFalse=cmt_cpp_nl_start=true|cmt_cpp_nl_start=false
+TrueFalseRegex=cmt_cpp_nl_start\s*=\s*true|cmt_cpp_nl_start\s*=\s*false
 ValueDefault=false
 
 [Cmt Cpp Nl End]
@@ -6627,7 +7366,8 @@ Category=8
 Description="<html>Whether to add a newline before the closing '*/' of the combined cpp-comment<br/>when converting to a c-comment.<br/><br/>Requires cmt_cpp_to_c=true and cmt_cpp_group=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_cpp_nl_end\s*=\s*true|cmt_cpp_nl_end\s*=\s*false
+TrueFalse=cmt_cpp_nl_end=true|cmt_cpp_nl_end=false
+TrueFalseRegex=cmt_cpp_nl_end\s*=\s*true|cmt_cpp_nl_end\s*=\s*false
 ValueDefault=false
 
 [Cmt Star Cont]
@@ -6635,7 +7375,8 @@ Category=8
 Description="<html>Whether to put a star on subsequent comment lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_star_cont\s*=\s*true|cmt_star_cont\s*=\s*false
+TrueFalse=cmt_star_cont=true|cmt_star_cont=false
+TrueFalseRegex=cmt_star_cont\s*=\s*true|cmt_star_cont\s*=\s*false
 ValueDefault=false
 
 [Cmt Sp Before Star Cont]
@@ -6643,7 +7384,8 @@ Category=8
 Description="<html>The number of spaces to insert at the start of subsequent comment lines.</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_sp_before_star_cont\s*=\s*"
+CallName="cmt_sp_before_star_cont="
+CallNameRegex="cmt_sp_before_star_cont\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6653,7 +7395,8 @@ Category=8
 Description="<html>The number of spaces to insert after the star on subsequent comment lines.</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_sp_after_star_cont\s*=\s*"
+CallName="cmt_sp_after_star_cont="
+CallNameRegex="cmt_sp_after_star_cont\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6663,7 +7406,8 @@ Category=8
 Description="<html>For multi-line comments with a '*' lead, remove leading spaces if the first<br/>and last lines of the comment are the same length.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_multi_check_last\s*=\s*true|cmt_multi_check_last\s*=\s*false
+TrueFalse=cmt_multi_check_last=true|cmt_multi_check_last=false
+TrueFalseRegex=cmt_multi_check_last\s*=\s*true|cmt_multi_check_last\s*=\s*false
 ValueDefault=true
 
 [Cmt Multi First Len Minimum]
@@ -6671,7 +7415,8 @@ Category=8
 Description="<html>For multi-line comments with a '*' lead, remove leading spaces if the first<br/>and last lines of the comment are the same length AND if the length is<br/>bigger as the first_len minimum.<br/><br/>Default: 4</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_multi_first_len_minimum\s*=\s*"
+CallName="cmt_multi_first_len_minimum="
+CallNameRegex="cmt_multi_first_len_minimum\s*=\s*"
 MinVal=1
 MaxVal=20
 ValueDefault=4
@@ -6680,7 +7425,8 @@ ValueDefault=4
 Category=8
 Description="<html>Path to a file that contains text to insert at the beginning of a file if<br/>the file doesn't start with a C/C++ comment. If the inserted text contains<br/>'$(filename)', that will be replaced with the current file's name.</html>"
 Enabled=false
-CallName=cmt_insert_file_header\s*=\s*
+CallName=cmt_insert_file_header=
+CallNameRegex=cmt_insert_file_header\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6688,7 +7434,8 @@ ValueDefault=
 Category=8
 Description="<html>Path to a file that contains text to insert at the end of a file if the<br/>file doesn't end with a C/C++ comment. If the inserted text contains<br/>'$(filename)', that will be replaced with the current file's name.</html>"
 Enabled=false
-CallName=cmt_insert_file_footer\s*=\s*
+CallName=cmt_insert_file_footer=
+CallNameRegex=cmt_insert_file_footer\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6696,7 +7443,8 @@ ValueDefault=
 Category=8
 Description="<html>Path to a file that contains text to insert before a function definition if<br/>the function isn't preceded by a C/C++ comment. If the inserted text<br/>contains '$(function)', '$(javaparam)' or '$(fclass)', these will be<br/>replaced with, respectively, the name of the function, the javadoc '@param'<br/>and '@return' stuff, or the name of the class to which the member function<br/>belongs.</html>"
 Enabled=false
-CallName=cmt_insert_func_header\s*=\s*
+CallName=cmt_insert_func_header=
+CallNameRegex=cmt_insert_func_header\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6704,7 +7452,8 @@ ValueDefault=
 Category=8
 Description="<html>Path to a file that contains text to insert before a class if the class<br/>isn't preceded by a C/C++ comment. If the inserted text contains '$(class)',<br/>that will be replaced with the class name.</html>"
 Enabled=false
-CallName=cmt_insert_class_header\s*=\s*
+CallName=cmt_insert_class_header=
+CallNameRegex=cmt_insert_class_header\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6712,7 +7461,8 @@ ValueDefault=
 Category=8
 Description="<html>Path to a file that contains text to insert before an Objective-C message<br/>specification, if the method isn't preceded by a C/C++ comment. If the<br/>inserted text contains '$(message)' or '$(javaparam)', these will be<br/>replaced with, respectively, the name of the function, or the javadoc<br/>'@param' and '@return' stuff.</html>"
 Enabled=false
-CallName=cmt_insert_oc_msg_header\s*=\s*
+CallName=cmt_insert_oc_msg_header=
+CallNameRegex=cmt_insert_oc_msg_header\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6721,7 +7471,8 @@ Category=8
 Description="<html>Whether a comment should be inserted if a preprocessor is encountered when<br/>stepping backwards from a function name.<br/><br/>Applies to cmt_insert_oc_msg_header, cmt_insert_func_header and<br/>cmt_insert_class_header.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_insert_before_preproc\s*=\s*true|cmt_insert_before_preproc\s*=\s*false
+TrueFalse=cmt_insert_before_preproc=true|cmt_insert_before_preproc=false
+TrueFalseRegex=cmt_insert_before_preproc\s*=\s*true|cmt_insert_before_preproc\s*=\s*false
 ValueDefault=false
 
 [Cmt Insert Before Inlines]
@@ -6729,7 +7480,8 @@ Category=8
 Description="<html>Whether a comment should be inserted if a function is declared inline to a<br/>class definition.<br/><br/>Applies to cmt_insert_func_header.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_insert_before_inlines\s*=\s*true|cmt_insert_before_inlines\s*=\s*false
+TrueFalse=cmt_insert_before_inlines=true|cmt_insert_before_inlines=false
+TrueFalseRegex=cmt_insert_before_inlines\s*=\s*true|cmt_insert_before_inlines\s*=\s*false
 ValueDefault=true
 
 [Cmt Insert Before Ctor Dtor]
@@ -6737,7 +7489,8 @@ Category=8
 Description="<html>Whether a comment should be inserted if the function is a class constructor<br/>or destructor.<br/><br/>Applies to cmt_insert_func_header.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_insert_before_ctor_dtor\s*=\s*true|cmt_insert_before_ctor_dtor\s*=\s*false
+TrueFalse=cmt_insert_before_ctor_dtor=true|cmt_insert_before_ctor_dtor=false
+TrueFalseRegex=cmt_insert_before_ctor_dtor\s*=\s*true|cmt_insert_before_ctor_dtor\s*=\s*false
 ValueDefault=false
 
 [Mod Full Brace Do]
@@ -6745,7 +7498,8 @@ Category=9
 Description="<html>Add or remove braces on a single-line 'do' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_do\s*=\s*ignore|mod_full_brace_do\s*=\s*add|mod_full_brace_do\s*=\s*remove|mod_full_brace_do\s*=\s*force|mod_full_brace_do\s*=\s*not_defined
+Choices=mod_full_brace_do=ignore|mod_full_brace_do=add|mod_full_brace_do=remove|mod_full_brace_do=force|mod_full_brace_do=not_defined
+ChoicesRegex=mod_full_brace_do\s*=\s*ignore|mod_full_brace_do\s*=\s*add|mod_full_brace_do\s*=\s*remove|mod_full_brace_do\s*=\s*force|mod_full_brace_do\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace Do|Add Mod Full Brace Do|Remove Mod Full Brace Do|Force Mod Full Brace Do"
 ValueDefault=ignore
 
@@ -6754,7 +7508,8 @@ Category=9
 Description="<html>Add or remove braces on a single-line 'for' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_for\s*=\s*ignore|mod_full_brace_for\s*=\s*add|mod_full_brace_for\s*=\s*remove|mod_full_brace_for\s*=\s*force|mod_full_brace_for\s*=\s*not_defined
+Choices=mod_full_brace_for=ignore|mod_full_brace_for=add|mod_full_brace_for=remove|mod_full_brace_for=force|mod_full_brace_for=not_defined
+ChoicesRegex=mod_full_brace_for\s*=\s*ignore|mod_full_brace_for\s*=\s*add|mod_full_brace_for\s*=\s*remove|mod_full_brace_for\s*=\s*force|mod_full_brace_for\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace For|Add Mod Full Brace For|Remove Mod Full Brace For|Force Mod Full Brace For"
 ValueDefault=ignore
 
@@ -6763,7 +7518,8 @@ Category=9
 Description="<html>(Pawn) Add or remove braces on a single-line function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_function\s*=\s*ignore|mod_full_brace_function\s*=\s*add|mod_full_brace_function\s*=\s*remove|mod_full_brace_function\s*=\s*force|mod_full_brace_function\s*=\s*not_defined
+Choices=mod_full_brace_function=ignore|mod_full_brace_function=add|mod_full_brace_function=remove|mod_full_brace_function=force|mod_full_brace_function=not_defined
+ChoicesRegex=mod_full_brace_function\s*=\s*ignore|mod_full_brace_function\s*=\s*add|mod_full_brace_function\s*=\s*remove|mod_full_brace_function\s*=\s*force|mod_full_brace_function\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace Function|Add Mod Full Brace Function|Remove Mod Full Brace Function|Force Mod Full Brace Function"
 ValueDefault=ignore
 
@@ -6772,7 +7528,8 @@ Category=9
 Description="<html>Add or remove braces on a single-line 'if' statement. Braces will not be<br/>removed if the braced statement contains an 'else'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_if\s*=\s*ignore|mod_full_brace_if\s*=\s*add|mod_full_brace_if\s*=\s*remove|mod_full_brace_if\s*=\s*force|mod_full_brace_if\s*=\s*not_defined
+Choices=mod_full_brace_if=ignore|mod_full_brace_if=add|mod_full_brace_if=remove|mod_full_brace_if=force|mod_full_brace_if=not_defined
+ChoicesRegex=mod_full_brace_if\s*=\s*ignore|mod_full_brace_if\s*=\s*add|mod_full_brace_if\s*=\s*remove|mod_full_brace_if\s*=\s*force|mod_full_brace_if\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace If|Add Mod Full Brace If|Remove Mod Full Brace If|Force Mod Full Brace If"
 ValueDefault=ignore
 
@@ -6781,7 +7538,8 @@ Category=9
 Description="<html>Whether to enforce that all blocks of an 'if'/'else if'/'else' chain either<br/>have, or do not have, braces. Overrides mod_full_brace_if.<br/><br/>0: Don't override mod_full_brace_if<br/>1: Add braces to all blocks if any block needs braces and remove braces if<br/>   they can be removed from all blocks<br/>2: Add braces to all blocks if any block already has braces, regardless of<br/>   whether it needs them<br/>3: Add braces to all blocks if any block needs braces and remove braces if<br/>   they can be removed from all blocks, except if all blocks have braces<br/>   despite none needing them</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_full_brace_if_chain\s*=\s*"
+CallName="mod_full_brace_if_chain="
+CallNameRegex="mod_full_brace_if_chain\s*=\s*"
 MinVal=0
 MaxVal=3
 ValueDefault=0
@@ -6791,7 +7549,8 @@ Category=9
 Description="<html>Whether to add braces to all blocks of an 'if'/'else if'/'else' chain.<br/>If true, mod_full_brace_if_chain will only remove braces from an 'if' that<br/>does not have an 'else if' or 'else'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_brace_if_chain_only\s*=\s*true|mod_full_brace_if_chain_only\s*=\s*false
+TrueFalse=mod_full_brace_if_chain_only=true|mod_full_brace_if_chain_only=false
+TrueFalseRegex=mod_full_brace_if_chain_only\s*=\s*true|mod_full_brace_if_chain_only\s*=\s*false
 ValueDefault=false
 
 [Mod Full Brace While]
@@ -6799,7 +7558,8 @@ Category=9
 Description="<html>Add or remove braces on single-line 'while' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_while\s*=\s*ignore|mod_full_brace_while\s*=\s*add|mod_full_brace_while\s*=\s*remove|mod_full_brace_while\s*=\s*force|mod_full_brace_while\s*=\s*not_defined
+Choices=mod_full_brace_while=ignore|mod_full_brace_while=add|mod_full_brace_while=remove|mod_full_brace_while=force|mod_full_brace_while=not_defined
+ChoicesRegex=mod_full_brace_while\s*=\s*ignore|mod_full_brace_while\s*=\s*add|mod_full_brace_while\s*=\s*remove|mod_full_brace_while\s*=\s*force|mod_full_brace_while\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace While|Add Mod Full Brace While|Remove Mod Full Brace While|Force Mod Full Brace While"
 ValueDefault=ignore
 
@@ -6808,7 +7568,8 @@ Category=9
 Description="<html>Add or remove braces on single-line 'using ()' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_using\s*=\s*ignore|mod_full_brace_using\s*=\s*add|mod_full_brace_using\s*=\s*remove|mod_full_brace_using\s*=\s*force|mod_full_brace_using\s*=\s*not_defined
+Choices=mod_full_brace_using=ignore|mod_full_brace_using=add|mod_full_brace_using=remove|mod_full_brace_using=force|mod_full_brace_using=not_defined
+ChoicesRegex=mod_full_brace_using\s*=\s*ignore|mod_full_brace_using\s*=\s*add|mod_full_brace_using\s*=\s*remove|mod_full_brace_using\s*=\s*force|mod_full_brace_using\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace Using|Add Mod Full Brace Using|Remove Mod Full Brace Using|Force Mod Full Brace Using"
 ValueDefault=ignore
 
@@ -6817,7 +7578,8 @@ Category=9
 Description="<html>Don't remove braces around statements that span N newlines</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_full_brace_nl\s*=\s*"
+CallName="mod_full_brace_nl="
+CallNameRegex="mod_full_brace_nl\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6827,7 +7589,8 @@ Category=9
 Description="<html>Whether to prevent removal of braces from 'if'/'for'/'while'/etc. blocks<br/>which span multiple lines.<br/><br/>Affects:<br/>  mod_full_brace_for<br/>  mod_full_brace_if<br/>  mod_full_brace_if_chain<br/>  mod_full_brace_if_chain_only<br/>  mod_full_brace_while<br/>  mod_full_brace_using<br/><br/>Does not affect:<br/>  mod_full_brace_do<br/>  mod_full_brace_function</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_brace_nl_block_rem_mlcond\s*=\s*true|mod_full_brace_nl_block_rem_mlcond\s*=\s*false
+TrueFalse=mod_full_brace_nl_block_rem_mlcond=true|mod_full_brace_nl_block_rem_mlcond=false
+TrueFalseRegex=mod_full_brace_nl_block_rem_mlcond\s*=\s*true|mod_full_brace_nl_block_rem_mlcond\s*=\s*false
 ValueDefault=false
 
 [Mod Paren On Return]
@@ -6835,7 +7598,8 @@ Category=9
 Description="<html>Add or remove unnecessary parentheses on 'return' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_paren_on_return\s*=\s*ignore|mod_paren_on_return\s*=\s*add|mod_paren_on_return\s*=\s*remove|mod_paren_on_return\s*=\s*force|mod_paren_on_return\s*=\s*not_defined
+Choices=mod_paren_on_return=ignore|mod_paren_on_return=add|mod_paren_on_return=remove|mod_paren_on_return=force|mod_paren_on_return=not_defined
+ChoicesRegex=mod_paren_on_return\s*=\s*ignore|mod_paren_on_return\s*=\s*add|mod_paren_on_return\s*=\s*remove|mod_paren_on_return\s*=\s*force|mod_paren_on_return\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Paren On Return|Add Mod Paren On Return|Remove Mod Paren On Return|Force Mod Paren On Return"
 ValueDefault=ignore
 
@@ -6844,7 +7608,8 @@ Category=9
 Description="<html>Add or remove unnecessary parentheses on 'throw' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_paren_on_throw\s*=\s*ignore|mod_paren_on_throw\s*=\s*add|mod_paren_on_throw\s*=\s*remove|mod_paren_on_throw\s*=\s*force|mod_paren_on_throw\s*=\s*not_defined
+Choices=mod_paren_on_throw=ignore|mod_paren_on_throw=add|mod_paren_on_throw=remove|mod_paren_on_throw=force|mod_paren_on_throw=not_defined
+ChoicesRegex=mod_paren_on_throw\s*=\s*ignore|mod_paren_on_throw\s*=\s*add|mod_paren_on_throw\s*=\s*remove|mod_paren_on_throw\s*=\s*force|mod_paren_on_throw\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Paren On Throw|Add Mod Paren On Throw|Remove Mod Paren On Throw|Force Mod Paren On Throw"
 ValueDefault=ignore
 
@@ -6853,7 +7618,8 @@ Category=9
 Description="<html>(Pawn) Whether to change optional semicolons to real semicolons.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_pawn_semicolon\s*=\s*true|mod_pawn_semicolon\s*=\s*false
+TrueFalse=mod_pawn_semicolon=true|mod_pawn_semicolon=false
+TrueFalseRegex=mod_pawn_semicolon\s*=\s*true|mod_pawn_semicolon\s*=\s*false
 ValueDefault=false
 
 [Mod Full Paren If Bool]
@@ -6861,7 +7627,8 @@ Category=9
 Description="<html>Whether to fully parenthesize Boolean expressions in 'while' and 'if'<br/>statement, as in 'if (a &amp;&amp; b &gt; c)' =&gt; 'if (a &amp;&amp; (b &gt; c))'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_paren_if_bool\s*=\s*true|mod_full_paren_if_bool\s*=\s*false
+TrueFalse=mod_full_paren_if_bool=true|mod_full_paren_if_bool=false
+TrueFalseRegex=mod_full_paren_if_bool\s*=\s*true|mod_full_paren_if_bool\s*=\s*false
 ValueDefault=false
 
 [Mod Full Paren Assign Bool]
@@ -6869,7 +7636,8 @@ Category=9
 Description="<html>Whether to fully parenthesize Boolean expressions after '='<br/>statement, as in 'x = a &amp;&amp; b &gt; c;' =&gt; 'x = (a &amp;&amp; (b &gt; c));'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_paren_assign_bool\s*=\s*true|mod_full_paren_assign_bool\s*=\s*false
+TrueFalse=mod_full_paren_assign_bool=true|mod_full_paren_assign_bool=false
+TrueFalseRegex=mod_full_paren_assign_bool\s*=\s*true|mod_full_paren_assign_bool\s*=\s*false
 ValueDefault=false
 
 [Mod Full Paren Return Bool]
@@ -6877,7 +7645,8 @@ Category=9
 Description="<html>Whether to fully parenthesize Boolean expressions after '='<br/>statement, as in 'return  a &amp;&amp; b &gt; c;' =&gt; 'return (a &amp;&amp; (b &gt; c));'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_paren_return_bool\s*=\s*true|mod_full_paren_return_bool\s*=\s*false
+TrueFalse=mod_full_paren_return_bool=true|mod_full_paren_return_bool=false
+TrueFalseRegex=mod_full_paren_return_bool\s*=\s*true|mod_full_paren_return_bool\s*=\s*false
 ValueDefault=false
 
 [Mod Remove Extra Semicolon]
@@ -6885,7 +7654,8 @@ Category=9
 Description="<html>Whether to remove superfluous semicolons.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_remove_extra_semicolon\s*=\s*true|mod_remove_extra_semicolon\s*=\s*false
+TrueFalse=mod_remove_extra_semicolon=true|mod_remove_extra_semicolon=false
+TrueFalseRegex=mod_remove_extra_semicolon\s*=\s*true|mod_remove_extra_semicolon\s*=\s*false
 ValueDefault=false
 
 [Mod Remove Duplicate Include]
@@ -6893,7 +7663,8 @@ Category=9
 Description="<html>Whether to remove duplicate include.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_remove_duplicate_include\s*=\s*true|mod_remove_duplicate_include\s*=\s*false
+TrueFalse=mod_remove_duplicate_include=true|mod_remove_duplicate_include=false
+TrueFalseRegex=mod_remove_duplicate_include\s*=\s*true|mod_remove_duplicate_include\s*=\s*false
 ValueDefault=false
 
 [Mod Add Force C Closebrace Comment]
@@ -6901,7 +7672,8 @@ Category=9
 Description="<html>the following options (mod_XX_closebrace_comment) use different comment,<br/>depending of the setting of the next option.<br/>false: Use the c comment (default)<br/>true : Use the cpp comment</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_add_force_c_closebrace_comment\s*=\s*true|mod_add_force_c_closebrace_comment\s*=\s*false
+TrueFalse=mod_add_force_c_closebrace_comment=true|mod_add_force_c_closebrace_comment=false
+TrueFalseRegex=mod_add_force_c_closebrace_comment\s*=\s*true|mod_add_force_c_closebrace_comment\s*=\s*false
 ValueDefault=false
 
 [Mod Add Long Function Closebrace Comment]
@@ -6909,7 +7681,8 @@ Category=9
 Description="<html>If a function body exceeds the specified number of newlines and doesn't have<br/>a comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_function_closebrace_comment\s*=\s*"
+CallName="mod_add_long_function_closebrace_comment="
+CallNameRegex="mod_add_long_function_closebrace_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6919,7 +7692,8 @@ Category=9
 Description="<html>If a namespace body exceeds the specified number of newlines and doesn't<br/>have a comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_namespace_closebrace_comment\s*=\s*"
+CallName="mod_add_long_namespace_closebrace_comment="
+CallNameRegex="mod_add_long_namespace_closebrace_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6929,7 +7703,8 @@ Category=9
 Description="<html>If a class body exceeds the specified number of newlines and doesn't have a<br/>comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_class_closebrace_comment\s*=\s*"
+CallName="mod_add_long_class_closebrace_comment="
+CallNameRegex="mod_add_long_class_closebrace_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6939,7 +7714,8 @@ Category=9
 Description="<html>If a switch body exceeds the specified number of newlines and doesn't have a<br/>comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_switch_closebrace_comment\s*=\s*"
+CallName="mod_add_long_switch_closebrace_comment="
+CallNameRegex="mod_add_long_switch_closebrace_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6949,7 +7725,8 @@ Category=9
 Description="<html>If an #ifdef body exceeds the specified number of newlines and doesn't have<br/>a comment after the #endif, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_ifdef_endif_comment\s*=\s*"
+CallName="mod_add_long_ifdef_endif_comment="
+CallNameRegex="mod_add_long_ifdef_endif_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6959,7 +7736,8 @@ Category=9
 Description="<html>If an #ifdef or #else body exceeds the specified number of newlines and<br/>doesn't have a comment after the #else, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_ifdef_else_comment\s*=\s*"
+CallName="mod_add_long_ifdef_else_comment="
+CallNameRegex="mod_add_long_ifdef_else_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6969,7 +7747,8 @@ Category=9
 Description="<html>Whether to take care of the case by the mod_sort_xx options.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_case_sensitive\s*=\s*true|mod_sort_case_sensitive\s*=\s*false
+TrueFalse=mod_sort_case_sensitive=true|mod_sort_case_sensitive=false
+TrueFalseRegex=mod_sort_case_sensitive\s*=\s*true|mod_sort_case_sensitive\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Import]
@@ -6977,7 +7756,8 @@ Category=9
 Description="<html>Whether to sort consecutive single-line 'import' statements.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_import\s*=\s*true|mod_sort_import\s*=\s*false
+TrueFalse=mod_sort_import=true|mod_sort_import=false
+TrueFalseRegex=mod_sort_import\s*=\s*true|mod_sort_import\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Using]
@@ -6985,7 +7765,8 @@ Category=9
 Description="<html>(C#) Whether to sort consecutive single-line 'using' statements.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_using\s*=\s*true|mod_sort_using\s*=\s*false
+TrueFalse=mod_sort_using=true|mod_sort_using=false
+TrueFalseRegex=mod_sort_using\s*=\s*true|mod_sort_using\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Include]
@@ -6993,7 +7774,8 @@ Category=9
 Description="<html>Whether to sort consecutive single-line '#include' statements (C/C++) and<br/>'#import' statements (Objective-C). Be aware that this has the potential to<br/>break your code if your includes/imports have ordering dependencies.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_include\s*=\s*true|mod_sort_include\s*=\s*false
+TrueFalse=mod_sort_include=true|mod_sort_include=false
+TrueFalseRegex=mod_sort_include\s*=\s*true|mod_sort_include\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Prioritize Filename]
@@ -7001,7 +7783,8 @@ Category=9
 Description="<html>Whether to prioritize '#include' and '#import' statements that contain<br/>filename without extension when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_prioritize_filename\s*=\s*true|mod_sort_incl_import_prioritize_filename\s*=\s*false
+TrueFalse=mod_sort_incl_import_prioritize_filename=true|mod_sort_incl_import_prioritize_filename=false
+TrueFalseRegex=mod_sort_incl_import_prioritize_filename\s*=\s*true|mod_sort_incl_import_prioritize_filename\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Prioritize Extensionless]
@@ -7009,7 +7792,8 @@ Category=9
 Description="<html>Whether to prioritize '#include' and '#import' statements that does not<br/>contain extensions when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_prioritize_extensionless\s*=\s*true|mod_sort_incl_import_prioritize_extensionless\s*=\s*false
+TrueFalse=mod_sort_incl_import_prioritize_extensionless=true|mod_sort_incl_import_prioritize_extensionless=false
+TrueFalseRegex=mod_sort_incl_import_prioritize_extensionless\s*=\s*true|mod_sort_incl_import_prioritize_extensionless\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Prioritize Angle Over Quotes]
@@ -7017,7 +7801,8 @@ Category=9
 Description="<html>Whether to prioritize '#include' and '#import' statements that contain<br/>angle over quotes when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_prioritize_angle_over_quotes\s*=\s*true|mod_sort_incl_import_prioritize_angle_over_quotes\s*=\s*false
+TrueFalse=mod_sort_incl_import_prioritize_angle_over_quotes=true|mod_sort_incl_import_prioritize_angle_over_quotes=false
+TrueFalseRegex=mod_sort_incl_import_prioritize_angle_over_quotes\s*=\s*true|mod_sort_incl_import_prioritize_angle_over_quotes\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Ignore Extension]
@@ -7025,7 +7810,8 @@ Category=9
 Description="<html>Whether to ignore file extension in '#include' and '#import' statements<br/>for sorting comparison.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_ignore_extension\s*=\s*true|mod_sort_incl_import_ignore_extension\s*=\s*false
+TrueFalse=mod_sort_incl_import_ignore_extension=true|mod_sort_incl_import_ignore_extension=false
+TrueFalseRegex=mod_sort_incl_import_ignore_extension\s*=\s*true|mod_sort_incl_import_ignore_extension\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Grouping Enabled]
@@ -7033,7 +7819,8 @@ Category=9
 Description="<html>Whether to group '#include' and '#import' statements when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_grouping_enabled\s*=\s*true|mod_sort_incl_import_grouping_enabled\s*=\s*false
+TrueFalse=mod_sort_incl_import_grouping_enabled=true|mod_sort_incl_import_grouping_enabled=false
+TrueFalseRegex=mod_sort_incl_import_grouping_enabled\s*=\s*true|mod_sort_incl_import_grouping_enabled\s*=\s*false
 ValueDefault=false
 
 [Mod Move Case Break]
@@ -7041,7 +7828,8 @@ Category=9
 Description="<html>Whether to move a 'break' that appears after a fully braced 'case' before<br/>the close brace, as in 'case X: { ... } break;' =&gt; 'case X: { ... break; }'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_move_case_break\s*=\s*true|mod_move_case_break\s*=\s*false
+TrueFalse=mod_move_case_break=true|mod_move_case_break=false
+TrueFalseRegex=mod_move_case_break\s*=\s*true|mod_move_case_break\s*=\s*false
 ValueDefault=false
 
 [Mod Move Case Return]
@@ -7049,7 +7837,8 @@ Category=9
 Description="<html>Whether to move a 'return' that appears after a fully braced 'case' before<br/>the close brace, as in 'case X: { ... } return;' =&gt; 'case X: { ... return; }'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_move_case_return\s*=\s*true|mod_move_case_return\s*=\s*false
+TrueFalse=mod_move_case_return=true|mod_move_case_return=false
+TrueFalseRegex=mod_move_case_return\s*=\s*true|mod_move_case_return\s*=\s*false
 ValueDefault=false
 
 [Mod Case Brace]
@@ -7057,7 +7846,8 @@ Category=9
 Description="<html>Add or remove braces around a fully braced case statement. Will only remove<br/>braces if there are no variable declarations in the block.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_case_brace\s*=\s*ignore|mod_case_brace\s*=\s*add|mod_case_brace\s*=\s*remove|mod_case_brace\s*=\s*force|mod_case_brace\s*=\s*not_defined
+Choices=mod_case_brace=ignore|mod_case_brace=add|mod_case_brace=remove|mod_case_brace=force|mod_case_brace=not_defined
+ChoicesRegex=mod_case_brace\s*=\s*ignore|mod_case_brace\s*=\s*add|mod_case_brace\s*=\s*remove|mod_case_brace\s*=\s*force|mod_case_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Case Brace|Add Mod Case Brace|Remove Mod Case Brace|Force Mod Case Brace"
 ValueDefault=ignore
 
@@ -7066,7 +7856,8 @@ Category=9
 Description="<html>Whether to remove a void 'return;' that appears as the last statement in a<br/>function.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_remove_empty_return\s*=\s*true|mod_remove_empty_return\s*=\s*false
+TrueFalse=mod_remove_empty_return=true|mod_remove_empty_return=false
+TrueFalseRegex=mod_remove_empty_return\s*=\s*true|mod_remove_empty_return\s*=\s*false
 ValueDefault=false
 
 [Mod Enum Last Comma]
@@ -7074,7 +7865,8 @@ Category=9
 Description="<html>Add or remove the comma after the last value of an enumeration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_enum_last_comma\s*=\s*ignore|mod_enum_last_comma\s*=\s*add|mod_enum_last_comma\s*=\s*remove|mod_enum_last_comma\s*=\s*force|mod_enum_last_comma\s*=\s*not_defined
+Choices=mod_enum_last_comma=ignore|mod_enum_last_comma=add|mod_enum_last_comma=remove|mod_enum_last_comma=force|mod_enum_last_comma=not_defined
+ChoicesRegex=mod_enum_last_comma\s*=\s*ignore|mod_enum_last_comma\s*=\s*add|mod_enum_last_comma\s*=\s*remove|mod_enum_last_comma\s*=\s*force|mod_enum_last_comma\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Enum Last Comma|Add Mod Enum Last Comma|Remove Mod Enum Last Comma|Force Mod Enum Last Comma"
 ValueDefault=ignore
 
@@ -7083,7 +7875,8 @@ Category=9
 Description="<html>Syntax to use for infinite loops.<br/><br/>0: Leave syntax alone (default)<br/>1: Rewrite as `for(;;)`<br/>2: Rewrite as `while(true)`<br/>3: Rewrite as `do`...`while(true);`<br/>4: Rewrite as `while(1)`<br/>5: Rewrite as `do`...`while(1);`<br/><br/>Infinite loops that do not already match one of these syntaxes are ignored.<br/>Other options that affect loop formatting will be applied after transforming<br/>the syntax.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_infinite_loop\s*=\s*"
+CallName="mod_infinite_loop="
+CallNameRegex="mod_infinite_loop\s*=\s*"
 MinVal=0
 MaxVal=5
 ValueDefault=0
@@ -7093,7 +7886,8 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'int short'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_int_short\s*=\s*ignore|mod_int_short\s*=\s*add|mod_int_short\s*=\s*remove|mod_int_short\s*=\s*force|mod_int_short\s*=\s*not_defined
+Choices=mod_int_short=ignore|mod_int_short=add|mod_int_short=remove|mod_int_short=force|mod_int_short=not_defined
+ChoicesRegex=mod_int_short\s*=\s*ignore|mod_int_short\s*=\s*add|mod_int_short\s*=\s*remove|mod_int_short\s*=\s*force|mod_int_short\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Int Short|Add Mod Int Short|Remove Mod Int Short|Force Mod Int Short"
 ValueDefault=ignore
 
@@ -7102,7 +7896,8 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'short int'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_short_int\s*=\s*ignore|mod_short_int\s*=\s*add|mod_short_int\s*=\s*remove|mod_short_int\s*=\s*force|mod_short_int\s*=\s*not_defined
+Choices=mod_short_int=ignore|mod_short_int=add|mod_short_int=remove|mod_short_int=force|mod_short_int=not_defined
+ChoicesRegex=mod_short_int\s*=\s*ignore|mod_short_int\s*=\s*add|mod_short_int\s*=\s*remove|mod_short_int\s*=\s*force|mod_short_int\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Short Int|Add Mod Short Int|Remove Mod Short Int|Force Mod Short Int"
 ValueDefault=ignore
 
@@ -7111,7 +7906,8 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'int long'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_int_long\s*=\s*ignore|mod_int_long\s*=\s*add|mod_int_long\s*=\s*remove|mod_int_long\s*=\s*force|mod_int_long\s*=\s*not_defined
+Choices=mod_int_long=ignore|mod_int_long=add|mod_int_long=remove|mod_int_long=force|mod_int_long=not_defined
+ChoicesRegex=mod_int_long\s*=\s*ignore|mod_int_long\s*=\s*add|mod_int_long\s*=\s*remove|mod_int_long\s*=\s*force|mod_int_long\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Int Long|Add Mod Int Long|Remove Mod Int Long|Force Mod Int Long"
 ValueDefault=ignore
 
@@ -7120,7 +7916,8 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'long int'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_long_int\s*=\s*ignore|mod_long_int\s*=\s*add|mod_long_int\s*=\s*remove|mod_long_int\s*=\s*force|mod_long_int\s*=\s*not_defined
+Choices=mod_long_int=ignore|mod_long_int=add|mod_long_int=remove|mod_long_int=force|mod_long_int=not_defined
+ChoicesRegex=mod_long_int\s*=\s*ignore|mod_long_int\s*=\s*add|mod_long_int\s*=\s*remove|mod_long_int\s*=\s*force|mod_long_int\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Long Int|Add Mod Long Int|Remove Mod Long Int|Force Mod Long Int"
 ValueDefault=ignore
 
@@ -7129,7 +7926,8 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'int signed'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_int_signed\s*=\s*ignore|mod_int_signed\s*=\s*add|mod_int_signed\s*=\s*remove|mod_int_signed\s*=\s*force|mod_int_signed\s*=\s*not_defined
+Choices=mod_int_signed=ignore|mod_int_signed=add|mod_int_signed=remove|mod_int_signed=force|mod_int_signed=not_defined
+ChoicesRegex=mod_int_signed\s*=\s*ignore|mod_int_signed\s*=\s*add|mod_int_signed\s*=\s*remove|mod_int_signed\s*=\s*force|mod_int_signed\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Int Signed|Add Mod Int Signed|Remove Mod Int Signed|Force Mod Int Signed"
 ValueDefault=ignore
 
@@ -7138,7 +7936,8 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'signed int'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_signed_int\s*=\s*ignore|mod_signed_int\s*=\s*add|mod_signed_int\s*=\s*remove|mod_signed_int\s*=\s*force|mod_signed_int\s*=\s*not_defined
+Choices=mod_signed_int=ignore|mod_signed_int=add|mod_signed_int=remove|mod_signed_int=force|mod_signed_int=not_defined
+ChoicesRegex=mod_signed_int\s*=\s*ignore|mod_signed_int\s*=\s*add|mod_signed_int\s*=\s*remove|mod_signed_int\s*=\s*force|mod_signed_int\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Signed Int|Add Mod Signed Int|Remove Mod Signed Int|Force Mod Signed Int"
 ValueDefault=ignore
 
@@ -7147,7 +7946,8 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'int unsigned'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_int_unsigned\s*=\s*ignore|mod_int_unsigned\s*=\s*add|mod_int_unsigned\s*=\s*remove|mod_int_unsigned\s*=\s*force|mod_int_unsigned\s*=\s*not_defined
+Choices=mod_int_unsigned=ignore|mod_int_unsigned=add|mod_int_unsigned=remove|mod_int_unsigned=force|mod_int_unsigned=not_defined
+ChoicesRegex=mod_int_unsigned\s*=\s*ignore|mod_int_unsigned\s*=\s*add|mod_int_unsigned\s*=\s*remove|mod_int_unsigned\s*=\s*force|mod_int_unsigned\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Int Unsigned|Add Mod Int Unsigned|Remove Mod Int Unsigned|Force Mod Int Unsigned"
 ValueDefault=ignore
 
@@ -7156,7 +7956,8 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'unsigned int'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_unsigned_int\s*=\s*ignore|mod_unsigned_int\s*=\s*add|mod_unsigned_int\s*=\s*remove|mod_unsigned_int\s*=\s*force|mod_unsigned_int\s*=\s*not_defined
+Choices=mod_unsigned_int=ignore|mod_unsigned_int=add|mod_unsigned_int=remove|mod_unsigned_int=force|mod_unsigned_int=not_defined
+ChoicesRegex=mod_unsigned_int\s*=\s*ignore|mod_unsigned_int\s*=\s*add|mod_unsigned_int\s*=\s*remove|mod_unsigned_int\s*=\s*force|mod_unsigned_int\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Unsigned Int|Add Mod Unsigned Int|Remove Mod Unsigned Int|Force Mod Unsigned Int"
 ValueDefault=ignore
 
@@ -7165,7 +7966,8 @@ Category=9
 Description="<html>If there is a situation where mod_int_* and mod_*_int would result in<br/>multiple int keywords, whether to keep the rightmost int (the default) or the<br/>leftmost int.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_int_prefer_int_on_left\s*=\s*true|mod_int_prefer_int_on_left\s*=\s*false
+TrueFalse=mod_int_prefer_int_on_left=true|mod_int_prefer_int_on_left=false
+TrueFalseRegex=mod_int_prefer_int_on_left\s*=\s*true|mod_int_prefer_int_on_left\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Oc Properties]
@@ -7173,7 +7975,8 @@ Category=9
 Description="<html>(OC) Whether to organize the properties. If true, properties will be<br/>rearranged according to the mod_sort_oc_property_*_weight factors.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_oc_properties\s*=\s*true|mod_sort_oc_properties\s*=\s*false
+TrueFalse=mod_sort_oc_properties=true|mod_sort_oc_properties=false
+TrueFalseRegex=mod_sort_oc_properties\s*=\s*true|mod_sort_oc_properties\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Oc Property Class Weight]
@@ -7181,7 +7984,8 @@ Category=9
 Description="<html>(OC) Weight of a class property modifier.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_class_weight\s*=\s*"
+CallName="mod_sort_oc_property_class_weight="
+CallNameRegex="mod_sort_oc_property_class_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7191,7 +7995,8 @@ Category=9
 Description="<html>(OC) Weight of 'atomic' and 'nonatomic'.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_thread_safe_weight\s*=\s*"
+CallName="mod_sort_oc_property_thread_safe_weight="
+CallNameRegex="mod_sort_oc_property_thread_safe_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7201,7 +8006,8 @@ Category=9
 Description="<html>(OC) Weight of 'readwrite' when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_readwrite_weight\s*=\s*"
+CallName="mod_sort_oc_property_readwrite_weight="
+CallNameRegex="mod_sort_oc_property_readwrite_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7211,7 +8017,8 @@ Category=9
 Description="<html>(OC) Weight of a reference type specifier ('retain', 'copy', 'assign',<br/>'weak', 'strong') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_reference_weight\s*=\s*"
+CallName="mod_sort_oc_property_reference_weight="
+CallNameRegex="mod_sort_oc_property_reference_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7221,7 +8028,8 @@ Category=9
 Description="<html>(OC) Weight of getter type ('getter=') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_getter_weight\s*=\s*"
+CallName="mod_sort_oc_property_getter_weight="
+CallNameRegex="mod_sort_oc_property_getter_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7231,7 +8039,8 @@ Category=9
 Description="<html>(OC) Weight of setter type ('setter=') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_setter_weight\s*=\s*"
+CallName="mod_sort_oc_property_setter_weight="
+CallNameRegex="mod_sort_oc_property_setter_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7241,7 +8050,8 @@ Category=9
 Description="<html>(OC) Weight of nullability type ('nullable', 'nonnull', 'null_unspecified',<br/>'null_resettable') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_nullability_weight\s*=\s*"
+CallName="mod_sort_oc_property_nullability_weight="
+CallNameRegex="mod_sort_oc_property_nullability_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7251,7 +8061,8 @@ Category=10
 Description="<html>How to use tabs when indenting preprocessor code.<br/><br/>-1: Use 'indent_with_tabs' setting (default)<br/> 0: Spaces only<br/> 1: Indent with tabs to brace level, align with spaces<br/> 2: Indent and align with tabs, using spaces when not on a tabstop<br/><br/>Default: -1</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_with_tabs\s*=\s*"
+CallName="pp_indent_with_tabs="
+CallNameRegex="pp_indent_with_tabs\s*=\s*"
 MinVal=-1
 MaxVal=2
 ValueDefault=-1
@@ -7261,7 +8072,8 @@ Category=10
 Description="<html>Add or remove indentation of preprocessor directives inside #if blocks<br/>at brace level 0 (file-level).</html>"
 Enabled=false
 EditorType=multiple
-Choices=pp_indent\s*=\s*ignore|pp_indent\s*=\s*add|pp_indent\s*=\s*remove|pp_indent\s*=\s*force|pp_indent\s*=\s*not_defined
+Choices=pp_indent=ignore|pp_indent=add|pp_indent=remove|pp_indent=force|pp_indent=not_defined
+ChoicesRegex=pp_indent\s*=\s*ignore|pp_indent\s*=\s*add|pp_indent\s*=\s*remove|pp_indent\s*=\s*force|pp_indent\s*=\s*not_defined
 ChoicesReadable="Ignore Pp Indent|Add Pp Indent|Remove Pp Indent|Force Pp Indent"
 ValueDefault=ignore
 
@@ -7270,7 +8082,8 @@ Category=10
 Description="<html>Whether to indent #if/#else/#endif at the brace level. If false, these are<br/>indented from column 1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_at_level\s*=\s*true|pp_indent_at_level\s*=\s*false
+TrueFalse=pp_indent_at_level=true|pp_indent_at_level=false
+TrueFalseRegex=pp_indent_at_level\s*=\s*true|pp_indent_at_level\s*=\s*false
 ValueDefault=false
 
 [Pp Indent At Level0]
@@ -7278,7 +8091,8 @@ Category=10
 Description="<html>Whether to indent #if/#else/#endif at the parenthesis level if the brace<br/>level is 0. If false, these are indented from column 1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_at_level0\s*=\s*true|pp_indent_at_level0\s*=\s*false
+TrueFalse=pp_indent_at_level0=true|pp_indent_at_level0=false
+TrueFalseRegex=pp_indent_at_level0\s*=\s*true|pp_indent_at_level0\s*=\s*false
 ValueDefault=false
 
 [Pp Indent Count]
@@ -7286,7 +8100,8 @@ Category=10
 Description="<html>Specifies the number of columns to indent preprocessors per level<br/>at brace level 0 (file-level). If pp_indent_at_level=false, also specifies<br/>the number of columns to indent preprocessors per level<br/>at brace level &gt; 0 (function-level).<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_count\s*=\s*"
+CallName="pp_indent_count="
+CallNameRegex="pp_indent_count\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -7296,7 +8111,8 @@ Category=10
 Description="<html>Add or remove space after # based on pp level of #if blocks.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pp_space_after\s*=\s*ignore|pp_space_after\s*=\s*add|pp_space_after\s*=\s*remove|pp_space_after\s*=\s*force|pp_space_after\s*=\s*not_defined
+Choices=pp_space_after=ignore|pp_space_after=add|pp_space_after=remove|pp_space_after=force|pp_space_after=not_defined
+ChoicesRegex=pp_space_after\s*=\s*ignore|pp_space_after\s*=\s*add|pp_space_after\s*=\s*remove|pp_space_after\s*=\s*force|pp_space_after\s*=\s*not_defined
 ChoicesReadable="Ignore Pp Space After|Add Pp Space After|Remove Pp Space After|Force Pp Space After"
 ValueDefault=ignore
 
@@ -7305,7 +8121,8 @@ Category=10
 Description="<html>Sets the number of spaces per level added with pp_space_after.</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_space_count\s*=\s*"
+CallName="pp_space_count="
+CallNameRegex="pp_space_count\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -7315,7 +8132,8 @@ Category=10
 Description="<html>The indent for '#region' and '#endregion' in C# and '#pragma region' in<br/>C/C++. Negative values decrease indent down to the first column.</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_region\s*=\s*"
+CallName="pp_indent_region="
+CallNameRegex="pp_indent_region\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -7325,7 +8143,8 @@ Category=10
 Description="<html>Whether to indent the code between #region and #endregion.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_region_indent_code\s*=\s*true|pp_region_indent_code\s*=\s*false
+TrueFalse=pp_region_indent_code=true|pp_region_indent_code=false
+TrueFalseRegex=pp_region_indent_code\s*=\s*true|pp_region_indent_code\s*=\s*false
 ValueDefault=false
 
 [Pp Indent If]
@@ -7333,7 +8152,8 @@ Category=10
 Description="<html>If pp_indent_at_level=true, sets the indent for #if, #else and #endif when<br/>not at file-level. Negative values decrease indent down to the first column.<br/><br/>=0: Indent preprocessors using output_tab_size<br/>&gt;0: Column at which all preprocessors will be indented</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_if\s*=\s*"
+CallName="pp_indent_if="
+CallNameRegex="pp_indent_if\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -7343,7 +8163,8 @@ Category=10
 Description="<html>Whether to indent the code between #if, #else and #endif.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_if_indent_code\s*=\s*true|pp_if_indent_code\s*=\s*false
+TrueFalse=pp_if_indent_code=true|pp_if_indent_code=false
+TrueFalseRegex=pp_if_indent_code\s*=\s*true|pp_if_indent_code\s*=\s*false
 ValueDefault=false
 
 [Pp Indent In Guard]
@@ -7351,7 +8172,8 @@ Category=10
 Description="<html>Whether to indent the body of an #if that encompasses all the code in the file.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_in_guard\s*=\s*true|pp_indent_in_guard\s*=\s*false
+TrueFalse=pp_indent_in_guard=true|pp_indent_in_guard=false
+TrueFalseRegex=pp_indent_in_guard\s*=\s*true|pp_indent_in_guard\s*=\s*false
 ValueDefault=false
 
 [Pp Define At Level]
@@ -7359,7 +8181,8 @@ Category=10
 Description="<html>Whether to indent '#define' at the brace level. If false, these are<br/>indented from column 1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_define_at_level\s*=\s*true|pp_define_at_level\s*=\s*false
+TrueFalse=pp_define_at_level=true|pp_define_at_level=false
+TrueFalseRegex=pp_define_at_level\s*=\s*true|pp_define_at_level\s*=\s*false
 ValueDefault=false
 
 [Pp Include At Level]
@@ -7367,7 +8190,8 @@ Category=10
 Description="<html>Whether to indent '#include' at the brace level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_include_at_level\s*=\s*true|pp_include_at_level\s*=\s*false
+TrueFalse=pp_include_at_level=true|pp_include_at_level=false
+TrueFalseRegex=pp_include_at_level\s*=\s*true|pp_include_at_level\s*=\s*false
 ValueDefault=false
 
 [Pp Ignore Define Body]
@@ -7375,7 +8199,8 @@ Category=10
 Description="<html>Whether to ignore the '#define' body while formatting.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_ignore_define_body\s*=\s*true|pp_ignore_define_body\s*=\s*false
+TrueFalse=pp_ignore_define_body=true|pp_ignore_define_body=false
+TrueFalseRegex=pp_ignore_define_body\s*=\s*true|pp_ignore_define_body\s*=\s*false
 ValueDefault=false
 
 [Pp Multiline Define Body Indent]
@@ -7383,7 +8208,8 @@ Category=10
 Description="<html>An offset value that controls the indentation of the body of a multiline #define.<br/>'body' refers to all the lines of a multiline #define except the first line.<br/>Requires 'pp_ignore_define_body = false'.<br/><br/> &lt;0: Absolute column: the body indentation starts off at the specified column<br/>     (ex. -3 ==&gt; the body is indented starting from column 3)<br/>&gt;=0: Relative to the column of the '#' of '#define'<br/>     (ex.  3 ==&gt; the body is indented starting 3 columns at the right of '#')<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_multiline_define_body_indent\s*=\s*"
+CallName="pp_multiline_define_body_indent="
+CallNameRegex="pp_multiline_define_body_indent\s*=\s*"
 MinVal=-32
 MaxVal=32
 ValueDefault=8
@@ -7393,7 +8219,8 @@ Category=10
 Description="<html>Whether to indent case statements between #if, #else, and #endif.<br/>Only applies to the indent of the preprocessor that the case statements<br/>directly inside of.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_case\s*=\s*true|pp_indent_case\s*=\s*false
+TrueFalse=pp_indent_case=true|pp_indent_case=false
+TrueFalseRegex=pp_indent_case\s*=\s*true|pp_indent_case\s*=\s*false
 ValueDefault=true
 
 [Pp Indent Func Def]
@@ -7401,7 +8228,8 @@ Category=10
 Description="<html>Whether to indent whole function definitions between #if, #else, and #endif.<br/>Only applies to the indent of the preprocessor that the function definition<br/>is directly inside of.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_func_def\s*=\s*true|pp_indent_func_def\s*=\s*false
+TrueFalse=pp_indent_func_def=true|pp_indent_func_def=false
+TrueFalseRegex=pp_indent_func_def\s*=\s*true|pp_indent_func_def\s*=\s*false
 ValueDefault=true
 
 [Pp Indent Extern]
@@ -7409,7 +8237,8 @@ Category=10
 Description="<html>Whether to indent extern C blocks between #if, #else, and #endif.<br/>Only applies to the indent of the preprocessor that the extern block is<br/>directly inside of.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_extern\s*=\s*true|pp_indent_extern\s*=\s*false
+TrueFalse=pp_indent_extern=true|pp_indent_extern=false
+TrueFalseRegex=pp_indent_extern\s*=\s*true|pp_indent_extern\s*=\s*false
 ValueDefault=true
 
 [Pp Indent Brace]
@@ -7417,7 +8246,8 @@ Category=10
 Description="<html>How to indent braces directly inside #if, #else, and #endif.<br/>Requires pp_if_indent_code=true and only applies to the indent of the<br/>preprocessor that the braces are directly inside of.<br/> 0: No extra indent<br/> 1: Indent by one level<br/>-1: Preserve original indentation<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_brace\s*=\s*"
+CallName="pp_indent_brace="
+CallNameRegex="pp_indent_brace\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=1
@@ -7427,14 +8257,16 @@ Category=10
 Description="<html>Whether to print warning messages for unbalanced #if and #else blocks.<br/>This will print a message in the following cases:<br/>- if an #ifdef block ends on a different indent level than<br/>  where it started from. Example:<br/><br/>   #ifdef TEST<br/>     int i;<br/>     {<br/>       int j;<br/>   #endif<br/><br/>- an #elif/#else block ends on a different indent level than<br/>  the corresponding #ifdef block. Example:<br/><br/>   #ifdef TEST<br/>       int i;<br/>   #else<br/>       }<br/>     int j;<br/>   #endif</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_warn_unbalanced_if\s*=\s*true|pp_warn_unbalanced_if\s*=\s*false
+TrueFalse=pp_warn_unbalanced_if=true|pp_warn_unbalanced_if=false
+TrueFalseRegex=pp_warn_unbalanced_if\s*=\s*true|pp_warn_unbalanced_if\s*=\s*false
 ValueDefault=false
 
 [Include Category 0]
 Category=11
 Description="<html>The regex for include category with priority 0.</html>"
 Enabled=false
-CallName=include_category_0\s*=\s*
+CallName=include_category_0=
+CallNameRegex=include_category_0\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -7442,7 +8274,8 @@ ValueDefault=
 Category=11
 Description="<html>The regex for include category with priority 1.</html>"
 Enabled=false
-CallName=include_category_1\s*=\s*
+CallName=include_category_1=
+CallNameRegex=include_category_1\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -7450,7 +8283,8 @@ ValueDefault=
 Category=11
 Description="<html>The regex for include category with priority 2.</html>"
 Enabled=false
-CallName=include_category_2\s*=\s*
+CallName=include_category_2=
+CallNameRegex=include_category_2\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -7459,7 +8293,8 @@ Category=12
 Description="<html>true:  indent_func_call_param will be used (default)<br/>false: indent_func_call_param will NOT be used<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_indent_func_call_param\s*=\s*true|use_indent_func_call_param\s*=\s*false
+TrueFalse=use_indent_func_call_param=true|use_indent_func_call_param=false
+TrueFalseRegex=use_indent_func_call_param\s*=\s*true|use_indent_func_call_param\s*=\s*false
 ValueDefault=true
 
 [Use Indent Continue Only Once]
@@ -7467,7 +8302,8 @@ Category=12
 Description="<html>The value of the indentation for a continuation line is calculated<br/>differently if the statement is:<br/>- a declaration: your case with QString fileName ...<br/>- an assignment: your case with pSettings = new QSettings( ...<br/><br/>At the second case the indentation value might be used twice:<br/>- at the assignment<br/>- at the function call (if present)<br/><br/>To prevent the double use of the indentation value, use this option with the<br/>value 'true'.<br/><br/>true:  indent_continue will be used only once<br/>false: indent_continue will be used every time (default)<br/><br/>Requires indent_ignore_first_continue=false.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_indent_continue_only_once\s*=\s*true|use_indent_continue_only_once\s*=\s*false
+TrueFalse=use_indent_continue_only_once=true|use_indent_continue_only_once=false
+TrueFalseRegex=use_indent_continue_only_once\s*=\s*true|use_indent_continue_only_once\s*=\s*false
 ValueDefault=false
 
 [Indent Cpp Lambda Only Once]
@@ -7475,7 +8311,8 @@ Category=12
 Description="<html>The indentation can be:<br/>- after the assignment, at the '[' character<br/>- at the beginning of the lambda body<br/><br/>true:  indentation will be at the beginning of the lambda body<br/>false: indentation will be after the assignment (default)</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cpp_lambda_only_once\s*=\s*true|indent_cpp_lambda_only_once\s*=\s*false
+TrueFalse=indent_cpp_lambda_only_once=true|indent_cpp_lambda_only_once=false
+TrueFalseRegex=indent_cpp_lambda_only_once\s*=\s*true|indent_cpp_lambda_only_once\s*=\s*false
 ValueDefault=false
 
 [Use Sp After Angle Always]
@@ -7483,7 +8320,8 @@ Category=12
 Description="<html>Whether sp_after_angle takes precedence over sp_inside_fparen. This was the<br/>historic behavior, but is probably not the desired behavior, so this is off<br/>by default.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_sp_after_angle_always\s*=\s*true|use_sp_after_angle_always\s*=\s*false
+TrueFalse=use_sp_after_angle_always=true|use_sp_after_angle_always=false
+TrueFalseRegex=use_sp_after_angle_always\s*=\s*true|use_sp_after_angle_always\s*=\s*false
 ValueDefault=false
 
 [Use Options Overriding For Qt Macros]
@@ -7491,7 +8329,8 @@ Category=12
 Description="<html>Whether to apply special formatting for Qt SIGNAL/SLOT macros. Essentially,<br/>this tries to format these so that they match Qt's normalized form (i.e. the<br/>result of QMetaObject::normalizedSignature), which can slightly improve the<br/>performance of the QObject::connect call, rather than how they would<br/>otherwise be formatted.<br/><br/>See options_for_QT.cpp for details.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_options_overriding_for_qt_macros\s*=\s*true|use_options_overriding_for_qt_macros\s*=\s*false
+TrueFalse=use_options_overriding_for_qt_macros=true|use_options_overriding_for_qt_macros=false
+TrueFalseRegex=use_options_overriding_for_qt_macros\s*=\s*true|use_options_overriding_for_qt_macros\s*=\s*false
 ValueDefault=true
 
 [Use Form Feed No More As Whitespace Character]
@@ -7499,7 +8338,8 @@ Category=12
 Description="<html>If true: the form feed character is removed from the list of whitespace<br/>characters. See https://en.cppreference.com/w/cpp/string/byte/isspace.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_form_feed_no_more_as_whitespace_character\s*=\s*true|use_form_feed_no_more_as_whitespace_character\s*=\s*false
+TrueFalse=use_form_feed_no_more_as_whitespace_character=true|use_form_feed_no_more_as_whitespace_character=false
+TrueFalseRegex=use_form_feed_no_more_as_whitespace_character\s*=\s*true|use_form_feed_no_more_as_whitespace_character\s*=\s*false
 ValueDefault=false
 
 [Warn Level Tabs Found In Verbatim String Literals]
@@ -7507,7 +8347,8 @@ Category=13
 Description="<html>(C#) Warning is given if doing tab-to-\t replacement and we have found one<br/>in a C# verbatim string literal.<br/><br/>Default: 2</html>"
 Enabled=false
 EditorType=numeric
-CallName="warn_level_tabs_found_in_verbatim_string_literals\s*=\s*"
+CallName="warn_level_tabs_found_in_verbatim_string_literals="
+CallNameRegex="warn_level_tabs_found_in_verbatim_string_literals\s*=\s*"
 MinVal=1
 MaxVal=3
 ValueDefault=2
@@ -7517,7 +8358,8 @@ Category=13
 Description="<html>Limit the number of loops.<br/>Used by uncrustify.cpp to exit from infinite loop.<br/>0: no limit.</html>"
 Enabled=false
 EditorType=numeric
-CallName="debug_max_number_of_loops\s*=\s*"
+CallName="debug_max_number_of_loops="
+CallNameRegex="debug_max_number_of_loops\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7527,7 +8369,8 @@ Category=13
 Description="<html>Set the number of the line to protocol;<br/>Used in the function prot_the_line if the 2. parameter is zero.<br/>0: nothing protocol.</html>"
 Enabled=false
 EditorType=numeric
-CallName="debug_line_number_to_protocol\s*=\s*"
+CallName="debug_line_number_to_protocol="
+CallNameRegex="debug_line_number_to_protocol\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7537,7 +8380,8 @@ Category=13
 Description="<html>Set the number of second(s) before terminating formatting the current file,<br/>0: no timeout.<br/>only for linux</html>"
 Enabled=false
 EditorType=numeric
-CallName="debug_timeout\s*=\s*"
+CallName="debug_timeout="
+CallNameRegex="debug_timeout\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7547,7 +8391,8 @@ Category=13
 Description="<html>Set the number of characters to be printed if the text is too long,<br/>0: do not truncate.</html>"
 Enabled=false
 EditorType=numeric
-CallName="debug_truncate\s*=\s*"
+CallName="debug_truncate="
+CallNameRegex="debug_truncate\s*=\s*"
 MinVal=0
 MaxVal=960
 ValueDefault=0
@@ -7557,7 +8402,8 @@ Category=13
 Description="<html>sort (or not) the tracking info.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=debug_sort_the_tracks\s*=\s*true|debug_sort_the_tracks\s*=\s*false
+TrueFalse=debug_sort_the_tracks=true|debug_sort_the_tracks=false
+TrueFalseRegex=debug_sort_the_tracks\s*=\s*true|debug_sort_the_tracks\s*=\s*false
 ValueDefault=true
 
 [Debug Decode The Flags]
@@ -7565,7 +8411,8 @@ Category=13
 Description="<html>decode (or not) the flags as a new line.<br/>only if the -p option is set.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=debug_decode_the_flags\s*=\s*true|debug_decode_the_flags\s*=\s*false
+TrueFalse=debug_decode_the_flags=true|debug_decode_the_flags=false
+TrueFalseRegex=debug_decode_the_flags\s*=\s*true|debug_decode_the_flags\s*=\s*false
 ValueDefault=false
 
 [Debug Use The Exit Function Pop]
@@ -7573,7 +8420,8 @@ Category=13
 Description="<html>use (or not) the exit(EX_SOFTWARE) function.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=debug_use_the_exit_function_pop\s*=\s*true|debug_use_the_exit_function_pop\s*=\s*false
+TrueFalse=debug_use_the_exit_function_pop=true|debug_use_the_exit_function_pop=false
+TrueFalseRegex=debug_use_the_exit_function_pop\s*=\s*true|debug_use_the_exit_function_pop\s*=\s*false
 ValueDefault=true
 
 [Set Numbering For Html Output]
@@ -7581,5 +8429,6 @@ Category=13
 Description="<html>insert the number of the line at the beginning of each line</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=set_numbering_for_html_output\s*=\s*true|set_numbering_for_html_output\s*=\s*false
+TrueFalse=set_numbering_for_html_output=true|set_numbering_for_html_output=false
+TrueFalseRegex=set_numbering_for_html_output\s*=\s*true|set_numbering_for_html_output\s*=\s*false
 ValueDefault=false

--- a/src/universalindentgui.cpp
+++ b/src/universalindentgui.cpp
@@ -42,7 +42,16 @@ std::vector<uncrustify::OptionGroup *> get_option_groups()
 void print_option_choices(FILE *pfile, uncrustify::GenericOption *option,
                           char const *key = "Choices")
 {
+   // Normal string
    fprintf(pfile, "%s=", key);
+
+   for (auto c = option->possibleValues(); *c; ++c)
+   {
+      fprintf(pfile, "%s=%s%c", option->name(), *c, c[1] ? '|' : '\n');
+   }
+
+   // Regex string
+   fprintf(pfile, "%sRegex=", key);
 
    for (auto c = option->possibleValues(); *c; ++c)
    {
@@ -152,8 +161,7 @@ void print_universal_indent_cfg(FILE *pfile)
            "parameterOrder=ipo\n"
            "showHelpParameter=-h\n"
            "stringparaminquotes=false\n"
-           "useCfgFileParameter=\"-c \"\n"
-           "useRegex=true\n");
+           "useCfgFileParameter=\"-c \"\n");
 
    fprintf(pfile, "version=%s\n", UNCRUSTIFY_VERSION);
 
@@ -250,7 +258,9 @@ void print_universal_indent_cfg(FILE *pfile)
             // only a number. Also it is by default enabled.
             fprintf(pfile, "Enabled=true\n");
             fprintf(pfile, "EditorType=multiple\n");
-            fprintf(pfile, "Choices=\"%s\\s*=\\s*0|%s\\s*=\\s*1|%s\\s*=\\s*2\"\n",
+            fprintf(pfile, "Choices=\"%s=0|%s=1|%s=2\"\n",
+                    option->name(), option->name(), option->name());
+            fprintf(pfile, "ChoicesRegex=\"%s\\s*=\\s*0|%s\\s*=\\s*1|%s\\s*=\\s*2\"\n",
                     option->name(), option->name(), option->name());
 #if defined (DEBUG) && !defined (WIN32)
             fprintf(pfile, "ChoicesReadable=\"(%zu)Spaces only|(%zu)Indent with tabs, align with spaces|(%zu)Indent and align with tabs\"\n",
@@ -293,7 +303,8 @@ void print_universal_indent_cfg(FILE *pfile)
 
             case uncrustify::OT_NUM:
                fprintf(pfile, "EditorType=numeric\n");
-               fprintf(pfile, "CallName=\"%s\\s*=\\s*\"\n", option->name());
+               fprintf(pfile, "CallName=\"%s=\"\n", option->name());
+               fprintf(pfile, "CallNameRegex=\"%s\\s*=\\s*\"\n", option->name());
                fprintf(pfile, "MinVal=%s\n", option->minStr().c_str());
                fprintf(pfile, "MaxVal=%s\n", option->maxStr().c_str());
                fprintf(pfile, "ValueDefault=%s\n", option->str().c_str());
@@ -301,7 +312,8 @@ void print_universal_indent_cfg(FILE *pfile)
 
             case uncrustify::OT_UNUM:
                fprintf(pfile, "EditorType=numeric\n");
-               fprintf(pfile, "CallName=\"%s\\s*=\\s*\"\n", option->name());
+               fprintf(pfile, "CallName=\"%s=\"\n", option->name());
+               fprintf(pfile, "CallNameRegex=\"%s\\s*=\\s*\"\n", option->name());
                fprintf(pfile, "MinVal=%s\n", option->minStr().c_str());
                fprintf(pfile, "MaxVal=%s\n", option->maxStr().c_str());
                fprintf(pfile, "ValueDefault=%s\n", option->str().c_str());
@@ -354,7 +366,8 @@ void print_universal_indent_cfg(FILE *pfile)
 
             case uncrustify::OT_STRING:
             {
-               fprintf(pfile, "CallName=%s\\s*=\\s*\n", option->name());
+               fprintf(pfile, "CallName=%s=\n", option->name());
+               fprintf(pfile, "CallNameRegex=%s\\s*=\\s*\n", option->name());
                fprintf(pfile, "EditorType=string\n");
                fprintf(pfile, "ValueDefault=%s\n", option->str().c_str());
                break;

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -15,7 +15,6 @@ parameterOrder=ipo
 showHelpParameter=-h
 stringparaminquotes=false
 useCfgFileParameter="-c "
-useRegex=true
 
 
 [Newlines]
@@ -23,7 +22,8 @@ Category=0
 Description="<html>The type of line endings.<br/><br/>Default: auto</html>"
 Enabled=false
 EditorType=multiple
-Choices=newlines\s*=\s*lf|newlines\s*=\s*crlf|newlines\s*=\s*cr|newlines\s*=\s*auto
+Choices=newlines=lf|newlines=crlf|newlines=cr|newlines=auto
+ChoicesRegex=newlines\s*=\s*lf|newlines\s*=\s*crlf|newlines\s*=\s*cr|newlines\s*=\s*auto
 ChoicesReadable="Newlines Unix|Newlines Win|Newlines Mac|Newlines Auto"
 ValueDefault=auto
 
@@ -32,7 +32,8 @@ Category=0
 Description="<html>The original size of tabs in the input.<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
-CallName="input_tab_size\s*=\s*"
+CallName="input_tab_size="
+CallNameRegex="input_tab_size\s*=\s*"
 MinVal=1
 MaxVal=32
 ValueDefault=8
@@ -42,7 +43,8 @@ Category=0
 Description="<html>The size of tabs in the output (only used if align_with_tabs=true).<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
-CallName="output_tab_size\s*=\s*"
+CallName="output_tab_size="
+CallNameRegex="output_tab_size\s*=\s*"
 MinVal=1
 MaxVal=32
 ValueDefault=8
@@ -52,7 +54,8 @@ Category=0
 Description="<html>The ASCII value of the string escape char, usually 92 (\) or (Pawn) 94 (^).<br/><br/>Default: 92</html>"
 Enabled=false
 EditorType=numeric
-CallName="string_escape_char\s*=\s*"
+CallName="string_escape_char="
+CallNameRegex="string_escape_char\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=92
@@ -62,7 +65,8 @@ Category=0
 Description="<html>Alternate string escape char (usually only used for Pawn).<br/>Only works right before the quote char.</html>"
 Enabled=false
 EditorType=numeric
-CallName="string_escape_char2\s*=\s*"
+CallName="string_escape_char2="
+CallNameRegex="string_escape_char2\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -72,7 +76,8 @@ Category=0
 Description="<html>Replace tab characters found in string literals with the escape sequence \t<br/>instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=string_replace_tab_chars\s*=\s*true|string_replace_tab_chars\s*=\s*false
+TrueFalse=string_replace_tab_chars=true|string_replace_tab_chars=false
+TrueFalseRegex=string_replace_tab_chars\s*=\s*true|string_replace_tab_chars\s*=\s*false
 ValueDefault=false
 
 [Tok Split Gte]
@@ -80,7 +85,8 @@ Category=0
 Description="<html>Allow interpreting '&gt;=' and '&gt;&gt;=' as part of a template in code like<br/>'void f(list&lt;list&lt;B&gt;&gt;=val);'. If true, 'assert(x&lt;0 &amp;&amp; y&gt;=3)' will be broken.<br/>Improvements to template detection may make this option obsolete.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=tok_split_gte\s*=\s*true|tok_split_gte\s*=\s*false
+TrueFalse=tok_split_gte=true|tok_split_gte=false
+TrueFalseRegex=tok_split_gte\s*=\s*true|tok_split_gte\s*=\s*false
 ValueDefault=false
 
 [Disable Processing Nl Cont]
@@ -88,14 +94,16 @@ Category=0
 Description="<html>Disable formatting of NL_CONT ('\\n') ended lines (e.g. multi-line macros).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=disable_processing_nl_cont\s*=\s*true|disable_processing_nl_cont\s*=\s*false
+TrueFalse=disable_processing_nl_cont=true|disable_processing_nl_cont=false
+TrueFalseRegex=disable_processing_nl_cont\s*=\s*true|disable_processing_nl_cont\s*=\s*false
 ValueDefault=false
 
 [Disable Processing Cmt]
 Category=0
 Description="<html>Specify the marker used in comments to disable processing of part of the<br/>file.<br/><br/>Default:  *INDENT-OFF*</html>"
 Enabled=false
-CallName=disable_processing_cmt\s*=\s*
+CallName=disable_processing_cmt=
+CallNameRegex=disable_processing_cmt\s*=\s*
 EditorType=string
 ValueDefault= *INDENT-OFF*
 
@@ -103,7 +111,8 @@ ValueDefault= *INDENT-OFF*
 Category=0
 Description="<html>Specify the marker used in comments to (re)enable processing in a file.<br/><br/>Default:  *INDENT-ON*</html>"
 Enabled=false
-CallName=enable_processing_cmt\s*=\s*
+CallName=enable_processing_cmt=
+CallNameRegex=enable_processing_cmt\s*=\s*
 EditorType=string
 ValueDefault= *INDENT-ON*
 
@@ -112,7 +121,8 @@ Category=0
 Description="<html>Enable parsing of digraphs.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=enable_digraphs\s*=\s*true|enable_digraphs\s*=\s*false
+TrueFalse=enable_digraphs=true|enable_digraphs=false
+TrueFalseRegex=enable_digraphs\s*=\s*true|enable_digraphs\s*=\s*false
 ValueDefault=false
 
 [Processing Cmt As Regex]
@@ -120,7 +130,8 @@ Category=0
 Description="<html>Option to allow both disable_processing_cmt and enable_processing_cmt<br/>strings, if specified, to be interpreted as ECMAScript regular expressions.<br/>If true, a regex search will be performed within comments according to the<br/>specified patterns in order to disable/enable processing.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=processing_cmt_as_regex\s*=\s*true|processing_cmt_as_regex\s*=\s*false
+TrueFalse=processing_cmt_as_regex=true|processing_cmt_as_regex=false
+TrueFalseRegex=processing_cmt_as_regex\s*=\s*true|processing_cmt_as_regex\s*=\s*false
 ValueDefault=false
 
 [Utf8 Bom]
@@ -128,7 +139,8 @@ Category=0
 Description="<html>Add or remove the UTF-8 BOM (recommend 'remove').</html>"
 Enabled=false
 EditorType=multiple
-Choices=utf8_bom\s*=\s*ignore|utf8_bom\s*=\s*add|utf8_bom\s*=\s*remove|utf8_bom\s*=\s*force|utf8_bom\s*=\s*not_defined
+Choices=utf8_bom=ignore|utf8_bom=add|utf8_bom=remove|utf8_bom=force|utf8_bom=not_defined
+ChoicesRegex=utf8_bom\s*=\s*ignore|utf8_bom\s*=\s*add|utf8_bom\s*=\s*remove|utf8_bom\s*=\s*force|utf8_bom\s*=\s*not_defined
 ChoicesReadable="Ignore Utf8 Bom|Add Utf8 Bom|Remove Utf8 Bom|Force Utf8 Bom"
 ValueDefault=ignore
 
@@ -137,7 +149,8 @@ Category=0
 Description="<html>If the file contains bytes with values between 128 and 255, but is not<br/>UTF-8, then output as UTF-8.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=utf8_byte\s*=\s*true|utf8_byte\s*=\s*false
+TrueFalse=utf8_byte=true|utf8_byte=false
+TrueFalseRegex=utf8_byte\s*=\s*true|utf8_byte\s*=\s*false
 ValueDefault=false
 
 [Utf8 Force]
@@ -145,7 +158,8 @@ Category=0
 Description="<html>Force the output encoding to UTF-8.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=utf8_force\s*=\s*true|utf8_force\s*=\s*false
+TrueFalse=utf8_force=true|utf8_force=false
+TrueFalseRegex=utf8_force\s*=\s*true|utf8_force\s*=\s*false
 ValueDefault=false
 
 [Sp Arith]
@@ -153,7 +167,8 @@ Category=1
 Description="<html>Add or remove space around non-assignment symbolic operators ('+', '/', '%',<br/>'&lt;&lt;', and so forth).</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_arith\s*=\s*ignore|sp_arith\s*=\s*add|sp_arith\s*=\s*remove|sp_arith\s*=\s*force|sp_arith\s*=\s*not_defined
+Choices=sp_arith=ignore|sp_arith=add|sp_arith=remove|sp_arith=force|sp_arith=not_defined
+ChoicesRegex=sp_arith\s*=\s*ignore|sp_arith\s*=\s*add|sp_arith\s*=\s*remove|sp_arith\s*=\s*force|sp_arith\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Arith|Add Sp Arith|Remove Sp Arith|Force Sp Arith"
 ValueDefault=ignore
 
@@ -162,7 +177,8 @@ Category=1
 Description="<html>Add or remove space around arithmetic operators '+' and '-'.<br/><br/>Overrides sp_arith.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_arith_additive\s*=\s*ignore|sp_arith_additive\s*=\s*add|sp_arith_additive\s*=\s*remove|sp_arith_additive\s*=\s*force|sp_arith_additive\s*=\s*not_defined
+Choices=sp_arith_additive=ignore|sp_arith_additive=add|sp_arith_additive=remove|sp_arith_additive=force|sp_arith_additive=not_defined
+ChoicesRegex=sp_arith_additive\s*=\s*ignore|sp_arith_additive\s*=\s*add|sp_arith_additive\s*=\s*remove|sp_arith_additive\s*=\s*force|sp_arith_additive\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Arith Additive|Add Sp Arith Additive|Remove Sp Arith Additive|Force Sp Arith Additive"
 ValueDefault=ignore
 
@@ -171,7 +187,8 @@ Category=1
 Description="<html>Add or remove space around assignment operator '=', '+=', etc.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_assign\s*=\s*ignore|sp_assign\s*=\s*add|sp_assign\s*=\s*remove|sp_assign\s*=\s*force|sp_assign\s*=\s*not_defined
+Choices=sp_assign=ignore|sp_assign=add|sp_assign=remove|sp_assign=force|sp_assign=not_defined
+ChoicesRegex=sp_assign\s*=\s*ignore|sp_assign\s*=\s*add|sp_assign\s*=\s*remove|sp_assign\s*=\s*force|sp_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Assign|Add Sp Assign|Remove Sp Assign|Force Sp Assign"
 ValueDefault=ignore
 
@@ -180,7 +197,8 @@ Category=1
 Description="<html>Add or remove space around '=' in C++11 lambda capture specifications.<br/><br/>Overrides sp_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_assign\s*=\s*ignore|sp_cpp_lambda_assign\s*=\s*add|sp_cpp_lambda_assign\s*=\s*remove|sp_cpp_lambda_assign\s*=\s*force|sp_cpp_lambda_assign\s*=\s*not_defined
+Choices=sp_cpp_lambda_assign=ignore|sp_cpp_lambda_assign=add|sp_cpp_lambda_assign=remove|sp_cpp_lambda_assign=force|sp_cpp_lambda_assign=not_defined
+ChoicesRegex=sp_cpp_lambda_assign\s*=\s*ignore|sp_cpp_lambda_assign\s*=\s*add|sp_cpp_lambda_assign\s*=\s*remove|sp_cpp_lambda_assign\s*=\s*force|sp_cpp_lambda_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Assign|Add Sp Cpp Lambda Assign|Remove Sp Cpp Lambda Assign|Force Sp Cpp Lambda Assign"
 ValueDefault=ignore
 
@@ -189,7 +207,8 @@ Category=1
 Description="<html>Add or remove space after the capture specification of a C++11 lambda when<br/>an argument list is present, as in '[] &lt;here&gt; (int x){ ... }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_square_paren\s*=\s*ignore|sp_cpp_lambda_square_paren\s*=\s*add|sp_cpp_lambda_square_paren\s*=\s*remove|sp_cpp_lambda_square_paren\s*=\s*force|sp_cpp_lambda_square_paren\s*=\s*not_defined
+Choices=sp_cpp_lambda_square_paren=ignore|sp_cpp_lambda_square_paren=add|sp_cpp_lambda_square_paren=remove|sp_cpp_lambda_square_paren=force|sp_cpp_lambda_square_paren=not_defined
+ChoicesRegex=sp_cpp_lambda_square_paren\s*=\s*ignore|sp_cpp_lambda_square_paren\s*=\s*add|sp_cpp_lambda_square_paren\s*=\s*remove|sp_cpp_lambda_square_paren\s*=\s*force|sp_cpp_lambda_square_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Square Paren|Add Sp Cpp Lambda Square Paren|Remove Sp Cpp Lambda Square Paren|Force Sp Cpp Lambda Square Paren"
 ValueDefault=ignore
 
@@ -198,7 +217,8 @@ Category=1
 Description="<html>Add or remove space after the capture specification of a C++11 lambda with<br/>no argument list is present, as in '[] &lt;here&gt; { ... }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_square_brace\s*=\s*ignore|sp_cpp_lambda_square_brace\s*=\s*add|sp_cpp_lambda_square_brace\s*=\s*remove|sp_cpp_lambda_square_brace\s*=\s*force|sp_cpp_lambda_square_brace\s*=\s*not_defined
+Choices=sp_cpp_lambda_square_brace=ignore|sp_cpp_lambda_square_brace=add|sp_cpp_lambda_square_brace=remove|sp_cpp_lambda_square_brace=force|sp_cpp_lambda_square_brace=not_defined
+ChoicesRegex=sp_cpp_lambda_square_brace\s*=\s*ignore|sp_cpp_lambda_square_brace\s*=\s*add|sp_cpp_lambda_square_brace\s*=\s*remove|sp_cpp_lambda_square_brace\s*=\s*force|sp_cpp_lambda_square_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Square Brace|Add Sp Cpp Lambda Square Brace|Remove Sp Cpp Lambda Square Brace|Force Sp Cpp Lambda Square Brace"
 ValueDefault=ignore
 
@@ -207,7 +227,8 @@ Category=1
 Description="<html>Add or remove space after the opening parenthesis and before the closing<br/>parenthesis of a argument list of a C++11 lambda, as in<br/>'[]( &lt;here&gt; ){ ... }'<br/>with an empty list.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_argument_list_empty\s*=\s*ignore|sp_cpp_lambda_argument_list_empty\s*=\s*add|sp_cpp_lambda_argument_list_empty\s*=\s*remove|sp_cpp_lambda_argument_list_empty\s*=\s*force|sp_cpp_lambda_argument_list_empty\s*=\s*not_defined
+Choices=sp_cpp_lambda_argument_list_empty=ignore|sp_cpp_lambda_argument_list_empty=add|sp_cpp_lambda_argument_list_empty=remove|sp_cpp_lambda_argument_list_empty=force|sp_cpp_lambda_argument_list_empty=not_defined
+ChoicesRegex=sp_cpp_lambda_argument_list_empty\s*=\s*ignore|sp_cpp_lambda_argument_list_empty\s*=\s*add|sp_cpp_lambda_argument_list_empty\s*=\s*remove|sp_cpp_lambda_argument_list_empty\s*=\s*force|sp_cpp_lambda_argument_list_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Argument List Empty|Add Sp Cpp Lambda Argument List Empty|Remove Sp Cpp Lambda Argument List Empty|Force Sp Cpp Lambda Argument List Empty"
 ValueDefault=ignore
 
@@ -216,7 +237,8 @@ Category=1
 Description="<html>Add or remove space after the opening parenthesis and before the closing<br/>parenthesis of a argument list of a C++11 lambda, as in<br/>'[]( &lt;here&gt; int x &lt;here&gt; ){ ... }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_argument_list\s*=\s*ignore|sp_cpp_lambda_argument_list\s*=\s*add|sp_cpp_lambda_argument_list\s*=\s*remove|sp_cpp_lambda_argument_list\s*=\s*force|sp_cpp_lambda_argument_list\s*=\s*not_defined
+Choices=sp_cpp_lambda_argument_list=ignore|sp_cpp_lambda_argument_list=add|sp_cpp_lambda_argument_list=remove|sp_cpp_lambda_argument_list=force|sp_cpp_lambda_argument_list=not_defined
+ChoicesRegex=sp_cpp_lambda_argument_list\s*=\s*ignore|sp_cpp_lambda_argument_list\s*=\s*add|sp_cpp_lambda_argument_list\s*=\s*remove|sp_cpp_lambda_argument_list\s*=\s*force|sp_cpp_lambda_argument_list\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Argument List|Add Sp Cpp Lambda Argument List|Remove Sp Cpp Lambda Argument List|Force Sp Cpp Lambda Argument List"
 ValueDefault=ignore
 
@@ -225,7 +247,8 @@ Category=1
 Description="<html>Add or remove space after the argument list of a C++11 lambda, as in<br/>'[](int x) &lt;here&gt; { ... }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_paren_brace\s*=\s*ignore|sp_cpp_lambda_paren_brace\s*=\s*add|sp_cpp_lambda_paren_brace\s*=\s*remove|sp_cpp_lambda_paren_brace\s*=\s*force|sp_cpp_lambda_paren_brace\s*=\s*not_defined
+Choices=sp_cpp_lambda_paren_brace=ignore|sp_cpp_lambda_paren_brace=add|sp_cpp_lambda_paren_brace=remove|sp_cpp_lambda_paren_brace=force|sp_cpp_lambda_paren_brace=not_defined
+ChoicesRegex=sp_cpp_lambda_paren_brace\s*=\s*ignore|sp_cpp_lambda_paren_brace\s*=\s*add|sp_cpp_lambda_paren_brace\s*=\s*remove|sp_cpp_lambda_paren_brace\s*=\s*force|sp_cpp_lambda_paren_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Paren Brace|Add Sp Cpp Lambda Paren Brace|Remove Sp Cpp Lambda Paren Brace|Force Sp Cpp Lambda Paren Brace"
 ValueDefault=ignore
 
@@ -234,7 +257,8 @@ Category=1
 Description="<html>Add or remove space between a lambda body and its call operator of an<br/>immediately invoked lambda, as in '[]( ... ){ ... } &lt;here&gt; ( ... )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_lambda_fparen\s*=\s*ignore|sp_cpp_lambda_fparen\s*=\s*add|sp_cpp_lambda_fparen\s*=\s*remove|sp_cpp_lambda_fparen\s*=\s*force|sp_cpp_lambda_fparen\s*=\s*not_defined
+Choices=sp_cpp_lambda_fparen=ignore|sp_cpp_lambda_fparen=add|sp_cpp_lambda_fparen=remove|sp_cpp_lambda_fparen=force|sp_cpp_lambda_fparen=not_defined
+ChoicesRegex=sp_cpp_lambda_fparen\s*=\s*ignore|sp_cpp_lambda_fparen\s*=\s*add|sp_cpp_lambda_fparen\s*=\s*remove|sp_cpp_lambda_fparen\s*=\s*force|sp_cpp_lambda_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Lambda Fparen|Add Sp Cpp Lambda Fparen|Remove Sp Cpp Lambda Fparen|Force Sp Cpp Lambda Fparen"
 ValueDefault=ignore
 
@@ -243,7 +267,8 @@ Category=1
 Description="<html>Add or remove space around assignment operator '=' in a prototype.<br/><br/>If set to ignore, use sp_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_assign_default\s*=\s*ignore|sp_assign_default\s*=\s*add|sp_assign_default\s*=\s*remove|sp_assign_default\s*=\s*force|sp_assign_default\s*=\s*not_defined
+Choices=sp_assign_default=ignore|sp_assign_default=add|sp_assign_default=remove|sp_assign_default=force|sp_assign_default=not_defined
+ChoicesRegex=sp_assign_default\s*=\s*ignore|sp_assign_default\s*=\s*add|sp_assign_default\s*=\s*remove|sp_assign_default\s*=\s*force|sp_assign_default\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Assign Default|Add Sp Assign Default|Remove Sp Assign Default|Force Sp Assign Default"
 ValueDefault=ignore
 
@@ -252,7 +277,8 @@ Category=1
 Description="<html>Add or remove space before assignment operator '=', '+=', etc.<br/><br/>Overrides sp_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_assign\s*=\s*ignore|sp_before_assign\s*=\s*add|sp_before_assign\s*=\s*remove|sp_before_assign\s*=\s*force|sp_before_assign\s*=\s*not_defined
+Choices=sp_before_assign=ignore|sp_before_assign=add|sp_before_assign=remove|sp_before_assign=force|sp_before_assign=not_defined
+ChoicesRegex=sp_before_assign\s*=\s*ignore|sp_before_assign\s*=\s*add|sp_before_assign\s*=\s*remove|sp_before_assign\s*=\s*force|sp_before_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Assign|Add Sp Before Assign|Remove Sp Before Assign|Force Sp Before Assign"
 ValueDefault=ignore
 
@@ -261,7 +287,8 @@ Category=1
 Description="<html>Add or remove space after assignment operator '=', '+=', etc.<br/><br/>Overrides sp_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_assign\s*=\s*ignore|sp_after_assign\s*=\s*add|sp_after_assign\s*=\s*remove|sp_after_assign\s*=\s*force|sp_after_assign\s*=\s*not_defined
+Choices=sp_after_assign=ignore|sp_after_assign=add|sp_after_assign=remove|sp_after_assign=force|sp_after_assign=not_defined
+ChoicesRegex=sp_after_assign\s*=\s*ignore|sp_after_assign\s*=\s*add|sp_after_assign\s*=\s*remove|sp_after_assign\s*=\s*force|sp_after_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Assign|Add Sp After Assign|Remove Sp After Assign|Force Sp After Assign"
 ValueDefault=ignore
 
@@ -270,7 +297,8 @@ Category=1
 Description="<html>Add or remove space in 'enum {'.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_brace\s*=\s*ignore|sp_enum_brace\s*=\s*add|sp_enum_brace\s*=\s*remove|sp_enum_brace\s*=\s*force|sp_enum_brace\s*=\s*not_defined
+Choices=sp_enum_brace=ignore|sp_enum_brace=add|sp_enum_brace=remove|sp_enum_brace=force|sp_enum_brace=not_defined
+ChoicesRegex=sp_enum_brace\s*=\s*ignore|sp_enum_brace\s*=\s*add|sp_enum_brace\s*=\s*remove|sp_enum_brace\s*=\s*force|sp_enum_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Brace|Add Sp Enum Brace|Remove Sp Enum Brace|Force Sp Enum Brace"
 ValueDefault=add
 
@@ -279,7 +307,8 @@ Category=1
 Description="<html>Add or remove space in 'NS_ENUM ('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_paren\s*=\s*ignore|sp_enum_paren\s*=\s*add|sp_enum_paren\s*=\s*remove|sp_enum_paren\s*=\s*force|sp_enum_paren\s*=\s*not_defined
+Choices=sp_enum_paren=ignore|sp_enum_paren=add|sp_enum_paren=remove|sp_enum_paren=force|sp_enum_paren=not_defined
+ChoicesRegex=sp_enum_paren\s*=\s*ignore|sp_enum_paren\s*=\s*add|sp_enum_paren\s*=\s*remove|sp_enum_paren\s*=\s*force|sp_enum_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Paren|Add Sp Enum Paren|Remove Sp Enum Paren|Force Sp Enum Paren"
 ValueDefault=ignore
 
@@ -288,7 +317,8 @@ Category=1
 Description="<html>Add or remove space around assignment '=' in enum.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_assign\s*=\s*ignore|sp_enum_assign\s*=\s*add|sp_enum_assign\s*=\s*remove|sp_enum_assign\s*=\s*force|sp_enum_assign\s*=\s*not_defined
+Choices=sp_enum_assign=ignore|sp_enum_assign=add|sp_enum_assign=remove|sp_enum_assign=force|sp_enum_assign=not_defined
+ChoicesRegex=sp_enum_assign\s*=\s*ignore|sp_enum_assign\s*=\s*add|sp_enum_assign\s*=\s*remove|sp_enum_assign\s*=\s*force|sp_enum_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Assign|Add Sp Enum Assign|Remove Sp Enum Assign|Force Sp Enum Assign"
 ValueDefault=ignore
 
@@ -297,7 +327,8 @@ Category=1
 Description="<html>Add or remove space before assignment '=' in enum.<br/><br/>Overrides sp_enum_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_before_assign\s*=\s*ignore|sp_enum_before_assign\s*=\s*add|sp_enum_before_assign\s*=\s*remove|sp_enum_before_assign\s*=\s*force|sp_enum_before_assign\s*=\s*not_defined
+Choices=sp_enum_before_assign=ignore|sp_enum_before_assign=add|sp_enum_before_assign=remove|sp_enum_before_assign=force|sp_enum_before_assign=not_defined
+ChoicesRegex=sp_enum_before_assign\s*=\s*ignore|sp_enum_before_assign\s*=\s*add|sp_enum_before_assign\s*=\s*remove|sp_enum_before_assign\s*=\s*force|sp_enum_before_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Before Assign|Add Sp Enum Before Assign|Remove Sp Enum Before Assign|Force Sp Enum Before Assign"
 ValueDefault=ignore
 
@@ -306,7 +337,8 @@ Category=1
 Description="<html>Add or remove space after assignment '=' in enum.<br/><br/>Overrides sp_enum_assign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_after_assign\s*=\s*ignore|sp_enum_after_assign\s*=\s*add|sp_enum_after_assign\s*=\s*remove|sp_enum_after_assign\s*=\s*force|sp_enum_after_assign\s*=\s*not_defined
+Choices=sp_enum_after_assign=ignore|sp_enum_after_assign=add|sp_enum_after_assign=remove|sp_enum_after_assign=force|sp_enum_after_assign=not_defined
+ChoicesRegex=sp_enum_after_assign\s*=\s*ignore|sp_enum_after_assign\s*=\s*add|sp_enum_after_assign\s*=\s*remove|sp_enum_after_assign\s*=\s*force|sp_enum_after_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum After Assign|Add Sp Enum After Assign|Remove Sp Enum After Assign|Force Sp Enum After Assign"
 ValueDefault=ignore
 
@@ -315,7 +347,8 @@ Category=1
 Description="<html>Add or remove space around assignment ':' in enum.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_enum_colon\s*=\s*ignore|sp_enum_colon\s*=\s*add|sp_enum_colon\s*=\s*remove|sp_enum_colon\s*=\s*force|sp_enum_colon\s*=\s*not_defined
+Choices=sp_enum_colon=ignore|sp_enum_colon=add|sp_enum_colon=remove|sp_enum_colon=force|sp_enum_colon=not_defined
+ChoicesRegex=sp_enum_colon\s*=\s*ignore|sp_enum_colon\s*=\s*add|sp_enum_colon\s*=\s*remove|sp_enum_colon\s*=\s*force|sp_enum_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Enum Colon|Add Sp Enum Colon|Remove Sp Enum Colon|Force Sp Enum Colon"
 ValueDefault=ignore
 
@@ -324,7 +357,8 @@ Category=1
 Description="<html>Add or remove space around preprocessor '##' concatenation operator.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_pp_concat\s*=\s*ignore|sp_pp_concat\s*=\s*add|sp_pp_concat\s*=\s*remove|sp_pp_concat\s*=\s*force|sp_pp_concat\s*=\s*not_defined
+Choices=sp_pp_concat=ignore|sp_pp_concat=add|sp_pp_concat=remove|sp_pp_concat=force|sp_pp_concat=not_defined
+ChoicesRegex=sp_pp_concat\s*=\s*ignore|sp_pp_concat\s*=\s*add|sp_pp_concat\s*=\s*remove|sp_pp_concat\s*=\s*force|sp_pp_concat\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Pp Concat|Add Sp Pp Concat|Remove Sp Pp Concat|Force Sp Pp Concat"
 ValueDefault=add
 
@@ -333,7 +367,8 @@ Category=1
 Description="<html>Add or remove space after preprocessor '#' stringify operator.<br/>Also affects the '#@' charizing operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_pp_stringify\s*=\s*ignore|sp_pp_stringify\s*=\s*add|sp_pp_stringify\s*=\s*remove|sp_pp_stringify\s*=\s*force|sp_pp_stringify\s*=\s*not_defined
+Choices=sp_pp_stringify=ignore|sp_pp_stringify=add|sp_pp_stringify=remove|sp_pp_stringify=force|sp_pp_stringify=not_defined
+ChoicesRegex=sp_pp_stringify\s*=\s*ignore|sp_pp_stringify\s*=\s*add|sp_pp_stringify\s*=\s*remove|sp_pp_stringify\s*=\s*force|sp_pp_stringify\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Pp Stringify|Add Sp Pp Stringify|Remove Sp Pp Stringify|Force Sp Pp Stringify"
 ValueDefault=ignore
 
@@ -342,7 +377,8 @@ Category=1
 Description="<html>Add or remove space before preprocessor '#' stringify operator<br/>as in '#define x(y) L#y'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_pp_stringify\s*=\s*ignore|sp_before_pp_stringify\s*=\s*add|sp_before_pp_stringify\s*=\s*remove|sp_before_pp_stringify\s*=\s*force|sp_before_pp_stringify\s*=\s*not_defined
+Choices=sp_before_pp_stringify=ignore|sp_before_pp_stringify=add|sp_before_pp_stringify=remove|sp_before_pp_stringify=force|sp_before_pp_stringify=not_defined
+ChoicesRegex=sp_before_pp_stringify\s*=\s*ignore|sp_before_pp_stringify\s*=\s*add|sp_before_pp_stringify\s*=\s*remove|sp_before_pp_stringify\s*=\s*force|sp_before_pp_stringify\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Pp Stringify|Add Sp Before Pp Stringify|Remove Sp Before Pp Stringify|Force Sp Before Pp Stringify"
 ValueDefault=ignore
 
@@ -351,7 +387,8 @@ Category=1
 Description="<html>Add or remove space around boolean operators '&amp;&amp;' and '||'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_bool\s*=\s*ignore|sp_bool\s*=\s*add|sp_bool\s*=\s*remove|sp_bool\s*=\s*force|sp_bool\s*=\s*not_defined
+Choices=sp_bool=ignore|sp_bool=add|sp_bool=remove|sp_bool=force|sp_bool=not_defined
+ChoicesRegex=sp_bool\s*=\s*ignore|sp_bool\s*=\s*add|sp_bool\s*=\s*remove|sp_bool\s*=\s*force|sp_bool\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Bool|Add Sp Bool|Remove Sp Bool|Force Sp Bool"
 ValueDefault=ignore
 
@@ -360,7 +397,8 @@ Category=1
 Description="<html>Add or remove space around compare operator '&lt;', '&gt;', '==', etc.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_compare\s*=\s*ignore|sp_compare\s*=\s*add|sp_compare\s*=\s*remove|sp_compare\s*=\s*force|sp_compare\s*=\s*not_defined
+Choices=sp_compare=ignore|sp_compare=add|sp_compare=remove|sp_compare=force|sp_compare=not_defined
+ChoicesRegex=sp_compare\s*=\s*ignore|sp_compare\s*=\s*add|sp_compare\s*=\s*remove|sp_compare\s*=\s*force|sp_compare\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Compare|Add Sp Compare|Remove Sp Compare|Force Sp Compare"
 ValueDefault=ignore
 
@@ -369,7 +407,8 @@ Category=1
 Description="<html>Add or remove space inside '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_paren\s*=\s*ignore|sp_inside_paren\s*=\s*add|sp_inside_paren\s*=\s*remove|sp_inside_paren\s*=\s*force|sp_inside_paren\s*=\s*not_defined
+Choices=sp_inside_paren=ignore|sp_inside_paren=add|sp_inside_paren=remove|sp_inside_paren=force|sp_inside_paren=not_defined
+ChoicesRegex=sp_inside_paren\s*=\s*ignore|sp_inside_paren\s*=\s*add|sp_inside_paren\s*=\s*remove|sp_inside_paren\s*=\s*force|sp_inside_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Paren|Add Sp Inside Paren|Remove Sp Inside Paren|Force Sp Inside Paren"
 ValueDefault=ignore
 
@@ -378,7 +417,8 @@ Category=1
 Description="<html>Add or remove space between nested parentheses, i.e. '((' vs. ') )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_paren\s*=\s*ignore|sp_paren_paren\s*=\s*add|sp_paren_paren\s*=\s*remove|sp_paren_paren\s*=\s*force|sp_paren_paren\s*=\s*not_defined
+Choices=sp_paren_paren=ignore|sp_paren_paren=add|sp_paren_paren=remove|sp_paren_paren=force|sp_paren_paren=not_defined
+ChoicesRegex=sp_paren_paren\s*=\s*ignore|sp_paren_paren\s*=\s*add|sp_paren_paren\s*=\s*remove|sp_paren_paren\s*=\s*force|sp_paren_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Paren|Add Sp Paren Paren|Remove Sp Paren Paren|Force Sp Paren Paren"
 ValueDefault=ignore
 
@@ -387,7 +427,8 @@ Category=1
 Description="<html>Add or remove space between back-to-back parentheses, i.e. ')(' vs. ') ('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cparen_oparen\s*=\s*ignore|sp_cparen_oparen\s*=\s*add|sp_cparen_oparen\s*=\s*remove|sp_cparen_oparen\s*=\s*force|sp_cparen_oparen\s*=\s*not_defined
+Choices=sp_cparen_oparen=ignore|sp_cparen_oparen=add|sp_cparen_oparen=remove|sp_cparen_oparen=force|sp_cparen_oparen=not_defined
+ChoicesRegex=sp_cparen_oparen\s*=\s*ignore|sp_cparen_oparen\s*=\s*add|sp_cparen_oparen\s*=\s*remove|sp_cparen_oparen\s*=\s*force|sp_cparen_oparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cparen Oparen|Add Sp Cparen Oparen|Remove Sp Cparen Oparen|Force Sp Cparen Oparen"
 ValueDefault=ignore
 
@@ -396,7 +437,8 @@ Category=1
 Description="<html>Whether to balance spaces inside nested parentheses.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_balance_nested_parens\s*=\s*true|sp_balance_nested_parens\s*=\s*false
+TrueFalse=sp_balance_nested_parens=true|sp_balance_nested_parens=false
+TrueFalseRegex=sp_balance_nested_parens\s*=\s*true|sp_balance_nested_parens\s*=\s*false
 ValueDefault=false
 
 [Sp Paren Brace]
@@ -404,7 +446,8 @@ Category=1
 Description="<html>Add or remove space between ')' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_brace\s*=\s*ignore|sp_paren_brace\s*=\s*add|sp_paren_brace\s*=\s*remove|sp_paren_brace\s*=\s*force|sp_paren_brace\s*=\s*not_defined
+Choices=sp_paren_brace=ignore|sp_paren_brace=add|sp_paren_brace=remove|sp_paren_brace=force|sp_paren_brace=not_defined
+ChoicesRegex=sp_paren_brace\s*=\s*ignore|sp_paren_brace\s*=\s*add|sp_paren_brace\s*=\s*remove|sp_paren_brace\s*=\s*force|sp_paren_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Brace|Add Sp Paren Brace|Remove Sp Paren Brace|Force Sp Paren Brace"
 ValueDefault=ignore
 
@@ -413,7 +456,8 @@ Category=1
 Description="<html>Add or remove space between nested braces, i.e. '{{' vs. '{ {'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_brace\s*=\s*ignore|sp_brace_brace\s*=\s*add|sp_brace_brace\s*=\s*remove|sp_brace_brace\s*=\s*force|sp_brace_brace\s*=\s*not_defined
+Choices=sp_brace_brace=ignore|sp_brace_brace=add|sp_brace_brace=remove|sp_brace_brace=force|sp_brace_brace=not_defined
+ChoicesRegex=sp_brace_brace\s*=\s*ignore|sp_brace_brace\s*=\s*add|sp_brace_brace\s*=\s*remove|sp_brace_brace\s*=\s*force|sp_brace_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Brace|Add Sp Brace Brace|Remove Sp Brace Brace|Force Sp Brace Brace"
 ValueDefault=ignore
 
@@ -422,7 +466,8 @@ Category=1
 Description="<html>Add or remove space before pointer star '*'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_ptr_star\s*=\s*ignore|sp_before_ptr_star\s*=\s*add|sp_before_ptr_star\s*=\s*remove|sp_before_ptr_star\s*=\s*force|sp_before_ptr_star\s*=\s*not_defined
+Choices=sp_before_ptr_star=ignore|sp_before_ptr_star=add|sp_before_ptr_star=remove|sp_before_ptr_star=force|sp_before_ptr_star=not_defined
+ChoicesRegex=sp_before_ptr_star\s*=\s*ignore|sp_before_ptr_star\s*=\s*add|sp_before_ptr_star\s*=\s*remove|sp_before_ptr_star\s*=\s*force|sp_before_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Ptr Star|Add Sp Before Ptr Star|Remove Sp Before Ptr Star|Force Sp Before Ptr Star"
 ValueDefault=ignore
 
@@ -431,7 +476,8 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that isn't followed by a<br/>variable name. If set to ignore, sp_before_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_unnamed_ptr_star\s*=\s*ignore|sp_before_unnamed_ptr_star\s*=\s*add|sp_before_unnamed_ptr_star\s*=\s*remove|sp_before_unnamed_ptr_star\s*=\s*force|sp_before_unnamed_ptr_star\s*=\s*not_defined
+Choices=sp_before_unnamed_ptr_star=ignore|sp_before_unnamed_ptr_star=add|sp_before_unnamed_ptr_star=remove|sp_before_unnamed_ptr_star=force|sp_before_unnamed_ptr_star=not_defined
+ChoicesRegex=sp_before_unnamed_ptr_star\s*=\s*ignore|sp_before_unnamed_ptr_star\s*=\s*add|sp_before_unnamed_ptr_star\s*=\s*remove|sp_before_unnamed_ptr_star\s*=\s*force|sp_before_unnamed_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Unnamed Ptr Star|Add Sp Before Unnamed Ptr Star|Remove Sp Before Unnamed Ptr Star|Force Sp Before Unnamed Ptr Star"
 ValueDefault=ignore
 
@@ -440,7 +486,8 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that is followed by a qualifier.<br/>If set to ignore, sp_before_unnamed_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_qualifier_ptr_star\s*=\s*ignore|sp_before_qualifier_ptr_star\s*=\s*add|sp_before_qualifier_ptr_star\s*=\s*remove|sp_before_qualifier_ptr_star\s*=\s*force|sp_before_qualifier_ptr_star\s*=\s*not_defined
+Choices=sp_before_qualifier_ptr_star=ignore|sp_before_qualifier_ptr_star=add|sp_before_qualifier_ptr_star=remove|sp_before_qualifier_ptr_star=force|sp_before_qualifier_ptr_star=not_defined
+ChoicesRegex=sp_before_qualifier_ptr_star\s*=\s*ignore|sp_before_qualifier_ptr_star\s*=\s*add|sp_before_qualifier_ptr_star\s*=\s*remove|sp_before_qualifier_ptr_star\s*=\s*force|sp_before_qualifier_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Qualifier Ptr Star|Add Sp Before Qualifier Ptr Star|Remove Sp Before Qualifier Ptr Star|Force Sp Before Qualifier Ptr Star"
 ValueDefault=ignore
 
@@ -449,7 +496,8 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that is followed by 'operator' keyword.<br/>If set to ignore, sp_before_unnamed_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_operator_ptr_star\s*=\s*ignore|sp_before_operator_ptr_star\s*=\s*add|sp_before_operator_ptr_star\s*=\s*remove|sp_before_operator_ptr_star\s*=\s*force|sp_before_operator_ptr_star\s*=\s*not_defined
+Choices=sp_before_operator_ptr_star=ignore|sp_before_operator_ptr_star=add|sp_before_operator_ptr_star=remove|sp_before_operator_ptr_star=force|sp_before_operator_ptr_star=not_defined
+ChoicesRegex=sp_before_operator_ptr_star\s*=\s*ignore|sp_before_operator_ptr_star\s*=\s*add|sp_before_operator_ptr_star\s*=\s*remove|sp_before_operator_ptr_star\s*=\s*force|sp_before_operator_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Operator Ptr Star|Add Sp Before Operator Ptr Star|Remove Sp Before Operator Ptr Star|Force Sp Before Operator Ptr Star"
 ValueDefault=ignore
 
@@ -458,7 +506,8 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that is followed by<br/>a class scope (as in 'int *MyClass::method()') or namespace scope<br/>(as in 'int *my_ns::func()').<br/>If set to ignore, sp_before_unnamed_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_scope_ptr_star\s*=\s*ignore|sp_before_scope_ptr_star\s*=\s*add|sp_before_scope_ptr_star\s*=\s*remove|sp_before_scope_ptr_star\s*=\s*force|sp_before_scope_ptr_star\s*=\s*not_defined
+Choices=sp_before_scope_ptr_star=ignore|sp_before_scope_ptr_star=add|sp_before_scope_ptr_star=remove|sp_before_scope_ptr_star=force|sp_before_scope_ptr_star=not_defined
+ChoicesRegex=sp_before_scope_ptr_star\s*=\s*ignore|sp_before_scope_ptr_star\s*=\s*add|sp_before_scope_ptr_star\s*=\s*remove|sp_before_scope_ptr_star\s*=\s*force|sp_before_scope_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Scope Ptr Star|Add Sp Before Scope Ptr Star|Remove Sp Before Scope Ptr Star|Force Sp Before Scope Ptr Star"
 ValueDefault=ignore
 
@@ -467,7 +516,8 @@ Category=1
 Description="<html>Add or remove space before pointer star '*' that is followed by '::',<br/>as in 'int *::func()'.<br/>If set to ignore, sp_before_unnamed_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_global_scope_ptr_star\s*=\s*ignore|sp_before_global_scope_ptr_star\s*=\s*add|sp_before_global_scope_ptr_star\s*=\s*remove|sp_before_global_scope_ptr_star\s*=\s*force|sp_before_global_scope_ptr_star\s*=\s*not_defined
+Choices=sp_before_global_scope_ptr_star=ignore|sp_before_global_scope_ptr_star=add|sp_before_global_scope_ptr_star=remove|sp_before_global_scope_ptr_star=force|sp_before_global_scope_ptr_star=not_defined
+ChoicesRegex=sp_before_global_scope_ptr_star\s*=\s*ignore|sp_before_global_scope_ptr_star\s*=\s*add|sp_before_global_scope_ptr_star\s*=\s*remove|sp_before_global_scope_ptr_star\s*=\s*force|sp_before_global_scope_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Global Scope Ptr Star|Add Sp Before Global Scope Ptr Star|Remove Sp Before Global Scope Ptr Star|Force Sp Before Global Scope Ptr Star"
 ValueDefault=ignore
 
@@ -476,7 +526,8 @@ Category=1
 Description="<html>Add or remove space between a qualifier and a pointer star '*' that isn't<br/>followed by a variable name, as in '(char const *)'. If set to ignore,<br/>sp_before_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_qualifier_unnamed_ptr_star\s*=\s*ignore|sp_qualifier_unnamed_ptr_star\s*=\s*add|sp_qualifier_unnamed_ptr_star\s*=\s*remove|sp_qualifier_unnamed_ptr_star\s*=\s*force|sp_qualifier_unnamed_ptr_star\s*=\s*not_defined
+Choices=sp_qualifier_unnamed_ptr_star=ignore|sp_qualifier_unnamed_ptr_star=add|sp_qualifier_unnamed_ptr_star=remove|sp_qualifier_unnamed_ptr_star=force|sp_qualifier_unnamed_ptr_star=not_defined
+ChoicesRegex=sp_qualifier_unnamed_ptr_star\s*=\s*ignore|sp_qualifier_unnamed_ptr_star\s*=\s*add|sp_qualifier_unnamed_ptr_star\s*=\s*remove|sp_qualifier_unnamed_ptr_star\s*=\s*force|sp_qualifier_unnamed_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Qualifier Unnamed Ptr Star|Add Sp Qualifier Unnamed Ptr Star|Remove Sp Qualifier Unnamed Ptr Star|Force Sp Qualifier Unnamed Ptr Star"
 ValueDefault=ignore
 
@@ -485,7 +536,8 @@ Category=1
 Description="<html>Add or remove space between pointer stars '*', as in 'int ***a;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_ptr_star\s*=\s*ignore|sp_between_ptr_star\s*=\s*add|sp_between_ptr_star\s*=\s*remove|sp_between_ptr_star\s*=\s*force|sp_between_ptr_star\s*=\s*not_defined
+Choices=sp_between_ptr_star=ignore|sp_between_ptr_star=add|sp_between_ptr_star=remove|sp_between_ptr_star=force|sp_between_ptr_star=not_defined
+ChoicesRegex=sp_between_ptr_star\s*=\s*ignore|sp_between_ptr_star\s*=\s*add|sp_between_ptr_star\s*=\s*remove|sp_between_ptr_star\s*=\s*force|sp_between_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between Ptr Star|Add Sp Between Ptr Star|Remove Sp Between Ptr Star|Force Sp Between Ptr Star"
 ValueDefault=ignore
 
@@ -494,7 +546,8 @@ Category=1
 Description="<html>Add or remove space between pointer star '*' and reference '&amp;', as in 'int *&amp; a;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_ptr_ref\s*=\s*ignore|sp_between_ptr_ref\s*=\s*add|sp_between_ptr_ref\s*=\s*remove|sp_between_ptr_ref\s*=\s*force|sp_between_ptr_ref\s*=\s*not_defined
+Choices=sp_between_ptr_ref=ignore|sp_between_ptr_ref=add|sp_between_ptr_ref=remove|sp_between_ptr_ref=force|sp_between_ptr_ref=not_defined
+ChoicesRegex=sp_between_ptr_ref\s*=\s*ignore|sp_between_ptr_ref\s*=\s*add|sp_between_ptr_ref\s*=\s*remove|sp_between_ptr_ref\s*=\s*force|sp_between_ptr_ref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between Ptr Ref|Add Sp Between Ptr Ref|Remove Sp Between Ptr Ref|Force Sp Between Ptr Ref"
 ValueDefault=ignore
 
@@ -503,7 +556,8 @@ Category=1
 Description="<html>Add or remove space after pointer star '*', if followed by a word.<br/><br/>Overrides sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_star\s*=\s*ignore|sp_after_ptr_star\s*=\s*add|sp_after_ptr_star\s*=\s*remove|sp_after_ptr_star\s*=\s*force|sp_after_ptr_star\s*=\s*not_defined
+Choices=sp_after_ptr_star=ignore|sp_after_ptr_star=add|sp_after_ptr_star=remove|sp_after_ptr_star=force|sp_after_ptr_star=not_defined
+ChoicesRegex=sp_after_ptr_star\s*=\s*ignore|sp_after_ptr_star\s*=\s*add|sp_after_ptr_star\s*=\s*remove|sp_after_ptr_star\s*=\s*force|sp_after_ptr_star\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Star|Add Sp After Ptr Star|Remove Sp After Ptr Star|Force Sp After Ptr Star"
 ValueDefault=ignore
 
@@ -512,7 +566,8 @@ Category=1
 Description="<html>Add or remove space after pointer caret '^', if followed by a word.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_block_caret\s*=\s*ignore|sp_after_ptr_block_caret\s*=\s*add|sp_after_ptr_block_caret\s*=\s*remove|sp_after_ptr_block_caret\s*=\s*force|sp_after_ptr_block_caret\s*=\s*not_defined
+Choices=sp_after_ptr_block_caret=ignore|sp_after_ptr_block_caret=add|sp_after_ptr_block_caret=remove|sp_after_ptr_block_caret=force|sp_after_ptr_block_caret=not_defined
+ChoicesRegex=sp_after_ptr_block_caret\s*=\s*ignore|sp_after_ptr_block_caret\s*=\s*add|sp_after_ptr_block_caret\s*=\s*remove|sp_after_ptr_block_caret\s*=\s*force|sp_after_ptr_block_caret\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Block Caret|Add Sp After Ptr Block Caret|Remove Sp After Ptr Block Caret|Force Sp After Ptr Block Caret"
 ValueDefault=ignore
 
@@ -521,7 +576,8 @@ Category=1
 Description="<html>Add or remove space after pointer star '*', if followed by a qualifier.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_star_qualifier\s*=\s*ignore|sp_after_ptr_star_qualifier\s*=\s*add|sp_after_ptr_star_qualifier\s*=\s*remove|sp_after_ptr_star_qualifier\s*=\s*force|sp_after_ptr_star_qualifier\s*=\s*not_defined
+Choices=sp_after_ptr_star_qualifier=ignore|sp_after_ptr_star_qualifier=add|sp_after_ptr_star_qualifier=remove|sp_after_ptr_star_qualifier=force|sp_after_ptr_star_qualifier=not_defined
+ChoicesRegex=sp_after_ptr_star_qualifier\s*=\s*ignore|sp_after_ptr_star_qualifier\s*=\s*add|sp_after_ptr_star_qualifier\s*=\s*remove|sp_after_ptr_star_qualifier\s*=\s*force|sp_after_ptr_star_qualifier\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Star Qualifier|Add Sp After Ptr Star Qualifier|Remove Sp After Ptr Star Qualifier|Force Sp After Ptr Star Qualifier"
 ValueDefault=ignore
 
@@ -530,7 +586,8 @@ Category=1
 Description="<html>Add or remove space after a pointer star '*', if followed by a function<br/>prototype or function definition.<br/><br/>Overrides sp_after_ptr_star and sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_star_func\s*=\s*ignore|sp_after_ptr_star_func\s*=\s*add|sp_after_ptr_star_func\s*=\s*remove|sp_after_ptr_star_func\s*=\s*force|sp_after_ptr_star_func\s*=\s*not_defined
+Choices=sp_after_ptr_star_func=ignore|sp_after_ptr_star_func=add|sp_after_ptr_star_func=remove|sp_after_ptr_star_func=force|sp_after_ptr_star_func=not_defined
+ChoicesRegex=sp_after_ptr_star_func\s*=\s*ignore|sp_after_ptr_star_func\s*=\s*add|sp_after_ptr_star_func\s*=\s*remove|sp_after_ptr_star_func\s*=\s*force|sp_after_ptr_star_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Star Func|Add Sp After Ptr Star Func|Remove Sp After Ptr Star Func|Force Sp After Ptr Star Func"
 ValueDefault=ignore
 
@@ -539,7 +596,8 @@ Category=1
 Description="<html>Add or remove space after a pointer star '*' in the trailing return of a<br/>function prototype or function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ptr_star_trailing\s*=\s*ignore|sp_after_ptr_star_trailing\s*=\s*add|sp_after_ptr_star_trailing\s*=\s*remove|sp_after_ptr_star_trailing\s*=\s*force|sp_after_ptr_star_trailing\s*=\s*not_defined
+Choices=sp_after_ptr_star_trailing=ignore|sp_after_ptr_star_trailing=add|sp_after_ptr_star_trailing=remove|sp_after_ptr_star_trailing=force|sp_after_ptr_star_trailing=not_defined
+ChoicesRegex=sp_after_ptr_star_trailing\s*=\s*ignore|sp_after_ptr_star_trailing\s*=\s*add|sp_after_ptr_star_trailing\s*=\s*remove|sp_after_ptr_star_trailing\s*=\s*force|sp_after_ptr_star_trailing\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ptr Star Trailing|Add Sp After Ptr Star Trailing|Remove Sp After Ptr Star Trailing|Force Sp After Ptr Star Trailing"
 ValueDefault=ignore
 
@@ -548,7 +606,8 @@ Category=1
 Description="<html>Add or remove space between the pointer star '*' and the name of the variable<br/>in a function pointer definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ptr_star_func_var\s*=\s*ignore|sp_ptr_star_func_var\s*=\s*add|sp_ptr_star_func_var\s*=\s*remove|sp_ptr_star_func_var\s*=\s*force|sp_ptr_star_func_var\s*=\s*not_defined
+Choices=sp_ptr_star_func_var=ignore|sp_ptr_star_func_var=add|sp_ptr_star_func_var=remove|sp_ptr_star_func_var=force|sp_ptr_star_func_var=not_defined
+ChoicesRegex=sp_ptr_star_func_var\s*=\s*ignore|sp_ptr_star_func_var\s*=\s*add|sp_ptr_star_func_var\s*=\s*remove|sp_ptr_star_func_var\s*=\s*force|sp_ptr_star_func_var\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ptr Star Func Var|Add Sp Ptr Star Func Var|Remove Sp Ptr Star Func Var|Force Sp Ptr Star Func Var"
 ValueDefault=ignore
 
@@ -557,7 +616,8 @@ Category=1
 Description="<html>Add or remove space between the pointer star '*' and the name of the type<br/>in a function pointer type definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ptr_star_func_type\s*=\s*ignore|sp_ptr_star_func_type\s*=\s*add|sp_ptr_star_func_type\s*=\s*remove|sp_ptr_star_func_type\s*=\s*force|sp_ptr_star_func_type\s*=\s*not_defined
+Choices=sp_ptr_star_func_type=ignore|sp_ptr_star_func_type=add|sp_ptr_star_func_type=remove|sp_ptr_star_func_type=force|sp_ptr_star_func_type=not_defined
+ChoicesRegex=sp_ptr_star_func_type\s*=\s*ignore|sp_ptr_star_func_type\s*=\s*add|sp_ptr_star_func_type\s*=\s*remove|sp_ptr_star_func_type\s*=\s*force|sp_ptr_star_func_type\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ptr Star Func Type|Add Sp Ptr Star Func Type|Remove Sp Ptr Star Func Type|Force Sp Ptr Star Func Type"
 ValueDefault=ignore
 
@@ -566,7 +626,8 @@ Category=1
 Description="<html>Add or remove space after a pointer star '*', if followed by an open<br/>parenthesis, as in 'void* (*)()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ptr_star_paren\s*=\s*ignore|sp_ptr_star_paren\s*=\s*add|sp_ptr_star_paren\s*=\s*remove|sp_ptr_star_paren\s*=\s*force|sp_ptr_star_paren\s*=\s*not_defined
+Choices=sp_ptr_star_paren=ignore|sp_ptr_star_paren=add|sp_ptr_star_paren=remove|sp_ptr_star_paren=force|sp_ptr_star_paren=not_defined
+ChoicesRegex=sp_ptr_star_paren\s*=\s*ignore|sp_ptr_star_paren\s*=\s*add|sp_ptr_star_paren\s*=\s*remove|sp_ptr_star_paren\s*=\s*force|sp_ptr_star_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ptr Star Paren|Add Sp Ptr Star Paren|Remove Sp Ptr Star Paren|Force Sp Ptr Star Paren"
 ValueDefault=ignore
 
@@ -575,7 +636,8 @@ Category=1
 Description="<html>Add or remove space before a pointer star '*', if followed by a function<br/>prototype or function definition. If set to ignore, sp_before_ptr_star is<br/>used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_ptr_star_func\s*=\s*ignore|sp_before_ptr_star_func\s*=\s*add|sp_before_ptr_star_func\s*=\s*remove|sp_before_ptr_star_func\s*=\s*force|sp_before_ptr_star_func\s*=\s*not_defined
+Choices=sp_before_ptr_star_func=ignore|sp_before_ptr_star_func=add|sp_before_ptr_star_func=remove|sp_before_ptr_star_func=force|sp_before_ptr_star_func=not_defined
+ChoicesRegex=sp_before_ptr_star_func\s*=\s*ignore|sp_before_ptr_star_func\s*=\s*add|sp_before_ptr_star_func\s*=\s*remove|sp_before_ptr_star_func\s*=\s*force|sp_before_ptr_star_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Ptr Star Func|Add Sp Before Ptr Star Func|Remove Sp Before Ptr Star Func|Force Sp Before Ptr Star Func"
 ValueDefault=ignore
 
@@ -584,7 +646,8 @@ Category=1
 Description="<html>Add or remove space between a qualifier and a pointer star '*' followed by<br/>the name of the function in a function prototype or definition, as in<br/>'char const *foo()`. If set to ignore, sp_before_ptr_star is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_qualifier_ptr_star_func\s*=\s*ignore|sp_qualifier_ptr_star_func\s*=\s*add|sp_qualifier_ptr_star_func\s*=\s*remove|sp_qualifier_ptr_star_func\s*=\s*force|sp_qualifier_ptr_star_func\s*=\s*not_defined
+Choices=sp_qualifier_ptr_star_func=ignore|sp_qualifier_ptr_star_func=add|sp_qualifier_ptr_star_func=remove|sp_qualifier_ptr_star_func=force|sp_qualifier_ptr_star_func=not_defined
+ChoicesRegex=sp_qualifier_ptr_star_func\s*=\s*ignore|sp_qualifier_ptr_star_func\s*=\s*add|sp_qualifier_ptr_star_func\s*=\s*remove|sp_qualifier_ptr_star_func\s*=\s*force|sp_qualifier_ptr_star_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Qualifier Ptr Star Func|Add Sp Qualifier Ptr Star Func|Remove Sp Qualifier Ptr Star Func|Force Sp Qualifier Ptr Star Func"
 ValueDefault=ignore
 
@@ -593,7 +656,8 @@ Category=1
 Description="<html>Add or remove space before a pointer star '*' in the trailing return of a<br/>function prototype or function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_ptr_star_trailing\s*=\s*ignore|sp_before_ptr_star_trailing\s*=\s*add|sp_before_ptr_star_trailing\s*=\s*remove|sp_before_ptr_star_trailing\s*=\s*force|sp_before_ptr_star_trailing\s*=\s*not_defined
+Choices=sp_before_ptr_star_trailing=ignore|sp_before_ptr_star_trailing=add|sp_before_ptr_star_trailing=remove|sp_before_ptr_star_trailing=force|sp_before_ptr_star_trailing=not_defined
+ChoicesRegex=sp_before_ptr_star_trailing\s*=\s*ignore|sp_before_ptr_star_trailing\s*=\s*add|sp_before_ptr_star_trailing\s*=\s*remove|sp_before_ptr_star_trailing\s*=\s*force|sp_before_ptr_star_trailing\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Ptr Star Trailing|Add Sp Before Ptr Star Trailing|Remove Sp Before Ptr Star Trailing|Force Sp Before Ptr Star Trailing"
 ValueDefault=ignore
 
@@ -602,7 +666,8 @@ Category=1
 Description="<html>Add or remove space between a qualifier and a pointer star '*' in the<br/>trailing return of a function prototype or function definition, as in<br/>'auto foo() -&gt; char const *'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_qualifier_ptr_star_trailing\s*=\s*ignore|sp_qualifier_ptr_star_trailing\s*=\s*add|sp_qualifier_ptr_star_trailing\s*=\s*remove|sp_qualifier_ptr_star_trailing\s*=\s*force|sp_qualifier_ptr_star_trailing\s*=\s*not_defined
+Choices=sp_qualifier_ptr_star_trailing=ignore|sp_qualifier_ptr_star_trailing=add|sp_qualifier_ptr_star_trailing=remove|sp_qualifier_ptr_star_trailing=force|sp_qualifier_ptr_star_trailing=not_defined
+ChoicesRegex=sp_qualifier_ptr_star_trailing\s*=\s*ignore|sp_qualifier_ptr_star_trailing\s*=\s*add|sp_qualifier_ptr_star_trailing\s*=\s*remove|sp_qualifier_ptr_star_trailing\s*=\s*force|sp_qualifier_ptr_star_trailing\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Qualifier Ptr Star Trailing|Add Sp Qualifier Ptr Star Trailing|Remove Sp Qualifier Ptr Star Trailing|Force Sp Qualifier Ptr Star Trailing"
 ValueDefault=ignore
 
@@ -611,7 +676,8 @@ Category=1
 Description="<html>Add or remove space before a reference sign '&amp;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_byref\s*=\s*ignore|sp_before_byref\s*=\s*add|sp_before_byref\s*=\s*remove|sp_before_byref\s*=\s*force|sp_before_byref\s*=\s*not_defined
+Choices=sp_before_byref=ignore|sp_before_byref=add|sp_before_byref=remove|sp_before_byref=force|sp_before_byref=not_defined
+ChoicesRegex=sp_before_byref\s*=\s*ignore|sp_before_byref\s*=\s*add|sp_before_byref\s*=\s*remove|sp_before_byref\s*=\s*force|sp_before_byref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Byref|Add Sp Before Byref|Remove Sp Before Byref|Force Sp Before Byref"
 ValueDefault=ignore
 
@@ -620,7 +686,8 @@ Category=1
 Description="<html>Add or remove space before a reference sign '&amp;' that isn't followed by a<br/>variable name. If set to ignore, sp_before_byref is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_unnamed_byref\s*=\s*ignore|sp_before_unnamed_byref\s*=\s*add|sp_before_unnamed_byref\s*=\s*remove|sp_before_unnamed_byref\s*=\s*force|sp_before_unnamed_byref\s*=\s*not_defined
+Choices=sp_before_unnamed_byref=ignore|sp_before_unnamed_byref=add|sp_before_unnamed_byref=remove|sp_before_unnamed_byref=force|sp_before_unnamed_byref=not_defined
+ChoicesRegex=sp_before_unnamed_byref\s*=\s*ignore|sp_before_unnamed_byref\s*=\s*add|sp_before_unnamed_byref\s*=\s*remove|sp_before_unnamed_byref\s*=\s*force|sp_before_unnamed_byref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Unnamed Byref|Add Sp Before Unnamed Byref|Remove Sp Before Unnamed Byref|Force Sp Before Unnamed Byref"
 ValueDefault=ignore
 
@@ -629,7 +696,8 @@ Category=1
 Description="<html>Add or remove space after reference sign '&amp;', if followed by a word.<br/><br/>Overrides sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_byref\s*=\s*ignore|sp_after_byref\s*=\s*add|sp_after_byref\s*=\s*remove|sp_after_byref\s*=\s*force|sp_after_byref\s*=\s*not_defined
+Choices=sp_after_byref=ignore|sp_after_byref=add|sp_after_byref=remove|sp_after_byref=force|sp_after_byref=not_defined
+ChoicesRegex=sp_after_byref\s*=\s*ignore|sp_after_byref\s*=\s*add|sp_after_byref\s*=\s*remove|sp_after_byref\s*=\s*force|sp_after_byref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Byref|Add Sp After Byref|Remove Sp After Byref|Force Sp After Byref"
 ValueDefault=ignore
 
@@ -638,7 +706,8 @@ Category=1
 Description="<html>Add or remove space after a reference sign '&amp;', if followed by a function<br/>prototype or function definition.<br/><br/>Overrides sp_after_byref and sp_type_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_byref_func\s*=\s*ignore|sp_after_byref_func\s*=\s*add|sp_after_byref_func\s*=\s*remove|sp_after_byref_func\s*=\s*force|sp_after_byref_func\s*=\s*not_defined
+Choices=sp_after_byref_func=ignore|sp_after_byref_func=add|sp_after_byref_func=remove|sp_after_byref_func=force|sp_after_byref_func=not_defined
+ChoicesRegex=sp_after_byref_func\s*=\s*ignore|sp_after_byref_func\s*=\s*add|sp_after_byref_func\s*=\s*remove|sp_after_byref_func\s*=\s*force|sp_after_byref_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Byref Func|Add Sp After Byref Func|Remove Sp After Byref Func|Force Sp After Byref Func"
 ValueDefault=ignore
 
@@ -647,7 +716,8 @@ Category=1
 Description="<html>Add or remove space before a reference sign '&amp;', if followed by a function<br/>prototype or function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_byref_func\s*=\s*ignore|sp_before_byref_func\s*=\s*add|sp_before_byref_func\s*=\s*remove|sp_before_byref_func\s*=\s*force|sp_before_byref_func\s*=\s*not_defined
+Choices=sp_before_byref_func=ignore|sp_before_byref_func=add|sp_before_byref_func=remove|sp_before_byref_func=force|sp_before_byref_func=not_defined
+ChoicesRegex=sp_before_byref_func\s*=\s*ignore|sp_before_byref_func\s*=\s*add|sp_before_byref_func\s*=\s*remove|sp_before_byref_func\s*=\s*force|sp_before_byref_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Byref Func|Add Sp Before Byref Func|Remove Sp Before Byref Func|Force Sp Before Byref Func"
 ValueDefault=ignore
 
@@ -656,7 +726,8 @@ Category=1
 Description="<html>Add or remove space after a reference sign '&amp;', if followed by an open<br/>parenthesis, as in 'char&amp; (*)()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_byref_paren\s*=\s*ignore|sp_byref_paren\s*=\s*add|sp_byref_paren\s*=\s*remove|sp_byref_paren\s*=\s*force|sp_byref_paren\s*=\s*not_defined
+Choices=sp_byref_paren=ignore|sp_byref_paren=add|sp_byref_paren=remove|sp_byref_paren=force|sp_byref_paren=not_defined
+ChoicesRegex=sp_byref_paren\s*=\s*ignore|sp_byref_paren\s*=\s*add|sp_byref_paren\s*=\s*remove|sp_byref_paren\s*=\s*force|sp_byref_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Byref Paren|Add Sp Byref Paren|Remove Sp Byref Paren|Force Sp Byref Paren"
 ValueDefault=ignore
 
@@ -665,7 +736,8 @@ Category=1
 Description="<html>Add or remove space between type and word. In cases where total removal of<br/>whitespace would be a syntax error, a value of 'remove' is treated the same<br/>as 'force'.<br/><br/>This also affects some other instances of space following a type that are<br/>not covered by other options; for example, between the return type and<br/>parenthesis of a function type template argument, between the type and<br/>parenthesis of an array parameter, or between 'decltype(...)' and the<br/>following word.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_type\s*=\s*ignore|sp_after_type\s*=\s*add|sp_after_type\s*=\s*remove|sp_after_type\s*=\s*force|sp_after_type\s*=\s*not_defined
+Choices=sp_after_type=ignore|sp_after_type=add|sp_after_type=remove|sp_after_type=force|sp_after_type=not_defined
+ChoicesRegex=sp_after_type\s*=\s*ignore|sp_after_type\s*=\s*add|sp_after_type\s*=\s*remove|sp_after_type\s*=\s*force|sp_after_type\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Type|Add Sp After Type|Remove Sp After Type|Force Sp After Type"
 ValueDefault=force
 
@@ -674,7 +746,8 @@ Category=1
 Description="<html>Add or remove space between 'decltype(...)' and word,<br/>brace or function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_decltype\s*=\s*ignore|sp_after_decltype\s*=\s*add|sp_after_decltype\s*=\s*remove|sp_after_decltype\s*=\s*force|sp_after_decltype\s*=\s*not_defined
+Choices=sp_after_decltype=ignore|sp_after_decltype=add|sp_after_decltype=remove|sp_after_decltype=force|sp_after_decltype=not_defined
+ChoicesRegex=sp_after_decltype\s*=\s*ignore|sp_after_decltype\s*=\s*add|sp_after_decltype\s*=\s*remove|sp_after_decltype\s*=\s*force|sp_after_decltype\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Decltype|Add Sp After Decltype|Remove Sp After Decltype|Force Sp After Decltype"
 ValueDefault=ignore
 
@@ -683,7 +756,8 @@ Category=1
 Description="<html>(D) Add or remove space before the parenthesis in the D constructs<br/>'template Foo(' and 'class Foo('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_template_paren\s*=\s*ignore|sp_before_template_paren\s*=\s*add|sp_before_template_paren\s*=\s*remove|sp_before_template_paren\s*=\s*force|sp_before_template_paren\s*=\s*not_defined
+Choices=sp_before_template_paren=ignore|sp_before_template_paren=add|sp_before_template_paren=remove|sp_before_template_paren=force|sp_before_template_paren=not_defined
+ChoicesRegex=sp_before_template_paren\s*=\s*ignore|sp_before_template_paren\s*=\s*add|sp_before_template_paren\s*=\s*remove|sp_before_template_paren\s*=\s*force|sp_before_template_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Template Paren|Add Sp Before Template Paren|Remove Sp Before Template Paren|Force Sp Before Template Paren"
 ValueDefault=ignore
 
@@ -692,7 +766,8 @@ Category=1
 Description="<html>Add or remove space between 'template' and '&lt;'.<br/>If set to ignore, sp_before_angle is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_template_angle\s*=\s*ignore|sp_template_angle\s*=\s*add|sp_template_angle\s*=\s*remove|sp_template_angle\s*=\s*force|sp_template_angle\s*=\s*not_defined
+Choices=sp_template_angle=ignore|sp_template_angle=add|sp_template_angle=remove|sp_template_angle=force|sp_template_angle=not_defined
+ChoicesRegex=sp_template_angle\s*=\s*ignore|sp_template_angle\s*=\s*add|sp_template_angle\s*=\s*remove|sp_template_angle\s*=\s*force|sp_template_angle\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Template Angle|Add Sp Template Angle|Remove Sp Template Angle|Force Sp Template Angle"
 ValueDefault=ignore
 
@@ -701,7 +776,8 @@ Category=1
 Description="<html>Add or remove space before '&lt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_angle\s*=\s*ignore|sp_before_angle\s*=\s*add|sp_before_angle\s*=\s*remove|sp_before_angle\s*=\s*force|sp_before_angle\s*=\s*not_defined
+Choices=sp_before_angle=ignore|sp_before_angle=add|sp_before_angle=remove|sp_before_angle=force|sp_before_angle=not_defined
+ChoicesRegex=sp_before_angle\s*=\s*ignore|sp_before_angle\s*=\s*add|sp_before_angle\s*=\s*remove|sp_before_angle\s*=\s*force|sp_before_angle\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Angle|Add Sp Before Angle|Remove Sp Before Angle|Force Sp Before Angle"
 ValueDefault=ignore
 
@@ -710,7 +786,8 @@ Category=1
 Description="<html>Add or remove space inside '&lt;' and '&gt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_angle\s*=\s*ignore|sp_inside_angle\s*=\s*add|sp_inside_angle\s*=\s*remove|sp_inside_angle\s*=\s*force|sp_inside_angle\s*=\s*not_defined
+Choices=sp_inside_angle=ignore|sp_inside_angle=add|sp_inside_angle=remove|sp_inside_angle=force|sp_inside_angle=not_defined
+ChoicesRegex=sp_inside_angle\s*=\s*ignore|sp_inside_angle\s*=\s*add|sp_inside_angle\s*=\s*remove|sp_inside_angle\s*=\s*force|sp_inside_angle\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Angle|Add Sp Inside Angle|Remove Sp Inside Angle|Force Sp Inside Angle"
 ValueDefault=ignore
 
@@ -719,7 +796,8 @@ Category=1
 Description="<html>Add or remove space inside '&lt;&gt;'.<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_angle_empty\s*=\s*ignore|sp_inside_angle_empty\s*=\s*add|sp_inside_angle_empty\s*=\s*remove|sp_inside_angle_empty\s*=\s*force|sp_inside_angle_empty\s*=\s*not_defined
+Choices=sp_inside_angle_empty=ignore|sp_inside_angle_empty=add|sp_inside_angle_empty=remove|sp_inside_angle_empty=force|sp_inside_angle_empty=not_defined
+ChoicesRegex=sp_inside_angle_empty\s*=\s*ignore|sp_inside_angle_empty\s*=\s*add|sp_inside_angle_empty\s*=\s*remove|sp_inside_angle_empty\s*=\s*force|sp_inside_angle_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Angle Empty|Add Sp Inside Angle Empty|Remove Sp Inside Angle Empty|Force Sp Inside Angle Empty"
 ValueDefault=ignore
 
@@ -728,7 +806,8 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_colon\s*=\s*ignore|sp_angle_colon\s*=\s*add|sp_angle_colon\s*=\s*remove|sp_angle_colon\s*=\s*force|sp_angle_colon\s*=\s*not_defined
+Choices=sp_angle_colon=ignore|sp_angle_colon=add|sp_angle_colon=remove|sp_angle_colon=force|sp_angle_colon=not_defined
+ChoicesRegex=sp_angle_colon\s*=\s*ignore|sp_angle_colon\s*=\s*add|sp_angle_colon\s*=\s*remove|sp_angle_colon\s*=\s*force|sp_angle_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Colon|Add Sp Angle Colon|Remove Sp Angle Colon|Force Sp Angle Colon"
 ValueDefault=ignore
 
@@ -737,7 +816,8 @@ Category=1
 Description="<html>Add or remove space after '&gt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_angle\s*=\s*ignore|sp_after_angle\s*=\s*add|sp_after_angle\s*=\s*remove|sp_after_angle\s*=\s*force|sp_after_angle\s*=\s*not_defined
+Choices=sp_after_angle=ignore|sp_after_angle=add|sp_after_angle=remove|sp_after_angle=force|sp_after_angle=not_defined
+ChoicesRegex=sp_after_angle\s*=\s*ignore|sp_after_angle\s*=\s*add|sp_after_angle\s*=\s*remove|sp_after_angle\s*=\s*force|sp_after_angle\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Angle|Add Sp After Angle|Remove Sp After Angle|Force Sp After Angle"
 ValueDefault=ignore
 
@@ -746,7 +826,8 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and '(' as found in 'new List&lt;byte&gt;(foo);'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_paren\s*=\s*ignore|sp_angle_paren\s*=\s*add|sp_angle_paren\s*=\s*remove|sp_angle_paren\s*=\s*force|sp_angle_paren\s*=\s*not_defined
+Choices=sp_angle_paren=ignore|sp_angle_paren=add|sp_angle_paren=remove|sp_angle_paren=force|sp_angle_paren=not_defined
+ChoicesRegex=sp_angle_paren\s*=\s*ignore|sp_angle_paren\s*=\s*add|sp_angle_paren\s*=\s*remove|sp_angle_paren\s*=\s*force|sp_angle_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Paren|Add Sp Angle Paren|Remove Sp Angle Paren|Force Sp Angle Paren"
 ValueDefault=ignore
 
@@ -755,7 +836,8 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and '()' as found in 'new List&lt;byte&gt;();'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_paren_empty\s*=\s*ignore|sp_angle_paren_empty\s*=\s*add|sp_angle_paren_empty\s*=\s*remove|sp_angle_paren_empty\s*=\s*force|sp_angle_paren_empty\s*=\s*not_defined
+Choices=sp_angle_paren_empty=ignore|sp_angle_paren_empty=add|sp_angle_paren_empty=remove|sp_angle_paren_empty=force|sp_angle_paren_empty=not_defined
+ChoicesRegex=sp_angle_paren_empty\s*=\s*ignore|sp_angle_paren_empty\s*=\s*add|sp_angle_paren_empty\s*=\s*remove|sp_angle_paren_empty\s*=\s*force|sp_angle_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Paren Empty|Add Sp Angle Paren Empty|Remove Sp Angle Paren Empty|Force Sp Angle Paren Empty"
 ValueDefault=ignore
 
@@ -764,7 +846,8 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and a word as in 'List&lt;byte&gt; m;' or<br/>'template &lt;typename T&gt; static ...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_word\s*=\s*ignore|sp_angle_word\s*=\s*add|sp_angle_word\s*=\s*remove|sp_angle_word\s*=\s*force|sp_angle_word\s*=\s*not_defined
+Choices=sp_angle_word=ignore|sp_angle_word=add|sp_angle_word=remove|sp_angle_word=force|sp_angle_word=not_defined
+ChoicesRegex=sp_angle_word\s*=\s*ignore|sp_angle_word\s*=\s*add|sp_angle_word\s*=\s*remove|sp_angle_word\s*=\s*force|sp_angle_word\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Word|Add Sp Angle Word|Remove Sp Angle Word|Force Sp Angle Word"
 ValueDefault=ignore
 
@@ -773,7 +856,8 @@ Category=1
 Description="<html>Add or remove space between '&gt;' and '&gt;' in '&gt;&gt;' (template stuff).<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_angle_shift\s*=\s*ignore|sp_angle_shift\s*=\s*add|sp_angle_shift\s*=\s*remove|sp_angle_shift\s*=\s*force|sp_angle_shift\s*=\s*not_defined
+Choices=sp_angle_shift=ignore|sp_angle_shift=add|sp_angle_shift=remove|sp_angle_shift=force|sp_angle_shift=not_defined
+ChoicesRegex=sp_angle_shift\s*=\s*ignore|sp_angle_shift\s*=\s*add|sp_angle_shift\s*=\s*remove|sp_angle_shift\s*=\s*force|sp_angle_shift\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Angle Shift|Add Sp Angle Shift|Remove Sp Angle Shift|Force Sp Angle Shift"
 ValueDefault=add
 
@@ -782,7 +866,8 @@ Category=1
 Description="<html>(C++11) Permit removal of the space between '&gt;&gt;' in 'foo&lt;bar&lt;int&gt; &gt;'. Note<br/>that sp_angle_shift cannot remove the space without this option.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_permit_cpp11_shift\s*=\s*true|sp_permit_cpp11_shift\s*=\s*false
+TrueFalse=sp_permit_cpp11_shift=true|sp_permit_cpp11_shift=false
+TrueFalseRegex=sp_permit_cpp11_shift\s*=\s*true|sp_permit_cpp11_shift\s*=\s*false
 ValueDefault=false
 
 [Sp Before Sparen]
@@ -790,7 +875,8 @@ Category=1
 Description="<html>Add or remove space before '(' of control statements ('if', 'for', 'switch',<br/>'while', etc.).</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_sparen\s*=\s*ignore|sp_before_sparen\s*=\s*add|sp_before_sparen\s*=\s*remove|sp_before_sparen\s*=\s*force|sp_before_sparen\s*=\s*not_defined
+Choices=sp_before_sparen=ignore|sp_before_sparen=add|sp_before_sparen=remove|sp_before_sparen=force|sp_before_sparen=not_defined
+ChoicesRegex=sp_before_sparen\s*=\s*ignore|sp_before_sparen\s*=\s*add|sp_before_sparen\s*=\s*remove|sp_before_sparen\s*=\s*force|sp_before_sparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Sparen|Add Sp Before Sparen|Remove Sp Before Sparen|Force Sp Before Sparen"
 ValueDefault=ignore
 
@@ -799,7 +885,8 @@ Category=1
 Description="<html>Add or remove space inside '(' and ')' of control statements other than<br/>'for'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_sparen\s*=\s*ignore|sp_inside_sparen\s*=\s*add|sp_inside_sparen\s*=\s*remove|sp_inside_sparen\s*=\s*force|sp_inside_sparen\s*=\s*not_defined
+Choices=sp_inside_sparen=ignore|sp_inside_sparen=add|sp_inside_sparen=remove|sp_inside_sparen=force|sp_inside_sparen=not_defined
+ChoicesRegex=sp_inside_sparen\s*=\s*ignore|sp_inside_sparen\s*=\s*add|sp_inside_sparen\s*=\s*remove|sp_inside_sparen\s*=\s*force|sp_inside_sparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Sparen|Add Sp Inside Sparen|Remove Sp Inside Sparen|Force Sp Inside Sparen"
 ValueDefault=ignore
 
@@ -808,7 +895,8 @@ Category=1
 Description="<html>Add or remove space after '(' of control statements other than 'for'.<br/><br/>Overrides sp_inside_sparen.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_sparen_open\s*=\s*ignore|sp_inside_sparen_open\s*=\s*add|sp_inside_sparen_open\s*=\s*remove|sp_inside_sparen_open\s*=\s*force|sp_inside_sparen_open\s*=\s*not_defined
+Choices=sp_inside_sparen_open=ignore|sp_inside_sparen_open=add|sp_inside_sparen_open=remove|sp_inside_sparen_open=force|sp_inside_sparen_open=not_defined
+ChoicesRegex=sp_inside_sparen_open\s*=\s*ignore|sp_inside_sparen_open\s*=\s*add|sp_inside_sparen_open\s*=\s*remove|sp_inside_sparen_open\s*=\s*force|sp_inside_sparen_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Sparen Open|Add Sp Inside Sparen Open|Remove Sp Inside Sparen Open|Force Sp Inside Sparen Open"
 ValueDefault=ignore
 
@@ -817,7 +905,8 @@ Category=1
 Description="<html>Add or remove space before ')' of control statements other than 'for'.<br/><br/>Overrides sp_inside_sparen.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_sparen_close\s*=\s*ignore|sp_inside_sparen_close\s*=\s*add|sp_inside_sparen_close\s*=\s*remove|sp_inside_sparen_close\s*=\s*force|sp_inside_sparen_close\s*=\s*not_defined
+Choices=sp_inside_sparen_close=ignore|sp_inside_sparen_close=add|sp_inside_sparen_close=remove|sp_inside_sparen_close=force|sp_inside_sparen_close=not_defined
+ChoicesRegex=sp_inside_sparen_close\s*=\s*ignore|sp_inside_sparen_close\s*=\s*add|sp_inside_sparen_close\s*=\s*remove|sp_inside_sparen_close\s*=\s*force|sp_inside_sparen_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Sparen Close|Add Sp Inside Sparen Close|Remove Sp Inside Sparen Close|Force Sp Inside Sparen Close"
 ValueDefault=ignore
 
@@ -826,7 +915,8 @@ Category=1
 Description="<html>Add or remove space inside '(' and ')' of 'for' statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_for\s*=\s*ignore|sp_inside_for\s*=\s*add|sp_inside_for\s*=\s*remove|sp_inside_for\s*=\s*force|sp_inside_for\s*=\s*not_defined
+Choices=sp_inside_for=ignore|sp_inside_for=add|sp_inside_for=remove|sp_inside_for=force|sp_inside_for=not_defined
+ChoicesRegex=sp_inside_for\s*=\s*ignore|sp_inside_for\s*=\s*add|sp_inside_for\s*=\s*remove|sp_inside_for\s*=\s*force|sp_inside_for\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside For|Add Sp Inside For|Remove Sp Inside For|Force Sp Inside For"
 ValueDefault=ignore
 
@@ -835,7 +925,8 @@ Category=1
 Description="<html>Add or remove space after '(' of 'for' statements.<br/><br/>Overrides sp_inside_for.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_for_open\s*=\s*ignore|sp_inside_for_open\s*=\s*add|sp_inside_for_open\s*=\s*remove|sp_inside_for_open\s*=\s*force|sp_inside_for_open\s*=\s*not_defined
+Choices=sp_inside_for_open=ignore|sp_inside_for_open=add|sp_inside_for_open=remove|sp_inside_for_open=force|sp_inside_for_open=not_defined
+ChoicesRegex=sp_inside_for_open\s*=\s*ignore|sp_inside_for_open\s*=\s*add|sp_inside_for_open\s*=\s*remove|sp_inside_for_open\s*=\s*force|sp_inside_for_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside For Open|Add Sp Inside For Open|Remove Sp Inside For Open|Force Sp Inside For Open"
 ValueDefault=ignore
 
@@ -844,7 +935,8 @@ Category=1
 Description="<html>Add or remove space before ')' of 'for' statements.<br/><br/>Overrides sp_inside_for.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_for_close\s*=\s*ignore|sp_inside_for_close\s*=\s*add|sp_inside_for_close\s*=\s*remove|sp_inside_for_close\s*=\s*force|sp_inside_for_close\s*=\s*not_defined
+Choices=sp_inside_for_close=ignore|sp_inside_for_close=add|sp_inside_for_close=remove|sp_inside_for_close=force|sp_inside_for_close=not_defined
+ChoicesRegex=sp_inside_for_close\s*=\s*ignore|sp_inside_for_close\s*=\s*add|sp_inside_for_close\s*=\s*remove|sp_inside_for_close\s*=\s*force|sp_inside_for_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside For Close|Add Sp Inside For Close|Remove Sp Inside For Close|Force Sp Inside For Close"
 ValueDefault=ignore
 
@@ -853,7 +945,8 @@ Category=1
 Description="<html>Add or remove space between '((' or '))' of control statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sparen_paren\s*=\s*ignore|sp_sparen_paren\s*=\s*add|sp_sparen_paren\s*=\s*remove|sp_sparen_paren\s*=\s*force|sp_sparen_paren\s*=\s*not_defined
+Choices=sp_sparen_paren=ignore|sp_sparen_paren=add|sp_sparen_paren=remove|sp_sparen_paren=force|sp_sparen_paren=not_defined
+ChoicesRegex=sp_sparen_paren\s*=\s*ignore|sp_sparen_paren\s*=\s*add|sp_sparen_paren\s*=\s*remove|sp_sparen_paren\s*=\s*force|sp_sparen_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sparen Paren|Add Sp Sparen Paren|Remove Sp Sparen Paren|Force Sp Sparen Paren"
 ValueDefault=ignore
 
@@ -862,7 +955,8 @@ Category=1
 Description="<html>Add or remove space after ')' of control statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_sparen\s*=\s*ignore|sp_after_sparen\s*=\s*add|sp_after_sparen\s*=\s*remove|sp_after_sparen\s*=\s*force|sp_after_sparen\s*=\s*not_defined
+Choices=sp_after_sparen=ignore|sp_after_sparen=add|sp_after_sparen=remove|sp_after_sparen=force|sp_after_sparen=not_defined
+ChoicesRegex=sp_after_sparen\s*=\s*ignore|sp_after_sparen\s*=\s*add|sp_after_sparen\s*=\s*remove|sp_after_sparen\s*=\s*force|sp_after_sparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Sparen|Add Sp After Sparen|Remove Sp After Sparen|Force Sp After Sparen"
 ValueDefault=ignore
 
@@ -871,7 +965,8 @@ Category=1
 Description="<html>Add or remove space between ')' and '{' of control statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sparen_brace\s*=\s*ignore|sp_sparen_brace\s*=\s*add|sp_sparen_brace\s*=\s*remove|sp_sparen_brace\s*=\s*force|sp_sparen_brace\s*=\s*not_defined
+Choices=sp_sparen_brace=ignore|sp_sparen_brace=add|sp_sparen_brace=remove|sp_sparen_brace=force|sp_sparen_brace=not_defined
+ChoicesRegex=sp_sparen_brace\s*=\s*ignore|sp_sparen_brace\s*=\s*add|sp_sparen_brace\s*=\s*remove|sp_sparen_brace\s*=\s*force|sp_sparen_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sparen Brace|Add Sp Sparen Brace|Remove Sp Sparen Brace|Force Sp Sparen Brace"
 ValueDefault=ignore
 
@@ -880,7 +975,8 @@ Category=1
 Description="<html>Add or remove space between 'do' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_do_brace_open\s*=\s*ignore|sp_do_brace_open\s*=\s*add|sp_do_brace_open\s*=\s*remove|sp_do_brace_open\s*=\s*force|sp_do_brace_open\s*=\s*not_defined
+Choices=sp_do_brace_open=ignore|sp_do_brace_open=add|sp_do_brace_open=remove|sp_do_brace_open=force|sp_do_brace_open=not_defined
+ChoicesRegex=sp_do_brace_open\s*=\s*ignore|sp_do_brace_open\s*=\s*add|sp_do_brace_open\s*=\s*remove|sp_do_brace_open\s*=\s*force|sp_do_brace_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Do Brace Open|Add Sp Do Brace Open|Remove Sp Do Brace Open|Force Sp Do Brace Open"
 ValueDefault=ignore
 
@@ -889,7 +985,8 @@ Category=1
 Description="<html>Add or remove space between '}' and 'while'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_close_while\s*=\s*ignore|sp_brace_close_while\s*=\s*add|sp_brace_close_while\s*=\s*remove|sp_brace_close_while\s*=\s*force|sp_brace_close_while\s*=\s*not_defined
+Choices=sp_brace_close_while=ignore|sp_brace_close_while=add|sp_brace_close_while=remove|sp_brace_close_while=force|sp_brace_close_while=not_defined
+ChoicesRegex=sp_brace_close_while\s*=\s*ignore|sp_brace_close_while\s*=\s*add|sp_brace_close_while\s*=\s*remove|sp_brace_close_while\s*=\s*force|sp_brace_close_while\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Close While|Add Sp Brace Close While|Remove Sp Brace Close While|Force Sp Brace Close While"
 ValueDefault=ignore
 
@@ -898,7 +995,8 @@ Category=1
 Description="<html>Add or remove space between 'while' and '('. Overrides sp_before_sparen.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_while_paren_open\s*=\s*ignore|sp_while_paren_open\s*=\s*add|sp_while_paren_open\s*=\s*remove|sp_while_paren_open\s*=\s*force|sp_while_paren_open\s*=\s*not_defined
+Choices=sp_while_paren_open=ignore|sp_while_paren_open=add|sp_while_paren_open=remove|sp_while_paren_open=force|sp_while_paren_open=not_defined
+ChoicesRegex=sp_while_paren_open\s*=\s*ignore|sp_while_paren_open\s*=\s*add|sp_while_paren_open\s*=\s*remove|sp_while_paren_open\s*=\s*force|sp_while_paren_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp While Paren Open|Add Sp While Paren Open|Remove Sp While Paren Open|Force Sp While Paren Open"
 ValueDefault=ignore
 
@@ -907,7 +1005,8 @@ Category=1
 Description="<html>(D) Add or remove space between 'invariant' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_invariant_paren\s*=\s*ignore|sp_invariant_paren\s*=\s*add|sp_invariant_paren\s*=\s*remove|sp_invariant_paren\s*=\s*force|sp_invariant_paren\s*=\s*not_defined
+Choices=sp_invariant_paren=ignore|sp_invariant_paren=add|sp_invariant_paren=remove|sp_invariant_paren=force|sp_invariant_paren=not_defined
+ChoicesRegex=sp_invariant_paren\s*=\s*ignore|sp_invariant_paren\s*=\s*add|sp_invariant_paren\s*=\s*remove|sp_invariant_paren\s*=\s*force|sp_invariant_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Invariant Paren|Add Sp Invariant Paren|Remove Sp Invariant Paren|Force Sp Invariant Paren"
 ValueDefault=ignore
 
@@ -916,7 +1015,8 @@ Category=1
 Description="<html>(D) Add or remove space after the ')' in 'invariant (C) c'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_invariant_paren\s*=\s*ignore|sp_after_invariant_paren\s*=\s*add|sp_after_invariant_paren\s*=\s*remove|sp_after_invariant_paren\s*=\s*force|sp_after_invariant_paren\s*=\s*not_defined
+Choices=sp_after_invariant_paren=ignore|sp_after_invariant_paren=add|sp_after_invariant_paren=remove|sp_after_invariant_paren=force|sp_after_invariant_paren=not_defined
+ChoicesRegex=sp_after_invariant_paren\s*=\s*ignore|sp_after_invariant_paren\s*=\s*add|sp_after_invariant_paren\s*=\s*remove|sp_after_invariant_paren\s*=\s*force|sp_after_invariant_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Invariant Paren|Add Sp After Invariant Paren|Remove Sp After Invariant Paren|Force Sp After Invariant Paren"
 ValueDefault=ignore
 
@@ -925,7 +1025,8 @@ Category=1
 Description="<html>Add or remove space before empty statement ';' on 'if', 'for' and 'while'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_special_semi\s*=\s*ignore|sp_special_semi\s*=\s*add|sp_special_semi\s*=\s*remove|sp_special_semi\s*=\s*force|sp_special_semi\s*=\s*not_defined
+Choices=sp_special_semi=ignore|sp_special_semi=add|sp_special_semi=remove|sp_special_semi=force|sp_special_semi=not_defined
+ChoicesRegex=sp_special_semi\s*=\s*ignore|sp_special_semi\s*=\s*add|sp_special_semi\s*=\s*remove|sp_special_semi\s*=\s*force|sp_special_semi\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Special Semi|Add Sp Special Semi|Remove Sp Special Semi|Force Sp Special Semi"
 ValueDefault=ignore
 
@@ -934,7 +1035,8 @@ Category=1
 Description="<html>Add or remove space before ';'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_semi\s*=\s*ignore|sp_before_semi\s*=\s*add|sp_before_semi\s*=\s*remove|sp_before_semi\s*=\s*force|sp_before_semi\s*=\s*not_defined
+Choices=sp_before_semi=ignore|sp_before_semi=add|sp_before_semi=remove|sp_before_semi=force|sp_before_semi=not_defined
+ChoicesRegex=sp_before_semi\s*=\s*ignore|sp_before_semi\s*=\s*add|sp_before_semi\s*=\s*remove|sp_before_semi\s*=\s*force|sp_before_semi\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Semi|Add Sp Before Semi|Remove Sp Before Semi|Force Sp Before Semi"
 ValueDefault=remove
 
@@ -943,7 +1045,8 @@ Category=1
 Description="<html>Add or remove space before ';' in non-empty 'for' statements.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_semi_for\s*=\s*ignore|sp_before_semi_for\s*=\s*add|sp_before_semi_for\s*=\s*remove|sp_before_semi_for\s*=\s*force|sp_before_semi_for\s*=\s*not_defined
+Choices=sp_before_semi_for=ignore|sp_before_semi_for=add|sp_before_semi_for=remove|sp_before_semi_for=force|sp_before_semi_for=not_defined
+ChoicesRegex=sp_before_semi_for\s*=\s*ignore|sp_before_semi_for\s*=\s*add|sp_before_semi_for\s*=\s*remove|sp_before_semi_for\s*=\s*force|sp_before_semi_for\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Semi For|Add Sp Before Semi For|Remove Sp Before Semi For|Force Sp Before Semi For"
 ValueDefault=ignore
 
@@ -952,7 +1055,8 @@ Category=1
 Description="<html>Add or remove space before a semicolon of an empty left part of a for<br/>statement, as in 'for ( &lt;here&gt; ; ; )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_semi_for_empty\s*=\s*ignore|sp_before_semi_for_empty\s*=\s*add|sp_before_semi_for_empty\s*=\s*remove|sp_before_semi_for_empty\s*=\s*force|sp_before_semi_for_empty\s*=\s*not_defined
+Choices=sp_before_semi_for_empty=ignore|sp_before_semi_for_empty=add|sp_before_semi_for_empty=remove|sp_before_semi_for_empty=force|sp_before_semi_for_empty=not_defined
+ChoicesRegex=sp_before_semi_for_empty\s*=\s*ignore|sp_before_semi_for_empty\s*=\s*add|sp_before_semi_for_empty\s*=\s*remove|sp_before_semi_for_empty\s*=\s*force|sp_before_semi_for_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Semi For Empty|Add Sp Before Semi For Empty|Remove Sp Before Semi For Empty|Force Sp Before Semi For Empty"
 ValueDefault=ignore
 
@@ -961,7 +1065,8 @@ Category=1
 Description="<html>Add or remove space between the semicolons of an empty middle part of a for<br/>statement, as in 'for ( ; &lt;here&gt; ; )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_semi_for_empty\s*=\s*ignore|sp_between_semi_for_empty\s*=\s*add|sp_between_semi_for_empty\s*=\s*remove|sp_between_semi_for_empty\s*=\s*force|sp_between_semi_for_empty\s*=\s*not_defined
+Choices=sp_between_semi_for_empty=ignore|sp_between_semi_for_empty=add|sp_between_semi_for_empty=remove|sp_between_semi_for_empty=force|sp_between_semi_for_empty=not_defined
+ChoicesRegex=sp_between_semi_for_empty\s*=\s*ignore|sp_between_semi_for_empty\s*=\s*add|sp_between_semi_for_empty\s*=\s*remove|sp_between_semi_for_empty\s*=\s*force|sp_between_semi_for_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between Semi For Empty|Add Sp Between Semi For Empty|Remove Sp Between Semi For Empty|Force Sp Between Semi For Empty"
 ValueDefault=ignore
 
@@ -970,7 +1075,8 @@ Category=1
 Description="<html>Add or remove space after ';', except when followed by a comment.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_semi\s*=\s*ignore|sp_after_semi\s*=\s*add|sp_after_semi\s*=\s*remove|sp_after_semi\s*=\s*force|sp_after_semi\s*=\s*not_defined
+Choices=sp_after_semi=ignore|sp_after_semi=add|sp_after_semi=remove|sp_after_semi=force|sp_after_semi=not_defined
+ChoicesRegex=sp_after_semi\s*=\s*ignore|sp_after_semi\s*=\s*add|sp_after_semi\s*=\s*remove|sp_after_semi\s*=\s*force|sp_after_semi\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Semi|Add Sp After Semi|Remove Sp After Semi|Force Sp After Semi"
 ValueDefault=add
 
@@ -979,7 +1085,8 @@ Category=1
 Description="<html>Add or remove space after ';' in non-empty 'for' statements.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_semi_for\s*=\s*ignore|sp_after_semi_for\s*=\s*add|sp_after_semi_for\s*=\s*remove|sp_after_semi_for\s*=\s*force|sp_after_semi_for\s*=\s*not_defined
+Choices=sp_after_semi_for=ignore|sp_after_semi_for=add|sp_after_semi_for=remove|sp_after_semi_for=force|sp_after_semi_for=not_defined
+ChoicesRegex=sp_after_semi_for\s*=\s*ignore|sp_after_semi_for\s*=\s*add|sp_after_semi_for\s*=\s*remove|sp_after_semi_for\s*=\s*force|sp_after_semi_for\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Semi For|Add Sp After Semi For|Remove Sp After Semi For|Force Sp After Semi For"
 ValueDefault=force
 
@@ -988,7 +1095,8 @@ Category=1
 Description="<html>Add or remove space after the final semicolon of an empty part of a for<br/>statement, as in 'for ( ; ; &lt;here&gt; )'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_semi_for_empty\s*=\s*ignore|sp_after_semi_for_empty\s*=\s*add|sp_after_semi_for_empty\s*=\s*remove|sp_after_semi_for_empty\s*=\s*force|sp_after_semi_for_empty\s*=\s*not_defined
+Choices=sp_after_semi_for_empty=ignore|sp_after_semi_for_empty=add|sp_after_semi_for_empty=remove|sp_after_semi_for_empty=force|sp_after_semi_for_empty=not_defined
+ChoicesRegex=sp_after_semi_for_empty\s*=\s*ignore|sp_after_semi_for_empty\s*=\s*add|sp_after_semi_for_empty\s*=\s*remove|sp_after_semi_for_empty\s*=\s*force|sp_after_semi_for_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Semi For Empty|Add Sp After Semi For Empty|Remove Sp After Semi For Empty|Force Sp After Semi For Empty"
 ValueDefault=ignore
 
@@ -997,7 +1105,8 @@ Category=1
 Description="<html>Add or remove space before '[' (except '[]').</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_square\s*=\s*ignore|sp_before_square\s*=\s*add|sp_before_square\s*=\s*remove|sp_before_square\s*=\s*force|sp_before_square\s*=\s*not_defined
+Choices=sp_before_square=ignore|sp_before_square=add|sp_before_square=remove|sp_before_square=force|sp_before_square=not_defined
+ChoicesRegex=sp_before_square\s*=\s*ignore|sp_before_square\s*=\s*add|sp_before_square\s*=\s*remove|sp_before_square\s*=\s*force|sp_before_square\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Square|Add Sp Before Square|Remove Sp Before Square|Force Sp Before Square"
 ValueDefault=ignore
 
@@ -1006,7 +1115,8 @@ Category=1
 Description="<html>Add or remove space before '[' for a variable definition.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_vardef_square\s*=\s*ignore|sp_before_vardef_square\s*=\s*add|sp_before_vardef_square\s*=\s*remove|sp_before_vardef_square\s*=\s*force|sp_before_vardef_square\s*=\s*not_defined
+Choices=sp_before_vardef_square=ignore|sp_before_vardef_square=add|sp_before_vardef_square=remove|sp_before_vardef_square=force|sp_before_vardef_square=not_defined
+ChoicesRegex=sp_before_vardef_square\s*=\s*ignore|sp_before_vardef_square\s*=\s*add|sp_before_vardef_square\s*=\s*remove|sp_before_vardef_square\s*=\s*force|sp_before_vardef_square\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Vardef Square|Add Sp Before Vardef Square|Remove Sp Before Vardef Square|Force Sp Before Vardef Square"
 ValueDefault=remove
 
@@ -1015,7 +1125,8 @@ Category=1
 Description="<html>Add or remove space before '[' for asm block.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_square_asm_block\s*=\s*ignore|sp_before_square_asm_block\s*=\s*add|sp_before_square_asm_block\s*=\s*remove|sp_before_square_asm_block\s*=\s*force|sp_before_square_asm_block\s*=\s*not_defined
+Choices=sp_before_square_asm_block=ignore|sp_before_square_asm_block=add|sp_before_square_asm_block=remove|sp_before_square_asm_block=force|sp_before_square_asm_block=not_defined
+ChoicesRegex=sp_before_square_asm_block\s*=\s*ignore|sp_before_square_asm_block\s*=\s*add|sp_before_square_asm_block\s*=\s*remove|sp_before_square_asm_block\s*=\s*force|sp_before_square_asm_block\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Square Asm Block|Add Sp Before Square Asm Block|Remove Sp Before Square Asm Block|Force Sp Before Square Asm Block"
 ValueDefault=ignore
 
@@ -1024,7 +1135,8 @@ Category=1
 Description="<html>Add or remove space before '[]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_squares\s*=\s*ignore|sp_before_squares\s*=\s*add|sp_before_squares\s*=\s*remove|sp_before_squares\s*=\s*force|sp_before_squares\s*=\s*not_defined
+Choices=sp_before_squares=ignore|sp_before_squares=add|sp_before_squares=remove|sp_before_squares=force|sp_before_squares=not_defined
+ChoicesRegex=sp_before_squares\s*=\s*ignore|sp_before_squares\s*=\s*add|sp_before_squares\s*=\s*remove|sp_before_squares\s*=\s*force|sp_before_squares\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Squares|Add Sp Before Squares|Remove Sp Before Squares|Force Sp Before Squares"
 ValueDefault=ignore
 
@@ -1033,7 +1145,8 @@ Category=1
 Description="<html>Add or remove space before C++17 structured bindings.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_before_struct_binding\s*=\s*ignore|sp_cpp_before_struct_binding\s*=\s*add|sp_cpp_before_struct_binding\s*=\s*remove|sp_cpp_before_struct_binding\s*=\s*force|sp_cpp_before_struct_binding\s*=\s*not_defined
+Choices=sp_cpp_before_struct_binding=ignore|sp_cpp_before_struct_binding=add|sp_cpp_before_struct_binding=remove|sp_cpp_before_struct_binding=force|sp_cpp_before_struct_binding=not_defined
+ChoicesRegex=sp_cpp_before_struct_binding\s*=\s*ignore|sp_cpp_before_struct_binding\s*=\s*add|sp_cpp_before_struct_binding\s*=\s*remove|sp_cpp_before_struct_binding\s*=\s*force|sp_cpp_before_struct_binding\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Before Struct Binding|Add Sp Cpp Before Struct Binding|Remove Sp Cpp Before Struct Binding|Force Sp Cpp Before Struct Binding"
 ValueDefault=ignore
 
@@ -1042,7 +1155,8 @@ Category=1
 Description="<html>Add or remove space inside a non-empty '[' and ']'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_square\s*=\s*ignore|sp_inside_square\s*=\s*add|sp_inside_square\s*=\s*remove|sp_inside_square\s*=\s*force|sp_inside_square\s*=\s*not_defined
+Choices=sp_inside_square=ignore|sp_inside_square=add|sp_inside_square=remove|sp_inside_square=force|sp_inside_square=not_defined
+ChoicesRegex=sp_inside_square\s*=\s*ignore|sp_inside_square\s*=\s*add|sp_inside_square\s*=\s*remove|sp_inside_square\s*=\s*force|sp_inside_square\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Square|Add Sp Inside Square|Remove Sp Inside Square|Force Sp Inside Square"
 ValueDefault=ignore
 
@@ -1051,7 +1165,8 @@ Category=1
 Description="<html>Add or remove space inside '[]'.<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_square_empty\s*=\s*ignore|sp_inside_square_empty\s*=\s*add|sp_inside_square_empty\s*=\s*remove|sp_inside_square_empty\s*=\s*force|sp_inside_square_empty\s*=\s*not_defined
+Choices=sp_inside_square_empty=ignore|sp_inside_square_empty=add|sp_inside_square_empty=remove|sp_inside_square_empty=force|sp_inside_square_empty=not_defined
+ChoicesRegex=sp_inside_square_empty\s*=\s*ignore|sp_inside_square_empty\s*=\s*add|sp_inside_square_empty\s*=\s*remove|sp_inside_square_empty\s*=\s*force|sp_inside_square_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Square Empty|Add Sp Inside Square Empty|Remove Sp Inside Square Empty|Force Sp Inside Square Empty"
 ValueDefault=ignore
 
@@ -1060,7 +1175,8 @@ Category=1
 Description="<html>(OC) Add or remove space inside a non-empty Objective-C boxed array '@[' and<br/>']'. If set to ignore, sp_inside_square is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_square_oc_array\s*=\s*ignore|sp_inside_square_oc_array\s*=\s*add|sp_inside_square_oc_array\s*=\s*remove|sp_inside_square_oc_array\s*=\s*force|sp_inside_square_oc_array\s*=\s*not_defined
+Choices=sp_inside_square_oc_array=ignore|sp_inside_square_oc_array=add|sp_inside_square_oc_array=remove|sp_inside_square_oc_array=force|sp_inside_square_oc_array=not_defined
+ChoicesRegex=sp_inside_square_oc_array\s*=\s*ignore|sp_inside_square_oc_array\s*=\s*add|sp_inside_square_oc_array\s*=\s*remove|sp_inside_square_oc_array\s*=\s*force|sp_inside_square_oc_array\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Square Oc Array|Add Sp Inside Square Oc Array|Remove Sp Inside Square Oc Array|Force Sp Inside Square Oc Array"
 ValueDefault=ignore
 
@@ -1069,7 +1185,8 @@ Category=1
 Description="<html>Add or remove space after ',', i.e. 'a,b' vs. 'a, b'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_comma\s*=\s*ignore|sp_after_comma\s*=\s*add|sp_after_comma\s*=\s*remove|sp_after_comma\s*=\s*force|sp_after_comma\s*=\s*not_defined
+Choices=sp_after_comma=ignore|sp_after_comma=add|sp_after_comma=remove|sp_after_comma=force|sp_after_comma=not_defined
+ChoicesRegex=sp_after_comma\s*=\s*ignore|sp_after_comma\s*=\s*add|sp_after_comma\s*=\s*remove|sp_after_comma\s*=\s*force|sp_after_comma\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Comma|Add Sp After Comma|Remove Sp After Comma|Force Sp After Comma"
 ValueDefault=ignore
 
@@ -1078,7 +1195,8 @@ Category=1
 Description="<html>Add or remove space before ',', i.e. 'a,b' vs. 'a ,b'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_comma\s*=\s*ignore|sp_before_comma\s*=\s*add|sp_before_comma\s*=\s*remove|sp_before_comma\s*=\s*force|sp_before_comma\s*=\s*not_defined
+Choices=sp_before_comma=ignore|sp_before_comma=add|sp_before_comma=remove|sp_before_comma=force|sp_before_comma=not_defined
+ChoicesRegex=sp_before_comma\s*=\s*ignore|sp_before_comma\s*=\s*add|sp_before_comma\s*=\s*remove|sp_before_comma\s*=\s*force|sp_before_comma\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Comma|Add Sp Before Comma|Remove Sp Before Comma|Force Sp Before Comma"
 ValueDefault=remove
 
@@ -1087,7 +1205,8 @@ Category=1
 Description="<html>(C#, Vala) Add or remove space between ',' and ']' in multidimensional array type<br/>like 'int[,,]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_mdatype_commas\s*=\s*ignore|sp_after_mdatype_commas\s*=\s*add|sp_after_mdatype_commas\s*=\s*remove|sp_after_mdatype_commas\s*=\s*force|sp_after_mdatype_commas\s*=\s*not_defined
+Choices=sp_after_mdatype_commas=ignore|sp_after_mdatype_commas=add|sp_after_mdatype_commas=remove|sp_after_mdatype_commas=force|sp_after_mdatype_commas=not_defined
+ChoicesRegex=sp_after_mdatype_commas\s*=\s*ignore|sp_after_mdatype_commas\s*=\s*add|sp_after_mdatype_commas\s*=\s*remove|sp_after_mdatype_commas\s*=\s*force|sp_after_mdatype_commas\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Mdatype Commas|Add Sp After Mdatype Commas|Remove Sp After Mdatype Commas|Force Sp After Mdatype Commas"
 ValueDefault=ignore
 
@@ -1096,7 +1215,8 @@ Category=1
 Description="<html>(C#, Vala) Add or remove space between '[' and ',' in multidimensional array type<br/>like 'int[,,]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_mdatype_commas\s*=\s*ignore|sp_before_mdatype_commas\s*=\s*add|sp_before_mdatype_commas\s*=\s*remove|sp_before_mdatype_commas\s*=\s*force|sp_before_mdatype_commas\s*=\s*not_defined
+Choices=sp_before_mdatype_commas=ignore|sp_before_mdatype_commas=add|sp_before_mdatype_commas=remove|sp_before_mdatype_commas=force|sp_before_mdatype_commas=not_defined
+ChoicesRegex=sp_before_mdatype_commas\s*=\s*ignore|sp_before_mdatype_commas\s*=\s*add|sp_before_mdatype_commas\s*=\s*remove|sp_before_mdatype_commas\s*=\s*force|sp_before_mdatype_commas\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Mdatype Commas|Add Sp Before Mdatype Commas|Remove Sp Before Mdatype Commas|Force Sp Before Mdatype Commas"
 ValueDefault=ignore
 
@@ -1105,7 +1225,8 @@ Category=1
 Description="<html>(C#, Vala) Add or remove space between ',' in multidimensional array type<br/>like 'int[,,]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_mdatype_commas\s*=\s*ignore|sp_between_mdatype_commas\s*=\s*add|sp_between_mdatype_commas\s*=\s*remove|sp_between_mdatype_commas\s*=\s*force|sp_between_mdatype_commas\s*=\s*not_defined
+Choices=sp_between_mdatype_commas=ignore|sp_between_mdatype_commas=add|sp_between_mdatype_commas=remove|sp_between_mdatype_commas=force|sp_between_mdatype_commas=not_defined
+ChoicesRegex=sp_between_mdatype_commas\s*=\s*ignore|sp_between_mdatype_commas\s*=\s*add|sp_between_mdatype_commas\s*=\s*remove|sp_between_mdatype_commas\s*=\s*force|sp_between_mdatype_commas\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between Mdatype Commas|Add Sp Between Mdatype Commas|Remove Sp Between Mdatype Commas|Force Sp Between Mdatype Commas"
 ValueDefault=ignore
 
@@ -1114,7 +1235,8 @@ Category=1
 Description="<html>Add or remove space between an open parenthesis and comma,<br/>i.e. '(,' vs. '( ,'.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_comma\s*=\s*ignore|sp_paren_comma\s*=\s*add|sp_paren_comma\s*=\s*remove|sp_paren_comma\s*=\s*force|sp_paren_comma\s*=\s*not_defined
+Choices=sp_paren_comma=ignore|sp_paren_comma=add|sp_paren_comma=remove|sp_paren_comma=force|sp_paren_comma=not_defined
+ChoicesRegex=sp_paren_comma\s*=\s*ignore|sp_paren_comma\s*=\s*add|sp_paren_comma\s*=\s*remove|sp_paren_comma\s*=\s*force|sp_paren_comma\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Comma|Add Sp Paren Comma|Remove Sp Paren Comma|Force Sp Paren Comma"
 ValueDefault=force
 
@@ -1123,7 +1245,8 @@ Category=1
 Description="<html>Add or remove space between a type and ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_type_colon\s*=\s*ignore|sp_type_colon\s*=\s*add|sp_type_colon\s*=\s*remove|sp_type_colon\s*=\s*force|sp_type_colon\s*=\s*not_defined
+Choices=sp_type_colon=ignore|sp_type_colon=add|sp_type_colon=remove|sp_type_colon=force|sp_type_colon=not_defined
+ChoicesRegex=sp_type_colon\s*=\s*ignore|sp_type_colon\s*=\s*add|sp_type_colon\s*=\s*remove|sp_type_colon\s*=\s*force|sp_type_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Type Colon|Add Sp Type Colon|Remove Sp Type Colon|Force Sp Type Colon"
 ValueDefault=ignore
 
@@ -1132,7 +1255,8 @@ Category=1
 Description="<html>Add or remove space after the variadic '...' when preceded by a<br/>non-punctuator.<br/>The value REMOVE will be overridden with FORCE</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_ellipsis\s*=\s*ignore|sp_after_ellipsis\s*=\s*add|sp_after_ellipsis\s*=\s*remove|sp_after_ellipsis\s*=\s*force|sp_after_ellipsis\s*=\s*not_defined
+Choices=sp_after_ellipsis=ignore|sp_after_ellipsis=add|sp_after_ellipsis=remove|sp_after_ellipsis=force|sp_after_ellipsis=not_defined
+ChoicesRegex=sp_after_ellipsis\s*=\s*ignore|sp_after_ellipsis\s*=\s*add|sp_after_ellipsis\s*=\s*remove|sp_after_ellipsis\s*=\s*force|sp_after_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Ellipsis|Add Sp After Ellipsis|Remove Sp After Ellipsis|Force Sp After Ellipsis"
 ValueDefault=ignore
 
@@ -1141,7 +1265,8 @@ Category=1
 Description="<html>Add or remove space before the variadic '...' when preceded by a<br/>non-punctuator.<br/>The value REMOVE will be overridden with FORCE</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_ellipsis\s*=\s*ignore|sp_before_ellipsis\s*=\s*add|sp_before_ellipsis\s*=\s*remove|sp_before_ellipsis\s*=\s*force|sp_before_ellipsis\s*=\s*not_defined
+Choices=sp_before_ellipsis=ignore|sp_before_ellipsis=add|sp_before_ellipsis=remove|sp_before_ellipsis=force|sp_before_ellipsis=not_defined
+ChoicesRegex=sp_before_ellipsis\s*=\s*ignore|sp_before_ellipsis\s*=\s*add|sp_before_ellipsis\s*=\s*remove|sp_before_ellipsis\s*=\s*force|sp_before_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Ellipsis|Add Sp Before Ellipsis|Remove Sp Before Ellipsis|Force Sp Before Ellipsis"
 ValueDefault=ignore
 
@@ -1150,7 +1275,8 @@ Category=1
 Description="<html>Add or remove space between a type and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_type_ellipsis\s*=\s*ignore|sp_type_ellipsis\s*=\s*add|sp_type_ellipsis\s*=\s*remove|sp_type_ellipsis\s*=\s*force|sp_type_ellipsis\s*=\s*not_defined
+Choices=sp_type_ellipsis=ignore|sp_type_ellipsis=add|sp_type_ellipsis=remove|sp_type_ellipsis=force|sp_type_ellipsis=not_defined
+ChoicesRegex=sp_type_ellipsis\s*=\s*ignore|sp_type_ellipsis\s*=\s*add|sp_type_ellipsis\s*=\s*remove|sp_type_ellipsis\s*=\s*force|sp_type_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Type Ellipsis|Add Sp Type Ellipsis|Remove Sp Type Ellipsis|Force Sp Type Ellipsis"
 ValueDefault=ignore
 
@@ -1159,7 +1285,8 @@ Category=1
 Description="<html>Add or remove space between a '*' and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ptr_type_ellipsis\s*=\s*ignore|sp_ptr_type_ellipsis\s*=\s*add|sp_ptr_type_ellipsis\s*=\s*remove|sp_ptr_type_ellipsis\s*=\s*force|sp_ptr_type_ellipsis\s*=\s*not_defined
+Choices=sp_ptr_type_ellipsis=ignore|sp_ptr_type_ellipsis=add|sp_ptr_type_ellipsis=remove|sp_ptr_type_ellipsis=force|sp_ptr_type_ellipsis=not_defined
+ChoicesRegex=sp_ptr_type_ellipsis\s*=\s*ignore|sp_ptr_type_ellipsis\s*=\s*add|sp_ptr_type_ellipsis\s*=\s*remove|sp_ptr_type_ellipsis\s*=\s*force|sp_ptr_type_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ptr Type Ellipsis|Add Sp Ptr Type Ellipsis|Remove Sp Ptr Type Ellipsis|Force Sp Ptr Type Ellipsis"
 ValueDefault=ignore
 
@@ -1168,7 +1295,8 @@ Category=1
 Description="<html>Add or remove space between ')' and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_ellipsis\s*=\s*ignore|sp_paren_ellipsis\s*=\s*add|sp_paren_ellipsis\s*=\s*remove|sp_paren_ellipsis\s*=\s*force|sp_paren_ellipsis\s*=\s*not_defined
+Choices=sp_paren_ellipsis=ignore|sp_paren_ellipsis=add|sp_paren_ellipsis=remove|sp_paren_ellipsis=force|sp_paren_ellipsis=not_defined
+ChoicesRegex=sp_paren_ellipsis\s*=\s*ignore|sp_paren_ellipsis\s*=\s*add|sp_paren_ellipsis\s*=\s*remove|sp_paren_ellipsis\s*=\s*force|sp_paren_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Ellipsis|Add Sp Paren Ellipsis|Remove Sp Paren Ellipsis|Force Sp Paren Ellipsis"
 ValueDefault=ignore
 
@@ -1177,7 +1305,8 @@ Category=1
 Description="<html>Add or remove space between '&amp;&amp;' and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_byref_ellipsis\s*=\s*ignore|sp_byref_ellipsis\s*=\s*add|sp_byref_ellipsis\s*=\s*remove|sp_byref_ellipsis\s*=\s*force|sp_byref_ellipsis\s*=\s*not_defined
+Choices=sp_byref_ellipsis=ignore|sp_byref_ellipsis=add|sp_byref_ellipsis=remove|sp_byref_ellipsis=force|sp_byref_ellipsis=not_defined
+ChoicesRegex=sp_byref_ellipsis\s*=\s*ignore|sp_byref_ellipsis\s*=\s*add|sp_byref_ellipsis\s*=\s*remove|sp_byref_ellipsis\s*=\s*force|sp_byref_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Byref Ellipsis|Add Sp Byref Ellipsis|Remove Sp Byref Ellipsis|Force Sp Byref Ellipsis"
 ValueDefault=ignore
 
@@ -1186,7 +1315,8 @@ Category=1
 Description="<html>Add or remove space between ')' and a qualifier such as 'const'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_qualifier\s*=\s*ignore|sp_paren_qualifier\s*=\s*add|sp_paren_qualifier\s*=\s*remove|sp_paren_qualifier\s*=\s*force|sp_paren_qualifier\s*=\s*not_defined
+Choices=sp_paren_qualifier=ignore|sp_paren_qualifier=add|sp_paren_qualifier=remove|sp_paren_qualifier=force|sp_paren_qualifier=not_defined
+ChoicesRegex=sp_paren_qualifier\s*=\s*ignore|sp_paren_qualifier\s*=\s*add|sp_paren_qualifier\s*=\s*remove|sp_paren_qualifier\s*=\s*force|sp_paren_qualifier\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Qualifier|Add Sp Paren Qualifier|Remove Sp Paren Qualifier|Force Sp Paren Qualifier"
 ValueDefault=ignore
 
@@ -1195,7 +1325,8 @@ Category=1
 Description="<html>Add or remove space between ')' and 'noexcept'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_paren_noexcept\s*=\s*ignore|sp_paren_noexcept\s*=\s*add|sp_paren_noexcept\s*=\s*remove|sp_paren_noexcept\s*=\s*force|sp_paren_noexcept\s*=\s*not_defined
+Choices=sp_paren_noexcept=ignore|sp_paren_noexcept=add|sp_paren_noexcept=remove|sp_paren_noexcept=force|sp_paren_noexcept=not_defined
+ChoicesRegex=sp_paren_noexcept\s*=\s*ignore|sp_paren_noexcept\s*=\s*add|sp_paren_noexcept\s*=\s*remove|sp_paren_noexcept\s*=\s*force|sp_paren_noexcept\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Paren Noexcept|Add Sp Paren Noexcept|Remove Sp Paren Noexcept|Force Sp Paren Noexcept"
 ValueDefault=ignore
 
@@ -1204,7 +1335,8 @@ Category=1
 Description="<html>Add or remove space after class ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_class_colon\s*=\s*ignore|sp_after_class_colon\s*=\s*add|sp_after_class_colon\s*=\s*remove|sp_after_class_colon\s*=\s*force|sp_after_class_colon\s*=\s*not_defined
+Choices=sp_after_class_colon=ignore|sp_after_class_colon=add|sp_after_class_colon=remove|sp_after_class_colon=force|sp_after_class_colon=not_defined
+ChoicesRegex=sp_after_class_colon\s*=\s*ignore|sp_after_class_colon\s*=\s*add|sp_after_class_colon\s*=\s*remove|sp_after_class_colon\s*=\s*force|sp_after_class_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Class Colon|Add Sp After Class Colon|Remove Sp After Class Colon|Force Sp After Class Colon"
 ValueDefault=ignore
 
@@ -1213,7 +1345,8 @@ Category=1
 Description="<html>Add or remove space before class ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_class_colon\s*=\s*ignore|sp_before_class_colon\s*=\s*add|sp_before_class_colon\s*=\s*remove|sp_before_class_colon\s*=\s*force|sp_before_class_colon\s*=\s*not_defined
+Choices=sp_before_class_colon=ignore|sp_before_class_colon=add|sp_before_class_colon=remove|sp_before_class_colon=force|sp_before_class_colon=not_defined
+ChoicesRegex=sp_before_class_colon\s*=\s*ignore|sp_before_class_colon\s*=\s*add|sp_before_class_colon\s*=\s*remove|sp_before_class_colon\s*=\s*force|sp_before_class_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Class Colon|Add Sp Before Class Colon|Remove Sp Before Class Colon|Force Sp Before Class Colon"
 ValueDefault=ignore
 
@@ -1222,7 +1355,8 @@ Category=1
 Description="<html>Add or remove space after class constructor ':'.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_constr_colon\s*=\s*ignore|sp_after_constr_colon\s*=\s*add|sp_after_constr_colon\s*=\s*remove|sp_after_constr_colon\s*=\s*force|sp_after_constr_colon\s*=\s*not_defined
+Choices=sp_after_constr_colon=ignore|sp_after_constr_colon=add|sp_after_constr_colon=remove|sp_after_constr_colon=force|sp_after_constr_colon=not_defined
+ChoicesRegex=sp_after_constr_colon\s*=\s*ignore|sp_after_constr_colon\s*=\s*add|sp_after_constr_colon\s*=\s*remove|sp_after_constr_colon\s*=\s*force|sp_after_constr_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Constr Colon|Add Sp After Constr Colon|Remove Sp After Constr Colon|Force Sp After Constr Colon"
 ValueDefault=add
 
@@ -1231,7 +1365,8 @@ Category=1
 Description="<html>Add or remove space before class constructor ':'.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_constr_colon\s*=\s*ignore|sp_before_constr_colon\s*=\s*add|sp_before_constr_colon\s*=\s*remove|sp_before_constr_colon\s*=\s*force|sp_before_constr_colon\s*=\s*not_defined
+Choices=sp_before_constr_colon=ignore|sp_before_constr_colon=add|sp_before_constr_colon=remove|sp_before_constr_colon=force|sp_before_constr_colon=not_defined
+ChoicesRegex=sp_before_constr_colon\s*=\s*ignore|sp_before_constr_colon\s*=\s*add|sp_before_constr_colon\s*=\s*remove|sp_before_constr_colon\s*=\s*force|sp_before_constr_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Constr Colon|Add Sp Before Constr Colon|Remove Sp Before Constr Colon|Force Sp Before Constr Colon"
 ValueDefault=add
 
@@ -1240,7 +1375,8 @@ Category=1
 Description="<html>Add or remove space before case ':'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_case_colon\s*=\s*ignore|sp_before_case_colon\s*=\s*add|sp_before_case_colon\s*=\s*remove|sp_before_case_colon\s*=\s*force|sp_before_case_colon\s*=\s*not_defined
+Choices=sp_before_case_colon=ignore|sp_before_case_colon=add|sp_before_case_colon=remove|sp_before_case_colon=force|sp_before_case_colon=not_defined
+ChoicesRegex=sp_before_case_colon\s*=\s*ignore|sp_before_case_colon\s*=\s*add|sp_before_case_colon\s*=\s*remove|sp_before_case_colon\s*=\s*force|sp_before_case_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Case Colon|Add Sp Before Case Colon|Remove Sp Before Case Colon|Force Sp Before Case Colon"
 ValueDefault=remove
 
@@ -1249,7 +1385,8 @@ Category=1
 Description="<html>Add or remove space between 'operator' and operator sign.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_operator\s*=\s*ignore|sp_after_operator\s*=\s*add|sp_after_operator\s*=\s*remove|sp_after_operator\s*=\s*force|sp_after_operator\s*=\s*not_defined
+Choices=sp_after_operator=ignore|sp_after_operator=add|sp_after_operator=remove|sp_after_operator=force|sp_after_operator=not_defined
+ChoicesRegex=sp_after_operator\s*=\s*ignore|sp_after_operator\s*=\s*add|sp_after_operator\s*=\s*remove|sp_after_operator\s*=\s*force|sp_after_operator\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Operator|Add Sp After Operator|Remove Sp After Operator|Force Sp After Operator"
 ValueDefault=ignore
 
@@ -1258,7 +1395,8 @@ Category=1
 Description="<html>Add or remove space between the operator symbol and the open parenthesis, as<br/>in 'operator ++('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_operator_sym\s*=\s*ignore|sp_after_operator_sym\s*=\s*add|sp_after_operator_sym\s*=\s*remove|sp_after_operator_sym\s*=\s*force|sp_after_operator_sym\s*=\s*not_defined
+Choices=sp_after_operator_sym=ignore|sp_after_operator_sym=add|sp_after_operator_sym=remove|sp_after_operator_sym=force|sp_after_operator_sym=not_defined
+ChoicesRegex=sp_after_operator_sym\s*=\s*ignore|sp_after_operator_sym\s*=\s*add|sp_after_operator_sym\s*=\s*remove|sp_after_operator_sym\s*=\s*force|sp_after_operator_sym\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Operator Sym|Add Sp After Operator Sym|Remove Sp After Operator Sym|Force Sp After Operator Sym"
 ValueDefault=ignore
 
@@ -1267,7 +1405,8 @@ Category=1
 Description="<html>Overrides sp_after_operator_sym when the operator has no arguments, as in<br/>'operator *()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_operator_sym_empty\s*=\s*ignore|sp_after_operator_sym_empty\s*=\s*add|sp_after_operator_sym_empty\s*=\s*remove|sp_after_operator_sym_empty\s*=\s*force|sp_after_operator_sym_empty\s*=\s*not_defined
+Choices=sp_after_operator_sym_empty=ignore|sp_after_operator_sym_empty=add|sp_after_operator_sym_empty=remove|sp_after_operator_sym_empty=force|sp_after_operator_sym_empty=not_defined
+ChoicesRegex=sp_after_operator_sym_empty\s*=\s*ignore|sp_after_operator_sym_empty\s*=\s*add|sp_after_operator_sym_empty\s*=\s*remove|sp_after_operator_sym_empty\s*=\s*force|sp_after_operator_sym_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Operator Sym Empty|Add Sp After Operator Sym Empty|Remove Sp After Operator Sym Empty|Force Sp After Operator Sym Empty"
 ValueDefault=ignore
 
@@ -1276,7 +1415,8 @@ Category=1
 Description="<html>Add or remove space after C/D cast, i.e. 'cast(int)a' vs. 'cast(int) a' or<br/>'(int)a' vs. '(int) a'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_cast\s*=\s*ignore|sp_after_cast\s*=\s*add|sp_after_cast\s*=\s*remove|sp_after_cast\s*=\s*force|sp_after_cast\s*=\s*not_defined
+Choices=sp_after_cast=ignore|sp_after_cast=add|sp_after_cast=remove|sp_after_cast=force|sp_after_cast=not_defined
+ChoicesRegex=sp_after_cast\s*=\s*ignore|sp_after_cast\s*=\s*add|sp_after_cast\s*=\s*remove|sp_after_cast\s*=\s*force|sp_after_cast\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Cast|Add Sp After Cast|Remove Sp After Cast|Force Sp After Cast"
 ValueDefault=ignore
 
@@ -1285,7 +1425,8 @@ Category=1
 Description="<html>Add or remove spaces inside cast parentheses.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_paren_cast\s*=\s*ignore|sp_inside_paren_cast\s*=\s*add|sp_inside_paren_cast\s*=\s*remove|sp_inside_paren_cast\s*=\s*force|sp_inside_paren_cast\s*=\s*not_defined
+Choices=sp_inside_paren_cast=ignore|sp_inside_paren_cast=add|sp_inside_paren_cast=remove|sp_inside_paren_cast=force|sp_inside_paren_cast=not_defined
+ChoicesRegex=sp_inside_paren_cast\s*=\s*ignore|sp_inside_paren_cast\s*=\s*add|sp_inside_paren_cast\s*=\s*remove|sp_inside_paren_cast\s*=\s*force|sp_inside_paren_cast\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Paren Cast|Add Sp Inside Paren Cast|Remove Sp Inside Paren Cast|Force Sp Inside Paren Cast"
 ValueDefault=ignore
 
@@ -1294,7 +1435,8 @@ Category=1
 Description="<html>Add or remove space between the type and open parenthesis in a C++ cast,<br/>i.e. 'int(exp)' vs. 'int (exp)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cpp_cast_paren\s*=\s*ignore|sp_cpp_cast_paren\s*=\s*add|sp_cpp_cast_paren\s*=\s*remove|sp_cpp_cast_paren\s*=\s*force|sp_cpp_cast_paren\s*=\s*not_defined
+Choices=sp_cpp_cast_paren=ignore|sp_cpp_cast_paren=add|sp_cpp_cast_paren=remove|sp_cpp_cast_paren=force|sp_cpp_cast_paren=not_defined
+ChoicesRegex=sp_cpp_cast_paren\s*=\s*ignore|sp_cpp_cast_paren\s*=\s*add|sp_cpp_cast_paren\s*=\s*remove|sp_cpp_cast_paren\s*=\s*force|sp_cpp_cast_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cpp Cast Paren|Add Sp Cpp Cast Paren|Remove Sp Cpp Cast Paren|Force Sp Cpp Cast Paren"
 ValueDefault=ignore
 
@@ -1303,7 +1445,8 @@ Category=1
 Description="<html>Add or remove space between 'sizeof' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sizeof_paren\s*=\s*ignore|sp_sizeof_paren\s*=\s*add|sp_sizeof_paren\s*=\s*remove|sp_sizeof_paren\s*=\s*force|sp_sizeof_paren\s*=\s*not_defined
+Choices=sp_sizeof_paren=ignore|sp_sizeof_paren=add|sp_sizeof_paren=remove|sp_sizeof_paren=force|sp_sizeof_paren=not_defined
+ChoicesRegex=sp_sizeof_paren\s*=\s*ignore|sp_sizeof_paren\s*=\s*add|sp_sizeof_paren\s*=\s*remove|sp_sizeof_paren\s*=\s*force|sp_sizeof_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sizeof Paren|Add Sp Sizeof Paren|Remove Sp Sizeof Paren|Force Sp Sizeof Paren"
 ValueDefault=ignore
 
@@ -1312,7 +1455,8 @@ Category=1
 Description="<html>Add or remove space between 'sizeof' and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sizeof_ellipsis\s*=\s*ignore|sp_sizeof_ellipsis\s*=\s*add|sp_sizeof_ellipsis\s*=\s*remove|sp_sizeof_ellipsis\s*=\s*force|sp_sizeof_ellipsis\s*=\s*not_defined
+Choices=sp_sizeof_ellipsis=ignore|sp_sizeof_ellipsis=add|sp_sizeof_ellipsis=remove|sp_sizeof_ellipsis=force|sp_sizeof_ellipsis=not_defined
+ChoicesRegex=sp_sizeof_ellipsis\s*=\s*ignore|sp_sizeof_ellipsis\s*=\s*add|sp_sizeof_ellipsis\s*=\s*remove|sp_sizeof_ellipsis\s*=\s*force|sp_sizeof_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sizeof Ellipsis|Add Sp Sizeof Ellipsis|Remove Sp Sizeof Ellipsis|Force Sp Sizeof Ellipsis"
 ValueDefault=ignore
 
@@ -1321,7 +1465,8 @@ Category=1
 Description="<html>Add or remove space between 'sizeof...' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sizeof_ellipsis_paren\s*=\s*ignore|sp_sizeof_ellipsis_paren\s*=\s*add|sp_sizeof_ellipsis_paren\s*=\s*remove|sp_sizeof_ellipsis_paren\s*=\s*force|sp_sizeof_ellipsis_paren\s*=\s*not_defined
+Choices=sp_sizeof_ellipsis_paren=ignore|sp_sizeof_ellipsis_paren=add|sp_sizeof_ellipsis_paren=remove|sp_sizeof_ellipsis_paren=force|sp_sizeof_ellipsis_paren=not_defined
+ChoicesRegex=sp_sizeof_ellipsis_paren\s*=\s*ignore|sp_sizeof_ellipsis_paren\s*=\s*add|sp_sizeof_ellipsis_paren\s*=\s*remove|sp_sizeof_ellipsis_paren\s*=\s*force|sp_sizeof_ellipsis_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sizeof Ellipsis Paren|Add Sp Sizeof Ellipsis Paren|Remove Sp Sizeof Ellipsis Paren|Force Sp Sizeof Ellipsis Paren"
 ValueDefault=ignore
 
@@ -1330,7 +1475,8 @@ Category=1
 Description="<html>Add or remove space between '...' and a parameter pack.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_ellipsis_parameter_pack\s*=\s*ignore|sp_ellipsis_parameter_pack\s*=\s*add|sp_ellipsis_parameter_pack\s*=\s*remove|sp_ellipsis_parameter_pack\s*=\s*force|sp_ellipsis_parameter_pack\s*=\s*not_defined
+Choices=sp_ellipsis_parameter_pack=ignore|sp_ellipsis_parameter_pack=add|sp_ellipsis_parameter_pack=remove|sp_ellipsis_parameter_pack=force|sp_ellipsis_parameter_pack=not_defined
+ChoicesRegex=sp_ellipsis_parameter_pack\s*=\s*ignore|sp_ellipsis_parameter_pack\s*=\s*add|sp_ellipsis_parameter_pack\s*=\s*remove|sp_ellipsis_parameter_pack\s*=\s*force|sp_ellipsis_parameter_pack\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Ellipsis Parameter Pack|Add Sp Ellipsis Parameter Pack|Remove Sp Ellipsis Parameter Pack|Force Sp Ellipsis Parameter Pack"
 ValueDefault=ignore
 
@@ -1339,7 +1485,8 @@ Category=1
 Description="<html>Add or remove space between a parameter pack and '...'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_parameter_pack_ellipsis\s*=\s*ignore|sp_parameter_pack_ellipsis\s*=\s*add|sp_parameter_pack_ellipsis\s*=\s*remove|sp_parameter_pack_ellipsis\s*=\s*force|sp_parameter_pack_ellipsis\s*=\s*not_defined
+Choices=sp_parameter_pack_ellipsis=ignore|sp_parameter_pack_ellipsis=add|sp_parameter_pack_ellipsis=remove|sp_parameter_pack_ellipsis=force|sp_parameter_pack_ellipsis=not_defined
+ChoicesRegex=sp_parameter_pack_ellipsis\s*=\s*ignore|sp_parameter_pack_ellipsis\s*=\s*add|sp_parameter_pack_ellipsis\s*=\s*remove|sp_parameter_pack_ellipsis\s*=\s*force|sp_parameter_pack_ellipsis\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Parameter Pack Ellipsis|Add Sp Parameter Pack Ellipsis|Remove Sp Parameter Pack Ellipsis|Force Sp Parameter Pack Ellipsis"
 ValueDefault=ignore
 
@@ -1348,7 +1495,8 @@ Category=1
 Description="<html>Add or remove space between 'decltype' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_decltype_paren\s*=\s*ignore|sp_decltype_paren\s*=\s*add|sp_decltype_paren\s*=\s*remove|sp_decltype_paren\s*=\s*force|sp_decltype_paren\s*=\s*not_defined
+Choices=sp_decltype_paren=ignore|sp_decltype_paren=add|sp_decltype_paren=remove|sp_decltype_paren=force|sp_decltype_paren=not_defined
+ChoicesRegex=sp_decltype_paren\s*=\s*ignore|sp_decltype_paren\s*=\s*add|sp_decltype_paren\s*=\s*remove|sp_decltype_paren\s*=\s*force|sp_decltype_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Decltype Paren|Add Sp Decltype Paren|Remove Sp Decltype Paren|Force Sp Decltype Paren"
 ValueDefault=ignore
 
@@ -1357,7 +1505,8 @@ Category=1
 Description="<html>(Pawn) Add or remove space after the tag keyword.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_tag\s*=\s*ignore|sp_after_tag\s*=\s*add|sp_after_tag\s*=\s*remove|sp_after_tag\s*=\s*force|sp_after_tag\s*=\s*not_defined
+Choices=sp_after_tag=ignore|sp_after_tag=add|sp_after_tag=remove|sp_after_tag=force|sp_after_tag=not_defined
+ChoicesRegex=sp_after_tag\s*=\s*ignore|sp_after_tag\s*=\s*add|sp_after_tag\s*=\s*remove|sp_after_tag\s*=\s*force|sp_after_tag\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Tag|Add Sp After Tag|Remove Sp After Tag|Force Sp After Tag"
 ValueDefault=ignore
 
@@ -1366,7 +1515,8 @@ Category=1
 Description="<html>Add or remove space inside enum '{' and '}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces_enum\s*=\s*ignore|sp_inside_braces_enum\s*=\s*add|sp_inside_braces_enum\s*=\s*remove|sp_inside_braces_enum\s*=\s*force|sp_inside_braces_enum\s*=\s*not_defined
+Choices=sp_inside_braces_enum=ignore|sp_inside_braces_enum=add|sp_inside_braces_enum=remove|sp_inside_braces_enum=force|sp_inside_braces_enum=not_defined
+ChoicesRegex=sp_inside_braces_enum\s*=\s*ignore|sp_inside_braces_enum\s*=\s*add|sp_inside_braces_enum\s*=\s*remove|sp_inside_braces_enum\s*=\s*force|sp_inside_braces_enum\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces Enum|Add Sp Inside Braces Enum|Remove Sp Inside Braces Enum|Force Sp Inside Braces Enum"
 ValueDefault=ignore
 
@@ -1375,7 +1525,8 @@ Category=1
 Description="<html>Add or remove space inside struct/union '{' and '}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces_struct\s*=\s*ignore|sp_inside_braces_struct\s*=\s*add|sp_inside_braces_struct\s*=\s*remove|sp_inside_braces_struct\s*=\s*force|sp_inside_braces_struct\s*=\s*not_defined
+Choices=sp_inside_braces_struct=ignore|sp_inside_braces_struct=add|sp_inside_braces_struct=remove|sp_inside_braces_struct=force|sp_inside_braces_struct=not_defined
+ChoicesRegex=sp_inside_braces_struct\s*=\s*ignore|sp_inside_braces_struct\s*=\s*add|sp_inside_braces_struct\s*=\s*remove|sp_inside_braces_struct\s*=\s*force|sp_inside_braces_struct\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces Struct|Add Sp Inside Braces Struct|Remove Sp Inside Braces Struct|Force Sp Inside Braces Struct"
 ValueDefault=ignore
 
@@ -1384,7 +1535,8 @@ Category=1
 Description="<html>(OC) Add or remove space inside Objective-C boxed dictionary '{' and '}'</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces_oc_dict\s*=\s*ignore|sp_inside_braces_oc_dict\s*=\s*add|sp_inside_braces_oc_dict\s*=\s*remove|sp_inside_braces_oc_dict\s*=\s*force|sp_inside_braces_oc_dict\s*=\s*not_defined
+Choices=sp_inside_braces_oc_dict=ignore|sp_inside_braces_oc_dict=add|sp_inside_braces_oc_dict=remove|sp_inside_braces_oc_dict=force|sp_inside_braces_oc_dict=not_defined
+ChoicesRegex=sp_inside_braces_oc_dict\s*=\s*ignore|sp_inside_braces_oc_dict\s*=\s*add|sp_inside_braces_oc_dict\s*=\s*remove|sp_inside_braces_oc_dict\s*=\s*force|sp_inside_braces_oc_dict\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces Oc Dict|Add Sp Inside Braces Oc Dict|Remove Sp Inside Braces Oc Dict|Force Sp Inside Braces Oc Dict"
 ValueDefault=ignore
 
@@ -1393,7 +1545,8 @@ Category=1
 Description="<html>Add or remove space after open brace in an unnamed temporary<br/>direct-list-initialization<br/>if statement is a brace_init_lst<br/>works only if sp_brace_brace is set to ignore.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_type_brace_init_lst_open\s*=\s*ignore|sp_after_type_brace_init_lst_open\s*=\s*add|sp_after_type_brace_init_lst_open\s*=\s*remove|sp_after_type_brace_init_lst_open\s*=\s*force|sp_after_type_brace_init_lst_open\s*=\s*not_defined
+Choices=sp_after_type_brace_init_lst_open=ignore|sp_after_type_brace_init_lst_open=add|sp_after_type_brace_init_lst_open=remove|sp_after_type_brace_init_lst_open=force|sp_after_type_brace_init_lst_open=not_defined
+ChoicesRegex=sp_after_type_brace_init_lst_open\s*=\s*ignore|sp_after_type_brace_init_lst_open\s*=\s*add|sp_after_type_brace_init_lst_open\s*=\s*remove|sp_after_type_brace_init_lst_open\s*=\s*force|sp_after_type_brace_init_lst_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Type Brace Init Lst Open|Add Sp After Type Brace Init Lst Open|Remove Sp After Type Brace Init Lst Open|Force Sp After Type Brace Init Lst Open"
 ValueDefault=ignore
 
@@ -1402,7 +1555,8 @@ Category=1
 Description="<html>Add or remove space before close brace in an unnamed temporary<br/>direct-list-initialization<br/>if statement is a brace_init_lst<br/>works only if sp_brace_brace is set to ignore.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_type_brace_init_lst_close\s*=\s*ignore|sp_before_type_brace_init_lst_close\s*=\s*add|sp_before_type_brace_init_lst_close\s*=\s*remove|sp_before_type_brace_init_lst_close\s*=\s*force|sp_before_type_brace_init_lst_close\s*=\s*not_defined
+Choices=sp_before_type_brace_init_lst_close=ignore|sp_before_type_brace_init_lst_close=add|sp_before_type_brace_init_lst_close=remove|sp_before_type_brace_init_lst_close=force|sp_before_type_brace_init_lst_close=not_defined
+ChoicesRegex=sp_before_type_brace_init_lst_close\s*=\s*ignore|sp_before_type_brace_init_lst_close\s*=\s*add|sp_before_type_brace_init_lst_close\s*=\s*remove|sp_before_type_brace_init_lst_close\s*=\s*force|sp_before_type_brace_init_lst_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Type Brace Init Lst Close|Add Sp Before Type Brace Init Lst Close|Remove Sp Before Type Brace Init Lst Close|Force Sp Before Type Brace Init Lst Close"
 ValueDefault=ignore
 
@@ -1411,7 +1565,8 @@ Category=1
 Description="<html>Add or remove space inside an unnamed temporary direct-list-initialization<br/>if statement is a brace_init_lst<br/>works only if sp_brace_brace is set to ignore<br/>works only if sp_before_type_brace_init_lst_close is set to ignore.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_type_brace_init_lst\s*=\s*ignore|sp_inside_type_brace_init_lst\s*=\s*add|sp_inside_type_brace_init_lst\s*=\s*remove|sp_inside_type_brace_init_lst\s*=\s*force|sp_inside_type_brace_init_lst\s*=\s*not_defined
+Choices=sp_inside_type_brace_init_lst=ignore|sp_inside_type_brace_init_lst=add|sp_inside_type_brace_init_lst=remove|sp_inside_type_brace_init_lst=force|sp_inside_type_brace_init_lst=not_defined
+ChoicesRegex=sp_inside_type_brace_init_lst\s*=\s*ignore|sp_inside_type_brace_init_lst\s*=\s*add|sp_inside_type_brace_init_lst\s*=\s*remove|sp_inside_type_brace_init_lst\s*=\s*force|sp_inside_type_brace_init_lst\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Type Brace Init Lst|Add Sp Inside Type Brace Init Lst|Remove Sp Inside Type Brace Init Lst|Force Sp Inside Type Brace Init Lst"
 ValueDefault=ignore
 
@@ -1420,7 +1575,8 @@ Category=1
 Description="<html>Add or remove space inside '{' and '}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces\s*=\s*ignore|sp_inside_braces\s*=\s*add|sp_inside_braces\s*=\s*remove|sp_inside_braces\s*=\s*force|sp_inside_braces\s*=\s*not_defined
+Choices=sp_inside_braces=ignore|sp_inside_braces=add|sp_inside_braces=remove|sp_inside_braces=force|sp_inside_braces=not_defined
+ChoicesRegex=sp_inside_braces\s*=\s*ignore|sp_inside_braces\s*=\s*add|sp_inside_braces\s*=\s*remove|sp_inside_braces\s*=\s*force|sp_inside_braces\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces|Add Sp Inside Braces|Remove Sp Inside Braces|Force Sp Inside Braces"
 ValueDefault=ignore
 
@@ -1429,7 +1585,8 @@ Category=1
 Description="<html>Add or remove space inside '{}'.<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_braces_empty\s*=\s*ignore|sp_inside_braces_empty\s*=\s*add|sp_inside_braces_empty\s*=\s*remove|sp_inside_braces_empty\s*=\s*force|sp_inside_braces_empty\s*=\s*not_defined
+Choices=sp_inside_braces_empty=ignore|sp_inside_braces_empty=add|sp_inside_braces_empty=remove|sp_inside_braces_empty=force|sp_inside_braces_empty=not_defined
+ChoicesRegex=sp_inside_braces_empty\s*=\s*ignore|sp_inside_braces_empty\s*=\s*add|sp_inside_braces_empty\s*=\s*remove|sp_inside_braces_empty\s*=\s*force|sp_inside_braces_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Braces Empty|Add Sp Inside Braces Empty|Remove Sp Inside Braces Empty|Force Sp Inside Braces Empty"
 ValueDefault=ignore
 
@@ -1438,7 +1595,8 @@ Category=1
 Description="<html>Add or remove space around trailing return operator '-&gt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_trailing_return\s*=\s*ignore|sp_trailing_return\s*=\s*add|sp_trailing_return\s*=\s*remove|sp_trailing_return\s*=\s*force|sp_trailing_return\s*=\s*not_defined
+Choices=sp_trailing_return=ignore|sp_trailing_return=add|sp_trailing_return=remove|sp_trailing_return=force|sp_trailing_return=not_defined
+ChoicesRegex=sp_trailing_return\s*=\s*ignore|sp_trailing_return\s*=\s*add|sp_trailing_return\s*=\s*remove|sp_trailing_return\s*=\s*force|sp_trailing_return\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Trailing Return|Add Sp Trailing Return|Remove Sp Trailing Return|Force Sp Trailing Return"
 ValueDefault=ignore
 
@@ -1447,7 +1605,8 @@ Category=1
 Description="<html>Add or remove space between return type and function name. A minimum of 1<br/>is forced except for pointer return types.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_type_func\s*=\s*ignore|sp_type_func\s*=\s*add|sp_type_func\s*=\s*remove|sp_type_func\s*=\s*force|sp_type_func\s*=\s*not_defined
+Choices=sp_type_func=ignore|sp_type_func=add|sp_type_func=remove|sp_type_func=force|sp_type_func=not_defined
+ChoicesRegex=sp_type_func\s*=\s*ignore|sp_type_func\s*=\s*add|sp_type_func\s*=\s*remove|sp_type_func\s*=\s*force|sp_type_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Type Func|Add Sp Type Func|Remove Sp Type Func|Force Sp Type Func"
 ValueDefault=ignore
 
@@ -1456,7 +1615,8 @@ Category=1
 Description="<html>Add or remove space between type and open brace of an unnamed temporary<br/>direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_type_brace_init_lst\s*=\s*ignore|sp_type_brace_init_lst\s*=\s*add|sp_type_brace_init_lst\s*=\s*remove|sp_type_brace_init_lst\s*=\s*force|sp_type_brace_init_lst\s*=\s*not_defined
+Choices=sp_type_brace_init_lst=ignore|sp_type_brace_init_lst=add|sp_type_brace_init_lst=remove|sp_type_brace_init_lst=force|sp_type_brace_init_lst=not_defined
+ChoicesRegex=sp_type_brace_init_lst\s*=\s*ignore|sp_type_brace_init_lst\s*=\s*add|sp_type_brace_init_lst\s*=\s*remove|sp_type_brace_init_lst\s*=\s*force|sp_type_brace_init_lst\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Type Brace Init Lst|Add Sp Type Brace Init Lst|Remove Sp Type Brace Init Lst|Force Sp Type Brace Init Lst"
 ValueDefault=ignore
 
@@ -1465,7 +1625,8 @@ Category=1
 Description="<html>Add or remove space between function name and '(' on function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_proto_paren\s*=\s*ignore|sp_func_proto_paren\s*=\s*add|sp_func_proto_paren\s*=\s*remove|sp_func_proto_paren\s*=\s*force|sp_func_proto_paren\s*=\s*not_defined
+Choices=sp_func_proto_paren=ignore|sp_func_proto_paren=add|sp_func_proto_paren=remove|sp_func_proto_paren=force|sp_func_proto_paren=not_defined
+ChoicesRegex=sp_func_proto_paren\s*=\s*ignore|sp_func_proto_paren\s*=\s*add|sp_func_proto_paren\s*=\s*remove|sp_func_proto_paren\s*=\s*force|sp_func_proto_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Proto Paren|Add Sp Func Proto Paren|Remove Sp Func Proto Paren|Force Sp Func Proto Paren"
 ValueDefault=ignore
 
@@ -1474,7 +1635,8 @@ Category=1
 Description="<html>Add or remove space between function name and '()' on function declaration<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_proto_paren_empty\s*=\s*ignore|sp_func_proto_paren_empty\s*=\s*add|sp_func_proto_paren_empty\s*=\s*remove|sp_func_proto_paren_empty\s*=\s*force|sp_func_proto_paren_empty\s*=\s*not_defined
+Choices=sp_func_proto_paren_empty=ignore|sp_func_proto_paren_empty=add|sp_func_proto_paren_empty=remove|sp_func_proto_paren_empty=force|sp_func_proto_paren_empty=not_defined
+ChoicesRegex=sp_func_proto_paren_empty\s*=\s*ignore|sp_func_proto_paren_empty\s*=\s*add|sp_func_proto_paren_empty\s*=\s*remove|sp_func_proto_paren_empty\s*=\s*force|sp_func_proto_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Proto Paren Empty|Add Sp Func Proto Paren Empty|Remove Sp Func Proto Paren Empty|Force Sp Func Proto Paren Empty"
 ValueDefault=ignore
 
@@ -1483,7 +1645,8 @@ Category=1
 Description="<html>Add or remove space between function name and '(' with a typedef specifier.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_type_paren\s*=\s*ignore|sp_func_type_paren\s*=\s*add|sp_func_type_paren\s*=\s*remove|sp_func_type_paren\s*=\s*force|sp_func_type_paren\s*=\s*not_defined
+Choices=sp_func_type_paren=ignore|sp_func_type_paren=add|sp_func_type_paren=remove|sp_func_type_paren=force|sp_func_type_paren=not_defined
+ChoicesRegex=sp_func_type_paren\s*=\s*ignore|sp_func_type_paren\s*=\s*add|sp_func_type_paren\s*=\s*remove|sp_func_type_paren\s*=\s*force|sp_func_type_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Type Paren|Add Sp Func Type Paren|Remove Sp Func Type Paren|Force Sp Func Type Paren"
 ValueDefault=ignore
 
@@ -1492,7 +1655,8 @@ Category=1
 Description="<html>Add or remove space between alias name and '(' of a non-pointer function type typedef.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_def_paren\s*=\s*ignore|sp_func_def_paren\s*=\s*add|sp_func_def_paren\s*=\s*remove|sp_func_def_paren\s*=\s*force|sp_func_def_paren\s*=\s*not_defined
+Choices=sp_func_def_paren=ignore|sp_func_def_paren=add|sp_func_def_paren=remove|sp_func_def_paren=force|sp_func_def_paren=not_defined
+ChoicesRegex=sp_func_def_paren\s*=\s*ignore|sp_func_def_paren\s*=\s*add|sp_func_def_paren\s*=\s*remove|sp_func_def_paren\s*=\s*force|sp_func_def_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Def Paren|Add Sp Func Def Paren|Remove Sp Func Def Paren|Force Sp Func Def Paren"
 ValueDefault=ignore
 
@@ -1501,7 +1665,8 @@ Category=1
 Description="<html>Add or remove space between function name and '()' on function definition<br/>if empty.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_def_paren_empty\s*=\s*ignore|sp_func_def_paren_empty\s*=\s*add|sp_func_def_paren_empty\s*=\s*remove|sp_func_def_paren_empty\s*=\s*force|sp_func_def_paren_empty\s*=\s*not_defined
+Choices=sp_func_def_paren_empty=ignore|sp_func_def_paren_empty=add|sp_func_def_paren_empty=remove|sp_func_def_paren_empty=force|sp_func_def_paren_empty=not_defined
+ChoicesRegex=sp_func_def_paren_empty\s*=\s*ignore|sp_func_def_paren_empty\s*=\s*add|sp_func_def_paren_empty\s*=\s*remove|sp_func_def_paren_empty\s*=\s*force|sp_func_def_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Def Paren Empty|Add Sp Func Def Paren Empty|Remove Sp Func Def Paren Empty|Force Sp Func Def Paren Empty"
 ValueDefault=ignore
 
@@ -1510,7 +1675,8 @@ Category=1
 Description="<html>Add or remove space inside empty function '()'.<br/>Overrides sp_after_angle unless use_sp_after_angle_always is set to true.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_fparens\s*=\s*ignore|sp_inside_fparens\s*=\s*add|sp_inside_fparens\s*=\s*remove|sp_inside_fparens\s*=\s*force|sp_inside_fparens\s*=\s*not_defined
+Choices=sp_inside_fparens=ignore|sp_inside_fparens=add|sp_inside_fparens=remove|sp_inside_fparens=force|sp_inside_fparens=not_defined
+ChoicesRegex=sp_inside_fparens\s*=\s*ignore|sp_inside_fparens\s*=\s*add|sp_inside_fparens\s*=\s*remove|sp_inside_fparens\s*=\s*force|sp_inside_fparens\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Fparens|Add Sp Inside Fparens|Remove Sp Inside Fparens|Force Sp Inside Fparens"
 ValueDefault=ignore
 
@@ -1519,7 +1685,8 @@ Category=1
 Description="<html>Add or remove space inside function '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_fparen\s*=\s*ignore|sp_inside_fparen\s*=\s*add|sp_inside_fparen\s*=\s*remove|sp_inside_fparen\s*=\s*force|sp_inside_fparen\s*=\s*not_defined
+Choices=sp_inside_fparen=ignore|sp_inside_fparen=add|sp_inside_fparen=remove|sp_inside_fparen=force|sp_inside_fparen=not_defined
+ChoicesRegex=sp_inside_fparen\s*=\s*ignore|sp_inside_fparen\s*=\s*add|sp_inside_fparen\s*=\s*remove|sp_inside_fparen\s*=\s*force|sp_inside_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Fparen|Add Sp Inside Fparen|Remove Sp Inside Fparen|Force Sp Inside Fparen"
 ValueDefault=ignore
 
@@ -1528,7 +1695,8 @@ Category=1
 Description="<html>Add or remove space inside user functor '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_user_inside_rparen\s*=\s*ignore|sp_func_call_user_inside_rparen\s*=\s*add|sp_func_call_user_inside_rparen\s*=\s*remove|sp_func_call_user_inside_rparen\s*=\s*force|sp_func_call_user_inside_rparen\s*=\s*not_defined
+Choices=sp_func_call_user_inside_rparen=ignore|sp_func_call_user_inside_rparen=add|sp_func_call_user_inside_rparen=remove|sp_func_call_user_inside_rparen=force|sp_func_call_user_inside_rparen=not_defined
+ChoicesRegex=sp_func_call_user_inside_rparen\s*=\s*ignore|sp_func_call_user_inside_rparen\s*=\s*add|sp_func_call_user_inside_rparen\s*=\s*remove|sp_func_call_user_inside_rparen\s*=\s*force|sp_func_call_user_inside_rparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call User Inside Rparen|Add Sp Func Call User Inside Rparen|Remove Sp Func Call User Inside Rparen|Force Sp Func Call User Inside Rparen"
 ValueDefault=ignore
 
@@ -1537,7 +1705,8 @@ Category=1
 Description="<html>Add or remove space inside empty functor '()'.<br/>Overrides sp_after_angle unless use_sp_after_angle_always is set to true.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_rparens\s*=\s*ignore|sp_inside_rparens\s*=\s*add|sp_inside_rparens\s*=\s*remove|sp_inside_rparens\s*=\s*force|sp_inside_rparens\s*=\s*not_defined
+Choices=sp_inside_rparens=ignore|sp_inside_rparens=add|sp_inside_rparens=remove|sp_inside_rparens=force|sp_inside_rparens=not_defined
+ChoicesRegex=sp_inside_rparens\s*=\s*ignore|sp_inside_rparens\s*=\s*add|sp_inside_rparens\s*=\s*remove|sp_inside_rparens\s*=\s*force|sp_inside_rparens\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Rparens|Add Sp Inside Rparens|Remove Sp Inside Rparens|Force Sp Inside Rparens"
 ValueDefault=ignore
 
@@ -1546,7 +1715,8 @@ Category=1
 Description="<html>Add or remove space inside functor '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_rparen\s*=\s*ignore|sp_inside_rparen\s*=\s*add|sp_inside_rparen\s*=\s*remove|sp_inside_rparen\s*=\s*force|sp_inside_rparen\s*=\s*not_defined
+Choices=sp_inside_rparen=ignore|sp_inside_rparen=add|sp_inside_rparen=remove|sp_inside_rparen=force|sp_inside_rparen=not_defined
+ChoicesRegex=sp_inside_rparen\s*=\s*ignore|sp_inside_rparen\s*=\s*add|sp_inside_rparen\s*=\s*remove|sp_inside_rparen\s*=\s*force|sp_inside_rparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Rparen|Add Sp Inside Rparen|Remove Sp Inside Rparen|Force Sp Inside Rparen"
 ValueDefault=ignore
 
@@ -1555,7 +1725,8 @@ Category=1
 Description="<html>Add or remove space inside the first parentheses in a function type, as in<br/>'void (*x)(...)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_tparen\s*=\s*ignore|sp_inside_tparen\s*=\s*add|sp_inside_tparen\s*=\s*remove|sp_inside_tparen\s*=\s*force|sp_inside_tparen\s*=\s*not_defined
+Choices=sp_inside_tparen=ignore|sp_inside_tparen=add|sp_inside_tparen=remove|sp_inside_tparen=force|sp_inside_tparen=not_defined
+ChoicesRegex=sp_inside_tparen\s*=\s*ignore|sp_inside_tparen\s*=\s*add|sp_inside_tparen\s*=\s*remove|sp_inside_tparen\s*=\s*force|sp_inside_tparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Tparen|Add Sp Inside Tparen|Remove Sp Inside Tparen|Force Sp Inside Tparen"
 ValueDefault=ignore
 
@@ -1564,7 +1735,8 @@ Category=1
 Description="<html>Add or remove space between the ')' and '(' in a function type, as in<br/>'void (*x)(...)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_tparen_close\s*=\s*ignore|sp_after_tparen_close\s*=\s*add|sp_after_tparen_close\s*=\s*remove|sp_after_tparen_close\s*=\s*force|sp_after_tparen_close\s*=\s*not_defined
+Choices=sp_after_tparen_close=ignore|sp_after_tparen_close=add|sp_after_tparen_close=remove|sp_after_tparen_close=force|sp_after_tparen_close=not_defined
+ChoicesRegex=sp_after_tparen_close\s*=\s*ignore|sp_after_tparen_close\s*=\s*add|sp_after_tparen_close\s*=\s*remove|sp_after_tparen_close\s*=\s*force|sp_after_tparen_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Tparen Close|Add Sp After Tparen Close|Remove Sp After Tparen Close|Force Sp After Tparen Close"
 ValueDefault=ignore
 
@@ -1573,7 +1745,8 @@ Category=1
 Description="<html>Add or remove space between ']' and '(' when part of a function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_square_fparen\s*=\s*ignore|sp_square_fparen\s*=\s*add|sp_square_fparen\s*=\s*remove|sp_square_fparen\s*=\s*force|sp_square_fparen\s*=\s*not_defined
+Choices=sp_square_fparen=ignore|sp_square_fparen=add|sp_square_fparen=remove|sp_square_fparen=force|sp_square_fparen=not_defined
+ChoicesRegex=sp_square_fparen\s*=\s*ignore|sp_square_fparen\s*=\s*add|sp_square_fparen\s*=\s*remove|sp_square_fparen\s*=\s*force|sp_square_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Square Fparen|Add Sp Square Fparen|Remove Sp Square Fparen|Force Sp Square Fparen"
 ValueDefault=ignore
 
@@ -1582,7 +1755,8 @@ Category=1
 Description="<html>Add or remove space between ')' and '{' of function.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_fparen_brace\s*=\s*ignore|sp_fparen_brace\s*=\s*add|sp_fparen_brace\s*=\s*remove|sp_fparen_brace\s*=\s*force|sp_fparen_brace\s*=\s*not_defined
+Choices=sp_fparen_brace=ignore|sp_fparen_brace=add|sp_fparen_brace=remove|sp_fparen_brace=force|sp_fparen_brace=not_defined
+ChoicesRegex=sp_fparen_brace\s*=\s*ignore|sp_fparen_brace\s*=\s*add|sp_fparen_brace\s*=\s*remove|sp_fparen_brace\s*=\s*force|sp_fparen_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Fparen Brace|Add Sp Fparen Brace|Remove Sp Fparen Brace|Force Sp Fparen Brace"
 ValueDefault=ignore
 
@@ -1591,7 +1765,8 @@ Category=1
 Description="<html>Add or remove space between ')' and '{' of a function call in object<br/>initialization.<br/><br/>Overrides sp_fparen_brace.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_fparen_brace_initializer\s*=\s*ignore|sp_fparen_brace_initializer\s*=\s*add|sp_fparen_brace_initializer\s*=\s*remove|sp_fparen_brace_initializer\s*=\s*force|sp_fparen_brace_initializer\s*=\s*not_defined
+Choices=sp_fparen_brace_initializer=ignore|sp_fparen_brace_initializer=add|sp_fparen_brace_initializer=remove|sp_fparen_brace_initializer=force|sp_fparen_brace_initializer=not_defined
+ChoicesRegex=sp_fparen_brace_initializer\s*=\s*ignore|sp_fparen_brace_initializer\s*=\s*add|sp_fparen_brace_initializer\s*=\s*remove|sp_fparen_brace_initializer\s*=\s*force|sp_fparen_brace_initializer\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Fparen Brace Initializer|Add Sp Fparen Brace Initializer|Remove Sp Fparen Brace Initializer|Force Sp Fparen Brace Initializer"
 ValueDefault=ignore
 
@@ -1600,7 +1775,8 @@ Category=1
 Description="<html>(Java) Add or remove space between ')' and '{{' of double brace initializer.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_fparen_dbrace\s*=\s*ignore|sp_fparen_dbrace\s*=\s*add|sp_fparen_dbrace\s*=\s*remove|sp_fparen_dbrace\s*=\s*force|sp_fparen_dbrace\s*=\s*not_defined
+Choices=sp_fparen_dbrace=ignore|sp_fparen_dbrace=add|sp_fparen_dbrace=remove|sp_fparen_dbrace=force|sp_fparen_dbrace=not_defined
+ChoicesRegex=sp_fparen_dbrace\s*=\s*ignore|sp_fparen_dbrace\s*=\s*add|sp_fparen_dbrace\s*=\s*remove|sp_fparen_dbrace\s*=\s*force|sp_fparen_dbrace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Fparen Dbrace|Add Sp Fparen Dbrace|Remove Sp Fparen Dbrace|Force Sp Fparen Dbrace"
 ValueDefault=ignore
 
@@ -1609,7 +1785,8 @@ Category=1
 Description="<html>Add or remove space between function name and '(' on function calls.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_paren\s*=\s*ignore|sp_func_call_paren\s*=\s*add|sp_func_call_paren\s*=\s*remove|sp_func_call_paren\s*=\s*force|sp_func_call_paren\s*=\s*not_defined
+Choices=sp_func_call_paren=ignore|sp_func_call_paren=add|sp_func_call_paren=remove|sp_func_call_paren=force|sp_func_call_paren=not_defined
+ChoicesRegex=sp_func_call_paren\s*=\s*ignore|sp_func_call_paren\s*=\s*add|sp_func_call_paren\s*=\s*remove|sp_func_call_paren\s*=\s*force|sp_func_call_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call Paren|Add Sp Func Call Paren|Remove Sp Func Call Paren|Force Sp Func Call Paren"
 ValueDefault=ignore
 
@@ -1618,7 +1795,8 @@ Category=1
 Description="<html>Add or remove space between function name and '()' on function calls without<br/>parameters. If set to ignore (the default), sp_func_call_paren is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_paren_empty\s*=\s*ignore|sp_func_call_paren_empty\s*=\s*add|sp_func_call_paren_empty\s*=\s*remove|sp_func_call_paren_empty\s*=\s*force|sp_func_call_paren_empty\s*=\s*not_defined
+Choices=sp_func_call_paren_empty=ignore|sp_func_call_paren_empty=add|sp_func_call_paren_empty=remove|sp_func_call_paren_empty=force|sp_func_call_paren_empty=not_defined
+ChoicesRegex=sp_func_call_paren_empty\s*=\s*ignore|sp_func_call_paren_empty\s*=\s*add|sp_func_call_paren_empty\s*=\s*remove|sp_func_call_paren_empty\s*=\s*force|sp_func_call_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call Paren Empty|Add Sp Func Call Paren Empty|Remove Sp Func Call Paren Empty|Force Sp Func Call Paren Empty"
 ValueDefault=ignore
 
@@ -1627,7 +1805,8 @@ Category=1
 Description="<html>Add or remove space between the user function name and '(' on function<br/>calls. You need to set a keyword to be a user function in the config file,<br/>like:<br/>  set func_call_user tr _ i18n</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_user_paren\s*=\s*ignore|sp_func_call_user_paren\s*=\s*add|sp_func_call_user_paren\s*=\s*remove|sp_func_call_user_paren\s*=\s*force|sp_func_call_user_paren\s*=\s*not_defined
+Choices=sp_func_call_user_paren=ignore|sp_func_call_user_paren=add|sp_func_call_user_paren=remove|sp_func_call_user_paren=force|sp_func_call_user_paren=not_defined
+ChoicesRegex=sp_func_call_user_paren\s*=\s*ignore|sp_func_call_user_paren\s*=\s*add|sp_func_call_user_paren\s*=\s*remove|sp_func_call_user_paren\s*=\s*force|sp_func_call_user_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call User Paren|Add Sp Func Call User Paren|Remove Sp Func Call User Paren|Force Sp Func Call User Paren"
 ValueDefault=ignore
 
@@ -1636,7 +1815,8 @@ Category=1
 Description="<html>Add or remove space inside user function '(' and ')'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_user_inside_fparen\s*=\s*ignore|sp_func_call_user_inside_fparen\s*=\s*add|sp_func_call_user_inside_fparen\s*=\s*remove|sp_func_call_user_inside_fparen\s*=\s*force|sp_func_call_user_inside_fparen\s*=\s*not_defined
+Choices=sp_func_call_user_inside_fparen=ignore|sp_func_call_user_inside_fparen=add|sp_func_call_user_inside_fparen=remove|sp_func_call_user_inside_fparen=force|sp_func_call_user_inside_fparen=not_defined
+ChoicesRegex=sp_func_call_user_inside_fparen\s*=\s*ignore|sp_func_call_user_inside_fparen\s*=\s*add|sp_func_call_user_inside_fparen\s*=\s*remove|sp_func_call_user_inside_fparen\s*=\s*force|sp_func_call_user_inside_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call User Inside Fparen|Add Sp Func Call User Inside Fparen|Remove Sp Func Call User Inside Fparen|Force Sp Func Call User Inside Fparen"
 ValueDefault=ignore
 
@@ -1645,7 +1825,8 @@ Category=1
 Description="<html>Add or remove space between nested parentheses with user functions,<br/>i.e. '((' vs. '( ('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_call_user_paren_paren\s*=\s*ignore|sp_func_call_user_paren_paren\s*=\s*add|sp_func_call_user_paren_paren\s*=\s*remove|sp_func_call_user_paren_paren\s*=\s*force|sp_func_call_user_paren_paren\s*=\s*not_defined
+Choices=sp_func_call_user_paren_paren=ignore|sp_func_call_user_paren_paren=add|sp_func_call_user_paren_paren=remove|sp_func_call_user_paren_paren=force|sp_func_call_user_paren_paren=not_defined
+ChoicesRegex=sp_func_call_user_paren_paren\s*=\s*ignore|sp_func_call_user_paren_paren\s*=\s*add|sp_func_call_user_paren_paren\s*=\s*remove|sp_func_call_user_paren_paren\s*=\s*force|sp_func_call_user_paren_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Call User Paren Paren|Add Sp Func Call User Paren Paren|Remove Sp Func Call User Paren Paren|Force Sp Func Call User Paren Paren"
 ValueDefault=ignore
 
@@ -1654,7 +1835,8 @@ Category=1
 Description="<html>Add or remove space between a constructor/destructor and the open<br/>parenthesis.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_class_paren\s*=\s*ignore|sp_func_class_paren\s*=\s*add|sp_func_class_paren\s*=\s*remove|sp_func_class_paren\s*=\s*force|sp_func_class_paren\s*=\s*not_defined
+Choices=sp_func_class_paren=ignore|sp_func_class_paren=add|sp_func_class_paren=remove|sp_func_class_paren=force|sp_func_class_paren=not_defined
+ChoicesRegex=sp_func_class_paren\s*=\s*ignore|sp_func_class_paren\s*=\s*add|sp_func_class_paren\s*=\s*remove|sp_func_class_paren\s*=\s*force|sp_func_class_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Class Paren|Add Sp Func Class Paren|Remove Sp Func Class Paren|Force Sp Func Class Paren"
 ValueDefault=ignore
 
@@ -1663,7 +1845,8 @@ Category=1
 Description="<html>Add or remove space between a constructor without parameters or destructor<br/>and '()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_func_class_paren_empty\s*=\s*ignore|sp_func_class_paren_empty\s*=\s*add|sp_func_class_paren_empty\s*=\s*remove|sp_func_class_paren_empty\s*=\s*force|sp_func_class_paren_empty\s*=\s*not_defined
+Choices=sp_func_class_paren_empty=ignore|sp_func_class_paren_empty=add|sp_func_class_paren_empty=remove|sp_func_class_paren_empty=force|sp_func_class_paren_empty=not_defined
+ChoicesRegex=sp_func_class_paren_empty\s*=\s*ignore|sp_func_class_paren_empty\s*=\s*add|sp_func_class_paren_empty\s*=\s*remove|sp_func_class_paren_empty\s*=\s*force|sp_func_class_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Func Class Paren Empty|Add Sp Func Class Paren Empty|Remove Sp Func Class Paren Empty|Force Sp Func Class Paren Empty"
 ValueDefault=ignore
 
@@ -1672,7 +1855,8 @@ Category=1
 Description="<html>Add or remove space after 'return'.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_return\s*=\s*ignore|sp_return\s*=\s*add|sp_return\s*=\s*remove|sp_return\s*=\s*force|sp_return\s*=\s*not_defined
+Choices=sp_return=ignore|sp_return=add|sp_return=remove|sp_return=force|sp_return=not_defined
+ChoicesRegex=sp_return\s*=\s*ignore|sp_return\s*=\s*add|sp_return\s*=\s*remove|sp_return\s*=\s*force|sp_return\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Return|Add Sp Return|Remove Sp Return|Force Sp Return"
 ValueDefault=force
 
@@ -1681,7 +1865,8 @@ Category=1
 Description="<html>Add or remove space between 'return' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_return_paren\s*=\s*ignore|sp_return_paren\s*=\s*add|sp_return_paren\s*=\s*remove|sp_return_paren\s*=\s*force|sp_return_paren\s*=\s*not_defined
+Choices=sp_return_paren=ignore|sp_return_paren=add|sp_return_paren=remove|sp_return_paren=force|sp_return_paren=not_defined
+ChoicesRegex=sp_return_paren\s*=\s*ignore|sp_return_paren\s*=\s*add|sp_return_paren\s*=\s*remove|sp_return_paren\s*=\s*force|sp_return_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Return Paren|Add Sp Return Paren|Remove Sp Return Paren|Force Sp Return Paren"
 ValueDefault=ignore
 
@@ -1690,7 +1875,8 @@ Category=1
 Description="<html>Add or remove space between 'return' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_return_brace\s*=\s*ignore|sp_return_brace\s*=\s*add|sp_return_brace\s*=\s*remove|sp_return_brace\s*=\s*force|sp_return_brace\s*=\s*not_defined
+Choices=sp_return_brace=ignore|sp_return_brace=add|sp_return_brace=remove|sp_return_brace=force|sp_return_brace=not_defined
+ChoicesRegex=sp_return_brace\s*=\s*ignore|sp_return_brace\s*=\s*add|sp_return_brace\s*=\s*remove|sp_return_brace\s*=\s*force|sp_return_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Return Brace|Add Sp Return Brace|Remove Sp Return Brace|Force Sp Return Brace"
 ValueDefault=ignore
 
@@ -1699,7 +1885,8 @@ Category=1
 Description="<html>Add or remove space between '__attribute__' and '('.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_attribute_paren\s*=\s*ignore|sp_attribute_paren\s*=\s*add|sp_attribute_paren\s*=\s*remove|sp_attribute_paren\s*=\s*force|sp_attribute_paren\s*=\s*not_defined
+Choices=sp_attribute_paren=ignore|sp_attribute_paren=add|sp_attribute_paren=remove|sp_attribute_paren=force|sp_attribute_paren=not_defined
+ChoicesRegex=sp_attribute_paren\s*=\s*ignore|sp_attribute_paren\s*=\s*add|sp_attribute_paren\s*=\s*remove|sp_attribute_paren\s*=\s*force|sp_attribute_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Attribute Paren|Add Sp Attribute Paren|Remove Sp Attribute Paren|Force Sp Attribute Paren"
 ValueDefault=ignore
 
@@ -1708,7 +1895,8 @@ Category=1
 Description="<html>Add or remove space between 'defined' and '(' in '#if defined (FOO)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_defined_paren\s*=\s*ignore|sp_defined_paren\s*=\s*add|sp_defined_paren\s*=\s*remove|sp_defined_paren\s*=\s*force|sp_defined_paren\s*=\s*not_defined
+Choices=sp_defined_paren=ignore|sp_defined_paren=add|sp_defined_paren=remove|sp_defined_paren=force|sp_defined_paren=not_defined
+ChoicesRegex=sp_defined_paren\s*=\s*ignore|sp_defined_paren\s*=\s*add|sp_defined_paren\s*=\s*remove|sp_defined_paren\s*=\s*force|sp_defined_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Defined Paren|Add Sp Defined Paren|Remove Sp Defined Paren|Force Sp Defined Paren"
 ValueDefault=ignore
 
@@ -1717,7 +1905,8 @@ Category=1
 Description="<html>Add or remove space between 'throw' and '(' in 'throw (something)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_throw_paren\s*=\s*ignore|sp_throw_paren\s*=\s*add|sp_throw_paren\s*=\s*remove|sp_throw_paren\s*=\s*force|sp_throw_paren\s*=\s*not_defined
+Choices=sp_throw_paren=ignore|sp_throw_paren=add|sp_throw_paren=remove|sp_throw_paren=force|sp_throw_paren=not_defined
+ChoicesRegex=sp_throw_paren\s*=\s*ignore|sp_throw_paren\s*=\s*add|sp_throw_paren\s*=\s*remove|sp_throw_paren\s*=\s*force|sp_throw_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Throw Paren|Add Sp Throw Paren|Remove Sp Throw Paren|Force Sp Throw Paren"
 ValueDefault=ignore
 
@@ -1726,7 +1915,8 @@ Category=1
 Description="<html>Add or remove space between 'throw' and anything other than '(' as in<br/>'@throw [...];'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_throw\s*=\s*ignore|sp_after_throw\s*=\s*add|sp_after_throw\s*=\s*remove|sp_after_throw\s*=\s*force|sp_after_throw\s*=\s*not_defined
+Choices=sp_after_throw=ignore|sp_after_throw=add|sp_after_throw=remove|sp_after_throw=force|sp_after_throw=not_defined
+ChoicesRegex=sp_after_throw\s*=\s*ignore|sp_after_throw\s*=\s*add|sp_after_throw\s*=\s*remove|sp_after_throw\s*=\s*force|sp_after_throw\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Throw|Add Sp After Throw|Remove Sp After Throw|Force Sp After Throw"
 ValueDefault=ignore
 
@@ -1735,7 +1925,8 @@ Category=1
 Description="<html>Add or remove space between 'catch' and '(' in 'catch (something) { }'.<br/>If set to ignore, sp_before_sparen is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_catch_paren\s*=\s*ignore|sp_catch_paren\s*=\s*add|sp_catch_paren\s*=\s*remove|sp_catch_paren\s*=\s*force|sp_catch_paren\s*=\s*not_defined
+Choices=sp_catch_paren=ignore|sp_catch_paren=add|sp_catch_paren=remove|sp_catch_paren=force|sp_catch_paren=not_defined
+ChoicesRegex=sp_catch_paren\s*=\s*ignore|sp_catch_paren\s*=\s*add|sp_catch_paren\s*=\s*remove|sp_catch_paren\s*=\s*force|sp_catch_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Catch Paren|Add Sp Catch Paren|Remove Sp Catch Paren|Force Sp Catch Paren"
 ValueDefault=ignore
 
@@ -1744,7 +1935,8 @@ Category=1
 Description="<html>(OC) Add or remove space between '@catch' and '('<br/>in '@catch (something) { }'. If set to ignore, sp_catch_paren is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_oc_catch_paren\s*=\s*ignore|sp_oc_catch_paren\s*=\s*add|sp_oc_catch_paren\s*=\s*remove|sp_oc_catch_paren\s*=\s*force|sp_oc_catch_paren\s*=\s*not_defined
+Choices=sp_oc_catch_paren=ignore|sp_oc_catch_paren=add|sp_oc_catch_paren=remove|sp_oc_catch_paren=force|sp_oc_catch_paren=not_defined
+ChoicesRegex=sp_oc_catch_paren\s*=\s*ignore|sp_oc_catch_paren\s*=\s*add|sp_oc_catch_paren\s*=\s*remove|sp_oc_catch_paren\s*=\s*force|sp_oc_catch_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Oc Catch Paren|Add Sp Oc Catch Paren|Remove Sp Oc Catch Paren|Force Sp Oc Catch Paren"
 ValueDefault=ignore
 
@@ -1753,7 +1945,8 @@ Category=1
 Description="<html>(OC) Add or remove space before Objective-C protocol list<br/>as in '@protocol Protocol&lt;here&gt;&lt;Protocol_A&gt;' or '@interface MyClass : NSObject&lt;here&gt;&lt;MyProtocol&gt;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_oc_proto_list\s*=\s*ignore|sp_before_oc_proto_list\s*=\s*add|sp_before_oc_proto_list\s*=\s*remove|sp_before_oc_proto_list\s*=\s*force|sp_before_oc_proto_list\s*=\s*not_defined
+Choices=sp_before_oc_proto_list=ignore|sp_before_oc_proto_list=add|sp_before_oc_proto_list=remove|sp_before_oc_proto_list=force|sp_before_oc_proto_list=not_defined
+ChoicesRegex=sp_before_oc_proto_list\s*=\s*ignore|sp_before_oc_proto_list\s*=\s*add|sp_before_oc_proto_list\s*=\s*remove|sp_before_oc_proto_list\s*=\s*force|sp_before_oc_proto_list\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Oc Proto List|Add Sp Before Oc Proto List|Remove Sp Before Oc Proto List|Force Sp Before Oc Proto List"
 ValueDefault=ignore
 
@@ -1762,7 +1955,8 @@ Category=1
 Description="<html>(OC) Add or remove space between class name and '('<br/>in '@interface className(categoryName)&lt;ProtocolName&gt;:BaseClass'</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_oc_classname_paren\s*=\s*ignore|sp_oc_classname_paren\s*=\s*add|sp_oc_classname_paren\s*=\s*remove|sp_oc_classname_paren\s*=\s*force|sp_oc_classname_paren\s*=\s*not_defined
+Choices=sp_oc_classname_paren=ignore|sp_oc_classname_paren=add|sp_oc_classname_paren=remove|sp_oc_classname_paren=force|sp_oc_classname_paren=not_defined
+ChoicesRegex=sp_oc_classname_paren\s*=\s*ignore|sp_oc_classname_paren\s*=\s*add|sp_oc_classname_paren\s*=\s*remove|sp_oc_classname_paren\s*=\s*force|sp_oc_classname_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Oc Classname Paren|Add Sp Oc Classname Paren|Remove Sp Oc Classname Paren|Force Sp Oc Classname Paren"
 ValueDefault=ignore
 
@@ -1771,7 +1965,8 @@ Category=1
 Description="<html>(D) Add or remove space between 'version' and '('<br/>in 'version (something) { }'. If set to ignore, sp_before_sparen is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_version_paren\s*=\s*ignore|sp_version_paren\s*=\s*add|sp_version_paren\s*=\s*remove|sp_version_paren\s*=\s*force|sp_version_paren\s*=\s*not_defined
+Choices=sp_version_paren=ignore|sp_version_paren=add|sp_version_paren=remove|sp_version_paren=force|sp_version_paren=not_defined
+ChoicesRegex=sp_version_paren\s*=\s*ignore|sp_version_paren\s*=\s*add|sp_version_paren\s*=\s*remove|sp_version_paren\s*=\s*force|sp_version_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Version Paren|Add Sp Version Paren|Remove Sp Version Paren|Force Sp Version Paren"
 ValueDefault=ignore
 
@@ -1780,7 +1975,8 @@ Category=1
 Description="<html>(D) Add or remove space between 'scope' and '('<br/>in 'scope (something) { }'. If set to ignore, sp_before_sparen is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_scope_paren\s*=\s*ignore|sp_scope_paren\s*=\s*add|sp_scope_paren\s*=\s*remove|sp_scope_paren\s*=\s*force|sp_scope_paren\s*=\s*not_defined
+Choices=sp_scope_paren=ignore|sp_scope_paren=add|sp_scope_paren=remove|sp_scope_paren=force|sp_scope_paren=not_defined
+ChoicesRegex=sp_scope_paren\s*=\s*ignore|sp_scope_paren\s*=\s*add|sp_scope_paren\s*=\s*remove|sp_scope_paren\s*=\s*force|sp_scope_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Scope Paren|Add Sp Scope Paren|Remove Sp Scope Paren|Force Sp Scope Paren"
 ValueDefault=ignore
 
@@ -1789,7 +1985,8 @@ Category=1
 Description="<html>Add or remove space between 'super' and '(' in 'super (something)'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_super_paren\s*=\s*ignore|sp_super_paren\s*=\s*add|sp_super_paren\s*=\s*remove|sp_super_paren\s*=\s*force|sp_super_paren\s*=\s*not_defined
+Choices=sp_super_paren=ignore|sp_super_paren=add|sp_super_paren=remove|sp_super_paren=force|sp_super_paren=not_defined
+ChoicesRegex=sp_super_paren\s*=\s*ignore|sp_super_paren\s*=\s*add|sp_super_paren\s*=\s*remove|sp_super_paren\s*=\s*force|sp_super_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Super Paren|Add Sp Super Paren|Remove Sp Super Paren|Force Sp Super Paren"
 ValueDefault=remove
 
@@ -1798,7 +1995,8 @@ Category=1
 Description="<html>Add or remove space between 'this' and '(' in 'this (something)'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_this_paren\s*=\s*ignore|sp_this_paren\s*=\s*add|sp_this_paren\s*=\s*remove|sp_this_paren\s*=\s*force|sp_this_paren\s*=\s*not_defined
+Choices=sp_this_paren=ignore|sp_this_paren=add|sp_this_paren=remove|sp_this_paren=force|sp_this_paren=not_defined
+ChoicesRegex=sp_this_paren\s*=\s*ignore|sp_this_paren\s*=\s*add|sp_this_paren\s*=\s*remove|sp_this_paren\s*=\s*force|sp_this_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp This Paren|Add Sp This Paren|Remove Sp This Paren|Force Sp This Paren"
 ValueDefault=remove
 
@@ -1807,7 +2005,8 @@ Category=1
 Description="<html>Add or remove space between a macro name and its definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_macro\s*=\s*ignore|sp_macro\s*=\s*add|sp_macro\s*=\s*remove|sp_macro\s*=\s*force|sp_macro\s*=\s*not_defined
+Choices=sp_macro=ignore|sp_macro=add|sp_macro=remove|sp_macro=force|sp_macro=not_defined
+ChoicesRegex=sp_macro\s*=\s*ignore|sp_macro\s*=\s*add|sp_macro\s*=\s*remove|sp_macro\s*=\s*force|sp_macro\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Macro|Add Sp Macro|Remove Sp Macro|Force Sp Macro"
 ValueDefault=ignore
 
@@ -1816,7 +2015,8 @@ Category=1
 Description="<html>Add or remove space between a macro function ')' and its definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_macro_func\s*=\s*ignore|sp_macro_func\s*=\s*add|sp_macro_func\s*=\s*remove|sp_macro_func\s*=\s*force|sp_macro_func\s*=\s*not_defined
+Choices=sp_macro_func=ignore|sp_macro_func=add|sp_macro_func=remove|sp_macro_func=force|sp_macro_func=not_defined
+ChoicesRegex=sp_macro_func\s*=\s*ignore|sp_macro_func\s*=\s*add|sp_macro_func\s*=\s*remove|sp_macro_func\s*=\s*force|sp_macro_func\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Macro Func|Add Sp Macro Func|Remove Sp Macro Func|Force Sp Macro Func"
 ValueDefault=ignore
 
@@ -1825,7 +2025,8 @@ Category=1
 Description="<html>Add or remove space between 'else' and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_else_brace\s*=\s*ignore|sp_else_brace\s*=\s*add|sp_else_brace\s*=\s*remove|sp_else_brace\s*=\s*force|sp_else_brace\s*=\s*not_defined
+Choices=sp_else_brace=ignore|sp_else_brace=add|sp_else_brace=remove|sp_else_brace=force|sp_else_brace=not_defined
+ChoicesRegex=sp_else_brace\s*=\s*ignore|sp_else_brace\s*=\s*add|sp_else_brace\s*=\s*remove|sp_else_brace\s*=\s*force|sp_else_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Else Brace|Add Sp Else Brace|Remove Sp Else Brace|Force Sp Else Brace"
 ValueDefault=ignore
 
@@ -1834,7 +2035,8 @@ Category=1
 Description="<html>Add or remove space between '}' and 'else' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_else\s*=\s*ignore|sp_brace_else\s*=\s*add|sp_brace_else\s*=\s*remove|sp_brace_else\s*=\s*force|sp_brace_else\s*=\s*not_defined
+Choices=sp_brace_else=ignore|sp_brace_else=add|sp_brace_else=remove|sp_brace_else=force|sp_brace_else=not_defined
+ChoicesRegex=sp_brace_else\s*=\s*ignore|sp_brace_else\s*=\s*add|sp_brace_else\s*=\s*remove|sp_brace_else\s*=\s*force|sp_brace_else\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Else|Add Sp Brace Else|Remove Sp Brace Else|Force Sp Brace Else"
 ValueDefault=ignore
 
@@ -1843,7 +2045,8 @@ Category=1
 Description="<html>Add or remove space between '}' and the name of a typedef on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_typedef\s*=\s*ignore|sp_brace_typedef\s*=\s*add|sp_brace_typedef\s*=\s*remove|sp_brace_typedef\s*=\s*force|sp_brace_typedef\s*=\s*not_defined
+Choices=sp_brace_typedef=ignore|sp_brace_typedef=add|sp_brace_typedef=remove|sp_brace_typedef=force|sp_brace_typedef=not_defined
+ChoicesRegex=sp_brace_typedef\s*=\s*ignore|sp_brace_typedef\s*=\s*add|sp_brace_typedef\s*=\s*remove|sp_brace_typedef\s*=\s*force|sp_brace_typedef\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Typedef|Add Sp Brace Typedef|Remove Sp Brace Typedef|Force Sp Brace Typedef"
 ValueDefault=ignore
 
@@ -1852,7 +2055,8 @@ Category=1
 Description="<html>Add or remove space before the '{' of a 'catch' statement, if the '{' and<br/>'catch' are on the same line, as in 'catch (decl) &lt;here&gt; {'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_catch_brace\s*=\s*ignore|sp_catch_brace\s*=\s*add|sp_catch_brace\s*=\s*remove|sp_catch_brace\s*=\s*force|sp_catch_brace\s*=\s*not_defined
+Choices=sp_catch_brace=ignore|sp_catch_brace=add|sp_catch_brace=remove|sp_catch_brace=force|sp_catch_brace=not_defined
+ChoicesRegex=sp_catch_brace\s*=\s*ignore|sp_catch_brace\s*=\s*add|sp_catch_brace\s*=\s*remove|sp_catch_brace\s*=\s*force|sp_catch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Catch Brace|Add Sp Catch Brace|Remove Sp Catch Brace|Force Sp Catch Brace"
 ValueDefault=ignore
 
@@ -1861,7 +2065,8 @@ Category=1
 Description="<html>(OC) Add or remove space before the '{' of a '@catch' statement, if the '{'<br/>and '@catch' are on the same line, as in '@catch (decl) &lt;here&gt; {'.<br/>If set to ignore, sp_catch_brace is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_oc_catch_brace\s*=\s*ignore|sp_oc_catch_brace\s*=\s*add|sp_oc_catch_brace\s*=\s*remove|sp_oc_catch_brace\s*=\s*force|sp_oc_catch_brace\s*=\s*not_defined
+Choices=sp_oc_catch_brace=ignore|sp_oc_catch_brace=add|sp_oc_catch_brace=remove|sp_oc_catch_brace=force|sp_oc_catch_brace=not_defined
+ChoicesRegex=sp_oc_catch_brace\s*=\s*ignore|sp_oc_catch_brace\s*=\s*add|sp_oc_catch_brace\s*=\s*remove|sp_oc_catch_brace\s*=\s*force|sp_oc_catch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Oc Catch Brace|Add Sp Oc Catch Brace|Remove Sp Oc Catch Brace|Force Sp Oc Catch Brace"
 ValueDefault=ignore
 
@@ -1870,7 +2075,8 @@ Category=1
 Description="<html>Add or remove space between '}' and 'catch' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_catch\s*=\s*ignore|sp_brace_catch\s*=\s*add|sp_brace_catch\s*=\s*remove|sp_brace_catch\s*=\s*force|sp_brace_catch\s*=\s*not_defined
+Choices=sp_brace_catch=ignore|sp_brace_catch=add|sp_brace_catch=remove|sp_brace_catch=force|sp_brace_catch=not_defined
+ChoicesRegex=sp_brace_catch\s*=\s*ignore|sp_brace_catch\s*=\s*add|sp_brace_catch\s*=\s*remove|sp_brace_catch\s*=\s*force|sp_brace_catch\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Catch|Add Sp Brace Catch|Remove Sp Brace Catch|Force Sp Brace Catch"
 ValueDefault=ignore
 
@@ -1879,7 +2085,8 @@ Category=1
 Description="<html>(OC) Add or remove space between '}' and '@catch' if on the same line.<br/>If set to ignore, sp_brace_catch is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_oc_brace_catch\s*=\s*ignore|sp_oc_brace_catch\s*=\s*add|sp_oc_brace_catch\s*=\s*remove|sp_oc_brace_catch\s*=\s*force|sp_oc_brace_catch\s*=\s*not_defined
+Choices=sp_oc_brace_catch=ignore|sp_oc_brace_catch=add|sp_oc_brace_catch=remove|sp_oc_brace_catch=force|sp_oc_brace_catch=not_defined
+ChoicesRegex=sp_oc_brace_catch\s*=\s*ignore|sp_oc_brace_catch\s*=\s*add|sp_oc_brace_catch\s*=\s*remove|sp_oc_brace_catch\s*=\s*force|sp_oc_brace_catch\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Oc Brace Catch|Add Sp Oc Brace Catch|Remove Sp Oc Brace Catch|Force Sp Oc Brace Catch"
 ValueDefault=ignore
 
@@ -1888,7 +2095,8 @@ Category=1
 Description="<html>Add or remove space between 'finally' and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_finally_brace\s*=\s*ignore|sp_finally_brace\s*=\s*add|sp_finally_brace\s*=\s*remove|sp_finally_brace\s*=\s*force|sp_finally_brace\s*=\s*not_defined
+Choices=sp_finally_brace=ignore|sp_finally_brace=add|sp_finally_brace=remove|sp_finally_brace=force|sp_finally_brace=not_defined
+ChoicesRegex=sp_finally_brace\s*=\s*ignore|sp_finally_brace\s*=\s*add|sp_finally_brace\s*=\s*remove|sp_finally_brace\s*=\s*force|sp_finally_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Finally Brace|Add Sp Finally Brace|Remove Sp Finally Brace|Force Sp Finally Brace"
 ValueDefault=ignore
 
@@ -1897,7 +2105,8 @@ Category=1
 Description="<html>Add or remove space between '}' and 'finally' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_brace_finally\s*=\s*ignore|sp_brace_finally\s*=\s*add|sp_brace_finally\s*=\s*remove|sp_brace_finally\s*=\s*force|sp_brace_finally\s*=\s*not_defined
+Choices=sp_brace_finally=ignore|sp_brace_finally=add|sp_brace_finally=remove|sp_brace_finally=force|sp_brace_finally=not_defined
+ChoicesRegex=sp_brace_finally\s*=\s*ignore|sp_brace_finally\s*=\s*add|sp_brace_finally\s*=\s*remove|sp_brace_finally\s*=\s*force|sp_brace_finally\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Brace Finally|Add Sp Brace Finally|Remove Sp Brace Finally|Force Sp Brace Finally"
 ValueDefault=ignore
 
@@ -1906,7 +2115,8 @@ Category=1
 Description="<html>Add or remove space between 'try' and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_try_brace\s*=\s*ignore|sp_try_brace\s*=\s*add|sp_try_brace\s*=\s*remove|sp_try_brace\s*=\s*force|sp_try_brace\s*=\s*not_defined
+Choices=sp_try_brace=ignore|sp_try_brace=add|sp_try_brace=remove|sp_try_brace=force|sp_try_brace=not_defined
+ChoicesRegex=sp_try_brace\s*=\s*ignore|sp_try_brace\s*=\s*add|sp_try_brace\s*=\s*remove|sp_try_brace\s*=\s*force|sp_try_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Try Brace|Add Sp Try Brace|Remove Sp Try Brace|Force Sp Try Brace"
 ValueDefault=ignore
 
@@ -1915,7 +2125,8 @@ Category=1
 Description="<html>Add or remove space between get/set and '{' if on the same line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_getset_brace\s*=\s*ignore|sp_getset_brace\s*=\s*add|sp_getset_brace\s*=\s*remove|sp_getset_brace\s*=\s*force|sp_getset_brace\s*=\s*not_defined
+Choices=sp_getset_brace=ignore|sp_getset_brace=add|sp_getset_brace=remove|sp_getset_brace=force|sp_getset_brace=not_defined
+ChoicesRegex=sp_getset_brace\s*=\s*ignore|sp_getset_brace\s*=\s*add|sp_getset_brace\s*=\s*remove|sp_getset_brace\s*=\s*force|sp_getset_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Getset Brace|Add Sp Getset Brace|Remove Sp Getset Brace|Force Sp Getset Brace"
 ValueDefault=ignore
 
@@ -1924,7 +2135,8 @@ Category=1
 Description="<html>Add or remove space between a variable and '{' for C++ uniform<br/>initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_word_brace_init_lst\s*=\s*ignore|sp_word_brace_init_lst\s*=\s*add|sp_word_brace_init_lst\s*=\s*remove|sp_word_brace_init_lst\s*=\s*force|sp_word_brace_init_lst\s*=\s*not_defined
+Choices=sp_word_brace_init_lst=ignore|sp_word_brace_init_lst=add|sp_word_brace_init_lst=remove|sp_word_brace_init_lst=force|sp_word_brace_init_lst=not_defined
+ChoicesRegex=sp_word_brace_init_lst\s*=\s*ignore|sp_word_brace_init_lst\s*=\s*add|sp_word_brace_init_lst\s*=\s*remove|sp_word_brace_init_lst\s*=\s*force|sp_word_brace_init_lst\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Word Brace Init Lst|Add Sp Word Brace Init Lst|Remove Sp Word Brace Init Lst|Force Sp Word Brace Init Lst"
 ValueDefault=ignore
 
@@ -1933,7 +2145,8 @@ Category=1
 Description="<html>Add or remove space between a variable and '{' for a namespace.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_word_brace_ns\s*=\s*ignore|sp_word_brace_ns\s*=\s*add|sp_word_brace_ns\s*=\s*remove|sp_word_brace_ns\s*=\s*force|sp_word_brace_ns\s*=\s*not_defined
+Choices=sp_word_brace_ns=ignore|sp_word_brace_ns=add|sp_word_brace_ns=remove|sp_word_brace_ns=force|sp_word_brace_ns=not_defined
+ChoicesRegex=sp_word_brace_ns\s*=\s*ignore|sp_word_brace_ns\s*=\s*add|sp_word_brace_ns\s*=\s*remove|sp_word_brace_ns\s*=\s*force|sp_word_brace_ns\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Word Brace Ns|Add Sp Word Brace Ns|Remove Sp Word Brace Ns|Force Sp Word Brace Ns"
 ValueDefault=add
 
@@ -1942,7 +2155,8 @@ Category=1
 Description="<html>Add or remove space before the '::' operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_dc\s*=\s*ignore|sp_before_dc\s*=\s*add|sp_before_dc\s*=\s*remove|sp_before_dc\s*=\s*force|sp_before_dc\s*=\s*not_defined
+Choices=sp_before_dc=ignore|sp_before_dc=add|sp_before_dc=remove|sp_before_dc=force|sp_before_dc=not_defined
+ChoicesRegex=sp_before_dc\s*=\s*ignore|sp_before_dc\s*=\s*add|sp_before_dc\s*=\s*remove|sp_before_dc\s*=\s*force|sp_before_dc\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Dc|Add Sp Before Dc|Remove Sp Before Dc|Force Sp Before Dc"
 ValueDefault=ignore
 
@@ -1951,7 +2165,8 @@ Category=1
 Description="<html>Add or remove space after the '::' operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_dc\s*=\s*ignore|sp_after_dc\s*=\s*add|sp_after_dc\s*=\s*remove|sp_after_dc\s*=\s*force|sp_after_dc\s*=\s*not_defined
+Choices=sp_after_dc=ignore|sp_after_dc=add|sp_after_dc=remove|sp_after_dc=force|sp_after_dc=not_defined
+ChoicesRegex=sp_after_dc\s*=\s*ignore|sp_after_dc\s*=\s*add|sp_after_dc\s*=\s*remove|sp_after_dc\s*=\s*force|sp_after_dc\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Dc|Add Sp After Dc|Remove Sp After Dc|Force Sp After Dc"
 ValueDefault=ignore
 
@@ -1960,7 +2175,8 @@ Category=1
 Description="<html>(D) Add or remove around the D named array initializer ':' operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_d_array_colon\s*=\s*ignore|sp_d_array_colon\s*=\s*add|sp_d_array_colon\s*=\s*remove|sp_d_array_colon\s*=\s*force|sp_d_array_colon\s*=\s*not_defined
+Choices=sp_d_array_colon=ignore|sp_d_array_colon=add|sp_d_array_colon=remove|sp_d_array_colon=force|sp_d_array_colon=not_defined
+ChoicesRegex=sp_d_array_colon\s*=\s*ignore|sp_d_array_colon\s*=\s*add|sp_d_array_colon\s*=\s*remove|sp_d_array_colon\s*=\s*force|sp_d_array_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp D Array Colon|Add Sp D Array Colon|Remove Sp D Array Colon|Force Sp D Array Colon"
 ValueDefault=ignore
 
@@ -1969,7 +2185,8 @@ Category=1
 Description="<html>Add or remove space after the '!' (not) unary operator.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_not\s*=\s*ignore|sp_not\s*=\s*add|sp_not\s*=\s*remove|sp_not\s*=\s*force|sp_not\s*=\s*not_defined
+Choices=sp_not=ignore|sp_not=add|sp_not=remove|sp_not=force|sp_not=not_defined
+ChoicesRegex=sp_not\s*=\s*ignore|sp_not\s*=\s*add|sp_not\s*=\s*remove|sp_not\s*=\s*force|sp_not\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Not|Add Sp Not|Remove Sp Not|Force Sp Not"
 ValueDefault=remove
 
@@ -1978,7 +2195,8 @@ Category=1
 Description="<html>Add or remove space between two '!' (not) unary operators.<br/>If set to ignore, sp_not will be used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_not_not\s*=\s*ignore|sp_not_not\s*=\s*add|sp_not_not\s*=\s*remove|sp_not_not\s*=\s*force|sp_not_not\s*=\s*not_defined
+Choices=sp_not_not=ignore|sp_not_not=add|sp_not_not=remove|sp_not_not=force|sp_not_not=not_defined
+ChoicesRegex=sp_not_not\s*=\s*ignore|sp_not_not\s*=\s*add|sp_not_not\s*=\s*remove|sp_not_not\s*=\s*force|sp_not_not\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Not Not|Add Sp Not Not|Remove Sp Not Not|Force Sp Not Not"
 ValueDefault=ignore
 
@@ -1987,7 +2205,8 @@ Category=1
 Description="<html>Add or remove space after the '~' (invert) unary operator.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inv\s*=\s*ignore|sp_inv\s*=\s*add|sp_inv\s*=\s*remove|sp_inv\s*=\s*force|sp_inv\s*=\s*not_defined
+Choices=sp_inv=ignore|sp_inv=add|sp_inv=remove|sp_inv=force|sp_inv=not_defined
+ChoicesRegex=sp_inv\s*=\s*ignore|sp_inv\s*=\s*add|sp_inv\s*=\s*remove|sp_inv\s*=\s*force|sp_inv\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inv|Add Sp Inv|Remove Sp Inv|Force Sp Inv"
 ValueDefault=remove
 
@@ -1996,7 +2215,8 @@ Category=1
 Description="<html>Add or remove space after the '&amp;' (address-of) unary operator. This does not<br/>affect the spacing after a '&amp;' that is part of a type.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_addr\s*=\s*ignore|sp_addr\s*=\s*add|sp_addr\s*=\s*remove|sp_addr\s*=\s*force|sp_addr\s*=\s*not_defined
+Choices=sp_addr=ignore|sp_addr=add|sp_addr=remove|sp_addr=force|sp_addr=not_defined
+ChoicesRegex=sp_addr\s*=\s*ignore|sp_addr\s*=\s*add|sp_addr\s*=\s*remove|sp_addr\s*=\s*force|sp_addr\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Addr|Add Sp Addr|Remove Sp Addr|Force Sp Addr"
 ValueDefault=remove
 
@@ -2005,7 +2225,8 @@ Category=1
 Description="<html>Add or remove space around the '.' or '-&gt;' operators.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_member\s*=\s*ignore|sp_member\s*=\s*add|sp_member\s*=\s*remove|sp_member\s*=\s*force|sp_member\s*=\s*not_defined
+Choices=sp_member=ignore|sp_member=add|sp_member=remove|sp_member=force|sp_member=not_defined
+ChoicesRegex=sp_member\s*=\s*ignore|sp_member\s*=\s*add|sp_member\s*=\s*remove|sp_member\s*=\s*force|sp_member\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Member|Add Sp Member|Remove Sp Member|Force Sp Member"
 ValueDefault=remove
 
@@ -2014,7 +2235,8 @@ Category=1
 Description="<html>Add or remove space after the '*' (dereference) unary operator. This does<br/>not affect the spacing after a '*' that is part of a type.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_deref\s*=\s*ignore|sp_deref\s*=\s*add|sp_deref\s*=\s*remove|sp_deref\s*=\s*force|sp_deref\s*=\s*not_defined
+Choices=sp_deref=ignore|sp_deref=add|sp_deref=remove|sp_deref=force|sp_deref=not_defined
+ChoicesRegex=sp_deref\s*=\s*ignore|sp_deref\s*=\s*add|sp_deref\s*=\s*remove|sp_deref\s*=\s*force|sp_deref\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Deref|Add Sp Deref|Remove Sp Deref|Force Sp Deref"
 ValueDefault=remove
 
@@ -2023,7 +2245,8 @@ Category=1
 Description="<html>Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_sign\s*=\s*ignore|sp_sign\s*=\s*add|sp_sign\s*=\s*remove|sp_sign\s*=\s*force|sp_sign\s*=\s*not_defined
+Choices=sp_sign=ignore|sp_sign=add|sp_sign=remove|sp_sign=force|sp_sign=not_defined
+ChoicesRegex=sp_sign\s*=\s*ignore|sp_sign\s*=\s*add|sp_sign\s*=\s*remove|sp_sign\s*=\s*force|sp_sign\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Sign|Add Sp Sign|Remove Sp Sign|Force Sp Sign"
 ValueDefault=remove
 
@@ -2032,7 +2255,8 @@ Category=1
 Description="<html>Add or remove space between '++' and '--' the word to which it is being<br/>applied, as in '(--x)' or 'y++;'.<br/><br/>Default: remove</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_incdec\s*=\s*ignore|sp_incdec\s*=\s*add|sp_incdec\s*=\s*remove|sp_incdec\s*=\s*force|sp_incdec\s*=\s*not_defined
+Choices=sp_incdec=ignore|sp_incdec=add|sp_incdec=remove|sp_incdec=force|sp_incdec=not_defined
+ChoicesRegex=sp_incdec\s*=\s*ignore|sp_incdec\s*=\s*add|sp_incdec\s*=\s*remove|sp_incdec\s*=\s*force|sp_incdec\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Incdec|Add Sp Incdec|Remove Sp Incdec|Force Sp Incdec"
 ValueDefault=remove
 
@@ -2041,7 +2265,8 @@ Category=1
 Description="<html>Add or remove space before a backslash-newline at the end of a line.<br/><br/>Default: add</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_nl_cont\s*=\s*ignore|sp_before_nl_cont\s*=\s*add|sp_before_nl_cont\s*=\s*remove|sp_before_nl_cont\s*=\s*force|sp_before_nl_cont\s*=\s*not_defined
+Choices=sp_before_nl_cont=ignore|sp_before_nl_cont=add|sp_before_nl_cont=remove|sp_before_nl_cont=force|sp_before_nl_cont=not_defined
+ChoicesRegex=sp_before_nl_cont\s*=\s*ignore|sp_before_nl_cont\s*=\s*add|sp_before_nl_cont\s*=\s*remove|sp_before_nl_cont\s*=\s*force|sp_before_nl_cont\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Nl Cont|Add Sp Before Nl Cont|Remove Sp Before Nl Cont|Force Sp Before Nl Cont"
 ValueDefault=add
 
@@ -2050,7 +2275,8 @@ Category=1
 Description="<html>(OC) Add or remove space after the scope '+' or '-', as in '-(void) foo;'<br/>or '+(int) bar;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_scope\s*=\s*ignore|sp_after_oc_scope\s*=\s*add|sp_after_oc_scope\s*=\s*remove|sp_after_oc_scope\s*=\s*force|sp_after_oc_scope\s*=\s*not_defined
+Choices=sp_after_oc_scope=ignore|sp_after_oc_scope=add|sp_after_oc_scope=remove|sp_after_oc_scope=force|sp_after_oc_scope=not_defined
+ChoicesRegex=sp_after_oc_scope\s*=\s*ignore|sp_after_oc_scope\s*=\s*add|sp_after_oc_scope\s*=\s*remove|sp_after_oc_scope\s*=\s*force|sp_after_oc_scope\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Scope|Add Sp After Oc Scope|Remove Sp After Oc Scope|Force Sp After Oc Scope"
 ValueDefault=ignore
 
@@ -2059,7 +2285,8 @@ Category=1
 Description="<html>(OC) Add or remove space after the colon in message specs,<br/>i.e. '-(int) f:(int) x;' vs. '-(int) f: (int) x;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_colon\s*=\s*ignore|sp_after_oc_colon\s*=\s*add|sp_after_oc_colon\s*=\s*remove|sp_after_oc_colon\s*=\s*force|sp_after_oc_colon\s*=\s*not_defined
+Choices=sp_after_oc_colon=ignore|sp_after_oc_colon=add|sp_after_oc_colon=remove|sp_after_oc_colon=force|sp_after_oc_colon=not_defined
+ChoicesRegex=sp_after_oc_colon\s*=\s*ignore|sp_after_oc_colon\s*=\s*add|sp_after_oc_colon\s*=\s*remove|sp_after_oc_colon\s*=\s*force|sp_after_oc_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Colon|Add Sp After Oc Colon|Remove Sp After Oc Colon|Force Sp After Oc Colon"
 ValueDefault=ignore
 
@@ -2068,7 +2295,8 @@ Category=1
 Description="<html>(OC) Add or remove space before the colon in message specs,<br/>i.e. '-(int) f: (int) x;' vs. '-(int) f : (int) x;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_oc_colon\s*=\s*ignore|sp_before_oc_colon\s*=\s*add|sp_before_oc_colon\s*=\s*remove|sp_before_oc_colon\s*=\s*force|sp_before_oc_colon\s*=\s*not_defined
+Choices=sp_before_oc_colon=ignore|sp_before_oc_colon=add|sp_before_oc_colon=remove|sp_before_oc_colon=force|sp_before_oc_colon=not_defined
+ChoicesRegex=sp_before_oc_colon\s*=\s*ignore|sp_before_oc_colon\s*=\s*add|sp_before_oc_colon\s*=\s*remove|sp_before_oc_colon\s*=\s*force|sp_before_oc_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Oc Colon|Add Sp Before Oc Colon|Remove Sp Before Oc Colon|Force Sp Before Oc Colon"
 ValueDefault=ignore
 
@@ -2077,7 +2305,8 @@ Category=1
 Description="<html>(OC) Add or remove space after the colon in immutable dictionary expression<br/>'NSDictionary *test = @{@"foo" :@"bar"};'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_dict_colon\s*=\s*ignore|sp_after_oc_dict_colon\s*=\s*add|sp_after_oc_dict_colon\s*=\s*remove|sp_after_oc_dict_colon\s*=\s*force|sp_after_oc_dict_colon\s*=\s*not_defined
+Choices=sp_after_oc_dict_colon=ignore|sp_after_oc_dict_colon=add|sp_after_oc_dict_colon=remove|sp_after_oc_dict_colon=force|sp_after_oc_dict_colon=not_defined
+ChoicesRegex=sp_after_oc_dict_colon\s*=\s*ignore|sp_after_oc_dict_colon\s*=\s*add|sp_after_oc_dict_colon\s*=\s*remove|sp_after_oc_dict_colon\s*=\s*force|sp_after_oc_dict_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Dict Colon|Add Sp After Oc Dict Colon|Remove Sp After Oc Dict Colon|Force Sp After Oc Dict Colon"
 ValueDefault=ignore
 
@@ -2086,7 +2315,8 @@ Category=1
 Description="<html>(OC) Add or remove space before the colon in immutable dictionary expression<br/>'NSDictionary *test = @{@"foo" :@"bar"};'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_oc_dict_colon\s*=\s*ignore|sp_before_oc_dict_colon\s*=\s*add|sp_before_oc_dict_colon\s*=\s*remove|sp_before_oc_dict_colon\s*=\s*force|sp_before_oc_dict_colon\s*=\s*not_defined
+Choices=sp_before_oc_dict_colon=ignore|sp_before_oc_dict_colon=add|sp_before_oc_dict_colon=remove|sp_before_oc_dict_colon=force|sp_before_oc_dict_colon=not_defined
+ChoicesRegex=sp_before_oc_dict_colon\s*=\s*ignore|sp_before_oc_dict_colon\s*=\s*add|sp_before_oc_dict_colon\s*=\s*remove|sp_before_oc_dict_colon\s*=\s*force|sp_before_oc_dict_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Oc Dict Colon|Add Sp Before Oc Dict Colon|Remove Sp Before Oc Dict Colon|Force Sp Before Oc Dict Colon"
 ValueDefault=ignore
 
@@ -2095,7 +2325,8 @@ Category=1
 Description="<html>(OC) Add or remove space after the colon in message specs,<br/>i.e. '[object setValue:1];' vs. '[object setValue: 1];'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_send_oc_colon\s*=\s*ignore|sp_after_send_oc_colon\s*=\s*add|sp_after_send_oc_colon\s*=\s*remove|sp_after_send_oc_colon\s*=\s*force|sp_after_send_oc_colon\s*=\s*not_defined
+Choices=sp_after_send_oc_colon=ignore|sp_after_send_oc_colon=add|sp_after_send_oc_colon=remove|sp_after_send_oc_colon=force|sp_after_send_oc_colon=not_defined
+ChoicesRegex=sp_after_send_oc_colon\s*=\s*ignore|sp_after_send_oc_colon\s*=\s*add|sp_after_send_oc_colon\s*=\s*remove|sp_after_send_oc_colon\s*=\s*force|sp_after_send_oc_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Send Oc Colon|Add Sp After Send Oc Colon|Remove Sp After Send Oc Colon|Force Sp After Send Oc Colon"
 ValueDefault=ignore
 
@@ -2104,7 +2335,8 @@ Category=1
 Description="<html>(OC) Add or remove space before the colon in message specs,<br/>i.e. '[object setValue:1];' vs. '[object setValue :1];'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_send_oc_colon\s*=\s*ignore|sp_before_send_oc_colon\s*=\s*add|sp_before_send_oc_colon\s*=\s*remove|sp_before_send_oc_colon\s*=\s*force|sp_before_send_oc_colon\s*=\s*not_defined
+Choices=sp_before_send_oc_colon=ignore|sp_before_send_oc_colon=add|sp_before_send_oc_colon=remove|sp_before_send_oc_colon=force|sp_before_send_oc_colon=not_defined
+ChoicesRegex=sp_before_send_oc_colon\s*=\s*ignore|sp_before_send_oc_colon\s*=\s*add|sp_before_send_oc_colon\s*=\s*remove|sp_before_send_oc_colon\s*=\s*force|sp_before_send_oc_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Send Oc Colon|Add Sp Before Send Oc Colon|Remove Sp Before Send Oc Colon|Force Sp Before Send Oc Colon"
 ValueDefault=ignore
 
@@ -2113,7 +2345,8 @@ Category=1
 Description="<html>(OC) Add or remove space after the (type) in message specs,<br/>i.e. '-(int)f: (int) x;' vs. '-(int)f: (int)x;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_type\s*=\s*ignore|sp_after_oc_type\s*=\s*add|sp_after_oc_type\s*=\s*remove|sp_after_oc_type\s*=\s*force|sp_after_oc_type\s*=\s*not_defined
+Choices=sp_after_oc_type=ignore|sp_after_oc_type=add|sp_after_oc_type=remove|sp_after_oc_type=force|sp_after_oc_type=not_defined
+ChoicesRegex=sp_after_oc_type\s*=\s*ignore|sp_after_oc_type\s*=\s*add|sp_after_oc_type\s*=\s*remove|sp_after_oc_type\s*=\s*force|sp_after_oc_type\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Type|Add Sp After Oc Type|Remove Sp After Oc Type|Force Sp After Oc Type"
 ValueDefault=ignore
 
@@ -2122,7 +2355,8 @@ Category=1
 Description="<html>(OC) Add or remove space after the first (type) in message specs,<br/>i.e. '-(int) f:(int)x;' vs. '-(int)f:(int)x;'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_return_type\s*=\s*ignore|sp_after_oc_return_type\s*=\s*add|sp_after_oc_return_type\s*=\s*remove|sp_after_oc_return_type\s*=\s*force|sp_after_oc_return_type\s*=\s*not_defined
+Choices=sp_after_oc_return_type=ignore|sp_after_oc_return_type=add|sp_after_oc_return_type=remove|sp_after_oc_return_type=force|sp_after_oc_return_type=not_defined
+ChoicesRegex=sp_after_oc_return_type\s*=\s*ignore|sp_after_oc_return_type\s*=\s*add|sp_after_oc_return_type\s*=\s*remove|sp_after_oc_return_type\s*=\s*force|sp_after_oc_return_type\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Return Type|Add Sp After Oc Return Type|Remove Sp After Oc Return Type|Force Sp After Oc Return Type"
 ValueDefault=ignore
 
@@ -2131,7 +2365,8 @@ Category=1
 Description="<html>(OC) Add or remove space between '@selector' and '(',<br/>i.e. '@selector(msgName)' vs. '@selector (msgName)'.<br/>Also applies to '@protocol()' constructs.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_at_sel\s*=\s*ignore|sp_after_oc_at_sel\s*=\s*add|sp_after_oc_at_sel\s*=\s*remove|sp_after_oc_at_sel\s*=\s*force|sp_after_oc_at_sel\s*=\s*not_defined
+Choices=sp_after_oc_at_sel=ignore|sp_after_oc_at_sel=add|sp_after_oc_at_sel=remove|sp_after_oc_at_sel=force|sp_after_oc_at_sel=not_defined
+ChoicesRegex=sp_after_oc_at_sel\s*=\s*ignore|sp_after_oc_at_sel\s*=\s*add|sp_after_oc_at_sel\s*=\s*remove|sp_after_oc_at_sel\s*=\s*force|sp_after_oc_at_sel\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc At Sel|Add Sp After Oc At Sel|Remove Sp After Oc At Sel|Force Sp After Oc At Sel"
 ValueDefault=ignore
 
@@ -2140,7 +2375,8 @@ Category=1
 Description="<html>(OC) Add or remove space between '@selector(x)' and the following word,<br/>i.e. '@selector(foo) a:' vs. '@selector(foo)a:'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_at_sel_parens\s*=\s*ignore|sp_after_oc_at_sel_parens\s*=\s*add|sp_after_oc_at_sel_parens\s*=\s*remove|sp_after_oc_at_sel_parens\s*=\s*force|sp_after_oc_at_sel_parens\s*=\s*not_defined
+Choices=sp_after_oc_at_sel_parens=ignore|sp_after_oc_at_sel_parens=add|sp_after_oc_at_sel_parens=remove|sp_after_oc_at_sel_parens=force|sp_after_oc_at_sel_parens=not_defined
+ChoicesRegex=sp_after_oc_at_sel_parens\s*=\s*ignore|sp_after_oc_at_sel_parens\s*=\s*add|sp_after_oc_at_sel_parens\s*=\s*remove|sp_after_oc_at_sel_parens\s*=\s*force|sp_after_oc_at_sel_parens\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc At Sel Parens|Add Sp After Oc At Sel Parens|Remove Sp After Oc At Sel Parens|Force Sp After Oc At Sel Parens"
 ValueDefault=ignore
 
@@ -2149,7 +2385,8 @@ Category=1
 Description="<html>(OC) Add or remove space inside '@selector' parentheses,<br/>i.e. '@selector(foo)' vs. '@selector( foo )'.<br/>Also applies to '@protocol()' constructs.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_oc_at_sel_parens\s*=\s*ignore|sp_inside_oc_at_sel_parens\s*=\s*add|sp_inside_oc_at_sel_parens\s*=\s*remove|sp_inside_oc_at_sel_parens\s*=\s*force|sp_inside_oc_at_sel_parens\s*=\s*not_defined
+Choices=sp_inside_oc_at_sel_parens=ignore|sp_inside_oc_at_sel_parens=add|sp_inside_oc_at_sel_parens=remove|sp_inside_oc_at_sel_parens=force|sp_inside_oc_at_sel_parens=not_defined
+ChoicesRegex=sp_inside_oc_at_sel_parens\s*=\s*ignore|sp_inside_oc_at_sel_parens\s*=\s*add|sp_inside_oc_at_sel_parens\s*=\s*remove|sp_inside_oc_at_sel_parens\s*=\s*force|sp_inside_oc_at_sel_parens\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Oc At Sel Parens|Add Sp Inside Oc At Sel Parens|Remove Sp Inside Oc At Sel Parens|Force Sp Inside Oc At Sel Parens"
 ValueDefault=ignore
 
@@ -2158,7 +2395,8 @@ Category=1
 Description="<html>(OC) Add or remove space before a block pointer caret,<br/>i.e. '^int (int arg){...}' vs. ' ^int (int arg){...}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_oc_block_caret\s*=\s*ignore|sp_before_oc_block_caret\s*=\s*add|sp_before_oc_block_caret\s*=\s*remove|sp_before_oc_block_caret\s*=\s*force|sp_before_oc_block_caret\s*=\s*not_defined
+Choices=sp_before_oc_block_caret=ignore|sp_before_oc_block_caret=add|sp_before_oc_block_caret=remove|sp_before_oc_block_caret=force|sp_before_oc_block_caret=not_defined
+ChoicesRegex=sp_before_oc_block_caret\s*=\s*ignore|sp_before_oc_block_caret\s*=\s*add|sp_before_oc_block_caret\s*=\s*remove|sp_before_oc_block_caret\s*=\s*force|sp_before_oc_block_caret\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Oc Block Caret|Add Sp Before Oc Block Caret|Remove Sp Before Oc Block Caret|Force Sp Before Oc Block Caret"
 ValueDefault=ignore
 
@@ -2167,7 +2405,8 @@ Category=1
 Description="<html>(OC) Add or remove space after a block pointer caret,<br/>i.e. '^int (int arg){...}' vs. '^ int (int arg){...}'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_block_caret\s*=\s*ignore|sp_after_oc_block_caret\s*=\s*add|sp_after_oc_block_caret\s*=\s*remove|sp_after_oc_block_caret\s*=\s*force|sp_after_oc_block_caret\s*=\s*not_defined
+Choices=sp_after_oc_block_caret=ignore|sp_after_oc_block_caret=add|sp_after_oc_block_caret=remove|sp_after_oc_block_caret=force|sp_after_oc_block_caret=not_defined
+ChoicesRegex=sp_after_oc_block_caret\s*=\s*ignore|sp_after_oc_block_caret\s*=\s*add|sp_after_oc_block_caret\s*=\s*remove|sp_after_oc_block_caret\s*=\s*force|sp_after_oc_block_caret\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Block Caret|Add Sp After Oc Block Caret|Remove Sp After Oc Block Caret|Force Sp After Oc Block Caret"
 ValueDefault=ignore
 
@@ -2176,7 +2415,8 @@ Category=1
 Description="<html>(OC) Add or remove space between the receiver and selector in a message,<br/>as in '[receiver selector ...]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_msg_receiver\s*=\s*ignore|sp_after_oc_msg_receiver\s*=\s*add|sp_after_oc_msg_receiver\s*=\s*remove|sp_after_oc_msg_receiver\s*=\s*force|sp_after_oc_msg_receiver\s*=\s*not_defined
+Choices=sp_after_oc_msg_receiver=ignore|sp_after_oc_msg_receiver=add|sp_after_oc_msg_receiver=remove|sp_after_oc_msg_receiver=force|sp_after_oc_msg_receiver=not_defined
+ChoicesRegex=sp_after_oc_msg_receiver\s*=\s*ignore|sp_after_oc_msg_receiver\s*=\s*add|sp_after_oc_msg_receiver\s*=\s*remove|sp_after_oc_msg_receiver\s*=\s*force|sp_after_oc_msg_receiver\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Msg Receiver|Add Sp After Oc Msg Receiver|Remove Sp After Oc Msg Receiver|Force Sp After Oc Msg Receiver"
 ValueDefault=ignore
 
@@ -2185,7 +2425,8 @@ Category=1
 Description="<html>(OC) Add or remove space after '@property'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_property\s*=\s*ignore|sp_after_oc_property\s*=\s*add|sp_after_oc_property\s*=\s*remove|sp_after_oc_property\s*=\s*force|sp_after_oc_property\s*=\s*not_defined
+Choices=sp_after_oc_property=ignore|sp_after_oc_property=add|sp_after_oc_property=remove|sp_after_oc_property=force|sp_after_oc_property=not_defined
+ChoicesRegex=sp_after_oc_property\s*=\s*ignore|sp_after_oc_property\s*=\s*add|sp_after_oc_property\s*=\s*remove|sp_after_oc_property\s*=\s*force|sp_after_oc_property\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Property|Add Sp After Oc Property|Remove Sp After Oc Property|Force Sp After Oc Property"
 ValueDefault=ignore
 
@@ -2194,7 +2435,8 @@ Category=1
 Description="<html>(OC) Add or remove space between '@synchronized' and the open parenthesis,<br/>i.e. '@synchronized(foo)' vs. '@synchronized (foo)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_oc_synchronized\s*=\s*ignore|sp_after_oc_synchronized\s*=\s*add|sp_after_oc_synchronized\s*=\s*remove|sp_after_oc_synchronized\s*=\s*force|sp_after_oc_synchronized\s*=\s*not_defined
+Choices=sp_after_oc_synchronized=ignore|sp_after_oc_synchronized=add|sp_after_oc_synchronized=remove|sp_after_oc_synchronized=force|sp_after_oc_synchronized=not_defined
+ChoicesRegex=sp_after_oc_synchronized\s*=\s*ignore|sp_after_oc_synchronized\s*=\s*add|sp_after_oc_synchronized\s*=\s*remove|sp_after_oc_synchronized\s*=\s*force|sp_after_oc_synchronized\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Oc Synchronized|Add Sp After Oc Synchronized|Remove Sp After Oc Synchronized|Force Sp After Oc Synchronized"
 ValueDefault=ignore
 
@@ -2203,7 +2445,8 @@ Category=1
 Description="<html>Add or remove space around the ':' in 'b ? t : f'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_colon\s*=\s*ignore|sp_cond_colon\s*=\s*add|sp_cond_colon\s*=\s*remove|sp_cond_colon\s*=\s*force|sp_cond_colon\s*=\s*not_defined
+Choices=sp_cond_colon=ignore|sp_cond_colon=add|sp_cond_colon=remove|sp_cond_colon=force|sp_cond_colon=not_defined
+ChoicesRegex=sp_cond_colon\s*=\s*ignore|sp_cond_colon\s*=\s*add|sp_cond_colon\s*=\s*remove|sp_cond_colon\s*=\s*force|sp_cond_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Colon|Add Sp Cond Colon|Remove Sp Cond Colon|Force Sp Cond Colon"
 ValueDefault=ignore
 
@@ -2212,7 +2455,8 @@ Category=1
 Description="<html>Add or remove space before the ':' in 'b ? t : f'.<br/><br/>Overrides sp_cond_colon.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_colon_before\s*=\s*ignore|sp_cond_colon_before\s*=\s*add|sp_cond_colon_before\s*=\s*remove|sp_cond_colon_before\s*=\s*force|sp_cond_colon_before\s*=\s*not_defined
+Choices=sp_cond_colon_before=ignore|sp_cond_colon_before=add|sp_cond_colon_before=remove|sp_cond_colon_before=force|sp_cond_colon_before=not_defined
+ChoicesRegex=sp_cond_colon_before\s*=\s*ignore|sp_cond_colon_before\s*=\s*add|sp_cond_colon_before\s*=\s*remove|sp_cond_colon_before\s*=\s*force|sp_cond_colon_before\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Colon Before|Add Sp Cond Colon Before|Remove Sp Cond Colon Before|Force Sp Cond Colon Before"
 ValueDefault=ignore
 
@@ -2221,7 +2465,8 @@ Category=1
 Description="<html>Add or remove space after the ':' in 'b ? t : f'.<br/><br/>Overrides sp_cond_colon.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_colon_after\s*=\s*ignore|sp_cond_colon_after\s*=\s*add|sp_cond_colon_after\s*=\s*remove|sp_cond_colon_after\s*=\s*force|sp_cond_colon_after\s*=\s*not_defined
+Choices=sp_cond_colon_after=ignore|sp_cond_colon_after=add|sp_cond_colon_after=remove|sp_cond_colon_after=force|sp_cond_colon_after=not_defined
+ChoicesRegex=sp_cond_colon_after\s*=\s*ignore|sp_cond_colon_after\s*=\s*add|sp_cond_colon_after\s*=\s*remove|sp_cond_colon_after\s*=\s*force|sp_cond_colon_after\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Colon After|Add Sp Cond Colon After|Remove Sp Cond Colon After|Force Sp Cond Colon After"
 ValueDefault=ignore
 
@@ -2230,7 +2475,8 @@ Category=1
 Description="<html>Add or remove space around the '?' in 'b ? t : f'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_question\s*=\s*ignore|sp_cond_question\s*=\s*add|sp_cond_question\s*=\s*remove|sp_cond_question\s*=\s*force|sp_cond_question\s*=\s*not_defined
+Choices=sp_cond_question=ignore|sp_cond_question=add|sp_cond_question=remove|sp_cond_question=force|sp_cond_question=not_defined
+ChoicesRegex=sp_cond_question\s*=\s*ignore|sp_cond_question\s*=\s*add|sp_cond_question\s*=\s*remove|sp_cond_question\s*=\s*force|sp_cond_question\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Question|Add Sp Cond Question|Remove Sp Cond Question|Force Sp Cond Question"
 ValueDefault=ignore
 
@@ -2239,7 +2485,8 @@ Category=1
 Description="<html>Add or remove space before the '?' in 'b ? t : f'.<br/><br/>Overrides sp_cond_question.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_question_before\s*=\s*ignore|sp_cond_question_before\s*=\s*add|sp_cond_question_before\s*=\s*remove|sp_cond_question_before\s*=\s*force|sp_cond_question_before\s*=\s*not_defined
+Choices=sp_cond_question_before=ignore|sp_cond_question_before=add|sp_cond_question_before=remove|sp_cond_question_before=force|sp_cond_question_before=not_defined
+ChoicesRegex=sp_cond_question_before\s*=\s*ignore|sp_cond_question_before\s*=\s*add|sp_cond_question_before\s*=\s*remove|sp_cond_question_before\s*=\s*force|sp_cond_question_before\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Question Before|Add Sp Cond Question Before|Remove Sp Cond Question Before|Force Sp Cond Question Before"
 ValueDefault=ignore
 
@@ -2248,7 +2495,8 @@ Category=1
 Description="<html>Add or remove space after the '?' in 'b ? t : f'.<br/><br/>Overrides sp_cond_question.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_question_after\s*=\s*ignore|sp_cond_question_after\s*=\s*add|sp_cond_question_after\s*=\s*remove|sp_cond_question_after\s*=\s*force|sp_cond_question_after\s*=\s*not_defined
+Choices=sp_cond_question_after=ignore|sp_cond_question_after=add|sp_cond_question_after=remove|sp_cond_question_after=force|sp_cond_question_after=not_defined
+ChoicesRegex=sp_cond_question_after\s*=\s*ignore|sp_cond_question_after\s*=\s*add|sp_cond_question_after\s*=\s*remove|sp_cond_question_after\s*=\s*force|sp_cond_question_after\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Question After|Add Sp Cond Question After|Remove Sp Cond Question After|Force Sp Cond Question After"
 ValueDefault=ignore
 
@@ -2257,7 +2505,8 @@ Category=1
 Description="<html>In the abbreviated ternary form '(a ?: b)', add or remove space between '?'<br/>and ':'.<br/><br/>Overrides all other sp_cond_* options.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cond_ternary_short\s*=\s*ignore|sp_cond_ternary_short\s*=\s*add|sp_cond_ternary_short\s*=\s*remove|sp_cond_ternary_short\s*=\s*force|sp_cond_ternary_short\s*=\s*not_defined
+Choices=sp_cond_ternary_short=ignore|sp_cond_ternary_short=add|sp_cond_ternary_short=remove|sp_cond_ternary_short=force|sp_cond_ternary_short=not_defined
+ChoicesRegex=sp_cond_ternary_short\s*=\s*ignore|sp_cond_ternary_short\s*=\s*add|sp_cond_ternary_short\s*=\s*remove|sp_cond_ternary_short\s*=\s*force|sp_cond_ternary_short\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cond Ternary Short|Add Sp Cond Ternary Short|Remove Sp Cond Ternary Short|Force Sp Cond Ternary Short"
 ValueDefault=ignore
 
@@ -2266,7 +2515,8 @@ Category=1
 Description="<html>Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make<br/>sense here.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_case_label\s*=\s*ignore|sp_case_label\s*=\s*add|sp_case_label\s*=\s*remove|sp_case_label\s*=\s*force|sp_case_label\s*=\s*not_defined
+Choices=sp_case_label=ignore|sp_case_label=add|sp_case_label=remove|sp_case_label=force|sp_case_label=not_defined
+ChoicesRegex=sp_case_label\s*=\s*ignore|sp_case_label\s*=\s*add|sp_case_label\s*=\s*remove|sp_case_label\s*=\s*force|sp_case_label\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Case Label|Add Sp Case Label|Remove Sp Case Label|Force Sp Case Label"
 ValueDefault=ignore
 
@@ -2275,7 +2525,8 @@ Category=1
 Description="<html>(D) Add or remove space around the D '..' operator.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_range\s*=\s*ignore|sp_range\s*=\s*add|sp_range\s*=\s*remove|sp_range\s*=\s*force|sp_range\s*=\s*not_defined
+Choices=sp_range=ignore|sp_range=add|sp_range=remove|sp_range=force|sp_range=not_defined
+ChoicesRegex=sp_range\s*=\s*ignore|sp_range\s*=\s*add|sp_range\s*=\s*remove|sp_range\s*=\s*force|sp_range\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Range|Add Sp Range|Remove Sp Range|Force Sp Range"
 ValueDefault=ignore
 
@@ -2284,7 +2535,8 @@ Category=1
 Description="<html>Add or remove space after ':' in a Java/C++11 range-based 'for',<br/>as in 'for (Type var : &lt;here&gt; expr)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_for_colon\s*=\s*ignore|sp_after_for_colon\s*=\s*add|sp_after_for_colon\s*=\s*remove|sp_after_for_colon\s*=\s*force|sp_after_for_colon\s*=\s*not_defined
+Choices=sp_after_for_colon=ignore|sp_after_for_colon=add|sp_after_for_colon=remove|sp_after_for_colon=force|sp_after_for_colon=not_defined
+ChoicesRegex=sp_after_for_colon\s*=\s*ignore|sp_after_for_colon\s*=\s*add|sp_after_for_colon\s*=\s*remove|sp_after_for_colon\s*=\s*force|sp_after_for_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After For Colon|Add Sp After For Colon|Remove Sp After For Colon|Force Sp After For Colon"
 ValueDefault=ignore
 
@@ -2293,7 +2545,8 @@ Category=1
 Description="<html>Add or remove space before ':' in a Java/C++11 range-based 'for',<br/>as in 'for (Type var &lt;here&gt; : expr)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_for_colon\s*=\s*ignore|sp_before_for_colon\s*=\s*add|sp_before_for_colon\s*=\s*remove|sp_before_for_colon\s*=\s*force|sp_before_for_colon\s*=\s*not_defined
+Choices=sp_before_for_colon=ignore|sp_before_for_colon=add|sp_before_for_colon=remove|sp_before_for_colon=force|sp_before_for_colon=not_defined
+ChoicesRegex=sp_before_for_colon\s*=\s*ignore|sp_before_for_colon\s*=\s*add|sp_before_for_colon\s*=\s*remove|sp_before_for_colon\s*=\s*force|sp_before_for_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before For Colon|Add Sp Before For Colon|Remove Sp Before For Colon|Force Sp Before For Colon"
 ValueDefault=ignore
 
@@ -2302,7 +2555,8 @@ Category=1
 Description="<html>(D) Add or remove space between 'extern' and '(' as in 'extern &lt;here&gt; (C)'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_extern_paren\s*=\s*ignore|sp_extern_paren\s*=\s*add|sp_extern_paren\s*=\s*remove|sp_extern_paren\s*=\s*force|sp_extern_paren\s*=\s*not_defined
+Choices=sp_extern_paren=ignore|sp_extern_paren=add|sp_extern_paren=remove|sp_extern_paren=force|sp_extern_paren=not_defined
+ChoicesRegex=sp_extern_paren\s*=\s*ignore|sp_extern_paren\s*=\s*add|sp_extern_paren\s*=\s*remove|sp_extern_paren\s*=\s*force|sp_extern_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Extern Paren|Add Sp Extern Paren|Remove Sp Extern Paren|Force Sp Extern Paren"
 ValueDefault=ignore
 
@@ -2311,7 +2565,8 @@ Category=1
 Description="<html>Add or remove space after the opening of a C++ comment, as in '// &lt;here&gt; A'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cmt_cpp_start\s*=\s*ignore|sp_cmt_cpp_start\s*=\s*add|sp_cmt_cpp_start\s*=\s*remove|sp_cmt_cpp_start\s*=\s*force|sp_cmt_cpp_start\s*=\s*not_defined
+Choices=sp_cmt_cpp_start=ignore|sp_cmt_cpp_start=add|sp_cmt_cpp_start=remove|sp_cmt_cpp_start=force|sp_cmt_cpp_start=not_defined
+ChoicesRegex=sp_cmt_cpp_start\s*=\s*ignore|sp_cmt_cpp_start\s*=\s*add|sp_cmt_cpp_start\s*=\s*remove|sp_cmt_cpp_start\s*=\s*force|sp_cmt_cpp_start\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cmt Cpp Start|Add Sp Cmt Cpp Start|Remove Sp Cmt Cpp Start|Force Sp Cmt Cpp Start"
 ValueDefault=ignore
 
@@ -2320,7 +2575,8 @@ Category=1
 Description="<html>remove space after the '//' and the pvs command '-V1234',<br/>only works with sp_cmt_cpp_start set to add or force.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_cmt_cpp_pvs\s*=\s*true|sp_cmt_cpp_pvs\s*=\s*false
+TrueFalse=sp_cmt_cpp_pvs=true|sp_cmt_cpp_pvs=false
+TrueFalseRegex=sp_cmt_cpp_pvs\s*=\s*true|sp_cmt_cpp_pvs\s*=\s*false
 ValueDefault=false
 
 [Sp Cmt Cpp Lint]
@@ -2328,7 +2584,8 @@ Category=1
 Description="<html>remove space after the '//' and the command 'lint',<br/>only works with sp_cmt_cpp_start set to add or force.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_cmt_cpp_lint\s*=\s*true|sp_cmt_cpp_lint\s*=\s*false
+TrueFalse=sp_cmt_cpp_lint=true|sp_cmt_cpp_lint=false
+TrueFalseRegex=sp_cmt_cpp_lint\s*=\s*true|sp_cmt_cpp_lint\s*=\s*false
 ValueDefault=false
 
 [Sp Cmt Cpp Region]
@@ -2336,7 +2593,8 @@ Category=1
 Description="<html>Add or remove space in a C++ region marker comment, as in '// &lt;here&gt; BEGIN'.<br/>A region marker is defined as a comment which is not preceded by other text<br/>(i.e. the comment is the first non-whitespace on the line), and which starts<br/>with either 'BEGIN' or 'END'.<br/><br/>Overrides sp_cmt_cpp_start.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_cmt_cpp_region\s*=\s*ignore|sp_cmt_cpp_region\s*=\s*add|sp_cmt_cpp_region\s*=\s*remove|sp_cmt_cpp_region\s*=\s*force|sp_cmt_cpp_region\s*=\s*not_defined
+Choices=sp_cmt_cpp_region=ignore|sp_cmt_cpp_region=add|sp_cmt_cpp_region=remove|sp_cmt_cpp_region=force|sp_cmt_cpp_region=not_defined
+ChoicesRegex=sp_cmt_cpp_region\s*=\s*ignore|sp_cmt_cpp_region\s*=\s*add|sp_cmt_cpp_region\s*=\s*remove|sp_cmt_cpp_region\s*=\s*force|sp_cmt_cpp_region\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Cmt Cpp Region|Add Sp Cmt Cpp Region|Remove Sp Cmt Cpp Region|Force Sp Cmt Cpp Region"
 ValueDefault=ignore
 
@@ -2345,7 +2603,8 @@ Category=1
 Description="<html>If true, space added with sp_cmt_cpp_start will be added after Doxygen<br/>sequences like '///', '///&lt;', '//!' and '//!&lt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_cmt_cpp_doxygen\s*=\s*true|sp_cmt_cpp_doxygen\s*=\s*false
+TrueFalse=sp_cmt_cpp_doxygen=true|sp_cmt_cpp_doxygen=false
+TrueFalseRegex=sp_cmt_cpp_doxygen\s*=\s*true|sp_cmt_cpp_doxygen\s*=\s*false
 ValueDefault=false
 
 [Sp Cmt Cpp Qttr]
@@ -2353,7 +2612,8 @@ Category=1
 Description="<html>If true, space added with sp_cmt_cpp_start will be added after Qt translator<br/>or meta-data comments like '//:', '//=', and '//~'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_cmt_cpp_qttr\s*=\s*true|sp_cmt_cpp_qttr\s*=\s*false
+TrueFalse=sp_cmt_cpp_qttr=true|sp_cmt_cpp_qttr=false
+TrueFalseRegex=sp_cmt_cpp_qttr\s*=\s*true|sp_cmt_cpp_qttr\s*=\s*false
 ValueDefault=false
 
 [Sp Endif Cmt]
@@ -2361,7 +2621,8 @@ Category=1
 Description="<html>Add or remove space between #else or #endif and a trailing comment.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_endif_cmt\s*=\s*ignore|sp_endif_cmt\s*=\s*add|sp_endif_cmt\s*=\s*remove|sp_endif_cmt\s*=\s*force|sp_endif_cmt\s*=\s*not_defined
+Choices=sp_endif_cmt=ignore|sp_endif_cmt=add|sp_endif_cmt=remove|sp_endif_cmt=force|sp_endif_cmt=not_defined
+ChoicesRegex=sp_endif_cmt\s*=\s*ignore|sp_endif_cmt\s*=\s*add|sp_endif_cmt\s*=\s*remove|sp_endif_cmt\s*=\s*force|sp_endif_cmt\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Endif Cmt|Add Sp Endif Cmt|Remove Sp Endif Cmt|Force Sp Endif Cmt"
 ValueDefault=ignore
 
@@ -2370,7 +2631,8 @@ Category=1
 Description="<html>Add or remove space after 'new', 'delete' and 'delete[]'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_new\s*=\s*ignore|sp_after_new\s*=\s*add|sp_after_new\s*=\s*remove|sp_after_new\s*=\s*force|sp_after_new\s*=\s*not_defined
+Choices=sp_after_new=ignore|sp_after_new=add|sp_after_new=remove|sp_after_new=force|sp_after_new=not_defined
+ChoicesRegex=sp_after_new\s*=\s*ignore|sp_after_new\s*=\s*add|sp_after_new\s*=\s*remove|sp_after_new\s*=\s*force|sp_after_new\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After New|Add Sp After New|Remove Sp After New|Force Sp After New"
 ValueDefault=ignore
 
@@ -2379,7 +2641,8 @@ Category=1
 Description="<html>Add or remove space between 'new' and '(' in 'new()'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_between_new_paren\s*=\s*ignore|sp_between_new_paren\s*=\s*add|sp_between_new_paren\s*=\s*remove|sp_between_new_paren\s*=\s*force|sp_between_new_paren\s*=\s*not_defined
+Choices=sp_between_new_paren=ignore|sp_between_new_paren=add|sp_between_new_paren=remove|sp_between_new_paren=force|sp_between_new_paren=not_defined
+ChoicesRegex=sp_between_new_paren\s*=\s*ignore|sp_between_new_paren\s*=\s*add|sp_between_new_paren\s*=\s*remove|sp_between_new_paren\s*=\s*force|sp_between_new_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Between New Paren|Add Sp Between New Paren|Remove Sp Between New Paren|Force Sp Between New Paren"
 ValueDefault=ignore
 
@@ -2388,7 +2651,8 @@ Category=1
 Description="<html>Add or remove space between ')' and type in 'new(foo) BAR'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_newop_paren\s*=\s*ignore|sp_after_newop_paren\s*=\s*add|sp_after_newop_paren\s*=\s*remove|sp_after_newop_paren\s*=\s*force|sp_after_newop_paren\s*=\s*not_defined
+Choices=sp_after_newop_paren=ignore|sp_after_newop_paren=add|sp_after_newop_paren=remove|sp_after_newop_paren=force|sp_after_newop_paren=not_defined
+ChoicesRegex=sp_after_newop_paren\s*=\s*ignore|sp_after_newop_paren\s*=\s*add|sp_after_newop_paren\s*=\s*remove|sp_after_newop_paren\s*=\s*force|sp_after_newop_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Newop Paren|Add Sp After Newop Paren|Remove Sp After Newop Paren|Force Sp After Newop Paren"
 ValueDefault=ignore
 
@@ -2397,7 +2661,8 @@ Category=1
 Description="<html>Add or remove space inside parentheses of the new operator<br/>as in 'new(foo) BAR'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_newop_paren\s*=\s*ignore|sp_inside_newop_paren\s*=\s*add|sp_inside_newop_paren\s*=\s*remove|sp_inside_newop_paren\s*=\s*force|sp_inside_newop_paren\s*=\s*not_defined
+Choices=sp_inside_newop_paren=ignore|sp_inside_newop_paren=add|sp_inside_newop_paren=remove|sp_inside_newop_paren=force|sp_inside_newop_paren=not_defined
+ChoicesRegex=sp_inside_newop_paren\s*=\s*ignore|sp_inside_newop_paren\s*=\s*add|sp_inside_newop_paren\s*=\s*remove|sp_inside_newop_paren\s*=\s*force|sp_inside_newop_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Newop Paren|Add Sp Inside Newop Paren|Remove Sp Inside Newop Paren|Force Sp Inside Newop Paren"
 ValueDefault=ignore
 
@@ -2406,7 +2671,8 @@ Category=1
 Description="<html>Add or remove space after the open parenthesis of the new operator,<br/>as in 'new(foo) BAR'.<br/><br/>Overrides sp_inside_newop_paren.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_newop_paren_open\s*=\s*ignore|sp_inside_newop_paren_open\s*=\s*add|sp_inside_newop_paren_open\s*=\s*remove|sp_inside_newop_paren_open\s*=\s*force|sp_inside_newop_paren_open\s*=\s*not_defined
+Choices=sp_inside_newop_paren_open=ignore|sp_inside_newop_paren_open=add|sp_inside_newop_paren_open=remove|sp_inside_newop_paren_open=force|sp_inside_newop_paren_open=not_defined
+ChoicesRegex=sp_inside_newop_paren_open\s*=\s*ignore|sp_inside_newop_paren_open\s*=\s*add|sp_inside_newop_paren_open\s*=\s*remove|sp_inside_newop_paren_open\s*=\s*force|sp_inside_newop_paren_open\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Newop Paren Open|Add Sp Inside Newop Paren Open|Remove Sp Inside Newop Paren Open|Force Sp Inside Newop Paren Open"
 ValueDefault=ignore
 
@@ -2415,7 +2681,8 @@ Category=1
 Description="<html>Add or remove space before the close parenthesis of the new operator,<br/>as in 'new(foo) BAR'.<br/><br/>Overrides sp_inside_newop_paren.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_inside_newop_paren_close\s*=\s*ignore|sp_inside_newop_paren_close\s*=\s*add|sp_inside_newop_paren_close\s*=\s*remove|sp_inside_newop_paren_close\s*=\s*force|sp_inside_newop_paren_close\s*=\s*not_defined
+Choices=sp_inside_newop_paren_close=ignore|sp_inside_newop_paren_close=add|sp_inside_newop_paren_close=remove|sp_inside_newop_paren_close=force|sp_inside_newop_paren_close=not_defined
+ChoicesRegex=sp_inside_newop_paren_close\s*=\s*ignore|sp_inside_newop_paren_close\s*=\s*add|sp_inside_newop_paren_close\s*=\s*remove|sp_inside_newop_paren_close\s*=\s*force|sp_inside_newop_paren_close\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Inside Newop Paren Close|Add Sp Inside Newop Paren Close|Remove Sp Inside Newop Paren Close|Force Sp Inside Newop Paren Close"
 ValueDefault=ignore
 
@@ -2424,7 +2691,8 @@ Category=1
 Description="<html>Add or remove space before a trailing comment.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_tr_cmt\s*=\s*ignore|sp_before_tr_cmt\s*=\s*add|sp_before_tr_cmt\s*=\s*remove|sp_before_tr_cmt\s*=\s*force|sp_before_tr_cmt\s*=\s*not_defined
+Choices=sp_before_tr_cmt=ignore|sp_before_tr_cmt=add|sp_before_tr_cmt=remove|sp_before_tr_cmt=force|sp_before_tr_cmt=not_defined
+ChoicesRegex=sp_before_tr_cmt\s*=\s*ignore|sp_before_tr_cmt\s*=\s*add|sp_before_tr_cmt\s*=\s*remove|sp_before_tr_cmt\s*=\s*force|sp_before_tr_cmt\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Tr Cmt|Add Sp Before Tr Cmt|Remove Sp Before Tr Cmt|Force Sp Before Tr Cmt"
 ValueDefault=ignore
 
@@ -2433,7 +2701,8 @@ Category=1
 Description="<html>Number of spaces before a trailing comment.</html>"
 Enabled=false
 EditorType=numeric
-CallName="sp_num_before_tr_cmt\s*=\s*"
+CallName="sp_num_before_tr_cmt="
+CallNameRegex="sp_num_before_tr_cmt\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2443,7 +2712,8 @@ Category=1
 Description="<html>Add or remove space before an embedded comment.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_emb_cmt\s*=\s*ignore|sp_before_emb_cmt\s*=\s*add|sp_before_emb_cmt\s*=\s*remove|sp_before_emb_cmt\s*=\s*force|sp_before_emb_cmt\s*=\s*not_defined
+Choices=sp_before_emb_cmt=ignore|sp_before_emb_cmt=add|sp_before_emb_cmt=remove|sp_before_emb_cmt=force|sp_before_emb_cmt=not_defined
+ChoicesRegex=sp_before_emb_cmt\s*=\s*ignore|sp_before_emb_cmt\s*=\s*add|sp_before_emb_cmt\s*=\s*remove|sp_before_emb_cmt\s*=\s*force|sp_before_emb_cmt\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Emb Cmt|Add Sp Before Emb Cmt|Remove Sp Before Emb Cmt|Force Sp Before Emb Cmt"
 ValueDefault=force
 
@@ -2452,7 +2722,8 @@ Category=1
 Description="<html>Number of spaces before an embedded comment.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="sp_num_before_emb_cmt\s*=\s*"
+CallName="sp_num_before_emb_cmt="
+CallNameRegex="sp_num_before_emb_cmt\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -2462,7 +2733,8 @@ Category=1
 Description="<html>Add or remove space after an embedded comment.<br/><br/>Default: force</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_emb_cmt\s*=\s*ignore|sp_after_emb_cmt\s*=\s*add|sp_after_emb_cmt\s*=\s*remove|sp_after_emb_cmt\s*=\s*force|sp_after_emb_cmt\s*=\s*not_defined
+Choices=sp_after_emb_cmt=ignore|sp_after_emb_cmt=add|sp_after_emb_cmt=remove|sp_after_emb_cmt=force|sp_after_emb_cmt=not_defined
+ChoicesRegex=sp_after_emb_cmt\s*=\s*ignore|sp_after_emb_cmt\s*=\s*add|sp_after_emb_cmt\s*=\s*remove|sp_after_emb_cmt\s*=\s*force|sp_after_emb_cmt\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Emb Cmt|Add Sp After Emb Cmt|Remove Sp After Emb Cmt|Force Sp After Emb Cmt"
 ValueDefault=force
 
@@ -2471,7 +2743,8 @@ Category=1
 Description="<html>Number of spaces after an embedded comment.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="sp_num_after_emb_cmt\s*=\s*"
+CallName="sp_num_after_emb_cmt="
+CallNameRegex="sp_num_after_emb_cmt\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -2481,7 +2754,8 @@ Category=1
 Description="<html>(Java) Add or remove space between an annotation and the open parenthesis.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_annotation_paren\s*=\s*ignore|sp_annotation_paren\s*=\s*add|sp_annotation_paren\s*=\s*remove|sp_annotation_paren\s*=\s*force|sp_annotation_paren\s*=\s*not_defined
+Choices=sp_annotation_paren=ignore|sp_annotation_paren=add|sp_annotation_paren=remove|sp_annotation_paren=force|sp_annotation_paren=not_defined
+ChoicesRegex=sp_annotation_paren\s*=\s*ignore|sp_annotation_paren\s*=\s*add|sp_annotation_paren\s*=\s*remove|sp_annotation_paren\s*=\s*force|sp_annotation_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Annotation Paren|Add Sp Annotation Paren|Remove Sp Annotation Paren|Force Sp Annotation Paren"
 ValueDefault=ignore
 
@@ -2490,7 +2764,8 @@ Category=1
 Description="<html>If true, vbrace tokens are dropped to the previous token and skipped.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=sp_skip_vbrace_tokens\s*=\s*true|sp_skip_vbrace_tokens\s*=\s*false
+TrueFalse=sp_skip_vbrace_tokens=true|sp_skip_vbrace_tokens=false
+TrueFalseRegex=sp_skip_vbrace_tokens\s*=\s*true|sp_skip_vbrace_tokens\s*=\s*false
 ValueDefault=false
 
 [Sp After Noexcept]
@@ -2498,7 +2773,8 @@ Category=1
 Description="<html>Add or remove space after 'noexcept'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_noexcept\s*=\s*ignore|sp_after_noexcept\s*=\s*add|sp_after_noexcept\s*=\s*remove|sp_after_noexcept\s*=\s*force|sp_after_noexcept\s*=\s*not_defined
+Choices=sp_after_noexcept=ignore|sp_after_noexcept=add|sp_after_noexcept=remove|sp_after_noexcept=force|sp_after_noexcept=not_defined
+ChoicesRegex=sp_after_noexcept\s*=\s*ignore|sp_after_noexcept\s*=\s*add|sp_after_noexcept\s*=\s*remove|sp_after_noexcept\s*=\s*force|sp_after_noexcept\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Noexcept|Add Sp After Noexcept|Remove Sp After Noexcept|Force Sp After Noexcept"
 ValueDefault=ignore
 
@@ -2507,7 +2783,8 @@ Category=1
 Description="<html>Add or remove space after '_'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_vala_after_translation\s*=\s*ignore|sp_vala_after_translation\s*=\s*add|sp_vala_after_translation\s*=\s*remove|sp_vala_after_translation\s*=\s*force|sp_vala_after_translation\s*=\s*not_defined
+Choices=sp_vala_after_translation=ignore|sp_vala_after_translation=add|sp_vala_after_translation=remove|sp_vala_after_translation=force|sp_vala_after_translation=not_defined
+ChoicesRegex=sp_vala_after_translation\s*=\s*ignore|sp_vala_after_translation\s*=\s*add|sp_vala_after_translation\s*=\s*remove|sp_vala_after_translation\s*=\s*force|sp_vala_after_translation\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Vala After Translation|Add Sp Vala After Translation|Remove Sp Vala After Translation|Force Sp Vala After Translation"
 ValueDefault=ignore
 
@@ -2516,7 +2793,8 @@ Category=1
 Description="<html>Add or remove space before a bit colon ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_before_bit_colon\s*=\s*ignore|sp_before_bit_colon\s*=\s*add|sp_before_bit_colon\s*=\s*remove|sp_before_bit_colon\s*=\s*force|sp_before_bit_colon\s*=\s*not_defined
+Choices=sp_before_bit_colon=ignore|sp_before_bit_colon=add|sp_before_bit_colon=remove|sp_before_bit_colon=force|sp_before_bit_colon=not_defined
+ChoicesRegex=sp_before_bit_colon\s*=\s*ignore|sp_before_bit_colon\s*=\s*add|sp_before_bit_colon\s*=\s*remove|sp_before_bit_colon\s*=\s*force|sp_before_bit_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp Before Bit Colon|Add Sp Before Bit Colon|Remove Sp Before Bit Colon|Force Sp Before Bit Colon"
 ValueDefault=ignore
 
@@ -2525,7 +2803,8 @@ Category=1
 Description="<html>Add or remove space after a bit colon ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=sp_after_bit_colon\s*=\s*ignore|sp_after_bit_colon\s*=\s*add|sp_after_bit_colon\s*=\s*remove|sp_after_bit_colon\s*=\s*force|sp_after_bit_colon\s*=\s*not_defined
+Choices=sp_after_bit_colon=ignore|sp_after_bit_colon=add|sp_after_bit_colon=remove|sp_after_bit_colon=force|sp_after_bit_colon=not_defined
+ChoicesRegex=sp_after_bit_colon\s*=\s*ignore|sp_after_bit_colon\s*=\s*add|sp_after_bit_colon\s*=\s*remove|sp_after_bit_colon\s*=\s*force|sp_after_bit_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Sp After Bit Colon|Add Sp After Bit Colon|Remove Sp After Bit Colon|Force Sp After Bit Colon"
 ValueDefault=ignore
 
@@ -2534,7 +2813,8 @@ Category=1
 Description="<html>If true, a &lt;TAB&gt; is inserted after #define.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=force_tab_after_define\s*=\s*true|force_tab_after_define\s*=\s*false
+TrueFalse=force_tab_after_define=true|force_tab_after_define=false
+TrueFalseRegex=force_tab_after_define\s*=\s*true|force_tab_after_define\s*=\s*false
 ValueDefault=false
 
 [Indent Columns]
@@ -2542,7 +2822,8 @@ Category=2
 Description="<html>The number of columns to indent per level. Usually 2, 3, 4, or 8.<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_columns\s*=\s*"
+CallName="indent_columns="
+CallNameRegex="indent_columns\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=8
@@ -2552,7 +2833,8 @@ Category=2
 Description="<html>Whether to ignore indent for the first continuation line. Subsequent<br/>continuation lines will still be indented to match the first.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_first_continue\s*=\s*true|indent_ignore_first_continue\s*=\s*false
+TrueFalse=indent_ignore_first_continue=true|indent_ignore_first_continue=false
+TrueFalseRegex=indent_ignore_first_continue\s*=\s*true|indent_ignore_first_continue\s*=\s*false
 ValueDefault=false
 
 [Indent Continue]
@@ -2560,7 +2842,8 @@ Category=2
 Description="<html>The continuation indent. If non-zero, this overrides the indent of '(', '['<br/>and '=' continuation indents. Negative values are OK; negative value is<br/>absolute and not increased for each '(' or '[' level.<br/><br/>For FreeBSD, this is set to 4.<br/>Requires indent_ignore_first_continue=false.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_continue\s*=\s*"
+CallName="indent_continue="
+CallNameRegex="indent_continue\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -2570,7 +2853,8 @@ Category=2
 Description="<html>The continuation indent, only for class header line(s). If non-zero, this<br/>overrides the indent of 'class' continuation indents.<br/>Requires indent_ignore_first_continue=false.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_continue_class_head\s*=\s*"
+CallName="indent_continue_class_head="
+CallNameRegex="indent_continue_class_head\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2580,7 +2864,8 @@ Category=2
 Description="<html>Whether to indent empty lines (i.e. lines which contain only spaces before<br/>the newline character).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_single_newlines\s*=\s*true|indent_single_newlines\s*=\s*false
+TrueFalse=indent_single_newlines=true|indent_single_newlines=false
+TrueFalseRegex=indent_single_newlines\s*=\s*true|indent_single_newlines\s*=\s*false
 ValueDefault=false
 
 [Indent Param]
@@ -2588,7 +2873,8 @@ Category=2
 Description="<html>The continuation indent for func_*_param if they are true. If non-zero, this<br/>overrides the indent.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_param\s*=\s*"
+CallName="indent_param="
+CallNameRegex="indent_param\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2598,7 +2884,8 @@ Category=2
 Description="<html>How to use tabs when indenting code.<br/><br/>0: Spaces only<br/>1: Indent with tabs to brace level, align with spaces (default)<br/>2: Indent and align with tabs, using spaces when not on a tabstop<br/><br/>Default: 1</html>"
 Enabled=true
 EditorType=multiple
-Choices="indent_with_tabs\s*=\s*0|indent_with_tabs\s*=\s*1|indent_with_tabs\s*=\s*2"
+Choices="indent_with_tabs=0|indent_with_tabs=1|indent_with_tabs=2"
+ChoicesRegex="indent_with_tabs\s*=\s*0|indent_with_tabs\s*=\s*1|indent_with_tabs\s*=\s*2"
 ChoicesReadable="Spaces only|Indent with tabs, align with spaces|Indent and align with tabs"
 ValueDefault=1
 
@@ -2607,7 +2894,8 @@ Category=2
 Description="<html>Whether to indent comments that are not at a brace level with tabs on a<br/>tabstop. Requires indent_with_tabs=2. If false, will use spaces.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cmt_with_tabs\s*=\s*true|indent_cmt_with_tabs\s*=\s*false
+TrueFalse=indent_cmt_with_tabs=true|indent_cmt_with_tabs=false
+TrueFalseRegex=indent_cmt_with_tabs\s*=\s*true|indent_cmt_with_tabs\s*=\s*false
 ValueDefault=false
 
 [Indent Align String]
@@ -2615,7 +2903,8 @@ Category=2
 Description="<html>Whether to indent strings broken by '\' so that they line up.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_align_string\s*=\s*true|indent_align_string\s*=\s*false
+TrueFalse=indent_align_string=true|indent_align_string=false
+TrueFalseRegex=indent_align_string\s*=\s*true|indent_align_string\s*=\s*false
 ValueDefault=false
 
 [Indent Xml String]
@@ -2623,7 +2912,8 @@ Category=2
 Description="<html>The number of spaces to indent multi-line XML strings.<br/>Requires indent_align_string=true.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_xml_string\s*=\s*"
+CallName="indent_xml_string="
+CallNameRegex="indent_xml_string\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2633,7 +2923,8 @@ Category=2
 Description="<html>Spaces to indent '{' from level.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_brace\s*=\s*"
+CallName="indent_brace="
+CallNameRegex="indent_brace\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2643,7 +2934,8 @@ Category=2
 Description="<html>Whether braces are indented to the body level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_braces\s*=\s*true|indent_braces\s*=\s*false
+TrueFalse=indent_braces=true|indent_braces=false
+TrueFalseRegex=indent_braces\s*=\s*true|indent_braces\s*=\s*false
 ValueDefault=false
 
 [Indent Braces No Func]
@@ -2651,7 +2943,8 @@ Category=2
 Description="<html>Whether to disable indenting function braces if indent_braces=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_braces_no_func\s*=\s*true|indent_braces_no_func\s*=\s*false
+TrueFalse=indent_braces_no_func=true|indent_braces_no_func=false
+TrueFalseRegex=indent_braces_no_func\s*=\s*true|indent_braces_no_func\s*=\s*false
 ValueDefault=false
 
 [Indent Braces No Class]
@@ -2659,7 +2952,8 @@ Category=2
 Description="<html>Whether to disable indenting class braces if indent_braces=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_braces_no_class\s*=\s*true|indent_braces_no_class\s*=\s*false
+TrueFalse=indent_braces_no_class=true|indent_braces_no_class=false
+TrueFalseRegex=indent_braces_no_class\s*=\s*true|indent_braces_no_class\s*=\s*false
 ValueDefault=false
 
 [Indent Braces No Struct]
@@ -2667,7 +2961,8 @@ Category=2
 Description="<html>Whether to disable indenting struct braces if indent_braces=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_braces_no_struct\s*=\s*true|indent_braces_no_struct\s*=\s*false
+TrueFalse=indent_braces_no_struct=true|indent_braces_no_struct=false
+TrueFalseRegex=indent_braces_no_struct\s*=\s*true|indent_braces_no_struct\s*=\s*false
 ValueDefault=false
 
 [Indent Brace Parent]
@@ -2675,7 +2970,8 @@ Category=2
 Description="<html>Whether to indent based on the size of the brace parent,<br/>i.e. 'if' =&gt; 3 spaces, 'for' =&gt; 4 spaces, etc.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_brace_parent\s*=\s*true|indent_brace_parent\s*=\s*false
+TrueFalse=indent_brace_parent=true|indent_brace_parent=false
+TrueFalseRegex=indent_brace_parent\s*=\s*true|indent_brace_parent\s*=\s*false
 ValueDefault=false
 
 [Indent Paren Open Brace]
@@ -2683,7 +2979,8 @@ Category=2
 Description="<html>Whether to indent based on the open parenthesis instead of the open brace<br/>in '({\n'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_open_brace\s*=\s*true|indent_paren_open_brace\s*=\s*false
+TrueFalse=indent_paren_open_brace=true|indent_paren_open_brace=false
+TrueFalseRegex=indent_paren_open_brace\s*=\s*true|indent_paren_open_brace\s*=\s*false
 ValueDefault=false
 
 [Indent Cs Delegate Brace]
@@ -2691,7 +2988,8 @@ Category=2
 Description="<html>(C#) Whether to indent the brace of a C# delegate by another level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cs_delegate_brace\s*=\s*true|indent_cs_delegate_brace\s*=\s*false
+TrueFalse=indent_cs_delegate_brace=true|indent_cs_delegate_brace=false
+TrueFalseRegex=indent_cs_delegate_brace\s*=\s*true|indent_cs_delegate_brace\s*=\s*false
 ValueDefault=false
 
 [Indent Cs Delegate Body]
@@ -2699,7 +2997,8 @@ Category=2
 Description="<html>(C#) Whether to indent a C# delegate (to handle delegates with no brace) by<br/>another level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cs_delegate_body\s*=\s*true|indent_cs_delegate_body\s*=\s*false
+TrueFalse=indent_cs_delegate_body=true|indent_cs_delegate_body=false
+TrueFalseRegex=indent_cs_delegate_body\s*=\s*true|indent_cs_delegate_body\s*=\s*false
 ValueDefault=false
 
 [Indent Namespace]
@@ -2707,7 +3006,8 @@ Category=2
 Description="<html>Whether to indent the body of a 'namespace'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_namespace\s*=\s*true|indent_namespace\s*=\s*false
+TrueFalse=indent_namespace=true|indent_namespace=false
+TrueFalseRegex=indent_namespace\s*=\s*true|indent_namespace\s*=\s*false
 ValueDefault=false
 
 [Indent Namespace Single Indent]
@@ -2715,7 +3015,8 @@ Category=2
 Description="<html>Whether to indent only the first namespace, and not any nested namespaces.<br/>Requires indent_namespace=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_namespace_single_indent\s*=\s*true|indent_namespace_single_indent\s*=\s*false
+TrueFalse=indent_namespace_single_indent=true|indent_namespace_single_indent=false
+TrueFalseRegex=indent_namespace_single_indent\s*=\s*true|indent_namespace_single_indent\s*=\s*false
 ValueDefault=false
 
 [Indent Namespace Level]
@@ -2723,7 +3024,8 @@ Category=2
 Description="<html>The number of spaces to indent a namespace block.<br/>If set to zero, use the value indent_columns</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_namespace_level\s*=\s*"
+CallName="indent_namespace_level="
+CallNameRegex="indent_namespace_level\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2733,7 +3035,8 @@ Category=2
 Description="<html>If the body of the namespace is longer than this number, it won't be<br/>indented. Requires indent_namespace=true. 0 means no limit.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_namespace_limit\s*=\s*"
+CallName="indent_namespace_limit="
+CallNameRegex="indent_namespace_limit\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -2743,7 +3046,8 @@ Category=2
 Description="<html>Whether to indent only in inner namespaces (nested in other namespaces).<br/>Requires indent_namespace=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_namespace_inner_only\s*=\s*true|indent_namespace_inner_only\s*=\s*false
+TrueFalse=indent_namespace_inner_only=true|indent_namespace_inner_only=false
+TrueFalseRegex=indent_namespace_inner_only\s*=\s*true|indent_namespace_inner_only\s*=\s*false
 ValueDefault=false
 
 [Indent Extern]
@@ -2751,7 +3055,8 @@ Category=2
 Description="<html>Whether the 'extern "C"' body is indented.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_extern\s*=\s*true|indent_extern\s*=\s*false
+TrueFalse=indent_extern=true|indent_extern=false
+TrueFalseRegex=indent_extern\s*=\s*true|indent_extern\s*=\s*false
 ValueDefault=false
 
 [Indent Class]
@@ -2759,7 +3064,8 @@ Category=2
 Description="<html>Whether the 'class' body is indented.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_class\s*=\s*true|indent_class\s*=\s*false
+TrueFalse=indent_class=true|indent_class=false
+TrueFalseRegex=indent_class\s*=\s*true|indent_class\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Before Class Colon]
@@ -2767,7 +3073,8 @@ Category=2
 Description="<html>Whether to ignore indent for the leading base class colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_before_class_colon\s*=\s*true|indent_ignore_before_class_colon\s*=\s*false
+TrueFalse=indent_ignore_before_class_colon=true|indent_ignore_before_class_colon=false
+TrueFalseRegex=indent_ignore_before_class_colon\s*=\s*true|indent_ignore_before_class_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Before Class Colon]
@@ -2775,7 +3082,8 @@ Category=2
 Description="<html>Additional indent before the leading base class colon.<br/>Negative values decrease indent down to the first column.<br/>Requires indent_ignore_before_class_colon=false and a newline break before<br/>the colon (see pos_class_colon and nl_class_colon)</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_before_class_colon\s*=\s*"
+CallName="indent_before_class_colon="
+CallNameRegex="indent_before_class_colon\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -2785,7 +3093,8 @@ Category=2
 Description="<html>Whether to indent the stuff after a leading base class colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_class_colon\s*=\s*true|indent_class_colon\s*=\s*false
+TrueFalse=indent_class_colon=true|indent_class_colon=false
+TrueFalseRegex=indent_class_colon\s*=\s*true|indent_class_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Class On Colon]
@@ -2793,7 +3102,8 @@ Category=2
 Description="<html>Whether to indent based on a class colon instead of the stuff after the<br/>colon. Requires indent_class_colon=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_class_on_colon\s*=\s*true|indent_class_on_colon\s*=\s*false
+TrueFalse=indent_class_on_colon=true|indent_class_on_colon=false
+TrueFalseRegex=indent_class_on_colon\s*=\s*true|indent_class_on_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Before Constr Colon]
@@ -2801,7 +3111,8 @@ Category=2
 Description="<html>Whether to ignore indent for a leading class initializer colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_before_constr_colon\s*=\s*true|indent_ignore_before_constr_colon\s*=\s*false
+TrueFalse=indent_ignore_before_constr_colon=true|indent_ignore_before_constr_colon=false
+TrueFalseRegex=indent_ignore_before_constr_colon\s*=\s*true|indent_ignore_before_constr_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Constr Colon]
@@ -2809,7 +3120,8 @@ Category=2
 Description="<html>Whether to indent the stuff after a leading class initializer colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_constr_colon\s*=\s*true|indent_constr_colon\s*=\s*false
+TrueFalse=indent_constr_colon=true|indent_constr_colon=false
+TrueFalseRegex=indent_constr_colon\s*=\s*true|indent_constr_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Ctor Init Leading]
@@ -2817,7 +3129,8 @@ Category=2
 Description="<html>Virtual indent from the ':' for leading member initializers.<br/><br/>Default: 2</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_ctor_init_leading\s*=\s*"
+CallName="indent_ctor_init_leading="
+CallNameRegex="indent_ctor_init_leading\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=2
@@ -2827,7 +3140,8 @@ Category=2
 Description="<html>Virtual indent from the ':' for following member initializers.<br/><br/>Default: 2</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_ctor_init_following\s*=\s*"
+CallName="indent_ctor_init_following="
+CallNameRegex="indent_ctor_init_following\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=2
@@ -2837,7 +3151,8 @@ Category=2
 Description="<html>Additional indent for constructor initializer list.<br/>Negative values decrease indent down to the first column.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_ctor_init\s*=\s*"
+CallName="indent_ctor_init="
+CallNameRegex="indent_ctor_init\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -2847,7 +3162,8 @@ Category=2
 Description="<html>Whether to indent 'if' following 'else' as a new block under the 'else'.<br/>If false, 'else\nif' is treated as 'else if' for indenting purposes.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_else_if\s*=\s*true|indent_else_if\s*=\s*false
+TrueFalse=indent_else_if=true|indent_else_if=false
+TrueFalseRegex=indent_else_if\s*=\s*true|indent_else_if\s*=\s*false
 ValueDefault=false
 
 [Indent Var Def Blk]
@@ -2855,7 +3171,8 @@ Category=2
 Description="<html>Amount to indent variable declarations after a open brace.<br/><br/> &lt;0: Relative<br/>&gt;=0: Absolute</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_var_def_blk\s*=\s*"
+CallName="indent_var_def_blk="
+CallNameRegex="indent_var_def_blk\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -2865,7 +3182,8 @@ Category=2
 Description="<html>Whether to indent continued variable declarations instead of aligning.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_var_def_cont\s*=\s*true|indent_var_def_cont\s*=\s*false
+TrueFalse=indent_var_def_cont=true|indent_var_def_cont=false
+TrueFalseRegex=indent_var_def_cont\s*=\s*true|indent_var_def_cont\s*=\s*false
 ValueDefault=false
 
 [Indent Shift]
@@ -2873,7 +3191,8 @@ Category=2
 Description="<html>How to indent continued shift expressions ('&lt;&lt;' and '&gt;&gt;').<br/>Set align_left_shift=false when using this.<br/> 0: Align shift operators instead of indenting them (default)<br/> 1: Indent by one level<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_shift\s*=\s*"
+CallName="indent_shift="
+CallNameRegex="indent_shift\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=0
@@ -2883,7 +3202,8 @@ Category=2
 Description="<html>Whether to force indentation of function definitions to start in column 1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_def_force_col1\s*=\s*true|indent_func_def_force_col1\s*=\s*false
+TrueFalse=indent_func_def_force_col1=true|indent_func_def_force_col1=false
+TrueFalseRegex=indent_func_def_force_col1\s*=\s*true|indent_func_def_force_col1\s*=\s*false
 ValueDefault=false
 
 [Indent Func Call Param]
@@ -2891,7 +3211,8 @@ Category=2
 Description="<html>Whether to indent continued function call parameters one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_call_param\s*=\s*true|indent_func_call_param\s*=\s*false
+TrueFalse=indent_func_call_param=true|indent_func_call_param=false
+TrueFalseRegex=indent_func_call_param\s*=\s*true|indent_func_call_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Def Param]
@@ -2899,7 +3220,8 @@ Category=2
 Description="<html>Whether to indent continued function definition parameters one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_def_param\s*=\s*true|indent_func_def_param\s*=\s*false
+TrueFalse=indent_func_def_param=true|indent_func_def_param=false
+TrueFalseRegex=indent_func_def_param\s*=\s*true|indent_func_def_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Def Param Paren Pos Threshold]
@@ -2907,7 +3229,8 @@ Category=2
 Description="<html>for function definitions, only if indent_func_def_param is false<br/>Allows to align params when appropriate and indent them when not<br/>behave as if it was true if paren position is more than this value<br/>if paren position is more than the option value</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_func_def_param_paren_pos_threshold\s*=\s*"
+CallName="indent_func_def_param_paren_pos_threshold="
+CallNameRegex="indent_func_def_param_paren_pos_threshold\s*=\s*"
 MinVal=0
 MaxVal=160
 ValueDefault=0
@@ -2917,7 +3240,8 @@ Category=2
 Description="<html>Whether to indent continued function call prototype one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_proto_param\s*=\s*true|indent_func_proto_param\s*=\s*false
+TrueFalse=indent_func_proto_param=true|indent_func_proto_param=false
+TrueFalseRegex=indent_func_proto_param\s*=\s*true|indent_func_proto_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Class Param]
@@ -2925,7 +3249,8 @@ Category=2
 Description="<html>Whether to indent continued function call declaration one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_class_param\s*=\s*true|indent_func_class_param\s*=\s*false
+TrueFalse=indent_func_class_param=true|indent_func_class_param=false
+TrueFalseRegex=indent_func_class_param\s*=\s*true|indent_func_class_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Ctor Var Param]
@@ -2933,7 +3258,8 @@ Category=2
 Description="<html>Whether to indent continued class variable constructors one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_ctor_var_param\s*=\s*true|indent_func_ctor_var_param\s*=\s*false
+TrueFalse=indent_func_ctor_var_param=true|indent_func_ctor_var_param=false
+TrueFalseRegex=indent_func_ctor_var_param\s*=\s*true|indent_func_ctor_var_param\s*=\s*false
 ValueDefault=false
 
 [Indent Template Param]
@@ -2941,7 +3267,8 @@ Category=2
 Description="<html>Whether to indent continued template parameter list one indent level,<br/>rather than aligning parameters under the open parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_template_param\s*=\s*true|indent_template_param\s*=\s*false
+TrueFalse=indent_template_param=true|indent_template_param=false
+TrueFalseRegex=indent_template_param\s*=\s*true|indent_template_param\s*=\s*false
 ValueDefault=false
 
 [Indent Func Param Double]
@@ -2949,7 +3276,8 @@ Category=2
 Description="<html>Double the indent for indent_func_xxx_param options.<br/>Use both values of the options indent_columns and indent_param.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_func_param_double\s*=\s*true|indent_func_param_double\s*=\s*false
+TrueFalse=indent_func_param_double=true|indent_func_param_double=false
+TrueFalseRegex=indent_func_param_double\s*=\s*true|indent_func_param_double\s*=\s*false
 ValueDefault=false
 
 [Indent Func Const]
@@ -2957,7 +3285,8 @@ Category=2
 Description="<html>Indentation column for standalone 'const' qualifier on a function<br/>prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_func_const\s*=\s*"
+CallName="indent_func_const="
+CallNameRegex="indent_func_const\s*=\s*"
 MinVal=0
 MaxVal=69
 ValueDefault=0
@@ -2967,7 +3296,8 @@ Category=2
 Description="<html>Indentation column for standalone 'throw' qualifier on a function<br/>prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_func_throw\s*=\s*"
+CallName="indent_func_throw="
+CallNameRegex="indent_func_throw\s*=\s*"
 MinVal=0
 MaxVal=41
 ValueDefault=0
@@ -2977,7 +3307,8 @@ Category=2
 Description="<html>How to indent within a macro followed by a brace on the same line<br/>This allows reducing the indent in macros that have (for example)<br/>`do { ... } while ` blocks bracketing them.<br/><br/>true:  add an indent for the brace on the same line as the macro<br/>false: do not add an indent for the brace on the same line as the macro<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_macro_brace\s*=\s*true|indent_macro_brace\s*=\s*false
+TrueFalse=indent_macro_brace=true|indent_macro_brace=false
+TrueFalseRegex=indent_macro_brace\s*=\s*true|indent_macro_brace\s*=\s*false
 ValueDefault=true
 
 [Indent Member]
@@ -2985,7 +3316,8 @@ Category=2
 Description="<html>The number of spaces to indent a continued '-&gt;' or '.'.<br/>Usually set to 0, 1, or indent_columns.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_member\s*=\s*"
+CallName="indent_member="
+CallNameRegex="indent_member\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -2995,7 +3327,8 @@ Category=2
 Description="<html>Whether lines broken at '.' or '-&gt;' should be indented by a single indent.<br/>The indent_member option will not be effective if this is set to true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_member_single\s*=\s*true|indent_member_single\s*=\s*false
+TrueFalse=indent_member_single=true|indent_member_single=false
+TrueFalseRegex=indent_member_single\s*=\s*true|indent_member_single\s*=\s*false
 ValueDefault=false
 
 [Indent Single Line Comments Before]
@@ -3003,7 +3336,8 @@ Category=2
 Description="<html>Spaces to indent single line ('//') comments on lines before code.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_single_line_comments_before\s*=\s*"
+CallName="indent_single_line_comments_before="
+CallNameRegex="indent_single_line_comments_before\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3013,7 +3347,8 @@ Category=2
 Description="<html>Spaces to indent single line ('//') comments on lines after code.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_single_line_comments_after\s*=\s*"
+CallName="indent_single_line_comments_after="
+CallNameRegex="indent_single_line_comments_after\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3023,7 +3358,8 @@ Category=2
 Description="<html>When opening a paren for a control statement (if, for, while, etc), increase<br/>the indent level by this value. Negative values decrease the indent level.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_sparen_extra\s*=\s*"
+CallName="indent_sparen_extra="
+CallNameRegex="indent_sparen_extra\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -3033,7 +3369,8 @@ Category=2
 Description="<html>Whether to indent trailing single line ('//') comments relative to the code<br/>instead of trying to keep the same absolute column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_relative_single_line_comments\s*=\s*true|indent_relative_single_line_comments\s*=\s*false
+TrueFalse=indent_relative_single_line_comments=true|indent_relative_single_line_comments=false
+TrueFalseRegex=indent_relative_single_line_comments\s*=\s*true|indent_relative_single_line_comments\s*=\s*false
 ValueDefault=false
 
 [Indent Switch Case]
@@ -3041,7 +3378,8 @@ Category=2
 Description="<html>Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.<br/>It might be wise to choose the same value for the option indent_case_brace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_switch_case\s*=\s*"
+CallName="indent_switch_case="
+CallNameRegex="indent_switch_case\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3051,7 +3389,8 @@ Category=2
 Description="<html>Spaces to indent the body of a 'switch' before any 'case'.<br/>Usually the same as indent_columns or indent_switch_case.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_switch_body\s*=\s*"
+CallName="indent_switch_body="
+CallNameRegex="indent_switch_body\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3061,7 +3400,8 @@ Category=2
 Description="<html>Whether to ignore indent for '{' following 'case'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_case_brace\s*=\s*true|indent_ignore_case_brace\s*=\s*false
+TrueFalse=indent_ignore_case_brace=true|indent_ignore_case_brace=false
+TrueFalseRegex=indent_ignore_case_brace\s*=\s*true|indent_ignore_case_brace\s*=\s*false
 ValueDefault=false
 
 [Indent Case Brace]
@@ -3069,7 +3409,8 @@ Category=2
 Description="<html>Spaces to indent '{' from 'case'. By default, the brace will appear under<br/>the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.<br/>It might be wise to choose the same value for the option indent_switch_case.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_case_brace\s*=\s*"
+CallName="indent_case_brace="
+CallNameRegex="indent_case_brace\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -3079,7 +3420,8 @@ Category=2
 Description="<html>indent 'break' with 'case' from 'switch'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_switch_break_with_case\s*=\s*true|indent_switch_break_with_case\s*=\s*false
+TrueFalse=indent_switch_break_with_case=true|indent_switch_break_with_case=false
+TrueFalseRegex=indent_switch_break_with_case\s*=\s*true|indent_switch_break_with_case\s*=\s*false
 ValueDefault=false
 
 [Indent Switch Pp]
@@ -3087,7 +3429,8 @@ Category=2
 Description="<html>Whether to indent preprocessor statements inside of switch statements.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_switch_pp\s*=\s*true|indent_switch_pp\s*=\s*false
+TrueFalse=indent_switch_pp=true|indent_switch_pp=false
+TrueFalseRegex=indent_switch_pp\s*=\s*true|indent_switch_pp\s*=\s*false
 ValueDefault=true
 
 [Indent Case Shift]
@@ -3095,7 +3438,8 @@ Category=2
 Description="<html>Spaces to shift the 'case' line, without affecting any other lines.<br/>Usually 0.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_case_shift\s*=\s*"
+CallName="indent_case_shift="
+CallNameRegex="indent_case_shift\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3105,7 +3449,8 @@ Category=2
 Description="<html>Whether to align comments before 'case' with the 'case'.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_case_comment\s*=\s*true|indent_case_comment\s*=\s*false
+TrueFalse=indent_case_comment=true|indent_case_comment=false
+TrueFalseRegex=indent_case_comment\s*=\s*true|indent_case_comment\s*=\s*false
 ValueDefault=true
 
 [Indent Comment]
@@ -3113,7 +3458,8 @@ Category=2
 Description="<html>Whether to indent comments not found in first column.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_comment\s*=\s*true|indent_comment\s*=\s*false
+TrueFalse=indent_comment=true|indent_comment=false
+TrueFalseRegex=indent_comment\s*=\s*true|indent_comment\s*=\s*false
 ValueDefault=true
 
 [Indent Col1 Comment]
@@ -3121,7 +3467,8 @@ Category=2
 Description="<html>Whether to indent comments found in first column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_col1_comment\s*=\s*true|indent_col1_comment\s*=\s*false
+TrueFalse=indent_col1_comment=true|indent_col1_comment=false
+TrueFalseRegex=indent_col1_comment\s*=\s*true|indent_col1_comment\s*=\s*false
 ValueDefault=false
 
 [Indent Col1 Multi String Literal]
@@ -3129,7 +3476,8 @@ Category=2
 Description="<html>Whether to indent multi string literal in first column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_col1_multi_string_literal\s*=\s*true|indent_col1_multi_string_literal\s*=\s*false
+TrueFalse=indent_col1_multi_string_literal=true|indent_col1_multi_string_literal=false
+TrueFalseRegex=indent_col1_multi_string_literal\s*=\s*true|indent_col1_multi_string_literal\s*=\s*false
 ValueDefault=false
 
 [Indent Comment Align Thresh]
@@ -3137,7 +3485,8 @@ Category=2
 Description="<html>Align comments on adjacent lines that are this many columns apart or less.<br/><br/>Default: 3</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_comment_align_thresh\s*=\s*"
+CallName="indent_comment_align_thresh="
+CallNameRegex="indent_comment_align_thresh\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=3
@@ -3147,7 +3496,8 @@ Category=2
 Description="<html>Whether to ignore indent for goto labels.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_label\s*=\s*true|indent_ignore_label\s*=\s*false
+TrueFalse=indent_ignore_label=true|indent_ignore_label=false
+TrueFalseRegex=indent_ignore_label\s*=\s*true|indent_ignore_label\s*=\s*false
 ValueDefault=false
 
 [Indent Label]
@@ -3155,7 +3505,8 @@ Category=2
 Description="<html>How to indent goto labels. Requires indent_ignore_label=false.<br/><br/> &gt;0: Absolute column where 1 is the leftmost column<br/>&lt;=0: Subtract from brace indent<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_label\s*=\s*"
+CallName="indent_label="
+CallNameRegex="indent_label\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=1
@@ -3165,7 +3516,8 @@ Category=2
 Description="<html>How to indent access specifiers that are followed by a<br/>colon.<br/><br/> &gt;0: Absolute column where 1 is the leftmost column<br/>&lt;=0: Subtract from brace indent<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_access_spec\s*=\s*"
+CallName="indent_access_spec="
+CallNameRegex="indent_access_spec\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=1
@@ -3175,7 +3527,8 @@ Category=2
 Description="<html>Whether to indent the code after an access specifier by one level.<br/>If true, this option forces 'indent_access_spec=0'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_access_spec_body\s*=\s*true|indent_access_spec_body\s*=\s*false
+TrueFalse=indent_access_spec_body=true|indent_access_spec_body=false
+TrueFalseRegex=indent_access_spec_body\s*=\s*true|indent_access_spec_body\s*=\s*false
 ValueDefault=false
 
 [Indent Paren Nl]
@@ -3183,7 +3536,8 @@ Category=2
 Description="<html>If an open parenthesis is followed by a newline, whether to indent the next<br/>line so that it lines up after the open parenthesis (not recommended).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_nl\s*=\s*true|indent_paren_nl\s*=\s*false
+TrueFalse=indent_paren_nl=true|indent_paren_nl=false
+TrueFalseRegex=indent_paren_nl\s*=\s*true|indent_paren_nl\s*=\s*false
 ValueDefault=false
 
 [Indent Paren Close]
@@ -3191,7 +3545,8 @@ Category=2
 Description="<html>How to indent a close parenthesis after a newline.<br/><br/> 0: Indent to body level (default)<br/> 1: Align under the open parenthesis<br/> 2: Indent to the brace level<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_paren_close\s*=\s*"
+CallName="indent_paren_close="
+CallNameRegex="indent_paren_close\s*=\s*"
 MinVal=-1
 MaxVal=2
 ValueDefault=0
@@ -3201,7 +3556,8 @@ Category=2
 Description="<html>Whether to indent the open parenthesis of a function definition,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_after_func_def\s*=\s*true|indent_paren_after_func_def\s*=\s*false
+TrueFalse=indent_paren_after_func_def=true|indent_paren_after_func_def=false
+TrueFalseRegex=indent_paren_after_func_def\s*=\s*true|indent_paren_after_func_def\s*=\s*false
 ValueDefault=false
 
 [Indent Paren After Func Decl]
@@ -3209,7 +3565,8 @@ Category=2
 Description="<html>Whether to indent the open parenthesis of a function declaration,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_after_func_decl\s*=\s*true|indent_paren_after_func_decl\s*=\s*false
+TrueFalse=indent_paren_after_func_decl=true|indent_paren_after_func_decl=false
+TrueFalseRegex=indent_paren_after_func_decl\s*=\s*true|indent_paren_after_func_decl\s*=\s*false
 ValueDefault=false
 
 [Indent Paren After Func Call]
@@ -3217,7 +3574,8 @@ Category=2
 Description="<html>Whether to indent the open parenthesis of a function call,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_paren_after_func_call\s*=\s*true|indent_paren_after_func_call\s*=\s*false
+TrueFalse=indent_paren_after_func_call=true|indent_paren_after_func_call=false
+TrueFalseRegex=indent_paren_after_func_call\s*=\s*true|indent_paren_after_func_call\s*=\s*false
 ValueDefault=false
 
 [Indent Comma Brace]
@@ -3225,7 +3583,8 @@ Category=2
 Description="<html>How to indent a comma when inside braces.<br/> 0: Indent by one level (default)<br/> 1: Align under the open brace<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_comma_brace\s*=\s*"
+CallName="indent_comma_brace="
+CallNameRegex="indent_comma_brace\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=0
@@ -3235,7 +3594,8 @@ Category=2
 Description="<html>How to indent a comma when inside parentheses.<br/> 0: Indent by one level (default)<br/> 1: Align under the open parenthesis<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_comma_paren\s*=\s*"
+CallName="indent_comma_paren="
+CallNameRegex="indent_comma_paren\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=0
@@ -3245,7 +3605,8 @@ Category=2
 Description="<html>How to indent a Boolean operator when inside parentheses.<br/> 0: Indent by one level (default)<br/> 1: Align under the open parenthesis<br/>-1: Preserve original indentation</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_bool_paren\s*=\s*"
+CallName="indent_bool_paren="
+CallNameRegex="indent_bool_paren\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=0
@@ -3255,7 +3616,8 @@ Category=2
 Description="<html>Whether to ignore the indentation of a Boolean operator when outside<br/>parentheses.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_bool\s*=\s*true|indent_ignore_bool\s*=\s*false
+TrueFalse=indent_ignore_bool=true|indent_ignore_bool=false
+TrueFalseRegex=indent_ignore_bool\s*=\s*true|indent_ignore_bool\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Arith]
@@ -3263,7 +3625,8 @@ Category=2
 Description="<html>Whether to ignore the indentation of an arithmetic operator.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_arith\s*=\s*true|indent_ignore_arith\s*=\s*false
+TrueFalse=indent_ignore_arith=true|indent_ignore_arith=false
+TrueFalseRegex=indent_ignore_arith\s*=\s*true|indent_ignore_arith\s*=\s*false
 ValueDefault=false
 
 [Indent Semicolon For Paren]
@@ -3271,7 +3634,8 @@ Category=2
 Description="<html>Whether to indent a semicolon when inside a for parenthesis.<br/>If true, aligns under the open for parenthesis.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_semicolon_for_paren\s*=\s*true|indent_semicolon_for_paren\s*=\s*false
+TrueFalse=indent_semicolon_for_paren=true|indent_semicolon_for_paren=false
+TrueFalseRegex=indent_semicolon_for_paren\s*=\s*true|indent_semicolon_for_paren\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Semicolon]
@@ -3279,7 +3643,8 @@ Category=2
 Description="<html>Whether to ignore the indentation of a semicolon outside of a 'for'<br/>statement.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_semicolon\s*=\s*true|indent_ignore_semicolon\s*=\s*false
+TrueFalse=indent_ignore_semicolon=true|indent_ignore_semicolon=false
+TrueFalseRegex=indent_ignore_semicolon\s*=\s*true|indent_ignore_semicolon\s*=\s*false
 ValueDefault=false
 
 [Indent First Bool Expr]
@@ -3287,7 +3652,8 @@ Category=2
 Description="<html>Whether to align the first expression to following ones<br/>if indent_bool_paren=1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_first_bool_expr\s*=\s*true|indent_first_bool_expr\s*=\s*false
+TrueFalse=indent_first_bool_expr=true|indent_first_bool_expr=false
+TrueFalseRegex=indent_first_bool_expr\s*=\s*true|indent_first_bool_expr\s*=\s*false
 ValueDefault=false
 
 [Indent First For Expr]
@@ -3295,7 +3661,8 @@ Category=2
 Description="<html>Whether to align the first expression to following ones<br/>if indent_semicolon_for_paren=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_first_for_expr\s*=\s*true|indent_first_for_expr\s*=\s*false
+TrueFalse=indent_first_for_expr=true|indent_first_for_expr=false
+TrueFalseRegex=indent_first_for_expr\s*=\s*true|indent_first_for_expr\s*=\s*false
 ValueDefault=false
 
 [Indent Square Nl]
@@ -3303,7 +3670,8 @@ Category=2
 Description="<html>If an open square is followed by a newline, whether to indent the next line<br/>so that it lines up after the open square (not recommended).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_square_nl\s*=\s*true|indent_square_nl\s*=\s*false
+TrueFalse=indent_square_nl=true|indent_square_nl=false
+TrueFalseRegex=indent_square_nl\s*=\s*true|indent_square_nl\s*=\s*false
 ValueDefault=false
 
 [Indent Preserve Sql]
@@ -3311,7 +3679,8 @@ Category=2
 Description="<html>(ESQL/C) Whether to preserve the relative indent of 'EXEC SQL' bodies.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_preserve_sql\s*=\s*true|indent_preserve_sql\s*=\s*false
+TrueFalse=indent_preserve_sql=true|indent_preserve_sql=false
+TrueFalseRegex=indent_preserve_sql\s*=\s*true|indent_preserve_sql\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Assign]
@@ -3319,7 +3688,8 @@ Category=2
 Description="<html>Whether to ignore the indentation of an assignment operator.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_assign\s*=\s*true|indent_ignore_assign\s*=\s*false
+TrueFalse=indent_ignore_assign=true|indent_ignore_assign=false
+TrueFalseRegex=indent_ignore_assign\s*=\s*true|indent_ignore_assign\s*=\s*false
 ValueDefault=false
 
 [Indent Align Assign]
@@ -3327,7 +3697,8 @@ Category=2
 Description="<html>Whether to align continued statements at the '='. If false or if the '=' is<br/>followed by a newline, the next line is indent one tab.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_align_assign\s*=\s*true|indent_align_assign\s*=\s*false
+TrueFalse=indent_align_assign=true|indent_align_assign=false
+TrueFalseRegex=indent_align_assign\s*=\s*true|indent_align_assign\s*=\s*false
 ValueDefault=true
 
 [Indent Off After Assign]
@@ -3335,7 +3706,8 @@ Category=2
 Description="<html>If true, the indentation of the chunks after a '=' sequence will be set at<br/>LHS token indentation column before '='.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_off_after_assign\s*=\s*true|indent_off_after_assign\s*=\s*false
+TrueFalse=indent_off_after_assign=true|indent_off_after_assign=false
+TrueFalseRegex=indent_off_after_assign\s*=\s*true|indent_off_after_assign\s*=\s*false
 ValueDefault=false
 
 [Indent Align Paren]
@@ -3343,7 +3715,8 @@ Category=2
 Description="<html>Whether to align continued statements at the '('. If false or the '(' is<br/>followed by a newline, the next line indent is one tab.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_align_paren\s*=\s*true|indent_align_paren\s*=\s*false
+TrueFalse=indent_align_paren=true|indent_align_paren=false
+TrueFalseRegex=indent_align_paren\s*=\s*true|indent_align_paren\s*=\s*false
 ValueDefault=true
 
 [Indent Oc Inside Msg Sel]
@@ -3351,7 +3724,8 @@ Category=2
 Description="<html>(OC) Whether to indent Objective-C code inside message selectors.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_inside_msg_sel\s*=\s*true|indent_oc_inside_msg_sel\s*=\s*false
+TrueFalse=indent_oc_inside_msg_sel=true|indent_oc_inside_msg_sel=false
+TrueFalseRegex=indent_oc_inside_msg_sel\s*=\s*true|indent_oc_inside_msg_sel\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block]
@@ -3359,7 +3733,8 @@ Category=2
 Description="<html>(OC) Whether to indent Objective-C blocks at brace level instead of usual<br/>rules.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block\s*=\s*true|indent_oc_block\s*=\s*false
+TrueFalse=indent_oc_block=true|indent_oc_block=false
+TrueFalseRegex=indent_oc_block\s*=\s*true|indent_oc_block\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg]
@@ -3367,7 +3742,8 @@ Category=2
 Description="<html>(OC) Indent for Objective-C blocks in a message relative to the parameter<br/>name.<br/><br/>=0: Use indent_oc_block rules<br/>&gt;0: Use specified number of spaces to indent</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_oc_block_msg\s*=\s*"
+CallName="indent_oc_block_msg="
+CallNameRegex="indent_oc_block_msg\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3377,7 +3753,8 @@ Category=2
 Description="<html>(OC) Minimum indent for subsequent parameters</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_oc_msg_colon\s*=\s*"
+CallName="indent_oc_msg_colon="
+CallNameRegex="indent_oc_msg_colon\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -3387,7 +3764,8 @@ Category=2
 Description="<html>(OC) Whether to prioritize aligning with initial colon (and stripping spaces<br/>from lines, if necessary).<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_msg_prioritize_first_colon\s*=\s*true|indent_oc_msg_prioritize_first_colon\s*=\s*false
+TrueFalse=indent_oc_msg_prioritize_first_colon=true|indent_oc_msg_prioritize_first_colon=false
+TrueFalseRegex=indent_oc_msg_prioritize_first_colon\s*=\s*true|indent_oc_msg_prioritize_first_colon\s*=\s*false
 ValueDefault=true
 
 [Indent Oc Block Msg Xcode Style]
@@ -3395,7 +3773,8 @@ Category=2
 Description="<html>(OC) Whether to indent blocks the way that Xcode does by default<br/>(from the keyword if the parameter is on its own line; otherwise, from the<br/>previous indentation level). Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_xcode_style\s*=\s*true|indent_oc_block_msg_xcode_style\s*=\s*false
+TrueFalse=indent_oc_block_msg_xcode_style=true|indent_oc_block_msg_xcode_style=false
+TrueFalseRegex=indent_oc_block_msg_xcode_style\s*=\s*true|indent_oc_block_msg_xcode_style\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg From Keyword]
@@ -3403,7 +3782,8 @@ Category=2
 Description="<html>(OC) Whether to indent blocks from where the brace is, relative to a<br/>message keyword. Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_from_keyword\s*=\s*true|indent_oc_block_msg_from_keyword\s*=\s*false
+TrueFalse=indent_oc_block_msg_from_keyword=true|indent_oc_block_msg_from_keyword=false
+TrueFalseRegex=indent_oc_block_msg_from_keyword\s*=\s*true|indent_oc_block_msg_from_keyword\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg From Colon]
@@ -3411,7 +3791,8 @@ Category=2
 Description="<html>(OC) Whether to indent blocks from where the brace is, relative to a message<br/>colon. Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_from_colon\s*=\s*true|indent_oc_block_msg_from_colon\s*=\s*false
+TrueFalse=indent_oc_block_msg_from_colon=true|indent_oc_block_msg_from_colon=false
+TrueFalseRegex=indent_oc_block_msg_from_colon\s*=\s*true|indent_oc_block_msg_from_colon\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg From Caret]
@@ -3419,7 +3800,8 @@ Category=2
 Description="<html>(OC) Whether to indent blocks from where the block caret is.<br/>Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_from_caret\s*=\s*true|indent_oc_block_msg_from_caret\s*=\s*false
+TrueFalse=indent_oc_block_msg_from_caret=true|indent_oc_block_msg_from_caret=false
+TrueFalseRegex=indent_oc_block_msg_from_caret\s*=\s*true|indent_oc_block_msg_from_caret\s*=\s*false
 ValueDefault=false
 
 [Indent Oc Block Msg From Brace]
@@ -3427,7 +3809,8 @@ Category=2
 Description="<html>(OC) Whether to indent blocks from where the brace caret is.<br/>Requires indent_oc_block_msg=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_oc_block_msg_from_brace\s*=\s*true|indent_oc_block_msg_from_brace\s*=\s*false
+TrueFalse=indent_oc_block_msg_from_brace=true|indent_oc_block_msg_from_brace=false
+TrueFalseRegex=indent_oc_block_msg_from_brace\s*=\s*true|indent_oc_block_msg_from_brace\s*=\s*false
 ValueDefault=false
 
 [Indent Min Vbrace Open]
@@ -3435,7 +3818,8 @@ Category=2
 Description="<html>When indenting after virtual brace open and newline add further spaces to<br/>reach this minimum indent.</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_min_vbrace_open\s*=\s*"
+CallName="indent_min_vbrace_open="
+CallNameRegex="indent_min_vbrace_open\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3445,7 +3829,8 @@ Category=2
 Description="<html>Whether to add further spaces after regular indent to reach next tabstop<br/>when indenting after virtual brace open and newline.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_vbrace_open_on_tabstop\s*=\s*true|indent_vbrace_open_on_tabstop\s*=\s*false
+TrueFalse=indent_vbrace_open_on_tabstop=true|indent_vbrace_open_on_tabstop=false
+TrueFalseRegex=indent_vbrace_open_on_tabstop\s*=\s*true|indent_vbrace_open_on_tabstop\s*=\s*false
 ValueDefault=false
 
 [Indent Token After Brace]
@@ -3453,7 +3838,8 @@ Category=2
 Description="<html>How to indent after a brace followed by another token (not a newline).<br/>true:  indent all contained lines to match the token<br/>false: indent all contained lines to match the brace<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_token_after_brace\s*=\s*true|indent_token_after_brace\s*=\s*false
+TrueFalse=indent_token_after_brace=true|indent_token_after_brace=false
+TrueFalseRegex=indent_token_after_brace\s*=\s*true|indent_token_after_brace\s*=\s*false
 ValueDefault=true
 
 [Indent Cpp Lambda Body]
@@ -3461,7 +3847,8 @@ Category=2
 Description="<html>Whether to indent the body of a C++11 lambda.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cpp_lambda_body\s*=\s*true|indent_cpp_lambda_body\s*=\s*false
+TrueFalse=indent_cpp_lambda_body=true|indent_cpp_lambda_body=false
+TrueFalseRegex=indent_cpp_lambda_body\s*=\s*true|indent_cpp_lambda_body\s*=\s*false
 ValueDefault=false
 
 [Indent Compound Literal Return]
@@ -3469,7 +3856,8 @@ Category=2
 Description="<html>How to indent compound literals that are being returned.<br/>true: add both the indent from return &amp; the compound literal open brace<br/>      (i.e. 2 indent levels)<br/>false: only indent 1 level, don't add the indent for the open brace, only<br/>       add the indent for the return.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_compound_literal_return\s*=\s*true|indent_compound_literal_return\s*=\s*false
+TrueFalse=indent_compound_literal_return=true|indent_compound_literal_return=false
+TrueFalseRegex=indent_compound_literal_return\s*=\s*true|indent_compound_literal_return\s*=\s*false
 ValueDefault=true
 
 [Indent Using Block]
@@ -3477,7 +3865,8 @@ Category=2
 Description="<html>(C#) Whether to indent a 'using' block if no braces are used.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_using_block\s*=\s*true|indent_using_block\s*=\s*false
+TrueFalse=indent_using_block=true|indent_using_block=false
+TrueFalseRegex=indent_using_block\s*=\s*true|indent_using_block\s*=\s*false
 ValueDefault=true
 
 [Indent Ternary Operator]
@@ -3485,7 +3874,8 @@ Category=2
 Description="<html>How to indent the continuation of ternary operator.<br/><br/>0: Off (default)<br/>1: When the `if_false` is a continuation, indent it under the `if_true` branch<br/>2: When the `:` is a continuation, indent it under `?`</html>"
 Enabled=false
 EditorType=numeric
-CallName="indent_ternary_operator\s*=\s*"
+CallName="indent_ternary_operator="
+CallNameRegex="indent_ternary_operator\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -3495,7 +3885,8 @@ Category=2
 Description="<html>Whether to indent the statements inside ternary operator.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_inside_ternary_operator\s*=\s*true|indent_inside_ternary_operator\s*=\s*false
+TrueFalse=indent_inside_ternary_operator=true|indent_inside_ternary_operator=false
+TrueFalseRegex=indent_inside_ternary_operator\s*=\s*true|indent_inside_ternary_operator\s*=\s*false
 ValueDefault=false
 
 [Indent Off After Return]
@@ -3503,7 +3894,8 @@ Category=2
 Description="<html>If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_off_after_return\s*=\s*true|indent_off_after_return\s*=\s*false
+TrueFalse=indent_off_after_return=true|indent_off_after_return=false
+TrueFalseRegex=indent_off_after_return\s*=\s*true|indent_off_after_return\s*=\s*false
 ValueDefault=false
 
 [Indent Off After Return New]
@@ -3511,7 +3903,8 @@ Category=2
 Description="<html>If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_off_after_return_new\s*=\s*true|indent_off_after_return_new\s*=\s*false
+TrueFalse=indent_off_after_return_new=true|indent_off_after_return_new=false
+TrueFalseRegex=indent_off_after_return_new\s*=\s*true|indent_off_after_return_new\s*=\s*false
 ValueDefault=false
 
 [Indent Single After Return]
@@ -3519,7 +3912,8 @@ Category=2
 Description="<html>If true, the tokens after return are indented with regular single indentation. By default (false) the indentation is after the return token.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_single_after_return\s*=\s*true|indent_single_after_return\s*=\s*false
+TrueFalse=indent_single_after_return=true|indent_single_after_return=false
+TrueFalseRegex=indent_single_after_return\s*=\s*true|indent_single_after_return\s*=\s*false
 ValueDefault=false
 
 [Indent Ignore Asm Block]
@@ -3527,7 +3921,8 @@ Category=2
 Description="<html>Whether to ignore indent and alignment for 'asm' blocks (i.e. assume they<br/>have their own indentation).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_ignore_asm_block\s*=\s*true|indent_ignore_asm_block\s*=\s*false
+TrueFalse=indent_ignore_asm_block=true|indent_ignore_asm_block=false
+TrueFalseRegex=indent_ignore_asm_block\s*=\s*true|indent_ignore_asm_block\s*=\s*false
 ValueDefault=false
 
 [Donot Indent Func Def Close Paren]
@@ -3535,7 +3930,8 @@ Category=2
 Description="<html>Don't indent the close parenthesis of a function definition,<br/>if the parenthesis is on its own line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=donot_indent_func_def_close_paren\s*=\s*true|donot_indent_func_def_close_paren\s*=\s*false
+TrueFalse=donot_indent_func_def_close_paren=true|donot_indent_func_def_close_paren=false
+TrueFalseRegex=donot_indent_func_def_close_paren\s*=\s*true|donot_indent_func_def_close_paren\s*=\s*false
 ValueDefault=false
 
 [Nl Collapse Empty Body]
@@ -3543,7 +3939,8 @@ Category=3
 Description="<html>Whether to collapse empty blocks between '{' and '}' except for functions.<br/>Use nl_collapse_empty_body_functions to specify how empty function braces<br/>should be formatted.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_collapse_empty_body\s*=\s*true|nl_collapse_empty_body\s*=\s*false
+TrueFalse=nl_collapse_empty_body=true|nl_collapse_empty_body=false
+TrueFalseRegex=nl_collapse_empty_body\s*=\s*true|nl_collapse_empty_body\s*=\s*false
 ValueDefault=false
 
 [Nl Collapse Empty Body Functions]
@@ -3551,7 +3948,8 @@ Category=3
 Description="<html>Whether to collapse empty blocks between '{' and '}' for functions only.<br/>If true, overrides nl_inside_empty_func.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_collapse_empty_body_functions\s*=\s*true|nl_collapse_empty_body_functions\s*=\s*false
+TrueFalse=nl_collapse_empty_body_functions=true|nl_collapse_empty_body_functions=false
+TrueFalseRegex=nl_collapse_empty_body_functions\s*=\s*true|nl_collapse_empty_body_functions\s*=\s*false
 ValueDefault=false
 
 [Nl Assign Leave One Liners]
@@ -3559,7 +3957,8 @@ Category=3
 Description="<html>Don't split one-line braced assignments, as in 'foo_t f = { 1, 2 };'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_assign_leave_one_liners\s*=\s*true|nl_assign_leave_one_liners\s*=\s*false
+TrueFalse=nl_assign_leave_one_liners=true|nl_assign_leave_one_liners=false
+TrueFalseRegex=nl_assign_leave_one_liners\s*=\s*true|nl_assign_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Class Leave One Liners]
@@ -3567,7 +3966,8 @@ Category=3
 Description="<html>Don't split one-line braced statements inside a 'class xx { }' body.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_class_leave_one_liners\s*=\s*true|nl_class_leave_one_liners\s*=\s*false
+TrueFalse=nl_class_leave_one_liners=true|nl_class_leave_one_liners=false
+TrueFalseRegex=nl_class_leave_one_liners\s*=\s*true|nl_class_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Enum Leave One Liners]
@@ -3575,7 +3975,8 @@ Category=3
 Description="<html>Don't split one-line enums, as in 'enum foo { BAR = 15 };'</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_enum_leave_one_liners\s*=\s*true|nl_enum_leave_one_liners\s*=\s*false
+TrueFalse=nl_enum_leave_one_liners=true|nl_enum_leave_one_liners=false
+TrueFalseRegex=nl_enum_leave_one_liners\s*=\s*true|nl_enum_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Getset Leave One Liners]
@@ -3583,7 +3984,8 @@ Category=3
 Description="<html>Don't split one-line get or set functions.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_getset_leave_one_liners\s*=\s*true|nl_getset_leave_one_liners\s*=\s*false
+TrueFalse=nl_getset_leave_one_liners=true|nl_getset_leave_one_liners=false
+TrueFalseRegex=nl_getset_leave_one_liners\s*=\s*true|nl_getset_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Cs Property Leave One Liners]
@@ -3591,7 +3993,8 @@ Category=3
 Description="<html>(C#) Don't split one-line property get or set functions.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_cs_property_leave_one_liners\s*=\s*true|nl_cs_property_leave_one_liners\s*=\s*false
+TrueFalse=nl_cs_property_leave_one_liners=true|nl_cs_property_leave_one_liners=false
+TrueFalseRegex=nl_cs_property_leave_one_liners\s*=\s*true|nl_cs_property_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Func Leave One Liners]
@@ -3599,7 +4002,8 @@ Category=3
 Description="<html>Don't split one-line function definitions, as in 'int foo() { return 0; }'.<br/>might modify nl_func_type_name</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_leave_one_liners\s*=\s*true|nl_func_leave_one_liners\s*=\s*false
+TrueFalse=nl_func_leave_one_liners=true|nl_func_leave_one_liners=false
+TrueFalseRegex=nl_func_leave_one_liners\s*=\s*true|nl_func_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Cpp Lambda Leave One Liners]
@@ -3607,7 +4011,8 @@ Category=3
 Description="<html>Don't split one-line C++11 lambdas, as in '[]() { return 0; }'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_cpp_lambda_leave_one_liners\s*=\s*true|nl_cpp_lambda_leave_one_liners\s*=\s*false
+TrueFalse=nl_cpp_lambda_leave_one_liners=true|nl_cpp_lambda_leave_one_liners=false
+TrueFalseRegex=nl_cpp_lambda_leave_one_liners\s*=\s*true|nl_cpp_lambda_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl If Leave One Liners]
@@ -3615,7 +4020,8 @@ Category=3
 Description="<html>Don't split one-line if/else statements, as in 'if(...) b++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_if_leave_one_liners\s*=\s*true|nl_if_leave_one_liners\s*=\s*false
+TrueFalse=nl_if_leave_one_liners=true|nl_if_leave_one_liners=false
+TrueFalseRegex=nl_if_leave_one_liners\s*=\s*true|nl_if_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl While Leave One Liners]
@@ -3623,7 +4029,8 @@ Category=3
 Description="<html>Don't split one-line while statements, as in 'while(...) b++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_while_leave_one_liners\s*=\s*true|nl_while_leave_one_liners\s*=\s*false
+TrueFalse=nl_while_leave_one_liners=true|nl_while_leave_one_liners=false
+TrueFalseRegex=nl_while_leave_one_liners\s*=\s*true|nl_while_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Do Leave One Liners]
@@ -3631,7 +4038,8 @@ Category=3
 Description="<html>Don't split one-line do statements, as in 'do { b++; } while(...);'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_do_leave_one_liners\s*=\s*true|nl_do_leave_one_liners\s*=\s*false
+TrueFalse=nl_do_leave_one_liners=true|nl_do_leave_one_liners=false
+TrueFalseRegex=nl_do_leave_one_liners\s*=\s*true|nl_do_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl For Leave One Liners]
@@ -3639,7 +4047,8 @@ Category=3
 Description="<html>Don't split one-line for statements, as in 'for(...) b++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_for_leave_one_liners\s*=\s*true|nl_for_leave_one_liners\s*=\s*false
+TrueFalse=nl_for_leave_one_liners=true|nl_for_leave_one_liners=false
+TrueFalseRegex=nl_for_leave_one_liners\s*=\s*true|nl_for_leave_one_liners\s*=\s*false
 ValueDefault=false
 
 [Nl Oc Msg Leave One Liner]
@@ -3647,7 +4056,8 @@ Category=3
 Description="<html>(OC) Don't split one-line Objective-C messages.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_oc_msg_leave_one_liner\s*=\s*true|nl_oc_msg_leave_one_liner\s*=\s*false
+TrueFalse=nl_oc_msg_leave_one_liner=true|nl_oc_msg_leave_one_liner=false
+TrueFalseRegex=nl_oc_msg_leave_one_liner\s*=\s*true|nl_oc_msg_leave_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Oc Mdef Brace]
@@ -3655,7 +4065,8 @@ Category=3
 Description="<html>(OC) Add or remove newline between method declaration and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_mdef_brace\s*=\s*ignore|nl_oc_mdef_brace\s*=\s*add|nl_oc_mdef_brace\s*=\s*remove|nl_oc_mdef_brace\s*=\s*force|nl_oc_mdef_brace\s*=\s*not_defined
+Choices=nl_oc_mdef_brace=ignore|nl_oc_mdef_brace=add|nl_oc_mdef_brace=remove|nl_oc_mdef_brace=force|nl_oc_mdef_brace=not_defined
+ChoicesRegex=nl_oc_mdef_brace\s*=\s*ignore|nl_oc_mdef_brace\s*=\s*add|nl_oc_mdef_brace\s*=\s*remove|nl_oc_mdef_brace\s*=\s*force|nl_oc_mdef_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Mdef Brace|Add Nl Oc Mdef Brace|Remove Nl Oc Mdef Brace|Force Nl Oc Mdef Brace"
 ValueDefault=ignore
 
@@ -3664,7 +4075,8 @@ Category=3
 Description="<html>(OC) Add or remove newline between Objective-C block signature and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_block_brace\s*=\s*ignore|nl_oc_block_brace\s*=\s*add|nl_oc_block_brace\s*=\s*remove|nl_oc_block_brace\s*=\s*force|nl_oc_block_brace\s*=\s*not_defined
+Choices=nl_oc_block_brace=ignore|nl_oc_block_brace=add|nl_oc_block_brace=remove|nl_oc_block_brace=force|nl_oc_block_brace=not_defined
+ChoicesRegex=nl_oc_block_brace\s*=\s*ignore|nl_oc_block_brace\s*=\s*add|nl_oc_block_brace\s*=\s*remove|nl_oc_block_brace\s*=\s*force|nl_oc_block_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Block Brace|Add Nl Oc Block Brace|Remove Nl Oc Block Brace|Force Nl Oc Block Brace"
 ValueDefault=ignore
 
@@ -3673,7 +4085,8 @@ Category=3
 Description="<html>(OC) Add or remove blank line before '@interface' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_before_interface\s*=\s*ignore|nl_oc_before_interface\s*=\s*add|nl_oc_before_interface\s*=\s*remove|nl_oc_before_interface\s*=\s*force|nl_oc_before_interface\s*=\s*not_defined
+Choices=nl_oc_before_interface=ignore|nl_oc_before_interface=add|nl_oc_before_interface=remove|nl_oc_before_interface=force|nl_oc_before_interface=not_defined
+ChoicesRegex=nl_oc_before_interface\s*=\s*ignore|nl_oc_before_interface\s*=\s*add|nl_oc_before_interface\s*=\s*remove|nl_oc_before_interface\s*=\s*force|nl_oc_before_interface\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Before Interface|Add Nl Oc Before Interface|Remove Nl Oc Before Interface|Force Nl Oc Before Interface"
 ValueDefault=ignore
 
@@ -3682,7 +4095,8 @@ Category=3
 Description="<html>(OC) Add or remove blank line before '@implementation' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_before_implementation\s*=\s*ignore|nl_oc_before_implementation\s*=\s*add|nl_oc_before_implementation\s*=\s*remove|nl_oc_before_implementation\s*=\s*force|nl_oc_before_implementation\s*=\s*not_defined
+Choices=nl_oc_before_implementation=ignore|nl_oc_before_implementation=add|nl_oc_before_implementation=remove|nl_oc_before_implementation=force|nl_oc_before_implementation=not_defined
+ChoicesRegex=nl_oc_before_implementation\s*=\s*ignore|nl_oc_before_implementation\s*=\s*add|nl_oc_before_implementation\s*=\s*remove|nl_oc_before_implementation\s*=\s*force|nl_oc_before_implementation\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Before Implementation|Add Nl Oc Before Implementation|Remove Nl Oc Before Implementation|Force Nl Oc Before Implementation"
 ValueDefault=ignore
 
@@ -3691,7 +4105,8 @@ Category=3
 Description="<html>(OC) Add or remove blank line before '@end' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_before_end\s*=\s*ignore|nl_oc_before_end\s*=\s*add|nl_oc_before_end\s*=\s*remove|nl_oc_before_end\s*=\s*force|nl_oc_before_end\s*=\s*not_defined
+Choices=nl_oc_before_end=ignore|nl_oc_before_end=add|nl_oc_before_end=remove|nl_oc_before_end=force|nl_oc_before_end=not_defined
+ChoicesRegex=nl_oc_before_end\s*=\s*ignore|nl_oc_before_end\s*=\s*add|nl_oc_before_end\s*=\s*remove|nl_oc_before_end\s*=\s*force|nl_oc_before_end\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Before End|Add Nl Oc Before End|Remove Nl Oc Before End|Force Nl Oc Before End"
 ValueDefault=ignore
 
@@ -3700,7 +4115,8 @@ Category=3
 Description="<html>(OC) Add or remove newline between '@interface' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_interface_brace\s*=\s*ignore|nl_oc_interface_brace\s*=\s*add|nl_oc_interface_brace\s*=\s*remove|nl_oc_interface_brace\s*=\s*force|nl_oc_interface_brace\s*=\s*not_defined
+Choices=nl_oc_interface_brace=ignore|nl_oc_interface_brace=add|nl_oc_interface_brace=remove|nl_oc_interface_brace=force|nl_oc_interface_brace=not_defined
+ChoicesRegex=nl_oc_interface_brace\s*=\s*ignore|nl_oc_interface_brace\s*=\s*add|nl_oc_interface_brace\s*=\s*remove|nl_oc_interface_brace\s*=\s*force|nl_oc_interface_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Interface Brace|Add Nl Oc Interface Brace|Remove Nl Oc Interface Brace|Force Nl Oc Interface Brace"
 ValueDefault=ignore
 
@@ -3709,7 +4125,8 @@ Category=3
 Description="<html>(OC) Add or remove newline between '@implementation' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_implementation_brace\s*=\s*ignore|nl_oc_implementation_brace\s*=\s*add|nl_oc_implementation_brace\s*=\s*remove|nl_oc_implementation_brace\s*=\s*force|nl_oc_implementation_brace\s*=\s*not_defined
+Choices=nl_oc_implementation_brace=ignore|nl_oc_implementation_brace=add|nl_oc_implementation_brace=remove|nl_oc_implementation_brace=force|nl_oc_implementation_brace=not_defined
+ChoicesRegex=nl_oc_implementation_brace\s*=\s*ignore|nl_oc_implementation_brace\s*=\s*add|nl_oc_implementation_brace\s*=\s*remove|nl_oc_implementation_brace\s*=\s*force|nl_oc_implementation_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Implementation Brace|Add Nl Oc Implementation Brace|Remove Nl Oc Implementation Brace|Force Nl Oc Implementation Brace"
 ValueDefault=ignore
 
@@ -3718,7 +4135,8 @@ Category=3
 Description="<html>Add or remove newlines at the start of the file.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_start_of_file\s*=\s*ignore|nl_start_of_file\s*=\s*add|nl_start_of_file\s*=\s*remove|nl_start_of_file\s*=\s*force|nl_start_of_file\s*=\s*not_defined
+Choices=nl_start_of_file=ignore|nl_start_of_file=add|nl_start_of_file=remove|nl_start_of_file=force|nl_start_of_file=not_defined
+ChoicesRegex=nl_start_of_file\s*=\s*ignore|nl_start_of_file\s*=\s*add|nl_start_of_file\s*=\s*remove|nl_start_of_file\s*=\s*force|nl_start_of_file\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Start Of File|Add Nl Start Of File|Remove Nl Start Of File|Force Nl Start Of File"
 ValueDefault=ignore
 
@@ -3727,7 +4145,8 @@ Category=3
 Description="<html>The minimum number of newlines at the start of the file (only used if<br/>nl_start_of_file is 'add' or 'force').</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_start_of_file_min\s*=\s*"
+CallName="nl_start_of_file_min="
+CallNameRegex="nl_start_of_file_min\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3737,7 +4156,8 @@ Category=3
 Description="<html>Add or remove newline at the end of the file.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_end_of_file\s*=\s*ignore|nl_end_of_file\s*=\s*add|nl_end_of_file\s*=\s*remove|nl_end_of_file\s*=\s*force|nl_end_of_file\s*=\s*not_defined
+Choices=nl_end_of_file=ignore|nl_end_of_file=add|nl_end_of_file=remove|nl_end_of_file=force|nl_end_of_file=not_defined
+ChoicesRegex=nl_end_of_file\s*=\s*ignore|nl_end_of_file\s*=\s*add|nl_end_of_file\s*=\s*remove|nl_end_of_file\s*=\s*force|nl_end_of_file\s*=\s*not_defined
 ChoicesReadable="Ignore Nl End Of File|Add Nl End Of File|Remove Nl End Of File|Force Nl End Of File"
 ValueDefault=ignore
 
@@ -3746,7 +4166,8 @@ Category=3
 Description="<html>The minimum number of newlines at the end of the file (only used if<br/>nl_end_of_file is 'add' or 'force').</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_end_of_file_min\s*=\s*"
+CallName="nl_end_of_file_min="
+CallNameRegex="nl_end_of_file_min\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -3756,7 +4177,8 @@ Category=3
 Description="<html>Add or remove newline between '=' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_assign_brace\s*=\s*ignore|nl_assign_brace\s*=\s*add|nl_assign_brace\s*=\s*remove|nl_assign_brace\s*=\s*force|nl_assign_brace\s*=\s*not_defined
+Choices=nl_assign_brace=ignore|nl_assign_brace=add|nl_assign_brace=remove|nl_assign_brace=force|nl_assign_brace=not_defined
+ChoicesRegex=nl_assign_brace\s*=\s*ignore|nl_assign_brace\s*=\s*add|nl_assign_brace\s*=\s*remove|nl_assign_brace\s*=\s*force|nl_assign_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Assign Brace|Add Nl Assign Brace|Remove Nl Assign Brace|Force Nl Assign Brace"
 ValueDefault=ignore
 
@@ -3765,7 +4187,8 @@ Category=3
 Description="<html>(D) Add or remove newline between '=' and '['.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_assign_square\s*=\s*ignore|nl_assign_square\s*=\s*add|nl_assign_square\s*=\s*remove|nl_assign_square\s*=\s*force|nl_assign_square\s*=\s*not_defined
+Choices=nl_assign_square=ignore|nl_assign_square=add|nl_assign_square=remove|nl_assign_square=force|nl_assign_square=not_defined
+ChoicesRegex=nl_assign_square\s*=\s*ignore|nl_assign_square\s*=\s*add|nl_assign_square\s*=\s*remove|nl_assign_square\s*=\s*force|nl_assign_square\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Assign Square|Add Nl Assign Square|Remove Nl Assign Square|Force Nl Assign Square"
 ValueDefault=ignore
 
@@ -3774,7 +4197,8 @@ Category=3
 Description="<html>Add or remove newline between '[]' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_tsquare_brace\s*=\s*ignore|nl_tsquare_brace\s*=\s*add|nl_tsquare_brace\s*=\s*remove|nl_tsquare_brace\s*=\s*force|nl_tsquare_brace\s*=\s*not_defined
+Choices=nl_tsquare_brace=ignore|nl_tsquare_brace=add|nl_tsquare_brace=remove|nl_tsquare_brace=force|nl_tsquare_brace=not_defined
+ChoicesRegex=nl_tsquare_brace\s*=\s*ignore|nl_tsquare_brace\s*=\s*add|nl_tsquare_brace\s*=\s*remove|nl_tsquare_brace\s*=\s*force|nl_tsquare_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Tsquare Brace|Add Nl Tsquare Brace|Remove Nl Tsquare Brace|Force Nl Tsquare Brace"
 ValueDefault=ignore
 
@@ -3783,7 +4207,8 @@ Category=3
 Description="<html>(D) Add or remove newline after '= ['. Will also affect the newline before<br/>the ']'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_square_assign\s*=\s*ignore|nl_after_square_assign\s*=\s*add|nl_after_square_assign\s*=\s*remove|nl_after_square_assign\s*=\s*force|nl_after_square_assign\s*=\s*not_defined
+Choices=nl_after_square_assign=ignore|nl_after_square_assign=add|nl_after_square_assign=remove|nl_after_square_assign=force|nl_after_square_assign=not_defined
+ChoicesRegex=nl_after_square_assign\s*=\s*ignore|nl_after_square_assign\s*=\s*add|nl_after_square_assign\s*=\s*remove|nl_after_square_assign\s*=\s*force|nl_after_square_assign\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Square Assign|Add Nl After Square Assign|Remove Nl After Square Assign|Force Nl After Square Assign"
 ValueDefault=ignore
 
@@ -3792,7 +4217,8 @@ Category=3
 Description="<html>Add or remove newline between a function call's ')' and '{', as in<br/>'list_for_each(item, &amp;list) { }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_fcall_brace\s*=\s*ignore|nl_fcall_brace\s*=\s*add|nl_fcall_brace\s*=\s*remove|nl_fcall_brace\s*=\s*force|nl_fcall_brace\s*=\s*not_defined
+Choices=nl_fcall_brace=ignore|nl_fcall_brace=add|nl_fcall_brace=remove|nl_fcall_brace=force|nl_fcall_brace=not_defined
+ChoicesRegex=nl_fcall_brace\s*=\s*ignore|nl_fcall_brace\s*=\s*add|nl_fcall_brace\s*=\s*remove|nl_fcall_brace\s*=\s*force|nl_fcall_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Fcall Brace|Add Nl Fcall Brace|Remove Nl Fcall Brace|Force Nl Fcall Brace"
 ValueDefault=ignore
 
@@ -3801,7 +4227,8 @@ Category=3
 Description="<html>Add or remove newline between 'enum' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_brace\s*=\s*ignore|nl_enum_brace\s*=\s*add|nl_enum_brace\s*=\s*remove|nl_enum_brace\s*=\s*force|nl_enum_brace\s*=\s*not_defined
+Choices=nl_enum_brace=ignore|nl_enum_brace=add|nl_enum_brace=remove|nl_enum_brace=force|nl_enum_brace=not_defined
+ChoicesRegex=nl_enum_brace\s*=\s*ignore|nl_enum_brace\s*=\s*add|nl_enum_brace\s*=\s*remove|nl_enum_brace\s*=\s*force|nl_enum_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Brace|Add Nl Enum Brace|Remove Nl Enum Brace|Force Nl Enum Brace"
 ValueDefault=ignore
 
@@ -3810,7 +4237,8 @@ Category=3
 Description="<html>Add or remove newline between 'enum' and 'class'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_class\s*=\s*ignore|nl_enum_class\s*=\s*add|nl_enum_class\s*=\s*remove|nl_enum_class\s*=\s*force|nl_enum_class\s*=\s*not_defined
+Choices=nl_enum_class=ignore|nl_enum_class=add|nl_enum_class=remove|nl_enum_class=force|nl_enum_class=not_defined
+ChoicesRegex=nl_enum_class\s*=\s*ignore|nl_enum_class\s*=\s*add|nl_enum_class\s*=\s*remove|nl_enum_class\s*=\s*force|nl_enum_class\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Class|Add Nl Enum Class|Remove Nl Enum Class|Force Nl Enum Class"
 ValueDefault=ignore
 
@@ -3819,7 +4247,8 @@ Category=3
 Description="<html>Add or remove newline between 'enum class' and the identifier.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_class_identifier\s*=\s*ignore|nl_enum_class_identifier\s*=\s*add|nl_enum_class_identifier\s*=\s*remove|nl_enum_class_identifier\s*=\s*force|nl_enum_class_identifier\s*=\s*not_defined
+Choices=nl_enum_class_identifier=ignore|nl_enum_class_identifier=add|nl_enum_class_identifier=remove|nl_enum_class_identifier=force|nl_enum_class_identifier=not_defined
+ChoicesRegex=nl_enum_class_identifier\s*=\s*ignore|nl_enum_class_identifier\s*=\s*add|nl_enum_class_identifier\s*=\s*remove|nl_enum_class_identifier\s*=\s*force|nl_enum_class_identifier\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Class Identifier|Add Nl Enum Class Identifier|Remove Nl Enum Class Identifier|Force Nl Enum Class Identifier"
 ValueDefault=ignore
 
@@ -3828,7 +4257,8 @@ Category=3
 Description="<html>Add or remove newline between 'enum class' type and ':'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_identifier_colon\s*=\s*ignore|nl_enum_identifier_colon\s*=\s*add|nl_enum_identifier_colon\s*=\s*remove|nl_enum_identifier_colon\s*=\s*force|nl_enum_identifier_colon\s*=\s*not_defined
+Choices=nl_enum_identifier_colon=ignore|nl_enum_identifier_colon=add|nl_enum_identifier_colon=remove|nl_enum_identifier_colon=force|nl_enum_identifier_colon=not_defined
+ChoicesRegex=nl_enum_identifier_colon\s*=\s*ignore|nl_enum_identifier_colon\s*=\s*add|nl_enum_identifier_colon\s*=\s*remove|nl_enum_identifier_colon\s*=\s*force|nl_enum_identifier_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Identifier Colon|Add Nl Enum Identifier Colon|Remove Nl Enum Identifier Colon|Force Nl Enum Identifier Colon"
 ValueDefault=ignore
 
@@ -3837,7 +4267,8 @@ Category=3
 Description="<html>Add or remove newline between 'enum class identifier :' and type.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_colon_type\s*=\s*ignore|nl_enum_colon_type\s*=\s*add|nl_enum_colon_type\s*=\s*remove|nl_enum_colon_type\s*=\s*force|nl_enum_colon_type\s*=\s*not_defined
+Choices=nl_enum_colon_type=ignore|nl_enum_colon_type=add|nl_enum_colon_type=remove|nl_enum_colon_type=force|nl_enum_colon_type=not_defined
+ChoicesRegex=nl_enum_colon_type\s*=\s*ignore|nl_enum_colon_type\s*=\s*add|nl_enum_colon_type\s*=\s*remove|nl_enum_colon_type\s*=\s*force|nl_enum_colon_type\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Colon Type|Add Nl Enum Colon Type|Remove Nl Enum Colon Type|Force Nl Enum Colon Type"
 ValueDefault=ignore
 
@@ -3846,7 +4277,8 @@ Category=3
 Description="<html>Add or remove newline between 'struct and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_struct_brace\s*=\s*ignore|nl_struct_brace\s*=\s*add|nl_struct_brace\s*=\s*remove|nl_struct_brace\s*=\s*force|nl_struct_brace\s*=\s*not_defined
+Choices=nl_struct_brace=ignore|nl_struct_brace=add|nl_struct_brace=remove|nl_struct_brace=force|nl_struct_brace=not_defined
+ChoicesRegex=nl_struct_brace\s*=\s*ignore|nl_struct_brace\s*=\s*add|nl_struct_brace\s*=\s*remove|nl_struct_brace\s*=\s*force|nl_struct_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Struct Brace|Add Nl Struct Brace|Remove Nl Struct Brace|Force Nl Struct Brace"
 ValueDefault=ignore
 
@@ -3855,7 +4287,8 @@ Category=3
 Description="<html>Add or remove newline between 'union' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_union_brace\s*=\s*ignore|nl_union_brace\s*=\s*add|nl_union_brace\s*=\s*remove|nl_union_brace\s*=\s*force|nl_union_brace\s*=\s*not_defined
+Choices=nl_union_brace=ignore|nl_union_brace=add|nl_union_brace=remove|nl_union_brace=force|nl_union_brace=not_defined
+ChoicesRegex=nl_union_brace\s*=\s*ignore|nl_union_brace\s*=\s*add|nl_union_brace\s*=\s*remove|nl_union_brace\s*=\s*force|nl_union_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Union Brace|Add Nl Union Brace|Remove Nl Union Brace|Force Nl Union Brace"
 ValueDefault=ignore
 
@@ -3864,7 +4297,8 @@ Category=3
 Description="<html>Add or remove newline between 'if' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_if_brace\s*=\s*ignore|nl_if_brace\s*=\s*add|nl_if_brace\s*=\s*remove|nl_if_brace\s*=\s*force|nl_if_brace\s*=\s*not_defined
+Choices=nl_if_brace=ignore|nl_if_brace=add|nl_if_brace=remove|nl_if_brace=force|nl_if_brace=not_defined
+ChoicesRegex=nl_if_brace\s*=\s*ignore|nl_if_brace\s*=\s*add|nl_if_brace\s*=\s*remove|nl_if_brace\s*=\s*force|nl_if_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl If Brace|Add Nl If Brace|Remove Nl If Brace|Force Nl If Brace"
 ValueDefault=ignore
 
@@ -3873,7 +4307,8 @@ Category=3
 Description="<html>Add or remove newline between '}' and 'else'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_else\s*=\s*ignore|nl_brace_else\s*=\s*add|nl_brace_else\s*=\s*remove|nl_brace_else\s*=\s*force|nl_brace_else\s*=\s*not_defined
+Choices=nl_brace_else=ignore|nl_brace_else=add|nl_brace_else=remove|nl_brace_else=force|nl_brace_else=not_defined
+ChoicesRegex=nl_brace_else\s*=\s*ignore|nl_brace_else\s*=\s*add|nl_brace_else\s*=\s*remove|nl_brace_else\s*=\s*force|nl_brace_else\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Else|Add Nl Brace Else|Remove Nl Brace Else|Force Nl Brace Else"
 ValueDefault=ignore
 
@@ -3882,7 +4317,8 @@ Category=3
 Description="<html>Add or remove newline between 'else if' and '{'. If set to ignore,<br/>nl_if_brace is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_elseif_brace\s*=\s*ignore|nl_elseif_brace\s*=\s*add|nl_elseif_brace\s*=\s*remove|nl_elseif_brace\s*=\s*force|nl_elseif_brace\s*=\s*not_defined
+Choices=nl_elseif_brace=ignore|nl_elseif_brace=add|nl_elseif_brace=remove|nl_elseif_brace=force|nl_elseif_brace=not_defined
+ChoicesRegex=nl_elseif_brace\s*=\s*ignore|nl_elseif_brace\s*=\s*add|nl_elseif_brace\s*=\s*remove|nl_elseif_brace\s*=\s*force|nl_elseif_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Elseif Brace|Add Nl Elseif Brace|Remove Nl Elseif Brace|Force Nl Elseif Brace"
 ValueDefault=ignore
 
@@ -3891,7 +4327,8 @@ Category=3
 Description="<html>Add or remove newline between 'else' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_else_brace\s*=\s*ignore|nl_else_brace\s*=\s*add|nl_else_brace\s*=\s*remove|nl_else_brace\s*=\s*force|nl_else_brace\s*=\s*not_defined
+Choices=nl_else_brace=ignore|nl_else_brace=add|nl_else_brace=remove|nl_else_brace=force|nl_else_brace=not_defined
+ChoicesRegex=nl_else_brace\s*=\s*ignore|nl_else_brace\s*=\s*add|nl_else_brace\s*=\s*remove|nl_else_brace\s*=\s*force|nl_else_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Else Brace|Add Nl Else Brace|Remove Nl Else Brace|Force Nl Else Brace"
 ValueDefault=ignore
 
@@ -3900,7 +4337,8 @@ Category=3
 Description="<html>Add or remove newline between 'else' and 'if'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_else_if\s*=\s*ignore|nl_else_if\s*=\s*add|nl_else_if\s*=\s*remove|nl_else_if\s*=\s*force|nl_else_if\s*=\s*not_defined
+Choices=nl_else_if=ignore|nl_else_if=add|nl_else_if=remove|nl_else_if=force|nl_else_if=not_defined
+ChoicesRegex=nl_else_if\s*=\s*ignore|nl_else_if\s*=\s*add|nl_else_if\s*=\s*remove|nl_else_if\s*=\s*force|nl_else_if\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Else If|Add Nl Else If|Remove Nl Else If|Force Nl Else If"
 ValueDefault=ignore
 
@@ -3909,7 +4347,8 @@ Category=3
 Description="<html>Add or remove newline before '{' opening brace</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_opening_brace_func_class_def\s*=\s*ignore|nl_before_opening_brace_func_class_def\s*=\s*add|nl_before_opening_brace_func_class_def\s*=\s*remove|nl_before_opening_brace_func_class_def\s*=\s*force|nl_before_opening_brace_func_class_def\s*=\s*not_defined
+Choices=nl_before_opening_brace_func_class_def=ignore|nl_before_opening_brace_func_class_def=add|nl_before_opening_brace_func_class_def=remove|nl_before_opening_brace_func_class_def=force|nl_before_opening_brace_func_class_def=not_defined
+ChoicesRegex=nl_before_opening_brace_func_class_def\s*=\s*ignore|nl_before_opening_brace_func_class_def\s*=\s*add|nl_before_opening_brace_func_class_def\s*=\s*remove|nl_before_opening_brace_func_class_def\s*=\s*force|nl_before_opening_brace_func_class_def\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Opening Brace Func Class Def|Add Nl Before Opening Brace Func Class Def|Remove Nl Before Opening Brace Func Class Def|Force Nl Before Opening Brace Func Class Def"
 ValueDefault=ignore
 
@@ -3918,7 +4357,8 @@ Category=3
 Description="<html>Add or remove newline before 'if'/'else if' closing parenthesis.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_if_closing_paren\s*=\s*ignore|nl_before_if_closing_paren\s*=\s*add|nl_before_if_closing_paren\s*=\s*remove|nl_before_if_closing_paren\s*=\s*force|nl_before_if_closing_paren\s*=\s*not_defined
+Choices=nl_before_if_closing_paren=ignore|nl_before_if_closing_paren=add|nl_before_if_closing_paren=remove|nl_before_if_closing_paren=force|nl_before_if_closing_paren=not_defined
+ChoicesRegex=nl_before_if_closing_paren\s*=\s*ignore|nl_before_if_closing_paren\s*=\s*add|nl_before_if_closing_paren\s*=\s*remove|nl_before_if_closing_paren\s*=\s*force|nl_before_if_closing_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before If Closing Paren|Add Nl Before If Closing Paren|Remove Nl Before If Closing Paren|Force Nl Before If Closing Paren"
 ValueDefault=ignore
 
@@ -3927,7 +4367,8 @@ Category=3
 Description="<html>Add or remove newline between '}' and 'finally'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_finally\s*=\s*ignore|nl_brace_finally\s*=\s*add|nl_brace_finally\s*=\s*remove|nl_brace_finally\s*=\s*force|nl_brace_finally\s*=\s*not_defined
+Choices=nl_brace_finally=ignore|nl_brace_finally=add|nl_brace_finally=remove|nl_brace_finally=force|nl_brace_finally=not_defined
+ChoicesRegex=nl_brace_finally\s*=\s*ignore|nl_brace_finally\s*=\s*add|nl_brace_finally\s*=\s*remove|nl_brace_finally\s*=\s*force|nl_brace_finally\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Finally|Add Nl Brace Finally|Remove Nl Brace Finally|Force Nl Brace Finally"
 ValueDefault=ignore
 
@@ -3936,7 +4377,8 @@ Category=3
 Description="<html>Add or remove newline between 'finally' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_finally_brace\s*=\s*ignore|nl_finally_brace\s*=\s*add|nl_finally_brace\s*=\s*remove|nl_finally_brace\s*=\s*force|nl_finally_brace\s*=\s*not_defined
+Choices=nl_finally_brace=ignore|nl_finally_brace=add|nl_finally_brace=remove|nl_finally_brace=force|nl_finally_brace=not_defined
+ChoicesRegex=nl_finally_brace\s*=\s*ignore|nl_finally_brace\s*=\s*add|nl_finally_brace\s*=\s*remove|nl_finally_brace\s*=\s*force|nl_finally_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Finally Brace|Add Nl Finally Brace|Remove Nl Finally Brace|Force Nl Finally Brace"
 ValueDefault=ignore
 
@@ -3945,7 +4387,8 @@ Category=3
 Description="<html>Add or remove newline between 'try' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_try_brace\s*=\s*ignore|nl_try_brace\s*=\s*add|nl_try_brace\s*=\s*remove|nl_try_brace\s*=\s*force|nl_try_brace\s*=\s*not_defined
+Choices=nl_try_brace=ignore|nl_try_brace=add|nl_try_brace=remove|nl_try_brace=force|nl_try_brace=not_defined
+ChoicesRegex=nl_try_brace\s*=\s*ignore|nl_try_brace\s*=\s*add|nl_try_brace\s*=\s*remove|nl_try_brace\s*=\s*force|nl_try_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Try Brace|Add Nl Try Brace|Remove Nl Try Brace|Force Nl Try Brace"
 ValueDefault=ignore
 
@@ -3954,7 +4397,8 @@ Category=3
 Description="<html>Add or remove newline between get/set and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_getset_brace\s*=\s*ignore|nl_getset_brace\s*=\s*add|nl_getset_brace\s*=\s*remove|nl_getset_brace\s*=\s*force|nl_getset_brace\s*=\s*not_defined
+Choices=nl_getset_brace=ignore|nl_getset_brace=add|nl_getset_brace=remove|nl_getset_brace=force|nl_getset_brace=not_defined
+ChoicesRegex=nl_getset_brace\s*=\s*ignore|nl_getset_brace\s*=\s*add|nl_getset_brace\s*=\s*remove|nl_getset_brace\s*=\s*force|nl_getset_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Getset Brace|Add Nl Getset Brace|Remove Nl Getset Brace|Force Nl Getset Brace"
 ValueDefault=ignore
 
@@ -3963,7 +4407,8 @@ Category=3
 Description="<html>Add or remove newline between 'for' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_for_brace\s*=\s*ignore|nl_for_brace\s*=\s*add|nl_for_brace\s*=\s*remove|nl_for_brace\s*=\s*force|nl_for_brace\s*=\s*not_defined
+Choices=nl_for_brace=ignore|nl_for_brace=add|nl_for_brace=remove|nl_for_brace=force|nl_for_brace=not_defined
+ChoicesRegex=nl_for_brace\s*=\s*ignore|nl_for_brace\s*=\s*add|nl_for_brace\s*=\s*remove|nl_for_brace\s*=\s*force|nl_for_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl For Brace|Add Nl For Brace|Remove Nl For Brace|Force Nl For Brace"
 ValueDefault=ignore
 
@@ -3972,7 +4417,8 @@ Category=3
 Description="<html>Add or remove newline before the '{' of a 'catch' statement, as in<br/>'catch (decl) &lt;here&gt; {'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_catch_brace\s*=\s*ignore|nl_catch_brace\s*=\s*add|nl_catch_brace\s*=\s*remove|nl_catch_brace\s*=\s*force|nl_catch_brace\s*=\s*not_defined
+Choices=nl_catch_brace=ignore|nl_catch_brace=add|nl_catch_brace=remove|nl_catch_brace=force|nl_catch_brace=not_defined
+ChoicesRegex=nl_catch_brace\s*=\s*ignore|nl_catch_brace\s*=\s*add|nl_catch_brace\s*=\s*remove|nl_catch_brace\s*=\s*force|nl_catch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Catch Brace|Add Nl Catch Brace|Remove Nl Catch Brace|Force Nl Catch Brace"
 ValueDefault=ignore
 
@@ -3981,7 +4427,8 @@ Category=3
 Description="<html>(OC) Add or remove newline before the '{' of a '@catch' statement, as in<br/>'@catch (decl) &lt;here&gt; {'. If set to ignore, nl_catch_brace is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_catch_brace\s*=\s*ignore|nl_oc_catch_brace\s*=\s*add|nl_oc_catch_brace\s*=\s*remove|nl_oc_catch_brace\s*=\s*force|nl_oc_catch_brace\s*=\s*not_defined
+Choices=nl_oc_catch_brace=ignore|nl_oc_catch_brace=add|nl_oc_catch_brace=remove|nl_oc_catch_brace=force|nl_oc_catch_brace=not_defined
+ChoicesRegex=nl_oc_catch_brace\s*=\s*ignore|nl_oc_catch_brace\s*=\s*add|nl_oc_catch_brace\s*=\s*remove|nl_oc_catch_brace\s*=\s*force|nl_oc_catch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Catch Brace|Add Nl Oc Catch Brace|Remove Nl Oc Catch Brace|Force Nl Oc Catch Brace"
 ValueDefault=ignore
 
@@ -3990,7 +4437,8 @@ Category=3
 Description="<html>Add or remove newline between '}' and 'catch'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_catch\s*=\s*ignore|nl_brace_catch\s*=\s*add|nl_brace_catch\s*=\s*remove|nl_brace_catch\s*=\s*force|nl_brace_catch\s*=\s*not_defined
+Choices=nl_brace_catch=ignore|nl_brace_catch=add|nl_brace_catch=remove|nl_brace_catch=force|nl_brace_catch=not_defined
+ChoicesRegex=nl_brace_catch\s*=\s*ignore|nl_brace_catch\s*=\s*add|nl_brace_catch\s*=\s*remove|nl_brace_catch\s*=\s*force|nl_brace_catch\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Catch|Add Nl Brace Catch|Remove Nl Brace Catch|Force Nl Brace Catch"
 ValueDefault=ignore
 
@@ -3999,7 +4447,8 @@ Category=3
 Description="<html>(OC) Add or remove newline between '}' and '@catch'. If set to ignore,<br/>nl_brace_catch is used.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_oc_brace_catch\s*=\s*ignore|nl_oc_brace_catch\s*=\s*add|nl_oc_brace_catch\s*=\s*remove|nl_oc_brace_catch\s*=\s*force|nl_oc_brace_catch\s*=\s*not_defined
+Choices=nl_oc_brace_catch=ignore|nl_oc_brace_catch=add|nl_oc_brace_catch=remove|nl_oc_brace_catch=force|nl_oc_brace_catch=not_defined
+ChoicesRegex=nl_oc_brace_catch\s*=\s*ignore|nl_oc_brace_catch\s*=\s*add|nl_oc_brace_catch\s*=\s*remove|nl_oc_brace_catch\s*=\s*force|nl_oc_brace_catch\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Oc Brace Catch|Add Nl Oc Brace Catch|Remove Nl Oc Brace Catch|Force Nl Oc Brace Catch"
 ValueDefault=ignore
 
@@ -4008,7 +4457,8 @@ Category=3
 Description="<html>Add or remove newline between '}' and ']'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_square\s*=\s*ignore|nl_brace_square\s*=\s*add|nl_brace_square\s*=\s*remove|nl_brace_square\s*=\s*force|nl_brace_square\s*=\s*not_defined
+Choices=nl_brace_square=ignore|nl_brace_square=add|nl_brace_square=remove|nl_brace_square=force|nl_brace_square=not_defined
+ChoicesRegex=nl_brace_square\s*=\s*ignore|nl_brace_square\s*=\s*add|nl_brace_square\s*=\s*remove|nl_brace_square\s*=\s*force|nl_brace_square\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Square|Add Nl Brace Square|Remove Nl Brace Square|Force Nl Brace Square"
 ValueDefault=ignore
 
@@ -4017,7 +4467,8 @@ Category=3
 Description="<html>Add or remove newline between '}' and ')' in a function invocation.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_fparen\s*=\s*ignore|nl_brace_fparen\s*=\s*add|nl_brace_fparen\s*=\s*remove|nl_brace_fparen\s*=\s*force|nl_brace_fparen\s*=\s*not_defined
+Choices=nl_brace_fparen=ignore|nl_brace_fparen=add|nl_brace_fparen=remove|nl_brace_fparen=force|nl_brace_fparen=not_defined
+ChoicesRegex=nl_brace_fparen\s*=\s*ignore|nl_brace_fparen\s*=\s*add|nl_brace_fparen\s*=\s*remove|nl_brace_fparen\s*=\s*force|nl_brace_fparen\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Fparen|Add Nl Brace Fparen|Remove Nl Brace Fparen|Force Nl Brace Fparen"
 ValueDefault=ignore
 
@@ -4026,7 +4477,8 @@ Category=3
 Description="<html>Add or remove newline between 'while' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_while_brace\s*=\s*ignore|nl_while_brace\s*=\s*add|nl_while_brace\s*=\s*remove|nl_while_brace\s*=\s*force|nl_while_brace\s*=\s*not_defined
+Choices=nl_while_brace=ignore|nl_while_brace=add|nl_while_brace=remove|nl_while_brace=force|nl_while_brace=not_defined
+ChoicesRegex=nl_while_brace\s*=\s*ignore|nl_while_brace\s*=\s*add|nl_while_brace\s*=\s*remove|nl_while_brace\s*=\s*force|nl_while_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl While Brace|Add Nl While Brace|Remove Nl While Brace|Force Nl While Brace"
 ValueDefault=ignore
 
@@ -4035,7 +4487,8 @@ Category=3
 Description="<html>(D) Add or remove newline between 'scope (x)' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_scope_brace\s*=\s*ignore|nl_scope_brace\s*=\s*add|nl_scope_brace\s*=\s*remove|nl_scope_brace\s*=\s*force|nl_scope_brace\s*=\s*not_defined
+Choices=nl_scope_brace=ignore|nl_scope_brace=add|nl_scope_brace=remove|nl_scope_brace=force|nl_scope_brace=not_defined
+ChoicesRegex=nl_scope_brace\s*=\s*ignore|nl_scope_brace\s*=\s*add|nl_scope_brace\s*=\s*remove|nl_scope_brace\s*=\s*force|nl_scope_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Scope Brace|Add Nl Scope Brace|Remove Nl Scope Brace|Force Nl Scope Brace"
 ValueDefault=ignore
 
@@ -4044,7 +4497,8 @@ Category=3
 Description="<html>(D) Add or remove newline between 'unittest' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_unittest_brace\s*=\s*ignore|nl_unittest_brace\s*=\s*add|nl_unittest_brace\s*=\s*remove|nl_unittest_brace\s*=\s*force|nl_unittest_brace\s*=\s*not_defined
+Choices=nl_unittest_brace=ignore|nl_unittest_brace=add|nl_unittest_brace=remove|nl_unittest_brace=force|nl_unittest_brace=not_defined
+ChoicesRegex=nl_unittest_brace\s*=\s*ignore|nl_unittest_brace\s*=\s*add|nl_unittest_brace\s*=\s*remove|nl_unittest_brace\s*=\s*force|nl_unittest_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Unittest Brace|Add Nl Unittest Brace|Remove Nl Unittest Brace|Force Nl Unittest Brace"
 ValueDefault=ignore
 
@@ -4053,7 +4507,8 @@ Category=3
 Description="<html>(D) Add or remove newline between 'version (x)' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_version_brace\s*=\s*ignore|nl_version_brace\s*=\s*add|nl_version_brace\s*=\s*remove|nl_version_brace\s*=\s*force|nl_version_brace\s*=\s*not_defined
+Choices=nl_version_brace=ignore|nl_version_brace=add|nl_version_brace=remove|nl_version_brace=force|nl_version_brace=not_defined
+ChoicesRegex=nl_version_brace\s*=\s*ignore|nl_version_brace\s*=\s*add|nl_version_brace\s*=\s*remove|nl_version_brace\s*=\s*force|nl_version_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Version Brace|Add Nl Version Brace|Remove Nl Version Brace|Force Nl Version Brace"
 ValueDefault=ignore
 
@@ -4062,7 +4517,8 @@ Category=3
 Description="<html>(C#) Add or remove newline between 'using' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_using_brace\s*=\s*ignore|nl_using_brace\s*=\s*add|nl_using_brace\s*=\s*remove|nl_using_brace\s*=\s*force|nl_using_brace\s*=\s*not_defined
+Choices=nl_using_brace=ignore|nl_using_brace=add|nl_using_brace=remove|nl_using_brace=force|nl_using_brace=not_defined
+ChoicesRegex=nl_using_brace\s*=\s*ignore|nl_using_brace\s*=\s*add|nl_using_brace\s*=\s*remove|nl_using_brace\s*=\s*force|nl_using_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Using Brace|Add Nl Using Brace|Remove Nl Using Brace|Force Nl Using Brace"
 ValueDefault=ignore
 
@@ -4071,7 +4527,8 @@ Category=3
 Description="<html>Add or remove newline between two open or close braces. Due to general<br/>newline/brace handling, REMOVE may not work.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_brace\s*=\s*ignore|nl_brace_brace\s*=\s*add|nl_brace_brace\s*=\s*remove|nl_brace_brace\s*=\s*force|nl_brace_brace\s*=\s*not_defined
+Choices=nl_brace_brace=ignore|nl_brace_brace=add|nl_brace_brace=remove|nl_brace_brace=force|nl_brace_brace=not_defined
+ChoicesRegex=nl_brace_brace\s*=\s*ignore|nl_brace_brace\s*=\s*add|nl_brace_brace\s*=\s*remove|nl_brace_brace\s*=\s*force|nl_brace_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Brace|Add Nl Brace Brace|Remove Nl Brace Brace|Force Nl Brace Brace"
 ValueDefault=ignore
 
@@ -4080,7 +4537,8 @@ Category=3
 Description="<html>Add or remove newline between 'do' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_do_brace\s*=\s*ignore|nl_do_brace\s*=\s*add|nl_do_brace\s*=\s*remove|nl_do_brace\s*=\s*force|nl_do_brace\s*=\s*not_defined
+Choices=nl_do_brace=ignore|nl_do_brace=add|nl_do_brace=remove|nl_do_brace=force|nl_do_brace=not_defined
+ChoicesRegex=nl_do_brace\s*=\s*ignore|nl_do_brace\s*=\s*add|nl_do_brace\s*=\s*remove|nl_do_brace\s*=\s*force|nl_do_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Do Brace|Add Nl Do Brace|Remove Nl Do Brace|Force Nl Do Brace"
 ValueDefault=ignore
 
@@ -4089,7 +4547,8 @@ Category=3
 Description="<html>Add or remove newline between '}' and 'while' of 'do' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_while\s*=\s*ignore|nl_brace_while\s*=\s*add|nl_brace_while\s*=\s*remove|nl_brace_while\s*=\s*force|nl_brace_while\s*=\s*not_defined
+Choices=nl_brace_while=ignore|nl_brace_while=add|nl_brace_while=remove|nl_brace_while=force|nl_brace_while=not_defined
+ChoicesRegex=nl_brace_while\s*=\s*ignore|nl_brace_while\s*=\s*add|nl_brace_while\s*=\s*remove|nl_brace_while\s*=\s*force|nl_brace_while\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace While|Add Nl Brace While|Remove Nl Brace While|Force Nl Brace While"
 ValueDefault=ignore
 
@@ -4098,7 +4557,8 @@ Category=3
 Description="<html>Add or remove newline between 'switch' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_switch_brace\s*=\s*ignore|nl_switch_brace\s*=\s*add|nl_switch_brace\s*=\s*remove|nl_switch_brace\s*=\s*force|nl_switch_brace\s*=\s*not_defined
+Choices=nl_switch_brace=ignore|nl_switch_brace=add|nl_switch_brace=remove|nl_switch_brace=force|nl_switch_brace=not_defined
+ChoicesRegex=nl_switch_brace\s*=\s*ignore|nl_switch_brace\s*=\s*add|nl_switch_brace\s*=\s*remove|nl_switch_brace\s*=\s*force|nl_switch_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Switch Brace|Add Nl Switch Brace|Remove Nl Switch Brace|Force Nl Switch Brace"
 ValueDefault=ignore
 
@@ -4107,7 +4567,8 @@ Category=3
 Description="<html>Add or remove newline between 'synchronized' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_synchronized_brace\s*=\s*ignore|nl_synchronized_brace\s*=\s*add|nl_synchronized_brace\s*=\s*remove|nl_synchronized_brace\s*=\s*force|nl_synchronized_brace\s*=\s*not_defined
+Choices=nl_synchronized_brace=ignore|nl_synchronized_brace=add|nl_synchronized_brace=remove|nl_synchronized_brace=force|nl_synchronized_brace=not_defined
+ChoicesRegex=nl_synchronized_brace\s*=\s*ignore|nl_synchronized_brace\s*=\s*add|nl_synchronized_brace\s*=\s*remove|nl_synchronized_brace\s*=\s*force|nl_synchronized_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Synchronized Brace|Add Nl Synchronized Brace|Remove Nl Synchronized Brace|Force Nl Synchronized Brace"
 ValueDefault=ignore
 
@@ -4116,7 +4577,8 @@ Category=3
 Description="<html>Add a newline between ')' and '{' if the ')' is on a different line than the<br/>if/for/etc.<br/><br/>Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch and<br/>nl_catch_brace.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_multi_line_cond\s*=\s*true|nl_multi_line_cond\s*=\s*false
+TrueFalse=nl_multi_line_cond=true|nl_multi_line_cond=false
+TrueFalseRegex=nl_multi_line_cond\s*=\s*true|nl_multi_line_cond\s*=\s*false
 ValueDefault=false
 
 [Nl Multi Line Sparen Open]
@@ -4124,7 +4586,8 @@ Category=3
 Description="<html>Add a newline after '(' if an if/for/while/switch condition spans multiple<br/>lines</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_multi_line_sparen_open\s*=\s*ignore|nl_multi_line_sparen_open\s*=\s*add|nl_multi_line_sparen_open\s*=\s*remove|nl_multi_line_sparen_open\s*=\s*force|nl_multi_line_sparen_open\s*=\s*not_defined
+Choices=nl_multi_line_sparen_open=ignore|nl_multi_line_sparen_open=add|nl_multi_line_sparen_open=remove|nl_multi_line_sparen_open=force|nl_multi_line_sparen_open=not_defined
+ChoicesRegex=nl_multi_line_sparen_open\s*=\s*ignore|nl_multi_line_sparen_open\s*=\s*add|nl_multi_line_sparen_open\s*=\s*remove|nl_multi_line_sparen_open\s*=\s*force|nl_multi_line_sparen_open\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Multi Line Sparen Open|Add Nl Multi Line Sparen Open|Remove Nl Multi Line Sparen Open|Force Nl Multi Line Sparen Open"
 ValueDefault=ignore
 
@@ -4133,7 +4596,8 @@ Category=3
 Description="<html>Add a newline before ')' if an if/for/while/switch condition spans multiple<br/>lines. Overrides nl_before_if_closing_paren if both are specified.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_multi_line_sparen_close\s*=\s*ignore|nl_multi_line_sparen_close\s*=\s*add|nl_multi_line_sparen_close\s*=\s*remove|nl_multi_line_sparen_close\s*=\s*force|nl_multi_line_sparen_close\s*=\s*not_defined
+Choices=nl_multi_line_sparen_close=ignore|nl_multi_line_sparen_close=add|nl_multi_line_sparen_close=remove|nl_multi_line_sparen_close=force|nl_multi_line_sparen_close=not_defined
+ChoicesRegex=nl_multi_line_sparen_close\s*=\s*ignore|nl_multi_line_sparen_close\s*=\s*add|nl_multi_line_sparen_close\s*=\s*remove|nl_multi_line_sparen_close\s*=\s*force|nl_multi_line_sparen_close\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Multi Line Sparen Close|Add Nl Multi Line Sparen Close|Remove Nl Multi Line Sparen Close|Force Nl Multi Line Sparen Close"
 ValueDefault=ignore
 
@@ -4142,7 +4606,8 @@ Category=3
 Description="<html>Force a newline in a define after the macro name for multi-line defines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_multi_line_define\s*=\s*true|nl_multi_line_define\s*=\s*false
+TrueFalse=nl_multi_line_define=true|nl_multi_line_define=false
+TrueFalseRegex=nl_multi_line_define\s*=\s*true|nl_multi_line_define\s*=\s*false
 ValueDefault=false
 
 [Nl Before Case]
@@ -4150,7 +4615,8 @@ Category=3
 Description="<html>Whether to add a newline before 'case', and a blank line before a 'case'<br/>statement that follows a ';' or '}'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_before_case\s*=\s*true|nl_before_case\s*=\s*false
+TrueFalse=nl_before_case=true|nl_before_case=false
+TrueFalseRegex=nl_before_case\s*=\s*true|nl_before_case\s*=\s*false
 ValueDefault=false
 
 [Nl After Case]
@@ -4158,7 +4624,8 @@ Category=3
 Description="<html>Whether to add a newline after a 'case' statement.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_case\s*=\s*true|nl_after_case\s*=\s*false
+TrueFalse=nl_after_case=true|nl_after_case=false
+TrueFalseRegex=nl_after_case\s*=\s*true|nl_after_case\s*=\s*false
 ValueDefault=false
 
 [Nl Case Colon Brace]
@@ -4166,7 +4633,8 @@ Category=3
 Description="<html>Add or remove newline between a case ':' and '{'.<br/><br/>Overrides nl_after_case.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_case_colon_brace\s*=\s*ignore|nl_case_colon_brace\s*=\s*add|nl_case_colon_brace\s*=\s*remove|nl_case_colon_brace\s*=\s*force|nl_case_colon_brace\s*=\s*not_defined
+Choices=nl_case_colon_brace=ignore|nl_case_colon_brace=add|nl_case_colon_brace=remove|nl_case_colon_brace=force|nl_case_colon_brace=not_defined
+ChoicesRegex=nl_case_colon_brace\s*=\s*ignore|nl_case_colon_brace\s*=\s*add|nl_case_colon_brace\s*=\s*remove|nl_case_colon_brace\s*=\s*force|nl_case_colon_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Case Colon Brace|Add Nl Case Colon Brace|Remove Nl Case Colon Brace|Force Nl Case Colon Brace"
 ValueDefault=ignore
 
@@ -4175,7 +4643,8 @@ Category=3
 Description="<html>Add or remove newline between ')' and 'throw'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_throw\s*=\s*ignore|nl_before_throw\s*=\s*add|nl_before_throw\s*=\s*remove|nl_before_throw\s*=\s*force|nl_before_throw\s*=\s*not_defined
+Choices=nl_before_throw=ignore|nl_before_throw=add|nl_before_throw=remove|nl_before_throw=force|nl_before_throw=not_defined
+ChoicesRegex=nl_before_throw\s*=\s*ignore|nl_before_throw\s*=\s*add|nl_before_throw\s*=\s*remove|nl_before_throw\s*=\s*force|nl_before_throw\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Throw|Add Nl Before Throw|Remove Nl Before Throw|Force Nl Before Throw"
 ValueDefault=ignore
 
@@ -4184,7 +4653,8 @@ Category=3
 Description="<html>Add or remove newline between 'namespace' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_namespace_brace\s*=\s*ignore|nl_namespace_brace\s*=\s*add|nl_namespace_brace\s*=\s*remove|nl_namespace_brace\s*=\s*force|nl_namespace_brace\s*=\s*not_defined
+Choices=nl_namespace_brace=ignore|nl_namespace_brace=add|nl_namespace_brace=remove|nl_namespace_brace=force|nl_namespace_brace=not_defined
+ChoicesRegex=nl_namespace_brace\s*=\s*ignore|nl_namespace_brace\s*=\s*add|nl_namespace_brace\s*=\s*remove|nl_namespace_brace\s*=\s*force|nl_namespace_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Namespace Brace|Add Nl Namespace Brace|Remove Nl Namespace Brace|Force Nl Namespace Brace"
 ValueDefault=ignore
 
@@ -4193,7 +4663,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template class.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class\s*=\s*ignore|nl_template_class\s*=\s*add|nl_template_class\s*=\s*remove|nl_template_class\s*=\s*force|nl_template_class\s*=\s*not_defined
+Choices=nl_template_class=ignore|nl_template_class=add|nl_template_class=remove|nl_template_class=force|nl_template_class=not_defined
+ChoicesRegex=nl_template_class\s*=\s*ignore|nl_template_class\s*=\s*add|nl_template_class\s*=\s*remove|nl_template_class\s*=\s*force|nl_template_class\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class|Add Nl Template Class|Remove Nl Template Class|Force Nl Template Class"
 ValueDefault=ignore
 
@@ -4202,7 +4673,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template class declaration.<br/><br/>Overrides nl_template_class.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class_decl\s*=\s*ignore|nl_template_class_decl\s*=\s*add|nl_template_class_decl\s*=\s*remove|nl_template_class_decl\s*=\s*force|nl_template_class_decl\s*=\s*not_defined
+Choices=nl_template_class_decl=ignore|nl_template_class_decl=add|nl_template_class_decl=remove|nl_template_class_decl=force|nl_template_class_decl=not_defined
+ChoicesRegex=nl_template_class_decl\s*=\s*ignore|nl_template_class_decl\s*=\s*add|nl_template_class_decl\s*=\s*remove|nl_template_class_decl\s*=\s*force|nl_template_class_decl\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class Decl|Add Nl Template Class Decl|Remove Nl Template Class Decl|Force Nl Template Class Decl"
 ValueDefault=ignore
 
@@ -4211,7 +4683,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized class declaration.<br/><br/>Overrides nl_template_class_decl.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class_decl_special\s*=\s*ignore|nl_template_class_decl_special\s*=\s*add|nl_template_class_decl_special\s*=\s*remove|nl_template_class_decl_special\s*=\s*force|nl_template_class_decl_special\s*=\s*not_defined
+Choices=nl_template_class_decl_special=ignore|nl_template_class_decl_special=add|nl_template_class_decl_special=remove|nl_template_class_decl_special=force|nl_template_class_decl_special=not_defined
+ChoicesRegex=nl_template_class_decl_special\s*=\s*ignore|nl_template_class_decl_special\s*=\s*add|nl_template_class_decl_special\s*=\s*remove|nl_template_class_decl_special\s*=\s*force|nl_template_class_decl_special\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class Decl Special|Add Nl Template Class Decl Special|Remove Nl Template Class Decl Special|Force Nl Template Class Decl Special"
 ValueDefault=ignore
 
@@ -4220,7 +4693,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template class definition.<br/><br/>Overrides nl_template_class.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class_def\s*=\s*ignore|nl_template_class_def\s*=\s*add|nl_template_class_def\s*=\s*remove|nl_template_class_def\s*=\s*force|nl_template_class_def\s*=\s*not_defined
+Choices=nl_template_class_def=ignore|nl_template_class_def=add|nl_template_class_def=remove|nl_template_class_def=force|nl_template_class_def=not_defined
+ChoicesRegex=nl_template_class_def\s*=\s*ignore|nl_template_class_def\s*=\s*add|nl_template_class_def\s*=\s*remove|nl_template_class_def\s*=\s*force|nl_template_class_def\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class Def|Add Nl Template Class Def|Remove Nl Template Class Def|Force Nl Template Class Def"
 ValueDefault=ignore
 
@@ -4229,7 +4703,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized class definition.<br/><br/>Overrides nl_template_class_def.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_class_def_special\s*=\s*ignore|nl_template_class_def_special\s*=\s*add|nl_template_class_def_special\s*=\s*remove|nl_template_class_def_special\s*=\s*force|nl_template_class_def_special\s*=\s*not_defined
+Choices=nl_template_class_def_special=ignore|nl_template_class_def_special=add|nl_template_class_def_special=remove|nl_template_class_def_special=force|nl_template_class_def_special=not_defined
+ChoicesRegex=nl_template_class_def_special\s*=\s*ignore|nl_template_class_def_special\s*=\s*add|nl_template_class_def_special\s*=\s*remove|nl_template_class_def_special\s*=\s*force|nl_template_class_def_special\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Class Def Special|Add Nl Template Class Def Special|Remove Nl Template Class Def Special|Force Nl Template Class Def Special"
 ValueDefault=ignore
 
@@ -4238,7 +4713,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template function.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func\s*=\s*ignore|nl_template_func\s*=\s*add|nl_template_func\s*=\s*remove|nl_template_func\s*=\s*force|nl_template_func\s*=\s*not_defined
+Choices=nl_template_func=ignore|nl_template_func=add|nl_template_func=remove|nl_template_func=force|nl_template_func=not_defined
+ChoicesRegex=nl_template_func\s*=\s*ignore|nl_template_func\s*=\s*add|nl_template_func\s*=\s*remove|nl_template_func\s*=\s*force|nl_template_func\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func|Add Nl Template Func|Remove Nl Template Func|Force Nl Template Func"
 ValueDefault=ignore
 
@@ -4247,7 +4723,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template function<br/>declaration.<br/><br/>Overrides nl_template_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func_decl\s*=\s*ignore|nl_template_func_decl\s*=\s*add|nl_template_func_decl\s*=\s*remove|nl_template_func_decl\s*=\s*force|nl_template_func_decl\s*=\s*not_defined
+Choices=nl_template_func_decl=ignore|nl_template_func_decl=add|nl_template_func_decl=remove|nl_template_func_decl=force|nl_template_func_decl=not_defined
+ChoicesRegex=nl_template_func_decl\s*=\s*ignore|nl_template_func_decl\s*=\s*add|nl_template_func_decl\s*=\s*remove|nl_template_func_decl\s*=\s*force|nl_template_func_decl\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func Decl|Add Nl Template Func Decl|Remove Nl Template Func Decl|Force Nl Template Func Decl"
 ValueDefault=ignore
 
@@ -4256,7 +4733,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized function<br/>declaration.<br/><br/>Overrides nl_template_func_decl.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func_decl_special\s*=\s*ignore|nl_template_func_decl_special\s*=\s*add|nl_template_func_decl_special\s*=\s*remove|nl_template_func_decl_special\s*=\s*force|nl_template_func_decl_special\s*=\s*not_defined
+Choices=nl_template_func_decl_special=ignore|nl_template_func_decl_special=add|nl_template_func_decl_special=remove|nl_template_func_decl_special=force|nl_template_func_decl_special=not_defined
+ChoicesRegex=nl_template_func_decl_special\s*=\s*ignore|nl_template_func_decl_special\s*=\s*add|nl_template_func_decl_special\s*=\s*remove|nl_template_func_decl_special\s*=\s*force|nl_template_func_decl_special\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func Decl Special|Add Nl Template Func Decl Special|Remove Nl Template Func Decl Special|Force Nl Template Func Decl Special"
 ValueDefault=ignore
 
@@ -4265,7 +4743,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template function<br/>definition.<br/><br/>Overrides nl_template_func.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func_def\s*=\s*ignore|nl_template_func_def\s*=\s*add|nl_template_func_def\s*=\s*remove|nl_template_func_def\s*=\s*force|nl_template_func_def\s*=\s*not_defined
+Choices=nl_template_func_def=ignore|nl_template_func_def=add|nl_template_func_def=remove|nl_template_func_def=force|nl_template_func_def=not_defined
+ChoicesRegex=nl_template_func_def\s*=\s*ignore|nl_template_func_def\s*=\s*add|nl_template_func_def\s*=\s*remove|nl_template_func_def\s*=\s*force|nl_template_func_def\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func Def|Add Nl Template Func Def|Remove Nl Template Func Def|Force Nl Template Func Def"
 ValueDefault=ignore
 
@@ -4274,7 +4753,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;&gt;' of a specialized function<br/>definition.<br/><br/>Overrides nl_template_func_def.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_func_def_special\s*=\s*ignore|nl_template_func_def_special\s*=\s*add|nl_template_func_def_special\s*=\s*remove|nl_template_func_def_special\s*=\s*force|nl_template_func_def_special\s*=\s*not_defined
+Choices=nl_template_func_def_special=ignore|nl_template_func_def_special=add|nl_template_func_def_special=remove|nl_template_func_def_special=force|nl_template_func_def_special=not_defined
+ChoicesRegex=nl_template_func_def_special\s*=\s*ignore|nl_template_func_def_special\s*=\s*add|nl_template_func_def_special\s*=\s*remove|nl_template_func_def_special\s*=\s*force|nl_template_func_def_special\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Func Def Special|Add Nl Template Func Def Special|Remove Nl Template Func Def Special|Force Nl Template Func Def Special"
 ValueDefault=ignore
 
@@ -4283,7 +4763,8 @@ Category=3
 Description="<html>Add or remove newline after 'template&lt;...&gt;' of a template variable.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_var\s*=\s*ignore|nl_template_var\s*=\s*add|nl_template_var\s*=\s*remove|nl_template_var\s*=\s*force|nl_template_var\s*=\s*not_defined
+Choices=nl_template_var=ignore|nl_template_var=add|nl_template_var=remove|nl_template_var=force|nl_template_var=not_defined
+ChoicesRegex=nl_template_var\s*=\s*ignore|nl_template_var\s*=\s*add|nl_template_var\s*=\s*remove|nl_template_var\s*=\s*force|nl_template_var\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Var|Add Nl Template Var|Remove Nl Template Var|Force Nl Template Var"
 ValueDefault=ignore
 
@@ -4292,7 +4773,8 @@ Category=3
 Description="<html>Add or remove newline between 'template&lt;...&gt;' and 'using' of a templated<br/>type alias.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_template_using\s*=\s*ignore|nl_template_using\s*=\s*add|nl_template_using\s*=\s*remove|nl_template_using\s*=\s*force|nl_template_using\s*=\s*not_defined
+Choices=nl_template_using=ignore|nl_template_using=add|nl_template_using=remove|nl_template_using=force|nl_template_using=not_defined
+ChoicesRegex=nl_template_using\s*=\s*ignore|nl_template_using\s*=\s*add|nl_template_using\s*=\s*remove|nl_template_using\s*=\s*force|nl_template_using\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Template Using|Add Nl Template Using|Remove Nl Template Using|Force Nl Template Using"
 ValueDefault=ignore
 
@@ -4301,7 +4783,8 @@ Category=3
 Description="<html>Add or remove newline between 'class' and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_class_brace\s*=\s*ignore|nl_class_brace\s*=\s*add|nl_class_brace\s*=\s*remove|nl_class_brace\s*=\s*force|nl_class_brace\s*=\s*not_defined
+Choices=nl_class_brace=ignore|nl_class_brace=add|nl_class_brace=remove|nl_class_brace=force|nl_class_brace=not_defined
+ChoicesRegex=nl_class_brace\s*=\s*ignore|nl_class_brace\s*=\s*add|nl_class_brace\s*=\s*remove|nl_class_brace\s*=\s*force|nl_class_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Class Brace|Add Nl Class Brace|Remove Nl Class Brace|Force Nl Class Brace"
 ValueDefault=ignore
 
@@ -4310,7 +4793,8 @@ Category=3
 Description="<html>Add or remove newline before or after (depending on pos_class_comma,<br/>may not be IGNORE) each',' in the base class list.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_class_init_args\s*=\s*ignore|nl_class_init_args\s*=\s*add|nl_class_init_args\s*=\s*remove|nl_class_init_args\s*=\s*force|nl_class_init_args\s*=\s*not_defined
+Choices=nl_class_init_args=ignore|nl_class_init_args=add|nl_class_init_args=remove|nl_class_init_args=force|nl_class_init_args=not_defined
+ChoicesRegex=nl_class_init_args\s*=\s*ignore|nl_class_init_args\s*=\s*add|nl_class_init_args\s*=\s*remove|nl_class_init_args\s*=\s*force|nl_class_init_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Class Init Args|Add Nl Class Init Args|Remove Nl Class Init Args|Force Nl Class Init Args"
 ValueDefault=ignore
 
@@ -4319,7 +4803,8 @@ Category=3
 Description="<html>Add or remove newline after each ',' in the constructor member<br/>initialization. Related to nl_constr_colon, pos_constr_colon and<br/>pos_constr_comma.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_constr_init_args\s*=\s*ignore|nl_constr_init_args\s*=\s*add|nl_constr_init_args\s*=\s*remove|nl_constr_init_args\s*=\s*force|nl_constr_init_args\s*=\s*not_defined
+Choices=nl_constr_init_args=ignore|nl_constr_init_args=add|nl_constr_init_args=remove|nl_constr_init_args=force|nl_constr_init_args=not_defined
+ChoicesRegex=nl_constr_init_args\s*=\s*ignore|nl_constr_init_args\s*=\s*add|nl_constr_init_args\s*=\s*remove|nl_constr_init_args\s*=\s*force|nl_constr_init_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Constr Init Args|Add Nl Constr Init Args|Remove Nl Constr Init Args|Force Nl Constr Init Args"
 ValueDefault=ignore
 
@@ -4328,7 +4813,8 @@ Category=3
 Description="<html>Add or remove newline before first element, after comma, and after last<br/>element, in 'enum'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_enum_own_lines\s*=\s*ignore|nl_enum_own_lines\s*=\s*add|nl_enum_own_lines\s*=\s*remove|nl_enum_own_lines\s*=\s*force|nl_enum_own_lines\s*=\s*not_defined
+Choices=nl_enum_own_lines=ignore|nl_enum_own_lines=add|nl_enum_own_lines=remove|nl_enum_own_lines=force|nl_enum_own_lines=not_defined
+ChoicesRegex=nl_enum_own_lines\s*=\s*ignore|nl_enum_own_lines\s*=\s*add|nl_enum_own_lines\s*=\s*remove|nl_enum_own_lines\s*=\s*force|nl_enum_own_lines\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Enum Own Lines|Add Nl Enum Own Lines|Remove Nl Enum Own Lines|Force Nl Enum Own Lines"
 ValueDefault=ignore
 
@@ -4337,7 +4823,8 @@ Category=3
 Description="<html>Add or remove newline between return type and function name in a function<br/>definition.<br/>might be modified by nl_func_leave_one_liners</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_type_name\s*=\s*ignore|nl_func_type_name\s*=\s*add|nl_func_type_name\s*=\s*remove|nl_func_type_name\s*=\s*force|nl_func_type_name\s*=\s*not_defined
+Choices=nl_func_type_name=ignore|nl_func_type_name=add|nl_func_type_name=remove|nl_func_type_name=force|nl_func_type_name=not_defined
+ChoicesRegex=nl_func_type_name\s*=\s*ignore|nl_func_type_name\s*=\s*add|nl_func_type_name\s*=\s*remove|nl_func_type_name\s*=\s*force|nl_func_type_name\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Type Name|Add Nl Func Type Name|Remove Nl Func Type Name|Force Nl Func Type Name"
 ValueDefault=ignore
 
@@ -4346,7 +4833,8 @@ Category=3
 Description="<html>Add or remove newline between return type and function name inside a class<br/>definition. If set to ignore, nl_func_type_name or nl_func_proto_type_name<br/>is used instead.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_type_name_class\s*=\s*ignore|nl_func_type_name_class\s*=\s*add|nl_func_type_name_class\s*=\s*remove|nl_func_type_name_class\s*=\s*force|nl_func_type_name_class\s*=\s*not_defined
+Choices=nl_func_type_name_class=ignore|nl_func_type_name_class=add|nl_func_type_name_class=remove|nl_func_type_name_class=force|nl_func_type_name_class=not_defined
+ChoicesRegex=nl_func_type_name_class\s*=\s*ignore|nl_func_type_name_class\s*=\s*add|nl_func_type_name_class\s*=\s*remove|nl_func_type_name_class\s*=\s*force|nl_func_type_name_class\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Type Name Class|Add Nl Func Type Name Class|Remove Nl Func Type Name Class|Force Nl Func Type Name Class"
 ValueDefault=ignore
 
@@ -4355,7 +4843,8 @@ Category=3
 Description="<html>Add or remove newline between class specification and '::'<br/>in 'void A::f() { }'. Only appears in separate member implementation (does<br/>not appear with in-line implementation).</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_class_scope\s*=\s*ignore|nl_func_class_scope\s*=\s*add|nl_func_class_scope\s*=\s*remove|nl_func_class_scope\s*=\s*force|nl_func_class_scope\s*=\s*not_defined
+Choices=nl_func_class_scope=ignore|nl_func_class_scope=add|nl_func_class_scope=remove|nl_func_class_scope=force|nl_func_class_scope=not_defined
+ChoicesRegex=nl_func_class_scope\s*=\s*ignore|nl_func_class_scope\s*=\s*add|nl_func_class_scope\s*=\s*remove|nl_func_class_scope\s*=\s*force|nl_func_class_scope\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Class Scope|Add Nl Func Class Scope|Remove Nl Func Class Scope|Force Nl Func Class Scope"
 ValueDefault=ignore
 
@@ -4364,7 +4853,8 @@ Category=3
 Description="<html>Add or remove newline between function scope and name, as in<br/>'void A :: &lt;here&gt; f() { }'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_scope_name\s*=\s*ignore|nl_func_scope_name\s*=\s*add|nl_func_scope_name\s*=\s*remove|nl_func_scope_name\s*=\s*force|nl_func_scope_name\s*=\s*not_defined
+Choices=nl_func_scope_name=ignore|nl_func_scope_name=add|nl_func_scope_name=remove|nl_func_scope_name=force|nl_func_scope_name=not_defined
+ChoicesRegex=nl_func_scope_name\s*=\s*ignore|nl_func_scope_name\s*=\s*add|nl_func_scope_name\s*=\s*remove|nl_func_scope_name\s*=\s*force|nl_func_scope_name\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Scope Name|Add Nl Func Scope Name|Remove Nl Func Scope Name|Force Nl Func Scope Name"
 ValueDefault=ignore
 
@@ -4373,7 +4863,8 @@ Category=3
 Description="<html>Add or remove newline between return type and function name in a prototype.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_proto_type_name\s*=\s*ignore|nl_func_proto_type_name\s*=\s*add|nl_func_proto_type_name\s*=\s*remove|nl_func_proto_type_name\s*=\s*force|nl_func_proto_type_name\s*=\s*not_defined
+Choices=nl_func_proto_type_name=ignore|nl_func_proto_type_name=add|nl_func_proto_type_name=remove|nl_func_proto_type_name=force|nl_func_proto_type_name=not_defined
+ChoicesRegex=nl_func_proto_type_name\s*=\s*ignore|nl_func_proto_type_name\s*=\s*add|nl_func_proto_type_name\s*=\s*remove|nl_func_proto_type_name\s*=\s*force|nl_func_proto_type_name\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Proto Type Name|Add Nl Func Proto Type Name|Remove Nl Func Proto Type Name|Force Nl Func Proto Type Name"
 ValueDefault=ignore
 
@@ -4382,7 +4873,8 @@ Category=3
 Description="<html>Add or remove newline between a function name and the opening '(' in the<br/>declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_paren\s*=\s*ignore|nl_func_paren\s*=\s*add|nl_func_paren\s*=\s*remove|nl_func_paren\s*=\s*force|nl_func_paren\s*=\s*not_defined
+Choices=nl_func_paren=ignore|nl_func_paren=add|nl_func_paren=remove|nl_func_paren=force|nl_func_paren=not_defined
+ChoicesRegex=nl_func_paren\s*=\s*ignore|nl_func_paren\s*=\s*add|nl_func_paren\s*=\s*remove|nl_func_paren\s*=\s*force|nl_func_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Paren|Add Nl Func Paren|Remove Nl Func Paren|Force Nl Func Paren"
 ValueDefault=ignore
 
@@ -4391,7 +4883,8 @@ Category=3
 Description="<html>Overrides nl_func_paren for functions with no parameters.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_paren_empty\s*=\s*ignore|nl_func_paren_empty\s*=\s*add|nl_func_paren_empty\s*=\s*remove|nl_func_paren_empty\s*=\s*force|nl_func_paren_empty\s*=\s*not_defined
+Choices=nl_func_paren_empty=ignore|nl_func_paren_empty=add|nl_func_paren_empty=remove|nl_func_paren_empty=force|nl_func_paren_empty=not_defined
+ChoicesRegex=nl_func_paren_empty\s*=\s*ignore|nl_func_paren_empty\s*=\s*add|nl_func_paren_empty\s*=\s*remove|nl_func_paren_empty\s*=\s*force|nl_func_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Paren Empty|Add Nl Func Paren Empty|Remove Nl Func Paren Empty|Force Nl Func Paren Empty"
 ValueDefault=ignore
 
@@ -4400,7 +4893,8 @@ Category=3
 Description="<html>Add or remove newline between a function name and the opening '(' in the<br/>definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_paren\s*=\s*ignore|nl_func_def_paren\s*=\s*add|nl_func_def_paren\s*=\s*remove|nl_func_def_paren\s*=\s*force|nl_func_def_paren\s*=\s*not_defined
+Choices=nl_func_def_paren=ignore|nl_func_def_paren=add|nl_func_def_paren=remove|nl_func_def_paren=force|nl_func_def_paren=not_defined
+ChoicesRegex=nl_func_def_paren\s*=\s*ignore|nl_func_def_paren\s*=\s*add|nl_func_def_paren\s*=\s*remove|nl_func_def_paren\s*=\s*force|nl_func_def_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Paren|Add Nl Func Def Paren|Remove Nl Func Def Paren|Force Nl Func Def Paren"
 ValueDefault=ignore
 
@@ -4409,7 +4903,8 @@ Category=3
 Description="<html>Overrides nl_func_def_paren for functions with no parameters.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_paren_empty\s*=\s*ignore|nl_func_def_paren_empty\s*=\s*add|nl_func_def_paren_empty\s*=\s*remove|nl_func_def_paren_empty\s*=\s*force|nl_func_def_paren_empty\s*=\s*not_defined
+Choices=nl_func_def_paren_empty=ignore|nl_func_def_paren_empty=add|nl_func_def_paren_empty=remove|nl_func_def_paren_empty=force|nl_func_def_paren_empty=not_defined
+ChoicesRegex=nl_func_def_paren_empty\s*=\s*ignore|nl_func_def_paren_empty\s*=\s*add|nl_func_def_paren_empty\s*=\s*remove|nl_func_def_paren_empty\s*=\s*force|nl_func_def_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Paren Empty|Add Nl Func Def Paren Empty|Remove Nl Func Def Paren Empty|Force Nl Func Def Paren Empty"
 ValueDefault=ignore
 
@@ -4418,7 +4913,8 @@ Category=3
 Description="<html>Add or remove newline between a function name and the opening '(' in the<br/>call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_paren\s*=\s*ignore|nl_func_call_paren\s*=\s*add|nl_func_call_paren\s*=\s*remove|nl_func_call_paren\s*=\s*force|nl_func_call_paren\s*=\s*not_defined
+Choices=nl_func_call_paren=ignore|nl_func_call_paren=add|nl_func_call_paren=remove|nl_func_call_paren=force|nl_func_call_paren=not_defined
+ChoicesRegex=nl_func_call_paren\s*=\s*ignore|nl_func_call_paren\s*=\s*add|nl_func_call_paren\s*=\s*remove|nl_func_call_paren\s*=\s*force|nl_func_call_paren\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Paren|Add Nl Func Call Paren|Remove Nl Func Call Paren|Force Nl Func Call Paren"
 ValueDefault=ignore
 
@@ -4427,7 +4923,8 @@ Category=3
 Description="<html>Overrides nl_func_call_paren for functions with no parameters.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_paren_empty\s*=\s*ignore|nl_func_call_paren_empty\s*=\s*add|nl_func_call_paren_empty\s*=\s*remove|nl_func_call_paren_empty\s*=\s*force|nl_func_call_paren_empty\s*=\s*not_defined
+Choices=nl_func_call_paren_empty=ignore|nl_func_call_paren_empty=add|nl_func_call_paren_empty=remove|nl_func_call_paren_empty=force|nl_func_call_paren_empty=not_defined
+ChoicesRegex=nl_func_call_paren_empty\s*=\s*ignore|nl_func_call_paren_empty\s*=\s*add|nl_func_call_paren_empty\s*=\s*remove|nl_func_call_paren_empty\s*=\s*force|nl_func_call_paren_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Paren Empty|Add Nl Func Call Paren Empty|Remove Nl Func Call Paren Empty|Force Nl Func Call Paren Empty"
 ValueDefault=ignore
 
@@ -4436,7 +4933,8 @@ Category=3
 Description="<html>Add or remove newline after '(' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_start\s*=\s*ignore|nl_func_decl_start\s*=\s*add|nl_func_decl_start\s*=\s*remove|nl_func_decl_start\s*=\s*force|nl_func_decl_start\s*=\s*not_defined
+Choices=nl_func_decl_start=ignore|nl_func_decl_start=add|nl_func_decl_start=remove|nl_func_decl_start=force|nl_func_decl_start=not_defined
+ChoicesRegex=nl_func_decl_start\s*=\s*ignore|nl_func_decl_start\s*=\s*add|nl_func_decl_start\s*=\s*remove|nl_func_decl_start\s*=\s*force|nl_func_decl_start\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl Start|Add Nl Func Decl Start|Remove Nl Func Decl Start|Force Nl Func Decl Start"
 ValueDefault=ignore
 
@@ -4445,7 +4943,8 @@ Category=3
 Description="<html>Add or remove newline after '(' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_start\s*=\s*ignore|nl_func_def_start\s*=\s*add|nl_func_def_start\s*=\s*remove|nl_func_def_start\s*=\s*force|nl_func_def_start\s*=\s*not_defined
+Choices=nl_func_def_start=ignore|nl_func_def_start=add|nl_func_def_start=remove|nl_func_def_start=force|nl_func_def_start=not_defined
+ChoicesRegex=nl_func_def_start\s*=\s*ignore|nl_func_def_start\s*=\s*add|nl_func_def_start\s*=\s*remove|nl_func_def_start\s*=\s*force|nl_func_def_start\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Start|Add Nl Func Def Start|Remove Nl Func Def Start|Force Nl Func Def Start"
 ValueDefault=ignore
 
@@ -4454,7 +4953,8 @@ Category=3
 Description="<html>Overrides nl_func_decl_start when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_start_single\s*=\s*ignore|nl_func_decl_start_single\s*=\s*add|nl_func_decl_start_single\s*=\s*remove|nl_func_decl_start_single\s*=\s*force|nl_func_decl_start_single\s*=\s*not_defined
+Choices=nl_func_decl_start_single=ignore|nl_func_decl_start_single=add|nl_func_decl_start_single=remove|nl_func_decl_start_single=force|nl_func_decl_start_single=not_defined
+ChoicesRegex=nl_func_decl_start_single\s*=\s*ignore|nl_func_decl_start_single\s*=\s*add|nl_func_decl_start_single\s*=\s*remove|nl_func_decl_start_single\s*=\s*force|nl_func_decl_start_single\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl Start Single|Add Nl Func Decl Start Single|Remove Nl Func Decl Start Single|Force Nl Func Decl Start Single"
 ValueDefault=ignore
 
@@ -4463,7 +4963,8 @@ Category=3
 Description="<html>Overrides nl_func_def_start when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_start_single\s*=\s*ignore|nl_func_def_start_single\s*=\s*add|nl_func_def_start_single\s*=\s*remove|nl_func_def_start_single\s*=\s*force|nl_func_def_start_single\s*=\s*not_defined
+Choices=nl_func_def_start_single=ignore|nl_func_def_start_single=add|nl_func_def_start_single=remove|nl_func_def_start_single=force|nl_func_def_start_single=not_defined
+ChoicesRegex=nl_func_def_start_single\s*=\s*ignore|nl_func_def_start_single\s*=\s*add|nl_func_def_start_single\s*=\s*remove|nl_func_def_start_single\s*=\s*force|nl_func_def_start_single\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Start Single|Add Nl Func Def Start Single|Remove Nl Func Def Start Single|Force Nl Func Def Start Single"
 ValueDefault=ignore
 
@@ -4472,7 +4973,8 @@ Category=3
 Description="<html>Whether to add a newline after '(' in a function declaration if '(' and ')'<br/>are in different lines. If false, nl_func_decl_start is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_decl_start_multi_line\s*=\s*true|nl_func_decl_start_multi_line\s*=\s*false
+TrueFalse=nl_func_decl_start_multi_line=true|nl_func_decl_start_multi_line=false
+TrueFalseRegex=nl_func_decl_start_multi_line\s*=\s*true|nl_func_decl_start_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Def Start Multi Line]
@@ -4480,7 +4982,8 @@ Category=3
 Description="<html>Whether to add a newline after '(' in a function definition if '(' and ')'<br/>are in different lines. If false, nl_func_def_start is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_def_start_multi_line\s*=\s*true|nl_func_def_start_multi_line\s*=\s*false
+TrueFalse=nl_func_def_start_multi_line=true|nl_func_def_start_multi_line=false
+TrueFalseRegex=nl_func_def_start_multi_line\s*=\s*true|nl_func_def_start_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Decl Args]
@@ -4488,7 +4991,8 @@ Category=3
 Description="<html>Add or remove newline after each ',' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_args\s*=\s*ignore|nl_func_decl_args\s*=\s*add|nl_func_decl_args\s*=\s*remove|nl_func_decl_args\s*=\s*force|nl_func_decl_args\s*=\s*not_defined
+Choices=nl_func_decl_args=ignore|nl_func_decl_args=add|nl_func_decl_args=remove|nl_func_decl_args=force|nl_func_decl_args=not_defined
+ChoicesRegex=nl_func_decl_args\s*=\s*ignore|nl_func_decl_args\s*=\s*add|nl_func_decl_args\s*=\s*remove|nl_func_decl_args\s*=\s*force|nl_func_decl_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl Args|Add Nl Func Decl Args|Remove Nl Func Decl Args|Force Nl Func Decl Args"
 ValueDefault=ignore
 
@@ -4497,7 +5001,8 @@ Category=3
 Description="<html>Add or remove newline after each ',' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_args\s*=\s*ignore|nl_func_def_args\s*=\s*add|nl_func_def_args\s*=\s*remove|nl_func_def_args\s*=\s*force|nl_func_def_args\s*=\s*not_defined
+Choices=nl_func_def_args=ignore|nl_func_def_args=add|nl_func_def_args=remove|nl_func_def_args=force|nl_func_def_args=not_defined
+ChoicesRegex=nl_func_def_args\s*=\s*ignore|nl_func_def_args\s*=\s*add|nl_func_def_args\s*=\s*remove|nl_func_def_args\s*=\s*force|nl_func_def_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Args|Add Nl Func Def Args|Remove Nl Func Def Args|Force Nl Func Def Args"
 ValueDefault=ignore
 
@@ -4506,7 +5011,8 @@ Category=3
 Description="<html>Add or remove newline after each ',' in a function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_args\s*=\s*ignore|nl_func_call_args\s*=\s*add|nl_func_call_args\s*=\s*remove|nl_func_call_args\s*=\s*force|nl_func_call_args\s*=\s*not_defined
+Choices=nl_func_call_args=ignore|nl_func_call_args=add|nl_func_call_args=remove|nl_func_call_args=force|nl_func_call_args=not_defined
+ChoicesRegex=nl_func_call_args\s*=\s*ignore|nl_func_call_args\s*=\s*add|nl_func_call_args\s*=\s*remove|nl_func_call_args\s*=\s*force|nl_func_call_args\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Args|Add Nl Func Call Args|Remove Nl Func Call Args|Force Nl Func Call Args"
 ValueDefault=ignore
 
@@ -4515,7 +5021,8 @@ Category=3
 Description="<html>Whether to add a newline after each ',' in a function declaration if '('<br/>and ')' are in different lines. If false, nl_func_decl_args is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_decl_args_multi_line\s*=\s*true|nl_func_decl_args_multi_line\s*=\s*false
+TrueFalse=nl_func_decl_args_multi_line=true|nl_func_decl_args_multi_line=false
+TrueFalseRegex=nl_func_decl_args_multi_line\s*=\s*true|nl_func_decl_args_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Def Args Multi Line]
@@ -4523,7 +5030,8 @@ Category=3
 Description="<html>Whether to add a newline after each ',' in a function definition if '('<br/>and ')' are in different lines. If false, nl_func_def_args is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_def_args_multi_line\s*=\s*true|nl_func_def_args_multi_line\s*=\s*false
+TrueFalse=nl_func_def_args_multi_line=true|nl_func_def_args_multi_line=false
+TrueFalseRegex=nl_func_def_args_multi_line\s*=\s*true|nl_func_def_args_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Decl End]
@@ -4531,7 +5039,8 @@ Category=3
 Description="<html>Add or remove newline before the ')' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_end\s*=\s*ignore|nl_func_decl_end\s*=\s*add|nl_func_decl_end\s*=\s*remove|nl_func_decl_end\s*=\s*force|nl_func_decl_end\s*=\s*not_defined
+Choices=nl_func_decl_end=ignore|nl_func_decl_end=add|nl_func_decl_end=remove|nl_func_decl_end=force|nl_func_decl_end=not_defined
+ChoicesRegex=nl_func_decl_end\s*=\s*ignore|nl_func_decl_end\s*=\s*add|nl_func_decl_end\s*=\s*remove|nl_func_decl_end\s*=\s*force|nl_func_decl_end\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl End|Add Nl Func Decl End|Remove Nl Func Decl End|Force Nl Func Decl End"
 ValueDefault=ignore
 
@@ -4540,7 +5049,8 @@ Category=3
 Description="<html>Add or remove newline before the ')' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_end\s*=\s*ignore|nl_func_def_end\s*=\s*add|nl_func_def_end\s*=\s*remove|nl_func_def_end\s*=\s*force|nl_func_def_end\s*=\s*not_defined
+Choices=nl_func_def_end=ignore|nl_func_def_end=add|nl_func_def_end=remove|nl_func_def_end=force|nl_func_def_end=not_defined
+ChoicesRegex=nl_func_def_end\s*=\s*ignore|nl_func_def_end\s*=\s*add|nl_func_def_end\s*=\s*remove|nl_func_def_end\s*=\s*force|nl_func_def_end\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def End|Add Nl Func Def End|Remove Nl Func Def End|Force Nl Func Def End"
 ValueDefault=ignore
 
@@ -4549,7 +5059,8 @@ Category=3
 Description="<html>Overrides nl_func_decl_end when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_end_single\s*=\s*ignore|nl_func_decl_end_single\s*=\s*add|nl_func_decl_end_single\s*=\s*remove|nl_func_decl_end_single\s*=\s*force|nl_func_decl_end_single\s*=\s*not_defined
+Choices=nl_func_decl_end_single=ignore|nl_func_decl_end_single=add|nl_func_decl_end_single=remove|nl_func_decl_end_single=force|nl_func_decl_end_single=not_defined
+ChoicesRegex=nl_func_decl_end_single\s*=\s*ignore|nl_func_decl_end_single\s*=\s*add|nl_func_decl_end_single\s*=\s*remove|nl_func_decl_end_single\s*=\s*force|nl_func_decl_end_single\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl End Single|Add Nl Func Decl End Single|Remove Nl Func Decl End Single|Force Nl Func Decl End Single"
 ValueDefault=ignore
 
@@ -4558,7 +5069,8 @@ Category=3
 Description="<html>Overrides nl_func_def_end when there is only one parameter.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_end_single\s*=\s*ignore|nl_func_def_end_single\s*=\s*add|nl_func_def_end_single\s*=\s*remove|nl_func_def_end_single\s*=\s*force|nl_func_def_end_single\s*=\s*not_defined
+Choices=nl_func_def_end_single=ignore|nl_func_def_end_single=add|nl_func_def_end_single=remove|nl_func_def_end_single=force|nl_func_def_end_single=not_defined
+ChoicesRegex=nl_func_def_end_single\s*=\s*ignore|nl_func_def_end_single\s*=\s*add|nl_func_def_end_single\s*=\s*remove|nl_func_def_end_single\s*=\s*force|nl_func_def_end_single\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def End Single|Add Nl Func Def End Single|Remove Nl Func Def End Single|Force Nl Func Def End Single"
 ValueDefault=ignore
 
@@ -4567,7 +5079,8 @@ Category=3
 Description="<html>Whether to add a newline before ')' in a function declaration if '(' and ')'<br/>are in different lines. If false, nl_func_decl_end is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_decl_end_multi_line\s*=\s*true|nl_func_decl_end_multi_line\s*=\s*false
+TrueFalse=nl_func_decl_end_multi_line=true|nl_func_decl_end_multi_line=false
+TrueFalseRegex=nl_func_decl_end_multi_line\s*=\s*true|nl_func_decl_end_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Def End Multi Line]
@@ -4575,7 +5088,8 @@ Category=3
 Description="<html>Whether to add a newline before ')' in a function definition if '(' and ')'<br/>are in different lines. If false, nl_func_def_end is used instead.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_def_end_multi_line\s*=\s*true|nl_func_def_end_multi_line\s*=\s*false
+TrueFalse=nl_func_def_end_multi_line=true|nl_func_def_end_multi_line=false
+TrueFalseRegex=nl_func_def_end_multi_line\s*=\s*true|nl_func_def_end_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Decl Empty]
@@ -4583,7 +5097,8 @@ Category=3
 Description="<html>Add or remove newline between '()' in a function declaration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_decl_empty\s*=\s*ignore|nl_func_decl_empty\s*=\s*add|nl_func_decl_empty\s*=\s*remove|nl_func_decl_empty\s*=\s*force|nl_func_decl_empty\s*=\s*not_defined
+Choices=nl_func_decl_empty=ignore|nl_func_decl_empty=add|nl_func_decl_empty=remove|nl_func_decl_empty=force|nl_func_decl_empty=not_defined
+ChoicesRegex=nl_func_decl_empty\s*=\s*ignore|nl_func_decl_empty\s*=\s*add|nl_func_decl_empty\s*=\s*remove|nl_func_decl_empty\s*=\s*force|nl_func_decl_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Decl Empty|Add Nl Func Decl Empty|Remove Nl Func Decl Empty|Force Nl Func Decl Empty"
 ValueDefault=ignore
 
@@ -4592,7 +5107,8 @@ Category=3
 Description="<html>Add or remove newline between '()' in a function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_def_empty\s*=\s*ignore|nl_func_def_empty\s*=\s*add|nl_func_def_empty\s*=\s*remove|nl_func_def_empty\s*=\s*force|nl_func_def_empty\s*=\s*not_defined
+Choices=nl_func_def_empty=ignore|nl_func_def_empty=add|nl_func_def_empty=remove|nl_func_def_empty=force|nl_func_def_empty=not_defined
+ChoicesRegex=nl_func_def_empty\s*=\s*ignore|nl_func_def_empty\s*=\s*add|nl_func_def_empty\s*=\s*remove|nl_func_def_empty\s*=\s*force|nl_func_def_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Def Empty|Add Nl Func Def Empty|Remove Nl Func Def Empty|Force Nl Func Def Empty"
 ValueDefault=ignore
 
@@ -4601,7 +5117,8 @@ Category=3
 Description="<html>Add or remove newline between '()' in a function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_empty\s*=\s*ignore|nl_func_call_empty\s*=\s*add|nl_func_call_empty\s*=\s*remove|nl_func_call_empty\s*=\s*force|nl_func_call_empty\s*=\s*not_defined
+Choices=nl_func_call_empty=ignore|nl_func_call_empty=add|nl_func_call_empty=remove|nl_func_call_empty=force|nl_func_call_empty=not_defined
+ChoicesRegex=nl_func_call_empty\s*=\s*ignore|nl_func_call_empty\s*=\s*add|nl_func_call_empty\s*=\s*remove|nl_func_call_empty\s*=\s*force|nl_func_call_empty\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Empty|Add Nl Func Call Empty|Remove Nl Func Call Empty|Force Nl Func Call Empty"
 ValueDefault=ignore
 
@@ -4610,7 +5127,8 @@ Category=3
 Description="<html>Whether to add a newline after '(' in a function call,<br/>has preference over nl_func_call_start_multi_line.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_start\s*=\s*ignore|nl_func_call_start\s*=\s*add|nl_func_call_start\s*=\s*remove|nl_func_call_start\s*=\s*force|nl_func_call_start\s*=\s*not_defined
+Choices=nl_func_call_start=ignore|nl_func_call_start=add|nl_func_call_start=remove|nl_func_call_start=force|nl_func_call_start=not_defined
+ChoicesRegex=nl_func_call_start\s*=\s*ignore|nl_func_call_start\s*=\s*add|nl_func_call_start\s*=\s*remove|nl_func_call_start\s*=\s*force|nl_func_call_start\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call Start|Add Nl Func Call Start|Remove Nl Func Call Start|Force Nl Func Call Start"
 ValueDefault=ignore
 
@@ -4619,7 +5137,8 @@ Category=3
 Description="<html>Whether to add a newline before ')' in a function call.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_func_call_end\s*=\s*ignore|nl_func_call_end\s*=\s*add|nl_func_call_end\s*=\s*remove|nl_func_call_end\s*=\s*force|nl_func_call_end\s*=\s*not_defined
+Choices=nl_func_call_end=ignore|nl_func_call_end=add|nl_func_call_end=remove|nl_func_call_end=force|nl_func_call_end=not_defined
+ChoicesRegex=nl_func_call_end\s*=\s*ignore|nl_func_call_end\s*=\s*add|nl_func_call_end\s*=\s*remove|nl_func_call_end\s*=\s*force|nl_func_call_end\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Func Call End|Add Nl Func Call End|Remove Nl Func Call End|Force Nl Func Call End"
 ValueDefault=ignore
 
@@ -4628,7 +5147,8 @@ Category=3
 Description="<html>Whether to add a newline after '(' in a function call if '(' and ')' are in<br/>different lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_call_start_multi_line\s*=\s*true|nl_func_call_start_multi_line\s*=\s*false
+TrueFalse=nl_func_call_start_multi_line=true|nl_func_call_start_multi_line=false
+TrueFalseRegex=nl_func_call_start_multi_line\s*=\s*true|nl_func_call_start_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Call Args Multi Line]
@@ -4636,7 +5156,8 @@ Category=3
 Description="<html>Whether to add a newline after each ',' in a function call if '(' and ')'<br/>are in different lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_call_args_multi_line\s*=\s*true|nl_func_call_args_multi_line\s*=\s*false
+TrueFalse=nl_func_call_args_multi_line=true|nl_func_call_args_multi_line=false
+TrueFalseRegex=nl_func_call_args_multi_line\s*=\s*true|nl_func_call_args_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Call End Multi Line]
@@ -4644,7 +5165,8 @@ Category=3
 Description="<html>Whether to add a newline before ')' in a function call if '(' and ')' are in<br/>different lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_call_end_multi_line\s*=\s*true|nl_func_call_end_multi_line\s*=\s*false
+TrueFalse=nl_func_call_end_multi_line=true|nl_func_call_end_multi_line=false
+TrueFalseRegex=nl_func_call_end_multi_line\s*=\s*true|nl_func_call_end_multi_line\s*=\s*false
 ValueDefault=false
 
 [Nl Func Call Args Multi Line Ignore Closures]
@@ -4652,7 +5174,8 @@ Category=3
 Description="<html>Whether to respect nl_func_call_XXX option in case of closure args.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_func_call_args_multi_line_ignore_closures\s*=\s*true|nl_func_call_args_multi_line_ignore_closures\s*=\s*false
+TrueFalse=nl_func_call_args_multi_line_ignore_closures=true|nl_func_call_args_multi_line_ignore_closures=false
+TrueFalseRegex=nl_func_call_args_multi_line_ignore_closures\s*=\s*true|nl_func_call_args_multi_line_ignore_closures\s*=\s*false
 ValueDefault=false
 
 [Nl Template Start]
@@ -4660,7 +5183,8 @@ Category=3
 Description="<html>Whether to add a newline after '&lt;' of a template parameter list.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_template_start\s*=\s*true|nl_template_start\s*=\s*false
+TrueFalse=nl_template_start=true|nl_template_start=false
+TrueFalseRegex=nl_template_start\s*=\s*true|nl_template_start\s*=\s*false
 ValueDefault=false
 
 [Nl Template Args]
@@ -4668,7 +5192,8 @@ Category=3
 Description="<html>Whether to add a newline after each ',' in a template parameter list.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_template_args\s*=\s*true|nl_template_args\s*=\s*false
+TrueFalse=nl_template_args=true|nl_template_args=false
+TrueFalseRegex=nl_template_args\s*=\s*true|nl_template_args\s*=\s*false
 ValueDefault=false
 
 [Nl Template End]
@@ -4676,7 +5201,8 @@ Category=3
 Description="<html>Whether to add a newline before '&gt;' of a template parameter list.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_template_end\s*=\s*true|nl_template_end\s*=\s*false
+TrueFalse=nl_template_end=true|nl_template_end=false
+TrueFalseRegex=nl_template_end\s*=\s*true|nl_template_end\s*=\s*false
 ValueDefault=false
 
 [Nl Oc Msg Args]
@@ -4684,7 +5210,8 @@ Category=3
 Description="<html>(OC) Whether to put each Objective-C message parameter on a separate line.<br/>See nl_oc_msg_leave_one_liner.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_oc_msg_args\s*=\s*true|nl_oc_msg_args\s*=\s*false
+TrueFalse=nl_oc_msg_args=true|nl_oc_msg_args=false
+TrueFalseRegex=nl_oc_msg_args\s*=\s*true|nl_oc_msg_args\s*=\s*false
 ValueDefault=false
 
 [Nl Oc Msg Args Min Params]
@@ -4692,7 +5219,8 @@ Category=3
 Description="<html>(OC) Minimum number of Objective-C message parameters before applying nl_oc_msg_args.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_oc_msg_args_min_params\s*=\s*"
+CallName="nl_oc_msg_args_min_params="
+CallNameRegex="nl_oc_msg_args_min_params\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -4702,7 +5230,8 @@ Category=3
 Description="<html>(OC) Max code width of Objective-C message before applying nl_oc_msg_args.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_oc_msg_args_max_code_width\s*=\s*"
+CallName="nl_oc_msg_args_max_code_width="
+CallNameRegex="nl_oc_msg_args_max_code_width\s*=\s*"
 MinVal=0
 MaxVal=10000
 ValueDefault=0
@@ -4712,7 +5241,8 @@ Category=3
 Description="<html>Add or remove newline between function signature and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_fdef_brace\s*=\s*ignore|nl_fdef_brace\s*=\s*add|nl_fdef_brace\s*=\s*remove|nl_fdef_brace\s*=\s*force|nl_fdef_brace\s*=\s*not_defined
+Choices=nl_fdef_brace=ignore|nl_fdef_brace=add|nl_fdef_brace=remove|nl_fdef_brace=force|nl_fdef_brace=not_defined
+ChoicesRegex=nl_fdef_brace\s*=\s*ignore|nl_fdef_brace\s*=\s*add|nl_fdef_brace\s*=\s*remove|nl_fdef_brace\s*=\s*force|nl_fdef_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Fdef Brace|Add Nl Fdef Brace|Remove Nl Fdef Brace|Force Nl Fdef Brace"
 ValueDefault=ignore
 
@@ -4721,7 +5251,8 @@ Category=3
 Description="<html>Add or remove newline between function signature and '{',<br/>if signature ends with ')'. Overrides nl_fdef_brace.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_fdef_brace_cond\s*=\s*ignore|nl_fdef_brace_cond\s*=\s*add|nl_fdef_brace_cond\s*=\s*remove|nl_fdef_brace_cond\s*=\s*force|nl_fdef_brace_cond\s*=\s*not_defined
+Choices=nl_fdef_brace_cond=ignore|nl_fdef_brace_cond=add|nl_fdef_brace_cond=remove|nl_fdef_brace_cond=force|nl_fdef_brace_cond=not_defined
+ChoicesRegex=nl_fdef_brace_cond\s*=\s*ignore|nl_fdef_brace_cond\s*=\s*add|nl_fdef_brace_cond\s*=\s*remove|nl_fdef_brace_cond\s*=\s*force|nl_fdef_brace_cond\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Fdef Brace Cond|Add Nl Fdef Brace Cond|Remove Nl Fdef Brace Cond|Force Nl Fdef Brace Cond"
 ValueDefault=ignore
 
@@ -4730,7 +5261,8 @@ Category=3
 Description="<html>Add or remove newline between C++11 lambda signature and '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_cpp_ldef_brace\s*=\s*ignore|nl_cpp_ldef_brace\s*=\s*add|nl_cpp_ldef_brace\s*=\s*remove|nl_cpp_ldef_brace\s*=\s*force|nl_cpp_ldef_brace\s*=\s*not_defined
+Choices=nl_cpp_ldef_brace=ignore|nl_cpp_ldef_brace=add|nl_cpp_ldef_brace=remove|nl_cpp_ldef_brace=force|nl_cpp_ldef_brace=not_defined
+ChoicesRegex=nl_cpp_ldef_brace\s*=\s*ignore|nl_cpp_ldef_brace\s*=\s*add|nl_cpp_ldef_brace\s*=\s*remove|nl_cpp_ldef_brace\s*=\s*force|nl_cpp_ldef_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Cpp Ldef Brace|Add Nl Cpp Ldef Brace|Remove Nl Cpp Ldef Brace|Force Nl Cpp Ldef Brace"
 ValueDefault=ignore
 
@@ -4739,7 +5271,8 @@ Category=3
 Description="<html>Add or remove newline between 'return' and the return expression.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_return_expr\s*=\s*ignore|nl_return_expr\s*=\s*add|nl_return_expr\s*=\s*remove|nl_return_expr\s*=\s*force|nl_return_expr\s*=\s*not_defined
+Choices=nl_return_expr=ignore|nl_return_expr=add|nl_return_expr=remove|nl_return_expr=force|nl_return_expr=not_defined
+ChoicesRegex=nl_return_expr\s*=\s*ignore|nl_return_expr\s*=\s*add|nl_return_expr\s*=\s*remove|nl_return_expr\s*=\s*force|nl_return_expr\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Return Expr|Add Nl Return Expr|Remove Nl Return Expr|Force Nl Return Expr"
 ValueDefault=ignore
 
@@ -4748,7 +5281,8 @@ Category=3
 Description="<html>Add or remove newline between 'throw' and the throw expression.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_throw_expr\s*=\s*ignore|nl_throw_expr\s*=\s*add|nl_throw_expr\s*=\s*remove|nl_throw_expr\s*=\s*force|nl_throw_expr\s*=\s*not_defined
+Choices=nl_throw_expr=ignore|nl_throw_expr=add|nl_throw_expr=remove|nl_throw_expr=force|nl_throw_expr=not_defined
+ChoicesRegex=nl_throw_expr\s*=\s*ignore|nl_throw_expr\s*=\s*add|nl_throw_expr\s*=\s*remove|nl_throw_expr\s*=\s*force|nl_throw_expr\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Throw Expr|Add Nl Throw Expr|Remove Nl Throw Expr|Force Nl Throw Expr"
 ValueDefault=ignore
 
@@ -4757,7 +5291,8 @@ Category=3
 Description="<html>Whether to add a newline after semicolons, except in 'for' statements.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_semicolon\s*=\s*true|nl_after_semicolon\s*=\s*false
+TrueFalse=nl_after_semicolon=true|nl_after_semicolon=false
+TrueFalseRegex=nl_after_semicolon\s*=\s*true|nl_after_semicolon\s*=\s*false
 ValueDefault=false
 
 [Nl Paren Dbrace Open]
@@ -4765,7 +5300,8 @@ Category=3
 Description="<html>(Java) Add or remove newline between the ')' and '{{' of the double brace<br/>initializer.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_paren_dbrace_open\s*=\s*ignore|nl_paren_dbrace_open\s*=\s*add|nl_paren_dbrace_open\s*=\s*remove|nl_paren_dbrace_open\s*=\s*force|nl_paren_dbrace_open\s*=\s*not_defined
+Choices=nl_paren_dbrace_open=ignore|nl_paren_dbrace_open=add|nl_paren_dbrace_open=remove|nl_paren_dbrace_open=force|nl_paren_dbrace_open=not_defined
+ChoicesRegex=nl_paren_dbrace_open\s*=\s*ignore|nl_paren_dbrace_open\s*=\s*add|nl_paren_dbrace_open\s*=\s*remove|nl_paren_dbrace_open\s*=\s*force|nl_paren_dbrace_open\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Paren Dbrace Open|Add Nl Paren Dbrace Open|Remove Nl Paren Dbrace Open|Force Nl Paren Dbrace Open"
 ValueDefault=ignore
 
@@ -4774,7 +5310,8 @@ Category=3
 Description="<html>Whether to add a newline after the type in an unnamed temporary<br/>direct-list-initialization, better:<br/>before a direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_type_brace_init_lst\s*=\s*ignore|nl_type_brace_init_lst\s*=\s*add|nl_type_brace_init_lst\s*=\s*remove|nl_type_brace_init_lst\s*=\s*force|nl_type_brace_init_lst\s*=\s*not_defined
+Choices=nl_type_brace_init_lst=ignore|nl_type_brace_init_lst=add|nl_type_brace_init_lst=remove|nl_type_brace_init_lst=force|nl_type_brace_init_lst=not_defined
+ChoicesRegex=nl_type_brace_init_lst\s*=\s*ignore|nl_type_brace_init_lst\s*=\s*add|nl_type_brace_init_lst\s*=\s*remove|nl_type_brace_init_lst\s*=\s*force|nl_type_brace_init_lst\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Type Brace Init Lst|Add Nl Type Brace Init Lst|Remove Nl Type Brace Init Lst|Force Nl Type Brace Init Lst"
 ValueDefault=ignore
 
@@ -4783,7 +5320,8 @@ Category=3
 Description="<html>Whether to add a newline after the open brace in an unnamed temporary<br/>direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_type_brace_init_lst_open\s*=\s*ignore|nl_type_brace_init_lst_open\s*=\s*add|nl_type_brace_init_lst_open\s*=\s*remove|nl_type_brace_init_lst_open\s*=\s*force|nl_type_brace_init_lst_open\s*=\s*not_defined
+Choices=nl_type_brace_init_lst_open=ignore|nl_type_brace_init_lst_open=add|nl_type_brace_init_lst_open=remove|nl_type_brace_init_lst_open=force|nl_type_brace_init_lst_open=not_defined
+ChoicesRegex=nl_type_brace_init_lst_open\s*=\s*ignore|nl_type_brace_init_lst_open\s*=\s*add|nl_type_brace_init_lst_open\s*=\s*remove|nl_type_brace_init_lst_open\s*=\s*force|nl_type_brace_init_lst_open\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Type Brace Init Lst Open|Add Nl Type Brace Init Lst Open|Remove Nl Type Brace Init Lst Open|Force Nl Type Brace Init Lst Open"
 ValueDefault=ignore
 
@@ -4792,7 +5330,8 @@ Category=3
 Description="<html>Whether to add a newline before the close brace in an unnamed temporary<br/>direct-list-initialization.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_type_brace_init_lst_close\s*=\s*ignore|nl_type_brace_init_lst_close\s*=\s*add|nl_type_brace_init_lst_close\s*=\s*remove|nl_type_brace_init_lst_close\s*=\s*force|nl_type_brace_init_lst_close\s*=\s*not_defined
+Choices=nl_type_brace_init_lst_close=ignore|nl_type_brace_init_lst_close=add|nl_type_brace_init_lst_close=remove|nl_type_brace_init_lst_close=force|nl_type_brace_init_lst_close=not_defined
+ChoicesRegex=nl_type_brace_init_lst_close\s*=\s*ignore|nl_type_brace_init_lst_close\s*=\s*add|nl_type_brace_init_lst_close\s*=\s*remove|nl_type_brace_init_lst_close\s*=\s*force|nl_type_brace_init_lst_close\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Type Brace Init Lst Close|Add Nl Type Brace Init Lst Close|Remove Nl Type Brace Init Lst Close|Force Nl Type Brace Init Lst Close"
 ValueDefault=ignore
 
@@ -4801,7 +5340,8 @@ Category=3
 Description="<html>Whether to add a newline before '{'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_before_brace_open\s*=\s*true|nl_before_brace_open\s*=\s*false
+TrueFalse=nl_before_brace_open=true|nl_before_brace_open=false
+TrueFalseRegex=nl_before_brace_open\s*=\s*true|nl_before_brace_open\s*=\s*false
 ValueDefault=false
 
 [Nl After Brace Open]
@@ -4809,7 +5349,8 @@ Category=3
 Description="<html>Whether to add a newline after '{'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_brace_open\s*=\s*true|nl_after_brace_open\s*=\s*false
+TrueFalse=nl_after_brace_open=true|nl_after_brace_open=false
+TrueFalseRegex=nl_after_brace_open\s*=\s*true|nl_after_brace_open\s*=\s*false
 ValueDefault=false
 
 [Nl After Brace Open Cmt]
@@ -4817,7 +5358,8 @@ Category=3
 Description="<html>Whether to add a newline between the open brace and a trailing single-line<br/>comment. Requires nl_after_brace_open=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_brace_open_cmt\s*=\s*true|nl_after_brace_open_cmt\s*=\s*false
+TrueFalse=nl_after_brace_open_cmt=true|nl_after_brace_open_cmt=false
+TrueFalseRegex=nl_after_brace_open_cmt\s*=\s*true|nl_after_brace_open_cmt\s*=\s*false
 ValueDefault=false
 
 [Nl After Vbrace Open]
@@ -4825,7 +5367,8 @@ Category=3
 Description="<html>Whether to add a newline after a virtual brace open with a non-empty body.<br/>These occur in un-braced if/while/do/for statement bodies.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_vbrace_open\s*=\s*true|nl_after_vbrace_open\s*=\s*false
+TrueFalse=nl_after_vbrace_open=true|nl_after_vbrace_open=false
+TrueFalseRegex=nl_after_vbrace_open\s*=\s*true|nl_after_vbrace_open\s*=\s*false
 ValueDefault=false
 
 [Nl After Vbrace Open Empty]
@@ -4833,7 +5376,8 @@ Category=3
 Description="<html>Whether to add a newline after a virtual brace open with an empty body.<br/>These occur in un-braced if/while/do/for statement bodies.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_vbrace_open_empty\s*=\s*true|nl_after_vbrace_open_empty\s*=\s*false
+TrueFalse=nl_after_vbrace_open_empty=true|nl_after_vbrace_open_empty=false
+TrueFalseRegex=nl_after_vbrace_open_empty\s*=\s*true|nl_after_vbrace_open_empty\s*=\s*false
 ValueDefault=false
 
 [Nl After Brace Close]
@@ -4841,7 +5385,8 @@ Category=3
 Description="<html>Whether to add a newline after '}'. Does not apply if followed by a<br/>necessary ';'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_brace_close\s*=\s*true|nl_after_brace_close\s*=\s*false
+TrueFalse=nl_after_brace_close=true|nl_after_brace_close=false
+TrueFalseRegex=nl_after_brace_close\s*=\s*true|nl_after_brace_close\s*=\s*false
 ValueDefault=false
 
 [Nl After Vbrace Close]
@@ -4849,7 +5394,8 @@ Category=3
 Description="<html>Whether to add a newline after a virtual brace close,<br/>as in 'if (foo) a++; &lt;here&gt; return;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_vbrace_close\s*=\s*true|nl_after_vbrace_close\s*=\s*false
+TrueFalse=nl_after_vbrace_close=true|nl_after_vbrace_close=false
+TrueFalseRegex=nl_after_vbrace_close\s*=\s*true|nl_after_vbrace_close\s*=\s*false
 ValueDefault=false
 
 [Nl Brace Struct Var]
@@ -4857,7 +5403,8 @@ Category=3
 Description="<html>Add or remove newline between the close brace and identifier,<br/>as in 'struct { int a; } &lt;here&gt; b;'. Affects enumerations, unions and<br/>structures. If set to ignore, uses nl_after_brace_close.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_brace_struct_var\s*=\s*ignore|nl_brace_struct_var\s*=\s*add|nl_brace_struct_var\s*=\s*remove|nl_brace_struct_var\s*=\s*force|nl_brace_struct_var\s*=\s*not_defined
+Choices=nl_brace_struct_var=ignore|nl_brace_struct_var=add|nl_brace_struct_var=remove|nl_brace_struct_var=force|nl_brace_struct_var=not_defined
+ChoicesRegex=nl_brace_struct_var\s*=\s*ignore|nl_brace_struct_var\s*=\s*add|nl_brace_struct_var\s*=\s*remove|nl_brace_struct_var\s*=\s*force|nl_brace_struct_var\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Brace Struct Var|Add Nl Brace Struct Var|Remove Nl Brace Struct Var|Force Nl Brace Struct Var"
 ValueDefault=ignore
 
@@ -4866,7 +5413,8 @@ Category=3
 Description="<html>Whether to alter newlines in '#define' macros.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_define_macro\s*=\s*true|nl_define_macro\s*=\s*false
+TrueFalse=nl_define_macro=true|nl_define_macro=false
+TrueFalseRegex=nl_define_macro\s*=\s*true|nl_define_macro\s*=\s*false
 ValueDefault=false
 
 [Nl Squeeze Paren Close]
@@ -4874,7 +5422,8 @@ Category=3
 Description="<html>Whether to alter newlines between consecutive parenthesis closes. The number<br/>of closing parentheses in a line will depend on respective open parenthesis<br/>lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_squeeze_paren_close\s*=\s*true|nl_squeeze_paren_close\s*=\s*false
+TrueFalse=nl_squeeze_paren_close=true|nl_squeeze_paren_close=false
+TrueFalseRegex=nl_squeeze_paren_close\s*=\s*true|nl_squeeze_paren_close\s*=\s*false
 ValueDefault=false
 
 [Nl Squeeze Ifdef]
@@ -4882,7 +5431,8 @@ Category=3
 Description="<html>Whether to remove blanks after '#ifxx' and '#elxx', or before '#elxx' and<br/>'#endif'. Does not affect top-level #ifdefs.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_squeeze_ifdef\s*=\s*true|nl_squeeze_ifdef\s*=\s*false
+TrueFalse=nl_squeeze_ifdef=true|nl_squeeze_ifdef=false
+TrueFalseRegex=nl_squeeze_ifdef\s*=\s*true|nl_squeeze_ifdef\s*=\s*false
 ValueDefault=false
 
 [Nl Squeeze Ifdef Top Level]
@@ -4890,7 +5440,8 @@ Category=3
 Description="<html>Makes the nl_squeeze_ifdef option affect the top-level #ifdefs as well.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_squeeze_ifdef_top_level\s*=\s*true|nl_squeeze_ifdef_top_level\s*=\s*false
+TrueFalse=nl_squeeze_ifdef_top_level=true|nl_squeeze_ifdef_top_level=false
+TrueFalseRegex=nl_squeeze_ifdef_top_level\s*=\s*true|nl_squeeze_ifdef_top_level\s*=\s*false
 ValueDefault=false
 
 [Nl Before If]
@@ -4898,7 +5449,8 @@ Category=3
 Description="<html>Add or remove blank line before 'if'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_if\s*=\s*ignore|nl_before_if\s*=\s*add|nl_before_if\s*=\s*remove|nl_before_if\s*=\s*force|nl_before_if\s*=\s*not_defined
+Choices=nl_before_if=ignore|nl_before_if=add|nl_before_if=remove|nl_before_if=force|nl_before_if=not_defined
+ChoicesRegex=nl_before_if\s*=\s*ignore|nl_before_if\s*=\s*add|nl_before_if\s*=\s*remove|nl_before_if\s*=\s*force|nl_before_if\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before If|Add Nl Before If|Remove Nl Before If|Force Nl Before If"
 ValueDefault=ignore
 
@@ -4907,7 +5459,8 @@ Category=3
 Description="<html>Add or remove blank line after 'if' statement. Add/Force work only if the<br/>next token is not a closing brace.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_if\s*=\s*ignore|nl_after_if\s*=\s*add|nl_after_if\s*=\s*remove|nl_after_if\s*=\s*force|nl_after_if\s*=\s*not_defined
+Choices=nl_after_if=ignore|nl_after_if=add|nl_after_if=remove|nl_after_if=force|nl_after_if=not_defined
+ChoicesRegex=nl_after_if\s*=\s*ignore|nl_after_if\s*=\s*add|nl_after_if\s*=\s*remove|nl_after_if\s*=\s*force|nl_after_if\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After If|Add Nl After If|Remove Nl After If|Force Nl After If"
 ValueDefault=ignore
 
@@ -4916,7 +5469,8 @@ Category=3
 Description="<html>Add or remove blank line before 'for'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_for\s*=\s*ignore|nl_before_for\s*=\s*add|nl_before_for\s*=\s*remove|nl_before_for\s*=\s*force|nl_before_for\s*=\s*not_defined
+Choices=nl_before_for=ignore|nl_before_for=add|nl_before_for=remove|nl_before_for=force|nl_before_for=not_defined
+ChoicesRegex=nl_before_for\s*=\s*ignore|nl_before_for\s*=\s*add|nl_before_for\s*=\s*remove|nl_before_for\s*=\s*force|nl_before_for\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before For|Add Nl Before For|Remove Nl Before For|Force Nl Before For"
 ValueDefault=ignore
 
@@ -4925,7 +5479,8 @@ Category=3
 Description="<html>Add or remove blank line after 'for' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_for\s*=\s*ignore|nl_after_for\s*=\s*add|nl_after_for\s*=\s*remove|nl_after_for\s*=\s*force|nl_after_for\s*=\s*not_defined
+Choices=nl_after_for=ignore|nl_after_for=add|nl_after_for=remove|nl_after_for=force|nl_after_for=not_defined
+ChoicesRegex=nl_after_for\s*=\s*ignore|nl_after_for\s*=\s*add|nl_after_for\s*=\s*remove|nl_after_for\s*=\s*force|nl_after_for\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After For|Add Nl After For|Remove Nl After For|Force Nl After For"
 ValueDefault=ignore
 
@@ -4934,7 +5489,8 @@ Category=3
 Description="<html>Add or remove blank line before 'while'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_while\s*=\s*ignore|nl_before_while\s*=\s*add|nl_before_while\s*=\s*remove|nl_before_while\s*=\s*force|nl_before_while\s*=\s*not_defined
+Choices=nl_before_while=ignore|nl_before_while=add|nl_before_while=remove|nl_before_while=force|nl_before_while=not_defined
+ChoicesRegex=nl_before_while\s*=\s*ignore|nl_before_while\s*=\s*add|nl_before_while\s*=\s*remove|nl_before_while\s*=\s*force|nl_before_while\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before While|Add Nl Before While|Remove Nl Before While|Force Nl Before While"
 ValueDefault=ignore
 
@@ -4943,7 +5499,8 @@ Category=3
 Description="<html>Add or remove blank line after 'while' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_while\s*=\s*ignore|nl_after_while\s*=\s*add|nl_after_while\s*=\s*remove|nl_after_while\s*=\s*force|nl_after_while\s*=\s*not_defined
+Choices=nl_after_while=ignore|nl_after_while=add|nl_after_while=remove|nl_after_while=force|nl_after_while=not_defined
+ChoicesRegex=nl_after_while\s*=\s*ignore|nl_after_while\s*=\s*add|nl_after_while\s*=\s*remove|nl_after_while\s*=\s*force|nl_after_while\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After While|Add Nl After While|Remove Nl After While|Force Nl After While"
 ValueDefault=ignore
 
@@ -4952,7 +5509,8 @@ Category=3
 Description="<html>Add or remove blank line before 'switch'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_switch\s*=\s*ignore|nl_before_switch\s*=\s*add|nl_before_switch\s*=\s*remove|nl_before_switch\s*=\s*force|nl_before_switch\s*=\s*not_defined
+Choices=nl_before_switch=ignore|nl_before_switch=add|nl_before_switch=remove|nl_before_switch=force|nl_before_switch=not_defined
+ChoicesRegex=nl_before_switch\s*=\s*ignore|nl_before_switch\s*=\s*add|nl_before_switch\s*=\s*remove|nl_before_switch\s*=\s*force|nl_before_switch\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Switch|Add Nl Before Switch|Remove Nl Before Switch|Force Nl Before Switch"
 ValueDefault=ignore
 
@@ -4961,7 +5519,8 @@ Category=3
 Description="<html>Add or remove blank line after 'switch' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_switch\s*=\s*ignore|nl_after_switch\s*=\s*add|nl_after_switch\s*=\s*remove|nl_after_switch\s*=\s*force|nl_after_switch\s*=\s*not_defined
+Choices=nl_after_switch=ignore|nl_after_switch=add|nl_after_switch=remove|nl_after_switch=force|nl_after_switch=not_defined
+ChoicesRegex=nl_after_switch\s*=\s*ignore|nl_after_switch\s*=\s*add|nl_after_switch\s*=\s*remove|nl_after_switch\s*=\s*force|nl_after_switch\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Switch|Add Nl After Switch|Remove Nl After Switch|Force Nl After Switch"
 ValueDefault=ignore
 
@@ -4970,7 +5529,8 @@ Category=3
 Description="<html>Add or remove blank line before 'synchronized'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_synchronized\s*=\s*ignore|nl_before_synchronized\s*=\s*add|nl_before_synchronized\s*=\s*remove|nl_before_synchronized\s*=\s*force|nl_before_synchronized\s*=\s*not_defined
+Choices=nl_before_synchronized=ignore|nl_before_synchronized=add|nl_before_synchronized=remove|nl_before_synchronized=force|nl_before_synchronized=not_defined
+ChoicesRegex=nl_before_synchronized\s*=\s*ignore|nl_before_synchronized\s*=\s*add|nl_before_synchronized\s*=\s*remove|nl_before_synchronized\s*=\s*force|nl_before_synchronized\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Synchronized|Add Nl Before Synchronized|Remove Nl Before Synchronized|Force Nl Before Synchronized"
 ValueDefault=ignore
 
@@ -4979,7 +5539,8 @@ Category=3
 Description="<html>Add or remove blank line after 'synchronized' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_synchronized\s*=\s*ignore|nl_after_synchronized\s*=\s*add|nl_after_synchronized\s*=\s*remove|nl_after_synchronized\s*=\s*force|nl_after_synchronized\s*=\s*not_defined
+Choices=nl_after_synchronized=ignore|nl_after_synchronized=add|nl_after_synchronized=remove|nl_after_synchronized=force|nl_after_synchronized=not_defined
+ChoicesRegex=nl_after_synchronized\s*=\s*ignore|nl_after_synchronized\s*=\s*add|nl_after_synchronized\s*=\s*remove|nl_after_synchronized\s*=\s*force|nl_after_synchronized\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Synchronized|Add Nl After Synchronized|Remove Nl After Synchronized|Force Nl After Synchronized"
 ValueDefault=ignore
 
@@ -4988,7 +5549,8 @@ Category=3
 Description="<html>Add or remove blank line before 'do'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_do\s*=\s*ignore|nl_before_do\s*=\s*add|nl_before_do\s*=\s*remove|nl_before_do\s*=\s*force|nl_before_do\s*=\s*not_defined
+Choices=nl_before_do=ignore|nl_before_do=add|nl_before_do=remove|nl_before_do=force|nl_before_do=not_defined
+ChoicesRegex=nl_before_do\s*=\s*ignore|nl_before_do\s*=\s*add|nl_before_do\s*=\s*remove|nl_before_do\s*=\s*force|nl_before_do\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Do|Add Nl Before Do|Remove Nl Before Do|Force Nl Before Do"
 ValueDefault=ignore
 
@@ -4997,7 +5559,8 @@ Category=3
 Description="<html>Add or remove blank line after 'do/while' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_do\s*=\s*ignore|nl_after_do\s*=\s*add|nl_after_do\s*=\s*remove|nl_after_do\s*=\s*force|nl_after_do\s*=\s*not_defined
+Choices=nl_after_do=ignore|nl_after_do=add|nl_after_do=remove|nl_after_do=force|nl_after_do=not_defined
+ChoicesRegex=nl_after_do\s*=\s*ignore|nl_after_do\s*=\s*add|nl_after_do\s*=\s*remove|nl_after_do\s*=\s*force|nl_after_do\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Do|Add Nl After Do|Remove Nl After Do|Force Nl After Do"
 ValueDefault=ignore
 
@@ -5006,7 +5569,8 @@ Category=3
 Description="<html>Ignore nl_before_{if,for,switch,do,synchronized} if the control<br/>statement is immediately after a case statement.<br/>if nl_before_{if,for,switch,do} is set to remove, this option<br/>does nothing.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_before_ignore_after_case\s*=\s*true|nl_before_ignore_after_case\s*=\s*false
+TrueFalse=nl_before_ignore_after_case=true|nl_before_ignore_after_case=false
+TrueFalseRegex=nl_before_ignore_after_case\s*=\s*true|nl_before_ignore_after_case\s*=\s*false
 ValueDefault=false
 
 [Nl Before Return]
@@ -5014,7 +5578,8 @@ Category=3
 Description="<html>Whether to put a blank line before 'return' statements, unless after an open<br/>brace.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_before_return\s*=\s*true|nl_before_return\s*=\s*false
+TrueFalse=nl_before_return=true|nl_before_return=false
+TrueFalseRegex=nl_before_return\s*=\s*true|nl_before_return\s*=\s*false
 ValueDefault=false
 
 [Nl After Return]
@@ -5022,7 +5587,8 @@ Category=3
 Description="<html>Whether to put a blank line after 'return' statements, unless followed by a<br/>close brace.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_return\s*=\s*true|nl_after_return\s*=\s*false
+TrueFalse=nl_after_return=true|nl_after_return=false
+TrueFalseRegex=nl_after_return\s*=\s*true|nl_after_return\s*=\s*false
 ValueDefault=false
 
 [Nl Before Member]
@@ -5030,7 +5596,8 @@ Category=3
 Description="<html>Whether to put a blank line before a member '.' or '-&gt;' operators.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_before_member\s*=\s*ignore|nl_before_member\s*=\s*add|nl_before_member\s*=\s*remove|nl_before_member\s*=\s*force|nl_before_member\s*=\s*not_defined
+Choices=nl_before_member=ignore|nl_before_member=add|nl_before_member=remove|nl_before_member=force|nl_before_member=not_defined
+ChoicesRegex=nl_before_member\s*=\s*ignore|nl_before_member\s*=\s*add|nl_before_member\s*=\s*remove|nl_before_member\s*=\s*force|nl_before_member\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Before Member|Add Nl Before Member|Remove Nl Before Member|Force Nl Before Member"
 ValueDefault=ignore
 
@@ -5039,7 +5606,8 @@ Category=3
 Description="<html>(Java) Whether to put a blank line after a member '.' or '-&gt;' operators.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_member\s*=\s*ignore|nl_after_member\s*=\s*add|nl_after_member\s*=\s*remove|nl_after_member\s*=\s*force|nl_after_member\s*=\s*not_defined
+Choices=nl_after_member=ignore|nl_after_member=add|nl_after_member=remove|nl_after_member=force|nl_after_member=not_defined
+ChoicesRegex=nl_after_member\s*=\s*ignore|nl_after_member\s*=\s*add|nl_after_member\s*=\s*remove|nl_after_member\s*=\s*force|nl_after_member\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Member|Add Nl After Member|Remove Nl After Member|Force Nl After Member"
 ValueDefault=ignore
 
@@ -5048,7 +5616,8 @@ Category=3
 Description="<html>Whether to double-space commented-entries in 'struct'/'union'/'enum'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_ds_struct_enum_cmt\s*=\s*true|nl_ds_struct_enum_cmt\s*=\s*false
+TrueFalse=nl_ds_struct_enum_cmt=true|nl_ds_struct_enum_cmt=false
+TrueFalseRegex=nl_ds_struct_enum_cmt\s*=\s*true|nl_ds_struct_enum_cmt\s*=\s*false
 ValueDefault=false
 
 [Nl Ds Struct Enum Close Brace]
@@ -5056,7 +5625,8 @@ Category=3
 Description="<html>Whether to force a newline before '}' of a 'struct'/'union'/'enum'.<br/>(Lower priority than eat_blanks_before_close_brace.)</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_ds_struct_enum_close_brace\s*=\s*true|nl_ds_struct_enum_close_brace\s*=\s*false
+TrueFalse=nl_ds_struct_enum_close_brace=true|nl_ds_struct_enum_close_brace=false
+TrueFalseRegex=nl_ds_struct_enum_close_brace\s*=\s*true|nl_ds_struct_enum_close_brace\s*=\s*false
 ValueDefault=false
 
 [Nl Class Colon]
@@ -5064,7 +5634,8 @@ Category=3
 Description="<html>Add or remove newline before or after (depending on pos_class_colon) a class<br/>colon, as in 'class Foo &lt;here&gt; : &lt;or here&gt; public Bar'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_class_colon\s*=\s*ignore|nl_class_colon\s*=\s*add|nl_class_colon\s*=\s*remove|nl_class_colon\s*=\s*force|nl_class_colon\s*=\s*not_defined
+Choices=nl_class_colon=ignore|nl_class_colon=add|nl_class_colon=remove|nl_class_colon=force|nl_class_colon=not_defined
+ChoicesRegex=nl_class_colon\s*=\s*ignore|nl_class_colon\s*=\s*add|nl_class_colon\s*=\s*remove|nl_class_colon\s*=\s*force|nl_class_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Class Colon|Add Nl Class Colon|Remove Nl Class Colon|Force Nl Class Colon"
 ValueDefault=ignore
 
@@ -5073,7 +5644,8 @@ Category=3
 Description="<html>Add or remove newline around a class constructor colon. The exact position<br/>depends on nl_constr_init_args, pos_constr_colon and pos_constr_comma.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_constr_colon\s*=\s*ignore|nl_constr_colon\s*=\s*add|nl_constr_colon\s*=\s*remove|nl_constr_colon\s*=\s*force|nl_constr_colon\s*=\s*not_defined
+Choices=nl_constr_colon=ignore|nl_constr_colon=add|nl_constr_colon=remove|nl_constr_colon=force|nl_constr_colon=not_defined
+ChoicesRegex=nl_constr_colon\s*=\s*ignore|nl_constr_colon\s*=\s*add|nl_constr_colon\s*=\s*remove|nl_constr_colon\s*=\s*force|nl_constr_colon\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Constr Colon|Add Nl Constr Colon|Remove Nl Constr Colon|Force Nl Constr Colon"
 ValueDefault=ignore
 
@@ -5082,7 +5654,8 @@ Category=3
 Description="<html>Whether to collapse a two-line namespace, like 'namespace foo\n{ decl; }'<br/>into a single line. If true, prevents other brace newline rules from turning<br/>such code into four lines. If true, it also preserves one-liner namespaces.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_namespace_two_to_one_liner\s*=\s*true|nl_namespace_two_to_one_liner\s*=\s*false
+TrueFalse=nl_namespace_two_to_one_liner=true|nl_namespace_two_to_one_liner=false
+TrueFalseRegex=nl_namespace_two_to_one_liner\s*=\s*true|nl_namespace_two_to_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create If One Liner]
@@ -5090,7 +5663,8 @@ Category=3
 Description="<html>Whether to remove a newline in simple unbraced if statements, turning them<br/>into one-liners, as in 'if(b)\n i++;' =&gt; 'if(b) i++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_if_one_liner\s*=\s*true|nl_create_if_one_liner\s*=\s*false
+TrueFalse=nl_create_if_one_liner=true|nl_create_if_one_liner=false
+TrueFalseRegex=nl_create_if_one_liner\s*=\s*true|nl_create_if_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create For One Liner]
@@ -5098,7 +5672,8 @@ Category=3
 Description="<html>Whether to remove a newline in simple unbraced for statements, turning them<br/>into one-liners, as in 'for (...)\n stmt;' =&gt; 'for (...) stmt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_for_one_liner\s*=\s*true|nl_create_for_one_liner\s*=\s*false
+TrueFalse=nl_create_for_one_liner=true|nl_create_for_one_liner=false
+TrueFalseRegex=nl_create_for_one_liner\s*=\s*true|nl_create_for_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create While One Liner]
@@ -5106,7 +5681,8 @@ Category=3
 Description="<html>Whether to remove a newline in simple unbraced while statements, turning<br/>them into one-liners, as in 'while (expr)\n stmt;' =&gt; 'while (expr) stmt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_while_one_liner\s*=\s*true|nl_create_while_one_liner\s*=\s*false
+TrueFalse=nl_create_while_one_liner=true|nl_create_while_one_liner=false
+TrueFalseRegex=nl_create_while_one_liner\s*=\s*true|nl_create_while_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create Func Def One Liner]
@@ -5114,7 +5690,8 @@ Category=3
 Description="<html>Whether to collapse a function definition whose body (not counting braces)<br/>is only one line so that the entire definition (prototype, braces, body) is<br/>a single line.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_func_def_one_liner\s*=\s*true|nl_create_func_def_one_liner\s*=\s*false
+TrueFalse=nl_create_func_def_one_liner=true|nl_create_func_def_one_liner=false
+TrueFalseRegex=nl_create_func_def_one_liner\s*=\s*true|nl_create_func_def_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Create List One Liner]
@@ -5122,7 +5699,8 @@ Category=3
 Description="<html>Whether to split one-line simple list definitions into three lines by<br/>adding newlines, as in 'int a[12] = { &lt;here&gt; 0 &lt;here&gt; };'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_create_list_one_liner\s*=\s*true|nl_create_list_one_liner\s*=\s*false
+TrueFalse=nl_create_list_one_liner=true|nl_create_list_one_liner=false
+TrueFalseRegex=nl_create_list_one_liner\s*=\s*true|nl_create_list_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Split If One Liner]
@@ -5130,7 +5708,8 @@ Category=3
 Description="<html>Whether to split one-line simple unbraced if statements into two lines by<br/>adding a newline, as in 'if(b) &lt;here&gt; i++;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_split_if_one_liner\s*=\s*true|nl_split_if_one_liner\s*=\s*false
+TrueFalse=nl_split_if_one_liner=true|nl_split_if_one_liner=false
+TrueFalseRegex=nl_split_if_one_liner\s*=\s*true|nl_split_if_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Split For One Liner]
@@ -5138,7 +5717,8 @@ Category=3
 Description="<html>Whether to split one-line simple unbraced for statements into two lines by<br/>adding a newline, as in 'for (...) &lt;here&gt; stmt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_split_for_one_liner\s*=\s*true|nl_split_for_one_liner\s*=\s*false
+TrueFalse=nl_split_for_one_liner=true|nl_split_for_one_liner=false
+TrueFalseRegex=nl_split_for_one_liner\s*=\s*true|nl_split_for_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Split While One Liner]
@@ -5146,7 +5726,8 @@ Category=3
 Description="<html>Whether to split one-line simple unbraced while statements into two lines by<br/>adding a newline, as in 'while (expr) &lt;here&gt; stmt;'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_split_while_one_liner\s*=\s*true|nl_split_while_one_liner\s*=\s*false
+TrueFalse=nl_split_while_one_liner=true|nl_split_while_one_liner=false
+TrueFalseRegex=nl_split_while_one_liner\s*=\s*true|nl_split_while_one_liner\s*=\s*false
 ValueDefault=false
 
 [Donot Add Nl Before Cpp Comment]
@@ -5154,7 +5735,8 @@ Category=3
 Description="<html>Don't add a newline before a cpp-comment in a parameter list of a function<br/>call.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=donot_add_nl_before_cpp_comment\s*=\s*true|donot_add_nl_before_cpp_comment\s*=\s*false
+TrueFalse=donot_add_nl_before_cpp_comment=true|donot_add_nl_before_cpp_comment=false
+TrueFalseRegex=donot_add_nl_before_cpp_comment\s*=\s*true|donot_add_nl_before_cpp_comment\s*=\s*false
 ValueDefault=false
 
 [Nl Max]
@@ -5162,7 +5744,8 @@ Category=4
 Description="<html>The maximum number of consecutive newlines (3 = 2 blank lines).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_max\s*=\s*"
+CallName="nl_max="
+CallNameRegex="nl_max\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5172,7 +5755,8 @@ Category=4
 Description="<html>The maximum number of consecutive newlines in a function.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_max_blank_in_func\s*=\s*"
+CallName="nl_max_blank_in_func="
+CallNameRegex="nl_max_blank_in_func\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5182,7 +5766,8 @@ Category=4
 Description="<html>The number of newlines inside an empty function body.<br/>This option overrides eat_blanks_after_open_brace and<br/>eat_blanks_before_close_brace, but is ignored when<br/>nl_collapse_empty_body_functions=true</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_inside_empty_func\s*=\s*"
+CallName="nl_inside_empty_func="
+CallNameRegex="nl_inside_empty_func\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5192,7 +5777,8 @@ Category=4
 Description="<html>The number of newlines before a function prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_func_body_proto\s*=\s*"
+CallName="nl_before_func_body_proto="
+CallNameRegex="nl_before_func_body_proto\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5202,7 +5788,8 @@ Category=4
 Description="<html>The number of newlines before a multi-line function definition. Where<br/>applicable, this option is overridden with eat_blanks_after_open_brace=true</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_func_body_def\s*=\s*"
+CallName="nl_before_func_body_def="
+CallNameRegex="nl_before_func_body_def\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5212,7 +5799,8 @@ Category=4
 Description="<html>The number of newlines before a class constructor/destructor prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_func_class_proto\s*=\s*"
+CallName="nl_before_func_class_proto="
+CallNameRegex="nl_before_func_class_proto\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5222,7 +5810,8 @@ Category=4
 Description="<html>The number of newlines before a class constructor/destructor definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_func_class_def\s*=\s*"
+CallName="nl_before_func_class_def="
+CallNameRegex="nl_before_func_class_def\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5232,7 +5821,8 @@ Category=4
 Description="<html>The number of newlines after a function prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_proto\s*=\s*"
+CallName="nl_after_func_proto="
+CallNameRegex="nl_after_func_proto\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5242,7 +5832,8 @@ Category=4
 Description="<html>The number of newlines after a function prototype, if not followed by<br/>another function prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_proto_group\s*=\s*"
+CallName="nl_after_func_proto_group="
+CallNameRegex="nl_after_func_proto_group\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5252,7 +5843,8 @@ Category=4
 Description="<html>The number of newlines after a class constructor/destructor prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_class_proto\s*=\s*"
+CallName="nl_after_func_class_proto="
+CallNameRegex="nl_after_func_class_proto\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5262,7 +5854,8 @@ Category=4
 Description="<html>The number of newlines after a class constructor/destructor prototype,<br/>if not followed by another constructor/destructor prototype.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_class_proto_group\s*=\s*"
+CallName="nl_after_func_class_proto_group="
+CallNameRegex="nl_after_func_class_proto_group\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5272,7 +5865,8 @@ Category=4
 Description="<html>Whether one-line method definitions inside a class body should be treated<br/>as if they were prototypes for the purposes of adding newlines.<br/><br/>Requires nl_class_leave_one_liners=true. Overrides nl_before_func_body_def<br/>and nl_before_func_class_def for one-liners.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_class_leave_one_liner_groups\s*=\s*true|nl_class_leave_one_liner_groups\s*=\s*false
+TrueFalse=nl_class_leave_one_liner_groups=true|nl_class_leave_one_liner_groups=false
+TrueFalseRegex=nl_class_leave_one_liner_groups\s*=\s*true|nl_class_leave_one_liner_groups\s*=\s*false
 ValueDefault=false
 
 [Nl After Func Body]
@@ -5280,7 +5874,8 @@ Category=4
 Description="<html>The number of newlines after '}' of a multi-line function body.<br/><br/>Overrides nl_min_after_func_body and nl_max_after_func_body.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_body\s*=\s*"
+CallName="nl_after_func_body="
+CallNameRegex="nl_after_func_body\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5290,7 +5885,8 @@ Category=4
 Description="<html>The minimum number of newlines after '}' of a multi-line function body.<br/><br/>Only works when nl_after_func_body is 0.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_min_after_func_body\s*=\s*"
+CallName="nl_min_after_func_body="
+CallNameRegex="nl_min_after_func_body\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5300,7 +5896,8 @@ Category=4
 Description="<html>The maximum number of newlines after '}' of a multi-line function body.<br/><br/>Only works when nl_after_func_body is 0.<br/>Takes precedence over nl_min_after_func_body.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_max_after_func_body\s*=\s*"
+CallName="nl_max_after_func_body="
+CallNameRegex="nl_max_after_func_body\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5310,7 +5907,8 @@ Category=4
 Description="<html>The number of newlines after '}' of a multi-line function body in a class<br/>declaration. Also affects class constructors/destructors.<br/><br/>Overrides nl_after_func_body.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_body_class\s*=\s*"
+CallName="nl_after_func_body_class="
+CallNameRegex="nl_after_func_body_class\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5320,7 +5918,8 @@ Category=4
 Description="<html>The number of newlines after '}' of a single line function body. Also<br/>affects class constructors/destructors.<br/><br/>Overrides nl_after_func_body and nl_after_func_body_class.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_func_body_one_liner\s*=\s*"
+CallName="nl_after_func_body_one_liner="
+CallNameRegex="nl_after_func_body_one_liner\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5330,7 +5929,8 @@ Category=4
 Description="<html>The number of newlines before a block of typedefs. If nl_after_access_spec<br/>is non-zero, that option takes precedence.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_typedef_blk_start\s*=\s*"
+CallName="nl_typedef_blk_start="
+CallNameRegex="nl_typedef_blk_start\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5340,7 +5940,8 @@ Category=4
 Description="<html>The number of newlines after a block of typedefs.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_typedef_blk_end\s*=\s*"
+CallName="nl_typedef_blk_end="
+CallNameRegex="nl_typedef_blk_end\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5350,7 +5951,8 @@ Category=4
 Description="<html>The maximum number of consecutive newlines within a block of typedefs.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_typedef_blk_in\s*=\s*"
+CallName="nl_typedef_blk_in="
+CallNameRegex="nl_typedef_blk_in\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5360,7 +5962,8 @@ Category=4
 Description="<html>The minimum number of blank lines after a block of variable definitions<br/>at the top of a function body. If any preprocessor directives appear<br/>between the opening brace of the function and the variable block, then<br/>it is considered as not at the top of the function.Newlines are added<br/>before trailing preprocessor directives, if any exist.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_var_def_blk_end_func_top\s*=\s*"
+CallName="nl_var_def_blk_end_func_top="
+CallNameRegex="nl_var_def_blk_end_func_top\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5370,7 +5973,8 @@ Category=4
 Description="<html>The minimum number of empty newlines before a block of variable definitions<br/>not at the top of a function body. If nl_after_access_spec is non-zero,<br/>that option takes precedence. Newlines are not added at the top of the<br/>file or just after an opening brace. Newlines are added above any<br/>preprocessor directives before the block.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_var_def_blk_start\s*=\s*"
+CallName="nl_var_def_blk_start="
+CallNameRegex="nl_var_def_blk_start\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5380,7 +5984,8 @@ Category=4
 Description="<html>The minimum number of empty newlines after a block of variable definitions<br/>not at the top of a function body. Newlines are not added if the block<br/>is at the bottom of the file or just before a preprocessor directive.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_var_def_blk_end\s*=\s*"
+CallName="nl_var_def_blk_end="
+CallNameRegex="nl_var_def_blk_end\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5390,7 +5995,8 @@ Category=4
 Description="<html>The maximum number of consecutive newlines within a block of variable<br/>definitions.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_var_def_blk_in\s*=\s*"
+CallName="nl_var_def_blk_in="
+CallNameRegex="nl_var_def_blk_in\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5400,7 +6006,8 @@ Category=4
 Description="<html>The minimum number of newlines before a multi-line comment.<br/>Doesn't apply if after a brace open or another multi-line comment.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_block_comment\s*=\s*"
+CallName="nl_before_block_comment="
+CallNameRegex="nl_before_block_comment\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5410,7 +6017,8 @@ Category=4
 Description="<html>The minimum number of newlines before a single-line C comment.<br/>Doesn't apply if after a brace open or other single-line C comments.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_c_comment\s*=\s*"
+CallName="nl_before_c_comment="
+CallNameRegex="nl_before_c_comment\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5420,7 +6028,8 @@ Category=4
 Description="<html>The minimum number of newlines before a CPP comment.<br/>Doesn't apply if after a brace open or other CPP comments.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_cpp_comment\s*=\s*"
+CallName="nl_before_cpp_comment="
+CallNameRegex="nl_before_cpp_comment\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5430,7 +6039,8 @@ Category=4
 Description="<html>Whether to force a newline after a multi-line comment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_multiline_comment\s*=\s*true|nl_after_multiline_comment\s*=\s*false
+TrueFalse=nl_after_multiline_comment=true|nl_after_multiline_comment=false
+TrueFalseRegex=nl_after_multiline_comment\s*=\s*true|nl_after_multiline_comment\s*=\s*false
 ValueDefault=false
 
 [Nl After Label Colon]
@@ -5438,7 +6048,8 @@ Category=4
 Description="<html>Whether to force a newline after a label's colon.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=nl_after_label_colon\s*=\s*true|nl_after_label_colon\s*=\s*false
+TrueFalse=nl_after_label_colon=true|nl_after_label_colon=false
+TrueFalseRegex=nl_after_label_colon\s*=\s*true|nl_after_label_colon\s*=\s*false
 ValueDefault=false
 
 [Nl Before Struct]
@@ -5446,7 +6057,8 @@ Category=4
 Description="<html>The number of newlines before a struct definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_struct\s*=\s*"
+CallName="nl_before_struct="
+CallNameRegex="nl_before_struct\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5456,7 +6068,8 @@ Category=4
 Description="<html>The number of newlines after '}' or ';' of a struct/enum/union definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_struct\s*=\s*"
+CallName="nl_after_struct="
+CallNameRegex="nl_after_struct\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5466,7 +6079,8 @@ Category=4
 Description="<html>The number of newlines before a class definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_class\s*=\s*"
+CallName="nl_before_class="
+CallNameRegex="nl_before_class\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5476,7 +6090,8 @@ Category=4
 Description="<html>The number of newlines after '}' or ';' of a class definition.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_class\s*=\s*"
+CallName="nl_after_class="
+CallNameRegex="nl_after_class\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5486,7 +6101,8 @@ Category=4
 Description="<html>The number of newlines before a namespace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_namespace\s*=\s*"
+CallName="nl_before_namespace="
+CallNameRegex="nl_before_namespace\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5496,7 +6112,8 @@ Category=4
 Description="<html>The number of newlines after '{' of a namespace. This also adds newlines<br/>before the matching '}'.<br/><br/>0: Apply eat_blanks_after_open_brace or eat_blanks_before_close_brace if<br/>    applicable, otherwise no change.<br/><br/>Overrides eat_blanks_after_open_brace and eat_blanks_before_close_brace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_inside_namespace\s*=\s*"
+CallName="nl_inside_namespace="
+CallNameRegex="nl_inside_namespace\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5506,7 +6123,8 @@ Category=4
 Description="<html>The number of newlines after '}' of a namespace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_namespace\s*=\s*"
+CallName="nl_after_namespace="
+CallNameRegex="nl_after_namespace\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5516,7 +6134,8 @@ Category=4
 Description="<html>The number of newlines before an access specifier label. This also includes<br/>the Qt-specific 'signals:' and 'slots:'. Will not change the newline count<br/>if after a brace open.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_access_spec\s*=\s*"
+CallName="nl_before_access_spec="
+CallNameRegex="nl_before_access_spec\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5526,7 +6145,8 @@ Category=4
 Description="<html>The number of newlines after an access specifier label. This also includes<br/>the Qt-specific 'signals:' and 'slots:'. Will not change the newline count<br/>if after a brace open.<br/><br/>0: No change (default).<br/><br/>Overrides nl_typedef_blk_start and nl_var_def_blk_start.</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_access_spec\s*=\s*"
+CallName="nl_after_access_spec="
+CallNameRegex="nl_after_access_spec\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5536,7 +6156,8 @@ Category=4
 Description="<html>The number of newlines between a function definition and the function<br/>comment, as in '// comment\n &lt;here&gt; void foo() {...}'.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_comment_func_def\s*=\s*"
+CallName="nl_comment_func_def="
+CallNameRegex="nl_comment_func_def\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5546,7 +6167,8 @@ Category=4
 Description="<html>The number of newlines after a try-catch-finally block that isn't followed<br/>by a brace close.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_try_catch_finally\s*=\s*"
+CallName="nl_after_try_catch_finally="
+CallNameRegex="nl_after_try_catch_finally\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5556,7 +6178,8 @@ Category=4
 Description="<html>(C#) The number of newlines before and after a property, indexer or event<br/>declaration.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_around_cs_property\s*=\s*"
+CallName="nl_around_cs_property="
+CallNameRegex="nl_around_cs_property\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5566,7 +6189,8 @@ Category=4
 Description="<html>(C#) The number of newlines between the get/set/add/remove handlers.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_between_get_set\s*=\s*"
+CallName="nl_between_get_set="
+CallNameRegex="nl_between_get_set\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5576,7 +6200,8 @@ Category=4
 Description="<html>(C#) Add or remove newline between property and the '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_property_brace\s*=\s*ignore|nl_property_brace\s*=\s*add|nl_property_brace\s*=\s*remove|nl_property_brace\s*=\s*force|nl_property_brace\s*=\s*not_defined
+Choices=nl_property_brace=ignore|nl_property_brace=add|nl_property_brace=remove|nl_property_brace=force|nl_property_brace=not_defined
+ChoicesRegex=nl_property_brace\s*=\s*ignore|nl_property_brace\s*=\s*add|nl_property_brace\s*=\s*remove|nl_property_brace\s*=\s*force|nl_property_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Property Brace|Add Nl Property Brace|Remove Nl Property Brace|Force Nl Property Brace"
 ValueDefault=ignore
 
@@ -5585,7 +6210,8 @@ Category=4
 Description="<html>Whether to remove blank lines after '{'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=eat_blanks_after_open_brace\s*=\s*true|eat_blanks_after_open_brace\s*=\s*false
+TrueFalse=eat_blanks_after_open_brace=true|eat_blanks_after_open_brace=false
+TrueFalseRegex=eat_blanks_after_open_brace\s*=\s*true|eat_blanks_after_open_brace\s*=\s*false
 ValueDefault=false
 
 [Eat Blanks Before Close Brace]
@@ -5593,7 +6219,8 @@ Category=4
 Description="<html>Whether to remove blank lines before '}'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=eat_blanks_before_close_brace\s*=\s*true|eat_blanks_before_close_brace\s*=\s*false
+TrueFalse=eat_blanks_before_close_brace=true|eat_blanks_before_close_brace=false
+TrueFalseRegex=eat_blanks_before_close_brace\s*=\s*true|eat_blanks_before_close_brace\s*=\s*false
 ValueDefault=false
 
 [Nl Remove Extra Newlines]
@@ -5601,7 +6228,8 @@ Category=4
 Description="<html>How aggressively to remove extra newlines not in preprocessor.<br/><br/>0: No change (default)<br/>1: Remove most newlines not handled by other config<br/>2: Remove all newlines and reformat completely by config</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_remove_extra_newlines\s*=\s*"
+CallName="nl_remove_extra_newlines="
+CallNameRegex="nl_remove_extra_newlines\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -5611,7 +6239,8 @@ Category=4
 Description="<html>(Java) Add or remove newline after an annotation statement. Only affects<br/>annotations that are after a newline.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_after_annotation\s*=\s*ignore|nl_after_annotation\s*=\s*add|nl_after_annotation\s*=\s*remove|nl_after_annotation\s*=\s*force|nl_after_annotation\s*=\s*not_defined
+Choices=nl_after_annotation=ignore|nl_after_annotation=add|nl_after_annotation=remove|nl_after_annotation=force|nl_after_annotation=not_defined
+ChoicesRegex=nl_after_annotation\s*=\s*ignore|nl_after_annotation\s*=\s*add|nl_after_annotation\s*=\s*remove|nl_after_annotation\s*=\s*force|nl_after_annotation\s*=\s*not_defined
 ChoicesReadable="Ignore Nl After Annotation|Add Nl After Annotation|Remove Nl After Annotation|Force Nl After Annotation"
 ValueDefault=ignore
 
@@ -5620,7 +6249,8 @@ Category=4
 Description="<html>(Java) Add or remove newline between two annotations.</html>"
 Enabled=false
 EditorType=multiple
-Choices=nl_between_annotation\s*=\s*ignore|nl_between_annotation\s*=\s*add|nl_between_annotation\s*=\s*remove|nl_between_annotation\s*=\s*force|nl_between_annotation\s*=\s*not_defined
+Choices=nl_between_annotation=ignore|nl_between_annotation=add|nl_between_annotation=remove|nl_between_annotation=force|nl_between_annotation=not_defined
+ChoicesRegex=nl_between_annotation\s*=\s*ignore|nl_between_annotation\s*=\s*add|nl_between_annotation\s*=\s*remove|nl_between_annotation\s*=\s*force|nl_between_annotation\s*=\s*not_defined
 ChoicesReadable="Ignore Nl Between Annotation|Add Nl Between Annotation|Remove Nl Between Annotation|Force Nl Between Annotation"
 ValueDefault=ignore
 
@@ -5629,7 +6259,8 @@ Category=4
 Description="<html>The number of newlines before a whole-file #ifdef.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_whole_file_ifdef\s*=\s*"
+CallName="nl_before_whole_file_ifdef="
+CallNameRegex="nl_before_whole_file_ifdef\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5639,7 +6270,8 @@ Category=4
 Description="<html>The number of newlines after a whole-file #ifdef.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_whole_file_ifdef\s*=\s*"
+CallName="nl_after_whole_file_ifdef="
+CallNameRegex="nl_after_whole_file_ifdef\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5649,7 +6281,8 @@ Category=4
 Description="<html>The number of newlines before a whole-file #endif.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_before_whole_file_endif\s*=\s*"
+CallName="nl_before_whole_file_endif="
+CallNameRegex="nl_before_whole_file_endif\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5659,7 +6292,8 @@ Category=4
 Description="<html>The number of newlines after a whole-file #endif.<br/><br/>0: No change (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="nl_after_whole_file_endif\s*=\s*"
+CallName="nl_after_whole_file_endif="
+CallNameRegex="nl_after_whole_file_endif\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5669,7 +6303,8 @@ Category=5
 Description="<html>The position of arithmetic operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_arith\s*=\s*ignore|pos_arith\s*=\s*break|pos_arith\s*=\s*force|pos_arith\s*=\s*lead|pos_arith\s*=\s*trail|pos_arith\s*=\s*join|pos_arith\s*=\s*lead_break|pos_arith\s*=\s*lead_force|pos_arith\s*=\s*trail_break|pos_arith\s*=\s*trail_force
+Choices=pos_arith=ignore|pos_arith=break|pos_arith=force|pos_arith=lead|pos_arith=trail|pos_arith=join|pos_arith=lead_break|pos_arith=lead_force|pos_arith=trail_break|pos_arith=trail_force
+ChoicesRegex=pos_arith\s*=\s*ignore|pos_arith\s*=\s*break|pos_arith\s*=\s*force|pos_arith\s*=\s*lead|pos_arith\s*=\s*trail|pos_arith\s*=\s*join|pos_arith\s*=\s*lead_break|pos_arith\s*=\s*lead_force|pos_arith\s*=\s*trail_break|pos_arith\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Arith|Break Pos Arith|Force Pos Arith|Lead Pos Arith|Trail Pos Arith|Join Pos Arith|Lead Break Pos Arith|Lead Force Pos Arith|Trail Break Pos Arith|Trail Force Pos Arith"
 ValueDefault=ignore
 
@@ -5678,7 +6313,8 @@ Category=5
 Description="<html>The position of assignment in wrapped expressions. Do not affect '='<br/>followed by '{'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_assign\s*=\s*ignore|pos_assign\s*=\s*break|pos_assign\s*=\s*force|pos_assign\s*=\s*lead|pos_assign\s*=\s*trail|pos_assign\s*=\s*join|pos_assign\s*=\s*lead_break|pos_assign\s*=\s*lead_force|pos_assign\s*=\s*trail_break|pos_assign\s*=\s*trail_force
+Choices=pos_assign=ignore|pos_assign=break|pos_assign=force|pos_assign=lead|pos_assign=trail|pos_assign=join|pos_assign=lead_break|pos_assign=lead_force|pos_assign=trail_break|pos_assign=trail_force
+ChoicesRegex=pos_assign\s*=\s*ignore|pos_assign\s*=\s*break|pos_assign\s*=\s*force|pos_assign\s*=\s*lead|pos_assign\s*=\s*trail|pos_assign\s*=\s*join|pos_assign\s*=\s*lead_break|pos_assign\s*=\s*lead_force|pos_assign\s*=\s*trail_break|pos_assign\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Assign|Break Pos Assign|Force Pos Assign|Lead Pos Assign|Trail Pos Assign|Join Pos Assign|Lead Break Pos Assign|Lead Force Pos Assign|Trail Break Pos Assign|Trail Force Pos Assign"
 ValueDefault=ignore
 
@@ -5687,7 +6323,8 @@ Category=5
 Description="<html>The position of Boolean operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_bool\s*=\s*ignore|pos_bool\s*=\s*break|pos_bool\s*=\s*force|pos_bool\s*=\s*lead|pos_bool\s*=\s*trail|pos_bool\s*=\s*join|pos_bool\s*=\s*lead_break|pos_bool\s*=\s*lead_force|pos_bool\s*=\s*trail_break|pos_bool\s*=\s*trail_force
+Choices=pos_bool=ignore|pos_bool=break|pos_bool=force|pos_bool=lead|pos_bool=trail|pos_bool=join|pos_bool=lead_break|pos_bool=lead_force|pos_bool=trail_break|pos_bool=trail_force
+ChoicesRegex=pos_bool\s*=\s*ignore|pos_bool\s*=\s*break|pos_bool\s*=\s*force|pos_bool\s*=\s*lead|pos_bool\s*=\s*trail|pos_bool\s*=\s*join|pos_bool\s*=\s*lead_break|pos_bool\s*=\s*lead_force|pos_bool\s*=\s*trail_break|pos_bool\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Bool|Break Pos Bool|Force Pos Bool|Lead Pos Bool|Trail Pos Bool|Join Pos Bool|Lead Break Pos Bool|Lead Force Pos Bool|Trail Break Pos Bool|Trail Force Pos Bool"
 ValueDefault=ignore
 
@@ -5696,7 +6333,8 @@ Category=5
 Description="<html>The position of comparison operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_compare\s*=\s*ignore|pos_compare\s*=\s*break|pos_compare\s*=\s*force|pos_compare\s*=\s*lead|pos_compare\s*=\s*trail|pos_compare\s*=\s*join|pos_compare\s*=\s*lead_break|pos_compare\s*=\s*lead_force|pos_compare\s*=\s*trail_break|pos_compare\s*=\s*trail_force
+Choices=pos_compare=ignore|pos_compare=break|pos_compare=force|pos_compare=lead|pos_compare=trail|pos_compare=join|pos_compare=lead_break|pos_compare=lead_force|pos_compare=trail_break|pos_compare=trail_force
+ChoicesRegex=pos_compare\s*=\s*ignore|pos_compare\s*=\s*break|pos_compare\s*=\s*force|pos_compare\s*=\s*lead|pos_compare\s*=\s*trail|pos_compare\s*=\s*join|pos_compare\s*=\s*lead_break|pos_compare\s*=\s*lead_force|pos_compare\s*=\s*trail_break|pos_compare\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Compare|Break Pos Compare|Force Pos Compare|Lead Pos Compare|Trail Pos Compare|Join Pos Compare|Lead Break Pos Compare|Lead Force Pos Compare|Trail Break Pos Compare|Trail Force Pos Compare"
 ValueDefault=ignore
 
@@ -5705,7 +6343,8 @@ Category=5
 Description="<html>The position of conditional operators, as in the '?' and ':' of<br/>'expr ? stmt : stmt', in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_conditional\s*=\s*ignore|pos_conditional\s*=\s*break|pos_conditional\s*=\s*force|pos_conditional\s*=\s*lead|pos_conditional\s*=\s*trail|pos_conditional\s*=\s*join|pos_conditional\s*=\s*lead_break|pos_conditional\s*=\s*lead_force|pos_conditional\s*=\s*trail_break|pos_conditional\s*=\s*trail_force
+Choices=pos_conditional=ignore|pos_conditional=break|pos_conditional=force|pos_conditional=lead|pos_conditional=trail|pos_conditional=join|pos_conditional=lead_break|pos_conditional=lead_force|pos_conditional=trail_break|pos_conditional=trail_force
+ChoicesRegex=pos_conditional\s*=\s*ignore|pos_conditional\s*=\s*break|pos_conditional\s*=\s*force|pos_conditional\s*=\s*lead|pos_conditional\s*=\s*trail|pos_conditional\s*=\s*join|pos_conditional\s*=\s*lead_break|pos_conditional\s*=\s*lead_force|pos_conditional\s*=\s*trail_break|pos_conditional\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Conditional|Break Pos Conditional|Force Pos Conditional|Lead Pos Conditional|Trail Pos Conditional|Join Pos Conditional|Lead Break Pos Conditional|Lead Force Pos Conditional|Trail Break Pos Conditional|Trail Force Pos Conditional"
 ValueDefault=ignore
 
@@ -5714,7 +6353,8 @@ Category=5
 Description="<html>The position of the comma in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_comma\s*=\s*ignore|pos_comma\s*=\s*break|pos_comma\s*=\s*force|pos_comma\s*=\s*lead|pos_comma\s*=\s*trail|pos_comma\s*=\s*join|pos_comma\s*=\s*lead_break|pos_comma\s*=\s*lead_force|pos_comma\s*=\s*trail_break|pos_comma\s*=\s*trail_force
+Choices=pos_comma=ignore|pos_comma=break|pos_comma=force|pos_comma=lead|pos_comma=trail|pos_comma=join|pos_comma=lead_break|pos_comma=lead_force|pos_comma=trail_break|pos_comma=trail_force
+ChoicesRegex=pos_comma\s*=\s*ignore|pos_comma\s*=\s*break|pos_comma\s*=\s*force|pos_comma\s*=\s*lead|pos_comma\s*=\s*trail|pos_comma\s*=\s*join|pos_comma\s*=\s*lead_break|pos_comma\s*=\s*lead_force|pos_comma\s*=\s*trail_break|pos_comma\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Comma|Break Pos Comma|Force Pos Comma|Lead Pos Comma|Trail Pos Comma|Join Pos Comma|Lead Break Pos Comma|Lead Force Pos Comma|Trail Break Pos Comma|Trail Force Pos Comma"
 ValueDefault=ignore
 
@@ -5723,7 +6363,8 @@ Category=5
 Description="<html>The position of the comma in enum entries.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_enum_comma\s*=\s*ignore|pos_enum_comma\s*=\s*break|pos_enum_comma\s*=\s*force|pos_enum_comma\s*=\s*lead|pos_enum_comma\s*=\s*trail|pos_enum_comma\s*=\s*join|pos_enum_comma\s*=\s*lead_break|pos_enum_comma\s*=\s*lead_force|pos_enum_comma\s*=\s*trail_break|pos_enum_comma\s*=\s*trail_force
+Choices=pos_enum_comma=ignore|pos_enum_comma=break|pos_enum_comma=force|pos_enum_comma=lead|pos_enum_comma=trail|pos_enum_comma=join|pos_enum_comma=lead_break|pos_enum_comma=lead_force|pos_enum_comma=trail_break|pos_enum_comma=trail_force
+ChoicesRegex=pos_enum_comma\s*=\s*ignore|pos_enum_comma\s*=\s*break|pos_enum_comma\s*=\s*force|pos_enum_comma\s*=\s*lead|pos_enum_comma\s*=\s*trail|pos_enum_comma\s*=\s*join|pos_enum_comma\s*=\s*lead_break|pos_enum_comma\s*=\s*lead_force|pos_enum_comma\s*=\s*trail_break|pos_enum_comma\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Enum Comma|Break Pos Enum Comma|Force Pos Enum Comma|Lead Pos Enum Comma|Trail Pos Enum Comma|Join Pos Enum Comma|Lead Break Pos Enum Comma|Lead Force Pos Enum Comma|Trail Break Pos Enum Comma|Trail Force Pos Enum Comma"
 ValueDefault=ignore
 
@@ -5732,7 +6373,8 @@ Category=5
 Description="<html>The position of the comma in the base class list if there is more than one<br/>line. Affects nl_class_init_args.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_class_comma\s*=\s*ignore|pos_class_comma\s*=\s*break|pos_class_comma\s*=\s*force|pos_class_comma\s*=\s*lead|pos_class_comma\s*=\s*trail|pos_class_comma\s*=\s*join|pos_class_comma\s*=\s*lead_break|pos_class_comma\s*=\s*lead_force|pos_class_comma\s*=\s*trail_break|pos_class_comma\s*=\s*trail_force
+Choices=pos_class_comma=ignore|pos_class_comma=break|pos_class_comma=force|pos_class_comma=lead|pos_class_comma=trail|pos_class_comma=join|pos_class_comma=lead_break|pos_class_comma=lead_force|pos_class_comma=trail_break|pos_class_comma=trail_force
+ChoicesRegex=pos_class_comma\s*=\s*ignore|pos_class_comma\s*=\s*break|pos_class_comma\s*=\s*force|pos_class_comma\s*=\s*lead|pos_class_comma\s*=\s*trail|pos_class_comma\s*=\s*join|pos_class_comma\s*=\s*lead_break|pos_class_comma\s*=\s*lead_force|pos_class_comma\s*=\s*trail_break|pos_class_comma\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Class Comma|Break Pos Class Comma|Force Pos Class Comma|Lead Pos Class Comma|Trail Pos Class Comma|Join Pos Class Comma|Lead Break Pos Class Comma|Lead Force Pos Class Comma|Trail Break Pos Class Comma|Trail Force Pos Class Comma"
 ValueDefault=ignore
 
@@ -5741,7 +6383,8 @@ Category=5
 Description="<html>The position of the comma in the constructor initialization list.<br/>Related to nl_constr_colon, nl_constr_init_args and pos_constr_colon.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_constr_comma\s*=\s*ignore|pos_constr_comma\s*=\s*break|pos_constr_comma\s*=\s*force|pos_constr_comma\s*=\s*lead|pos_constr_comma\s*=\s*trail|pos_constr_comma\s*=\s*join|pos_constr_comma\s*=\s*lead_break|pos_constr_comma\s*=\s*lead_force|pos_constr_comma\s*=\s*trail_break|pos_constr_comma\s*=\s*trail_force
+Choices=pos_constr_comma=ignore|pos_constr_comma=break|pos_constr_comma=force|pos_constr_comma=lead|pos_constr_comma=trail|pos_constr_comma=join|pos_constr_comma=lead_break|pos_constr_comma=lead_force|pos_constr_comma=trail_break|pos_constr_comma=trail_force
+ChoicesRegex=pos_constr_comma\s*=\s*ignore|pos_constr_comma\s*=\s*break|pos_constr_comma\s*=\s*force|pos_constr_comma\s*=\s*lead|pos_constr_comma\s*=\s*trail|pos_constr_comma\s*=\s*join|pos_constr_comma\s*=\s*lead_break|pos_constr_comma\s*=\s*lead_force|pos_constr_comma\s*=\s*trail_break|pos_constr_comma\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Constr Comma|Break Pos Constr Comma|Force Pos Constr Comma|Lead Pos Constr Comma|Trail Pos Constr Comma|Join Pos Constr Comma|Lead Break Pos Constr Comma|Lead Force Pos Constr Comma|Trail Break Pos Constr Comma|Trail Force Pos Constr Comma"
 ValueDefault=ignore
 
@@ -5750,7 +6393,8 @@ Category=5
 Description="<html>The position of trailing/leading class colon, between class and base class<br/>list. Affects nl_class_colon.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_class_colon\s*=\s*ignore|pos_class_colon\s*=\s*break|pos_class_colon\s*=\s*force|pos_class_colon\s*=\s*lead|pos_class_colon\s*=\s*trail|pos_class_colon\s*=\s*join|pos_class_colon\s*=\s*lead_break|pos_class_colon\s*=\s*lead_force|pos_class_colon\s*=\s*trail_break|pos_class_colon\s*=\s*trail_force
+Choices=pos_class_colon=ignore|pos_class_colon=break|pos_class_colon=force|pos_class_colon=lead|pos_class_colon=trail|pos_class_colon=join|pos_class_colon=lead_break|pos_class_colon=lead_force|pos_class_colon=trail_break|pos_class_colon=trail_force
+ChoicesRegex=pos_class_colon\s*=\s*ignore|pos_class_colon\s*=\s*break|pos_class_colon\s*=\s*force|pos_class_colon\s*=\s*lead|pos_class_colon\s*=\s*trail|pos_class_colon\s*=\s*join|pos_class_colon\s*=\s*lead_break|pos_class_colon\s*=\s*lead_force|pos_class_colon\s*=\s*trail_break|pos_class_colon\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Class Colon|Break Pos Class Colon|Force Pos Class Colon|Lead Pos Class Colon|Trail Pos Class Colon|Join Pos Class Colon|Lead Break Pos Class Colon|Lead Force Pos Class Colon|Trail Break Pos Class Colon|Trail Force Pos Class Colon"
 ValueDefault=ignore
 
@@ -5759,7 +6403,8 @@ Category=5
 Description="<html>The position of colons between constructor and member initialization.<br/>Related to nl_constr_colon, nl_constr_init_args and pos_constr_comma.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_constr_colon\s*=\s*ignore|pos_constr_colon\s*=\s*break|pos_constr_colon\s*=\s*force|pos_constr_colon\s*=\s*lead|pos_constr_colon\s*=\s*trail|pos_constr_colon\s*=\s*join|pos_constr_colon\s*=\s*lead_break|pos_constr_colon\s*=\s*lead_force|pos_constr_colon\s*=\s*trail_break|pos_constr_colon\s*=\s*trail_force
+Choices=pos_constr_colon=ignore|pos_constr_colon=break|pos_constr_colon=force|pos_constr_colon=lead|pos_constr_colon=trail|pos_constr_colon=join|pos_constr_colon=lead_break|pos_constr_colon=lead_force|pos_constr_colon=trail_break|pos_constr_colon=trail_force
+ChoicesRegex=pos_constr_colon\s*=\s*ignore|pos_constr_colon\s*=\s*break|pos_constr_colon\s*=\s*force|pos_constr_colon\s*=\s*lead|pos_constr_colon\s*=\s*trail|pos_constr_colon\s*=\s*join|pos_constr_colon\s*=\s*lead_break|pos_constr_colon\s*=\s*lead_force|pos_constr_colon\s*=\s*trail_break|pos_constr_colon\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Constr Colon|Break Pos Constr Colon|Force Pos Constr Colon|Lead Pos Constr Colon|Trail Pos Constr Colon|Join Pos Constr Colon|Lead Break Pos Constr Colon|Lead Force Pos Constr Colon|Trail Break Pos Constr Colon|Trail Force Pos Constr Colon"
 ValueDefault=ignore
 
@@ -5768,7 +6413,8 @@ Category=5
 Description="<html>The position of shift operators in wrapped expressions.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pos_shift\s*=\s*ignore|pos_shift\s*=\s*break|pos_shift\s*=\s*force|pos_shift\s*=\s*lead|pos_shift\s*=\s*trail|pos_shift\s*=\s*join|pos_shift\s*=\s*lead_break|pos_shift\s*=\s*lead_force|pos_shift\s*=\s*trail_break|pos_shift\s*=\s*trail_force
+Choices=pos_shift=ignore|pos_shift=break|pos_shift=force|pos_shift=lead|pos_shift=trail|pos_shift=join|pos_shift=lead_break|pos_shift=lead_force|pos_shift=trail_break|pos_shift=trail_force
+ChoicesRegex=pos_shift\s*=\s*ignore|pos_shift\s*=\s*break|pos_shift\s*=\s*force|pos_shift\s*=\s*lead|pos_shift\s*=\s*trail|pos_shift\s*=\s*join|pos_shift\s*=\s*lead_break|pos_shift\s*=\s*lead_force|pos_shift\s*=\s*trail_break|pos_shift\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Shift|Break Pos Shift|Force Pos Shift|Lead Pos Shift|Trail Pos Shift|Join Pos Shift|Lead Break Pos Shift|Lead Force Pos Shift|Trail Break Pos Shift|Trail Force Pos Shift"
 ValueDefault=ignore
 
@@ -5777,7 +6423,8 @@ Category=6
 Description="<html>Try to limit code width to N columns.</html>"
 Enabled=false
 EditorType=numeric
-CallName="code_width\s*=\s*"
+CallName="code_width="
+CallNameRegex="code_width\s*=\s*"
 MinVal=0
 MaxVal=10000
 ValueDefault=0
@@ -5787,7 +6434,8 @@ Category=6
 Description="<html>Whether to fully split long 'for' statements at semi-colons.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=ls_for_split_full\s*=\s*true|ls_for_split_full\s*=\s*false
+TrueFalse=ls_for_split_full=true|ls_for_split_full=false
+TrueFalseRegex=ls_for_split_full\s*=\s*true|ls_for_split_full\s*=\s*false
 ValueDefault=false
 
 [Ls Func Split Full]
@@ -5795,7 +6443,8 @@ Category=6
 Description="<html>Whether to fully split long function prototypes/calls at commas.<br/>The option ls_code_width has priority over the option ls_func_split_full.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=ls_func_split_full\s*=\s*true|ls_func_split_full\s*=\s*false
+TrueFalse=ls_func_split_full=true|ls_func_split_full=false
+TrueFalseRegex=ls_func_split_full\s*=\s*true|ls_func_split_full\s*=\s*false
 ValueDefault=false
 
 [Ls Code Width]
@@ -5803,7 +6452,8 @@ Category=6
 Description="<html>Whether to split lines as close to code_width as possible and ignore some<br/>groupings.<br/>The option ls_code_width has priority over the option ls_func_split_full.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=ls_code_width\s*=\s*true|ls_code_width\s*=\s*false
+TrueFalse=ls_code_width=true|ls_code_width=false
+TrueFalseRegex=ls_code_width\s*=\s*true|ls_code_width\s*=\s*false
 ValueDefault=false
 
 [Align Keep Tabs]
@@ -5811,7 +6461,8 @@ Category=7
 Description="<html>Whether to keep non-indenting tabs.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_keep_tabs\s*=\s*true|align_keep_tabs\s*=\s*false
+TrueFalse=align_keep_tabs=true|align_keep_tabs=false
+TrueFalseRegex=align_keep_tabs\s*=\s*true|align_keep_tabs\s*=\s*false
 ValueDefault=false
 
 [Align With Tabs]
@@ -5819,7 +6470,8 @@ Category=7
 Description="<html>Whether to use tabs for aligning.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_with_tabs\s*=\s*true|align_with_tabs\s*=\s*false
+TrueFalse=align_with_tabs=true|align_with_tabs=false
+TrueFalseRegex=align_with_tabs\s*=\s*true|align_with_tabs\s*=\s*false
 ValueDefault=false
 
 [Align On Tabstop]
@@ -5827,7 +6479,8 @@ Category=7
 Description="<html>Whether to bump out to the next tab when aligning.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_on_tabstop\s*=\s*true|align_on_tabstop\s*=\s*false
+TrueFalse=align_on_tabstop=true|align_on_tabstop=false
+TrueFalseRegex=align_on_tabstop\s*=\s*true|align_on_tabstop\s*=\s*false
 ValueDefault=false
 
 [Align Number Right]
@@ -5835,7 +6488,8 @@ Category=7
 Description="<html>Whether to right-align numbers.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_number_right\s*=\s*true|align_number_right\s*=\s*false
+TrueFalse=align_number_right=true|align_number_right=false
+TrueFalseRegex=align_number_right\s*=\s*true|align_number_right\s*=\s*false
 ValueDefault=false
 
 [Align Keep Extra Space]
@@ -5843,7 +6497,8 @@ Category=7
 Description="<html>Whether to keep whitespace not required for alignment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_keep_extra_space\s*=\s*true|align_keep_extra_space\s*=\s*false
+TrueFalse=align_keep_extra_space=true|align_keep_extra_space=false
+TrueFalseRegex=align_keep_extra_space\s*=\s*true|align_keep_extra_space\s*=\s*false
 ValueDefault=false
 
 [Align Func Params]
@@ -5851,7 +6506,8 @@ Category=7
 Description="<html>Whether to align variable definitions in prototypes and functions.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_func_params\s*=\s*true|align_func_params\s*=\s*false
+TrueFalse=align_func_params=true|align_func_params=false
+TrueFalseRegex=align_func_params\s*=\s*true|align_func_params\s*=\s*false
 ValueDefault=false
 
 [Align Func Params Span]
@@ -5859,7 +6515,8 @@ Category=7
 Description="<html>The span for aligning parameter definitions in function on parameter name.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_params_span\s*=\s*"
+CallName="align_func_params_span="
+CallNameRegex="align_func_params_span\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5869,7 +6526,8 @@ Category=7
 Description="<html>The threshold for aligning function parameter definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_params_thresh\s*=\s*"
+CallName="align_func_params_thresh="
+CallNameRegex="align_func_params_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -5879,7 +6537,8 @@ Category=7
 Description="<html>The gap for aligning function parameter definitions.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_params_gap\s*=\s*"
+CallName="align_func_params_gap="
+CallNameRegex="align_func_params_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5889,7 +6548,8 @@ Category=7
 Description="<html>The span for aligning constructor value.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_constr_value_span\s*=\s*"
+CallName="align_constr_value_span="
+CallNameRegex="align_constr_value_span\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5899,7 +6559,8 @@ Category=7
 Description="<html>The threshold for aligning constructor value.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_constr_value_thresh\s*=\s*"
+CallName="align_constr_value_thresh="
+CallNameRegex="align_constr_value_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -5909,7 +6570,8 @@ Category=7
 Description="<html>The gap for aligning constructor value.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_constr_value_gap\s*=\s*"
+CallName="align_constr_value_gap="
+CallNameRegex="align_constr_value_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5919,7 +6581,8 @@ Category=7
 Description="<html>Whether to align parameters in single-line functions that have the same<br/>name. The function names must already be aligned with each other.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_same_func_call_params\s*=\s*true|align_same_func_call_params\s*=\s*false
+TrueFalse=align_same_func_call_params=true|align_same_func_call_params=false
+TrueFalseRegex=align_same_func_call_params\s*=\s*true|align_same_func_call_params\s*=\s*false
 ValueDefault=false
 
 [Align Same Func Call Params Span]
@@ -5927,7 +6590,8 @@ Category=7
 Description="<html>The span for aligning function-call parameters for single line functions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_same_func_call_params_span\s*=\s*"
+CallName="align_same_func_call_params_span="
+CallNameRegex="align_same_func_call_params_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -5937,7 +6601,8 @@ Category=7
 Description="<html>The threshold for aligning function-call parameters for single line<br/>functions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_same_func_call_params_thresh\s*=\s*"
+CallName="align_same_func_call_params_thresh="
+CallNameRegex="align_same_func_call_params_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -5947,7 +6612,8 @@ Category=7
 Description="<html>The span for aligning variable definitions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_span\s*=\s*"
+CallName="align_var_def_span="
+CallNameRegex="align_var_def_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -5957,7 +6623,8 @@ Category=7
 Description="<html>How to consider (or treat) the '*' in the alignment of variable definitions.<br/><br/>0: Part of the type     'void *   foo;' (default)<br/>1: Part of the variable 'void     *foo;'<br/>2: Dangling             'void    *foo;'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_star_style\s*=\s*"
+CallName="align_var_def_star_style="
+CallNameRegex="align_var_def_star_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -5967,7 +6634,8 @@ Category=7
 Description="<html>How to consider (or treat) the '&amp;' in the alignment of variable definitions.<br/><br/>0: Part of the type     'long &amp;   foo;' (default)<br/>1: Part of the variable 'long     &amp;foo;'<br/>2: Dangling             'long    &amp;foo;'<br/>Dangling: the '&amp;' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_amp_style\s*=\s*"
+CallName="align_var_def_amp_style="
+CallNameRegex="align_var_def_amp_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -5977,7 +6645,8 @@ Category=7
 Description="<html>The threshold for aligning variable definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_thresh\s*=\s*"
+CallName="align_var_def_thresh="
+CallNameRegex="align_var_def_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -5987,7 +6656,8 @@ Category=7
 Description="<html>The gap for aligning variable definitions.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_gap\s*=\s*"
+CallName="align_var_def_gap="
+CallNameRegex="align_var_def_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -5997,7 +6667,8 @@ Category=7
 Description="<html>Whether to align the colon in struct bit fields.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_var_def_colon\s*=\s*true|align_var_def_colon\s*=\s*false
+TrueFalse=align_var_def_colon=true|align_var_def_colon=false
+TrueFalseRegex=align_var_def_colon\s*=\s*true|align_var_def_colon\s*=\s*false
 ValueDefault=false
 
 [Align Var Def Colon Gap]
@@ -6005,7 +6676,8 @@ Category=7
 Description="<html>The gap for aligning the colon in struct bit fields.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_def_colon_gap\s*=\s*"
+CallName="align_var_def_colon_gap="
+CallNameRegex="align_var_def_colon_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6015,7 +6687,8 @@ Category=7
 Description="<html>Whether to align any attribute after the variable name.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_var_def_attribute\s*=\s*true|align_var_def_attribute\s*=\s*false
+TrueFalse=align_var_def_attribute=true|align_var_def_attribute=false
+TrueFalseRegex=align_var_def_attribute\s*=\s*true|align_var_def_attribute\s*=\s*false
 ValueDefault=false
 
 [Align Var Def Inline]
@@ -6023,7 +6696,8 @@ Category=7
 Description="<html>Whether to align inline struct/enum/union variable definitions.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_var_def_inline\s*=\s*true|align_var_def_inline\s*=\s*false
+TrueFalse=align_var_def_inline=true|align_var_def_inline=false
+TrueFalseRegex=align_var_def_inline\s*=\s*true|align_var_def_inline\s*=\s*false
 ValueDefault=false
 
 [Align Assign Span]
@@ -6031,7 +6705,8 @@ Category=7
 Description="<html>The span for aligning on '=' in assignments.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_assign_span\s*=\s*"
+CallName="align_assign_span="
+CallNameRegex="align_assign_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6041,7 +6716,8 @@ Category=7
 Description="<html>The span for aligning on '=' in function prototype modifier.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_assign_func_proto_span\s*=\s*"
+CallName="align_assign_func_proto_span="
+CallNameRegex="align_assign_func_proto_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6051,7 +6727,8 @@ Category=7
 Description="<html>The threshold for aligning on '=' in assignments.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_assign_thresh\s*=\s*"
+CallName="align_assign_thresh="
+CallNameRegex="align_assign_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6061,7 +6738,8 @@ Category=7
 Description="<html>Whether to align on the left most assignment when multiple<br/>definitions are found on the same line.<br/>Depends on 'align_assign_span' and 'align_assign_thresh' settings.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_assign_on_multi_var_defs\s*=\s*true|align_assign_on_multi_var_defs\s*=\s*false
+TrueFalse=align_assign_on_multi_var_defs=true|align_assign_on_multi_var_defs=false
+TrueFalseRegex=align_assign_on_multi_var_defs\s*=\s*true|align_assign_on_multi_var_defs\s*=\s*false
 ValueDefault=false
 
 [Align Braced Init List Span]
@@ -6069,7 +6747,8 @@ Category=7
 Description="<html>The span for aligning on '{' in braced init list.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_braced_init_list_span\s*=\s*"
+CallName="align_braced_init_list_span="
+CallNameRegex="align_braced_init_list_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6079,7 +6758,8 @@ Category=7
 Description="<html>The threshold for aligning on '{' in braced init list.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_braced_init_list_thresh\s*=\s*"
+CallName="align_braced_init_list_thresh="
+CallNameRegex="align_braced_init_list_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6089,7 +6769,8 @@ Category=7
 Description="<html>How to apply align_assign_span to function declaration "assignments", i.e.<br/>'virtual void foo() = 0' or '~foo() = {default|delete}'.<br/><br/>0: Align with other assignments (default)<br/>1: Align with each other, ignoring regular assignments<br/>2: Don't align</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_assign_decl_func\s*=\s*"
+CallName="align_assign_decl_func="
+CallNameRegex="align_assign_decl_func\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6099,7 +6780,8 @@ Category=7
 Description="<html>The span for aligning on '=' in enums.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_enum_equ_span\s*=\s*"
+CallName="align_enum_equ_span="
+CallNameRegex="align_enum_equ_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6109,7 +6791,8 @@ Category=7
 Description="<html>The threshold for aligning on '=' in enums.<br/>Use a negative number for absolute thresholds.<br/><br/>0: no limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_enum_equ_thresh\s*=\s*"
+CallName="align_enum_equ_thresh="
+CallNameRegex="align_enum_equ_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6119,7 +6802,8 @@ Category=7
 Description="<html>The span for aligning class member definitions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_class_span\s*=\s*"
+CallName="align_var_class_span="
+CallNameRegex="align_var_class_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6129,7 +6813,8 @@ Category=7
 Description="<html>The threshold for aligning class member definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_class_thresh\s*=\s*"
+CallName="align_var_class_thresh="
+CallNameRegex="align_var_class_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6139,7 +6824,8 @@ Category=7
 Description="<html>The gap for aligning class member definitions.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_class_gap\s*=\s*"
+CallName="align_var_class_gap="
+CallNameRegex="align_var_class_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6149,7 +6835,8 @@ Category=7
 Description="<html>The span for aligning struct/union member definitions.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_struct_span\s*=\s*"
+CallName="align_var_struct_span="
+CallNameRegex="align_var_struct_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6159,7 +6846,8 @@ Category=7
 Description="<html>The threshold for aligning struct/union member definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_struct_thresh\s*=\s*"
+CallName="align_var_struct_thresh="
+CallNameRegex="align_var_struct_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6169,7 +6857,8 @@ Category=7
 Description="<html>The gap for aligning struct/union member definitions.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_var_struct_gap\s*=\s*"
+CallName="align_var_struct_gap="
+CallNameRegex="align_var_struct_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6179,7 +6868,8 @@ Category=7
 Description="<html>The span for aligning struct initializer values.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_struct_init_span\s*=\s*"
+CallName="align_struct_init_span="
+CallNameRegex="align_struct_init_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6189,7 +6879,8 @@ Category=7
 Description="<html>The span for aligning single-line typedefs.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_span\s*=\s*"
+CallName="align_typedef_span="
+CallNameRegex="align_typedef_span\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6199,7 +6890,8 @@ Category=7
 Description="<html>The minimum space between the type and the synonym of a typedef.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_gap\s*=\s*"
+CallName="align_typedef_gap="
+CallNameRegex="align_typedef_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6209,7 +6901,8 @@ Category=7
 Description="<html>How to align typedef'd functions with other typedefs.<br/><br/>0: Don't mix them at all (default)<br/>1: Align the open parenthesis with the types<br/>2: Align the function type name with the other type names</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_func\s*=\s*"
+CallName="align_typedef_func="
+CallNameRegex="align_typedef_func\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6219,7 +6912,8 @@ Category=7
 Description="<html>How to consider (or treat) the '*' in the alignment of typedefs.<br/><br/>0: Part of the typedef type, 'typedef int * pint;' (default)<br/>1: Part of type name:        'typedef int   *pint;'<br/>2: Dangling:                 'typedef int  *pint;'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_star_style\s*=\s*"
+CallName="align_typedef_star_style="
+CallNameRegex="align_typedef_star_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6229,7 +6923,8 @@ Category=7
 Description="<html>How to consider (or treat) the '&amp;' in the alignment of typedefs.<br/><br/>0: Part of the typedef type, 'typedef int &amp; intref;' (default)<br/>1: Part of type name:        'typedef int   &amp;intref;'<br/>2: Dangling:                 'typedef int  &amp;intref;'<br/>Dangling: the '&amp;' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_typedef_amp_style\s*=\s*"
+CallName="align_typedef_amp_style="
+CallNameRegex="align_typedef_amp_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6239,7 +6934,8 @@ Category=7
 Description="<html>The span for aligning comments that end lines.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_right_cmt_span\s*=\s*"
+CallName="align_right_cmt_span="
+CallNameRegex="align_right_cmt_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6249,7 +6945,8 @@ Category=7
 Description="<html>Minimum number of columns between preceding text and a trailing comment in<br/>order for the comment to qualify for being aligned. Must be non-zero to have<br/>an effect.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_right_cmt_gap\s*=\s*"
+CallName="align_right_cmt_gap="
+CallNameRegex="align_right_cmt_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6259,7 +6956,8 @@ Category=7
 Description="<html>If aligning comments, whether to mix with comments after '}' and #endif with<br/>less than three spaces before the comment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_right_cmt_mix\s*=\s*true|align_right_cmt_mix\s*=\s*false
+TrueFalse=align_right_cmt_mix=true|align_right_cmt_mix=false
+TrueFalseRegex=align_right_cmt_mix\s*=\s*true|align_right_cmt_mix\s*=\s*false
 ValueDefault=false
 
 [Align Right Cmt Same Level]
@@ -6267,7 +6965,8 @@ Category=7
 Description="<html>Whether to only align trailing comments that are at the same brace level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_right_cmt_same_level\s*=\s*true|align_right_cmt_same_level\s*=\s*false
+TrueFalse=align_right_cmt_same_level=true|align_right_cmt_same_level=false
+TrueFalseRegex=align_right_cmt_same_level\s*=\s*true|align_right_cmt_same_level\s*=\s*false
 ValueDefault=false
 
 [Align Right Cmt At Col]
@@ -6275,7 +6974,8 @@ Category=7
 Description="<html>Minimum column at which to align trailing comments. Comments which are<br/>aligned beyond this column, but which can be aligned in a lesser column,<br/>may be "pulled in".<br/><br/>0: Ignore (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_right_cmt_at_col\s*=\s*"
+CallName="align_right_cmt_at_col="
+CallNameRegex="align_right_cmt_at_col\s*=\s*"
 MinVal=0
 MaxVal=200
 ValueDefault=0
@@ -6285,7 +6985,8 @@ Category=7
 Description="<html>The span for aligning function prototypes.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_span\s*=\s*"
+CallName="align_func_proto_span="
+CallNameRegex="align_func_proto_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6295,7 +6996,8 @@ Category=7
 Description="<html>Whether to ignore continuation lines when evaluating the number of<br/>new lines for the function prototype alignment's span.<br/><br/>false: continuation lines are part of the newlines count<br/>true:  continuation lines are not counted</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_func_proto_span_ignore_cont_lines\s*=\s*true|align_func_proto_span_ignore_cont_lines\s*=\s*false
+TrueFalse=align_func_proto_span_ignore_cont_lines=true|align_func_proto_span_ignore_cont_lines=false
+TrueFalseRegex=align_func_proto_span_ignore_cont_lines\s*=\s*true|align_func_proto_span_ignore_cont_lines\s*=\s*false
 ValueDefault=false
 
 [Align Func Proto Star Style]
@@ -6303,7 +7005,8 @@ Category=7
 Description="<html>How to consider (or treat) the '*' in the alignment of function prototypes.<br/><br/>0: Part of the type     'void *   foo();' (default)<br/>1: Part of the function 'void     *foo();'<br/>2: Dangling             'void    *foo();'<br/>Dangling: the '*' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_star_style\s*=\s*"
+CallName="align_func_proto_star_style="
+CallNameRegex="align_func_proto_star_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6313,7 +7016,8 @@ Category=7
 Description="<html>How to consider (or treat) the '&amp;' in the alignment of function prototypes.<br/><br/>0: Part of the type     'long &amp;   foo();' (default)<br/>1: Part of the function 'long     &amp;foo();'<br/>2: Dangling             'long    &amp;foo();'<br/>Dangling: the '&amp;' will not be taken into account when aligning.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_amp_style\s*=\s*"
+CallName="align_func_proto_amp_style="
+CallNameRegex="align_func_proto_amp_style\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6323,7 +7027,8 @@ Category=7
 Description="<html>The threshold for aligning function prototypes.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_thresh\s*=\s*"
+CallName="align_func_proto_thresh="
+CallNameRegex="align_func_proto_thresh\s*=\s*"
 MinVal=-1000
 MaxVal=5000
 ValueDefault=0
@@ -6333,7 +7038,8 @@ Category=7
 Description="<html>Minimum gap between the return type and the function name.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_func_proto_gap\s*=\s*"
+CallName="align_func_proto_gap="
+CallNameRegex="align_func_proto_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6343,7 +7049,8 @@ Category=7
 Description="<html>Whether to align function prototypes on the 'operator' keyword instead of<br/>what follows.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_on_operator\s*=\s*true|align_on_operator\s*=\s*false
+TrueFalse=align_on_operator=true|align_on_operator=false
+TrueFalseRegex=align_on_operator\s*=\s*true|align_on_operator\s*=\s*false
 ValueDefault=false
 
 [Align Mix Var Proto]
@@ -6351,7 +7058,8 @@ Category=7
 Description="<html>Whether to mix aligning prototype and variable declarations. If true,<br/>align_var_def_XXX options are used instead of align_func_proto_XXX options.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_mix_var_proto\s*=\s*true|align_mix_var_proto\s*=\s*false
+TrueFalse=align_mix_var_proto=true|align_mix_var_proto=false
+TrueFalseRegex=align_mix_var_proto\s*=\s*true|align_mix_var_proto\s*=\s*false
 ValueDefault=false
 
 [Align Single Line Func]
@@ -6359,7 +7067,8 @@ Category=7
 Description="<html>Whether to align single-line functions with function prototypes.<br/>Uses align_func_proto_span.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_single_line_func\s*=\s*true|align_single_line_func\s*=\s*false
+TrueFalse=align_single_line_func=true|align_single_line_func=false
+TrueFalseRegex=align_single_line_func\s*=\s*true|align_single_line_func\s*=\s*false
 ValueDefault=false
 
 [Align Single Line Brace]
@@ -6367,7 +7076,8 @@ Category=7
 Description="<html>Whether to align the open brace of single-line functions.<br/>Requires align_single_line_func=true. Uses align_func_proto_span.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_single_line_brace\s*=\s*true|align_single_line_brace\s*=\s*false
+TrueFalse=align_single_line_brace=true|align_single_line_brace=false
+TrueFalseRegex=align_single_line_brace\s*=\s*true|align_single_line_brace\s*=\s*false
 ValueDefault=false
 
 [Align Single Line Brace Gap]
@@ -6375,7 +7085,8 @@ Category=7
 Description="<html>Gap for align_single_line_brace.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_single_line_brace_gap\s*=\s*"
+CallName="align_single_line_brace_gap="
+CallNameRegex="align_single_line_brace_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6385,7 +7096,8 @@ Category=7
 Description="<html>(OC) The span for aligning Objective-C message specifications.<br/><br/>0: Don't align (default).</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_oc_msg_spec_span\s*=\s*"
+CallName="align_oc_msg_spec_span="
+CallNameRegex="align_oc_msg_spec_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6395,7 +7107,8 @@ Category=7
 Description="<html>Whether and how to align backslashes that split a macro onto multiple lines.<br/>This will not work right if the macro contains a multi-line comment.<br/><br/>0: Do nothing (default)<br/>1: Align the backslashes in the column at the end of the longest line<br/>2: Align with the backslash that is farthest to the left, or, if that<br/>   backslash is farther left than the end of the longest line, at the end of<br/>   the longest line<br/>3: Align with the backslash that is farthest to the right</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_nl_cont\s*=\s*"
+CallName="align_nl_cont="
+CallNameRegex="align_nl_cont\s*=\s*"
 MinVal=0
 MaxVal=3
 ValueDefault=0
@@ -6405,7 +7118,8 @@ Category=7
 Description="<html>The minimum number of spaces between the end of a line and its continuation<br/>backslash. Requires align_nl_cont.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_nl_cont_spaces\s*=\s*"
+CallName="align_nl_cont_spaces="
+CallNameRegex="align_nl_cont_spaces\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -6415,7 +7129,8 @@ Category=7
 Description="<html>Whether to align macro functions and variables together.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_pp_define_together\s*=\s*true|align_pp_define_together\s*=\s*false
+TrueFalse=align_pp_define_together=true|align_pp_define_together=false
+TrueFalseRegex=align_pp_define_together\s*=\s*true|align_pp_define_together\s*=\s*false
 ValueDefault=false
 
 [Align Pp Define Span]
@@ -6423,7 +7138,8 @@ Category=7
 Description="<html>The span for aligning on '#define' bodies.<br/><br/>=0: Don't align (default)<br/>&gt;0: Number of lines (including comments) between blocks</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_pp_define_span\s*=\s*"
+CallName="align_pp_define_span="
+CallNameRegex="align_pp_define_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6433,7 +7149,8 @@ Category=7
 Description="<html>The minimum space between label and value of a preprocessor define.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_pp_define_gap\s*=\s*"
+CallName="align_pp_define_gap="
+CallNameRegex="align_pp_define_gap\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6443,7 +7160,8 @@ Category=7
 Description="<html>Whether to align lines that start with '&lt;&lt;' with previous '&lt;&lt;'.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_left_shift\s*=\s*true|align_left_shift\s*=\s*false
+TrueFalse=align_left_shift=true|align_left_shift=false
+TrueFalseRegex=align_left_shift\s*=\s*true|align_left_shift\s*=\s*false
 ValueDefault=true
 
 [Align Eigen Comma Init]
@@ -6451,7 +7169,8 @@ Category=7
 Description="<html>Whether to align comma-separated statements following '&lt;&lt;' (as used to<br/>initialize Eigen matrices).</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_eigen_comma_init\s*=\s*true|align_eigen_comma_init\s*=\s*false
+TrueFalse=align_eigen_comma_init=true|align_eigen_comma_init=false
+TrueFalseRegex=align_eigen_comma_init\s*=\s*true|align_eigen_comma_init\s*=\s*false
 ValueDefault=false
 
 [Align Asm Colon]
@@ -6459,7 +7178,8 @@ Category=7
 Description="<html>Whether to align text after 'asm volatile ()' colons.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_asm_colon\s*=\s*true|align_asm_colon\s*=\s*false
+TrueFalse=align_asm_colon=true|align_asm_colon=false
+TrueFalseRegex=align_asm_colon\s*=\s*true|align_asm_colon\s*=\s*false
 ValueDefault=false
 
 [Align Oc Msg Colon Span]
@@ -6467,7 +7187,8 @@ Category=7
 Description="<html>(OC) Span for aligning parameters in an Objective-C message call<br/>on the ':'.<br/><br/>0: Don't align.</html>"
 Enabled=false
 EditorType=numeric
-CallName="align_oc_msg_colon_span\s*=\s*"
+CallName="align_oc_msg_colon_span="
+CallNameRegex="align_oc_msg_colon_span\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6477,7 +7198,8 @@ Category=7
 Description="<html>(OC) Whether to always align with the first parameter, even if it is too<br/>short.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_oc_msg_colon_first\s*=\s*true|align_oc_msg_colon_first\s*=\s*false
+TrueFalse=align_oc_msg_colon_first=true|align_oc_msg_colon_first=false
+TrueFalseRegex=align_oc_msg_colon_first\s*=\s*true|align_oc_msg_colon_first\s*=\s*false
 ValueDefault=false
 
 [Align Oc Decl Colon]
@@ -6485,7 +7207,8 @@ Category=7
 Description="<html>(OC) Whether to align parameters in an Objective-C '+' or '-' declaration<br/>on the ':'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_oc_decl_colon\s*=\s*true|align_oc_decl_colon\s*=\s*false
+TrueFalse=align_oc_decl_colon=true|align_oc_decl_colon=false
+TrueFalseRegex=align_oc_decl_colon\s*=\s*true|align_oc_decl_colon\s*=\s*false
 ValueDefault=false
 
 [Align Oc Msg Colon Xcode Like]
@@ -6493,7 +7216,8 @@ Category=7
 Description="<html>(OC) Whether to not align parameters in an Objectve-C message call if first<br/>colon is not on next line of the message call (the same way Xcode does<br/>alignment)</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=align_oc_msg_colon_xcode_like\s*=\s*true|align_oc_msg_colon_xcode_like\s*=\s*false
+TrueFalse=align_oc_msg_colon_xcode_like=true|align_oc_msg_colon_xcode_like=false
+TrueFalseRegex=align_oc_msg_colon_xcode_like\s*=\s*true|align_oc_msg_colon_xcode_like\s*=\s*false
 ValueDefault=false
 
 [Cmt Width]
@@ -6501,7 +7225,8 @@ Category=8
 Description="<html>Try to wrap comments at N columns.</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_width\s*=\s*"
+CallName="cmt_width="
+CallNameRegex="cmt_width\s*=\s*"
 MinVal=0
 MaxVal=256
 ValueDefault=0
@@ -6511,7 +7236,8 @@ Category=8
 Description="<html>How to reflow comments.<br/><br/>0: No reflowing (apart from the line wrapping due to cmt_width) (default)<br/>1: No touching at all<br/>2: Full reflow (enable cmt_indent_multi for indent with line wrapping due to cmt_width)</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_reflow_mode\s*=\s*"
+CallName="cmt_reflow_mode="
+CallNameRegex="cmt_reflow_mode\s*=\s*"
 MinVal=0
 MaxVal=2
 ValueDefault=0
@@ -6520,7 +7246,8 @@ ValueDefault=0
 Category=8
 Description="<html>Path to a file that contains regular expressions describing patterns for<br/>which the end of one line and the beginning of the next will be folded into<br/>the same sentence or paragraph during full comment reflow. The regular<br/>expressions are described using ECMAScript syntax. The syntax for this<br/>specification is as follows, where "..." indicates the custom regular<br/>expression and "n" indicates the nth end_of_prev_line_regex and<br/>beg_of_next_line_regex regular expression pair:<br/><br/>end_of_prev_line_regex[1] = "...$"<br/>beg_of_next_line_regex[1] = "^..."<br/>end_of_prev_line_regex[2] = "...$"<br/>beg_of_next_line_regex[2] = "^..."<br/>            .<br/>            .<br/>            .<br/>end_of_prev_line_regex[n] = "...$"<br/>beg_of_next_line_regex[n] = "^..."<br/><br/>Note that use of this option overrides the default reflow fold regular<br/>expressions, which are internally defined as follows:<br/><br/>end_of_prev_line_regex[1] = "[\w,\]\)]$"<br/>beg_of_next_line_regex[1] = "^[\w,\[\(]"<br/>end_of_prev_line_regex[2] = "\.$"<br/>beg_of_next_line_regex[2] = "^[A-Z]"</html>"
 Enabled=false
-CallName=cmt_reflow_fold_regex_file\s*=\s*
+CallName=cmt_reflow_fold_regex_file=
+CallNameRegex=cmt_reflow_fold_regex_file\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6529,7 +7256,8 @@ Category=8
 Description="<html>Whether to indent wrapped lines to the start of the encompassing paragraph<br/>during full comment reflow (cmt_reflow_mode = 2). Overrides the value<br/>specified by cmt_sp_after_star_cont.<br/><br/>Note that cmt_align_doxygen_javadoc_tags overrides this option for<br/>paragraphs associated with javadoc tags</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_reflow_indent_to_paragraph_start\s*=\s*true|cmt_reflow_indent_to_paragraph_start\s*=\s*false
+TrueFalse=cmt_reflow_indent_to_paragraph_start=true|cmt_reflow_indent_to_paragraph_start=false
+TrueFalseRegex=cmt_reflow_indent_to_paragraph_start\s*=\s*true|cmt_reflow_indent_to_paragraph_start\s*=\s*false
 ValueDefault=false
 
 [Cmt Convert Tab To Spaces]
@@ -6537,7 +7265,8 @@ Category=8
 Description="<html>Whether to convert all tabs to spaces in comments. If false, tabs in<br/>comments are left alone, unless used for indenting.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_convert_tab_to_spaces\s*=\s*true|cmt_convert_tab_to_spaces\s*=\s*false
+TrueFalse=cmt_convert_tab_to_spaces=true|cmt_convert_tab_to_spaces=false
+TrueFalseRegex=cmt_convert_tab_to_spaces\s*=\s*true|cmt_convert_tab_to_spaces\s*=\s*false
 ValueDefault=false
 
 [Cmt Indent Multi]
@@ -6545,7 +7274,8 @@ Category=8
 Description="<html>Whether to apply changes to multi-line comments, including cmt_width,<br/>keyword substitution and leading chars.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_indent_multi\s*=\s*true|cmt_indent_multi\s*=\s*false
+TrueFalse=cmt_indent_multi=true|cmt_indent_multi=false
+TrueFalseRegex=cmt_indent_multi\s*=\s*true|cmt_indent_multi\s*=\s*false
 ValueDefault=true
 
 [Cmt Align Doxygen Javadoc Tags]
@@ -6553,7 +7283,8 @@ Category=8
 Description="<html>Whether to align doxygen javadoc-style tags ('@param', '@return', etc.)<br/>and corresponding fields such that groups of consecutive block tags,<br/>parameter names, and descriptions align with one another. Overrides that<br/>which is specified by the cmt_sp_after_star_cont. If cmt_width &gt; 0, it may<br/>be necessary to enable cmt_indent_multi and set cmt_reflow_mode = 2<br/>in order to achieve the desired alignment for line-wrapping.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_align_doxygen_javadoc_tags\s*=\s*true|cmt_align_doxygen_javadoc_tags\s*=\s*false
+TrueFalse=cmt_align_doxygen_javadoc_tags=true|cmt_align_doxygen_javadoc_tags=false
+TrueFalseRegex=cmt_align_doxygen_javadoc_tags\s*=\s*true|cmt_align_doxygen_javadoc_tags\s*=\s*false
 ValueDefault=false
 
 [Cmt Sp Before Doxygen Javadoc Tags]
@@ -6561,7 +7292,8 @@ Category=8
 Description="<html>The number of spaces to insert after the star and before doxygen<br/>javadoc-style tags (@param, @return, etc). Requires enabling<br/>cmt_align_doxygen_javadoc_tags. Overrides that which is specified by the<br/>cmt_sp_after_star_cont.<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_sp_before_doxygen_javadoc_tags\s*=\s*"
+CallName="cmt_sp_before_doxygen_javadoc_tags="
+CallNameRegex="cmt_sp_before_doxygen_javadoc_tags\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -6571,7 +7303,8 @@ Category=8
 Description="<html>Whether to change trailing, single-line c-comments into cpp-comments.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_trailing_single_line_c_to_cpp\s*=\s*true|cmt_trailing_single_line_c_to_cpp\s*=\s*false
+TrueFalse=cmt_trailing_single_line_c_to_cpp=true|cmt_trailing_single_line_c_to_cpp=false
+TrueFalseRegex=cmt_trailing_single_line_c_to_cpp\s*=\s*true|cmt_trailing_single_line_c_to_cpp\s*=\s*false
 ValueDefault=false
 
 [Cmt C Group]
@@ -6579,7 +7312,8 @@ Category=8
 Description="<html>Whether to group c-comments that look like they are in a block.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_c_group\s*=\s*true|cmt_c_group\s*=\s*false
+TrueFalse=cmt_c_group=true|cmt_c_group=false
+TrueFalseRegex=cmt_c_group\s*=\s*true|cmt_c_group\s*=\s*false
 ValueDefault=false
 
 [Cmt C Nl Start]
@@ -6587,7 +7321,8 @@ Category=8
 Description="<html>Whether to put an empty '/*' on the first line of the combined c-comment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_c_nl_start\s*=\s*true|cmt_c_nl_start\s*=\s*false
+TrueFalse=cmt_c_nl_start=true|cmt_c_nl_start=false
+TrueFalseRegex=cmt_c_nl_start\s*=\s*true|cmt_c_nl_start\s*=\s*false
 ValueDefault=false
 
 [Cmt C Nl End]
@@ -6595,7 +7330,8 @@ Category=8
 Description="<html>Whether to add a newline before the closing '*/' of the combined c-comment.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_c_nl_end\s*=\s*true|cmt_c_nl_end\s*=\s*false
+TrueFalse=cmt_c_nl_end=true|cmt_c_nl_end=false
+TrueFalseRegex=cmt_c_nl_end\s*=\s*true|cmt_c_nl_end\s*=\s*false
 ValueDefault=false
 
 [Cmt Cpp To C]
@@ -6603,7 +7339,8 @@ Category=8
 Description="<html>Whether to change cpp-comments into c-comments.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_cpp_to_c\s*=\s*true|cmt_cpp_to_c\s*=\s*false
+TrueFalse=cmt_cpp_to_c=true|cmt_cpp_to_c=false
+TrueFalseRegex=cmt_cpp_to_c\s*=\s*true|cmt_cpp_to_c\s*=\s*false
 ValueDefault=false
 
 [Cmt Cpp Group]
@@ -6611,7 +7348,8 @@ Category=8
 Description="<html>Whether to group cpp-comments that look like they are in a block. Only<br/>meaningful if cmt_cpp_to_c=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_cpp_group\s*=\s*true|cmt_cpp_group\s*=\s*false
+TrueFalse=cmt_cpp_group=true|cmt_cpp_group=false
+TrueFalseRegex=cmt_cpp_group\s*=\s*true|cmt_cpp_group\s*=\s*false
 ValueDefault=false
 
 [Cmt Cpp Nl Start]
@@ -6619,7 +7357,8 @@ Category=8
 Description="<html>Whether to put an empty '/*' on the first line of the combined cpp-comment<br/>when converting to a c-comment.<br/><br/>Requires cmt_cpp_to_c=true and cmt_cpp_group=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_cpp_nl_start\s*=\s*true|cmt_cpp_nl_start\s*=\s*false
+TrueFalse=cmt_cpp_nl_start=true|cmt_cpp_nl_start=false
+TrueFalseRegex=cmt_cpp_nl_start\s*=\s*true|cmt_cpp_nl_start\s*=\s*false
 ValueDefault=false
 
 [Cmt Cpp Nl End]
@@ -6627,7 +7366,8 @@ Category=8
 Description="<html>Whether to add a newline before the closing '*/' of the combined cpp-comment<br/>when converting to a c-comment.<br/><br/>Requires cmt_cpp_to_c=true and cmt_cpp_group=true.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_cpp_nl_end\s*=\s*true|cmt_cpp_nl_end\s*=\s*false
+TrueFalse=cmt_cpp_nl_end=true|cmt_cpp_nl_end=false
+TrueFalseRegex=cmt_cpp_nl_end\s*=\s*true|cmt_cpp_nl_end\s*=\s*false
 ValueDefault=false
 
 [Cmt Star Cont]
@@ -6635,7 +7375,8 @@ Category=8
 Description="<html>Whether to put a star on subsequent comment lines.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_star_cont\s*=\s*true|cmt_star_cont\s*=\s*false
+TrueFalse=cmt_star_cont=true|cmt_star_cont=false
+TrueFalseRegex=cmt_star_cont\s*=\s*true|cmt_star_cont\s*=\s*false
 ValueDefault=false
 
 [Cmt Sp Before Star Cont]
@@ -6643,7 +7384,8 @@ Category=8
 Description="<html>The number of spaces to insert at the start of subsequent comment lines.</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_sp_before_star_cont\s*=\s*"
+CallName="cmt_sp_before_star_cont="
+CallNameRegex="cmt_sp_before_star_cont\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6653,7 +7395,8 @@ Category=8
 Description="<html>The number of spaces to insert after the star on subsequent comment lines.</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_sp_after_star_cont\s*=\s*"
+CallName="cmt_sp_after_star_cont="
+CallNameRegex="cmt_sp_after_star_cont\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -6663,7 +7406,8 @@ Category=8
 Description="<html>For multi-line comments with a '*' lead, remove leading spaces if the first<br/>and last lines of the comment are the same length.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_multi_check_last\s*=\s*true|cmt_multi_check_last\s*=\s*false
+TrueFalse=cmt_multi_check_last=true|cmt_multi_check_last=false
+TrueFalseRegex=cmt_multi_check_last\s*=\s*true|cmt_multi_check_last\s*=\s*false
 ValueDefault=true
 
 [Cmt Multi First Len Minimum]
@@ -6671,7 +7415,8 @@ Category=8
 Description="<html>For multi-line comments with a '*' lead, remove leading spaces if the first<br/>and last lines of the comment are the same length AND if the length is<br/>bigger as the first_len minimum.<br/><br/>Default: 4</html>"
 Enabled=false
 EditorType=numeric
-CallName="cmt_multi_first_len_minimum\s*=\s*"
+CallName="cmt_multi_first_len_minimum="
+CallNameRegex="cmt_multi_first_len_minimum\s*=\s*"
 MinVal=1
 MaxVal=20
 ValueDefault=4
@@ -6680,7 +7425,8 @@ ValueDefault=4
 Category=8
 Description="<html>Path to a file that contains text to insert at the beginning of a file if<br/>the file doesn't start with a C/C++ comment. If the inserted text contains<br/>'$(filename)', that will be replaced with the current file's name.</html>"
 Enabled=false
-CallName=cmt_insert_file_header\s*=\s*
+CallName=cmt_insert_file_header=
+CallNameRegex=cmt_insert_file_header\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6688,7 +7434,8 @@ ValueDefault=
 Category=8
 Description="<html>Path to a file that contains text to insert at the end of a file if the<br/>file doesn't end with a C/C++ comment. If the inserted text contains<br/>'$(filename)', that will be replaced with the current file's name.</html>"
 Enabled=false
-CallName=cmt_insert_file_footer\s*=\s*
+CallName=cmt_insert_file_footer=
+CallNameRegex=cmt_insert_file_footer\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6696,7 +7443,8 @@ ValueDefault=
 Category=8
 Description="<html>Path to a file that contains text to insert before a function definition if<br/>the function isn't preceded by a C/C++ comment. If the inserted text<br/>contains '$(function)', '$(javaparam)' or '$(fclass)', these will be<br/>replaced with, respectively, the name of the function, the javadoc '@param'<br/>and '@return' stuff, or the name of the class to which the member function<br/>belongs.</html>"
 Enabled=false
-CallName=cmt_insert_func_header\s*=\s*
+CallName=cmt_insert_func_header=
+CallNameRegex=cmt_insert_func_header\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6704,7 +7452,8 @@ ValueDefault=
 Category=8
 Description="<html>Path to a file that contains text to insert before a class if the class<br/>isn't preceded by a C/C++ comment. If the inserted text contains '$(class)',<br/>that will be replaced with the class name.</html>"
 Enabled=false
-CallName=cmt_insert_class_header\s*=\s*
+CallName=cmt_insert_class_header=
+CallNameRegex=cmt_insert_class_header\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6712,7 +7461,8 @@ ValueDefault=
 Category=8
 Description="<html>Path to a file that contains text to insert before an Objective-C message<br/>specification, if the method isn't preceded by a C/C++ comment. If the<br/>inserted text contains '$(message)' or '$(javaparam)', these will be<br/>replaced with, respectively, the name of the function, or the javadoc<br/>'@param' and '@return' stuff.</html>"
 Enabled=false
-CallName=cmt_insert_oc_msg_header\s*=\s*
+CallName=cmt_insert_oc_msg_header=
+CallNameRegex=cmt_insert_oc_msg_header\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -6721,7 +7471,8 @@ Category=8
 Description="<html>Whether a comment should be inserted if a preprocessor is encountered when<br/>stepping backwards from a function name.<br/><br/>Applies to cmt_insert_oc_msg_header, cmt_insert_func_header and<br/>cmt_insert_class_header.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_insert_before_preproc\s*=\s*true|cmt_insert_before_preproc\s*=\s*false
+TrueFalse=cmt_insert_before_preproc=true|cmt_insert_before_preproc=false
+TrueFalseRegex=cmt_insert_before_preproc\s*=\s*true|cmt_insert_before_preproc\s*=\s*false
 ValueDefault=false
 
 [Cmt Insert Before Inlines]
@@ -6729,7 +7480,8 @@ Category=8
 Description="<html>Whether a comment should be inserted if a function is declared inline to a<br/>class definition.<br/><br/>Applies to cmt_insert_func_header.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_insert_before_inlines\s*=\s*true|cmt_insert_before_inlines\s*=\s*false
+TrueFalse=cmt_insert_before_inlines=true|cmt_insert_before_inlines=false
+TrueFalseRegex=cmt_insert_before_inlines\s*=\s*true|cmt_insert_before_inlines\s*=\s*false
 ValueDefault=true
 
 [Cmt Insert Before Ctor Dtor]
@@ -6737,7 +7489,8 @@ Category=8
 Description="<html>Whether a comment should be inserted if the function is a class constructor<br/>or destructor.<br/><br/>Applies to cmt_insert_func_header.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=cmt_insert_before_ctor_dtor\s*=\s*true|cmt_insert_before_ctor_dtor\s*=\s*false
+TrueFalse=cmt_insert_before_ctor_dtor=true|cmt_insert_before_ctor_dtor=false
+TrueFalseRegex=cmt_insert_before_ctor_dtor\s*=\s*true|cmt_insert_before_ctor_dtor\s*=\s*false
 ValueDefault=false
 
 [Mod Full Brace Do]
@@ -6745,7 +7498,8 @@ Category=9
 Description="<html>Add or remove braces on a single-line 'do' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_do\s*=\s*ignore|mod_full_brace_do\s*=\s*add|mod_full_brace_do\s*=\s*remove|mod_full_brace_do\s*=\s*force|mod_full_brace_do\s*=\s*not_defined
+Choices=mod_full_brace_do=ignore|mod_full_brace_do=add|mod_full_brace_do=remove|mod_full_brace_do=force|mod_full_brace_do=not_defined
+ChoicesRegex=mod_full_brace_do\s*=\s*ignore|mod_full_brace_do\s*=\s*add|mod_full_brace_do\s*=\s*remove|mod_full_brace_do\s*=\s*force|mod_full_brace_do\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace Do|Add Mod Full Brace Do|Remove Mod Full Brace Do|Force Mod Full Brace Do"
 ValueDefault=ignore
 
@@ -6754,7 +7508,8 @@ Category=9
 Description="<html>Add or remove braces on a single-line 'for' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_for\s*=\s*ignore|mod_full_brace_for\s*=\s*add|mod_full_brace_for\s*=\s*remove|mod_full_brace_for\s*=\s*force|mod_full_brace_for\s*=\s*not_defined
+Choices=mod_full_brace_for=ignore|mod_full_brace_for=add|mod_full_brace_for=remove|mod_full_brace_for=force|mod_full_brace_for=not_defined
+ChoicesRegex=mod_full_brace_for\s*=\s*ignore|mod_full_brace_for\s*=\s*add|mod_full_brace_for\s*=\s*remove|mod_full_brace_for\s*=\s*force|mod_full_brace_for\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace For|Add Mod Full Brace For|Remove Mod Full Brace For|Force Mod Full Brace For"
 ValueDefault=ignore
 
@@ -6763,7 +7518,8 @@ Category=9
 Description="<html>(Pawn) Add or remove braces on a single-line function definition.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_function\s*=\s*ignore|mod_full_brace_function\s*=\s*add|mod_full_brace_function\s*=\s*remove|mod_full_brace_function\s*=\s*force|mod_full_brace_function\s*=\s*not_defined
+Choices=mod_full_brace_function=ignore|mod_full_brace_function=add|mod_full_brace_function=remove|mod_full_brace_function=force|mod_full_brace_function=not_defined
+ChoicesRegex=mod_full_brace_function\s*=\s*ignore|mod_full_brace_function\s*=\s*add|mod_full_brace_function\s*=\s*remove|mod_full_brace_function\s*=\s*force|mod_full_brace_function\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace Function|Add Mod Full Brace Function|Remove Mod Full Brace Function|Force Mod Full Brace Function"
 ValueDefault=ignore
 
@@ -6772,7 +7528,8 @@ Category=9
 Description="<html>Add or remove braces on a single-line 'if' statement. Braces will not be<br/>removed if the braced statement contains an 'else'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_if\s*=\s*ignore|mod_full_brace_if\s*=\s*add|mod_full_brace_if\s*=\s*remove|mod_full_brace_if\s*=\s*force|mod_full_brace_if\s*=\s*not_defined
+Choices=mod_full_brace_if=ignore|mod_full_brace_if=add|mod_full_brace_if=remove|mod_full_brace_if=force|mod_full_brace_if=not_defined
+ChoicesRegex=mod_full_brace_if\s*=\s*ignore|mod_full_brace_if\s*=\s*add|mod_full_brace_if\s*=\s*remove|mod_full_brace_if\s*=\s*force|mod_full_brace_if\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace If|Add Mod Full Brace If|Remove Mod Full Brace If|Force Mod Full Brace If"
 ValueDefault=ignore
 
@@ -6781,7 +7538,8 @@ Category=9
 Description="<html>Whether to enforce that all blocks of an 'if'/'else if'/'else' chain either<br/>have, or do not have, braces. Overrides mod_full_brace_if.<br/><br/>0: Don't override mod_full_brace_if<br/>1: Add braces to all blocks if any block needs braces and remove braces if<br/>   they can be removed from all blocks<br/>2: Add braces to all blocks if any block already has braces, regardless of<br/>   whether it needs them<br/>3: Add braces to all blocks if any block needs braces and remove braces if<br/>   they can be removed from all blocks, except if all blocks have braces<br/>   despite none needing them</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_full_brace_if_chain\s*=\s*"
+CallName="mod_full_brace_if_chain="
+CallNameRegex="mod_full_brace_if_chain\s*=\s*"
 MinVal=0
 MaxVal=3
 ValueDefault=0
@@ -6791,7 +7549,8 @@ Category=9
 Description="<html>Whether to add braces to all blocks of an 'if'/'else if'/'else' chain.<br/>If true, mod_full_brace_if_chain will only remove braces from an 'if' that<br/>does not have an 'else if' or 'else'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_brace_if_chain_only\s*=\s*true|mod_full_brace_if_chain_only\s*=\s*false
+TrueFalse=mod_full_brace_if_chain_only=true|mod_full_brace_if_chain_only=false
+TrueFalseRegex=mod_full_brace_if_chain_only\s*=\s*true|mod_full_brace_if_chain_only\s*=\s*false
 ValueDefault=false
 
 [Mod Full Brace While]
@@ -6799,7 +7558,8 @@ Category=9
 Description="<html>Add or remove braces on single-line 'while' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_while\s*=\s*ignore|mod_full_brace_while\s*=\s*add|mod_full_brace_while\s*=\s*remove|mod_full_brace_while\s*=\s*force|mod_full_brace_while\s*=\s*not_defined
+Choices=mod_full_brace_while=ignore|mod_full_brace_while=add|mod_full_brace_while=remove|mod_full_brace_while=force|mod_full_brace_while=not_defined
+ChoicesRegex=mod_full_brace_while\s*=\s*ignore|mod_full_brace_while\s*=\s*add|mod_full_brace_while\s*=\s*remove|mod_full_brace_while\s*=\s*force|mod_full_brace_while\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace While|Add Mod Full Brace While|Remove Mod Full Brace While|Force Mod Full Brace While"
 ValueDefault=ignore
 
@@ -6808,7 +7568,8 @@ Category=9
 Description="<html>Add or remove braces on single-line 'using ()' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_full_brace_using\s*=\s*ignore|mod_full_brace_using\s*=\s*add|mod_full_brace_using\s*=\s*remove|mod_full_brace_using\s*=\s*force|mod_full_brace_using\s*=\s*not_defined
+Choices=mod_full_brace_using=ignore|mod_full_brace_using=add|mod_full_brace_using=remove|mod_full_brace_using=force|mod_full_brace_using=not_defined
+ChoicesRegex=mod_full_brace_using\s*=\s*ignore|mod_full_brace_using\s*=\s*add|mod_full_brace_using\s*=\s*remove|mod_full_brace_using\s*=\s*force|mod_full_brace_using\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Full Brace Using|Add Mod Full Brace Using|Remove Mod Full Brace Using|Force Mod Full Brace Using"
 ValueDefault=ignore
 
@@ -6817,7 +7578,8 @@ Category=9
 Description="<html>Don't remove braces around statements that span N newlines</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_full_brace_nl\s*=\s*"
+CallName="mod_full_brace_nl="
+CallNameRegex="mod_full_brace_nl\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -6827,7 +7589,8 @@ Category=9
 Description="<html>Whether to prevent removal of braces from 'if'/'for'/'while'/etc. blocks<br/>which span multiple lines.<br/><br/>Affects:<br/>  mod_full_brace_for<br/>  mod_full_brace_if<br/>  mod_full_brace_if_chain<br/>  mod_full_brace_if_chain_only<br/>  mod_full_brace_while<br/>  mod_full_brace_using<br/><br/>Does not affect:<br/>  mod_full_brace_do<br/>  mod_full_brace_function</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_brace_nl_block_rem_mlcond\s*=\s*true|mod_full_brace_nl_block_rem_mlcond\s*=\s*false
+TrueFalse=mod_full_brace_nl_block_rem_mlcond=true|mod_full_brace_nl_block_rem_mlcond=false
+TrueFalseRegex=mod_full_brace_nl_block_rem_mlcond\s*=\s*true|mod_full_brace_nl_block_rem_mlcond\s*=\s*false
 ValueDefault=false
 
 [Mod Paren On Return]
@@ -6835,7 +7598,8 @@ Category=9
 Description="<html>Add or remove unnecessary parentheses on 'return' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_paren_on_return\s*=\s*ignore|mod_paren_on_return\s*=\s*add|mod_paren_on_return\s*=\s*remove|mod_paren_on_return\s*=\s*force|mod_paren_on_return\s*=\s*not_defined
+Choices=mod_paren_on_return=ignore|mod_paren_on_return=add|mod_paren_on_return=remove|mod_paren_on_return=force|mod_paren_on_return=not_defined
+ChoicesRegex=mod_paren_on_return\s*=\s*ignore|mod_paren_on_return\s*=\s*add|mod_paren_on_return\s*=\s*remove|mod_paren_on_return\s*=\s*force|mod_paren_on_return\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Paren On Return|Add Mod Paren On Return|Remove Mod Paren On Return|Force Mod Paren On Return"
 ValueDefault=ignore
 
@@ -6844,7 +7608,8 @@ Category=9
 Description="<html>Add or remove unnecessary parentheses on 'throw' statement.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_paren_on_throw\s*=\s*ignore|mod_paren_on_throw\s*=\s*add|mod_paren_on_throw\s*=\s*remove|mod_paren_on_throw\s*=\s*force|mod_paren_on_throw\s*=\s*not_defined
+Choices=mod_paren_on_throw=ignore|mod_paren_on_throw=add|mod_paren_on_throw=remove|mod_paren_on_throw=force|mod_paren_on_throw=not_defined
+ChoicesRegex=mod_paren_on_throw\s*=\s*ignore|mod_paren_on_throw\s*=\s*add|mod_paren_on_throw\s*=\s*remove|mod_paren_on_throw\s*=\s*force|mod_paren_on_throw\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Paren On Throw|Add Mod Paren On Throw|Remove Mod Paren On Throw|Force Mod Paren On Throw"
 ValueDefault=ignore
 
@@ -6853,7 +7618,8 @@ Category=9
 Description="<html>(Pawn) Whether to change optional semicolons to real semicolons.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_pawn_semicolon\s*=\s*true|mod_pawn_semicolon\s*=\s*false
+TrueFalse=mod_pawn_semicolon=true|mod_pawn_semicolon=false
+TrueFalseRegex=mod_pawn_semicolon\s*=\s*true|mod_pawn_semicolon\s*=\s*false
 ValueDefault=false
 
 [Mod Full Paren If Bool]
@@ -6861,7 +7627,8 @@ Category=9
 Description="<html>Whether to fully parenthesize Boolean expressions in 'while' and 'if'<br/>statement, as in 'if (a &amp;&amp; b &gt; c)' =&gt; 'if (a &amp;&amp; (b &gt; c))'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_paren_if_bool\s*=\s*true|mod_full_paren_if_bool\s*=\s*false
+TrueFalse=mod_full_paren_if_bool=true|mod_full_paren_if_bool=false
+TrueFalseRegex=mod_full_paren_if_bool\s*=\s*true|mod_full_paren_if_bool\s*=\s*false
 ValueDefault=false
 
 [Mod Full Paren Assign Bool]
@@ -6869,7 +7636,8 @@ Category=9
 Description="<html>Whether to fully parenthesize Boolean expressions after '='<br/>statement, as in 'x = a &amp;&amp; b &gt; c;' =&gt; 'x = (a &amp;&amp; (b &gt; c));'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_paren_assign_bool\s*=\s*true|mod_full_paren_assign_bool\s*=\s*false
+TrueFalse=mod_full_paren_assign_bool=true|mod_full_paren_assign_bool=false
+TrueFalseRegex=mod_full_paren_assign_bool\s*=\s*true|mod_full_paren_assign_bool\s*=\s*false
 ValueDefault=false
 
 [Mod Full Paren Return Bool]
@@ -6877,7 +7645,8 @@ Category=9
 Description="<html>Whether to fully parenthesize Boolean expressions after '='<br/>statement, as in 'return  a &amp;&amp; b &gt; c;' =&gt; 'return (a &amp;&amp; (b &gt; c));'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_full_paren_return_bool\s*=\s*true|mod_full_paren_return_bool\s*=\s*false
+TrueFalse=mod_full_paren_return_bool=true|mod_full_paren_return_bool=false
+TrueFalseRegex=mod_full_paren_return_bool\s*=\s*true|mod_full_paren_return_bool\s*=\s*false
 ValueDefault=false
 
 [Mod Remove Extra Semicolon]
@@ -6885,7 +7654,8 @@ Category=9
 Description="<html>Whether to remove superfluous semicolons.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_remove_extra_semicolon\s*=\s*true|mod_remove_extra_semicolon\s*=\s*false
+TrueFalse=mod_remove_extra_semicolon=true|mod_remove_extra_semicolon=false
+TrueFalseRegex=mod_remove_extra_semicolon\s*=\s*true|mod_remove_extra_semicolon\s*=\s*false
 ValueDefault=false
 
 [Mod Remove Duplicate Include]
@@ -6893,7 +7663,8 @@ Category=9
 Description="<html>Whether to remove duplicate include.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_remove_duplicate_include\s*=\s*true|mod_remove_duplicate_include\s*=\s*false
+TrueFalse=mod_remove_duplicate_include=true|mod_remove_duplicate_include=false
+TrueFalseRegex=mod_remove_duplicate_include\s*=\s*true|mod_remove_duplicate_include\s*=\s*false
 ValueDefault=false
 
 [Mod Add Force C Closebrace Comment]
@@ -6901,7 +7672,8 @@ Category=9
 Description="<html>the following options (mod_XX_closebrace_comment) use different comment,<br/>depending of the setting of the next option.<br/>false: Use the c comment (default)<br/>true : Use the cpp comment</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_add_force_c_closebrace_comment\s*=\s*true|mod_add_force_c_closebrace_comment\s*=\s*false
+TrueFalse=mod_add_force_c_closebrace_comment=true|mod_add_force_c_closebrace_comment=false
+TrueFalseRegex=mod_add_force_c_closebrace_comment\s*=\s*true|mod_add_force_c_closebrace_comment\s*=\s*false
 ValueDefault=false
 
 [Mod Add Long Function Closebrace Comment]
@@ -6909,7 +7681,8 @@ Category=9
 Description="<html>If a function body exceeds the specified number of newlines and doesn't have<br/>a comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_function_closebrace_comment\s*=\s*"
+CallName="mod_add_long_function_closebrace_comment="
+CallNameRegex="mod_add_long_function_closebrace_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6919,7 +7692,8 @@ Category=9
 Description="<html>If a namespace body exceeds the specified number of newlines and doesn't<br/>have a comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_namespace_closebrace_comment\s*=\s*"
+CallName="mod_add_long_namespace_closebrace_comment="
+CallNameRegex="mod_add_long_namespace_closebrace_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6929,7 +7703,8 @@ Category=9
 Description="<html>If a class body exceeds the specified number of newlines and doesn't have a<br/>comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_class_closebrace_comment\s*=\s*"
+CallName="mod_add_long_class_closebrace_comment="
+CallNameRegex="mod_add_long_class_closebrace_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6939,7 +7714,8 @@ Category=9
 Description="<html>If a switch body exceeds the specified number of newlines and doesn't have a<br/>comment after the close brace, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_switch_closebrace_comment\s*=\s*"
+CallName="mod_add_long_switch_closebrace_comment="
+CallNameRegex="mod_add_long_switch_closebrace_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6949,7 +7725,8 @@ Category=9
 Description="<html>If an #ifdef body exceeds the specified number of newlines and doesn't have<br/>a comment after the #endif, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_ifdef_endif_comment\s*=\s*"
+CallName="mod_add_long_ifdef_endif_comment="
+CallNameRegex="mod_add_long_ifdef_endif_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6959,7 +7736,8 @@ Category=9
 Description="<html>If an #ifdef or #else body exceeds the specified number of newlines and<br/>doesn't have a comment after the #else, a comment will be added.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_add_long_ifdef_else_comment\s*=\s*"
+CallName="mod_add_long_ifdef_else_comment="
+CallNameRegex="mod_add_long_ifdef_else_comment\s*=\s*"
 MinVal=0
 MaxVal=255
 ValueDefault=0
@@ -6969,7 +7747,8 @@ Category=9
 Description="<html>Whether to take care of the case by the mod_sort_xx options.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_case_sensitive\s*=\s*true|mod_sort_case_sensitive\s*=\s*false
+TrueFalse=mod_sort_case_sensitive=true|mod_sort_case_sensitive=false
+TrueFalseRegex=mod_sort_case_sensitive\s*=\s*true|mod_sort_case_sensitive\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Import]
@@ -6977,7 +7756,8 @@ Category=9
 Description="<html>Whether to sort consecutive single-line 'import' statements.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_import\s*=\s*true|mod_sort_import\s*=\s*false
+TrueFalse=mod_sort_import=true|mod_sort_import=false
+TrueFalseRegex=mod_sort_import\s*=\s*true|mod_sort_import\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Using]
@@ -6985,7 +7765,8 @@ Category=9
 Description="<html>(C#) Whether to sort consecutive single-line 'using' statements.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_using\s*=\s*true|mod_sort_using\s*=\s*false
+TrueFalse=mod_sort_using=true|mod_sort_using=false
+TrueFalseRegex=mod_sort_using\s*=\s*true|mod_sort_using\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Include]
@@ -6993,7 +7774,8 @@ Category=9
 Description="<html>Whether to sort consecutive single-line '#include' statements (C/C++) and<br/>'#import' statements (Objective-C). Be aware that this has the potential to<br/>break your code if your includes/imports have ordering dependencies.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_include\s*=\s*true|mod_sort_include\s*=\s*false
+TrueFalse=mod_sort_include=true|mod_sort_include=false
+TrueFalseRegex=mod_sort_include\s*=\s*true|mod_sort_include\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Prioritize Filename]
@@ -7001,7 +7783,8 @@ Category=9
 Description="<html>Whether to prioritize '#include' and '#import' statements that contain<br/>filename without extension when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_prioritize_filename\s*=\s*true|mod_sort_incl_import_prioritize_filename\s*=\s*false
+TrueFalse=mod_sort_incl_import_prioritize_filename=true|mod_sort_incl_import_prioritize_filename=false
+TrueFalseRegex=mod_sort_incl_import_prioritize_filename\s*=\s*true|mod_sort_incl_import_prioritize_filename\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Prioritize Extensionless]
@@ -7009,7 +7792,8 @@ Category=9
 Description="<html>Whether to prioritize '#include' and '#import' statements that does not<br/>contain extensions when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_prioritize_extensionless\s*=\s*true|mod_sort_incl_import_prioritize_extensionless\s*=\s*false
+TrueFalse=mod_sort_incl_import_prioritize_extensionless=true|mod_sort_incl_import_prioritize_extensionless=false
+TrueFalseRegex=mod_sort_incl_import_prioritize_extensionless\s*=\s*true|mod_sort_incl_import_prioritize_extensionless\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Prioritize Angle Over Quotes]
@@ -7017,7 +7801,8 @@ Category=9
 Description="<html>Whether to prioritize '#include' and '#import' statements that contain<br/>angle over quotes when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_prioritize_angle_over_quotes\s*=\s*true|mod_sort_incl_import_prioritize_angle_over_quotes\s*=\s*false
+TrueFalse=mod_sort_incl_import_prioritize_angle_over_quotes=true|mod_sort_incl_import_prioritize_angle_over_quotes=false
+TrueFalseRegex=mod_sort_incl_import_prioritize_angle_over_quotes\s*=\s*true|mod_sort_incl_import_prioritize_angle_over_quotes\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Ignore Extension]
@@ -7025,7 +7810,8 @@ Category=9
 Description="<html>Whether to ignore file extension in '#include' and '#import' statements<br/>for sorting comparison.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_ignore_extension\s*=\s*true|mod_sort_incl_import_ignore_extension\s*=\s*false
+TrueFalse=mod_sort_incl_import_ignore_extension=true|mod_sort_incl_import_ignore_extension=false
+TrueFalseRegex=mod_sort_incl_import_ignore_extension\s*=\s*true|mod_sort_incl_import_ignore_extension\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Incl Import Grouping Enabled]
@@ -7033,7 +7819,8 @@ Category=9
 Description="<html>Whether to group '#include' and '#import' statements when sorting is enabled.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_incl_import_grouping_enabled\s*=\s*true|mod_sort_incl_import_grouping_enabled\s*=\s*false
+TrueFalse=mod_sort_incl_import_grouping_enabled=true|mod_sort_incl_import_grouping_enabled=false
+TrueFalseRegex=mod_sort_incl_import_grouping_enabled\s*=\s*true|mod_sort_incl_import_grouping_enabled\s*=\s*false
 ValueDefault=false
 
 [Mod Move Case Break]
@@ -7041,7 +7828,8 @@ Category=9
 Description="<html>Whether to move a 'break' that appears after a fully braced 'case' before<br/>the close brace, as in 'case X: { ... } break;' =&gt; 'case X: { ... break; }'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_move_case_break\s*=\s*true|mod_move_case_break\s*=\s*false
+TrueFalse=mod_move_case_break=true|mod_move_case_break=false
+TrueFalseRegex=mod_move_case_break\s*=\s*true|mod_move_case_break\s*=\s*false
 ValueDefault=false
 
 [Mod Move Case Return]
@@ -7049,7 +7837,8 @@ Category=9
 Description="<html>Whether to move a 'return' that appears after a fully braced 'case' before<br/>the close brace, as in 'case X: { ... } return;' =&gt; 'case X: { ... return; }'.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_move_case_return\s*=\s*true|mod_move_case_return\s*=\s*false
+TrueFalse=mod_move_case_return=true|mod_move_case_return=false
+TrueFalseRegex=mod_move_case_return\s*=\s*true|mod_move_case_return\s*=\s*false
 ValueDefault=false
 
 [Mod Case Brace]
@@ -7057,7 +7846,8 @@ Category=9
 Description="<html>Add or remove braces around a fully braced case statement. Will only remove<br/>braces if there are no variable declarations in the block.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_case_brace\s*=\s*ignore|mod_case_brace\s*=\s*add|mod_case_brace\s*=\s*remove|mod_case_brace\s*=\s*force|mod_case_brace\s*=\s*not_defined
+Choices=mod_case_brace=ignore|mod_case_brace=add|mod_case_brace=remove|mod_case_brace=force|mod_case_brace=not_defined
+ChoicesRegex=mod_case_brace\s*=\s*ignore|mod_case_brace\s*=\s*add|mod_case_brace\s*=\s*remove|mod_case_brace\s*=\s*force|mod_case_brace\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Case Brace|Add Mod Case Brace|Remove Mod Case Brace|Force Mod Case Brace"
 ValueDefault=ignore
 
@@ -7066,7 +7856,8 @@ Category=9
 Description="<html>Whether to remove a void 'return;' that appears as the last statement in a<br/>function.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_remove_empty_return\s*=\s*true|mod_remove_empty_return\s*=\s*false
+TrueFalse=mod_remove_empty_return=true|mod_remove_empty_return=false
+TrueFalseRegex=mod_remove_empty_return\s*=\s*true|mod_remove_empty_return\s*=\s*false
 ValueDefault=false
 
 [Mod Enum Last Comma]
@@ -7074,7 +7865,8 @@ Category=9
 Description="<html>Add or remove the comma after the last value of an enumeration.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_enum_last_comma\s*=\s*ignore|mod_enum_last_comma\s*=\s*add|mod_enum_last_comma\s*=\s*remove|mod_enum_last_comma\s*=\s*force|mod_enum_last_comma\s*=\s*not_defined
+Choices=mod_enum_last_comma=ignore|mod_enum_last_comma=add|mod_enum_last_comma=remove|mod_enum_last_comma=force|mod_enum_last_comma=not_defined
+ChoicesRegex=mod_enum_last_comma\s*=\s*ignore|mod_enum_last_comma\s*=\s*add|mod_enum_last_comma\s*=\s*remove|mod_enum_last_comma\s*=\s*force|mod_enum_last_comma\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Enum Last Comma|Add Mod Enum Last Comma|Remove Mod Enum Last Comma|Force Mod Enum Last Comma"
 ValueDefault=ignore
 
@@ -7083,7 +7875,8 @@ Category=9
 Description="<html>Syntax to use for infinite loops.<br/><br/>0: Leave syntax alone (default)<br/>1: Rewrite as `for(;;)`<br/>2: Rewrite as `while(true)`<br/>3: Rewrite as `do`...`while(true);`<br/>4: Rewrite as `while`<br/>5: Rewrite as `do`...`while;`<br/><br/>Infinite loops that do not already match one of these syntaxes are ignored.<br/>Other options that affect loop formatting will be applied after transforming<br/>the syntax.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_infinite_loop\s*=\s*"
+CallName="mod_infinite_loop="
+CallNameRegex="mod_infinite_loop\s*=\s*"
 MinVal=0
 MaxVal=5
 ValueDefault=0
@@ -7093,7 +7886,8 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'int short'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_int_short\s*=\s*ignore|mod_int_short\s*=\s*add|mod_int_short\s*=\s*remove|mod_int_short\s*=\s*force|mod_int_short\s*=\s*not_defined
+Choices=mod_int_short=ignore|mod_int_short=add|mod_int_short=remove|mod_int_short=force|mod_int_short=not_defined
+ChoicesRegex=mod_int_short\s*=\s*ignore|mod_int_short\s*=\s*add|mod_int_short\s*=\s*remove|mod_int_short\s*=\s*force|mod_int_short\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Int Short|Add Mod Int Short|Remove Mod Int Short|Force Mod Int Short"
 ValueDefault=ignore
 
@@ -7102,7 +7896,8 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'short int'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_short_int\s*=\s*ignore|mod_short_int\s*=\s*add|mod_short_int\s*=\s*remove|mod_short_int\s*=\s*force|mod_short_int\s*=\s*not_defined
+Choices=mod_short_int=ignore|mod_short_int=add|mod_short_int=remove|mod_short_int=force|mod_short_int=not_defined
+ChoicesRegex=mod_short_int\s*=\s*ignore|mod_short_int\s*=\s*add|mod_short_int\s*=\s*remove|mod_short_int\s*=\s*force|mod_short_int\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Short Int|Add Mod Short Int|Remove Mod Short Int|Force Mod Short Int"
 ValueDefault=ignore
 
@@ -7111,7 +7906,8 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'int long'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_int_long\s*=\s*ignore|mod_int_long\s*=\s*add|mod_int_long\s*=\s*remove|mod_int_long\s*=\s*force|mod_int_long\s*=\s*not_defined
+Choices=mod_int_long=ignore|mod_int_long=add|mod_int_long=remove|mod_int_long=force|mod_int_long=not_defined
+ChoicesRegex=mod_int_long\s*=\s*ignore|mod_int_long\s*=\s*add|mod_int_long\s*=\s*remove|mod_int_long\s*=\s*force|mod_int_long\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Int Long|Add Mod Int Long|Remove Mod Int Long|Force Mod Int Long"
 ValueDefault=ignore
 
@@ -7120,7 +7916,8 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'long int'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_long_int\s*=\s*ignore|mod_long_int\s*=\s*add|mod_long_int\s*=\s*remove|mod_long_int\s*=\s*force|mod_long_int\s*=\s*not_defined
+Choices=mod_long_int=ignore|mod_long_int=add|mod_long_int=remove|mod_long_int=force|mod_long_int=not_defined
+ChoicesRegex=mod_long_int\s*=\s*ignore|mod_long_int\s*=\s*add|mod_long_int\s*=\s*remove|mod_long_int\s*=\s*force|mod_long_int\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Long Int|Add Mod Long Int|Remove Mod Long Int|Force Mod Long Int"
 ValueDefault=ignore
 
@@ -7129,7 +7926,8 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'int signed'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_int_signed\s*=\s*ignore|mod_int_signed\s*=\s*add|mod_int_signed\s*=\s*remove|mod_int_signed\s*=\s*force|mod_int_signed\s*=\s*not_defined
+Choices=mod_int_signed=ignore|mod_int_signed=add|mod_int_signed=remove|mod_int_signed=force|mod_int_signed=not_defined
+ChoicesRegex=mod_int_signed\s*=\s*ignore|mod_int_signed\s*=\s*add|mod_int_signed\s*=\s*remove|mod_int_signed\s*=\s*force|mod_int_signed\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Int Signed|Add Mod Int Signed|Remove Mod Int Signed|Force Mod Int Signed"
 ValueDefault=ignore
 
@@ -7138,7 +7936,8 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'signed int'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_signed_int\s*=\s*ignore|mod_signed_int\s*=\s*add|mod_signed_int\s*=\s*remove|mod_signed_int\s*=\s*force|mod_signed_int\s*=\s*not_defined
+Choices=mod_signed_int=ignore|mod_signed_int=add|mod_signed_int=remove|mod_signed_int=force|mod_signed_int=not_defined
+ChoicesRegex=mod_signed_int\s*=\s*ignore|mod_signed_int\s*=\s*add|mod_signed_int\s*=\s*remove|mod_signed_int\s*=\s*force|mod_signed_int\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Signed Int|Add Mod Signed Int|Remove Mod Signed Int|Force Mod Signed Int"
 ValueDefault=ignore
 
@@ -7147,7 +7946,8 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'int unsigned'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_int_unsigned\s*=\s*ignore|mod_int_unsigned\s*=\s*add|mod_int_unsigned\s*=\s*remove|mod_int_unsigned\s*=\s*force|mod_int_unsigned\s*=\s*not_defined
+Choices=mod_int_unsigned=ignore|mod_int_unsigned=add|mod_int_unsigned=remove|mod_int_unsigned=force|mod_int_unsigned=not_defined
+ChoicesRegex=mod_int_unsigned\s*=\s*ignore|mod_int_unsigned\s*=\s*add|mod_int_unsigned\s*=\s*remove|mod_int_unsigned\s*=\s*force|mod_int_unsigned\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Int Unsigned|Add Mod Int Unsigned|Remove Mod Int Unsigned|Force Mod Int Unsigned"
 ValueDefault=ignore
 
@@ -7156,7 +7956,8 @@ Category=9
 Description="<html>Add or remove the 'int' keyword in 'unsigned int'.</html>"
 Enabled=false
 EditorType=multiple
-Choices=mod_unsigned_int\s*=\s*ignore|mod_unsigned_int\s*=\s*add|mod_unsigned_int\s*=\s*remove|mod_unsigned_int\s*=\s*force|mod_unsigned_int\s*=\s*not_defined
+Choices=mod_unsigned_int=ignore|mod_unsigned_int=add|mod_unsigned_int=remove|mod_unsigned_int=force|mod_unsigned_int=not_defined
+ChoicesRegex=mod_unsigned_int\s*=\s*ignore|mod_unsigned_int\s*=\s*add|mod_unsigned_int\s*=\s*remove|mod_unsigned_int\s*=\s*force|mod_unsigned_int\s*=\s*not_defined
 ChoicesReadable="Ignore Mod Unsigned Int|Add Mod Unsigned Int|Remove Mod Unsigned Int|Force Mod Unsigned Int"
 ValueDefault=ignore
 
@@ -7165,7 +7966,8 @@ Category=9
 Description="<html>If there is a situation where mod_int_* and mod_*_int would result in<br/>multiple int keywords, whether to keep the rightmost int (the default) or the<br/>leftmost int.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_int_prefer_int_on_left\s*=\s*true|mod_int_prefer_int_on_left\s*=\s*false
+TrueFalse=mod_int_prefer_int_on_left=true|mod_int_prefer_int_on_left=false
+TrueFalseRegex=mod_int_prefer_int_on_left\s*=\s*true|mod_int_prefer_int_on_left\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Oc Properties]
@@ -7173,7 +7975,8 @@ Category=9
 Description="<html>(OC) Whether to organize the properties. If true, properties will be<br/>rearranged according to the mod_sort_oc_property_*_weight factors.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=mod_sort_oc_properties\s*=\s*true|mod_sort_oc_properties\s*=\s*false
+TrueFalse=mod_sort_oc_properties=true|mod_sort_oc_properties=false
+TrueFalseRegex=mod_sort_oc_properties\s*=\s*true|mod_sort_oc_properties\s*=\s*false
 ValueDefault=false
 
 [Mod Sort Oc Property Class Weight]
@@ -7181,7 +7984,8 @@ Category=9
 Description="<html>(OC) Weight of a class property modifier.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_class_weight\s*=\s*"
+CallName="mod_sort_oc_property_class_weight="
+CallNameRegex="mod_sort_oc_property_class_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7191,7 +7995,8 @@ Category=9
 Description="<html>(OC) Weight of 'atomic' and 'nonatomic'.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_thread_safe_weight\s*=\s*"
+CallName="mod_sort_oc_property_thread_safe_weight="
+CallNameRegex="mod_sort_oc_property_thread_safe_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7201,7 +8006,8 @@ Category=9
 Description="<html>(OC) Weight of 'readwrite' when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_readwrite_weight\s*=\s*"
+CallName="mod_sort_oc_property_readwrite_weight="
+CallNameRegex="mod_sort_oc_property_readwrite_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7211,7 +8017,8 @@ Category=9
 Description="<html>(OC) Weight of a reference type specifier ('retain', 'copy', 'assign',<br/>'weak', 'strong') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_reference_weight\s*=\s*"
+CallName="mod_sort_oc_property_reference_weight="
+CallNameRegex="mod_sort_oc_property_reference_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7221,7 +8028,8 @@ Category=9
 Description="<html>(OC) Weight of getter type ('getter=') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_getter_weight\s*=\s*"
+CallName="mod_sort_oc_property_getter_weight="
+CallNameRegex="mod_sort_oc_property_getter_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7231,7 +8039,8 @@ Category=9
 Description="<html>(OC) Weight of setter type ('setter=') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_setter_weight\s*=\s*"
+CallName="mod_sort_oc_property_setter_weight="
+CallNameRegex="mod_sort_oc_property_setter_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7241,7 +8050,8 @@ Category=9
 Description="<html>(OC) Weight of nullability type ('nullable', 'nonnull', 'null_unspecified',<br/>'null_resettable') when organizing properties.</html>"
 Enabled=false
 EditorType=numeric
-CallName="mod_sort_oc_property_nullability_weight\s*=\s*"
+CallName="mod_sort_oc_property_nullability_weight="
+CallNameRegex="mod_sort_oc_property_nullability_weight\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7251,7 +8061,8 @@ Category=10
 Description="<html>How to use tabs when indenting preprocessor code.<br/><br/>-1: Use 'indent_with_tabs' setting (default)<br/> 0: Spaces only<br/> 1: Indent with tabs to brace level, align with spaces<br/> 2: Indent and align with tabs, using spaces when not on a tabstop<br/><br/>Default: -1</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_with_tabs\s*=\s*"
+CallName="pp_indent_with_tabs="
+CallNameRegex="pp_indent_with_tabs\s*=\s*"
 MinVal=-1
 MaxVal=2
 ValueDefault=-1
@@ -7261,7 +8072,8 @@ Category=10
 Description="<html>Add or remove indentation of preprocessor directives inside #if blocks<br/>at brace level 0 (file-level).</html>"
 Enabled=false
 EditorType=multiple
-Choices=pp_indent\s*=\s*ignore|pp_indent\s*=\s*add|pp_indent\s*=\s*remove|pp_indent\s*=\s*force|pp_indent\s*=\s*not_defined
+Choices=pp_indent=ignore|pp_indent=add|pp_indent=remove|pp_indent=force|pp_indent=not_defined
+ChoicesRegex=pp_indent\s*=\s*ignore|pp_indent\s*=\s*add|pp_indent\s*=\s*remove|pp_indent\s*=\s*force|pp_indent\s*=\s*not_defined
 ChoicesReadable="Ignore Pp Indent|Add Pp Indent|Remove Pp Indent|Force Pp Indent"
 ValueDefault=ignore
 
@@ -7270,7 +8082,8 @@ Category=10
 Description="<html>Whether to indent #if/#else/#endif at the brace level. If false, these are<br/>indented from column 1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_at_level\s*=\s*true|pp_indent_at_level\s*=\s*false
+TrueFalse=pp_indent_at_level=true|pp_indent_at_level=false
+TrueFalseRegex=pp_indent_at_level\s*=\s*true|pp_indent_at_level\s*=\s*false
 ValueDefault=false
 
 [Pp Indent At Level0]
@@ -7278,7 +8091,8 @@ Category=10
 Description="<html>Whether to indent #if/#else/#endif at the parenthesis level if the brace<br/>level is 0. If false, these are indented from column 1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_at_level0\s*=\s*true|pp_indent_at_level0\s*=\s*false
+TrueFalse=pp_indent_at_level0=true|pp_indent_at_level0=false
+TrueFalseRegex=pp_indent_at_level0\s*=\s*true|pp_indent_at_level0\s*=\s*false
 ValueDefault=false
 
 [Pp Indent Count]
@@ -7286,7 +8100,8 @@ Category=10
 Description="<html>Specifies the number of columns to indent preprocessors per level<br/>at brace level 0 (file-level). If pp_indent_at_level=false, also specifies<br/>the number of columns to indent preprocessors per level<br/>at brace level &gt; 0 (function-level).<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_count\s*=\s*"
+CallName="pp_indent_count="
+CallNameRegex="pp_indent_count\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=1
@@ -7296,7 +8111,8 @@ Category=10
 Description="<html>Add or remove space after # based on pp level of #if blocks.</html>"
 Enabled=false
 EditorType=multiple
-Choices=pp_space_after\s*=\s*ignore|pp_space_after\s*=\s*add|pp_space_after\s*=\s*remove|pp_space_after\s*=\s*force|pp_space_after\s*=\s*not_defined
+Choices=pp_space_after=ignore|pp_space_after=add|pp_space_after=remove|pp_space_after=force|pp_space_after=not_defined
+ChoicesRegex=pp_space_after\s*=\s*ignore|pp_space_after\s*=\s*add|pp_space_after\s*=\s*remove|pp_space_after\s*=\s*force|pp_space_after\s*=\s*not_defined
 ChoicesReadable="Ignore Pp Space After|Add Pp Space After|Remove Pp Space After|Force Pp Space After"
 ValueDefault=ignore
 
@@ -7305,7 +8121,8 @@ Category=10
 Description="<html>Sets the number of spaces per level added with pp_space_after.</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_space_count\s*=\s*"
+CallName="pp_space_count="
+CallNameRegex="pp_space_count\s*=\s*"
 MinVal=0
 MaxVal=16
 ValueDefault=0
@@ -7315,7 +8132,8 @@ Category=10
 Description="<html>The indent for '#region' and '#endregion' in C# and '#pragma region' in<br/>C/C++. Negative values decrease indent down to the first column.</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_region\s*=\s*"
+CallName="pp_indent_region="
+CallNameRegex="pp_indent_region\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -7325,7 +8143,8 @@ Category=10
 Description="<html>Whether to indent the code between #region and #endregion.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_region_indent_code\s*=\s*true|pp_region_indent_code\s*=\s*false
+TrueFalse=pp_region_indent_code=true|pp_region_indent_code=false
+TrueFalseRegex=pp_region_indent_code\s*=\s*true|pp_region_indent_code\s*=\s*false
 ValueDefault=false
 
 [Pp Indent If]
@@ -7333,7 +8152,8 @@ Category=10
 Description="<html>If pp_indent_at_level=true, sets the indent for #if, #else and #endif when<br/>not at file-level. Negative values decrease indent down to the first column.<br/><br/>=0: Indent preprocessors using output_tab_size<br/>&gt;0: Column at which all preprocessors will be indented</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_if\s*=\s*"
+CallName="pp_indent_if="
+CallNameRegex="pp_indent_if\s*=\s*"
 MinVal=-16
 MaxVal=16
 ValueDefault=0
@@ -7343,7 +8163,8 @@ Category=10
 Description="<html>Whether to indent the code between #if, #else and #endif.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_if_indent_code\s*=\s*true|pp_if_indent_code\s*=\s*false
+TrueFalse=pp_if_indent_code=true|pp_if_indent_code=false
+TrueFalseRegex=pp_if_indent_code\s*=\s*true|pp_if_indent_code\s*=\s*false
 ValueDefault=false
 
 [Pp Indent In Guard]
@@ -7351,7 +8172,8 @@ Category=10
 Description="<html>Whether to indent the body of an #if that encompasses all the code in the file.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_in_guard\s*=\s*true|pp_indent_in_guard\s*=\s*false
+TrueFalse=pp_indent_in_guard=true|pp_indent_in_guard=false
+TrueFalseRegex=pp_indent_in_guard\s*=\s*true|pp_indent_in_guard\s*=\s*false
 ValueDefault=false
 
 [Pp Define At Level]
@@ -7359,7 +8181,8 @@ Category=10
 Description="<html>Whether to indent '#define' at the brace level. If false, these are<br/>indented from column 1.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_define_at_level\s*=\s*true|pp_define_at_level\s*=\s*false
+TrueFalse=pp_define_at_level=true|pp_define_at_level=false
+TrueFalseRegex=pp_define_at_level\s*=\s*true|pp_define_at_level\s*=\s*false
 ValueDefault=false
 
 [Pp Include At Level]
@@ -7367,7 +8190,8 @@ Category=10
 Description="<html>Whether to indent '#include' at the brace level.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_include_at_level\s*=\s*true|pp_include_at_level\s*=\s*false
+TrueFalse=pp_include_at_level=true|pp_include_at_level=false
+TrueFalseRegex=pp_include_at_level\s*=\s*true|pp_include_at_level\s*=\s*false
 ValueDefault=false
 
 [Pp Ignore Define Body]
@@ -7375,7 +8199,8 @@ Category=10
 Description="<html>Whether to ignore the '#define' body while formatting.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_ignore_define_body\s*=\s*true|pp_ignore_define_body\s*=\s*false
+TrueFalse=pp_ignore_define_body=true|pp_ignore_define_body=false
+TrueFalseRegex=pp_ignore_define_body\s*=\s*true|pp_ignore_define_body\s*=\s*false
 ValueDefault=false
 
 [Pp Multiline Define Body Indent]
@@ -7383,7 +8208,8 @@ Category=10
 Description="<html>An offset value that controls the indentation of the body of a multiline #define.<br/>'body' refers to all the lines of a multiline #define except the first line.<br/>Requires 'pp_ignore_define_body = false'.<br/><br/> &lt;0: Absolute column: the body indentation starts off at the specified column<br/>     (ex. -3 ==&gt; the body is indented starting from column 3)<br/>&gt;=0: Relative to the column of the '#' of '#define'<br/>     (ex.  3 ==&gt; the body is indented starting 3 columns at the right of '#')<br/><br/>Default: 8</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_multiline_define_body_indent\s*=\s*"
+CallName="pp_multiline_define_body_indent="
+CallNameRegex="pp_multiline_define_body_indent\s*=\s*"
 MinVal=-32
 MaxVal=32
 ValueDefault=8
@@ -7393,7 +8219,8 @@ Category=10
 Description="<html>Whether to indent case statements between #if, #else, and #endif.<br/>Only applies to the indent of the preprocessor that the case statements<br/>directly inside of.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_case\s*=\s*true|pp_indent_case\s*=\s*false
+TrueFalse=pp_indent_case=true|pp_indent_case=false
+TrueFalseRegex=pp_indent_case\s*=\s*true|pp_indent_case\s*=\s*false
 ValueDefault=true
 
 [Pp Indent Func Def]
@@ -7401,7 +8228,8 @@ Category=10
 Description="<html>Whether to indent whole function definitions between #if, #else, and #endif.<br/>Only applies to the indent of the preprocessor that the function definition<br/>is directly inside of.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_func_def\s*=\s*true|pp_indent_func_def\s*=\s*false
+TrueFalse=pp_indent_func_def=true|pp_indent_func_def=false
+TrueFalseRegex=pp_indent_func_def\s*=\s*true|pp_indent_func_def\s*=\s*false
 ValueDefault=true
 
 [Pp Indent Extern]
@@ -7409,7 +8237,8 @@ Category=10
 Description="<html>Whether to indent extern C blocks between #if, #else, and #endif.<br/>Only applies to the indent of the preprocessor that the extern block is<br/>directly inside of.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_indent_extern\s*=\s*true|pp_indent_extern\s*=\s*false
+TrueFalse=pp_indent_extern=true|pp_indent_extern=false
+TrueFalseRegex=pp_indent_extern\s*=\s*true|pp_indent_extern\s*=\s*false
 ValueDefault=true
 
 [Pp Indent Brace]
@@ -7417,7 +8246,8 @@ Category=10
 Description="<html>How to indent braces directly inside #if, #else, and #endif.<br/>Requires pp_if_indent_code=true and only applies to the indent of the<br/>preprocessor that the braces are directly inside of.<br/> 0: No extra indent<br/> 1: Indent by one level<br/>-1: Preserve original indentation<br/><br/>Default: 1</html>"
 Enabled=false
 EditorType=numeric
-CallName="pp_indent_brace\s*=\s*"
+CallName="pp_indent_brace="
+CallNameRegex="pp_indent_brace\s*=\s*"
 MinVal=-1
 MaxVal=1
 ValueDefault=1
@@ -7427,14 +8257,16 @@ Category=10
 Description="<html>Whether to print warning messages for unbalanced #if and #else blocks.<br/>This will print a message in the following cases:<br/>- if an #ifdef block ends on a different indent level than<br/>  where it started from. Example:<br/><br/>   #ifdef TEST<br/>     int i;<br/>     {<br/>       int j;<br/>   #endif<br/><br/>- an #elif/#else block ends on a different indent level than<br/>  the corresponding #ifdef block. Example:<br/><br/>   #ifdef TEST<br/>       int i;<br/>   #else<br/>       }<br/>     int j;<br/>   #endif</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=pp_warn_unbalanced_if\s*=\s*true|pp_warn_unbalanced_if\s*=\s*false
+TrueFalse=pp_warn_unbalanced_if=true|pp_warn_unbalanced_if=false
+TrueFalseRegex=pp_warn_unbalanced_if\s*=\s*true|pp_warn_unbalanced_if\s*=\s*false
 ValueDefault=false
 
 [Include Category 0]
 Category=11
 Description="<html>The regex for include category with priority 0.</html>"
 Enabled=false
-CallName=include_category_0\s*=\s*
+CallName=include_category_0=
+CallNameRegex=include_category_0\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -7442,7 +8274,8 @@ ValueDefault=
 Category=11
 Description="<html>The regex for include category with priority 1.</html>"
 Enabled=false
-CallName=include_category_1\s*=\s*
+CallName=include_category_1=
+CallNameRegex=include_category_1\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -7450,7 +8283,8 @@ ValueDefault=
 Category=11
 Description="<html>The regex for include category with priority 2.</html>"
 Enabled=false
-CallName=include_category_2\s*=\s*
+CallName=include_category_2=
+CallNameRegex=include_category_2\s*=\s*
 EditorType=string
 ValueDefault=
 
@@ -7459,7 +8293,8 @@ Category=12
 Description="<html>true:  indent_func_call_param will be used (default)<br/>false: indent_func_call_param will NOT be used<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_indent_func_call_param\s*=\s*true|use_indent_func_call_param\s*=\s*false
+TrueFalse=use_indent_func_call_param=true|use_indent_func_call_param=false
+TrueFalseRegex=use_indent_func_call_param\s*=\s*true|use_indent_func_call_param\s*=\s*false
 ValueDefault=true
 
 [Use Indent Continue Only Once]
@@ -7467,7 +8302,8 @@ Category=12
 Description="<html>The value of the indentation for a continuation line is calculated<br/>differently if the statement is:<br/>- a declaration: your case with QString fileName ...<br/>- an assignment: your case with pSettings = new QSettings( ...<br/><br/>At the second case the indentation value might be used twice:<br/>- at the assignment<br/>- at the function call (if present)<br/><br/>To prevent the double use of the indentation value, use this option with the<br/>value 'true'.<br/><br/>true:  indent_continue will be used only once<br/>false: indent_continue will be used every time (default)<br/><br/>Requires indent_ignore_first_continue=false.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_indent_continue_only_once\s*=\s*true|use_indent_continue_only_once\s*=\s*false
+TrueFalse=use_indent_continue_only_once=true|use_indent_continue_only_once=false
+TrueFalseRegex=use_indent_continue_only_once\s*=\s*true|use_indent_continue_only_once\s*=\s*false
 ValueDefault=false
 
 [Indent Cpp Lambda Only Once]
@@ -7475,7 +8311,8 @@ Category=12
 Description="<html>The indentation can be:<br/>- after the assignment, at the '[' character<br/>- at the beginning of the lambda body<br/><br/>true:  indentation will be at the beginning of the lambda body<br/>false: indentation will be after the assignment (default)</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=indent_cpp_lambda_only_once\s*=\s*true|indent_cpp_lambda_only_once\s*=\s*false
+TrueFalse=indent_cpp_lambda_only_once=true|indent_cpp_lambda_only_once=false
+TrueFalseRegex=indent_cpp_lambda_only_once\s*=\s*true|indent_cpp_lambda_only_once\s*=\s*false
 ValueDefault=false
 
 [Use Sp After Angle Always]
@@ -7483,7 +8320,8 @@ Category=12
 Description="<html>Whether sp_after_angle takes precedence over sp_inside_fparen. This was the<br/>historic behavior, but is probably not the desired behavior, so this is off<br/>by default.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_sp_after_angle_always\s*=\s*true|use_sp_after_angle_always\s*=\s*false
+TrueFalse=use_sp_after_angle_always=true|use_sp_after_angle_always=false
+TrueFalseRegex=use_sp_after_angle_always\s*=\s*true|use_sp_after_angle_always\s*=\s*false
 ValueDefault=false
 
 [Use Options Overriding For Qt Macros]
@@ -7491,7 +8329,8 @@ Category=12
 Description="<html>Whether to apply special formatting for Qt SIGNAL/SLOT macros. Essentially,<br/>this tries to format these so that they match Qt's normalized form (i.e. the<br/>result of QMetaObject::normalizedSignature), which can slightly improve the<br/>performance of the QObject::connect call, rather than how they would<br/>otherwise be formatted.<br/><br/>See options_for_QT.cpp for details.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_options_overriding_for_qt_macros\s*=\s*true|use_options_overriding_for_qt_macros\s*=\s*false
+TrueFalse=use_options_overriding_for_qt_macros=true|use_options_overriding_for_qt_macros=false
+TrueFalseRegex=use_options_overriding_for_qt_macros\s*=\s*true|use_options_overriding_for_qt_macros\s*=\s*false
 ValueDefault=true
 
 [Use Form Feed No More As Whitespace Character]
@@ -7499,7 +8338,8 @@ Category=12
 Description="<html>If true: the form feed character is removed from the list of whitespace<br/>characters. See https://en.cppreference.com/w/cpp/string/byte/isspace.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=use_form_feed_no_more_as_whitespace_character\s*=\s*true|use_form_feed_no_more_as_whitespace_character\s*=\s*false
+TrueFalse=use_form_feed_no_more_as_whitespace_character=true|use_form_feed_no_more_as_whitespace_character=false
+TrueFalseRegex=use_form_feed_no_more_as_whitespace_character\s*=\s*true|use_form_feed_no_more_as_whitespace_character\s*=\s*false
 ValueDefault=false
 
 [Warn Level Tabs Found In Verbatim String Literals]
@@ -7507,7 +8347,8 @@ Category=13
 Description="<html>(C#) Warning is given if doing tab-to-\t replacement and we have found one<br/>in a C# verbatim string literal.<br/><br/>Default: 2</html>"
 Enabled=false
 EditorType=numeric
-CallName="warn_level_tabs_found_in_verbatim_string_literals\s*=\s*"
+CallName="warn_level_tabs_found_in_verbatim_string_literals="
+CallNameRegex="warn_level_tabs_found_in_verbatim_string_literals\s*=\s*"
 MinVal=1
 MaxVal=3
 ValueDefault=2
@@ -7517,7 +8358,8 @@ Category=13
 Description="<html>Limit the number of loops.<br/>Used by uncrustify.cpp to exit from infinite loop.<br/>0: no limit.</html>"
 Enabled=false
 EditorType=numeric
-CallName="debug_max_number_of_loops\s*=\s*"
+CallName="debug_max_number_of_loops="
+CallNameRegex="debug_max_number_of_loops\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7527,7 +8369,8 @@ Category=13
 Description="<html>Set the number of the line to protocol;<br/>Used in the function prot_the_line if the 2. parameter is zero.<br/>0: nothing protocol.</html>"
 Enabled=false
 EditorType=numeric
-CallName="debug_line_number_to_protocol\s*=\s*"
+CallName="debug_line_number_to_protocol="
+CallNameRegex="debug_line_number_to_protocol\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7537,7 +8380,8 @@ Category=13
 Description="<html>Set the number of second(s) before terminating formatting the current file,<br/>0: no timeout.<br/>only for linux</html>"
 Enabled=false
 EditorType=numeric
-CallName="debug_timeout\s*=\s*"
+CallName="debug_timeout="
+CallNameRegex="debug_timeout\s*=\s*"
 MinVal=
 MaxVal=
 ValueDefault=0
@@ -7547,7 +8391,8 @@ Category=13
 Description="<html>Set the number of characters to be printed if the text is too long,<br/>0: do not truncate.</html>"
 Enabled=false
 EditorType=numeric
-CallName="debug_truncate\s*=\s*"
+CallName="debug_truncate="
+CallNameRegex="debug_truncate\s*=\s*"
 MinVal=0
 MaxVal=960
 ValueDefault=0
@@ -7557,7 +8402,8 @@ Category=13
 Description="<html>sort (or not) the tracking info.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=debug_sort_the_tracks\s*=\s*true|debug_sort_the_tracks\s*=\s*false
+TrueFalse=debug_sort_the_tracks=true|debug_sort_the_tracks=false
+TrueFalseRegex=debug_sort_the_tracks\s*=\s*true|debug_sort_the_tracks\s*=\s*false
 ValueDefault=true
 
 [Debug Decode The Flags]
@@ -7565,7 +8411,8 @@ Category=13
 Description="<html>decode (or not) the flags as a new line.<br/>only if the -p option is set.</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=debug_decode_the_flags\s*=\s*true|debug_decode_the_flags\s*=\s*false
+TrueFalse=debug_decode_the_flags=true|debug_decode_the_flags=false
+TrueFalseRegex=debug_decode_the_flags\s*=\s*true|debug_decode_the_flags\s*=\s*false
 ValueDefault=false
 
 [Debug Use The Exit Function Pop]
@@ -7573,7 +8420,8 @@ Category=13
 Description="<html>use (or not) the exit(EX_SOFTWARE) function.<br/><br/>Default: true</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=debug_use_the_exit_function_pop\s*=\s*true|debug_use_the_exit_function_pop\s*=\s*false
+TrueFalse=debug_use_the_exit_function_pop=true|debug_use_the_exit_function_pop=false
+TrueFalseRegex=debug_use_the_exit_function_pop\s*=\s*true|debug_use_the_exit_function_pop\s*=\s*false
 ValueDefault=true
 
 [Set Numbering For Html Output]
@@ -7581,5 +8429,6 @@ Category=13
 Description="<html>insert the number of the line at the beginning of each line</html>"
 Enabled=false
 EditorType=boolean
-TrueFalse=set_numbering_for_html_output\s*=\s*true|set_numbering_for_html_output\s*=\s*false
+TrueFalse=set_numbering_for_html_output=true|set_numbering_for_html_output=false
+TrueFalseRegex=set_numbering_for_html_output\s*=\s*true|set_numbering_for_html_output\s*=\s*false
 ValueDefault=false


### PR DESCRIPTION
This allows universal-indent-gui-tqt to work also with the original (pre regex) indenter option file.