### PR TITLE
Add C++20 support by updating strings

### DIFF
--- a/scripts/make_options.py
+++ b/scripts/make_options.py
@@ -49,7 +49,7 @@ class Option(object):
     def write_declaration(self, out):
         out.write(u'{} {} = {{\n'.format(self.decl, self.name))
         out.write(u'  "{}",\n'.format(self.name))
-        out.write(u'  u8R"__(\n{}\n)__"'.format(self.desc))
+        out.write(u'  R"__(\n{}\n)__"'.format(self.desc))
         if self.dval is not None:
             out.write(u',\n  {}'.format(self.dval))
         out.write(u'\n};\n\n')
@@ -90,7 +90,7 @@ def write_declarations(out, args):
 # -----------------------------------------------------------------------------
 def write_registrations(out, args):
     for group in groups:
-        out.write(u'\n  begin_option_group(u8R"__(\n{}\n)__");\n\n'.format(
+        out.write(u'\n  begin_option_group(R"__(\n{}\n)__");\n\n'.format(
             group.desc))
 
         for option in group.options:

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -28,7 +28,7 @@ namespace uncrustify
 namespace
 {
 
-static const char *DOC_TEXT_END = u8R"___(
+static const char *DOC_TEXT_END = R"___(
 # Meaning of the settings:
 #   Ignore - do not do any changes
 #   Add    - makes sure there is 1 or more space/brace/newline/etc


### PR DESCRIPTION
It would be nice to add support for the latest version of C++ and eventually upgrade. This PR adds support for C++20.

Currently the build fails when using C++20:

```
uncrustify/src/option.cpp:31:20: error: cannot initialize a variable of type 'const char *' with an lvalue of type 'const char8_t[1639]'
static const char *DOC_TEXT_END = u8R"___(
                   ^              ~~~~~~~~
1 error generated.
make[2]: *** [CMakeFiles/uncrustify.dir/src/option.cpp.o] Error 1
make[1]: *** [CMakeFiles/uncrustify.dir/all] Error 2
make: *** [all] Error 2
```

The "u8" prefix of the literal will interpret strings as UTF-8. C++20 added a distinct type, char8_t, and along a distinct u8string type for this. However since there are only ansi characters within these literals, the "u8" prefix isn't necessary and we can keep using the same type.

Dropping the prefix is the simplest way to make the code compatible with C++20.

After this change, the building with C++20 works.
