### PR TITLE
Use snprintf (instead of sprintf)

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -77,7 +77,7 @@ void print_numbering()
    if (get_numbering())
    {
       line_number++;
-      sprintf(char_number, "%d ", line_number);
+      snprintf(char_number, sizeof(char_number), "%d ", line_number);
       write_string(char_number);
    }
 }
@@ -538,7 +538,7 @@ void output_parsed(FILE *pfile, bool withOptions)
               pc->GetBraceLevel(), pc->GetLevel(), pc->GetPpLevel());
       // Print pc flags in groups of 4 hex characters
       char flag_string[24];
-      sprintf(flag_string, "%16llx", static_cast<PcfFlags::int_t>(pc->GetFlags()));
+      snprintf(flag_string, sizeof(flag_string), "%16llx", static_cast<PcfFlags::int_t>(pc->GetFlags()));
       fprintf(pfile, "[%.4s %.4s %.4s %.4s]", flag_string, flag_string + 4, flag_string + 8, flag_string + 12);
       fprintf(pfile, "[%zu-%d]",
               pc->GetNlCount(), pc->GetAfterTab());
@@ -1079,7 +1079,7 @@ void output_text(FILE *pfile)
 
                if (first_text)
                {
-                  sprintf(tempText, "%s", Bsecond);
+                  snprintf(tempText, sizeof(tempText), "%s", Bsecond);
                   add_text(tempText);
                   add_text(": ");
                   first_text = false;
@@ -1089,7 +1089,7 @@ void output_text(FILE *pfile)
             {
                add_text(", ");
             }
-            sprintf(tempText, "%zu", Bfirst);
+            snprintf(tempText, sizeof(tempText), "%zu", Bfirst);
             add_text(tempText);
          } // for (size_t track = 0; track < pc->GetTrackingData()->size(); track++)
 

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -3341,7 +3341,7 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
             || it.second == second->GetType()))
       {
          char text[80];
-         sprintf(text, "REMOVE from no_space_table @ %zu.", number);
+         snprintf(text, sizeof(text), "REMOVE from no_space_table @ %zu.", number);
          log_rule(text);
          return(IARF_REMOVE);
       }
@@ -3359,7 +3359,7 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
          && it.second == second->GetType())
       {
          char text[80];
-         sprintf(text, "ADD from add_space_table @ %zu.", number);
+         snprintf(text, sizeof(text), "ADD from add_space_table @ %zu.", number);
          log_rule(text);
          return(IARF_ADD);
       }

--- a/src/unc_tools.cpp
+++ b/src/unc_tools.cpp
@@ -454,11 +454,11 @@ void dump_out(unsigned int type)
 
    if (cpd.dumped_file == nullptr)
    {
-      sprintf(dumpFileName, "%s.%u", cpd.filename.c_str(), type);
+      snprintf(dumpFileName, sizeof(dumpFileName), "%s.%u", cpd.filename.c_str(), type);
    }
    else
    {
-      sprintf(dumpFileName, "%s.%u", cpd.dumped_file, type);
+      snprintf(dumpFileName, sizeof(dumpFileName), "%s.%u", cpd.dumped_file, type);
    }
    FILE *D_file = fopen(dumpFileName, "w");
 
@@ -532,11 +532,11 @@ void dump_in(unsigned int type)
 
    if (cpd.dumped_file == nullptr)
    {
-      sprintf(dumpFileName, "%s.%u", cpd.filename.c_str(), type);
+      snprintf(dumpFileName, sizeof(dumpFileName), "%s.%u", cpd.filename.c_str(), type);
    }
    else
    {
-      sprintf(dumpFileName, "%s.%u", cpd.dumped_file, type);
+      snprintf(dumpFileName, sizeof(dumpFileName), "%s.%u", cpd.dumped_file, type);
    }
    FILE *D_file = fopen(dumpFileName, "r");
 
@@ -722,7 +722,7 @@ char dump_file_name[80];
 
 void set_dump_file_name(const char *name)
 {
-   sprintf(dump_file_name, "%s", name);
+   snprintf(dump_file_name, sizeof(dump_file_name), "%s", name);
 }
 
 


### PR DESCRIPTION
`snprintf` is safer than `sprintf`. This change replaces all instances of `sprintf` with `snprintf`.

## Tests pass
```
ctest -C Debug -j
Test project /Users/petertao/Desktop/fb/uncrustify/build
      Start  3: cpp
      Start 12: sources_format
      Start  2: c
      Start  8: objective-c
      Start  4: d
      Start  1: c-sharp
      Start  7: java
      Start  9: pawn
      Start 10: vala
      Start 13: cli_options
      Start 11: staging
      Start  5: ecma
      Start  6: imported
      Start 14: sanity
 1/14 Test #14: sanity ...........................   Passed    0.01 sec
 2/14 Test  #6: imported .........................   Passed    0.08 sec
 3/14 Test  #5: ecma .............................   Passed    0.25 sec
 4/14 Test #11: staging ..........................   Passed    0.77 sec
 5/14 Test #13: cli_options ......................   Passed    1.02 sec
 6/14 Test #10: vala .............................   Passed    4.41 sec
 7/14 Test  #9: pawn .............................   Passed    4.86 sec
 8/14 Test  #7: java .............................   Passed    7.68 sec
 9/14 Test  #1: c-sharp ..........................   Passed   21.47 sec
10/14 Test  #4: d ................................   Passed   40.15 sec
11/14 Test  #8: objective-c ......................   Passed   40.25 sec
12/14 Test #12: sources_format ...................   Passed   87.80 sec
13/14 Test  #2: c ................................   Passed   88.84 sec
14/14 Test  #3: cpp ..............................   Passed  133.27 sec

100% tests passed, 0 tests failed out of 14

Total Test time (real) = 133.30 sec
```