### PR TITLE
Allow setting the filename when reading from stdin

### DIFF
--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -286,7 +286,7 @@ void usage(const char *argv0)
            "                refers to blocking logging info from being sent to stderr.\n"
            " --frag       : Code fragment, assume the first line is indented correctly.\n"
            " --assume FN  : Uses the filename FN for automatic language detection if reading\n"
-           "                from stdin unless -l is specified.\n"
+           "                from stdin unless -l is specified. The filename is also used for formatting logic (ie. sorting headers).\n"
            "\n"
            "Config/Help Options:\n"
            " -h -? --help --usage     : Print this message and exit.\n"
@@ -1028,7 +1028,7 @@ int main(int argc, char *argv[])
          LOG_FMT(LERR, "Failed to read stdin\n");
          exit(EX_IOERR);
       }
-      cpd.filename = "stdin";
+      cpd.filename = assume != nullptr ? assume : "stdin";
 
       // Done reading from stdin
       LOG_FMT(LSYS, "%s(%d): Parsing: %zu bytes (%zu chars) from stdin as language %s\n",

--- a/src/uncrustify_emscripten.cpp
+++ b/src/uncrustify_emscripten.cpp
@@ -20,7 +20,6 @@
  *   --files ( no batch processing will be available )
  *   --prefix
  *   --suffix
- *   --assume
  *   --no-backup
  *   --replace
  *   --mtime

--- a/tests/cli/output/help.txt
+++ b/tests/cli/output/help.txt
@@ -37,7 +37,7 @@ Basic Options:
                 refers to blocking logging info from being sent to stderr.
  --frag       : Code fragment, assume the first line is indented correctly.
  --assume FN  : Uses the filename FN for automatic language detection if reading
-                from stdin unless -l is specified.
+                from stdin unless -l is specified. The filename is also used for formatting logic (ie. sorting headers).
 
 Config/Help Options:
  -h -? --help --usage     : Print this message and exit.


### PR DESCRIPTION
Some options, such as `mod_sort_incl_import_prioritize_filename` use the filename to format the file. For example, for "Foo.m":

```
// unformatted
#import <Bar/Bar.h>
#import "Foo.h"

// formatted (with mod_sort_incl_import_prioritize_filename enabled)
#import "Foo.h"
#import <Bar/Bar.h>
```

When formatting from stdin, there currently is no way to set a filename. We currently have `--assume`, which allows passing in a file name, but we're only using it to auto-detect the language.

This PR:
1. Makes the existing `--assume` API less confusing by using the filename passed in to `--assume` for formatting
2. Supports formatting options that depend on the filename, when using stdin

Test plan. Don't think we have boilerplate for stdin testing yet -- manually tested using Foo.m:

```
#import <Baz/Baz.h>

#import "Foo.h"
#import "Baz.h"
```

config.cfg:
```
mod_sort_include = true
mod_sort_incl_import_prioritize_filename = true
mod_sort_incl_import_grouping_enabled = true
```

Running `cat Foo.m | ./build/uncrustify -c test.cfg -l OC+ --assume /Foo.m` (the slash in `/Foo.m` is needed until https://github.com/uncrustify/uncrustify/pull/4423 is merged):
```
// Before this PR
#import "Baz.h"
#import "Foo.h"

#import <Baz/Baz.h>
```

```
// After this PR. `#import "Foo.h"` is correctly formatted to the top of the file.
#import "Foo.h"

#import "Baz.h"

#import <Baz/Baz.h>
```

