### PR TITLE
Fix constructors not being detected as such in nested namespaces if indent_namespace_single_indent = true

### DIFF
--- a/src/tokenizer/EnumStructUnionParser.cpp
+++ b/src/tokenizer/EnumStructUnionParser.cpp
@@ -1600,16 +1600,16 @@ void EnumStructUnionParser::mark_constructors()
       /**
        * get the name of the type
        */
-      auto *body_end   = get_body_end();
-      auto *body_start = get_body_start();
-      auto *name       = m_type->Text();
+      auto *name = m_type->Text();
 
       LOG_FMT(LFTOR, "%s(%d): Name of type is '%s'\n",
               __unqualified_func__, __LINE__, name);
       log_pcf_flags(LFTOR, m_type->GetFlags());
 
-      Chunk       *next = Chunk::NullChunkPtr;
-      std::size_t level = m_type->GetBraceLevel() + 1;
+      Chunk       *body_start = get_body_start();
+      Chunk       *body_end   = get_body_end();
+      Chunk       *next       = Chunk::NullChunkPtr;
+      std::size_t braceLevel  = m_type->GetBraceLevel() + 1;
 
       for (auto *prev = body_start; next != body_end; prev = next)
       {
@@ -1626,7 +1626,7 @@ void EnumStructUnionParser::mark_constructors()
          }
 
          if (  std::strcmp(prev->Text(), name) == 0
-            && prev->GetLevel() == level
+            && prev->GetBraceLevel() == braceLevel
             && next->IsParenOpen())
          {
             prev->SetType(CT_FUNC_CLASS_DEF);

--- a/tests/config/cpp/Issue_4346.cfg
+++ b/tests/config/cpp/Issue_4346.cfg
@@ -1,0 +1,9 @@
+indent_columns                  = 4
+indent_with_tabs                = 0
+indent_namespace                = true
+indent_namespace_single_indent  = true
+indent_class                    = true
+nl_constr_init_args             = force
+nl_constr_colon                 = force
+pos_constr_comma                = trail_force
+pos_constr_colon                = trail_force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -304,6 +304,7 @@
 30301  cpp/al.cfg                                           cpp/enum_class.h
 30302  cpp/bug_1315.cfg                                     cpp/bug_1315.cpp
 30303  cpp/Issue_2902.cfg                                   cpp/Issue_2902.cpp
+30304  cpp/Issue_4346.cfg                                   cpp/Issue_4346.cpp
 
 # TODO: Make a tests for a braced_init_list. See also 34153-34166.
 30310  cpp/sp_word_brace_force.cfg                          cpp/braced_init_list.cpp

--- a/tests/expected/cpp/30304-Issue_4346.cpp
+++ b/tests/expected/cpp/30304-Issue_4346.cpp
@@ -1,0 +1,11 @@
+namespace LevelOneNamespace {
+namespace LevelTwoNamespace {
+
+    class B : {
+        explicit B() :
+            a(9) {
+        };
+    }
+
+}
+}

--- a/tests/input/cpp/Issue_4346.cpp
+++ b/tests/input/cpp/Issue_4346.cpp
@@ -1,0 +1,9 @@
+namespace LevelOneNamespace {
+namespace LevelTwoNamespace {
+
+class B : {
+    explicit B() : a(9) {};
+}
+
+}
+}


### PR DESCRIPTION
Fixes https://github.com/uncrustify/uncrustify/issues/4346

Previously, for a constructor to be detected as such one of the conditions was that the brace level of the namespace plus 1 had to be equal to the level of the constructor definition (note brace level vs. level). Normally the brace level and the level of such chunks are equal so it does not matter that you compare these two different types of levels. For nested namespaces and if `indent_namespace` and `indent_namespace_single_indent` are both set to true, this does not hold up anymore because of https://github.com/uncrustify/uncrustify/commit/896c25688a24b14e30eaaa11f3635ef8105c66c3#diff-e040a4103d2245520694a6804cb2e3de5f1f00d5c78a8bd9f1167eb8394f0290R625.
As a result, the "brace level" is not really the brace level anymore but acts more as an indention indicator.

To fix the behavior, the comparison now uses the brace level for both chunks.