### PR TITLE
add cmake option FORCE_GNUINSTALLDIRS for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -613,7 +613,10 @@ include(CPack)
 #
 # Install
 #
-if(MSVC)
+
+option(FORCE_GNUINSTALLDIRS "Force UNIX installation layout under MSVC" OFF)
+
+if(MSVC AND NOT FORCE_GNUINSTALLDIRS)
   install(TARGETS uncrustify DESTINATION ".")
   install(FILES ${uncrustify_docs}
     DESTINATION "."


### PR DESCRIPTION
Add cmake option FORCE_GNUINSTALLDIRS to force using the UNIX GNUInstallDirs installation method under MSVC. This can be helpful for projects using uncrustify as an external project in their build systems.