### PR TITLE
Fix typo in "uncrustify --show-config"

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -3726,7 +3726,7 @@ set_numbering_for_html_output   = false    # true/false
 #     Example:
 #       `file_ext CPP .ch .cxx .cpp.in`
 #
-#     langTypes are defined in uncrusify_types.h in the lang_flag_e enum, use
+#     langTypes are defined in uncrustify_types.h in the lang_flag_e enum, use
 #     them without the 'LANG_' prefix: 'LANG_CPP' => 'CPP'
 #
 #

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -3726,7 +3726,7 @@ set_numbering_for_html_output   = false    # true/false
 #     Example:
 #       `file_ext CPP .ch .cxx .cpp.in`
 #
-#     langTypes are defined in uncrusify_types.h in the lang_flag_e enum, use
+#     langTypes are defined in uncrustify_types.h in the lang_flag_e enum, use
 #     them without the 'LANG_' prefix: 'LANG_CPP' => 'CPP'
 #
 #

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -3726,7 +3726,7 @@ set_numbering_for_html_output   = false    # true/false
 #     Example:
 #       `file_ext CPP .ch .cxx .cpp.in`
 #
-#     langTypes are defined in uncrusify_types.h in the lang_flag_e enum, use
+#     langTypes are defined in uncrustify_types.h in the lang_flag_e enum, use
 #     them without the 'LANG_' prefix: 'LANG_CPP' => 'CPP'
 #
 #

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -66,7 +66,7 @@ static const char *DOC_TEXT_END = R"___(
 #     Example:
 #       `file_ext CPP .ch .cxx .cpp.in`
 #
-#     langTypes are defined in uncrusify_types.h in the lang_flag_e enum, use
+#     langTypes are defined in uncrustify_types.h in the lang_flag_e enum, use
 #     them without the 'LANG_' prefix: 'LANG_CPP' => 'CPP'
 #
 #

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -3726,7 +3726,7 @@ set_numbering_for_html_output   = false    # true/false
 #     Example:
 #       `file_ext CPP .ch .cxx .cpp.in`
 #
-#     langTypes are defined in uncrusify_types.h in the lang_flag_e enum, use
+#     langTypes are defined in uncrustify_types.h in the lang_flag_e enum, use
 #     them without the 'LANG_' prefix: 'LANG_CPP' => 'CPP'
 #
 #

--- a/tests/cli/output/update-config-with-doc.txt
+++ b/tests/cli/output/update-config-with-doc.txt
@@ -3726,7 +3726,7 @@ set_numbering_for_html_output   = false    # true/false
 #     Example:
 #       `file_ext CPP .ch .cxx .cpp.in`
 #
-#     langTypes are defined in uncrusify_types.h in the lang_flag_e enum, use
+#     langTypes are defined in uncrustify_types.h in the lang_flag_e enum, use
 #     them without the 'LANG_' prefix: 'LANG_CPP' => 'CPP'
 #
 #

--- a/tests/config/common/neovim.cfg
+++ b/tests/config/common/neovim.cfg
@@ -3622,7 +3622,7 @@ set_numbering_for_html_output   = false    # true/false
 #     Example:
 #       `file_ext CPP .ch .cxx .cpp.in`
 #
-#     langTypes are defined in uncrusify_types.h in the lang_flag_e enum, use
+#     langTypes are defined in uncrustify_types.h in the lang_flag_e enum, use
 #     them without the 'LANG_' prefix: 'LANG_CPP' => 'CPP'
 #
 #


### PR DESCRIPTION
This patch corrects a typo in the output of `uncrustify --show-config`.