### PR TITLE
Fix typos in how_to_choose_an_sp_option.txt

### DIFF
--- a/documentation/how_to_choose_an_sp_option.txt
+++ b/documentation/how_to_choose_an_sp_option.txt
@@ -1,9 +1,9 @@
 uncrustify has may options (today 266) for "space".
-There are named wit sp_ at the beginning.
+There are named with sp_ at the beginning.
 
-If you dont know which option(s) you need for a place in your code, try this:
+If you don't know which option(s) you need for a place in your code, try this:
 
-uncrustify -f <your_config_file> -c  <your_code_file> --tracking space:a.html
+uncrustify -c <your_config_file> -f <your_code_file> --tracking space:a.html
 
 The a.html file can be used with any browser.
 


### PR DESCRIPTION
Swap the `-c` and `-f` options to the correct place in the example command, and fix some English typos.