### PR TITLE
Remove 'using namespace' from header file

### DIFF
--- a/src/align/func_params.cpp
+++ b/src/align/func_params.cpp
@@ -135,7 +135,7 @@ Chunk *align_func_param(Chunk *start)
                log_flush(true);
                exit(EX_SOFTWARE);
             }
-            max_level_is = max(max_level_is, pc->GetLevel());
+            max_level_is = std::max(max_level_is, pc->GetLevel());
             many_as[pc->GetLevel()].Add(pc);
          }
       }

--- a/src/align/func_proto.cpp
+++ b/src/align/func_proto.cpp
@@ -51,13 +51,13 @@ void align_func_proto(size_t span)
 
 
    // Issue #2984
-   vector<vector<AlignStack *> > many_as;
+   std::vector<std::vector<AlignStack *> > many_as;
    // Issue #2771
-   vector<vector<AlignStack *> > many_as_brace;
+   std::vector<std::vector<AlignStack *> > many_as_brace;
 
    // init the vector ...
-   many_as.resize(num_of_column, vector<AlignStack *>(num_of_row, stack_init_value));
-   many_as_brace.resize(num_of_column, vector<AlignStack *>(num_of_row, stack_init_value));
+   many_as.resize(num_of_column, std::vector<AlignStack *>(num_of_row, stack_init_value));
+   many_as_brace.resize(num_of_column, std::vector<AlignStack *>(num_of_row, stack_init_value));
 
    log_rule_B("align_single_line_brace_gap");
    size_t mybr_gap = options::align_single_line_brace_gap();

--- a/src/align/same_func_call_params.cpp
+++ b/src/align/same_func_call_params.cpp
@@ -31,8 +31,8 @@ void align_same_func_call_params()
    Chunk             *align_fcn;
    UncText           align_fcn_name;
    UncText           align_root_name;
-   deque<Chunk *>    chunks;
-   deque<AlignStack> array_of_AlignStack;
+   std::deque<Chunk *>    chunks;
+   std::deque<AlignStack> array_of_AlignStack;
    AlignStack        fcn_as;
    const char        *add_str;
 
@@ -247,7 +247,7 @@ void align_same_func_call_params()
 } // align_same_func_call_params
 
 
