### PR TITLE
If an argument is missing in a doxygen comment, uncrutify should stop.

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -2473,6 +2473,15 @@ static void output_comment_multi(Chunk *pc)
             {
                line.append(' ');
             }
+
+            if (pc->GetStr()[end_idx] == 10)
+            {
+               // Issue #4378
+               fprintf(stderr, "%s\n", pc->ElidedText(copy));
+               fprintf(stderr, "FATAL: a doygen argument is missing.\n");
+               log_flush(true);
+               exit(EX_SOFTWARE);
+            }
             cmt_idx += (end_idx - start_idx);
             line.append(match.c_str());
 


### PR DESCRIPTION
The issue #4378 shows the problem.
The comment is not closed  properly.
PR #4378 is a bug fix proposal.
Please test it and report.