### PR TITLE
Fix/issue/4354

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -1,4 +1,4 @@
-# Uncrustify-0.79.0
+# Uncrustify-0.79.0-dev
 
 #
 # General options
@@ -422,6 +422,10 @@ sp_invariant_paren              = ignore   # ignore/add/remove/force
 sp_after_invariant_paren        = ignore   # ignore/add/remove/force
 
 # Add or remove space before empty statement ';' on 'if', 'for' and 'while'.
+# examples:
+#   if (b) <here> ;
+#   for (a=1; a<10; a++) <here> ;
+#   while (*p++ = ' ') <here> ;
 sp_special_semi                 = ignore   # ignore/add/remove/force
 
 # Add or remove space before ';'.
@@ -1126,6 +1130,12 @@ force_tab_after_define          = false    # true/false
 
 # Add or remove space between two strings.
 sp_string_string                = ignore   # ignore/add/remove/force
+
+# Add or remove space between '_Pragma' and the opening paarenthesis
+sp_pragma_open_parenthesis      = ignore   # ignore/add/remove/force
+
+# Add or remove space inside '(' and ')' of _Pragma.
+sp_inside_gparen                = ignore   # ignore/add/remove/force
 
 #
 # Indenting options

--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -1107,6 +1107,10 @@ sp_after_emb_cmt                = force    # ignore/add/remove/force
 # Default: 1
 sp_num_after_emb_cmt            = 1        # unsigned number
 
+# Embedded comment spacing options have higher priority (== override)
+# than other spacing options (comma, parenthesis, braces, ...)
+sp_emb_cmt_priority             = false    # true/false
+
 # (Java) Add or remove space between an annotation and the open parenthesis.
 sp_annotation_paren             = ignore   # ignore/add/remove/force
 

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -1,4 +1,4 @@
-# Uncrustify-0.79.0
+# Uncrustify-0.79.0-dev
 
 #
 # General options
@@ -422,6 +422,10 @@ sp_invariant_paren              = ignore   # ignore/add/remove/force
 sp_after_invariant_paren        = ignore   # ignore/add/remove/force
 
 # Add or remove space before empty statement ';' on 'if', 'for' and 'while'.
+# examples:
+#   if (b) <here> ;
+#   for (a=1; a<10; a++) <here> ;
+#   while (*p++ = ' ') <here> ;
 sp_special_semi                 = ignore   # ignore/add/remove/force
 
 # Add or remove space before ';'.
@@ -1126,6 +1130,12 @@ force_tab_after_define          = false    # true/false
 
 # Add or remove space between two strings.
 sp_string_string                = ignore   # ignore/add/remove/force
+
+# Add or remove space between '_Pragma' and the opening paarenthesis
+sp_pragma_open_parenthesis      = ignore   # ignore/add/remove/force
+
+# Add or remove space inside '(' and ')' of _Pragma.
+sp_inside_gparen                = ignore   # ignore/add/remove/force
 
 #
 # Indenting options

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -1107,6 +1107,10 @@ sp_after_emb_cmt                = force    # ignore/add/remove/force
 # Default: 1
 sp_num_after_emb_cmt            = 1        # unsigned number
 
+# Embedded comment spacing options have higher priority (== override)
+# than other spacing options (comma, parenthesis, braces, ...)
+sp_emb_cmt_priority             = false    # true/false
+
 # (Java) Add or remove space between an annotation and the open parenthesis.
 sp_annotation_paren             = ignore   # ignore/add/remove/force
 

--- a/documentation/htdocs/index.html
+++ b/documentation/htdocs/index.html
@@ -54,7 +54,7 @@ Create a highly configurable, easily modifiable source code beautifier.</p>
    <li>Add or remove parens on return statements</li>
    <li>Add or remove braces on single-statement if/do/while/for statements</li>
    <li>Supports embedded SQL 'EXEC SQL' stuff</li>
-   <li>Highly configurable - 855 configurable options as of version 0.79.0</li>
+   <li>Highly configurable - 856 configurable options as of version 0.79.0</li>
 </ul>
 
 <p>

