### PR TITLE
Option To Limit Code Width For Split Lines

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -3193,6 +3193,11 @@ pos_shift;
 extern BoundedOption<unsigned, 0, 10000>
 code_width;
 
+// When a line is split due to code_width, limit width of split lines to N columns.
+// Values within [0, code_width]
+extern BoundedOption<unsigned, 0, 10000>
+code_split_width;
+
 // Whether to fully split long 'for' statements at semi-colons.
 extern Option<bool>
 ls_for_split_full;


### PR DESCRIPTION
If code is determined to be split due to code_width, split the line to as if code_width was set to the value contained in code_split_width.

This gives users the ability to be lenient with determining when to apply line splitting. Once line splitting is required, strict rules can be applied. This is useful as users can now make sure splitting a line does not separate off only a few columns.

For example, using:
```
code_width = 75
code_split_width = 65
```
will only split lines over 75 columns, but split lines will be limited to 65 columns. This has the effect of ensuring the segment split onto a new line has at least 10 columns.