### PR TITLE
Fix global pointer pointing to local variable in uncrustify.cpp bugfix

### DIFF
--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -696,7 +696,7 @@ int main(int argc, char *argv[])
       const char *tracking_art = strtok(buffer, ":");
       const char *html_file    = strtok(nullptr, ":");
 
-      if (html_file != nullptr)
+      if (html_file != nullptr && cpd.html_file == nullptr)
       {
          if (strcmp(tracking_art, "space") == 0)
          {
@@ -717,7 +717,7 @@ int main(int argc, char *argv[])
             log_flush(true);
             return(EXIT_FAILURE);
          }
-         cpd.html_file = html_file;
+         cpd.html_file = strdup(html_file);
       }
    }
    LOG_FMT(LDATA, "%s\n", UNCRUSTIFY_VERSION);

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -696,7 +696,7 @@ int main(int argc, char *argv[])
       const char *tracking_art = strtok(buffer, ":");
       const char *html_file    = strtok(nullptr, ":");
 
-      if (html_file != nullptr 
+      if (  html_file != nullptr 
          && cpd.html_file == nullptr)
       {
          if (strcmp(tracking_art, "space") == 0)

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -696,7 +696,8 @@ int main(int argc, char *argv[])
       const char *tracking_art = strtok(buffer, ":");
       const char *html_file    = strtok(nullptr, ":");
 
-      if (html_file != nullptr && cpd.html_file == nullptr)
+      if (html_file != nullptr 
+         && cpd.html_file == nullptr)
       {
          if (strcmp(tracking_art, "space") == 0)
          {

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -696,7 +696,7 @@ int main(int argc, char *argv[])
       const char *tracking_art = strtok(buffer, ":");
       const char *html_file    = strtok(nullptr, ":");
 
-      if (  html_file != nullptr 
+      if (  html_file != nullptr
          && cpd.html_file == nullptr)
       {
          if (strcmp(tracking_art, "space") == 0)


### PR DESCRIPTION
BUG: In uncrustify.cpp the **global** pointer `cdp.html_file` points inside the **local** variable `buffer`.
This PR fixes this bug described in detail in #4216
