### PR TITLE
Fix initialization of first_text in output.cpp bugfix

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1063,10 +1063,10 @@ void output_text(FILE *pfile)
 
          for (size_t track = 0; track < pc->GetTrackingData()->size(); track++)
          {
-            const TrackList   *A         = pc->GetTrackingData();
-            const TrackNumber B          = A->at(track);
-            size_t            Bfirst     = B.first;
-            char              *Bsecond   = B.second;
+            const TrackList   *A       = pc->GetTrackingData();
+            const TrackNumber B        = A->at(track);
+            size_t            Bfirst   = B.first;
+            char              *Bsecond = B.second;
 
             if (  old_one == nullptr
                || strcmp(old_one, Bsecond) != 0)

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1058,7 +1058,8 @@ void output_text(FILE *pfile)
             }
 #endif
          }
-         char *old_one = nullptr;
+         char *old_one   = nullptr;
+         bool first_text = true;
 
          for (size_t track = 0; track < pc->GetTrackingData()->size(); track++)
          {
@@ -1066,7 +1067,6 @@ void output_text(FILE *pfile)
             const TrackNumber B          = A->at(track);
             size_t            Bfirst     = B.first;
             char              *Bsecond   = B.second;
-            bool              first_text = true;
 
             if (  old_one == nullptr
                || strcmp(old_one, Bsecond) != 0)


### PR DESCRIPTION
BUG: In output.cpp the flag `first_text` is initialised **inside** the loop but, to distinguish the first text from subsequent ones, it should be **initialised** before the loop.
This PR fixes this bug described in detail in #4217
