### PR TITLE
Add const to inline operators

### DIFF
--- a/src/enum_flags.h
+++ b/src/enum_flags.h
@@ -50,13 +50,13 @@ public:
       : m_i{static_cast<int_t>(flag)}
    {}
 
-   inline bool operator==(Enum const &other)
+   inline bool operator==(Enum const &other) const
    { return(m_i == static_cast<int_t>(other)); }
-   inline bool operator==(flags const &other)
+   inline bool operator==(flags const &other) const
    { return(m_i == other.m_i); }
-   inline bool operator!=(Enum const &other)
+   inline bool operator!=(Enum const &other) const
    { return(m_i != static_cast<int_t>(other)); }
-   inline bool operator!=(flags const &other)
+   inline bool operator!=(flags const &other) const
    { return(m_i != other.m_i); }
 
    template<typename T, integral<T> = true>


### PR DESCRIPTION
Just add const to inline operator overloads to ensure the member variables (ie. `m_i`) can't be modified