### PR TITLE
macro after closing parenthese

### DIFF
--- a/src/tokenizer/combine.cpp
+++ b/src/tokenizer/combine.cpp
@@ -1613,6 +1613,7 @@ void do_symbol_check(Chunk *prev, Chunk *pc, Chunk *next)
          }
          else if (  pc->TestFlags(PCF_IN_PREPROC) // Issue #3559
                  && prev->IsNot(CT_WORD)          // Issue #2205
+                 && prev->IsNot(CT_PAREN_CLOSE)   // Issue #4539
                  && pc->Is(CT_AMP)
                  && next->Is(CT_WORD)
                  && !pc->TestFlags(PCF_IN_SPAREN))

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -198,6 +198,8 @@
 30168  cpp/nl_comment_func_def.cfg                          cpp/nl_comment_func_def.cpp
 30169  cpp/nl_comment_func_def-1.cfg                        cpp/nl_comment_func_def-1.cpp
 
+30170  common/empty.cfg                                     cpp/Issue_4539.cpp
+
 30200  cpp/bug_1862.cfg                                     cpp/bug_1862.cpp
 30201  cpp/cmt_indent-1.cfg                                 cpp/cmt_indent.cpp
 30202  cpp/cmt_indent-2.cfg                                 cpp/cmt_indent.cpp

--- a/tests/expected/cpp/30170-Issue_4539.cpp
+++ b/tests/expected/cpp/30170-Issue_4539.cpp
@@ -1,0 +1,1 @@
+#define MACRO2(a, b)    (a + b) & B

--- a/tests/input/cpp/Issue_4539.cpp
+++ b/tests/input/cpp/Issue_4539.cpp
@@ -1,0 +1,1 @@
+#define MACRO2(a, b)    (a + b) & B


### PR DESCRIPTION
correct the tokenizer
fix #4539 