### PR TITLE
Fix out-of-bounds memory access in tokenize

### DIFF
--- a/src/tokenizer/tokenize.cpp
+++ b/src/tokenizer/tokenize.cpp
@@ -2856,7 +2856,7 @@ void tokenize(const deque<int> &data, Chunk *ref)
          // Disable indentation if a #pragma asm directive is found
          if (cpd.in_preproc == CT_PP_PRAGMA)
          {
-            if (memcmp(pc->Text(), "asm", 3) == 0)
+            if (strncmp(pc->Text(), "asm", 3) == 0)
             {
                LOG_FMT(LBCTRL, "Found a pragma %s on line %zu\n", "asm", pc->GetOrigLine());
                cpd.unc_off = true;

--- a/tests/expected/c/10004-pragma_asm.c
+++ b/tests/expected/c/10004-pragma_asm.c
@@ -93,6 +93,11 @@ sub_1f:
     xor     a,#$1f      ; 2
 #endasm
 
+// This odd macro triggered an out-of-bounds read before we
+// switched from memcmp to strncmp in tokenize.cpp
+#define M() _Pragma("foo"); if (false) { \
+	}
+
 int main3(int argc, char *argv[])
 {
    int a         = 1;

--- a/tests/input/c/pragma_asm.c
+++ b/tests/input/c/pragma_asm.c
@@ -89,6 +89,11 @@ sub_1f:
     xor     a,#$1f      ; 2
 #endasm
 
+// This odd macro triggered an out-of-bounds read before we
+// switched from memcmp to strncmp in tokenize.cpp
+#define M() _Pragma("foo"); if (false) { \
+        }
+
 int main3(int argc, char *argv[])
 {
     int a = 1;


### PR DESCRIPTION
We compile uncrustify with ASAN, which uncovered that certain strange macros can trigger an out-of-bounds read here due to the use of `memcmp` without a bounds check on `pc->Text()`. Just use `strncmp` which gives us the semantics we want and won't read off the end of a string.