### PR TITLE
Fix spacings for pointer reference parameters

### DIFF
--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1456,6 +1456,14 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
          log_rule("sp_before_byref_func");                         // byref 4
          return(options::sp_before_byref_func());
       }
+
+      if (first->Is(CT_PTR_TYPE))
+      {
+         // Add or remove space between pointer and Ref.
+         // as in 'int *& a'.
+         log_rule("sp_between_ptr_ref");                           // ptr_ref 1
+         return(options::sp_between_ptr_ref());
+      }
       Chunk *next = second->GetNext();
 
       if (  next->IsNotNullChunk()
@@ -1478,14 +1486,6 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
             log_rule("sp_before_byref");                           // byref 3
             return(options::sp_before_byref());
          }
-      }
-
-      if (first->Is(CT_PTR_TYPE))
-      {
-         // Add or remove space between pointer and Ref.
-         // as in 'int *& a'.
-         log_rule("sp_between_ptr_ref");                           // ptr_ref 1
-         return(options::sp_between_ptr_ref());
       }
       // Add or remove space before a reference sign '&'.
       log_rule("sp_before_byref");                                 // byref 3
@@ -2739,7 +2739,8 @@ static iarf_e do_space(Chunk *first, Chunk *second, int &min_sp)
 
          next = second->GetNextNc();
 
-         while (next->Is(CT_PTR_TYPE))
+         while (  next->Is(CT_PTR_TYPE)
+               || next->Is(CT_BYREF))   // Issue #4438
          {
             next = next->GetNextNc();
          }

--- a/tests/expected/cpp/30012-misc2.cpp
+++ b/tests/expected/cpp/30012-misc2.cpp
@@ -20,9 +20,9 @@ typedef std::list<StreamedData*>::iterator iterator;
 typedef void (T::*Routine)(void);
 
 //Similar with "sp_before_byref = remove":
-unsigned long allocate(unsigned long size, void*& p);
+unsigned long allocate(unsigned long size, void*& p, void*&);
 
-//unsigned long allocate(unsigned long size, void* & p);
+//unsigned long allocate(unsigned long size, void* & p, void* &);
 //------------------------------------------------^ The same here
 
 void foo(void)

--- a/tests/expected/cpp/30805-ptr-star.cpp
+++ b/tests/expected/cpp/30805-ptr-star.cpp
@@ -15,6 +15,8 @@ int YerFunc(std::string& s, char**) {
 }
 
 int* X(int* i, int*);
+int* Y(int*& i, int*&);
+int* Z(int**& i, int**&);
 
 int* i = &a;
 int* i = *b;

--- a/tests/expected/cpp/30806-ptr-star.cpp
+++ b/tests/expected/cpp/30806-ptr-star.cpp
@@ -15,6 +15,8 @@ int YerFunc(std::string &s, char **) {
 }
 
 int *X(int *i, int *);
+int *Y(int *&i, int *&);
+int *Z(int **&i, int **&);
 
 int *i = &a;
 int *i = *b;

--- a/tests/expected/cpp/30807-ptr-star.cpp
+++ b/tests/expected/cpp/30807-ptr-star.cpp
@@ -15,6 +15,8 @@ int YerFunc(std::string& s, char**) {
 }
 
 int* X(int *i, int*);
+int* Y(int *& i, int*&);
+int* Z(int **& i, int**&);
 
 int *i = &a;
 int *i = *b;

--- a/tests/expected/cpp/30808-ptr-star.cpp
+++ b/tests/expected/cpp/30808-ptr-star.cpp
@@ -15,6 +15,8 @@ int YerFunc(std::string& s, char**) {
 }
 
 int*X(int *i, int*);
+int*Y(int*& i, int*&);
+int*Z(int**& i, int**&);
 
 int *i = &a;
 int *i = *b;

--- a/tests/expected/cpp/30810-ptr-star.cpp
+++ b/tests/expected/cpp/30810-ptr-star.cpp
@@ -17,6 +17,8 @@ int YerFunc(std::string& s, char **)
 }
 
 int *X(int *i, int *);
