### PR TITLE
refactor(chunk/indent): String truncation and logging functionality

### DIFF
--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -6,6 +6,8 @@
  * @license GPL v2+
  */
 
+#include <cstdio>
+
 #include "chunk.h"
 
 #include "ListManager.h"
@@ -90,30 +92,35 @@ void Chunk::Reset()
 
 const char *Chunk::ElidedText(char *for_the_copy) const
 {
-   const char *test_it       = Text();
-   size_t     test_it_length = strlen(test_it);
+   const char *test_it = Text();
 
    size_t     truncate_value = uncrustify::options::debug_truncate();
 
    if (truncate_value != 0)
    {
+      size_t test_it_length = strlen(test_it);
+
       if (test_it_length > truncate_value)
       {
-         memset(for_the_copy, 0, 1000);
+         const char trunc_msg[31] = " ... <The string is truncated>";
 
-         if (test_it_length < truncate_value + 30)
+         memset(for_the_copy, 0, 1000);
+         size_t snprintf_len;  //!< Number of chars to copy from test_it + '\0'
+
+         if (test_it_length < truncate_value + (sizeof(trunc_msg) - 1))
          {
-            strncpy(for_the_copy, test_it, truncate_value - 30);
-            for_the_copy[truncate_value - 30] = 0;
+            snprintf_len = truncate_value - (sizeof(trunc_msg) - 2);
          }
          else
          {
-            strncpy(for_the_copy, test_it, truncate_value);
-            for_the_copy[truncate_value] = 0;
+            snprintf_len = truncate_value + 1;
          }
-         char *message = strcat(for_the_copy, " ... <The string is truncated>");
+         snprintf(for_the_copy, snprintf_len, "%s", test_it);
+         for_the_copy[snprintf_len - 1] = '\0';   // MSVC19 does not include EOS
 
-         return(message);
+         snprintf(for_the_copy + strlen(for_the_copy), 1000 - strlen(for_the_copy), trunc_msg);
+
+         return(for_the_copy);
       }
       else
       {
@@ -180,7 +187,7 @@ Chunk *Chunk::GetPrev(const E_Scope scope) const
 } // Chunk::GetPrev
 
 
-static void chunk_log(Chunk *pc, const char *text);
+static void chunk_log(const Chunk *pc, const char *text);
 
 
 Chunk *Chunk::GetHead()
@@ -228,7 +235,7 @@ bool Chunk::IsOnSameLine(const Chunk *end) const
    {
       return(false);
    }
-   Chunk *tmp = GetNext();
+   const Chunk *tmp = GetNext();
 
    while (  tmp->IsNotNullChunk()
          && tmp != end)
@@ -313,7 +320,7 @@ Chunk *Chunk::SearchPpa(const T_CheckFnPtr checkFn, const bool cond) const
 } // Chunk::SearchPpa
 
 
-static void chunk_log_msg(Chunk *chunk, const log_sev_t log, const char *str)
+static void chunk_log_msg(const Chunk *chunk, const log_sev_t log, const char *str)
 {
    LOG_FMT(log, "%s orig line is %zu, orig col is %zu, ",
            str, chunk->GetOrigLine(), chunk->GetOrigCol());
@@ -337,7 +344,7 @@ static void chunk_log_msg(Chunk *chunk, const log_sev_t log, const char *str)
 } // chunk_log_msg
 
 
-static void chunk_log(Chunk *pc, const char *text)
+static void chunk_log(const Chunk *pc, const char *text)
 {
    if (  pc->IsNullChunk()
       || (  cpd.unc_stage != unc_stage_e::TOKENIZE
@@ -346,8 +353,8 @@ static void chunk_log(Chunk *pc, const char *text)
       return;
    }
    const log_sev_t log   = LCHUNK;
-   Chunk           *prev = pc->GetPrev();
-   Chunk           *next = pc->GetNext();
+   const Chunk     *prev = pc->GetPrev();
+   const Chunk     *next = pc->GetNext();
 
    chunk_log_msg(pc, log, text);
 
@@ -411,7 +418,7 @@ bool Chunk::IsAddress() const
             && m_str[0] == '&'
             && IsNot(CT_OPERATOR_VAL))))
    {
-      Chunk *prevc = GetPrev();
+      const Chunk *prevc = GetPrev();
 
       if (  TestFlags(PCF_IN_TEMPLATE)
          && (  prevc->Is(CT_COMMA)
@@ -721,8 +728,8 @@ Chunk *Chunk::SkipDcMember() const
 {
    LOG_FUNC_ENTRY();
 
-   Chunk *pc  = const_cast<Chunk *>(this);
-   Chunk *nxt = pc->Is(CT_DC_MEMBER) ? pc : pc->GetNextNcNnl(E_Scope::ALL);
+   Chunk       *pc  = const_cast<Chunk *>(this);
+   const Chunk *nxt = pc->Is(CT_DC_MEMBER) ? pc : pc->GetNextNcNnl(E_Scope::ALL);
 
    while (nxt->Is(CT_DC_MEMBER))
    {
@@ -765,7 +772,7 @@ bool Chunk::IsOCForinOpenParen() const
       && Is(CT_SPAREN_OPEN)
       && GetPrevNcNnl()->Is(CT_FOR))
    {
-      Chunk *nxt = const_cast<Chunk *>(this);
+      const Chunk *nxt = const_cast<Chunk *>(this);
 
       while (  nxt->IsNotNullChunk()
             && nxt->IsNot(CT_SPAREN_CLOSE)
@@ -897,7 +904,7 @@ bool Chunk::IsTypeDefinition() const
 
 bool Chunk::IsNewlineBetween(const Chunk *other) const
 {
-   Chunk *pc = const_cast<Chunk *>(this);
+   const Chunk *pc = const_cast<Chunk *>(this);
 
    while (pc != other)
    {

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -1844,7 +1844,7 @@ inline bool Chunk::IsSamePreproc(const Chunk *other) const
 
 inline bool Chunk::SafeToDeleteNl() const
 {
-   Chunk *tmp = GetPrev();
+   const Chunk *tmp = GetPrev();
 
    if (tmp->Is(CT_COMMENT_CPP))
    {

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -19,6 +19,8 @@
 #include "space.h"
 
 #include <cstdint>
+#include <cstdio>                      // to get fprintf
+#include <string>
 
 #ifdef WIN32
 #include <algorithm>                   // to get max
@@ -316,7 +318,7 @@ void align_to_column(Chunk *pc, size_t column)
       {
          // Shift by the same amount, keep above negative values
          pc->SetColumn((  col_delta >= 0
-                       || (size_t)(abs(col_delta)) < pc->GetColumn())
+                       || static_cast<size_t>(abs(col_delta)) < pc->GetColumn())
                       ? pc->GetColumn() + col_delta : 0);
          pc->SetColumn(max(pc->GetColumn(), min_col));
       }
@@ -364,7 +366,7 @@ static size_t token_indent(E_Token type)
 #define indent_column_set(X)                                                                 \
    do {                                                                                      \
       LOG_FMT(LINDENT2, "%s(%d): orig line is %zu, indent_column changed from %zu to %zu\n", \
-              __func__, __LINE__, pc->GetOrigLine(), indent_column, (size_t)X);              \
+              __func__, __LINE__, pc->GetOrigLine(), indent_column, static_cast<size_t>(X)); \
       indent_column = (X);                                                                   \
    } while (false)
 
@@ -1045,9 +1047,9 @@ void indent_text()
             if (val != 0)
             {
                size_t indent = frm.top().GetIndent();
-               indent = (val > 0) ? val                     // reassign if positive val,
-                        : ((size_t)(abs(val)) < indent)     // else if no underflow
-                        ? (indent + val) : 0;               // reduce, else 0
+               indent = (val > 0) ? val                            // reassign if positive val,
+                        : (static_cast<size_t>(abs(val)) < indent) // else if no underflow
+                        ? (indent + val) : 0;                      // reduce, else 0
                frm.top().SetIndent(indent);
             }
             frm.top().SetIndentTmp(frm.top().GetIndent());
@@ -2350,7 +2352,7 @@ void indent_text()
             }
             else
             {
-               bool no_underflow = (size_t)(abs(val)) < pse_indent;
+               bool no_underflow = static_cast<size_t>(abs(val)) < pse_indent;
                indent_column_set((no_underflow ? (pse_indent + val) : 0));
             }
          }
@@ -2407,7 +2409,7 @@ void indent_text()
             else
             {
                size_t pse_indent   = frm.top().GetIndent();
-               bool   no_underflow = (size_t)(abs(val)) < pse_indent;
+               bool   no_underflow = static_cast<size_t>(abs(val)) < pse_indent;
 
                indent_column_set(no_underflow ? (pse_indent + val) : 0);
             }
@@ -2752,7 +2754,7 @@ void indent_text()
                   && frm.at(idx).GetOpenChunk()->IsOnSameLine(frm.top().GetOpenChunk()))
             {
                idx--;
-               skipped = true;
+               // skipped = true;  // Assigned true at end of code block.
             }
             frm.top().SetIndent(frm.at(idx).GetIndent() + indent_size);
             log_indent();
@@ -2805,7 +2807,7 @@ void indent_text()
                         && frm.at(sub).GetOpenChunk()->IsOnSameLine(frm.top().GetOpenChunk()))
                   {
                      sub--;
-                     skipped = true;
+                     // skipped = true;  // Set to true at the end of the code block
                   }
 
                   if (  (  frm.at(sub + 1).GetOpenToken() == CT_CLASS_COLON
@@ -3838,14 +3840,14 @@ void indent_text()
             if (frm.top().GetOpenChunk()->IsParenOpen())
             {
                log_rule_B("indent_comma_paren");
-               indent_align  = options::indent_comma_paren() == (int)indent_mode_e::ALIGN;
-               indent_ignore = options::indent_comma_paren() == (int)indent_mode_e::IGNORE;
+               indent_align  = options::indent_comma_paren() == static_cast<int>(indent_mode_e::ALIGN);
+               indent_ignore = options::indent_comma_paren() == static_cast<int>(indent_mode_e::IGNORE);
             }
             else if (frm.top().GetOpenChunk()->IsBraceOpen())
             {
                log_rule_B("indent_comma_brace");
-               indent_align  = options::indent_comma_brace() == (int)indent_mode_e::ALIGN;
-               indent_ignore = options::indent_comma_brace() == (int)indent_mode_e::IGNORE;
+               indent_align  = options::indent_comma_brace() == static_cast<int>(indent_mode_e::ALIGN);
+               indent_ignore = options::indent_comma_brace() == static_cast<int>(indent_mode_e::IGNORE);
             }
 
             if (indent_ignore)
@@ -3925,11 +3927,11 @@ void indent_text()
             {
                log_rule_B("indent_bool_paren");
 
-               if (options::indent_bool_paren() == (int)indent_mode_e::IGNORE)
+               if (options::indent_bool_paren() == static_cast<int>(indent_mode_e::IGNORE))
                {
                   indent_column_set(pc->GetOrigCol());
                }
-               else if (options::indent_bool_paren() == (int)indent_mode_e::ALIGN)
+               else if (options::indent_bool_paren() == static_cast<int>(indent_mode_e::ALIGN))
                {
                   indent_column_set(frm.top().GetOpenChunk()->GetColumn());
 
@@ -4205,9 +4207,9 @@ void indent_text()
                if (val != 0)
                {
                   size_t indent = indent_column;
-                  indent = (val > 0) ? val                  // reassign if positive val,
-                           : ((size_t)(abs(val)) < indent)  // else if no underflow
-                           ? (indent + val) : 0;            // reduce, else 0
+                  indent = (val > 0) ? val                            // reassign if positive val,
+                           : (static_cast<size_t>(abs(val)) < indent) // else if no underflow
+                           ? (indent + val) : 0;                      // reduce, else 0
 
                   LOG_FMT(LINDENT, "%s(%d): %zu] var_type indent => %zu [%s]\n",
                           __func__, __LINE__, pc->GetOrigLine(), indent, pc->Text());


### PR DESCRIPTION
- Fixed potential buffer overflow in string truncation
- Refactored string truncation logic in ElidedText function for better readability and safety
- Added cstdio header include for printf functions (include-what-you-use)
- Improved logging functionality by making chunk_log functions const-correct
- Updated various functions to use const-correct Chunk pointers where appropriate