-void align_params(Chunk *start, deque<Chunk *> &chunks)
+void align_params(Chunk *start, std::deque<Chunk *> &chunks)
 {
    LOG_FUNC_ENTRY();
 

--- a/src/log_rules.cpp
+++ b/src/log_rules.cpp
@@ -69,7 +69,7 @@ void log_rule4(const char *rule, Chunk *first)
 
    strcpy(r, rule);
    size_t      a_number = get_A_Number();
-   TrackNumber A        = make_pair(a_number, r);
+   TrackNumber A        = std::make_pair(a_number, r);
 
    first->TrackingData()->push_back(A);
    size_t sizeOfTrack = first->GetTrackingData()->size();
@@ -96,7 +96,7 @@ void log_ruleStart(const char *rule, Chunk *first)
 
    strcpy(r, rule);
    size_t      a_number = get_A_Number();
-   TrackNumber A        = make_pair(a_number, r);
+   TrackNumber A        = std::make_pair(a_number, r);
 
    first->TrackingData()->push_back(A);
    size_t sizeOfTrack = first->GetTrackingData()->size();
@@ -123,7 +123,7 @@ void log_ruleNL(const char *rule, Chunk *pc)
 
    strcpy(r, rule);
    size_t      a_number = get_A_Number();
-   TrackNumber A        = make_pair(a_number, r);
+   TrackNumber A        = std::make_pair(a_number, r);
 
    pc->TrackingData()->push_back(A);
    size_t sizeOfTrack = pc->GetTrackingData()->size();

--- a/src/newlines/brace_pair.cpp
+++ b/src/newlines/brace_pair.cpp
@@ -121,7 +121,7 @@ void newlines_brace_pair(Chunk *br_open)
             // Issue 2795
             // we have to check if it could be too long for code_width
             // make a vector to save the chunk
-            vector<Chunk> saved_chunk;
+            std::vector<Chunk> saved_chunk;
             log_rule_B("code_width");
 
             if (options::code_width() > 0)

--- a/src/newlines/cleanup.cpp
+++ b/src/newlines/cleanup.cpp
@@ -1269,7 +1269,7 @@ void newlines_cleanup_dup()
       if (  pc->Is(CT_NEWLINE)
          && next->Is(CT_NEWLINE))
       {
-         next->SetNlCount(max(pc->GetNlCount(), next->GetNlCount()));
+         next->SetNlCount(std::max(pc->GetNlCount(), next->GetNlCount()));
          Chunk::Delete(pc);
          MARK_CHANGE();
       }

--- a/src/parent_for_pp.cpp
+++ b/src/parent_for_pp.cpp
@@ -16,7 +16,7 @@ void do_parent_for_pp()
 
    std::vector<Chunk *> viz;
 
-   Chunk           *pc = Chunk::GetHead()->GetNextNcNnl();
+   Chunk                *pc = Chunk::GetHead()->GetNextNcNnl();
 
    while (pc->IsNotNullChunk())
    {

--- a/src/parent_for_pp.cpp
+++ b/src/parent_for_pp.cpp
@@ -14,7 +14,7 @@ void do_parent_for_pp()
 {
    LOG_FUNC_ENTRY();
 
-   vector<Chunk *> viz;
+   std::vector<Chunk *> viz;
 
    Chunk           *pc = Chunk::GetHead()->GetNextNcNnl();
 

--- a/src/pcf_flags.h
+++ b/src/pcf_flags.h
@@ -16,9 +16,6 @@
 //#define ARRAY_SIZE(x)    (sizeof(x) / sizeof((x)[0]))
 //#endif
 
-using namespace std;
-
-
 constexpr auto pcf_bit(size_t b) -> decltype(0ULL)
 {
    return(1ULL << b);

--- a/src/pcf_flags.h
+++ b/src/pcf_flags.h
@@ -11,10 +11,18 @@
 #include "enum_flags.h"
 #include "logger.h"
 
+
 //// and the ever-so-important array size macro
+
+
 //#ifndef ARRAY_SIZE
+
+
 //#define ARRAY_SIZE(x)    (sizeof(x) / sizeof((x)[0]))
+
+
 //#endif
+
 
 constexpr auto pcf_bit(size_t b) -> decltype(0ULL)
 {

--- a/src/pcf_flags.h
+++ b/src/pcf_flags.h
@@ -12,18 +12,6 @@
 #include "logger.h"
 
 
-//// and the ever-so-important array size macro
-
-
-//#ifndef ARRAY_SIZE
-
-
-//#define ARRAY_SIZE(x)    (sizeof(x) / sizeof((x)[0]))
-
-
-//#endif
-
-
 constexpr auto pcf_bit(size_t b) -> decltype(0ULL)
 {
    return(1ULL << b);

--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -45,7 +45,7 @@ struct include_category
 };
 
 
-include_category                 *include_categories[kIncludeCategoriesCount];
+include_category                      *include_categories[kIncludeCategoriesCount];
 std::unordered_map<Chunk *, int>      chunk_priority_cache;
 std::unordered_map<std::string, bool> filename_without_ext_cache;
 

--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -46,8 +46,8 @@ struct include_category
 
 
 include_category                 *include_categories[kIncludeCategoriesCount];
-unordered_map<Chunk *, int>      chunk_priority_cache;
-unordered_map<std::string, bool> filename_without_ext_cache;
+std::unordered_map<Chunk *, int>      chunk_priority_cache;
+std::unordered_map<std::string, bool> filename_without_ext_cache;
 
 
 /**


### PR DESCRIPTION
`using namespace` in headers files can unexpectedly cause underlying files to use the namespace. Clang even has a warning for this. Here's a [link](https://bugzilla.mozilla.org/show_bug.cgi?id=1443444) to Firefox enabling the warning.

This PR just removes the single instances of `using namespace std;` in a header file