### PR TITLE
Support templated lambda

### DIFF
--- a/src/tokenizer/check_template.cpp
+++ b/src/tokenizer/check_template.cpp
@@ -31,11 +31,14 @@ bool invalid_open_angle_template(Chunk *prev)
       return(false);
    }
    // A template requires a word/type right before the open angle
+   // It can also appear after the square brackets of a lambda
    return(  prev->IsNot(CT_WORD)
          && prev->IsNot(CT_TYPE)
          && prev->IsNot(CT_COMMA)
          && prev->IsNot(CT_QUALIFIER)
          && prev->IsNot(CT_OPERATOR_VAL)
+         && prev->IsNot(CT_SQUARE_CLOSE)
+         && prev->IsNot(CT_TSQUARE)
          && prev->GetParentType() != CT_OPERATOR);
 }
 

--- a/src/tokenizer/combine.cpp
+++ b/src/tokenizer/combine.cpp
@@ -10,6 +10,7 @@
 #include "tokenizer/combine.h"
 
 #include "ChunkStack.h"
+#include "check_template.h"
 #include "lang_pawn.h"
 #include "log_rules.h"
 #include "newlines/iarf.h"
@@ -2518,7 +2519,22 @@ static void handle_cpp_lambda(Chunk *sq_o)
          return;
       }
    }
-   Chunk *pa_o = sq_c->GetNextNcNnl();
+
+   Chunk *angle_open  = sq_c->GetNextNcNnl();
+   Chunk *angle_close = Chunk::NullChunkPtr;
+
+   if (angle_open->Is(CT_ANGLE_OPEN))
+   {
+      // make sure there is a '>'
+      angle_close = angle_open->GetClosingParen();
+
+      if (angle_close->IsNullChunk())
+      {
+         LOG_FMT(LFCNR, "%s(%d): return\n", __func__, __LINE__);
+         return;
+      }
+   }
+   Chunk *pa_o = (angle_close == Chunk::NullChunkPtr) ? sq_c->GetNextNcNnl() : angle_close->GetNextNcNnl();
 
    // check to see if there is a lambda-specifier in the pa_o chunk;
    // assuming chunk is CT_EXECUTION_CONTEXT, ignore lambda-specifier

--- a/tests/config/cpp/Issue_4242.cfg
+++ b/tests/config/cpp/Issue_4242.cfg
@@ -1,0 +1,3 @@
+sp_compare       = force
+indent_columns   = 4
+indent_with_tabs = 0

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -1237,3 +1237,4 @@
 60162  cpp/nl_max_after_func_body.cfg                       cpp/nl_func.cpp
 60163  cpp/nl_max_after_func_body.cfg                       cpp/nl_func-2.cpp
 60164  cpp/Issue_3191.cfg                                   cpp/Issue_3191.cpp
+60165  cpp/Issue_4242.cfg                                   cpp/Issue_4242.cpp

--- a/tests/expected/cpp/30750-lambda.cpp
+++ b/tests/expected/cpp/30750-lambda.cpp
@@ -95,7 +95,7 @@ void h1()
       return(33);
    }();
 
-   []() noexcept ->int
+   []() noexcept -> int
    {
       return(33);
    }();
@@ -108,7 +108,7 @@ void h2()
       return(a + 33);
    }(21);
 
-   [](int a) noexcept ->int
+   [](int a) noexcept -> int
    {
       return(a + 33);
    }(21);

--- a/tests/expected/cpp/30751-lambda.cpp
+++ b/tests/expected/cpp/30751-lambda.cpp
@@ -77,7 +77,7 @@ void h1()
       return(33);
    }();
 
-   [] () noexcept ->int {
+   [] () noexcept -> int {
       return(33);
    }();
 }
@@ -88,7 +88,7 @@ void h2()
       return(a + 33);
    }(21);
 
-   [] (int a) noexcept ->int {
+   [] (int a) noexcept -> int {
       return(a + 33);
    }(21);
 }

--- a/tests/expected/cpp/30752-lambda.cpp
+++ b/tests/expected/cpp/30752-lambda.cpp
@@ -108,7 +108,7 @@ void h1()
       return(33);
    }();
 
