### PR TITLE
Add indent_bool_nested_all = true/false option

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -1814,6 +1814,11 @@ indent_bool_paren;
 extern Option<bool>
 indent_ignore_bool;
 
+
+// Whether to indent lines that are nested in boolean expression one more level for each nesting
+extern Option<bool>
+indent_bool_nested_all; // = false
+
 // Whether to ignore the indentation of an arithmetic operator.
 extern Option<bool>
 indent_ignore_arith;

--- a/tests/c.test
+++ b/tests/c.test
@@ -226,6 +226,7 @@
 00512  common/bool-pos-eol-force.cfg                    c/bool-pos.c
 00513  c/bool-pos-sol-force.cfg                         c/bool-pos.c
 00514  c/my_conf.cfg                                    c/my_infile.c
+00515  c/indent_bool_nested_all.cfg                     c/indent_bool_nested_all.c
 
 00600  common/indent_columns-3.cfg                      c/dos.c
 00601  common/indent_columns-3.cfg                      c/mac.c

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1499,6 +1499,9 @@ indent_bool_paren               = 0        # number
 # parentheses.
 indent_ignore_bool              = false    # true/false
 
+# Whether to indent lines that are nested in boolean expression one more level for each nesting
+indent_bool_nested_all          = false    # true/false
+
 # Whether to ignore the indentation of an arithmetic operator.
 indent_ignore_arith             = false    # true/false
 

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -3650,6 +3650,15 @@ TrueFalse=indent_ignore_bool=true|indent_ignore_bool=false
 TrueFalseRegex=indent_ignore_bool\s*=\s*true|indent_ignore_bool\s*=\s*false
 ValueDefault=false
 
+[Indent Bool Nested All]
+Category=2
+Description="<html>Whether to indent lines that are nested in boolean expression one more level for each nesting</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=indent_bool_nested_all=true|indent_bool_nested_all=false
+TrueFalseRegex=indent_bool_nested_all\s*=\s*true|indent_bool_nested_all\s*=\s*false
+ValueDefault=false
+
 [Indent Ignore Arith]
 Category=2
 Description="<html>Whether to ignore the indentation of an arithmetic operator.</html>"

--- a/tests/config/c/indent_bool_nested_all.cfg
+++ b/tests/config/c/indent_bool_nested_all.cfg
@@ -1,0 +1,2 @@
+indent_bool_nested_all               = true
+indent_continue                      = indent_columns        # number

--- a/tests/expected/c/00515-indent_bool_nested_all.c
+++ b/tests/expected/c/00515-indent_bool_nested_all.c
@@ -1,0 +1,77 @@
+#include <stdbool.h>
+#include <stdio.h>
+
+bool nested_boolean_example(int a, int b, int c, int d)
+{
+	// it looks a little bit weird when boolean operators are at the end of lines
+	if ((a > 10 &&
+	                (b < 5 || c > 7)) &&
+	        (d != 0 &&
+	                (a * d > b + c)))
+	{
+		return true;
+	}
+	return false;
+}
+
+bool complex_nested_conditions(int x, int y, int z)
+{
+	// it looks good when boolean operators are at the beginning of lines
+	if ((x == y
+	                || (y < z && z > 20))
+	        && ((x + y > z * 2)
+	                || (x - z < y * 3 && x > 100)))
+	{
+		return true;
+	}
+	return false;
+}
+
+int main()
+{
+	if ((type_ != type_a
+	                || !use_type_a)
+	        && (type_ != type_b
+	                || !use_type_b)
+	        && (type_ != type_c
+	                || !use_type_c)
+	        && (type_ != type_d
+	                || !use_type_d)
+	        && !use_something_else)
+	{
+		do_something();
+	}
+	int a = 15;
+	int b = 3;
+	int c = 8;
+	int d = 2;
+
+	int x = 5;
+	int y = 5;
+	int z = 25;
+
+	if (nested_boolean_example(a, b, c, d)
+	        && complex_nested_conditions(x, y, z))
+	{
+		printf("Both nested conditions are true.\n");
+	}
+
+	// here also the != operator is indented more, because it is nested
+	if (a < b
+	        && (some_ultra_long_name_function()
+	                != another_ultra_long_name_function()))
+	{
+		printf("Complex condition with nested expressions is true.\n");
+	}
+
+	if ((a < b
+	                && (b == c
+	                        || d > 100))
+	        || ((a * b - d < c * c + b)
+	                && (d != 1)))
+	{
+		printf("Complex condition with nested expressions is true.\n");
+	}
+
+	return 0;
+}

--- a/tests/input/c/indent_bool_nested_all.c
+++ b/tests/input/c/indent_bool_nested_all.c
@@ -1,0 +1,77 @@
+#include <stdbool.h>
+#include <stdio.h>
+
+bool nested_boolean_example(int a, int b, int c, int d)
+{
+    // it looks a little bit weird when boolean operators are at the end of lines
+	if ((a > 10 &&
+	   (b < 5 || c > 7)) &&
+	   (d != 0 &&
+	   (a * d > b + c)))
+	{
+		return true;
+	}
+	return false;
+}
+
+bool complex_nested_conditions(int x, int y, int z)
+{
+	// it looks good when boolean operators are at the beginning of lines
+	if ((x == y
+	   || (y < z && z > 20))
+	   && ((x + y > z * 2)
+	   || (x - z < y * 3 && x > 100)))
+	{
+		return true;
+	}
+	return false;
+}
+
+int main()
+{
+	if ((type_ != type_a
+	   || !use_type_a)
+	   && (type_ != type_b
+	   || !use_type_b)
+	   && (type_ != type_c
+	   || !use_type_c)
+	   && (type_ != type_d
+	   || !use_type_d)
+	   && !use_something_else)
+	{
+		do_something();
+	}
+	int a = 15;
+	int b = 3;
+	int c = 8;
+	int d = 2;
+
+	int x = 5;
+	int y = 5;
+	int z = 25;
+
+	if (nested_boolean_example(a, b, c, d)
+	   && complex_nested_conditions(x, y, z))
+	{
+		printf("Both nested conditions are true.\n");
+	}
+
+	// here also the != operator is indented more, because it is nested
+        if (a < b
+            && (some_ultra_long_name_function()
+            != another_ultra_long_name_function()))
+          {
+	    printf("Complex condition with nested expressions is true.\n");
+	  }
+
+	if ((a < b
+	   && (b == c
+	   || d > 100))
+	   || ((a * b - d < c * c + b)
+	   && (d != 1)))
+	{
+		printf("Complex condition with nested expressions is true.\n");
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Everything nested in boolean expression is indented by one more level for every nesting level. The idea is to be able to have something like this:

```
	if ((type_ != type_a 
			|| !use_type_a)
		&& (type_ != type_b 
			|| !use_type_b)
		&& (type_ != type_c 
			|| !use_type_c)
		&& (type_ != type_d 
			|| !use_type_d)
		&& !use_something_else)
	{
		do_something();
	}
```
Here, you can see that the first `||` is indented one level more, because its nested one level more compared to the `&&`. 