### PR TITLE
fix tab indentation for blank lines

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -849,11 +849,11 @@ void output_text(FILE *pfile)
 
                if (pc->IsPreproc())
                {
-                  output_to_column(pc->GetNlColumn(), (pp_indent_with_tabs == 2));
+                  output_to_column(pc->GetNlColumn(), (pp_indent_with_tabs >= 1));
                }
                else
                {
-                  output_to_column(pc->GetNlColumn(), (options::indent_with_tabs() == 2));
+                  output_to_column(pc->GetNlColumn(), (options::indent_with_tabs() >= 1));
                }
             }
             add_char('\n');

--- a/tests/c.test
+++ b/tests/c.test
@@ -576,3 +576,6 @@
 10124  common/tde.cfg                             c/Issue_3985.c
 10125  common/tde.cfg                             c/Issue_3992.c
 10126  c/Issue_3259.cfg                           c/Issue_3259.h
+10127  c/indent_single_newlines_indent_0.cfg      c/indent_single_newlines.c
+10128  c/indent_single_newlines_indent_1.cfg      c/indent_single_newlines.c
+10129  c/indent_single_newlines_indent_2.cfg      c/indent_single_newlines.c

--- a/tests/config/c/indent_single_newlines_indent_0.cfg
+++ b/tests/config/c/indent_single_newlines_indent_0.cfg
@@ -1,0 +1,2 @@
+indent_single_newlines = true
+indent_with_tabs = 0

--- a/tests/config/c/indent_single_newlines_indent_1.cfg
+++ b/tests/config/c/indent_single_newlines_indent_1.cfg
@@ -1,0 +1,2 @@
+indent_single_newlines = true
+indent_with_tabs = 1

--- a/tests/config/c/indent_single_newlines_indent_2.cfg
+++ b/tests/config/c/indent_single_newlines_indent_2.cfg
@@ -1,0 +1,2 @@
+indent_single_newlines = true
+indent_with_tabs = 2

--- a/tests/expected/c/10127-indent_single_newlines.c
+++ b/tests/expected/c/10127-indent_single_newlines.c
@@ -1,0 +1,5 @@
+void main() {
+        int var = 0;
+        
+        printf("%08x\n", var);
+}

--- a/tests/expected/c/10128-indent_single_newlines.c
+++ b/tests/expected/c/10128-indent_single_newlines.c
@@ -1,0 +1,5 @@
+void main() {
+	int var = 0;
+	
+	printf("%08x\n", var);
+}

--- a/tests/expected/c/10129-indent_single_newlines.c
+++ b/tests/expected/c/10129-indent_single_newlines.c
@@ -1,0 +1,5 @@
+void main() {
+	int var = 0;
+	
+	printf("%08x\n", var);
+}

--- a/tests/input/c/indent_single_newlines.c
+++ b/tests/input/c/indent_single_newlines.c
@@ -1,0 +1,5 @@
+void main() {
+int var = 0;
+
+printf("%08x\n", var);
+}


### PR DESCRIPTION
Blank lines were indented using spaces even though `indent_with_tabs` specifies that 1 and 2 indent with tabs.
```cfg
indent_single_newlines = true
indent_with_tabs = 1
```