-   [] () noexcept ->int
+   [] () noexcept -> int
    {
       return(33);
    }();
@@ -121,7 +121,7 @@ void h2()
       return(a + 33);
    }(21);
 
-   [] (int a) noexcept ->int
+   [] (int a) noexcept -> int
    {
       return(a + 33);
    }(21);

--- a/tests/expected/cpp/30753-lambda2.cpp
+++ b/tests/expected/cpp/30753-lambda2.cpp
@@ -81,7 +81,7 @@ void h1()
       return(33);
    }();
 
-   [] () noexcept ->int {
+   [] () noexcept -> int {
       return(33);
    }();
 }
@@ -92,7 +92,7 @@ void h2()
       return(a + 33);
    }(21);
 
-   [] (int a) noexcept ->int {
+   [] (int a) noexcept -> int {
       return(a + 33);
    }(21);
 }

--- a/tests/expected/cpp/30759-lambda2.cpp
+++ b/tests/expected/cpp/30759-lambda2.cpp
@@ -81,7 +81,7 @@ void h1()
       return(33);
    }();
 
-   [] () noexcept ->int {
+   [] () noexcept -> int {
       return(33);
    }();
 }
@@ -92,7 +92,7 @@ void h2()
       return(a + 33);
    }(21);
 
-   [] (int a) noexcept ->int {
+   [] (int a) noexcept -> int {
       return(a + 33);
    }(21);
 }

--- a/tests/expected/cpp/30765-lambda.cpp
+++ b/tests/expected/cpp/30765-lambda.cpp
@@ -94,7 +94,7 @@ void h1()
 		return 33;
 	}();
 
-	[]() noexcept ->int
+	[]() noexcept -> int
 	{
 		return 33;
 	}();
@@ -107,7 +107,7 @@ void h2()
 		return a + 33;
 	}(21);
 
-	[](int a) noexcept ->int
+	[](int a) noexcept -> int
 	{
 		return a + 33;
 	}(21);

--- a/tests/expected/cpp/30766-lambda.cpp
+++ b/tests/expected/cpp/30766-lambda.cpp
@@ -94,7 +94,7 @@ void h1()
 		return 33;
 	}();
 
-	[]() noexcept ->int
+	[]() noexcept -> int
 	{
 		return 33;
 	}();
@@ -107,7 +107,7 @@ void h2()
 		return a + 33;
 	}(21);
 
-	[](int a) noexcept ->int
+	[](int a) noexcept -> int
 	{
 		return a + 33;
 	}(21);

--- a/tests/expected/cpp/30767-lambda.cpp
+++ b/tests/expected/cpp/30767-lambda.cpp
@@ -94,7 +94,7 @@ void h1()
 		return 33;
 	}();
 
-	[]() noexcept ->int
+	[]() noexcept -> int
 	{
 		return 33;
 	}();
@@ -107,7 +107,7 @@ void h2()
 		return a + 33;
 	}(21);
 
-	[](int a) noexcept ->int
+	[](int a) noexcept -> int
 	{
 		return a + 33;
 	}(21);

--- a/tests/expected/cpp/30770-lambda.cpp
+++ b/tests/expected/cpp/30770-lambda.cpp
@@ -94,7 +94,7 @@ void h1()
 		return 33;
 	}();
 
-	[]() noexcept ->int
+	[]() noexcept -> int
 	{
 		return 33;
 	}();
@@ -107,7 +107,7 @@ void h2()
 		return a + 33;
 	}(21);
 
-	[](int a) noexcept ->int
+	[](int a) noexcept -> int
 	{
 		return a + 33;
 	}(21);

--- a/tests/expected/cpp/30771-lambda.cpp
+++ b/tests/expected/cpp/30771-lambda.cpp
@@ -94,7 +94,7 @@ void h1()
 		return 33;
 	}();
 
-	[] () noexcept ->int
+	[] () noexcept -> int
 	{
 		return 33;
 	}();
@@ -107,7 +107,7 @@ void h2()
 		return a + 33;
 	}(21);
 
-	[] (int a) noexcept ->int
+	[] (int a) noexcept -> int
 	{
 		return a + 33;
 	}(21);