--- a/documentation/htdocs/index.html
+++ b/documentation/htdocs/index.html
@@ -54,7 +54,7 @@ Create a highly configurable, easily modifiable source code beautifier.</p>
    <li>Add or remove parens on return statements</li>
    <li>Add or remove braces on single-statement if/do/while/for statements</li>
    <li>Supports embedded SQL 'EXEC SQL' stuff</li>
-   <li>Highly configurable - 853 configurable options as of version 0.79.0</li>
+   <li>Highly configurable - 855 configurable options as of version 0.79.0</li>
 </ul>
 
 <p>

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1,4 +1,4 @@
-# Uncrustify-0.79.0
+# Uncrustify-0.79.0-dev
 
 #
 # General options
@@ -422,6 +422,10 @@ sp_invariant_paren              = ignore   # ignore/add/remove/force
 sp_after_invariant_paren        = ignore   # ignore/add/remove/force
 
 # Add or remove space before empty statement ';' on 'if', 'for' and 'while'.
+# examples:
+#   if (b) <here> ;
+#   for (a=1; a<10; a++) <here> ;
+#   while (*p++ = ' ') <here> ;
 sp_special_semi                 = ignore   # ignore/add/remove/force
 
 # Add or remove space before ';'.
@@ -1126,6 +1130,12 @@ force_tab_after_define          = false    # true/false
 
 # Add or remove space between two strings.
 sp_string_string                = ignore   # ignore/add/remove/force
+
+# Add or remove space between '_Pragma' and the opening paarenthesis
+sp_pragma_open_parenthesis      = ignore   # ignore/add/remove/force
+
+# Add or remove space inside '(' and ')' of _Pragma.
+sp_inside_gparen                = ignore   # ignore/add/remove/force
 
 #
 # Indenting options

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1107,6 +1107,10 @@ sp_after_emb_cmt                = force    # ignore/add/remove/force
 # Default: 1
 sp_num_after_emb_cmt            = 1        # unsigned number
 
+# Embedded comment spacing options have higher priority (== override)
+# than other spacing options (comma, parenthesis, braces, ...)
+sp_emb_cmt_priority             = false    # true/false
+
 # (Java) Add or remove space between an annotation and the open parenthesis.
 sp_annotation_paren             = ignore   # ignore/add/remove/force
 

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -2750,6 +2750,15 @@ MinVal=0
 MaxVal=16
 ValueDefault=1
 
+[Sp Emb Cmt Priority]
+Category=1
+Description="<html>Embedded comment spacing options have higher priority (== override)<br/>than other spacing options (comma, parenthesis, braces, ...)</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=sp_emb_cmt_priority=true|sp_emb_cmt_priority=false
+TrueFalseRegex=sp_emb_cmt_priority\s*=\s*true|sp_emb_cmt_priority\s*=\s*false
+ValueDefault=false
+
 [Sp Annotation Paren]
 Category=1
 Description="<html>(Java) Add or remove space between an annotation and the open parenthesis.</html>"

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -15,7 +15,7 @@ parameterOrder=ipo
 showHelpParameter=-h
 stringparaminquotes=false
 useCfgFileParameter="-c "
-version=Uncrustify-0.79.0
+version=Uncrustify-0.79.0-dev
 
 [Newlines]
 Category=0
@@ -1013,7 +1013,7 @@ ValueDefault=ignore
 
 [Sp Special Semi]
 Category=1
-Description="<html>Add or remove space before empty statement ';' on 'if', 'for' and 'while'.</html>"
+Description="<html>Add or remove space before empty statement ';' on 'if', 'for' and 'while'.<br/>examples:<br/>  if (b) &lt;here&gt; ;<br/>  for (a=1; a&lt;10; a++) &lt;here&gt; ;<br/>  while (*p++ = ' ') &lt;here&gt; ;</html>"
 Enabled=false
 EditorType=multiple
 Choices=sp_special_semi=ignore|sp_special_semi=add|sp_special_semi=remove|sp_special_semi=force
@@ -2826,6 +2826,26 @@ EditorType=multiple
 Choices=sp_string_string=ignore|sp_string_string=add|sp_string_string=remove|sp_string_string=force
 ChoicesRegex=sp_string_string\s*=\s*ignore|sp_string_string\s*=\s*add|sp_string_string\s*=\s*remove|sp_string_string\s*=\s*force
 ChoicesReadable="Ignore Sp String String|Add Sp String String|Remove Sp String String|Force Sp String String"
