### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ cmake-build-*/
 
 # Compilation database
 compile_commands.json
+
+# macOS
+.DS_Store


### PR DESCRIPTION
`.DS_Store` is a MacOS specific file that does not need to be tracked in source control. Add to `.gitignore`