### PR TITLE
Fix a bug preventing to use --tracking with a path including a colon

### DIFF
--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -693,7 +693,7 @@ int main(int argc, char *argv[])
 
       // Tokenize and extract key and value
       const char *tracking_art = strtok(buffer, ":");
-      const char *html_file    = strtok(nullptr, ":");
+      const char *html_file    = strtok(nullptr, "\0");
 
       if (  html_file != nullptr
          && cpd.html_file == nullptr)


### PR DESCRIPTION
The way uncrustify.cpp parses `--tracking <art>:<path>` prevents to use a path including a colon.
This PR fixes this bug described in issue #4261