### PR TITLE
Fix wrong test (always true) and silence gcc warning

### DIFF
--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -340,8 +340,8 @@ static void chunk_log_msg(Chunk *chunk, const log_sev_t log, const char *str)
 static void chunk_log(Chunk *pc, const char *text)
 {
    if (  pc->IsNullChunk()
-      || (cpd.unc_stage != unc_stage_e::TOKENIZE)
-      || (cpd.unc_stage != unc_stage_e::CLEANUP))
+      || (  cpd.unc_stage != unc_stage_e::TOKENIZE
+         && cpd.unc_stage != unc_stage_e::CLEANUP))
    {
       return;
    }


### PR DESCRIPTION
The test was always successful, therefore always returning from the call and `gcc` was giving a warning about it.