### PR TITLE
Fix indent_shift = 1 behaviour with multiline operands

### DIFF
--- a/tests/expected/cpp/30291-indent_shift.cpp
+++ b/tests/expected/cpp/30291-indent_shift.cpp
@@ -110,6 +110,14 @@ void case4()
 }
 
 void foo() {
+    logError("Exception occurred while checking other exception %1\n%2")
+        << std::string(
+	    reinterpret_cast<const char*>(error.getMessage().data()),
+	    error.getMessage().size()
+        )
+        << foo() +
+        bar()
+        << "something";
 
     if (head())
 	os << "HEAD,";

--- a/tests/input/cpp/indent_shift.cpp
+++ b/tests/input/cpp/indent_shift.cpp
@@ -110,6 +110,14 @@ void case4()
 }
 
 void foo() {
+    logError("Exception occurred while checking other exception %1\n%2")
+       << std::string(
+	    reinterpret_cast<const char*>(error.getMessage().data()),
+	    error.getMessage().size()
+       )
+       << foo() +
+       bar()
+        << "something";
 
 	if (head())
 		os << "HEAD,";


### PR DESCRIPTION
#4410 reported incorrect behaviour of indent_shift = 1 in certain cases. In PR #4418 I tried to fix this and I actually did, but my implementation did not handled correctly a corner case where the right operand of shift spreads across multiple lines. Something like this:
```
	logError("Exception occurred while checking other exception %1\n%2")
		<< std::string(
			reinterpret_cast<const char*>(error.getMessage().data()),
			error.getMessage().size()
		)
```
Such a use case was not covered by unit tests so this all passed. Now I changed the implementation to also cover this use case and I also added unit test that checks for this.

I am sorry that I did not find the corner case before PR #4418 was merged, I could save you some time, now you have to review twice.

EDIT:

Actual wrong output:
```
	logError("Exception occurred while checking other exception %1\n%2")
		<< std::string(
		reinterpret_cast<const char*>(error.getMessage().data()),
		error.getMessage().size()
		)
```

Expected correct output:
```
	logError("Exception occurred while checking other exception %1\n%2")
		<< std::string(
			reinterpret_cast<const char*>(error.getMessage().data()),
			error.getMessage().size()
		)
```