+int *Y(int *& i, int *&);
+int *Z(int **& i, int **&);
 
 int *i = &a;
 int *i = *b;

--- a/tests/expected/cpp/31638-misc2.cpp
+++ b/tests/expected/cpp/31638-misc2.cpp
@@ -20,9 +20,9 @@ typedef std::list<StreamedData*>::iterator iterator;
 typedef void (T::*Routine)(void);
 
 //Similar with "sp_before_byref = remove":
-unsigned long allocate(unsigned long size, void* & p);
+unsigned long allocate(unsigned long size, void* & p, void* &);
 
-//unsigned long allocate(unsigned long size, void* & p);
+//unsigned long allocate(unsigned long size, void* & p, void* &);
 //------------------------------------------------^ The same here
 
 void foo(void)

--- a/tests/expected/cpp/31639-misc2.cpp
+++ b/tests/expected/cpp/31639-misc2.cpp
@@ -20,9 +20,9 @@ typedef std::list<StreamedData*>::iterator iterator;
 typedef void (T::*Routine)(void);
 
 //Similar with "sp_before_byref = remove":
-unsigned long allocate(unsigned long size, void*& p);
+unsigned long allocate(unsigned long size, void*& p, void*&);
 
-//unsigned long allocate(unsigned long size, void* & p);
+//unsigned long allocate(unsigned long size, void* & p, void* &);
 //------------------------------------------------^ The same here
 
 void foo(void)

--- a/tests/expected/cpp/31640-misc2.cpp
+++ b/tests/expected/cpp/31640-misc2.cpp
@@ -20,9 +20,9 @@ typedef std::list<StreamedData*>::iterator iterator;
 typedef void (T::*Routine)(void);
 
 //Similar with "sp_before_byref = remove":
-unsigned long allocate(unsigned long size, void* & p);
+unsigned long allocate(unsigned long size, void* & p, void* &);
 
-//unsigned long allocate(unsigned long size, void* & p);
+//unsigned long allocate(unsigned long size, void* & p, void* &);
 //------------------------------------------------^ The same here
 
 void foo(void)

--- a/tests/expected/cpp/31641-misc2.cpp
+++ b/tests/expected/cpp/31641-misc2.cpp
@@ -20,9 +20,9 @@ typedef std::list<StreamedData*>::iterator iterator;
 typedef void (T::*Routine)(void);
 
 //Similar with "sp_before_byref = remove":
-unsigned long allocate(unsigned long size, void* & p);
+unsigned long allocate(unsigned long size, void* & p, void* &);
 
-//unsigned long allocate(unsigned long size, void* & p);
+//unsigned long allocate(unsigned long size, void* & p, void* &);
 //------------------------------------------------^ The same here
 
 void foo(void)

--- a/tests/input/cpp/misc2.cpp
+++ b/tests/input/cpp/misc2.cpp
@@ -20,8 +20,8 @@ typedef std::list<StreamedData *>::iterator iterator;
 typedef void (T::*Routine)(void);
 
 //Similar with "sp_before_byref = remove":
-unsigned long allocate(unsigned long size, void* & p);
-//unsigned long allocate(unsigned long size, void* & p);
+unsigned long allocate(unsigned long size, void* & p, void* &);
+//unsigned long allocate(unsigned long size, void* & p, void* &);
 //------------------------------------------------^ The same here
 
 void foo(void)

--- a/tests/input/cpp/ptr-star.cpp
+++ b/tests/input/cpp/ptr-star.cpp
@@ -15,6 +15,8 @@ int a = b[0] * c;
 }
 
 int*X(int *i, int*);
+int*Y(int*& i, int*&);
+int*Z(int**& i, int**&);
 
 int *i = &a;
 int *i = *b;


### PR DESCRIPTION
Fixes two bugs:
1. Spacing before pointer characters for named pointer reference parameter using `unnamed` option (fixes https://github.com/uncrustify/uncrustify/issues/4438)
2. Spacing between pointer characters and reference character for unnamed reference parameter using `sp_before_unnamed_byref` option