### PR TITLE
Fix indent_shift = 1 behaviour to not indent irrelevant lines

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -3337,65 +3337,14 @@ void indent_text()
          bool in_shift    = false;
          bool is_operator = false;
 
-         // Are we in such an expression? Go both forwards and backwards.
-         Chunk *tmp = pc;
-
-         do
+         // Are we in continued shift expressions?
+         if (  (  pc->GetPrevNcNnl()->Is(CT_SHIFT)
+               && pc->GetPrevNc()->IsNewline())
+            || (  pc->Is(CT_SHIFT)
+               && pc->GetPrev()->IsNewline()))
          {
-            if (tmp->Is(CT_SHIFT))
-            {
-               in_shift = true;
-               LOG_FMT(LINDENT2, "%s(%d): in_shift set to TRUE\n",
-                       __func__, __LINE__);
-
-               tmp = tmp->GetPrevNcNnl();
-
-               if (tmp->Is(CT_OPERATOR))
-               {
-                  is_operator = true;
-               }
-               break;
-            }
-            tmp = tmp->GetPrevNcNnl();
-         } while (  !in_shift
-                 && tmp->IsNotNullChunk()
-                 && tmp->IsNot(CT_SEMICOLON)
-                 && tmp->IsNot(CT_BRACE_OPEN)
-                 && tmp->IsNot(CT_BRACE_CLOSE)
-                 && tmp->IsNot(CT_COMMA)
-                 && tmp->IsNot(CT_SPAREN_OPEN)
-                 && tmp->IsNot(CT_SPAREN_CLOSE));
-
-         tmp = pc;
-
-         do
-         {
-            tmp = tmp->GetNextNcNnl();
-
-            if (  tmp->IsNotNullChunk()
-               && tmp->Is(CT_SHIFT))
-            {
-               in_shift = true;
-               LOG_FMT(LINDENT2, "%s(%d): in_shift set to TRUE\n",
-                       __func__, __LINE__);
-
-               tmp = tmp->GetPrevNcNnl();
-
-               if (tmp->Is(CT_OPERATOR))
-               {
-                  is_operator = true;
-               }
-               break;
-            }
-         } while (  !in_shift
-                 && tmp->IsNotNullChunk()
-                 && tmp->IsNot(CT_SEMICOLON)
-                 && tmp->IsNot(CT_BRACE_OPEN)
-                 && tmp->IsNot(CT_BRACE_CLOSE)
-                 && tmp->IsNot(CT_COMMA)
-                 && tmp->IsNot(CT_SPAREN_OPEN)
-                 && tmp->IsNot(CT_SPAREN_CLOSE));
-
+            in_shift = true;
+         }
          LOG_FMT(LINDENT2, "%s(%d): in_shift is %s\n",
                  __func__, __LINE__, in_shift ? "TRUE" : "FALSE");
          Chunk *prev_nonl = pc->GetPrevNcNnl();

--- a/tests/expected/cpp/30290-align_left_shift.cpp
+++ b/tests/expected/cpp/30290-align_left_shift.cpp
@@ -34,7 +34,7 @@ void f() {
             << "World!"
             << std::endl);
     A_LONG_MACRO_NAME(
-	    std::cout << "Hello, "
+	std::cout << "Hello, "
 	    << "World!"
 	    << std::endl);
 }

--- a/tests/expected/cpp/30291-indent_shift.cpp
+++ b/tests/expected/cpp/30291-indent_shift.cpp
@@ -33,7 +33,7 @@ int case2() {
 	    << "hi"
 	    << "and"
 	    << "more"
-	    ;
+	;
 
     switch (var) {
     case 0:
@@ -50,7 +50,7 @@ int case2() {
     return log
         >> var
         >> second
-        ;
+    ;
 }
 
 
@@ -134,6 +134,6 @@ void check() {
         " terminated by signal " << WTERMSIG(exitStatus);
 
     return theAddr.addrN().family() == AF_INET6 ?
-        (theAddr.octet(idx * 2) << 8) + theAddr.octet(idx * 2 + 1) :
-        theAddr.octet(idx);
+           (theAddr.octet(idx * 2) << 8) + theAddr.octet(idx * 2 + 1) :
+           theAddr.octet(idx);
 }


### PR DESCRIPTION
Related to #4410

This fixes problem mentioned in #4410 . It also makes more sense this way, since only truly continued shift expressions are indented, as the rule says.