### PR TITLE
style: Add cppcheck suppress comments, remove continue

### DIFF
--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -54,7 +54,7 @@ static inline size_t calc_next_tab_column(size_t col, size_t tabsize)
  */
 static inline size_t next_tab_column(size_t col)
 {
-   constexpr static auto LCURRENT = LINDENT;
+   constexpr static auto LCURRENT = LINDENT; // cppcheck-suppress shadowVariable
 
    log_rule_B("output_tab_size");
    return(calc_next_tab_column(col, uncrustify::options::output_tab_size()));

--- a/src/punctuators.cpp
+++ b/src/punctuators.cpp
@@ -33,7 +33,7 @@ using namespace uncrustify;
 
 #include "symbols_table.h"
 // must be positioned here, after all symbolsX[], because punc_table uses them
-#include "punctuator_table.h"
+#include "punctuator_table.h" // cppcheck-suppress missingInclude
 
 
 const chunk_tag_t *find_punctuator(const char *str, int lang_flags)
@@ -81,7 +81,7 @@ const chunk_tag_t *find_punctuator(const char *str, int lang_flags)
       }
       parent = &punc_table[parent->next_idx]; // point at the first child node
       ch_idx++;
-      continue;
+      // continue;  // Redundant, last statement in while block.
    }
    return(match);
 } // find_punctuator


### PR DESCRIPTION
Added cppcheck suppress comments to address false positives in the code analysis. Comment out useless continue (reported by cppcheck).