### PR TITLE
Fix filename parsing by handling paths without a slash

### DIFF
--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -139,13 +139,21 @@ static bool text_contains_filename_without_ext(const char *text)
       return(filename_without_ext_cache[text]);
    }
    std::string filepath             = cpd.filename;
-   size_t      slash_idx            = filepath.find_last_of("/\\");
    std::string filename_without_ext = filepath;
+   size_t      startIndex           = filepath.find_last_of("/\\");
 
-   if (  slash_idx != std::string::npos
-      && slash_idx < (filepath.size() - 1))
+   if (startIndex == std::string::npos)
    {
-      std::string filename = filepath.substr(slash_idx + 1);
+      startIndex = 0;
+   }
+   else
+   {
+      startIndex += 1;
+   }
+
+   if (startIndex < filepath.size())
+   {
+      std::string filename = filepath.substr(startIndex);
       size_t      dot_idx  = filename.find_last_of('.');
       filename_without_ext = filename.substr(0, dot_idx);
    }


### PR DESCRIPTION
It's common to supply a file to uncrustify using `-f`:

```
./build/uncrustify -c config.cfg -f foo.m
```

We use this file name to sort imports. For example, `mod_sort_incl_import_prioritize_filename` will sort a `#import foo.h` import to the top:

```
// unformatted
#import <baz/baz.h>
#import "foo.h"

// formatted
#import "foo.h"
#import <baz/baz.h>
```

However, the current logic doesn't parse file names without a slash correctly. If a slash isn't found, `text_contains_filename_without_ext` returns `false`. This results in:

```
// formatted, this is incorrect. `#import "foo.h"` should be at the top
#import <baz/baz.h>
#import "foo.h"
```


This PR fixes the logic by handling paths without a slash.
