### PR TITLE
Do not mistake explicit operator== call for function prototype

### DIFF
--- a/src/tokenizer/combine_fix_mark.cpp
+++ b/src/tokenizer/combine_fix_mark.cpp
@@ -1216,7 +1216,6 @@ void mark_function(Chunk *pc)
          while ((tmp = tmp->GetPrevNcNnlNi())->IsNotNullChunk()) // Issue #2279
          {
             if (  tmp->Is(CT_BRACE_CLOSE)
-               || tmp->Is(CT_BRACE_OPEN)             // Issue 575
                || tmp->Is(CT_SEMICOLON))
             {
                break;


### PR DESCRIPTION
This code
```
bool operator ==(const Derived& item) const
{
	return property == item.property
		&& Base::operator==(item);
}
```
is not properly tokenized. `Base::operator==(btt)` is recognized as a function prototype, but it should be actually function call. I attached tokens dump. [These lines of code](https://github.com/uncrustify/uncrustify/blob/28d4229f3c17a1371abe37bd07a5e8d6168805c5/src/tokenizer/combine_fix_mark.cpp#L1252-L1269) should actually solve this. However, this code is unreachable because of [this](https://github.com/uncrustify/uncrustify/blob/28d4229f3c17a1371abe37bd07a5e8d6168805c5/src/tokenizer/combine_fix_mark.cpp#L1219), which was meant to solve issue [575](https://github.com/uncrustify/uncrustify/issues/575). Uncrustify had probably went a long way since than and now removing this solves my problem and the problem in [575](https://github.com/uncrustify/uncrustify/issues/575) isn't broken by this anymore. 

[example.txt](https://github.com/user-attachments/files/17866064/example.txt)