+ValueDefault=ignore
+
+[Sp Pragma Open Parenthesis]
+Category=1
+Description="<html>Add or remove space between '_Pragma' and the opening paarenthesis</html>"
+Enabled=false
+EditorType=multiple
+Choices=sp_pragma_open_parenthesis=ignore|sp_pragma_open_parenthesis=add|sp_pragma_open_parenthesis=remove|sp_pragma_open_parenthesis=force
+ChoicesRegex=sp_pragma_open_parenthesis\s*=\s*ignore|sp_pragma_open_parenthesis\s*=\s*add|sp_pragma_open_parenthesis\s*=\s*remove|sp_pragma_open_parenthesis\s*=\s*force
+ChoicesReadable="Ignore Sp Pragma Open Parenthesis|Add Sp Pragma Open Parenthesis|Remove Sp Pragma Open Parenthesis|Force Sp Pragma Open Parenthesis"
+ValueDefault=ignore
+
+[Sp Inside Gparen]
+Category=1
+Description="<html>Add or remove space inside '(' and ')' of _Pragma.</html>"
+Enabled=false
+EditorType=multiple
+Choices=sp_inside_gparen=ignore|sp_inside_gparen=add|sp_inside_gparen=remove|sp_inside_gparen=force
+ChoicesRegex=sp_inside_gparen\s*=\s*ignore|sp_inside_gparen\s*=\s*add|sp_inside_gparen\s*=\s*remove|sp_inside_gparen\s*=\s*force
+ChoicesReadable="Ignore Sp Inside Gparen|Add Sp Inside Gparen|Remove Sp Inside Gparen|Force Sp Inside Gparen"
 ValueDefault=ignore
 
 [Indent Columns]

--- a/src/newlines/brace_pair.cpp
+++ b/src/newlines/brace_pair.cpp
@@ -45,8 +45,6 @@ using namespace uncrustify;
  * void foo() {
  * }
  */
