### PR TITLE
Add support for new lining the rest of OC messages

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -2110,6 +2110,10 @@ nl_oc_msg_args_min_params       = 0        # unsigned number
 # (OC) Max code width of Objective-C message before applying nl_oc_msg_args.
 nl_oc_msg_args_max_code_width   = 0        # unsigned number
 
+# (OC) Whether to apply nl_oc_msg_args if some of the parameters are already
+# on new lines. Overrides nl_oc_msg_args_min_params and nl_oc_msg_args_max_code_width.
+nl_oc_msg_args_finish_multi_line = false   # true/false
+
 # Add or remove newline between function signature and '{'.
 nl_fdef_brace                   = ignore   # ignore/add/remove/force/not_defined
 

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -2110,6 +2110,10 @@ nl_oc_msg_args_min_params       = 0        # unsigned number
 # (OC) Max code width of Objective-C message before applying nl_oc_msg_args.
 nl_oc_msg_args_max_code_width   = 0        # unsigned number
 
+# (OC) Whether to apply nl_oc_msg_args if some of the parameters are already
+# on new lines. Overrides nl_oc_msg_args_min_params and nl_oc_msg_args_max_code_width.
+nl_oc_msg_args_finish_multi_line = false   # true/false
+
 # Add or remove newline between function signature and '{'.
 nl_fdef_brace                   = ignore   # ignore/add/remove/force/not_defined
 

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -2110,6 +2110,10 @@ nl_oc_msg_args_min_params       = 0        # unsigned number
 # (OC) Max code width of Objective-C message before applying nl_oc_msg_args.
 nl_oc_msg_args_max_code_width   = 0        # unsigned number
 
+# (OC) Whether to apply nl_oc_msg_args if some of the parameters are already
+# on new lines. Overrides nl_oc_msg_args_min_params and nl_oc_msg_args_max_code_width.
+nl_oc_msg_args_finish_multi_line = false   # true/false
+
 # Add or remove newline between function signature and '{'.
 nl_fdef_brace                   = ignore   # ignore/add/remove/force/not_defined
 

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -5256,6 +5256,15 @@ MinVal=0
 MaxVal=10000
 ValueDefault=0
 
+[Nl Oc Msg Args Finish Multi Line]
+Category=3
+Description="<html>(OC) Whether to apply nl_oc_msg_args if some of the parameters are already<br/>on new lines. Overrides nl_oc_msg_args_min_params and nl_oc_msg_args_max_code_width.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=nl_oc_msg_args_finish_multi_line=true|nl_oc_msg_args_finish_multi_line=false
+TrueFalseRegex=nl_oc_msg_args_finish_multi_line\s*=\s*true|nl_oc_msg_args_finish_multi_line\s*=\s*false
+ValueDefault=false
+
 [Nl Fdef Brace]
 Category=3
 Description="<html>Add or remove newline between function signature and '{'.</html>"

--- a/src/newlines/oc_msg.cpp
+++ b/src/newlines/oc_msg.cpp
@@ -89,6 +89,24 @@ void newline_oc_msg(Chunk *start)
       should_nl_msg = true;
    }
 
