### PR TITLE
fix(log/rules): Add memory allocation checks and improve error handling

### DIFF
--- a/src/log_rules.cpp
+++ b/src/log_rules.cpp
@@ -9,6 +9,8 @@
 #include "log_rules.h"
 
 #include "unc_tools.h"
+#include <cstdio>  // for snprintf
+#include <utility> // for make_pair
 
 
 void log_rule2(const char *func, size_t line, const char *rule, Chunk *first, Chunk *second)
@@ -65,9 +67,16 @@ void log_rule4(const char *rule, Chunk *first)
    }
    // copy the rule
    size_t length = strlen(rule) + 1;
-   char   *r     = (char *)malloc(length);
+   char   *r     = reinterpret_cast<char *>(malloc(length));
 
-   strcpy(r, rule);
+   if (r == NULL)
+   {
+      fprintf(stderr, "%s(%d): Not enough memory for log_rule4\n",
+              __func__, __LINE__);
+      log_flush(true);
+      exit(EX_SOFTWARE);
+   }
+   snprintf(r, length, "%s", rule);
    size_t      a_number = get_A_Number();
    TrackNumber A        = std::make_pair(a_number, r);
 
@@ -92,9 +101,16 @@ void log_ruleStart(const char *rule, Chunk *first)
    }
    // copy the rule
    size_t length = strlen(rule) + 1;
-   char   *r     = (char *)malloc(length);
+   char   *r     = reinterpret_cast<char *>(malloc(length));
 
-   strcpy(r, rule);
+   if (r == NULL)
+   {
+      fprintf(stderr, "%s(%d): Not enough memory for log_ruleStart\n",
+              __func__, __LINE__);
+      log_flush(true);
+      exit(EX_SOFTWARE);
+   }
+   snprintf(r, length, "%s", rule);
    size_t      a_number = get_A_Number();
    TrackNumber A        = std::make_pair(a_number, r);
 
@@ -119,9 +135,16 @@ void log_ruleNL(const char *rule, Chunk *pc)
    }
    // copy the rule
    size_t length = strlen(rule) + 1;
-   char   *r     = (char *)malloc(length);
+   char   *r     = reinterpret_cast<char *>(malloc(length));
 
-   strcpy(r, rule);
+   if (r == NULL)
+   {
+      fprintf(stderr, "%s(%d): Not enough memory for log_ruleNL\n",
+              __func__, __LINE__);
+      log_flush(true);
+      exit(EX_SOFTWARE);
+   }
+   snprintf(r, length, "%s", rule);
    size_t      a_number = get_A_Number();
    TrackNumber A        = std::make_pair(a_number, r);
 

--- a/src/pcf_flags.cpp
+++ b/src/pcf_flags.cpp
@@ -7,6 +7,10 @@
 
 #include "pcf_flags.h"
 
+#include <cstdio>
+#include <string>
+
+
 static const char *pcf_names[] =
 {
    "IN_PREPROC",        // 0
@@ -68,7 +72,7 @@ std::string pcf_flags_str(PcfFlags flags)
    char buffer[64];
 
    // Generate hex representation first
-   snprintf(buffer, 63, "[0x%llx:", (long long unsigned int)(flags));
+   snprintf(buffer, sizeof(buffer) - 1, "[0x%llx:", (long long unsigned int)(flags));
 
    // Add human-readable names
    auto out   = std::string{ buffer };


### PR DESCRIPTION
The changes in log_rules.cpp address several issues:
1. Added memory allocation checks for malloc calls
2. Improved error handling with proper error messages and exit codes
3. Used snprintf instead of strcpy for safer string copying
4. Added necessary includes for cstdio and utility

The changes in pcf_flags.cpp:
1. Added necessary includes for cstdio and string
2. Improved buffer size handling in snprintf call