-
-
 void newlines_brace_pair(Chunk *br_open)
 {
    LOG_FUNC_ENTRY();

--- a/src/newlines/double_newline.cpp
+++ b/src/newlines/double_newline.cpp
@@ -35,6 +35,7 @@ void double_newline(Chunk *nl)
    LOG_FMT(LNEWLINE, "on line %zu", prev->GetOrigLine());
 
    LOG_FMT(LNEWLINE, "%s(%d): ", __func__, __LINE__);
+
    if (!can_increase_nl(nl))
    {
       LOG_FMT(LNEWLINE, " - denied\n");

--- a/src/options.h
+++ b/src/options.h
@@ -1351,6 +1351,11 @@ sp_after_emb_cmt; // = IARF_FORCE
 extern BoundedOption<unsigned, 0, 16>
 sp_num_after_emb_cmt; // = 1
 
+// Embedded comment spacing options have higher priority (== override)
+// than other spacing options (comma, parenthesis, braces, ...)
+extern Option<bool>
+sp_emb_cmt_priority; // = false
+
 // (Java) Add or remove space between an annotation and the open parenthesis.
 extern Option<iarf_e>
 sp_annotation_paren;

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -2122,17 +2122,6 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
       return(options::sp_paren_paren());
    }
 
-   if (  first->Is(CT_COMMENT)                                      // Issue #4327
-      && first->GetParentType() == CT_COMMENT_EMBED)
-   {
-      // Add or remove space after an embedded comment.
-      // Number of spaces after an embedded comment.
-      log_rule("sp_after_emb_cmt");
-      log_rule("sp_num_after_emb_cmt");
-      min_sp = options::sp_num_after_emb_cmt();
-      return(options::sp_after_emb_cmt());
-   }
-
    // "foo(...)" vs. "foo( ... )"
    if (  first->Is(CT_FPAREN_OPEN)
       || second->Is(CT_FPAREN_CLOSE))
@@ -3210,9 +3199,17 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
       // Add or remove space before an embedded comment.
       // Number of spaces before an embedded comment.
       log_rule("sp_before_emb_cmt");
-      log_rule("sp_num_before_emb_cmt");
       min_sp = options::sp_num_before_emb_cmt();
       return(options::sp_before_emb_cmt());
+   }
+
+   if (first->Is(CT_COMMENT))
+   {
+      // Add or remove space after an embedded comment.
+      // Number of spaces after an embedded comment.
+      log_rule("sp_after_emb_cmt");
+      min_sp = options::sp_num_after_emb_cmt();
+      return(options::sp_after_emb_cmt());
    }
 
    if (  first->Is(CT_NEW)

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -20,6 +20,7 @@
 
 #include "add_space_table.h"
 #include "log_rules.h"
+#include "options.h"
 #include "options_for_QT.h"
 #include "punctuators.h"
 #include "token_is_within_trailing_return.h"
@@ -69,6 +70,26 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
    LOG_FMT(LSPACE, "%s(%d): second: orig line %zu, orig col %zu, text '%s', type %s\n",
            __func__, __LINE__, second->GetOrigLine(), second->GetOrigCol(), second->Text(), get_token_name(second->GetType()));
    min_sp = 1;
+
+   if (  first->Is(CT_COMMENT)                                      // Issue #4327
+      && first->GetParentType() == CT_COMMENT_EMBED
+      && (options::sp_emb_cmt_priority()))
+   {
+      // Add or remove space bewteen an embedded comment and a close parenthesis.
+      log_rule("sp_emb_cmt_priority (after)");
+      min_sp = options::sp_num_after_emb_cmt();
+      return(options::sp_after_emb_cmt());
+   }
+
+   if (  second->Is(CT_COMMENT)                                     // Issue #4327
+      && second->GetParentType() == CT_COMMENT_EMBED
+      && (options::sp_emb_cmt_priority()))
+   {
+      // Add or remove space bewteen an open parenthesis and an embedded comment.
+      log_rule("sp_between_open_paren_and_emb_cmt (before)");
+      min_sp = options::sp_num_before_emb_cmt();
+      return(options::sp_before_emb_cmt());
+   }
 
    if (  first->Is(CT_VBRACE_OPEN)
       && first->GetPrev()->Is(CT_SPAREN_CLOSE)
@@ -3199,15 +3220,18 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
       // Add or remove space before an embedded comment.
       // Number of spaces before an embedded comment.
       log_rule("sp_before_emb_cmt");
+      log_rule("sp_num_before_emb_cmt");
       min_sp = options::sp_num_before_emb_cmt();
       return(options::sp_before_emb_cmt());
    }
 
-   if (first->Is(CT_COMMENT))
+   if (  first->Is(CT_COMMENT)
+      && first->GetParentType() == CT_COMMENT_EMBED)
    {
       // Add or remove space after an embedded comment.
       // Number of spaces after an embedded comment.
       log_rule("sp_after_emb_cmt");
+      log_rule("sp_num_after_emb_cmt");
       min_sp = options::sp_num_after_emb_cmt();
       return(options::sp_after_emb_cmt());
    }

--- a/src/tokenizer/mark_question_colon.cpp
+++ b/src/tokenizer/mark_question_colon.cpp
@@ -21,15 +21,16 @@
 Chunk *search_for_colon(Chunk *pc_question, int depth)
 {
    Chunk *pc2                 = pc_question->GetNextNcNnl();
-   bool           colon_found = false;
+   bool  colon_found          = false;
    int   square_bracket_depth = 0;
 
    LOG_FMT(LCOMBINE, "%s(%d): pc_question.orig line is %zu, orig col is %zu, level is %zu, Text() is '%s'\n",
            __func__, __LINE__, pc_question->GetOrigLine(), pc_question->GetOrigCol(), pc_question->GetLevel(),
            pc_question->Text());
 
-   if (pc2->Is(CT_COLON)) {
-      return pc2;
+   if (pc2->Is(CT_COLON))
+   {
+      return(pc2);
    }
 
    // examine the next tokens, look for E2, E3, COLON, might be for a next CT_QUESTION
@@ -107,7 +108,7 @@ Chunk *search_for_colon(Chunk *pc_question, int depth)
             }
          }
       }
