### PR TITLE
ci: parallelize build and test scripts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,10 +26,12 @@ before_build:
   - cd build
   - cmake -DUNCRUSTIFY_SEPARATE_TESTS=ON -G "%GENERATOR%" ..
 build_script:
-  - cmake --build . --config %CONFIGURATION%
+  - for /f %%i in ('wmic cpu get NumberOfCores ^| findstr [0-9]') do set CORES=%%i
+  - cmake --build . --config %CONFIGURATION% --parallel %CORES%
 test_script:
 #  - echo This is for test only
 #  - C:/projects/uncrustify/build/Debug/uncrustify.exe -c C:/projects/uncrustify/tests/config/mono.cfg -f C:/projects/uncrustify/tests/input/cs/simple.cs -L 66
   - set PYTHONIOENCODING=utf-8
-  - python ../scripts/run_ctest.py -- -C %CONFIGURATION%
+  - for /f %%i in ('wmic cpu get NumberOfCores ^| findstr [0-9]') do set CORES=%%i
+  - python ../scripts/run_ctest.py -- -j %CORES% -C %CONFIGURATION%
 deploy: off


### PR DESCRIPTION
- Add commands to get the number of CPU cores available
- Update build and test scripts to use parallel execution based on the number of cores