+   bool finish_multi_line = options::nl_oc_msg_args_finish_multi_line();
+   if (finish_multi_line) {
+      size_t prev_line = -1;
+      for (Chunk *pc = start->GetNextNcNnl(); pc->IsNotNullChunk(); pc = pc->GetNextNcNnl())
+      {
+         if (pc->GetLevel() <= start->GetLevel())
+         {
+            break;
+         }
+
+         if (prev_line != -1 && pc->GetOrigLine() != prev_line)
+         {
+            should_nl_msg = true;
+         }
+         prev_line = pc->GetOrigLine();
+      }
+   }
+
    // If both nl_oc_msg_args_min_params and nl_oc_msg_args_max_code_width are disabled
    // we should newline all messages.
    if (  max_code_width == 0

--- a/src/options.h
+++ b/src/options.h
@@ -2580,6 +2580,11 @@ nl_oc_msg_args_min_params;
 extern BoundedOption<unsigned, 0, 10000>
 nl_oc_msg_args_max_code_width;
 
+// (OC) Whether to apply nl_oc_msg_args if some of the parameters are already
+// on new lines. Overrides nl_oc_msg_args_min_params and nl_oc_msg_args_max_code_width.
+extern Option<bool>
+nl_oc_msg_args_finish_multi_line;
+
 // Add or remove newline between function signature and '{'.
 extern Option<iarf_e>
 nl_fdef_brace;

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -5256,6 +5256,15 @@ MinVal=0
 MaxVal=10000
 ValueDefault=0
 
+[Nl Oc Msg Args Finish Multi Line]
+Category=3
+Description="<html>(OC) Whether to apply nl_oc_msg_args if some of the parameters are already<br/>on new lines. Overrides nl_oc_msg_args_min_params and nl_oc_msg_args_max_code_width.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=nl_oc_msg_args_finish_multi_line=true|nl_oc_msg_args_finish_multi_line=false
+TrueFalseRegex=nl_oc_msg_args_finish_multi_line\s*=\s*true|nl_oc_msg_args_finish_multi_line\s*=\s*false
+ValueDefault=false
+
 [Nl Fdef Brace]
 Category=3
 Description="<html>Add or remove newline between function signature and '{'.</html>"

--- a/tests/config/oc/nl_oc_msg_args_finish_multi_line.cfg
+++ b/tests/config/oc/nl_oc_msg_args_finish_multi_line.cfg
@@ -1,0 +1,5 @@
+nl_oc_msg_args                     = true
+nl_oc_msg_args_finish_multi_line   = true
+indent_columns                     = 4
+indent_with_tabs                   = 0
+align_oc_msg_colon_span            = 1

--- a/tests/expected/oc/50634-nl_oc_msg_args_finish_multi_line.m
+++ b/tests/expected/oc/50634-nl_oc_msg_args_finish_multi_line.m
@@ -1,0 +1,40 @@
+static void function() {
+    [object param1:nil
+            param2:nil
+            param3:nil];
+
+    [object param1:nil
+            param2:nil
+            param3:nil
+            param4:nil];
+
+    [object param1:nil
+            param2:nil];
+
+    [object param1:nil];
+
+    [object func];
+
+    [obj param1:nil
+         param2:nil
+         param3:[obj2 param1:nil
+                      param2:nil]];
+
+    [obj param1:nil
+         param2:[obj2 param1:nil
+                      param2:nil
+                      param3:nil
+                      param4:nil
+                      param5:nil
+                      param6:nil]
+         param3:nil];
+
+    [obj param1:nil
+         param2:[obj2 param1:nil
+                      param2:nil
+                      param3:nil
+                      param4:nil
+                      param5:nil
+                      param6:nil]
+         param3:nil];
+}

--- a/tests/input/oc/nl_oc_msg_args_finish_multi_line.m
+++ b/tests/input/oc/nl_oc_msg_args_finish_multi_line.m
@@ -1,0 +1,32 @@
+static void function() {
+    [object param1:nil
+            param2:nil param3:nil];
+
+    [object param1:nil param2:nil
+            param3:nil
+            param4:nil];
+
+    [object param1:nil param2:nil];
+
+    [object param1:nil];
+
+    [object func];
+
+    [obj param1:nil param2:nil param3:[obj2 param1:nil
+                                            param2:nil]];
+
+    [obj param1:nil param2:[obj2 param1:nil
+                                 param2:nil
+                                 param3:nil
+                                 param4:nil
+                                 param5:nil
+                                 param6:nil]
+         param3:nil];
+
+    [obj param1:nil param2:[obj2 param1:nil
+                                 param2:nil
+                                 param3:nil
+                                 param4:nil
+                                 param5:nil
+                                 param6:nil] param3:nil];
+}

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -145,6 +145,7 @@
 
 50631  oc/nl_oc_msg_args_min_params.cfg         oc/nl_oc_msg_args_min_params.m
 50632  oc/nl_oc_msg_args_max_code_width.cfg     oc/nl_oc_msg_args_max_code_width.m
+50634  oc/nl_oc_msg_args_finish_multi_line.cfg  oc/nl_oc_msg_args_finish_multi_line.m
 
 50633  common/aet.cfg                           oc/ocpp_msg_access.mm
 


### PR DESCRIPTION
Often times, we'll want every OC message (function) to be on a separate line. It can be tedious to do the line by line.

```
// Before
[obj param1:nil param2:nil param3:nil param4:nil param5:nil];

// After
[object param1:nil
        param2:nil
        param3:nil
        param4:nil
        param5:nil];
```

This change adds support for newlining the entire OC message if the message is already on multiple lines. This way we can just newline the 2nd parameter to newline the entire message.