--- a/tests/expected/cpp/30772-lambda.cpp
+++ b/tests/expected/cpp/30772-lambda.cpp
@@ -94,7 +94,7 @@ void h1()
 		return 33;
 	}();
 
-	[]() noexcept ->int
+	[]() noexcept -> int
 	{
 		return 33;
 	}();
@@ -107,7 +107,7 @@ void h2()
 		return a + 33;
 	}(21);
 
-	[](int a) noexcept ->int
+	[](int a) noexcept -> int
 	{
 		return a + 33;
 	}(21);

--- a/tests/expected/cpp/30773-lambda.cpp
+++ b/tests/expected/cpp/30773-lambda.cpp
@@ -94,7 +94,7 @@ void h1()
 		return 33;
 	}();
 
-	[]() noexcept ->int
+	[]() noexcept -> int
 	{
 		return 33;
 	}();
@@ -107,7 +107,7 @@ void h2()
 		return a + 33;
 	}(21);
 
-	[](int a) noexcept ->int
+	[](int a) noexcept -> int
 	{
 		return a + 33;
 	}(21);

--- a/tests/expected/cpp/30774-lambda.cpp
+++ b/tests/expected/cpp/30774-lambda.cpp
@@ -94,7 +94,7 @@ void h1()
 		return 33;
 	}();
 
-	[]() noexcept ->int
+	[]() noexcept -> int
 	{
 		return 33;
 	}();
@@ -107,7 +107,7 @@ void h2()
 		return a + 33;
 	}(21);
 
-	[](int a) noexcept ->int
+	[](int a) noexcept -> int
 	{
 		return a + 33;
 	}(21);

--- a/tests/expected/cpp/30775-lambda.cpp
+++ b/tests/expected/cpp/30775-lambda.cpp
@@ -94,7 +94,7 @@ void h1()
 		return 33;
 	}();
 
-	[]() noexcept ->int
+	[]() noexcept -> int
 	{
 		return 33;
 	}();
@@ -107,7 +107,7 @@ void h2()
 		return a + 33;
 	}(21);
 
-	[](int a) noexcept ->int
+	[](int a) noexcept -> int
 	{
 		return a + 33;
 	}(21);

--- a/tests/expected/cpp/60165-Issue_4242.cpp
+++ b/tests/expected/cpp/60165-Issue_4242.cpp
@@ -4,3 +4,6 @@ auto lam = []<typename T>() mutable -> void
 auto lam2 = [a = 42]<typename T>() mutable -> void
             {
             };
+auto lam3 = [a = 42]<typename T>() mutable constexpr consteval noexcept noexcept(true) noexcept(noexcept(true)) -> void
+            {
+            };

--- a/tests/expected/cpp/60165-Issue_4242.cpp
+++ b/tests/expected/cpp/60165-Issue_4242.cpp
@@ -1,0 +1,6 @@
+auto lam = []<typename T>() mutable -> void
+           {
+           };
+auto lam2 = [a = 42]<typename T>() mutable -> void
+            {
+            };

--- a/tests/input/cpp/Issue_4242.cpp
+++ b/tests/input/cpp/Issue_4242.cpp
@@ -4,3 +4,6 @@ auto lam = []<typename T>() mutable -> void
 auto lam2 = [a = 42]<typename T>() mutable -> void
             {
             };
+auto lam3 = [a = 42]<typename T>() mutable constexpr consteval noexcept noexcept(true) noexcept(noexcept(true)) -> void
+            {
+            };

--- a/tests/input/cpp/Issue_4242.cpp
+++ b/tests/input/cpp/Issue_4242.cpp
@@ -1,0 +1,6 @@
+auto lam = []<typename T>() mutable -> void
+           {
+           };
+auto lam2 = [a = 42]<typename T>() mutable -> void
+            {
+            };


### PR DESCRIPTION
This MR is pickung up the work from #4115.
Additionally to the original MR this one also allows a template specifier to appear after `CT_TSQUARE`.

The support for additional keywords besides `mutable` is expanded as well to support `noexcept(...)`.

Further, I added a test for the new template parsing.

Lastly, existing tests are adapted. Before this change, a lambda containing any keyword other than `mutable` was not formatted correctly (this was part of the expected output). After this change, the lambda is formatted correctly and the expected output had to be changed accordingly 