### PR TITLE
Fix: Repeated author key in package.json, add contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,23 @@
     "uncrustify",
     "source code beautifier"
   ],
+  "author": "Ben Gardner",
   "contributors": [
     {
-      "name": "Ben Gardner"
+      "name": "Guillaume Maurel",
+      "url": "https://github.com/gmaurel"
     },
     {
-      "name": "Guy Maurel"
+      "name": "Matthew Woehlke",
+      "url": "https://github.com/mwoehlke-kitware"
+    },
+    {
+      "name": "Michele Calgaro",
+      "url": "https://github.com/micheleCTDEAdmin"
+    },
+    {
+      "name": "Peter Tao",
+      "url": "https://github.com/PoeticPeteAdmin"
     }
   ],
   "license": "GPL-2.0-or-later"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,13 @@
     "uncrustify",
     "source code beautifier"
   ],
-  "author": "Ben Gardner",
-  "author": "Guy Maurel",
+  "contributors": [
+    {
+      "name": "Ben Gardner"
+    },
+    {
+      "name": "Guy Maurel"
+    }
+  ],
   "license": "GPL-2.0-or-later"
 }


### PR DESCRIPTION
Repeated keys are not allowed in json objects.  The contributors key is more appropriate in this case