-      else if (pc2->Is(CT_COLON)
+      else if (  pc2->Is(CT_COLON)
               && square_bracket_depth == 0)
       {
          LOG_FMT(LCOMBINE, "%s(%d): orig line is %zu, orig col is %zu, level is %zu, Text() is '%s'\n",
@@ -132,10 +133,12 @@ Chunk *search_for_colon(Chunk *pc_question, int depth)
             colon_found = true;
          }
       }
-      else if (pc2->Is(CT_SQUARE_OPEN)) {
+      else if (pc2->Is(CT_SQUARE_OPEN))
+      {
          square_bracket_depth++;
       }
-      else if (pc2->Is(CT_SQUARE_CLOSE)) {
+      else if (pc2->Is(CT_SQUARE_CLOSE))
+      {
          square_bracket_depth--;
       }
       pc2 = pc2->GetNextNcNnl();

--- a/tests/c.test
+++ b/tests/c.test
@@ -154,6 +154,10 @@
 00313  c/comment_conversion.cfg                   c/comment_conversion_long_lines.c
 00314  c/comment_conversion.cfg                   c/comment_conversion_javadoc_single.c
 00315  common/tde.cfg                             c/comment_conversion_trailing_c_multiline.c
+00316  c/emb_cmt_normal.cfg                       c/emb_cmt_spacing.c
+00317  c/emb_cmt_high_priority.cfg                c/emb_cmt_spacing.c
+00318  c/emb_cmt_high_priority_before.cfg         c/emb_cmt_spacing.c
+00319  c/emb_cmt_high_priority_after.cfg          c/emb_cmt_spacing.c
 
 00320  c/rdan.cfg                                 c/indent_first_bool_expr.c
 

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -2750,6 +2750,15 @@ MinVal=0
 MaxVal=16
 ValueDefault=1
 
+[Sp Emb Cmt Priority]
+Category=1
+Description="<html>Embedded comment spacing options have higher priority (== override)<br/>than other spacing options (comma, parenthesis, braces, ...)</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=sp_emb_cmt_priority=true|sp_emb_cmt_priority=false
+TrueFalseRegex=sp_emb_cmt_priority\s*=\s*true|sp_emb_cmt_priority\s*=\s*false
+ValueDefault=false
+
 [Sp Annotation Paren]
 Category=1
 Description="<html>(Java) Add or remove space between an annotation and the open parenthesis.</html>"

--- a/tests/config/c/emb_cmt_high_priority.cfg
+++ b/tests/config/c/emb_cmt_high_priority.cfg
@@ -1,0 +1,5 @@
+sp_before_emb_cmt     = force
+sp_num_before_emb_cmt = 2
+sp_after_emb_cmt      = force
+sp_num_after_emb_cmt  = 3
+sp_emb_cmt_priority   = true

--- a/tests/config/c/emb_cmt_high_priority_after.cfg
+++ b/tests/config/c/emb_cmt_high_priority_after.cfg
@@ -1,0 +1,3 @@
+sp_after_emb_cmt      = force
+sp_num_after_emb_cmt  = 3
+sp_emb_cmt_priority   = true

--- a/tests/config/c/emb_cmt_high_priority_before.cfg
+++ b/tests/config/c/emb_cmt_high_priority_before.cfg
@@ -1,0 +1,3 @@
+sp_before_emb_cmt     = force
+sp_num_before_emb_cmt = 3
+sp_emb_cmt_priority   = true

--- a/tests/config/c/emb_cmt_normal.cfg
+++ b/tests/config/c/emb_cmt_normal.cfg
@@ -1,0 +1,2 @@
+sp_before_emb_cmt     = force
+sp_after_emb_cmt      = force

--- a/tests/expected/c/00310-sp_embed_comment.c
+++ b/tests/expected/c/00310-sp_embed_comment.c
@@ -2,7 +2,7 @@ void f();
 void g(int);
 void h()
 {
-	f(/*foo*/ );
-	g(42 /*foo*/ );
+	f(/*foo*/);
+	g(42 /*foo*/);
 	g(/*foo*/ 42);
 }

--- a/tests/expected/c/00316-emb_cmt_spacing.c
+++ b/tests/expected/c/00316-emb_cmt_spacing.c
@@ -1,0 +1,1 @@
+FooBar::CFooBar(CWnd* pParent /*=NULL*/, int dummy /*=0*/);

--- a/tests/expected/c/00317-emb_cmt_spacing.c
+++ b/tests/expected/c/00317-emb_cmt_spacing.c
@@ -1,0 +1,1 @@
+FooBar::CFooBar(CWnd* pParent  /*=NULL*/   , int dummy  /*=0*/   );

--- a/tests/expected/c/00318-emb_cmt_spacing.c
+++ b/tests/expected/c/00318-emb_cmt_spacing.c
@@ -1,0 +1,1 @@
+FooBar::CFooBar(CWnd* pParent   /*=NULL*/ , int dummy   /*=0*/ );

--- a/tests/expected/c/00319-emb_cmt_spacing.c
+++ b/tests/expected/c/00319-emb_cmt_spacing.c
@@ -1,0 +1,1 @@
+FooBar::CFooBar(CWnd* pParent /*=NULL*/   , int dummy /*=0*/   );

--- a/tests/expected/cpp/30002-constructor.cpp
+++ b/tests/expected/cpp/30002-constructor.cpp
@@ -1,7 +1,7 @@
 
 IMPLEMENT_DYNAMIC(CPropertiesDlg, CDialog)
 CPropertiesDlg::CPropertiesDlg(CPtcMsgSimControlModule *pcmPtcMsg,
-                               CWnd                    *pParent /*=NULL*/ ) :
+                               CWnd                    *pParent /*=NULL*/) :
    CDialog(CPropertiesDlg::IDD, pParent),
    m_pspRouter(pcmPtcMsg),
    m_pspScm(pcmPtcMsg)
@@ -18,7 +18,7 @@ void CPropertiesDlg::DoDataExchange(CDataExchange *pDX)
    CDialog::DoDataExchange(pDX);
 }
 
-CFooBar::CFooBar(CWnd *pParent /*=NULL*/ )
+CFooBar::CFooBar(CWnd *pParent /*=NULL*/)
    : CDialog(CFooBar::IDD, pParent),
    m_parent(pParent)
 {

--- a/tests/expected/cpp/30108-templates3.cpp
+++ b/tests/expected/cpp/30108-templates3.cpp
@@ -7,7 +7,7 @@ template <bool a, bool b> struct X {
 
 template <class T> class new_alloc {
 public:
-   void deallocate(int* p, int /*num*/ )
+   void deallocate(int* p, int /*num*/)
    {
       T::operator delete((void*) p);
    }

--- a/tests/expected/cpp/30280-sf557.cpp
+++ b/tests/expected/cpp/30280-sf557.cpp
@@ -1,4 +1,4 @@
 //test.cpp
 void test_fun(std::size_t a,
-              std::size_t /* b */ );
+              std::size_t /* b */);
 

--- a/tests/expected/cpp/30702-function-def.cpp
+++ b/tests/expected/cpp/30702-function-def.cpp
@@ -15,7 +15,7 @@ void foo3(int param1,
           int param2,                                        // comment
           char *param2);
 
-struct whoopee *foo4(int param1, int param2, char *param2 /* comment */ );
+struct whoopee *foo4(int param1, int param2, char *param2 /* comment */);
 
 const struct snickers *foo5(int param1, int param2, char *param2);
 

--- a/tests/expected/cpp/30703-function-def.cpp
+++ b/tests/expected/cpp/30703-function-def.cpp
@@ -11,7 +11,7 @@ void foo2(int param1,int param2,char *param2);
 void foo3(int param1,int param2,                                        // comment
           char *param2);
 
-struct whoopee *foo4(int param1, int param2, char *param2 /* comment */ );
+struct whoopee *foo4(int param1, int param2, char *param2 /* comment */);
 
 const struct snickers *foo5(int param1, int param2, char *param2);
 

--- a/tests/expected/cpp/30809-bug_1289.cpp
+++ b/tests/expected/cpp/30809-bug_1289.cpp
@@ -1,3 +1,3 @@
-extern "C" void __declspec(dllexport) GetAccountNameAndDomain(HWND /*hwndParent*/, int string_size, TCHAR * variables, stack_t** stacktop, extra_parameters* /*extra*/ )
+extern "C" void __declspec(dllexport) GetAccountNameAndDomain(HWND /*hwndParent*/, int string_size, TCHAR * variables, stack_t** stacktop, extra_parameters* /*extra*/)
 {
 }

--- a/tests/expected/cpp/30925-function-def.cpp
+++ b/tests/expected/cpp/30925-function-def.cpp
@@ -16,7 +16,7 @@ void foo3(int  param1,
           char *param2
           );
 
-struct whoopee *foo4(int param1, int param2, char *param2 /* comment */ );
+struct whoopee *foo4(int param1, int param2, char *param2 /* comment */);
 
 const struct snickers *
 foo5(int param1, int param2, char *param2);

--- a/tests/expected/cpp/30926-function-def.cpp
+++ b/tests/expected/cpp/30926-function-def.cpp
@@ -16,7 +16,7 @@ void foo3(int  param1,
           char *param2
           );
 
-struct whoopee *foo4(int param1, int param2, char *param2 /* comment */ );
+struct whoopee *foo4(int param1, int param2, char *param2 /* comment */);
 
 const struct snickers *
 foo5(int param1, int param2, char *param2);

--- a/tests/expected/cpp/30927-function-def.cpp
+++ b/tests/expected/cpp/30927-function-def.cpp
@@ -16,7 +16,7 @@ void foo3(int  param1,
           char *param2
           );
 
-struct whoopee *foo4(int param1, int param2, char *param2 /* comment */ );
+struct whoopee *foo4(int param1, int param2, char *param2 /* comment */);
 
 const struct snickers *
 foo5(int param1, int param2, char *param2);

--- a/tests/expected/cpp/30928-function-def.cpp
+++ b/tests/expected/cpp/30928-function-def.cpp
@@ -16,7 +16,7 @@ void foo3(int  param1,
           char *param2
           );
 
-struct whoopee *foo4(int param1, int param2, char *param2 /* comment */ );
+struct whoopee *foo4(int param1, int param2, char *param2 /* comment */);
 
 const struct snickers *
 foo5(int param1, int param2, char *param2);

--- a/tests/expected/cpp/31730-ms-style-ref.cpp
+++ b/tests/expected/cpp/31730-ms-style-ref.cpp
@@ -2,7 +2,7 @@ Foo^ foo = dynamic_cast<Bar^>(bar);
 Foo* foo = dynamic_cast<Bar*>(bar);
 x = a ^ b;
 
-int main(Platform::Array<Platform::String^>^ /*args*/ )
+int main(Platform::Array<Platform::String^>^ /*args*/)
 {
 }
 

--- a/tests/expected/cpp/60032-UNI-21729.cpp
+++ b/tests/expected/cpp/60032-UNI-21729.cpp
@@ -1,3 +1,3 @@
-extern "C" void __declspec(dllexport) GetAccountNameAndDomain(HWND /*hwndParent*/, int string_size, TCHAR * variables, stack_t** stacktop, extra_parameters* /*extra*/ )
+extern "C" void __declspec(dllexport) GetAccountNameAndDomain(HWND /*hwndParent*/, int string_size, TCHAR * variables, stack_t** stacktop, extra_parameters* /*extra*/)
 {
 }

--- a/tests/expected/oc/51004-block_pointer.m
+++ b/tests/expected/oc/51004-block_pointer.m
@@ -6,7 +6,7 @@ the result file:
 Foo^ foo = dynamic_cast<Bar^>(bar);
 Foo* foo = dynamic_cast<Bar*>(bar);
 x = a ^ b;
-int main(Platform::Array<Platform::String^>^ /*args*/ )
+int main(Platform::Array<Platform::String^>^ /*args*/)
 {
 }
 

--- a/tests/input/c/emb_cmt_spacing.c
+++ b/tests/input/c/emb_cmt_spacing.c
@@ -1,0 +1,1 @@
+FooBar::CFooBar(CWnd* pParent/*=NULL*/, int dummy/*=0*/);


### PR DESCRIPTION
The solution for issue #4327 provided by PR #4328 affected too many places without providing existing users an option to keep the old behavior. This was likely to raise user complains after the coming release.
The new solution achieves the following things:
1. replace the previous solution for issue #4327, providing users an option to enable the old (default) or new behavior
2. solve the regression explained in issue #4354
3. extend the logic of #4327 to each side of an embedded comment (before and after)