### PR TITLE
Prepare Uncrustify v0.80.1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ endif()
 # Generate uncrustify_version.h
 #
 
-set(UNCRUSTIFY_VERSION "0.80.0_f")
+set(UNCRUSTIFY_VERSION "0.80.1_f")
 
 option(NoGitVersionString "Do not use make_version.py and git to build a version string" OFF)
 if(NoGitVersionString)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+Change highlights in uncrustify-0.80.1 (November 2024)
+-------------------------------------------------------------------------------
+   d0ad61170436df7afab2b8041b49837f06f087ec
+     Removed : sp_pragma_open_parenthesis           Nov 16 2024
+     Removed : sp_inside_gparen                     Nov 16 2024
+
 Change highlights in uncrustify-0.80.0 (November 2024)
 -------------------------------------------------------------------------------
    273a37afbf5500d19011d4a392339160fffbfb11

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 A source code beautifier for C, C++, C#, Objective-C, D, Java, Pawn and Vala.
 
 ## Features
-* Highly configurable - 857 configurable options as of version 0.80.0
+* Highly configurable - 855 configurable options as of version 0.80.1
 - <details><summary>add/remove spaces</summary>
 
   - `sp_before_sparen`: _Add or remove space before '(' of 'if', 'for', 'switch', 'while', etc._

--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -1,4 +1,4 @@
-# Uncrustify-0.80.0
+# Uncrustify-0.80.1
 
 #
 # General options

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -1,4 +1,4 @@
-# Uncrustify-0.80.0
+# Uncrustify-0.80.1
 
 #
 # General options

--- a/documentation/htdocs/index.html
+++ b/documentation/htdocs/index.html
@@ -54,7 +54,7 @@ Create a highly configurable, easily modifiable source code beautifier.</p>
    <li>Add or remove parens on return statements</li>
    <li>Add or remove braces on single-statement if/do/while/for statements</li>
    <li>Supports embedded SQL 'EXEC SQL' stuff</li>
-   <li>Highly configurable - 857 configurable options as of version 0.80.0</li>
+   <li>Highly configurable - 855 configurable options as of version 0.80.1</li>
 </ul>
 
 <p>

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1,4 +1,4 @@
-# Uncrustify-0.80.0
+# Uncrustify-0.80.1
 
 #
 # General options

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -15,7 +15,7 @@ parameterOrder=ipo
 showHelpParameter=-h
 stringparaminquotes=false
 useCfgFileParameter="-c "
-version=Uncrustify-0.80.0
+version=Uncrustify-0.80.1
 
 [Newlines]
 Category=0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uncrustify",
-  "version": "0.80.0",
+  "version": "0.80.1",
   "description": "A highly configurable, easily modifiable source code beautifier for C, C++, C#, ObjectiveC, D, Java, Pawn and VALA",
   "main": "uncrustify",
   "scripts": {

--- a/release-process.rst
+++ b/release-process.rst
@@ -4,7 +4,7 @@
 
 .. Update the date in the next line when editing this document!
 
-*This document was last updated on 2024-11-15, for Uncrustify 0.80.0.*
+*This document was last updated on 2024-11-17, for Uncrustify 0.80.1.*
 
 This document uses "0.1.2" throughout as an example version number.
 Whenever you see this, you should substitute the version number


### PR DESCRIPTION
As per title. See comments on PR#4349 and issue #4401 for reasons why version 0.80.1 is being created.