### PR TITLE
vala: handle missing optional expression after catch

### DIFF
--- a/src/brace_cleanup.cpp
+++ b/src/brace_cleanup.cpp
@@ -978,15 +978,15 @@ static bool check_complex_statements(ParsingFrame &frm, Chunk *pc, const BraceSt
          // Replace CT_TRY with CT_CATCH or CT_FINALLY on the stack & we are done
          frm.top().SetOpenToken(pc->GetType());
 
-         if (language_is_set(LANG_CS))
+         if (language_is_set(LANG_CS | LANG_VALA))
          {
             frm.top().SetStage((pc->Is(CT_CATCH)) ? E_BraceStage::CATCH_WHEN : E_BraceStage::BRACE2);
          }
          else
          {
             // historically this used OP_PAREN1; however, to my knowledge the expression after a catch clause
-            // is only optional for C# which has been handled above; therefore, this should now always expect
-            // a parenthetical expression after the catch keyword and brace after the finally keyword
+            // is only optional for C# and Vala which has been handled above; therefore, this should now always
+            // expect a parenthetical expression after the catch keyword and brace after the finally keyword
             frm.top().SetStage((pc->Is(CT_CATCH)) ? E_BraceStage::PAREN1 : E_BraceStage::BRACE2);
          }
          print_stack(LBCSSWAP, "=Swap   ", frm);

--- a/tests/config/vala/ben_036.cfg
+++ b/tests/config/vala/ben_036.cfg
@@ -1,0 +1,6 @@
+indent_columns                  = 3
+indent_with_tabs                = 0
+indent_class                    = true
+nl_var_def_blk_end_func_top     = 1
+nl_try_brace                    = add
+nl_after_brace_close            = true

--- a/tests/expected/vala/70306-exception-filters.vala
+++ b/tests/expected/vala/70306-exception-filters.vala
@@ -1,0 +1,22 @@
+class Test
+{
+   void TestExceptionFilter()
+   {
+      try
+      {
+         int i = 0;
+      }
+      catch (Exception e)
+      {
+         int j = -1;
+      }
+      try
+      {
+         int i = 0;
+      }
+      catch
+      {
+         int j = -1;
+      }
+   }
+}

--- a/tests/input/vala/exception-filters.vala
+++ b/tests/input/vala/exception-filters.vala
@@ -1,0 +1,18 @@
+class Test
+{
+void TestExceptionFilter()
+{
+try {
+  int i = 0;
+} catch (Exception e)
+{
+  int j = -1;
+}
+try {
+  int i = 0;
+} catch
+{
+  int j = -1;
+}
+}
+}

--- a/tests/vala.test
+++ b/tests/vala.test
@@ -16,6 +16,7 @@
 70302  common/sp_after_cast.cfg             vala/cast.vala
 70303  vala/nullable.cfg                    vala/nullable.vala
 70304  common/empty.cfg                     vala/identifier.vala
+70306  vala/ben_036.cfg                     vala/exception-filters.vala
 
 70310  vala/mda_space_a.cfg                 vala/mdarray_space.vala
 70311  vala/sp_after_comma-a.cfg            vala/mdarray_space.vala


### PR DESCRIPTION
Vala and C# share optional expr after 'catch' keyword.