### PR TITLE
feat(options/newlines): Add nl_collapse_*_one_liner options

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 A source code beautifier for C, C++, C#, Objective-C, D, Java, Pawn and Vala.
 
 ## Features
-* Highly configurable - 857 configurable options as of version 0.82.0
+* Highly configurable - 875 configurable options as of version 0.82.0
 - <details><summary>add/remove spaces</summary>
 
   - `sp_before_sparen`: _Add or remove space before '(' of 'if', 'for', 'switch', 'while', etc._

--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -1,4 +1,4 @@
-# Uncrustify-0.82.0
+# Uncrustify-0.82.0-dev
 
 #
 # General options
@@ -546,6 +546,12 @@ sp_paren_qualifier              = ignore   # ignore/add/remove/force
 
 # Add or remove space between ')' and 'noexcept'.
 sp_paren_noexcept               = ignore   # ignore/add/remove/force
+
+# Add or remove space between as PAREN '(' and '*' as deref.
+# if ((<here>*it).startsWith("SCREEN ")) {}
+# TQFileInfoListIterator it(<here>*list);
+# if(<here>*memory == NULL) return;
+sp_paren_deref                  = ignore   # ignore/add/remove/force
 
 # Add or remove space after class ':'.
 sp_after_class_colon            = ignore   # ignore/add/remove/force
@@ -2328,6 +2334,26 @@ nl_split_while_one_liner        = false    # true/false
 # call.
 donot_add_nl_before_cpp_comment = false    # true/false
 
+# Whether to collapse a braced single-statement 'if' block to one line,
+# as in 'if (cond)\n{\n    stmt;\n}' => 'if (cond) { stmt; }'.
+nl_collapse_if_one_liner        = false    # true/false
+
+# Whether to collapse a braced single-statement 'for' block to one line,
+# as in 'for (...)\n{\n    stmt;\n}' => 'for (...) { stmt; }'.
+nl_collapse_for_one_liner       = false    # true/false
+
+# Whether to collapse a braced single-statement 'while' block to one line,
+# as in 'while (...)\n{\n    stmt;\n}' => 'while (...) { stmt; }'.
+nl_collapse_while_one_liner     = false    # true/false
+
+# Whether to collapse a braced single-statement 'do' block to one line,
+# as in 'do\n{\n    stmt;\n} while (...)' => 'do { stmt; } while (...)'.
+nl_collapse_do_one_liner        = false    # true/false
+
+# Whether to collapse a braced single-statement 'case' block to one line,
+# as in 'case X:\n{\n    stmt;\n}' => 'case X: { stmt; }'.
+nl_collapse_switch_one_liner    = false    # true/false
+
 #
 # Blank line options
 #
@@ -2753,6 +2779,21 @@ align_var_def_attribute         = false    # true/false
 # Whether to align inline struct/enum/union variable definitions.
 align_var_def_inline            = false    # true/false
 
+# Number of empty lines to ignore in span calculation for align_var_def_span.
+#
+# 0: Don't skip any lines (default).
+align_var_def_span_num_empty_lines = 0        # unsigned number
+
+# Number of preprocessor directive lines to ignore in span calculation for align_var_def_span.
+#
+# 0: Don't skip any lines (default).
+align_var_def_span_num_pp_lines = 0        # unsigned number
+
+# Number of comment-only lines to ignore in span calculation for align_var_def_span.
+#
+# 0: Don't skip any lines (default).
+align_var_def_span_num_cmt_lines = 0        # unsigned number
+
 # The span for aligning on '=' in assignments.
 #
 # 0: Don't align (default).
@@ -2809,6 +2850,21 @@ align_enum_equ_thresh           = 0        # number
 # 0: Don't align (default).
 align_var_class_span            = 0        # unsigned number
 
+# Number of empty lines to ignore in span calculation for align_var_class_span.
+#
+# 0: Don't skip any lines (default).
+align_var_class_span_num_empty_lines = 0        # unsigned number
+
+# Number of preprocessor directive lines to ignore in span calculation for align_var_class_span.
+#
+# 0: Don't skip any lines (default).
+align_var_class_span_num_pp_lines = 0        # unsigned number
+
+# Number of comment-only lines to ignore in span calculation for align_var_class_span.
+#
+# 0: Don't skip any lines (default).
+align_var_class_span_num_cmt_lines = 0        # unsigned number
+
 # The threshold for aligning class member definitions.
 # Use a negative number for absolute thresholds.
 #
@@ -2822,6 +2878,21 @@ align_var_class_gap             = 0        # unsigned number
 #
 # 0: Don't align (default).
 align_var_struct_span           = 0        # unsigned number
+
+# Number of empty lines to ignore in span calculation for align_var_struct_span.
+#
+# 0: Don't skip any lines (default).
+align_var_struct_span_num_empty_lines = 0        # unsigned number
+
+# Number of preprocessor directive lines to ignore in span calculation for align_var_struct_span.
+#
+# 0: Don't skip any lines (default).
+align_var_struct_span_num_pp_lines = 0        # unsigned number
+
+# Number of comment-only lines to ignore in span calculation for align_var_struct_span.
+#
+# 0: Don't skip any lines (default).
+align_var_struct_span_num_cmt_lines = 0        # unsigned number
 
 # The threshold for aligning struct/union member definitions.
 # Use a negative number for absolute thresholds.
@@ -2903,6 +2974,21 @@ align_func_proto_span           = 0        # unsigned number
 # false: continuation lines are part of the newlines count
 # true:  continuation lines are not counted
 align_func_proto_span_ignore_cont_lines = false    # true/false
+
+# Number of empty lines to ignore in span calculation for align_func_proto_span.
+#
+# 0: Don't skip any lines (default).
+align_func_proto_span_num_empty_lines = 0        # unsigned number
+
+# Number of preprocessor directive lines to ignore in span calculation for align_func_proto_span.
+#
+# 0: Don't skip any lines (default).
+align_func_proto_span_num_pp_lines = 0        # unsigned number
+
+# Number of comment-only lines to ignore in span calculation for align_func_proto_span.
+#
+# 0: Don't skip any lines (default).
+align_func_proto_span_num_cmt_lines = 0        # unsigned number
 
 # How to consider (or treat) the '*' in the alignment of function prototypes.
 #

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -1,4 +1,4 @@
-# Uncrustify-0.82.0
+# Uncrustify-0.82.0-dev
 
 #
 # General options
@@ -546,6 +546,12 @@ sp_paren_qualifier              = ignore   # ignore/add/remove/force
 
 # Add or remove space between ')' and 'noexcept'.
 sp_paren_noexcept               = ignore   # ignore/add/remove/force
+
+# Add or remove space between as PAREN '(' and '*' as deref.
+# if ((<here>*it).startsWith("SCREEN ")) {}
+# TQFileInfoListIterator it(<here>*list);
+# if(<here>*memory == NULL) return;
+sp_paren_deref                  = ignore   # ignore/add/remove/force
 
 # Add or remove space after class ':'.
 sp_after_class_colon            = ignore   # ignore/add/remove/force
@@ -2328,6 +2334,26 @@ nl_split_while_one_liner        = false    # true/false
 # call.
 donot_add_nl_before_cpp_comment = false    # true/false
 
+# Whether to collapse a braced single-statement 'if' block to one line,
+# as in 'if (cond)\n{\n    stmt;\n}' => 'if (cond) { stmt; }'.
+nl_collapse_if_one_liner        = false    # true/false
+
+# Whether to collapse a braced single-statement 'for' block to one line,
+# as in 'for (...)\n{\n    stmt;\n}' => 'for (...) { stmt; }'.
+nl_collapse_for_one_liner       = false    # true/false
+
+# Whether to collapse a braced single-statement 'while' block to one line,
+# as in 'while (...)\n{\n    stmt;\n}' => 'while (...) { stmt; }'.
+nl_collapse_while_one_liner     = false    # true/false
+
+# Whether to collapse a braced single-statement 'do' block to one line,
+# as in 'do\n{\n    stmt;\n} while (...)' => 'do { stmt; } while (...)'.
+nl_collapse_do_one_liner        = false    # true/false
+
+# Whether to collapse a braced single-statement 'case' block to one line,
+# as in 'case X:\n{\n    stmt;\n}' => 'case X: { stmt; }'.
+nl_collapse_switch_one_liner    = false    # true/false
+
 #
 # Blank line options
 #
@@ -2756,17 +2782,17 @@ align_var_def_inline            = false    # true/false
 # Number of empty lines to ignore in span calculation for align_var_def_span.
 #
 # 0: Don't skip any lines (default).
-align_var_def_span_num_empty_lines = 0     # unsigned number
+align_var_def_span_num_empty_lines = 0        # unsigned number
 
 # Number of preprocessor directive lines to ignore in span calculation for align_var_def_span.
 #
 # 0: Don't skip any lines (default).
-align_var_def_span_num_pp_lines    = 0     # unsigned number
+align_var_def_span_num_pp_lines = 0        # unsigned number
 
 # Number of comment-only lines to ignore in span calculation for align_var_def_span.
 #
 # 0: Don't skip any lines (default).
-align_var_def_span_num_cmt_lines   = 0     # unsigned number
+align_var_def_span_num_cmt_lines = 0        # unsigned number
 
 # The span for aligning on '=' in assignments.
 #
@@ -2824,6 +2850,21 @@ align_enum_equ_thresh           = 0        # number
 # 0: Don't align (default).
 align_var_class_span            = 0        # unsigned number
 
+# Number of empty lines to ignore in span calculation for align_var_class_span.
+#
+# 0: Don't skip any lines (default).
+align_var_class_span_num_empty_lines = 0        # unsigned number
+
+# Number of preprocessor directive lines to ignore in span calculation for align_var_class_span.
+#
+# 0: Don't skip any lines (default).
+align_var_class_span_num_pp_lines = 0        # unsigned number
+
+# Number of comment-only lines to ignore in span calculation for align_var_class_span.
+#
+# 0: Don't skip any lines (default).
+align_var_class_span_num_cmt_lines = 0        # unsigned number
+
 # The threshold for aligning class member definitions.
 # Use a negative number for absolute thresholds.
 #
@@ -2833,25 +2874,25 @@ align_var_class_thresh          = 0        # number
 # The gap for aligning class member definitions.
 align_var_class_gap             = 0        # unsigned number
 
-# Number of empty lines to ignore in span calculation for align_var_class_span.
-#
-# 0: Don't skip any lines (default).
-align_var_class_span_num_empty_lines = 0   # unsigned number
-
-# Number of preprocessor directive lines to ignore in span calculation for align_var_class_span.
-#
-# 0: Don't skip any lines (default).
-align_var_class_span_num_pp_lines    = 0   # unsigned number
-
-# Number of comment-only lines to ignore in span calculation for align_var_class_span.
-#
-# 0: Don't skip any lines (default).
-align_var_class_span_num_cmt_lines   = 0   # unsigned number
-
 # The span for aligning struct/union member definitions.
 #
 # 0: Don't align (default).
 align_var_struct_span           = 0        # unsigned number
+
+# Number of empty lines to ignore in span calculation for align_var_struct_span.
+#
+# 0: Don't skip any lines (default).
+align_var_struct_span_num_empty_lines = 0        # unsigned number
+
+# Number of preprocessor directive lines to ignore in span calculation for align_var_struct_span.
+#
+# 0: Don't skip any lines (default).
+align_var_struct_span_num_pp_lines = 0        # unsigned number
+
+# Number of comment-only lines to ignore in span calculation for align_var_struct_span.
+#
+# 0: Don't skip any lines (default).
+align_var_struct_span_num_cmt_lines = 0        # unsigned number
 
 # The threshold for aligning struct/union member definitions.
 # Use a negative number for absolute thresholds.
@@ -2861,21 +2902,6 @@ align_var_struct_thresh         = 0        # number
 
 # The gap for aligning struct/union member definitions.
 align_var_struct_gap            = 0        # unsigned number
-
-# Number of empty lines to ignore in span calculation for align_var_struct_span.
-#
-# 0: Don't skip any lines (default).
-align_var_struct_span_num_empty_lines = 0  # unsigned number
-
-# Number of preprocessor directive lines to ignore in span calculation for align_var_struct_span.
-#
-# 0: Don't skip any lines (default).
-align_var_struct_span_num_pp_lines    = 0  # unsigned number
-
-# Number of comment-only lines to ignore in span calculation for align_var_struct_span.
-#
-# 0: Don't skip any lines (default).
-align_var_struct_span_num_cmt_lines   = 0  # unsigned number
 
 # The span for aligning struct initializer values.
 #
@@ -2952,17 +2978,17 @@ align_func_proto_span_ignore_cont_lines = false    # true/false
 # Number of empty lines to ignore in span calculation for align_func_proto_span.
 #
 # 0: Don't skip any lines (default).
-align_func_proto_span_num_empty_lines = 0  # unsigned number
+align_func_proto_span_num_empty_lines = 0        # unsigned number
 
 # Number of preprocessor directive lines to ignore in span calculation for align_func_proto_span.
 #
 # 0: Don't skip any lines (default).
-align_func_proto_span_num_pp_lines    = 0  # unsigned number
+align_func_proto_span_num_pp_lines = 0        # unsigned number
 
 # Number of comment-only lines to ignore in span calculation for align_func_proto_span.
 #
 # 0: Don't skip any lines (default).
-align_func_proto_span_num_cmt_lines   = 0  # unsigned number
+align_func_proto_span_num_cmt_lines = 0        # unsigned number
 
 # How to consider (or treat) the '*' in the alignment of function prototypes.
 #

--- a/documentation/htdocs/index.html
+++ b/documentation/htdocs/index.html
@@ -54,7 +54,7 @@ Create a highly configurable, easily modifiable source code beautifier.</p>
    <li>Add or remove parens on return statements</li>
    <li>Add or remove braces on single-statement if/do/while/for statements</li>
    <li>Supports embedded SQL 'EXEC SQL' stuff</li>
-   <li>Highly configurable - 857 configurable options as of version 0.82.0</li>
+   <li>Highly configurable - 875 configurable options as of version 0.82.0</li>
 </ul>
 
 <p>

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -1,4 +1,4 @@
-# Uncrustify-0.82.0
+# Uncrustify-0.82.0-dev
 
 #
 # General options
@@ -546,6 +546,12 @@ sp_paren_qualifier              = ignore   # ignore/add/remove/force
 
 # Add or remove space between ')' and 'noexcept'.
 sp_paren_noexcept               = ignore   # ignore/add/remove/force
+
+# Add or remove space between as PAREN '(' and '*' as deref.
+# if ((<here>*it).startsWith("SCREEN ")) {}
+# TQFileInfoListIterator it(<here>*list);
+# if(<here>*memory == NULL) return;
+sp_paren_deref                  = ignore   # ignore/add/remove/force
 
 # Add or remove space after class ':'.
 sp_after_class_colon            = ignore   # ignore/add/remove/force
@@ -2328,6 +2334,26 @@ nl_split_while_one_liner        = false    # true/false
 # call.
 donot_add_nl_before_cpp_comment = false    # true/false
 
+# Whether to collapse a braced single-statement 'if' block to one line,
+# as in 'if (cond)\n{\n    stmt;\n}' => 'if (cond) { stmt; }'.
+nl_collapse_if_one_liner        = false    # true/false
+
+# Whether to collapse a braced single-statement 'for' block to one line,
+# as in 'for (...)\n{\n    stmt;\n}' => 'for (...) { stmt; }'.
+nl_collapse_for_one_liner       = false    # true/false
+
+# Whether to collapse a braced single-statement 'while' block to one line,
+# as in 'while (...)\n{\n    stmt;\n}' => 'while (...) { stmt; }'.
+nl_collapse_while_one_liner     = false    # true/false
+
+# Whether to collapse a braced single-statement 'do' block to one line,
+# as in 'do\n{\n    stmt;\n} while (...)' => 'do { stmt; } while (...)'.
+nl_collapse_do_one_liner        = false    # true/false
+
+# Whether to collapse a braced single-statement 'case' block to one line,
+# as in 'case X:\n{\n    stmt;\n}' => 'case X: { stmt; }'.
+nl_collapse_switch_one_liner    = false    # true/false
+
 #
 # Blank line options
 #
@@ -2756,17 +2782,17 @@ align_var_def_inline            = false    # true/false
 # Number of empty lines to ignore in span calculation for align_var_def_span.
 #
 # 0: Don't skip any lines (default).
-align_var_def_span_num_empty_lines = 0     # unsigned number
+align_var_def_span_num_empty_lines = 0        # unsigned number
 
 # Number of preprocessor directive lines to ignore in span calculation for align_var_def_span.
 #
 # 0: Don't skip any lines (default).
-align_var_def_span_num_pp_lines    = 0     # unsigned number
+align_var_def_span_num_pp_lines = 0        # unsigned number
 
 # Number of comment-only lines to ignore in span calculation for align_var_def_span.
 #
 # 0: Don't skip any lines (default).
-align_var_def_span_num_cmt_lines   = 0     # unsigned number
+align_var_def_span_num_cmt_lines = 0        # unsigned number
 
 # The span for aligning on '=' in assignments.
 #
@@ -2824,6 +2850,21 @@ align_enum_equ_thresh           = 0        # number
 # 0: Don't align (default).
 align_var_class_span            = 0        # unsigned number
 
+# Number of empty lines to ignore in span calculation for align_var_class_span.
+#
+# 0: Don't skip any lines (default).
+align_var_class_span_num_empty_lines = 0        # unsigned number
+
+# Number of preprocessor directive lines to ignore in span calculation for align_var_class_span.
+#
+# 0: Don't skip any lines (default).
+align_var_class_span_num_pp_lines = 0        # unsigned number
+
+# Number of comment-only lines to ignore in span calculation for align_var_class_span.
+#
+# 0: Don't skip any lines (default).
+align_var_class_span_num_cmt_lines = 0        # unsigned number
+
 # The threshold for aligning class member definitions.
 # Use a negative number for absolute thresholds.
 #
@@ -2833,25 +2874,25 @@ align_var_class_thresh          = 0        # number
 # The gap for aligning class member definitions.
 align_var_class_gap             = 0        # unsigned number
 
-# Number of empty lines to ignore in span calculation for align_var_class_span.
-#
-# 0: Don't skip any lines (default).
-align_var_class_span_num_empty_lines = 0   # unsigned number
-
-# Number of preprocessor directive lines to ignore in span calculation for align_var_class_span.
-#
-# 0: Don't skip any lines (default).
-align_var_class_span_num_pp_lines    = 0   # unsigned number
-
-# Number of comment-only lines to ignore in span calculation for align_var_class_span.
-#
-# 0: Don't skip any lines (default).
-align_var_class_span_num_cmt_lines   = 0   # unsigned number
-
 # The span for aligning struct/union member definitions.
 #
 # 0: Don't align (default).
 align_var_struct_span           = 0        # unsigned number
+
+# Number of empty lines to ignore in span calculation for align_var_struct_span.
+#
+# 0: Don't skip any lines (default).
+align_var_struct_span_num_empty_lines = 0        # unsigned number
+
+# Number of preprocessor directive lines to ignore in span calculation for align_var_struct_span.
+#
+# 0: Don't skip any lines (default).
+align_var_struct_span_num_pp_lines = 0        # unsigned number
+
+# Number of comment-only lines to ignore in span calculation for align_var_struct_span.
+#
+# 0: Don't skip any lines (default).
+align_var_struct_span_num_cmt_lines = 0        # unsigned number
 
 # The threshold for aligning struct/union member definitions.
 # Use a negative number for absolute thresholds.
@@ -2861,21 +2902,6 @@ align_var_struct_thresh         = 0        # number
 
 # The gap for aligning struct/union member definitions.
 align_var_struct_gap            = 0        # unsigned number
-
-# Number of empty lines to ignore in span calculation for align_var_struct_span.
-#
-# 0: Don't skip any lines (default).
-align_var_struct_span_num_empty_lines = 0  # unsigned number
-
-# Number of preprocessor directive lines to ignore in span calculation for align_var_struct_span.
-#
-# 0: Don't skip any lines (default).
-align_var_struct_span_num_pp_lines    = 0  # unsigned number
-
-# Number of comment-only lines to ignore in span calculation for align_var_struct_span.
-#
-# 0: Don't skip any lines (default).
-align_var_struct_span_num_cmt_lines   = 0  # unsigned number
 
 # The span for aligning struct initializer values.
 #
@@ -2952,17 +2978,17 @@ align_func_proto_span_ignore_cont_lines = false    # true/false
 # Number of empty lines to ignore in span calculation for align_func_proto_span.
 #
 # 0: Don't skip any lines (default).
-align_func_proto_span_num_empty_lines = 0  # unsigned number
+align_func_proto_span_num_empty_lines = 0        # unsigned number
 
 # Number of preprocessor directive lines to ignore in span calculation for align_func_proto_span.
 #
 # 0: Don't skip any lines (default).
-align_func_proto_span_num_pp_lines    = 0  # unsigned number
+align_func_proto_span_num_pp_lines = 0        # unsigned number
 
 # Number of comment-only lines to ignore in span calculation for align_func_proto_span.
 #
 # 0: Don't skip any lines (default).
-align_func_proto_span_num_cmt_lines   = 0  # unsigned number
+align_func_proto_span_num_cmt_lines = 0        # unsigned number
 
 # How to consider (or treat) the '*' in the alignment of function prototypes.
 #

--- a/etc/uigui_uncrustify.ini
+++ b/etc/uigui_uncrustify.ini
@@ -15,7 +15,7 @@ parameterOrder=ipo
 showHelpParameter=-h
 stringparaminquotes=false
 useCfgFileParameter="-c "
-version=Uncrustify-0.82.0
+version=Uncrustify-0.82.0-dev
 
 [Newlines]
 Category=0
@@ -170,7 +170,7 @@ EditorType=multiple
 Choices=sp_arith=ignore|sp_arith=add|sp_arith=remove|sp_arith=force
 ChoicesRegex=sp_arith\s*=\s*ignore|sp_arith\s*=\s*add|sp_arith\s*=\s*remove|sp_arith\s*=\s*force
 ChoicesReadable="Ignore Sp Arith|Add Sp Arith|Remove Sp Arith|Force Sp Arith"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Arith Additive]
 Category=1
@@ -190,7 +190,7 @@ EditorType=multiple
 Choices=sp_assign=ignore|sp_assign=add|sp_assign=remove|sp_assign=force
 ChoicesRegex=sp_assign\s*=\s*ignore|sp_assign\s*=\s*add|sp_assign\s*=\s*remove|sp_assign\s*=\s*force
 ChoicesReadable="Ignore Sp Assign|Add Sp Assign|Remove Sp Assign|Force Sp Assign"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Cpp Lambda Assign]
 Category=1
@@ -390,7 +390,7 @@ EditorType=multiple
 Choices=sp_bool=ignore|sp_bool=add|sp_bool=remove|sp_bool=force
 ChoicesRegex=sp_bool\s*=\s*ignore|sp_bool\s*=\s*add|sp_bool\s*=\s*remove|sp_bool\s*=\s*force
 ChoicesReadable="Ignore Sp Bool|Add Sp Bool|Remove Sp Bool|Force Sp Bool"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Compare]
 Category=1
@@ -400,7 +400,7 @@ EditorType=multiple
 Choices=sp_compare=ignore|sp_compare=add|sp_compare=remove|sp_compare=force
 ChoicesRegex=sp_compare\s*=\s*ignore|sp_compare\s*=\s*add|sp_compare\s*=\s*remove|sp_compare\s*=\s*force
 ChoicesReadable="Ignore Sp Compare|Add Sp Compare|Remove Sp Compare|Force Sp Compare"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Inside Paren]
 Category=1
@@ -410,7 +410,7 @@ EditorType=multiple
 Choices=sp_inside_paren=ignore|sp_inside_paren=add|sp_inside_paren=remove|sp_inside_paren=force
 ChoicesRegex=sp_inside_paren\s*=\s*ignore|sp_inside_paren\s*=\s*add|sp_inside_paren\s*=\s*remove|sp_inside_paren\s*=\s*force
 ChoicesReadable="Ignore Sp Inside Paren|Add Sp Inside Paren|Remove Sp Inside Paren|Force Sp Inside Paren"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Paren Paren]
 Category=1
@@ -460,7 +460,7 @@ EditorType=multiple
 Choices=sp_before_ptr_star=ignore|sp_before_ptr_star=add|sp_before_ptr_star=remove|sp_before_ptr_star=force
 ChoicesRegex=sp_before_ptr_star\s*=\s*ignore|sp_before_ptr_star\s*=\s*add|sp_before_ptr_star\s*=\s*remove|sp_before_ptr_star\s*=\s*force
 ChoicesReadable="Ignore Sp Before Ptr Star|Add Sp Before Ptr Star|Remove Sp Before Ptr Star|Force Sp Before Ptr Star"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Before Unnamed Ptr Star]
 Category=1
@@ -530,7 +530,7 @@ EditorType=multiple
 Choices=sp_between_ptr_star=ignore|sp_between_ptr_star=add|sp_between_ptr_star=remove|sp_between_ptr_star=force
 ChoicesRegex=sp_between_ptr_star\s*=\s*ignore|sp_between_ptr_star\s*=\s*add|sp_between_ptr_star\s*=\s*remove|sp_between_ptr_star\s*=\s*force
 ChoicesReadable="Ignore Sp Between Ptr Star|Add Sp Between Ptr Star|Remove Sp Between Ptr Star|Force Sp Between Ptr Star"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Between Ptr Ref]
 Category=1
@@ -550,7 +550,7 @@ EditorType=multiple
 Choices=sp_after_ptr_star=ignore|sp_after_ptr_star=add|sp_after_ptr_star=remove|sp_after_ptr_star=force
 ChoicesRegex=sp_after_ptr_star\s*=\s*ignore|sp_after_ptr_star\s*=\s*add|sp_after_ptr_star\s*=\s*remove|sp_after_ptr_star\s*=\s*force
 ChoicesReadable="Ignore Sp After Ptr Star|Add Sp After Ptr Star|Remove Sp After Ptr Star|Force Sp After Ptr Star"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp After Ptr Block Caret]
 Category=1
@@ -580,7 +580,7 @@ EditorType=multiple
 Choices=sp_after_ptr_star_func=ignore|sp_after_ptr_star_func=add|sp_after_ptr_star_func=remove|sp_after_ptr_star_func=force
 ChoicesRegex=sp_after_ptr_star_func\s*=\s*ignore|sp_after_ptr_star_func\s*=\s*add|sp_after_ptr_star_func\s*=\s*remove|sp_after_ptr_star_func\s*=\s*force
 ChoicesReadable="Ignore Sp After Ptr Star Func|Add Sp After Ptr Star Func|Remove Sp After Ptr Star Func|Force Sp After Ptr Star Func"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp After Ptr Star Trailing]
 Category=1
@@ -630,7 +630,7 @@ EditorType=multiple
 Choices=sp_before_ptr_star_func=ignore|sp_before_ptr_star_func=add|sp_before_ptr_star_func=remove|sp_before_ptr_star_func=force
 ChoicesRegex=sp_before_ptr_star_func\s*=\s*ignore|sp_before_ptr_star_func\s*=\s*add|sp_before_ptr_star_func\s*=\s*remove|sp_before_ptr_star_func\s*=\s*force
 ChoicesReadable="Ignore Sp Before Ptr Star Func|Add Sp Before Ptr Star Func|Remove Sp Before Ptr Star Func|Force Sp Before Ptr Star Func"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Qualifier Ptr Star Func]
 Category=1
@@ -869,7 +869,7 @@ EditorType=multiple
 Choices=sp_before_sparen=ignore|sp_before_sparen=add|sp_before_sparen=remove|sp_before_sparen=force
 ChoicesRegex=sp_before_sparen\s*=\s*ignore|sp_before_sparen\s*=\s*add|sp_before_sparen\s*=\s*remove|sp_before_sparen\s*=\s*force
 ChoicesReadable="Ignore Sp Before Sparen|Add Sp Before Sparen|Remove Sp Before Sparen|Force Sp Before Sparen"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Inside Sparen]
 Category=1
@@ -879,7 +879,7 @@ EditorType=multiple
 Choices=sp_inside_sparen=ignore|sp_inside_sparen=add|sp_inside_sparen=remove|sp_inside_sparen=force
 ChoicesRegex=sp_inside_sparen\s*=\s*ignore|sp_inside_sparen\s*=\s*add|sp_inside_sparen\s*=\s*remove|sp_inside_sparen\s*=\s*force
 ChoicesReadable="Ignore Sp Inside Sparen|Add Sp Inside Sparen|Remove Sp Inside Sparen|Force Sp Inside Sparen"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Inside Sparen Open]
 Category=1
@@ -1089,7 +1089,7 @@ EditorType=multiple
 Choices=sp_after_semi_for_empty=ignore|sp_after_semi_for_empty=add|sp_after_semi_for_empty=remove|sp_after_semi_for_empty=force
 ChoicesRegex=sp_after_semi_for_empty\s*=\s*ignore|sp_after_semi_for_empty\s*=\s*add|sp_after_semi_for_empty\s*=\s*remove|sp_after_semi_for_empty\s*=\s*force
 ChoicesReadable="Ignore Sp After Semi For Empty|Add Sp After Semi For Empty|Remove Sp After Semi For Empty|Force Sp After Semi For Empty"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Before Square]
 Category=1
@@ -1159,7 +1159,7 @@ EditorType=multiple
 Choices=sp_inside_square=ignore|sp_inside_square=add|sp_inside_square=remove|sp_inside_square=force
 ChoicesRegex=sp_inside_square\s*=\s*ignore|sp_inside_square\s*=\s*add|sp_inside_square\s*=\s*remove|sp_inside_square\s*=\s*force
 ChoicesReadable="Ignore Sp Inside Square|Add Sp Inside Square|Remove Sp Inside Square|Force Sp Inside Square"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Inside Square Empty]
 Category=1
@@ -1189,7 +1189,7 @@ EditorType=multiple
 Choices=sp_after_comma=ignore|sp_after_comma=add|sp_after_comma=remove|sp_after_comma=force
 ChoicesRegex=sp_after_comma\s*=\s*ignore|sp_after_comma\s*=\s*add|sp_after_comma\s*=\s*remove|sp_after_comma\s*=\s*force
 ChoicesReadable="Ignore Sp After Comma|Add Sp After Comma|Remove Sp After Comma|Force Sp After Comma"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Before Comma]
 Category=1
@@ -1331,6 +1331,16 @@ ChoicesRegex=sp_paren_noexcept\s*=\s*ignore|sp_paren_noexcept\s*=\s*add|sp_paren
 ChoicesReadable="Ignore Sp Paren Noexcept|Add Sp Paren Noexcept|Remove Sp Paren Noexcept|Force Sp Paren Noexcept"
 ValueDefault=ignore
 
+[Sp Paren Deref]
+Category=1
+Description="<html>Add or remove space between as PAREN '(' and '*' as deref.<br/>if ((&lt;here&gt;*it).startsWith("SCREEN ")) {}<br/>TQFileInfoListIterator it(&lt;here&gt;*list);<br/>if(&lt;here&gt;*memory == NULL) return;</html>"
+Enabled=false
+EditorType=multiple
+Choices=sp_paren_deref=ignore|sp_paren_deref=add|sp_paren_deref=remove|sp_paren_deref=force
+ChoicesRegex=sp_paren_deref\s*=\s*ignore|sp_paren_deref\s*=\s*add|sp_paren_deref\s*=\s*remove|sp_paren_deref\s*=\s*force
+ChoicesReadable="Ignore Sp Paren Deref|Add Sp Paren Deref|Remove Sp Paren Deref|Force Sp Paren Deref"
+ValueDefault=ignore
+
 [Sp After Class Colon]
 Category=1
 Description="<html>Add or remove space after class ':'.</html>"
@@ -1419,7 +1429,7 @@ EditorType=multiple
 Choices=sp_after_cast=ignore|sp_after_cast=add|sp_after_cast=remove|sp_after_cast=force
 ChoicesRegex=sp_after_cast\s*=\s*ignore|sp_after_cast\s*=\s*add|sp_after_cast\s*=\s*remove|sp_after_cast\s*=\s*force
 ChoicesReadable="Ignore Sp After Cast|Add Sp After Cast|Remove Sp After Cast|Force Sp After Cast"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Inside Paren Cast]
 Category=1
@@ -1529,7 +1539,7 @@ EditorType=multiple
 Choices=sp_inside_braces_struct=ignore|sp_inside_braces_struct=add|sp_inside_braces_struct=remove|sp_inside_braces_struct=force
 ChoicesRegex=sp_inside_braces_struct\s*=\s*ignore|sp_inside_braces_struct\s*=\s*add|sp_inside_braces_struct\s*=\s*remove|sp_inside_braces_struct\s*=\s*force
 ChoicesReadable="Ignore Sp Inside Braces Struct|Add Sp Inside Braces Struct|Remove Sp Inside Braces Struct|Force Sp Inside Braces Struct"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Inside Braces Oc Dict]
 Category=1
@@ -1579,7 +1589,7 @@ EditorType=multiple
 Choices=sp_inside_braces=ignore|sp_inside_braces=add|sp_inside_braces=remove|sp_inside_braces=force
 ChoicesRegex=sp_inside_braces\s*=\s*ignore|sp_inside_braces\s*=\s*add|sp_inside_braces\s*=\s*remove|sp_inside_braces\s*=\s*force
 ChoicesReadable="Ignore Sp Inside Braces|Add Sp Inside Braces|Remove Sp Inside Braces|Force Sp Inside Braces"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Inside Braces Empty]
 Category=1
@@ -1589,7 +1599,7 @@ EditorType=multiple
 Choices=sp_inside_braces_empty=ignore|sp_inside_braces_empty=add|sp_inside_braces_empty=remove|sp_inside_braces_empty=force
 ChoicesRegex=sp_inside_braces_empty\s*=\s*ignore|sp_inside_braces_empty\s*=\s*add|sp_inside_braces_empty\s*=\s*remove|sp_inside_braces_empty\s*=\s*force
 ChoicesReadable="Ignore Sp Inside Braces Empty|Add Sp Inside Braces Empty|Remove Sp Inside Braces Empty|Force Sp Inside Braces Empty"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Trailing Return]
 Category=1
@@ -1629,7 +1639,7 @@ EditorType=multiple
 Choices=sp_func_proto_paren=ignore|sp_func_proto_paren=add|sp_func_proto_paren=remove|sp_func_proto_paren=force
 ChoicesRegex=sp_func_proto_paren\s*=\s*ignore|sp_func_proto_paren\s*=\s*add|sp_func_proto_paren\s*=\s*remove|sp_func_proto_paren\s*=\s*force
 ChoicesReadable="Ignore Sp Func Proto Paren|Add Sp Func Proto Paren|Remove Sp Func Proto Paren|Force Sp Func Proto Paren"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Func Proto Paren Empty]
 Category=1
@@ -1659,7 +1669,7 @@ EditorType=multiple
 Choices=sp_func_def_paren=ignore|sp_func_def_paren=add|sp_func_def_paren=remove|sp_func_def_paren=force
 ChoicesRegex=sp_func_def_paren\s*=\s*ignore|sp_func_def_paren\s*=\s*add|sp_func_def_paren\s*=\s*remove|sp_func_def_paren\s*=\s*force
 ChoicesReadable="Ignore Sp Func Def Paren|Add Sp Func Def Paren|Remove Sp Func Def Paren|Force Sp Func Def Paren"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Func Def Paren Empty]
 Category=1
@@ -1789,7 +1799,7 @@ EditorType=multiple
 Choices=sp_func_call_paren=ignore|sp_func_call_paren=add|sp_func_call_paren=remove|sp_func_call_paren=force
 ChoicesRegex=sp_func_call_paren\s*=\s*ignore|sp_func_call_paren\s*=\s*add|sp_func_call_paren\s*=\s*remove|sp_func_call_paren\s*=\s*force
 ChoicesReadable="Ignore Sp Func Call Paren|Add Sp Func Call Paren|Remove Sp Func Call Paren|Force Sp Func Call Paren"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Func Call Paren Empty]
 Category=1
@@ -2049,7 +2059,7 @@ EditorType=multiple
 Choices=sp_brace_typedef=ignore|sp_brace_typedef=add|sp_brace_typedef=remove|sp_brace_typedef=force
 ChoicesRegex=sp_brace_typedef\s*=\s*ignore|sp_brace_typedef\s*=\s*add|sp_brace_typedef\s*=\s*remove|sp_brace_typedef\s*=\s*force
 ChoicesReadable="Ignore Sp Brace Typedef|Add Sp Brace Typedef|Remove Sp Brace Typedef|Force Sp Brace Typedef"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Catch Brace]
 Category=1
@@ -2856,7 +2866,7 @@ CallName="indent_columns="
 CallNameRegex="indent_columns\s*=\s*"
 MinVal=0
 MaxVal=16
-ValueDefault=8
+ValueDefault=4
 
 [Indent Ignore First Continue]
 Category=2
@@ -2876,7 +2886,7 @@ CallName="indent_continue="
 CallNameRegex="indent_continue\s*=\s*"
 MinVal=-16
 MaxVal=16
-ValueDefault=0
+ValueDefault=4
 
 [Indent Continue Class Head]
 Category=2
@@ -2917,7 +2927,7 @@ EditorType=multiple
 Choices="indent_with_tabs=0|indent_with_tabs=1|indent_with_tabs=2"
 ChoicesRegex="indent_with_tabs\s*=\s*0|indent_with_tabs\s*=\s*1|indent_with_tabs\s*=\s*2"
 ChoicesReadable="Spaces only|Indent with tabs, align with spaces|Indent and align with tabs"
-ValueDefault=1
+ValueDefault=0
 
 [Indent Cmt With Tabs]
 Category=2
@@ -3412,7 +3422,7 @@ CallName="indent_switch_case="
 CallNameRegex="indent_switch_case\s*=\s*"
 MinVal=0
 MaxVal=16
-ValueDefault=0
+ValueDefault=4
 
 [Indent Switch Body]
 Category=2
@@ -3756,7 +3766,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=indent_align_paren=true|indent_align_paren=false
 TrueFalseRegex=indent_align_paren\s*=\s*true|indent_align_paren\s*=\s*false
-ValueDefault=true
+ValueDefault=false
 
 [Indent Oc Inside Msg Sel]
 Category=2
@@ -4061,7 +4071,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_if_leave_one_liners=true|nl_if_leave_one_liners=false
 TrueFalseRegex=nl_if_leave_one_liners\s*=\s*true|nl_if_leave_one_liners\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl While Leave One Liners]
 Category=3
@@ -4070,7 +4080,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_while_leave_one_liners=true|nl_while_leave_one_liners=false
 TrueFalseRegex=nl_while_leave_one_liners\s*=\s*true|nl_while_leave_one_liners\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl Do Leave One Liners]
 Category=3
@@ -4079,7 +4089,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_do_leave_one_liners=true|nl_do_leave_one_liners=false
 TrueFalseRegex=nl_do_leave_one_liners\s*=\s*true|nl_do_leave_one_liners\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl For Leave One Liners]
 Category=3
@@ -4088,7 +4098,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_for_leave_one_liners=true|nl_for_leave_one_liners=false
 TrueFalseRegex=nl_for_leave_one_liners\s*=\s*true|nl_for_leave_one_liners\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl Oc Msg Leave One Liner]
 Category=3
@@ -4198,7 +4208,7 @@ EditorType=multiple
 Choices=nl_end_of_file=ignore|nl_end_of_file=add|nl_end_of_file=remove|nl_end_of_file=force
 ChoicesRegex=nl_end_of_file\s*=\s*ignore|nl_end_of_file\s*=\s*add|nl_end_of_file\s*=\s*remove|nl_end_of_file\s*=\s*force
 ChoicesReadable="Ignore Nl End Of File|Add Nl End Of File|Remove Nl End Of File|Force Nl End Of File"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl End Of File Min]
 Category=3
@@ -4209,7 +4219,7 @@ CallName="nl_end_of_file_min="
 CallNameRegex="nl_end_of_file_min\s*=\s*"
 MinVal=0
 MaxVal=16
-ValueDefault=0
+ValueDefault=1
 
 [Nl Assign Brace]
 Category=3
@@ -4269,7 +4279,7 @@ EditorType=multiple
 Choices=nl_enum_brace=ignore|nl_enum_brace=add|nl_enum_brace=remove|nl_enum_brace=force
 ChoicesRegex=nl_enum_brace\s*=\s*ignore|nl_enum_brace\s*=\s*add|nl_enum_brace\s*=\s*remove|nl_enum_brace\s*=\s*force
 ChoicesReadable="Ignore Nl Enum Brace|Add Nl Enum Brace|Remove Nl Enum Brace|Force Nl Enum Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Enum Class]
 Category=3
@@ -4319,7 +4329,7 @@ EditorType=multiple
 Choices=nl_struct_brace=ignore|nl_struct_brace=add|nl_struct_brace=remove|nl_struct_brace=force
 ChoicesRegex=nl_struct_brace\s*=\s*ignore|nl_struct_brace\s*=\s*add|nl_struct_brace\s*=\s*remove|nl_struct_brace\s*=\s*force
 ChoicesReadable="Ignore Nl Struct Brace|Add Nl Struct Brace|Remove Nl Struct Brace|Force Nl Struct Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Union Brace]
 Category=3
@@ -4329,7 +4339,7 @@ EditorType=multiple
 Choices=nl_union_brace=ignore|nl_union_brace=add|nl_union_brace=remove|nl_union_brace=force
 ChoicesRegex=nl_union_brace\s*=\s*ignore|nl_union_brace\s*=\s*add|nl_union_brace\s*=\s*remove|nl_union_brace\s*=\s*force
 ChoicesReadable="Ignore Nl Union Brace|Add Nl Union Brace|Remove Nl Union Brace|Force Nl Union Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl If Brace]
 Category=3
@@ -4339,7 +4349,7 @@ EditorType=multiple
 Choices=nl_if_brace=ignore|nl_if_brace=add|nl_if_brace=remove|nl_if_brace=force
 ChoicesRegex=nl_if_brace\s*=\s*ignore|nl_if_brace\s*=\s*add|nl_if_brace\s*=\s*remove|nl_if_brace\s*=\s*force
 ChoicesReadable="Ignore Nl If Brace|Add Nl If Brace|Remove Nl If Brace|Force Nl If Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Brace Else]
 Category=3
@@ -4349,7 +4359,7 @@ EditorType=multiple
 Choices=nl_brace_else=ignore|nl_brace_else=add|nl_brace_else=remove|nl_brace_else=force
 ChoicesRegex=nl_brace_else\s*=\s*ignore|nl_brace_else\s*=\s*add|nl_brace_else\s*=\s*remove|nl_brace_else\s*=\s*force
 ChoicesReadable="Ignore Nl Brace Else|Add Nl Brace Else|Remove Nl Brace Else|Force Nl Brace Else"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Elseif Brace]
 Category=3
@@ -4359,7 +4369,7 @@ EditorType=multiple
 Choices=nl_elseif_brace=ignore|nl_elseif_brace=add|nl_elseif_brace=remove|nl_elseif_brace=force
 ChoicesRegex=nl_elseif_brace\s*=\s*ignore|nl_elseif_brace\s*=\s*add|nl_elseif_brace\s*=\s*remove|nl_elseif_brace\s*=\s*force
 ChoicesReadable="Ignore Nl Elseif Brace|Add Nl Elseif Brace|Remove Nl Elseif Brace|Force Nl Elseif Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Else Brace]
 Category=3
@@ -4369,7 +4379,7 @@ EditorType=multiple
 Choices=nl_else_brace=ignore|nl_else_brace=add|nl_else_brace=remove|nl_else_brace=force
 ChoicesRegex=nl_else_brace\s*=\s*ignore|nl_else_brace\s*=\s*add|nl_else_brace\s*=\s*remove|nl_else_brace\s*=\s*force
 ChoicesReadable="Ignore Nl Else Brace|Add Nl Else Brace|Remove Nl Else Brace|Force Nl Else Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Else If]
 Category=3
@@ -4379,7 +4389,7 @@ EditorType=multiple
 Choices=nl_else_if=ignore|nl_else_if=add|nl_else_if=remove|nl_else_if=force
 ChoicesRegex=nl_else_if\s*=\s*ignore|nl_else_if\s*=\s*add|nl_else_if\s*=\s*remove|nl_else_if\s*=\s*force
 ChoicesReadable="Ignore Nl Else If|Add Nl Else If|Remove Nl Else If|Force Nl Else If"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Nl Before Opening Brace Func Class Def]
 Category=3
@@ -4449,7 +4459,7 @@ EditorType=multiple
 Choices=nl_for_brace=ignore|nl_for_brace=add|nl_for_brace=remove|nl_for_brace=force
 ChoicesRegex=nl_for_brace\s*=\s*ignore|nl_for_brace\s*=\s*add|nl_for_brace\s*=\s*remove|nl_for_brace\s*=\s*force
 ChoicesReadable="Ignore Nl For Brace|Add Nl For Brace|Remove Nl For Brace|Force Nl For Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Catch Brace]
 Category=3
@@ -4519,7 +4529,7 @@ EditorType=multiple
 Choices=nl_while_brace=ignore|nl_while_brace=add|nl_while_brace=remove|nl_while_brace=force
 ChoicesRegex=nl_while_brace\s*=\s*ignore|nl_while_brace\s*=\s*add|nl_while_brace\s*=\s*remove|nl_while_brace\s*=\s*force
 ChoicesReadable="Ignore Nl While Brace|Add Nl While Brace|Remove Nl While Brace|Force Nl While Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Scope Brace]
 Category=3
@@ -4579,7 +4589,7 @@ EditorType=multiple
 Choices=nl_do_brace=ignore|nl_do_brace=add|nl_do_brace=remove|nl_do_brace=force
 ChoicesRegex=nl_do_brace\s*=\s*ignore|nl_do_brace\s*=\s*add|nl_do_brace\s*=\s*remove|nl_do_brace\s*=\s*force
 ChoicesReadable="Ignore Nl Do Brace|Add Nl Do Brace|Remove Nl Do Brace|Force Nl Do Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Brace While]
 Category=3
@@ -4599,7 +4609,7 @@ EditorType=multiple
 Choices=nl_switch_brace=ignore|nl_switch_brace=add|nl_switch_brace=remove|nl_switch_brace=force
 ChoicesRegex=nl_switch_brace\s*=\s*ignore|nl_switch_brace\s*=\s*add|nl_switch_brace\s*=\s*remove|nl_switch_brace\s*=\s*force
 ChoicesReadable="Ignore Nl Switch Brace|Add Nl Switch Brace|Remove Nl Switch Brace|Force Nl Switch Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Synchronized Brace]
 Category=3
@@ -4665,7 +4675,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_case=true|nl_after_case=false
 TrueFalseRegex=nl_after_case\s*=\s*true|nl_after_case\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl Case Colon Brace]
 Category=3
@@ -4865,7 +4875,7 @@ EditorType=multiple
 Choices=nl_func_type_name=ignore|nl_func_type_name=add|nl_func_type_name=remove|nl_func_type_name=force
 ChoicesRegex=nl_func_type_name\s*=\s*ignore|nl_func_type_name\s*=\s*add|nl_func_type_name\s*=\s*remove|nl_func_type_name\s*=\s*force
 ChoicesReadable="Ignore Nl Func Type Name|Add Nl Func Type Name|Remove Nl Func Type Name|Force Nl Func Type Name"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Nl Func Type Name Class]
 Category=3
@@ -4955,7 +4965,7 @@ EditorType=multiple
 Choices=nl_func_call_paren=ignore|nl_func_call_paren=add|nl_func_call_paren=remove|nl_func_call_paren=force
 ChoicesRegex=nl_func_call_paren\s*=\s*ignore|nl_func_call_paren\s*=\s*add|nl_func_call_paren\s*=\s*remove|nl_func_call_paren\s*=\s*force
 ChoicesReadable="Ignore Nl Func Call Paren|Add Nl Func Call Paren|Remove Nl Func Call Paren|Force Nl Func Call Paren"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Nl Func Call Paren Empty]
 Category=3
@@ -4965,7 +4975,7 @@ EditorType=multiple
 Choices=nl_func_call_paren_empty=ignore|nl_func_call_paren_empty=add|nl_func_call_paren_empty=remove|nl_func_call_paren_empty=force
 ChoicesRegex=nl_func_call_paren_empty\s*=\s*ignore|nl_func_call_paren_empty\s*=\s*add|nl_func_call_paren_empty\s*=\s*remove|nl_func_call_paren_empty\s*=\s*force
 ChoicesReadable="Ignore Nl Func Call Paren Empty|Add Nl Func Call Paren Empty|Remove Nl Func Call Paren Empty|Force Nl Func Call Paren Empty"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Nl Func Decl Start]
 Category=3
@@ -5033,7 +5043,7 @@ EditorType=multiple
 Choices=nl_func_decl_args=ignore|nl_func_decl_args=add|nl_func_decl_args=remove|nl_func_decl_args=force
 ChoicesRegex=nl_func_decl_args\s*=\s*ignore|nl_func_decl_args\s*=\s*add|nl_func_decl_args\s*=\s*remove|nl_func_decl_args\s*=\s*force
 ChoicesReadable="Ignore Nl Func Decl Args|Add Nl Func Decl Args|Remove Nl Func Decl Args|Force Nl Func Decl Args"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Nl Func Def Args]
 Category=3
@@ -5043,7 +5053,7 @@ EditorType=multiple
 Choices=nl_func_def_args=ignore|nl_func_def_args=add|nl_func_def_args=remove|nl_func_def_args=force
 ChoicesRegex=nl_func_def_args\s*=\s*ignore|nl_func_def_args\s*=\s*add|nl_func_def_args\s*=\s*remove|nl_func_def_args\s*=\s*force
 ChoicesReadable="Ignore Nl Func Def Args|Add Nl Func Def Args|Remove Nl Func Def Args|Force Nl Func Def Args"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Nl Func Call Args]
 Category=3
@@ -5053,7 +5063,7 @@ EditorType=multiple
 Choices=nl_func_call_args=ignore|nl_func_call_args=add|nl_func_call_args=remove|nl_func_call_args=force
 ChoicesRegex=nl_func_call_args\s*=\s*ignore|nl_func_call_args\s*=\s*add|nl_func_call_args\s*=\s*remove|nl_func_call_args\s*=\s*force
 ChoicesReadable="Ignore Nl Func Call Args|Add Nl Func Call Args|Remove Nl Func Call Args|Force Nl Func Call Args"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Nl Func Decl Args Multi Line]
 Category=3
@@ -5169,7 +5179,7 @@ EditorType=multiple
 Choices=nl_func_call_start=ignore|nl_func_call_start=add|nl_func_call_start=remove|nl_func_call_start=force
 ChoicesRegex=nl_func_call_start\s*=\s*ignore|nl_func_call_start\s*=\s*add|nl_func_call_start\s*=\s*remove|nl_func_call_start\s*=\s*force
 ChoicesReadable="Ignore Nl Func Call Start|Add Nl Func Call Start|Remove Nl Func Call Start|Force Nl Func Call Start"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Nl Func Call End]
 Category=3
@@ -5179,7 +5189,7 @@ EditorType=multiple
 Choices=nl_func_call_end=ignore|nl_func_call_end=add|nl_func_call_end=remove|nl_func_call_end=force
 ChoicesRegex=nl_func_call_end\s*=\s*ignore|nl_func_call_end\s*=\s*add|nl_func_call_end\s*=\s*remove|nl_func_call_end\s*=\s*force
 ChoicesReadable="Ignore Nl Func Call End|Add Nl Func Call End|Remove Nl Func Call End|Force Nl Func Call End"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Nl Func Call Start Multi Line]
 Category=3
@@ -5341,7 +5351,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_semicolon=true|nl_after_semicolon=false
 TrueFalseRegex=nl_after_semicolon\s*=\s*true|nl_after_semicolon\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl Paren Dbrace Open]
 Category=3
@@ -5435,7 +5445,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_brace_close=true|nl_after_brace_close=false
 TrueFalseRegex=nl_after_brace_close\s*=\s*true|nl_after_brace_close\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl After Vbrace Close]
 Category=3
@@ -5519,7 +5529,7 @@ EditorType=multiple
 Choices=nl_after_if=ignore|nl_after_if=add|nl_after_if=remove|nl_after_if=force
 ChoicesRegex=nl_after_if\s*=\s*ignore|nl_after_if\s*=\s*add|nl_after_if\s*=\s*remove|nl_after_if\s*=\s*force
 ChoicesReadable="Ignore Nl After If|Add Nl After If|Remove Nl After If|Force Nl After If"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Before For]
 Category=3
@@ -5722,7 +5732,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_create_if_one_liner=true|nl_create_if_one_liner=false
 TrueFalseRegex=nl_create_if_one_liner\s*=\s*true|nl_create_if_one_liner\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl Create For One Liner]
 Category=3
@@ -5731,7 +5741,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_create_for_one_liner=true|nl_create_for_one_liner=false
 TrueFalseRegex=nl_create_for_one_liner\s*=\s*true|nl_create_for_one_liner\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl Create While One Liner]
 Category=3
@@ -5740,7 +5750,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_create_while_one_liner=true|nl_create_while_one_liner=false
 TrueFalseRegex=nl_create_while_one_liner\s*=\s*true|nl_create_while_one_liner\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl Create Func Def One Liner]
 Category=3
@@ -5794,6 +5804,51 @@ Enabled=false
 EditorType=boolean
 TrueFalse=donot_add_nl_before_cpp_comment=true|donot_add_nl_before_cpp_comment=false
 TrueFalseRegex=donot_add_nl_before_cpp_comment\s*=\s*true|donot_add_nl_before_cpp_comment\s*=\s*false
+ValueDefault=false
+
+[Nl Collapse If One Liner]
+Category=3
+Description="<html>Whether to collapse a braced single-statement 'if' block to one line,<br/>as in 'if (cond)\n{\n    stmt;\n}' =&gt; 'if (cond) { stmt; }'.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=nl_collapse_if_one_liner=true|nl_collapse_if_one_liner=false
+TrueFalseRegex=nl_collapse_if_one_liner\s*=\s*true|nl_collapse_if_one_liner\s*=\s*false
+ValueDefault=false
+
+[Nl Collapse For One Liner]
+Category=3
+Description="<html>Whether to collapse a braced single-statement 'for' block to one line,<br/>as in 'for (...)\n{\n    stmt;\n}' =&gt; 'for (...) { stmt; }'.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=nl_collapse_for_one_liner=true|nl_collapse_for_one_liner=false
+TrueFalseRegex=nl_collapse_for_one_liner\s*=\s*true|nl_collapse_for_one_liner\s*=\s*false
+ValueDefault=false
+
+[Nl Collapse While One Liner]
+Category=3
+Description="<html>Whether to collapse a braced single-statement 'while' block to one line,<br/>as in 'while (...)\n{\n    stmt;\n}' =&gt; 'while (...) { stmt; }'.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=nl_collapse_while_one_liner=true|nl_collapse_while_one_liner=false
+TrueFalseRegex=nl_collapse_while_one_liner\s*=\s*true|nl_collapse_while_one_liner\s*=\s*false
+ValueDefault=false
+
+[Nl Collapse Do One Liner]
+Category=3
+Description="<html>Whether to collapse a braced single-statement 'do' block to one line,<br/>as in 'do\n{\n    stmt;\n} while (...)' =&gt; 'do { stmt; } while (...)'.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=nl_collapse_do_one_liner=true|nl_collapse_do_one_liner=false
+TrueFalseRegex=nl_collapse_do_one_liner\s*=\s*true|nl_collapse_do_one_liner\s*=\s*false
+ValueDefault=false
+
+[Nl Collapse Switch One Liner]
+Category=3
+Description="<html>Whether to collapse a braced single-statement 'case' block to one line,<br/>as in 'case X:\n{\n    stmt;\n}' =&gt; 'case X: { stmt; }'.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=nl_collapse_switch_one_liner=true|nl_collapse_switch_one_liner=false
+TrueFalseRegex=nl_collapse_switch_one_liner\s*=\s*true|nl_collapse_switch_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Max]
@@ -5935,7 +5990,7 @@ CallName="nl_after_func_body="
 CallNameRegex="nl_after_func_body\s*=\s*"
 MinVal=0
 MaxVal=16
-ValueDefault=0
+ValueDefault=2
 
 [Nl Min After Func Body]
 Category=4
@@ -5968,7 +6023,7 @@ CallName="nl_after_func_body_class="
 CallNameRegex="nl_after_func_body_class\s*=\s*"
 MinVal=0
 MaxVal=16
-ValueDefault=0
+ValueDefault=2
 
 [Nl After Func Body One Liner]
 Category=4
@@ -5979,7 +6034,7 @@ CallName="nl_after_func_body_one_liner="
 CallNameRegex="nl_after_func_body_one_liner\s*=\s*"
 MinVal=0
 MaxVal=16
-ValueDefault=0
+ValueDefault=2
 
 [Nl Typedef Blk Start]
 Category=4
@@ -6383,7 +6438,7 @@ EditorType=multiple
 Choices=pos_bool=ignore|pos_bool=break|pos_bool=force|pos_bool=lead|pos_bool=trail|pos_bool=join|pos_bool=lead_break|pos_bool=lead_force|pos_bool=trail_break|pos_bool=trail_force
 ChoicesRegex=pos_bool\s*=\s*ignore|pos_bool\s*=\s*break|pos_bool\s*=\s*force|pos_bool\s*=\s*lead|pos_bool\s*=\s*trail|pos_bool\s*=\s*join|pos_bool\s*=\s*lead_break|pos_bool\s*=\s*lead_force|pos_bool\s*=\s*trail_break|pos_bool\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Bool|Break Pos Bool|Force Pos Bool|Lead Pos Bool|Trail Pos Bool|Join Pos Bool|Lead Break Pos Bool|Lead Force Pos Bool|Trail Break Pos Bool|Trail Force Pos Bool"
-ValueDefault=ignore
+ValueDefault=join
 
 [Pos Compare]
 Category=5
@@ -6393,7 +6448,7 @@ EditorType=multiple
 Choices=pos_compare=ignore|pos_compare=break|pos_compare=force|pos_compare=lead|pos_compare=trail|pos_compare=join|pos_compare=lead_break|pos_compare=lead_force|pos_compare=trail_break|pos_compare=trail_force
 ChoicesRegex=pos_compare\s*=\s*ignore|pos_compare\s*=\s*break|pos_compare\s*=\s*force|pos_compare\s*=\s*lead|pos_compare\s*=\s*trail|pos_compare\s*=\s*join|pos_compare\s*=\s*lead_break|pos_compare\s*=\s*lead_force|pos_compare\s*=\s*trail_break|pos_compare\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Compare|Break Pos Compare|Force Pos Compare|Lead Pos Compare|Trail Pos Compare|Join Pos Compare|Lead Break Pos Compare|Lead Force Pos Compare|Trail Break Pos Compare|Trail Force Pos Compare"
-ValueDefault=ignore
+ValueDefault=join
 
 [Pos Conditional]
 Category=5
@@ -6403,7 +6458,7 @@ EditorType=multiple
 Choices=pos_conditional=ignore|pos_conditional=break|pos_conditional=force|pos_conditional=lead|pos_conditional=trail|pos_conditional=join|pos_conditional=lead_break|pos_conditional=lead_force|pos_conditional=trail_break|pos_conditional=trail_force
 ChoicesRegex=pos_conditional\s*=\s*ignore|pos_conditional\s*=\s*break|pos_conditional\s*=\s*force|pos_conditional\s*=\s*lead|pos_conditional\s*=\s*trail|pos_conditional\s*=\s*join|pos_conditional\s*=\s*lead_break|pos_conditional\s*=\s*lead_force|pos_conditional\s*=\s*trail_break|pos_conditional\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Conditional|Break Pos Conditional|Force Pos Conditional|Lead Pos Conditional|Trail Pos Conditional|Join Pos Conditional|Lead Break Pos Conditional|Lead Force Pos Conditional|Trail Break Pos Conditional|Trail Force Pos Conditional"
-ValueDefault=ignore
+ValueDefault=join
 
 [Pos Comma]
 Category=5
@@ -6413,7 +6468,7 @@ EditorType=multiple
 Choices=pos_comma=ignore|pos_comma=break|pos_comma=force|pos_comma=lead|pos_comma=trail|pos_comma=join|pos_comma=lead_break|pos_comma=lead_force|pos_comma=trail_break|pos_comma=trail_force
 ChoicesRegex=pos_comma\s*=\s*ignore|pos_comma\s*=\s*break|pos_comma\s*=\s*force|pos_comma\s*=\s*lead|pos_comma\s*=\s*trail|pos_comma\s*=\s*join|pos_comma\s*=\s*lead_break|pos_comma\s*=\s*lead_force|pos_comma\s*=\s*trail_break|pos_comma\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Comma|Break Pos Comma|Force Pos Comma|Lead Pos Comma|Trail Pos Comma|Join Pos Comma|Lead Break Pos Comma|Lead Force Pos Comma|Trail Break Pos Comma|Trail Force Pos Comma"
-ValueDefault=ignore
+ValueDefault=join
 
 [Pos Enum Comma]
 Category=5
@@ -6684,7 +6739,7 @@ CallName="align_var_def_star_style="
 CallNameRegex="align_var_def_star_style\s*=\s*"
 MinVal=0
 MaxVal=2
-ValueDefault=0
+ValueDefault=2
 
 [Align Var Def Amp Style]
 Category=7
@@ -6695,7 +6750,7 @@ CallName="align_var_def_amp_style="
 CallNameRegex="align_var_def_amp_style\s*=\s*"
 MinVal=0
 MaxVal=2
-ValueDefault=0
+ValueDefault=2
 
 [Align Var Def Thresh]
 Category=7
@@ -6756,6 +6811,39 @@ EditorType=boolean
 TrueFalse=align_var_def_inline=true|align_var_def_inline=false
 TrueFalseRegex=align_var_def_inline\s*=\s*true|align_var_def_inline\s*=\s*false
 ValueDefault=false
+
+[Align Var Def Span Num Empty Lines]
+Category=7
+Description="<html>Number of empty lines to ignore in span calculation for align_var_def_span.<br/><br/>0: Don't skip any lines (default).</html>"
+Enabled=false
+EditorType=numeric
+CallName="align_var_def_span_num_empty_lines="
+CallNameRegex="align_var_def_span_num_empty_lines\s*=\s*"
+MinVal=0
+MaxVal=5000
+ValueDefault=0
+
+[Align Var Def Span Num Pp Lines]
+Category=7
+Description="<html>Number of preprocessor directive lines to ignore in span calculation for align_var_def_span.<br/><br/>0: Don't skip any lines (default).</html>"
+Enabled=false
+EditorType=numeric
+CallName="align_var_def_span_num_pp_lines="
+CallNameRegex="align_var_def_span_num_pp_lines\s*=\s*"
+MinVal=0
+MaxVal=5000
+ValueDefault=0
+
+[Align Var Def Span Num Cmt Lines]
+Category=7
+Description="<html>Number of comment-only lines to ignore in span calculation for align_var_def_span.<br/><br/>0: Don't skip any lines (default).</html>"
+Enabled=false
+EditorType=numeric
+CallName="align_var_def_span_num_cmt_lines="
+CallNameRegex="align_var_def_span_num_cmt_lines\s*=\s*"
+MinVal=0
+MaxVal=5000
+ValueDefault=0
 
 [Align Assign Span]
 Category=7
@@ -6865,6 +6953,39 @@ MinVal=0
 MaxVal=5000
 ValueDefault=0
 
+[Align Var Class Span Num Empty Lines]
+Category=7
+Description="<html>Number of empty lines to ignore in span calculation for align_var_class_span.<br/><br/>0: Don't skip any lines (default).</html>"
+Enabled=false
+EditorType=numeric
+CallName="align_var_class_span_num_empty_lines="
+CallNameRegex="align_var_class_span_num_empty_lines\s*=\s*"
+MinVal=0
+MaxVal=5000
+ValueDefault=0
+
+[Align Var Class Span Num Pp Lines]
+Category=7
+Description="<html>Number of preprocessor directive lines to ignore in span calculation for align_var_class_span.<br/><br/>0: Don't skip any lines (default).</html>"
+Enabled=false
+EditorType=numeric
+CallName="align_var_class_span_num_pp_lines="
+CallNameRegex="align_var_class_span_num_pp_lines\s*=\s*"
+MinVal=0
+MaxVal=5000
+ValueDefault=0
+
+[Align Var Class Span Num Cmt Lines]
+Category=7
+Description="<html>Number of comment-only lines to ignore in span calculation for align_var_class_span.<br/><br/>0: Don't skip any lines (default).</html>"
+Enabled=false
+EditorType=numeric
+CallName="align_var_class_span_num_cmt_lines="
+CallNameRegex="align_var_class_span_num_cmt_lines\s*=\s*"
+MinVal=0
+MaxVal=5000
+ValueDefault=0
+
 [Align Var Class Thresh]
 Category=7
 Description="<html>The threshold for aligning class member definitions.<br/>Use a negative number for absolute thresholds.<br/><br/>0: No limit (default).</html>"
@@ -6894,6 +7015,39 @@ Enabled=false
 EditorType=numeric
 CallName="align_var_struct_span="
 CallNameRegex="align_var_struct_span\s*=\s*"
+MinVal=0
+MaxVal=5000
+ValueDefault=0
+
+[Align Var Struct Span Num Empty Lines]
+Category=7
+Description="<html>Number of empty lines to ignore in span calculation for align_var_struct_span.<br/><br/>0: Don't skip any lines (default).</html>"
+Enabled=false
+EditorType=numeric
+CallName="align_var_struct_span_num_empty_lines="
+CallNameRegex="align_var_struct_span_num_empty_lines\s*=\s*"
+MinVal=0
+MaxVal=5000
+ValueDefault=0
+
+[Align Var Struct Span Num Pp Lines]
+Category=7
+Description="<html>Number of preprocessor directive lines to ignore in span calculation for align_var_struct_span.<br/><br/>0: Don't skip any lines (default).</html>"
+Enabled=false
+EditorType=numeric
+CallName="align_var_struct_span_num_pp_lines="
+CallNameRegex="align_var_struct_span_num_pp_lines\s*=\s*"
+MinVal=0
+MaxVal=5000
+ValueDefault=0
+
+[Align Var Struct Span Num Cmt Lines]
+Category=7
+Description="<html>Number of comment-only lines to ignore in span calculation for align_var_struct_span.<br/><br/>0: Don't skip any lines (default).</html>"
+Enabled=false
+EditorType=numeric
+CallName="align_var_struct_span_num_cmt_lines="
+CallNameRegex="align_var_struct_span_num_cmt_lines\s*=\s*"
 MinVal=0
 MaxVal=5000
 ValueDefault=0
@@ -7056,6 +7210,39 @@ EditorType=boolean
 TrueFalse=align_func_proto_span_ignore_cont_lines=true|align_func_proto_span_ignore_cont_lines=false
 TrueFalseRegex=align_func_proto_span_ignore_cont_lines\s*=\s*true|align_func_proto_span_ignore_cont_lines\s*=\s*false
 ValueDefault=false
+
+[Align Func Proto Span Num Empty Lines]
+Category=7
+Description="<html>Number of empty lines to ignore in span calculation for align_func_proto_span.<br/><br/>0: Don't skip any lines (default).</html>"
+Enabled=false
+EditorType=numeric
+CallName="align_func_proto_span_num_empty_lines="
+CallNameRegex="align_func_proto_span_num_empty_lines\s*=\s*"
+MinVal=0
+MaxVal=5000
+ValueDefault=0
+
+[Align Func Proto Span Num Pp Lines]
+Category=7
+Description="<html>Number of preprocessor directive lines to ignore in span calculation for align_func_proto_span.<br/><br/>0: Don't skip any lines (default).</html>"
+Enabled=false
+EditorType=numeric
+CallName="align_func_proto_span_num_pp_lines="
+CallNameRegex="align_func_proto_span_num_pp_lines\s*=\s*"
+MinVal=0
+MaxVal=5000
+ValueDefault=0
+
+[Align Func Proto Span Num Cmt Lines]
+Category=7
+Description="<html>Number of comment-only lines to ignore in span calculation for align_func_proto_span.<br/><br/>0: Don't skip any lines (default).</html>"
+Enabled=false
+EditorType=numeric
+CallName="align_func_proto_span_num_cmt_lines="
+CallNameRegex="align_func_proto_span_num_cmt_lines\s*=\s*"
+MinVal=0
+MaxVal=5000
+ValueDefault=0
 
 [Align Func Proto Star Style]
 Category=7
@@ -7333,7 +7520,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=cmt_indent_multi=true|cmt_indent_multi=false
 TrueFalseRegex=cmt_indent_multi\s*=\s*true|cmt_indent_multi\s*=\s*false
-ValueDefault=true
+ValueDefault=false
 
 [Cmt Align Doxygen Javadoc Tags]
 Category=8
@@ -7456,7 +7643,7 @@ CallName="cmt_sp_after_star_cont="
 CallNameRegex="cmt_sp_after_star_cont\s*=\s*"
 MinVal=0
 MaxVal=16
-ValueDefault=0
+ValueDefault=1
 
 [Cmt Multi Check Last]
 Category=8
@@ -8132,7 +8319,7 @@ EditorType=multiple
 Choices=pp_indent=ignore|pp_indent=add|pp_indent=remove|pp_indent=force
 ChoicesRegex=pp_indent\s*=\s*ignore|pp_indent\s*=\s*add|pp_indent\s*=\s*remove|pp_indent\s*=\s*force
 ChoicesReadable="Ignore Pp Indent|Add Pp Indent|Remove Pp Indent|Force Pp Indent"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Pp Indent At Level]
 Category=10
@@ -8363,7 +8550,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=use_indent_continue_only_once=true|use_indent_continue_only_once=false
 TrueFalseRegex=use_indent_continue_only_once\s*=\s*true|use_indent_continue_only_once\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Indent Cpp Lambda Only Once]
 Category=12

--- a/src/newlines/brace_pair.cpp
+++ b/src/newlines/brace_pair.cpp
@@ -205,6 +205,71 @@ void newlines_brace_pair(Chunk *br_open)
          }
       }
    }
+   // Collapse braced single-statement control blocks to one-liner
+   E_Token parent = br_open->GetParentType();
+
+   if (  parent == CT_IF
+      || parent == CT_ELSEIF
+      || parent == CT_ELSE)
+   {
+      log_rule_B("nl_collapse_if_one_liner");
+
+      if (options::nl_collapse_if_one_liner())
+      {
+         if (nl_collapse_braced_one_liner(br_open))
+         {
+            return;
+         }
+      }
+   }
+   else if (parent == CT_FOR)
+   {
+      log_rule_B("nl_collapse_for_one_liner");
+
+      if (options::nl_collapse_for_one_liner())
+      {
+         if (nl_collapse_braced_one_liner(br_open))
+         {
+            return;
+         }
+      }
+   }
+   else if (parent == CT_WHILE)
+   {
+      log_rule_B("nl_collapse_while_one_liner");
+
+      if (options::nl_collapse_while_one_liner())
+      {
+         if (nl_collapse_braced_one_liner(br_open))
+         {
+            return;
+         }
+      }
+   }
+   else if (parent == CT_DO)
+   {
+      log_rule_B("nl_collapse_do_one_liner");
+
+      if (options::nl_collapse_do_one_liner())
+      {
+         if (nl_collapse_braced_one_liner(br_open))
+         {
+            return;
+         }
+      }
+   }
+   else if (parent == CT_CASE)
+   {
+      log_rule_B("nl_collapse_switch_one_liner");
+
+      if (options::nl_collapse_switch_one_liner())
+      {
+         if (nl_collapse_braced_one_liner(br_open))
+         {
+            return;
+         }
+      }
+   }
 
    // Make sure we don't break a one-liner
    if (!one_liner_nl_ok(br_open))

--- a/src/newlines/one_liner.h
+++ b/src/newlines/one_liner.h
@@ -32,4 +32,13 @@ bool one_liner_nl_ok(Chunk *pc);
  */
 void undo_one_liner(Chunk *pc);
 
+/**
+ * Collapse a braced single-statement control block to inline style.
+ * Works on real braces (not virtual braces).
+ * return value:
+ *  true: block was collapsed
+ * false: block was not collapsed
+ */
+bool nl_collapse_braced_one_liner(Chunk *br_open);
+
 #endif /* NEWLINES_ONE_LINER_H_INCLUDED */

--- a/src/options.h
+++ b/src/options.h
@@ -2867,6 +2867,31 @@ nl_split_while_one_liner;
 extern Option<bool>
 donot_add_nl_before_cpp_comment;
 
+// Whether to collapse a braced single-statement 'if' block to one line,
+// as in 'if (cond)\n{\n    stmt;\n}' => 'if (cond) { stmt; }'.
+extern Option<bool>
+nl_collapse_if_one_liner;
+
+// Whether to collapse a braced single-statement 'for' block to one line,
+// as in 'for (...)\n{\n    stmt;\n}' => 'for (...) { stmt; }'.
+extern Option<bool>
+nl_collapse_for_one_liner;
+
+// Whether to collapse a braced single-statement 'while' block to one line,
+// as in 'while (...)\n{\n    stmt;\n}' => 'while (...) { stmt; }'.
+extern Option<bool>
+nl_collapse_while_one_liner;
+
+// Whether to collapse a braced single-statement 'do' block to one line,
+// as in 'do\n{\n    stmt;\n} while (...)' => 'do { stmt; } while (...)'.
+extern Option<bool>
+nl_collapse_do_one_liner;
+
+// Whether to collapse a braced single-statement 'case' block to one line,
+// as in 'case X:\n{\n    stmt;\n}' => 'case X: { stmt; }'.
+extern Option<bool>
+nl_collapse_switch_one_liner;
+
 //END
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/cli/output/show_config.txt
+++ b/tests/cli/output/show_config.txt
@@ -1,4 +1,4 @@
-# Uncrustify
+# Uncrustify_d-0.82.0-73-4b2179d02-dirty
 
 #
 # General options
@@ -2333,6 +2333,26 @@ nl_split_while_one_liner        = false    # true/false
 # Don't add a newline before a cpp-comment in a parameter list of a function
 # call.
 donot_add_nl_before_cpp_comment = false    # true/false
+
+# Whether to collapse a braced single-statement 'if' block to one line,
+# as in 'if (cond)\n{\n    stmt;\n}' => 'if (cond) { stmt; }'.
+nl_collapse_if_one_liner        = false    # true/false
+
+# Whether to collapse a braced single-statement 'for' block to one line,
+# as in 'for (...)\n{\n    stmt;\n}' => 'for (...) { stmt; }'.
+nl_collapse_for_one_liner       = false    # true/false
+
+# Whether to collapse a braced single-statement 'while' block to one line,
+# as in 'while (...)\n{\n    stmt;\n}' => 'while (...) { stmt; }'.
+nl_collapse_while_one_liner     = false    # true/false
+
+# Whether to collapse a braced single-statement 'do' block to one line,
+# as in 'do\n{\n    stmt;\n} while (...)' => 'do { stmt; } while (...)'.
+nl_collapse_do_one_liner        = false    # true/false
+
+# Whether to collapse a braced single-statement 'case' block to one line,
+# as in 'case X:\n{\n    stmt;\n}' => 'case X: { stmt; }'.
+nl_collapse_switch_one_liner    = false    # true/false
 
 #
 # Blank line options

--- a/tests/cli/output/universalindent.cfg
+++ b/tests/cli/output/universalindent.cfg
@@ -170,7 +170,7 @@ EditorType=multiple
 Choices=sp_arith=ignore|sp_arith=add|sp_arith=remove|sp_arith=force
 ChoicesRegex=sp_arith\s*=\s*ignore|sp_arith\s*=\s*add|sp_arith\s*=\s*remove|sp_arith\s*=\s*force
 ChoicesReadable="Ignore Sp Arith|Add Sp Arith|Remove Sp Arith|Force Sp Arith"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Arith Additive]
 Category=1
@@ -190,7 +190,7 @@ EditorType=multiple
 Choices=sp_assign=ignore|sp_assign=add|sp_assign=remove|sp_assign=force
 ChoicesRegex=sp_assign\s*=\s*ignore|sp_assign\s*=\s*add|sp_assign\s*=\s*remove|sp_assign\s*=\s*force
 ChoicesReadable="Ignore Sp Assign|Add Sp Assign|Remove Sp Assign|Force Sp Assign"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Cpp Lambda Assign]
 Category=1
@@ -390,7 +390,7 @@ EditorType=multiple
 Choices=sp_bool=ignore|sp_bool=add|sp_bool=remove|sp_bool=force
 ChoicesRegex=sp_bool\s*=\s*ignore|sp_bool\s*=\s*add|sp_bool\s*=\s*remove|sp_bool\s*=\s*force
 ChoicesReadable="Ignore Sp Bool|Add Sp Bool|Remove Sp Bool|Force Sp Bool"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Compare]
 Category=1
@@ -400,7 +400,7 @@ EditorType=multiple
 Choices=sp_compare=ignore|sp_compare=add|sp_compare=remove|sp_compare=force
 ChoicesRegex=sp_compare\s*=\s*ignore|sp_compare\s*=\s*add|sp_compare\s*=\s*remove|sp_compare\s*=\s*force
 ChoicesReadable="Ignore Sp Compare|Add Sp Compare|Remove Sp Compare|Force Sp Compare"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Inside Paren]
 Category=1
@@ -410,7 +410,7 @@ EditorType=multiple
 Choices=sp_inside_paren=ignore|sp_inside_paren=add|sp_inside_paren=remove|sp_inside_paren=force
 ChoicesRegex=sp_inside_paren\s*=\s*ignore|sp_inside_paren\s*=\s*add|sp_inside_paren\s*=\s*remove|sp_inside_paren\s*=\s*force
 ChoicesReadable="Ignore Sp Inside Paren|Add Sp Inside Paren|Remove Sp Inside Paren|Force Sp Inside Paren"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Paren Paren]
 Category=1
@@ -460,7 +460,7 @@ EditorType=multiple
 Choices=sp_before_ptr_star=ignore|sp_before_ptr_star=add|sp_before_ptr_star=remove|sp_before_ptr_star=force
 ChoicesRegex=sp_before_ptr_star\s*=\s*ignore|sp_before_ptr_star\s*=\s*add|sp_before_ptr_star\s*=\s*remove|sp_before_ptr_star\s*=\s*force
 ChoicesReadable="Ignore Sp Before Ptr Star|Add Sp Before Ptr Star|Remove Sp Before Ptr Star|Force Sp Before Ptr Star"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Before Unnamed Ptr Star]
 Category=1
@@ -530,7 +530,7 @@ EditorType=multiple
 Choices=sp_between_ptr_star=ignore|sp_between_ptr_star=add|sp_between_ptr_star=remove|sp_between_ptr_star=force
 ChoicesRegex=sp_between_ptr_star\s*=\s*ignore|sp_between_ptr_star\s*=\s*add|sp_between_ptr_star\s*=\s*remove|sp_between_ptr_star\s*=\s*force
 ChoicesReadable="Ignore Sp Between Ptr Star|Add Sp Between Ptr Star|Remove Sp Between Ptr Star|Force Sp Between Ptr Star"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Between Ptr Ref]
 Category=1
@@ -550,7 +550,7 @@ EditorType=multiple
 Choices=sp_after_ptr_star=ignore|sp_after_ptr_star=add|sp_after_ptr_star=remove|sp_after_ptr_star=force
 ChoicesRegex=sp_after_ptr_star\s*=\s*ignore|sp_after_ptr_star\s*=\s*add|sp_after_ptr_star\s*=\s*remove|sp_after_ptr_star\s*=\s*force
 ChoicesReadable="Ignore Sp After Ptr Star|Add Sp After Ptr Star|Remove Sp After Ptr Star|Force Sp After Ptr Star"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp After Ptr Block Caret]
 Category=1
@@ -580,7 +580,7 @@ EditorType=multiple
 Choices=sp_after_ptr_star_func=ignore|sp_after_ptr_star_func=add|sp_after_ptr_star_func=remove|sp_after_ptr_star_func=force
 ChoicesRegex=sp_after_ptr_star_func\s*=\s*ignore|sp_after_ptr_star_func\s*=\s*add|sp_after_ptr_star_func\s*=\s*remove|sp_after_ptr_star_func\s*=\s*force
 ChoicesReadable="Ignore Sp After Ptr Star Func|Add Sp After Ptr Star Func|Remove Sp After Ptr Star Func|Force Sp After Ptr Star Func"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp After Ptr Star Trailing]
 Category=1
@@ -630,7 +630,7 @@ EditorType=multiple
 Choices=sp_before_ptr_star_func=ignore|sp_before_ptr_star_func=add|sp_before_ptr_star_func=remove|sp_before_ptr_star_func=force
 ChoicesRegex=sp_before_ptr_star_func\s*=\s*ignore|sp_before_ptr_star_func\s*=\s*add|sp_before_ptr_star_func\s*=\s*remove|sp_before_ptr_star_func\s*=\s*force
 ChoicesReadable="Ignore Sp Before Ptr Star Func|Add Sp Before Ptr Star Func|Remove Sp Before Ptr Star Func|Force Sp Before Ptr Star Func"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Qualifier Ptr Star Func]
 Category=1
@@ -869,7 +869,7 @@ EditorType=multiple
 Choices=sp_before_sparen=ignore|sp_before_sparen=add|sp_before_sparen=remove|sp_before_sparen=force
 ChoicesRegex=sp_before_sparen\s*=\s*ignore|sp_before_sparen\s*=\s*add|sp_before_sparen\s*=\s*remove|sp_before_sparen\s*=\s*force
 ChoicesReadable="Ignore Sp Before Sparen|Add Sp Before Sparen|Remove Sp Before Sparen|Force Sp Before Sparen"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Inside Sparen]
 Category=1
@@ -879,7 +879,7 @@ EditorType=multiple
 Choices=sp_inside_sparen=ignore|sp_inside_sparen=add|sp_inside_sparen=remove|sp_inside_sparen=force
 ChoicesRegex=sp_inside_sparen\s*=\s*ignore|sp_inside_sparen\s*=\s*add|sp_inside_sparen\s*=\s*remove|sp_inside_sparen\s*=\s*force
 ChoicesReadable="Ignore Sp Inside Sparen|Add Sp Inside Sparen|Remove Sp Inside Sparen|Force Sp Inside Sparen"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Inside Sparen Open]
 Category=1
@@ -1089,7 +1089,7 @@ EditorType=multiple
 Choices=sp_after_semi_for_empty=ignore|sp_after_semi_for_empty=add|sp_after_semi_for_empty=remove|sp_after_semi_for_empty=force
 ChoicesRegex=sp_after_semi_for_empty\s*=\s*ignore|sp_after_semi_for_empty\s*=\s*add|sp_after_semi_for_empty\s*=\s*remove|sp_after_semi_for_empty\s*=\s*force
 ChoicesReadable="Ignore Sp After Semi For Empty|Add Sp After Semi For Empty|Remove Sp After Semi For Empty|Force Sp After Semi For Empty"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Before Square]
 Category=1
@@ -1159,7 +1159,7 @@ EditorType=multiple
 Choices=sp_inside_square=ignore|sp_inside_square=add|sp_inside_square=remove|sp_inside_square=force
 ChoicesRegex=sp_inside_square\s*=\s*ignore|sp_inside_square\s*=\s*add|sp_inside_square\s*=\s*remove|sp_inside_square\s*=\s*force
 ChoicesReadable="Ignore Sp Inside Square|Add Sp Inside Square|Remove Sp Inside Square|Force Sp Inside Square"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Inside Square Empty]
 Category=1
@@ -1189,7 +1189,7 @@ EditorType=multiple
 Choices=sp_after_comma=ignore|sp_after_comma=add|sp_after_comma=remove|sp_after_comma=force
 ChoicesRegex=sp_after_comma\s*=\s*ignore|sp_after_comma\s*=\s*add|sp_after_comma\s*=\s*remove|sp_after_comma\s*=\s*force
 ChoicesReadable="Ignore Sp After Comma|Add Sp After Comma|Remove Sp After Comma|Force Sp After Comma"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Before Comma]
 Category=1
@@ -1429,7 +1429,7 @@ EditorType=multiple
 Choices=sp_after_cast=ignore|sp_after_cast=add|sp_after_cast=remove|sp_after_cast=force
 ChoicesRegex=sp_after_cast\s*=\s*ignore|sp_after_cast\s*=\s*add|sp_after_cast\s*=\s*remove|sp_after_cast\s*=\s*force
 ChoicesReadable="Ignore Sp After Cast|Add Sp After Cast|Remove Sp After Cast|Force Sp After Cast"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Inside Paren Cast]
 Category=1
@@ -1539,7 +1539,7 @@ EditorType=multiple
 Choices=sp_inside_braces_struct=ignore|sp_inside_braces_struct=add|sp_inside_braces_struct=remove|sp_inside_braces_struct=force
 ChoicesRegex=sp_inside_braces_struct\s*=\s*ignore|sp_inside_braces_struct\s*=\s*add|sp_inside_braces_struct\s*=\s*remove|sp_inside_braces_struct\s*=\s*force
 ChoicesReadable="Ignore Sp Inside Braces Struct|Add Sp Inside Braces Struct|Remove Sp Inside Braces Struct|Force Sp Inside Braces Struct"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Inside Braces Oc Dict]
 Category=1
@@ -1589,7 +1589,7 @@ EditorType=multiple
 Choices=sp_inside_braces=ignore|sp_inside_braces=add|sp_inside_braces=remove|sp_inside_braces=force
 ChoicesRegex=sp_inside_braces\s*=\s*ignore|sp_inside_braces\s*=\s*add|sp_inside_braces\s*=\s*remove|sp_inside_braces\s*=\s*force
 ChoicesReadable="Ignore Sp Inside Braces|Add Sp Inside Braces|Remove Sp Inside Braces|Force Sp Inside Braces"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Inside Braces Empty]
 Category=1
@@ -1599,7 +1599,7 @@ EditorType=multiple
 Choices=sp_inside_braces_empty=ignore|sp_inside_braces_empty=add|sp_inside_braces_empty=remove|sp_inside_braces_empty=force
 ChoicesRegex=sp_inside_braces_empty\s*=\s*ignore|sp_inside_braces_empty\s*=\s*add|sp_inside_braces_empty\s*=\s*remove|sp_inside_braces_empty\s*=\s*force
 ChoicesReadable="Ignore Sp Inside Braces Empty|Add Sp Inside Braces Empty|Remove Sp Inside Braces Empty|Force Sp Inside Braces Empty"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Trailing Return]
 Category=1
@@ -1639,7 +1639,7 @@ EditorType=multiple
 Choices=sp_func_proto_paren=ignore|sp_func_proto_paren=add|sp_func_proto_paren=remove|sp_func_proto_paren=force
 ChoicesRegex=sp_func_proto_paren\s*=\s*ignore|sp_func_proto_paren\s*=\s*add|sp_func_proto_paren\s*=\s*remove|sp_func_proto_paren\s*=\s*force
 ChoicesReadable="Ignore Sp Func Proto Paren|Add Sp Func Proto Paren|Remove Sp Func Proto Paren|Force Sp Func Proto Paren"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Func Proto Paren Empty]
 Category=1
@@ -1669,7 +1669,7 @@ EditorType=multiple
 Choices=sp_func_def_paren=ignore|sp_func_def_paren=add|sp_func_def_paren=remove|sp_func_def_paren=force
 ChoicesRegex=sp_func_def_paren\s*=\s*ignore|sp_func_def_paren\s*=\s*add|sp_func_def_paren\s*=\s*remove|sp_func_def_paren\s*=\s*force
 ChoicesReadable="Ignore Sp Func Def Paren|Add Sp Func Def Paren|Remove Sp Func Def Paren|Force Sp Func Def Paren"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Func Def Paren Empty]
 Category=1
@@ -1799,7 +1799,7 @@ EditorType=multiple
 Choices=sp_func_call_paren=ignore|sp_func_call_paren=add|sp_func_call_paren=remove|sp_func_call_paren=force
 ChoicesRegex=sp_func_call_paren\s*=\s*ignore|sp_func_call_paren\s*=\s*add|sp_func_call_paren\s*=\s*remove|sp_func_call_paren\s*=\s*force
 ChoicesReadable="Ignore Sp Func Call Paren|Add Sp Func Call Paren|Remove Sp Func Call Paren|Force Sp Func Call Paren"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Sp Func Call Paren Empty]
 Category=1
@@ -2059,7 +2059,7 @@ EditorType=multiple
 Choices=sp_brace_typedef=ignore|sp_brace_typedef=add|sp_brace_typedef=remove|sp_brace_typedef=force
 ChoicesRegex=sp_brace_typedef\s*=\s*ignore|sp_brace_typedef\s*=\s*add|sp_brace_typedef\s*=\s*remove|sp_brace_typedef\s*=\s*force
 ChoicesReadable="Ignore Sp Brace Typedef|Add Sp Brace Typedef|Remove Sp Brace Typedef|Force Sp Brace Typedef"
-ValueDefault=ignore
+ValueDefault=force
 
 [Sp Catch Brace]
 Category=1
@@ -2866,7 +2866,7 @@ CallName="indent_columns="
 CallNameRegex="indent_columns\s*=\s*"
 MinVal=0
 MaxVal=16
-ValueDefault=8
+ValueDefault=4
 
 [Indent Ignore First Continue]
 Category=2
@@ -2886,7 +2886,7 @@ CallName="indent_continue="
 CallNameRegex="indent_continue\s*=\s*"
 MinVal=-16
 MaxVal=16
-ValueDefault=0
+ValueDefault=4
 
 [Indent Continue Class Head]
 Category=2
@@ -2927,7 +2927,7 @@ EditorType=multiple
 Choices="indent_with_tabs=0|indent_with_tabs=1|indent_with_tabs=2"
 ChoicesRegex="indent_with_tabs\s*=\s*0|indent_with_tabs\s*=\s*1|indent_with_tabs\s*=\s*2"
 ChoicesReadable="Spaces only|Indent with tabs, align with spaces|Indent and align with tabs"
-ValueDefault=1
+ValueDefault=0
 
 [Indent Cmt With Tabs]
 Category=2
@@ -3422,7 +3422,7 @@ CallName="indent_switch_case="
 CallNameRegex="indent_switch_case\s*=\s*"
 MinVal=0
 MaxVal=16
-ValueDefault=0
+ValueDefault=4
 
 [Indent Switch Body]
 Category=2
@@ -3766,7 +3766,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=indent_align_paren=true|indent_align_paren=false
 TrueFalseRegex=indent_align_paren\s*=\s*true|indent_align_paren\s*=\s*false
-ValueDefault=true
+ValueDefault=false
 
 [Indent Oc Inside Msg Sel]
 Category=2
@@ -4071,7 +4071,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_if_leave_one_liners=true|nl_if_leave_one_liners=false
 TrueFalseRegex=nl_if_leave_one_liners\s*=\s*true|nl_if_leave_one_liners\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl While Leave One Liners]
 Category=3
@@ -4080,7 +4080,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_while_leave_one_liners=true|nl_while_leave_one_liners=false
 TrueFalseRegex=nl_while_leave_one_liners\s*=\s*true|nl_while_leave_one_liners\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl Do Leave One Liners]
 Category=3
@@ -4089,7 +4089,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_do_leave_one_liners=true|nl_do_leave_one_liners=false
 TrueFalseRegex=nl_do_leave_one_liners\s*=\s*true|nl_do_leave_one_liners\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl For Leave One Liners]
 Category=3
@@ -4098,7 +4098,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_for_leave_one_liners=true|nl_for_leave_one_liners=false
 TrueFalseRegex=nl_for_leave_one_liners\s*=\s*true|nl_for_leave_one_liners\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl Oc Msg Leave One Liner]
 Category=3
@@ -4208,7 +4208,7 @@ EditorType=multiple
 Choices=nl_end_of_file=ignore|nl_end_of_file=add|nl_end_of_file=remove|nl_end_of_file=force
 ChoicesRegex=nl_end_of_file\s*=\s*ignore|nl_end_of_file\s*=\s*add|nl_end_of_file\s*=\s*remove|nl_end_of_file\s*=\s*force
 ChoicesReadable="Ignore Nl End Of File|Add Nl End Of File|Remove Nl End Of File|Force Nl End Of File"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl End Of File Min]
 Category=3
@@ -4219,7 +4219,7 @@ CallName="nl_end_of_file_min="
 CallNameRegex="nl_end_of_file_min\s*=\s*"
 MinVal=0
 MaxVal=16
-ValueDefault=0
+ValueDefault=1
 
 [Nl Assign Brace]
 Category=3
@@ -4279,7 +4279,7 @@ EditorType=multiple
 Choices=nl_enum_brace=ignore|nl_enum_brace=add|nl_enum_brace=remove|nl_enum_brace=force
 ChoicesRegex=nl_enum_brace\s*=\s*ignore|nl_enum_brace\s*=\s*add|nl_enum_brace\s*=\s*remove|nl_enum_brace\s*=\s*force
 ChoicesReadable="Ignore Nl Enum Brace|Add Nl Enum Brace|Remove Nl Enum Brace|Force Nl Enum Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Enum Class]
 Category=3
@@ -4329,7 +4329,7 @@ EditorType=multiple
 Choices=nl_struct_brace=ignore|nl_struct_brace=add|nl_struct_brace=remove|nl_struct_brace=force
 ChoicesRegex=nl_struct_brace\s*=\s*ignore|nl_struct_brace\s*=\s*add|nl_struct_brace\s*=\s*remove|nl_struct_brace\s*=\s*force
 ChoicesReadable="Ignore Nl Struct Brace|Add Nl Struct Brace|Remove Nl Struct Brace|Force Nl Struct Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Union Brace]
 Category=3
@@ -4339,7 +4339,7 @@ EditorType=multiple
 Choices=nl_union_brace=ignore|nl_union_brace=add|nl_union_brace=remove|nl_union_brace=force
 ChoicesRegex=nl_union_brace\s*=\s*ignore|nl_union_brace\s*=\s*add|nl_union_brace\s*=\s*remove|nl_union_brace\s*=\s*force
 ChoicesReadable="Ignore Nl Union Brace|Add Nl Union Brace|Remove Nl Union Brace|Force Nl Union Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl If Brace]
 Category=3
@@ -4349,7 +4349,7 @@ EditorType=multiple
 Choices=nl_if_brace=ignore|nl_if_brace=add|nl_if_brace=remove|nl_if_brace=force
 ChoicesRegex=nl_if_brace\s*=\s*ignore|nl_if_brace\s*=\s*add|nl_if_brace\s*=\s*remove|nl_if_brace\s*=\s*force
 ChoicesReadable="Ignore Nl If Brace|Add Nl If Brace|Remove Nl If Brace|Force Nl If Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Brace Else]
 Category=3
@@ -4359,7 +4359,7 @@ EditorType=multiple
 Choices=nl_brace_else=ignore|nl_brace_else=add|nl_brace_else=remove|nl_brace_else=force
 ChoicesRegex=nl_brace_else\s*=\s*ignore|nl_brace_else\s*=\s*add|nl_brace_else\s*=\s*remove|nl_brace_else\s*=\s*force
 ChoicesReadable="Ignore Nl Brace Else|Add Nl Brace Else|Remove Nl Brace Else|Force Nl Brace Else"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Elseif Brace]
 Category=3
@@ -4369,7 +4369,7 @@ EditorType=multiple
 Choices=nl_elseif_brace=ignore|nl_elseif_brace=add|nl_elseif_brace=remove|nl_elseif_brace=force
 ChoicesRegex=nl_elseif_brace\s*=\s*ignore|nl_elseif_brace\s*=\s*add|nl_elseif_brace\s*=\s*remove|nl_elseif_brace\s*=\s*force
 ChoicesReadable="Ignore Nl Elseif Brace|Add Nl Elseif Brace|Remove Nl Elseif Brace|Force Nl Elseif Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Else Brace]
 Category=3
@@ -4379,7 +4379,7 @@ EditorType=multiple
 Choices=nl_else_brace=ignore|nl_else_brace=add|nl_else_brace=remove|nl_else_brace=force
 ChoicesRegex=nl_else_brace\s*=\s*ignore|nl_else_brace\s*=\s*add|nl_else_brace\s*=\s*remove|nl_else_brace\s*=\s*force
 ChoicesReadable="Ignore Nl Else Brace|Add Nl Else Brace|Remove Nl Else Brace|Force Nl Else Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Else If]
 Category=3
@@ -4389,7 +4389,7 @@ EditorType=multiple
 Choices=nl_else_if=ignore|nl_else_if=add|nl_else_if=remove|nl_else_if=force
 ChoicesRegex=nl_else_if\s*=\s*ignore|nl_else_if\s*=\s*add|nl_else_if\s*=\s*remove|nl_else_if\s*=\s*force
 ChoicesReadable="Ignore Nl Else If|Add Nl Else If|Remove Nl Else If|Force Nl Else If"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Nl Before Opening Brace Func Class Def]
 Category=3
@@ -4459,7 +4459,7 @@ EditorType=multiple
 Choices=nl_for_brace=ignore|nl_for_brace=add|nl_for_brace=remove|nl_for_brace=force
 ChoicesRegex=nl_for_brace\s*=\s*ignore|nl_for_brace\s*=\s*add|nl_for_brace\s*=\s*remove|nl_for_brace\s*=\s*force
 ChoicesReadable="Ignore Nl For Brace|Add Nl For Brace|Remove Nl For Brace|Force Nl For Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Catch Brace]
 Category=3
@@ -4529,7 +4529,7 @@ EditorType=multiple
 Choices=nl_while_brace=ignore|nl_while_brace=add|nl_while_brace=remove|nl_while_brace=force
 ChoicesRegex=nl_while_brace\s*=\s*ignore|nl_while_brace\s*=\s*add|nl_while_brace\s*=\s*remove|nl_while_brace\s*=\s*force
 ChoicesReadable="Ignore Nl While Brace|Add Nl While Brace|Remove Nl While Brace|Force Nl While Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Scope Brace]
 Category=3
@@ -4589,7 +4589,7 @@ EditorType=multiple
 Choices=nl_do_brace=ignore|nl_do_brace=add|nl_do_brace=remove|nl_do_brace=force
 ChoicesRegex=nl_do_brace\s*=\s*ignore|nl_do_brace\s*=\s*add|nl_do_brace\s*=\s*remove|nl_do_brace\s*=\s*force
 ChoicesReadable="Ignore Nl Do Brace|Add Nl Do Brace|Remove Nl Do Brace|Force Nl Do Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Brace While]
 Category=3
@@ -4609,7 +4609,7 @@ EditorType=multiple
 Choices=nl_switch_brace=ignore|nl_switch_brace=add|nl_switch_brace=remove|nl_switch_brace=force
 ChoicesRegex=nl_switch_brace\s*=\s*ignore|nl_switch_brace\s*=\s*add|nl_switch_brace\s*=\s*remove|nl_switch_brace\s*=\s*force
 ChoicesReadable="Ignore Nl Switch Brace|Add Nl Switch Brace|Remove Nl Switch Brace|Force Nl Switch Brace"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Synchronized Brace]
 Category=3
@@ -4675,7 +4675,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_case=true|nl_after_case=false
 TrueFalseRegex=nl_after_case\s*=\s*true|nl_after_case\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl Case Colon Brace]
 Category=3
@@ -4875,7 +4875,7 @@ EditorType=multiple
 Choices=nl_func_type_name=ignore|nl_func_type_name=add|nl_func_type_name=remove|nl_func_type_name=force
 ChoicesRegex=nl_func_type_name\s*=\s*ignore|nl_func_type_name\s*=\s*add|nl_func_type_name\s*=\s*remove|nl_func_type_name\s*=\s*force
 ChoicesReadable="Ignore Nl Func Type Name|Add Nl Func Type Name|Remove Nl Func Type Name|Force Nl Func Type Name"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Nl Func Type Name Class]
 Category=3
@@ -4965,7 +4965,7 @@ EditorType=multiple
 Choices=nl_func_call_paren=ignore|nl_func_call_paren=add|nl_func_call_paren=remove|nl_func_call_paren=force
 ChoicesRegex=nl_func_call_paren\s*=\s*ignore|nl_func_call_paren\s*=\s*add|nl_func_call_paren\s*=\s*remove|nl_func_call_paren\s*=\s*force
 ChoicesReadable="Ignore Nl Func Call Paren|Add Nl Func Call Paren|Remove Nl Func Call Paren|Force Nl Func Call Paren"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Nl Func Call Paren Empty]
 Category=3
@@ -4975,7 +4975,7 @@ EditorType=multiple
 Choices=nl_func_call_paren_empty=ignore|nl_func_call_paren_empty=add|nl_func_call_paren_empty=remove|nl_func_call_paren_empty=force
 ChoicesRegex=nl_func_call_paren_empty\s*=\s*ignore|nl_func_call_paren_empty\s*=\s*add|nl_func_call_paren_empty\s*=\s*remove|nl_func_call_paren_empty\s*=\s*force
 ChoicesReadable="Ignore Nl Func Call Paren Empty|Add Nl Func Call Paren Empty|Remove Nl Func Call Paren Empty|Force Nl Func Call Paren Empty"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Nl Func Decl Start]
 Category=3
@@ -5043,7 +5043,7 @@ EditorType=multiple
 Choices=nl_func_decl_args=ignore|nl_func_decl_args=add|nl_func_decl_args=remove|nl_func_decl_args=force
 ChoicesRegex=nl_func_decl_args\s*=\s*ignore|nl_func_decl_args\s*=\s*add|nl_func_decl_args\s*=\s*remove|nl_func_decl_args\s*=\s*force
 ChoicesReadable="Ignore Nl Func Decl Args|Add Nl Func Decl Args|Remove Nl Func Decl Args|Force Nl Func Decl Args"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Nl Func Def Args]
 Category=3
@@ -5053,7 +5053,7 @@ EditorType=multiple
 Choices=nl_func_def_args=ignore|nl_func_def_args=add|nl_func_def_args=remove|nl_func_def_args=force
 ChoicesRegex=nl_func_def_args\s*=\s*ignore|nl_func_def_args\s*=\s*add|nl_func_def_args\s*=\s*remove|nl_func_def_args\s*=\s*force
 ChoicesReadable="Ignore Nl Func Def Args|Add Nl Func Def Args|Remove Nl Func Def Args|Force Nl Func Def Args"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Nl Func Call Args]
 Category=3
@@ -5063,7 +5063,7 @@ EditorType=multiple
 Choices=nl_func_call_args=ignore|nl_func_call_args=add|nl_func_call_args=remove|nl_func_call_args=force
 ChoicesRegex=nl_func_call_args\s*=\s*ignore|nl_func_call_args\s*=\s*add|nl_func_call_args\s*=\s*remove|nl_func_call_args\s*=\s*force
 ChoicesReadable="Ignore Nl Func Call Args|Add Nl Func Call Args|Remove Nl Func Call Args|Force Nl Func Call Args"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Nl Func Decl Args Multi Line]
 Category=3
@@ -5179,7 +5179,7 @@ EditorType=multiple
 Choices=nl_func_call_start=ignore|nl_func_call_start=add|nl_func_call_start=remove|nl_func_call_start=force
 ChoicesRegex=nl_func_call_start\s*=\s*ignore|nl_func_call_start\s*=\s*add|nl_func_call_start\s*=\s*remove|nl_func_call_start\s*=\s*force
 ChoicesReadable="Ignore Nl Func Call Start|Add Nl Func Call Start|Remove Nl Func Call Start|Force Nl Func Call Start"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Nl Func Call End]
 Category=3
@@ -5189,7 +5189,7 @@ EditorType=multiple
 Choices=nl_func_call_end=ignore|nl_func_call_end=add|nl_func_call_end=remove|nl_func_call_end=force
 ChoicesRegex=nl_func_call_end\s*=\s*ignore|nl_func_call_end\s*=\s*add|nl_func_call_end\s*=\s*remove|nl_func_call_end\s*=\s*force
 ChoicesReadable="Ignore Nl Func Call End|Add Nl Func Call End|Remove Nl Func Call End|Force Nl Func Call End"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Nl Func Call Start Multi Line]
 Category=3
@@ -5351,7 +5351,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_semicolon=true|nl_after_semicolon=false
 TrueFalseRegex=nl_after_semicolon\s*=\s*true|nl_after_semicolon\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl Paren Dbrace Open]
 Category=3
@@ -5445,7 +5445,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_after_brace_close=true|nl_after_brace_close=false
 TrueFalseRegex=nl_after_brace_close\s*=\s*true|nl_after_brace_close\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl After Vbrace Close]
 Category=3
@@ -5529,7 +5529,7 @@ EditorType=multiple
 Choices=nl_after_if=ignore|nl_after_if=add|nl_after_if=remove|nl_after_if=force
 ChoicesRegex=nl_after_if\s*=\s*ignore|nl_after_if\s*=\s*add|nl_after_if\s*=\s*remove|nl_after_if\s*=\s*force
 ChoicesReadable="Ignore Nl After If|Add Nl After If|Remove Nl After If|Force Nl After If"
-ValueDefault=ignore
+ValueDefault=force
 
 [Nl Before For]
 Category=3
@@ -5732,7 +5732,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_create_if_one_liner=true|nl_create_if_one_liner=false
 TrueFalseRegex=nl_create_if_one_liner\s*=\s*true|nl_create_if_one_liner\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl Create For One Liner]
 Category=3
@@ -5741,7 +5741,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_create_for_one_liner=true|nl_create_for_one_liner=false
 TrueFalseRegex=nl_create_for_one_liner\s*=\s*true|nl_create_for_one_liner\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl Create While One Liner]
 Category=3
@@ -5750,7 +5750,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=nl_create_while_one_liner=true|nl_create_while_one_liner=false
 TrueFalseRegex=nl_create_while_one_liner\s*=\s*true|nl_create_while_one_liner\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Nl Create Func Def One Liner]
 Category=3
@@ -5804,6 +5804,51 @@ Enabled=false
 EditorType=boolean
 TrueFalse=donot_add_nl_before_cpp_comment=true|donot_add_nl_before_cpp_comment=false
 TrueFalseRegex=donot_add_nl_before_cpp_comment\s*=\s*true|donot_add_nl_before_cpp_comment\s*=\s*false
+ValueDefault=false
+
+[Nl Collapse If One Liner]
+Category=3
+Description="<html>Whether to collapse a braced single-statement 'if' block to one line,<br/>as in 'if (cond)\n{\n    stmt;\n}' =&gt; 'if (cond) { stmt; }'.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=nl_collapse_if_one_liner=true|nl_collapse_if_one_liner=false
+TrueFalseRegex=nl_collapse_if_one_liner\s*=\s*true|nl_collapse_if_one_liner\s*=\s*false
+ValueDefault=false
+
+[Nl Collapse For One Liner]
+Category=3
+Description="<html>Whether to collapse a braced single-statement 'for' block to one line,<br/>as in 'for (...)\n{\n    stmt;\n}' =&gt; 'for (...) { stmt; }'.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=nl_collapse_for_one_liner=true|nl_collapse_for_one_liner=false
+TrueFalseRegex=nl_collapse_for_one_liner\s*=\s*true|nl_collapse_for_one_liner\s*=\s*false
+ValueDefault=false
+
+[Nl Collapse While One Liner]
+Category=3
+Description="<html>Whether to collapse a braced single-statement 'while' block to one line,<br/>as in 'while (...)\n{\n    stmt;\n}' =&gt; 'while (...) { stmt; }'.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=nl_collapse_while_one_liner=true|nl_collapse_while_one_liner=false
+TrueFalseRegex=nl_collapse_while_one_liner\s*=\s*true|nl_collapse_while_one_liner\s*=\s*false
+ValueDefault=false
+
+[Nl Collapse Do One Liner]
+Category=3
+Description="<html>Whether to collapse a braced single-statement 'do' block to one line,<br/>as in 'do\n{\n    stmt;\n} while (...)' =&gt; 'do { stmt; } while (...)'.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=nl_collapse_do_one_liner=true|nl_collapse_do_one_liner=false
+TrueFalseRegex=nl_collapse_do_one_liner\s*=\s*true|nl_collapse_do_one_liner\s*=\s*false
+ValueDefault=false
+
+[Nl Collapse Switch One Liner]
+Category=3
+Description="<html>Whether to collapse a braced single-statement 'case' block to one line,<br/>as in 'case X:\n{\n    stmt;\n}' =&gt; 'case X: { stmt; }'.</html>"
+Enabled=false
+EditorType=boolean
+TrueFalse=nl_collapse_switch_one_liner=true|nl_collapse_switch_one_liner=false
+TrueFalseRegex=nl_collapse_switch_one_liner\s*=\s*true|nl_collapse_switch_one_liner\s*=\s*false
 ValueDefault=false
 
 [Nl Max]
@@ -5945,7 +5990,7 @@ CallName="nl_after_func_body="
 CallNameRegex="nl_after_func_body\s*=\s*"
 MinVal=0
 MaxVal=16
-ValueDefault=0
+ValueDefault=2
 
 [Nl Min After Func Body]
 Category=4
@@ -5978,7 +6023,7 @@ CallName="nl_after_func_body_class="
 CallNameRegex="nl_after_func_body_class\s*=\s*"
 MinVal=0
 MaxVal=16
-ValueDefault=0
+ValueDefault=2
 
 [Nl After Func Body One Liner]
 Category=4
@@ -5989,7 +6034,7 @@ CallName="nl_after_func_body_one_liner="
 CallNameRegex="nl_after_func_body_one_liner\s*=\s*"
 MinVal=0
 MaxVal=16
-ValueDefault=0
+ValueDefault=2
 
 [Nl Typedef Blk Start]
 Category=4
@@ -6393,7 +6438,7 @@ EditorType=multiple
 Choices=pos_bool=ignore|pos_bool=break|pos_bool=force|pos_bool=lead|pos_bool=trail|pos_bool=join|pos_bool=lead_break|pos_bool=lead_force|pos_bool=trail_break|pos_bool=trail_force
 ChoicesRegex=pos_bool\s*=\s*ignore|pos_bool\s*=\s*break|pos_bool\s*=\s*force|pos_bool\s*=\s*lead|pos_bool\s*=\s*trail|pos_bool\s*=\s*join|pos_bool\s*=\s*lead_break|pos_bool\s*=\s*lead_force|pos_bool\s*=\s*trail_break|pos_bool\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Bool|Break Pos Bool|Force Pos Bool|Lead Pos Bool|Trail Pos Bool|Join Pos Bool|Lead Break Pos Bool|Lead Force Pos Bool|Trail Break Pos Bool|Trail Force Pos Bool"
-ValueDefault=ignore
+ValueDefault=join
 
 [Pos Compare]
 Category=5
@@ -6403,7 +6448,7 @@ EditorType=multiple
 Choices=pos_compare=ignore|pos_compare=break|pos_compare=force|pos_compare=lead|pos_compare=trail|pos_compare=join|pos_compare=lead_break|pos_compare=lead_force|pos_compare=trail_break|pos_compare=trail_force
 ChoicesRegex=pos_compare\s*=\s*ignore|pos_compare\s*=\s*break|pos_compare\s*=\s*force|pos_compare\s*=\s*lead|pos_compare\s*=\s*trail|pos_compare\s*=\s*join|pos_compare\s*=\s*lead_break|pos_compare\s*=\s*lead_force|pos_compare\s*=\s*trail_break|pos_compare\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Compare|Break Pos Compare|Force Pos Compare|Lead Pos Compare|Trail Pos Compare|Join Pos Compare|Lead Break Pos Compare|Lead Force Pos Compare|Trail Break Pos Compare|Trail Force Pos Compare"
-ValueDefault=ignore
+ValueDefault=join
 
 [Pos Conditional]
 Category=5
@@ -6413,7 +6458,7 @@ EditorType=multiple
 Choices=pos_conditional=ignore|pos_conditional=break|pos_conditional=force|pos_conditional=lead|pos_conditional=trail|pos_conditional=join|pos_conditional=lead_break|pos_conditional=lead_force|pos_conditional=trail_break|pos_conditional=trail_force
 ChoicesRegex=pos_conditional\s*=\s*ignore|pos_conditional\s*=\s*break|pos_conditional\s*=\s*force|pos_conditional\s*=\s*lead|pos_conditional\s*=\s*trail|pos_conditional\s*=\s*join|pos_conditional\s*=\s*lead_break|pos_conditional\s*=\s*lead_force|pos_conditional\s*=\s*trail_break|pos_conditional\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Conditional|Break Pos Conditional|Force Pos Conditional|Lead Pos Conditional|Trail Pos Conditional|Join Pos Conditional|Lead Break Pos Conditional|Lead Force Pos Conditional|Trail Break Pos Conditional|Trail Force Pos Conditional"
-ValueDefault=ignore
+ValueDefault=join
 
 [Pos Comma]
 Category=5
@@ -6423,7 +6468,7 @@ EditorType=multiple
 Choices=pos_comma=ignore|pos_comma=break|pos_comma=force|pos_comma=lead|pos_comma=trail|pos_comma=join|pos_comma=lead_break|pos_comma=lead_force|pos_comma=trail_break|pos_comma=trail_force
 ChoicesRegex=pos_comma\s*=\s*ignore|pos_comma\s*=\s*break|pos_comma\s*=\s*force|pos_comma\s*=\s*lead|pos_comma\s*=\s*trail|pos_comma\s*=\s*join|pos_comma\s*=\s*lead_break|pos_comma\s*=\s*lead_force|pos_comma\s*=\s*trail_break|pos_comma\s*=\s*trail_force
 ChoicesReadable="Ignore Pos Comma|Break Pos Comma|Force Pos Comma|Lead Pos Comma|Trail Pos Comma|Join Pos Comma|Lead Break Pos Comma|Lead Force Pos Comma|Trail Break Pos Comma|Trail Force Pos Comma"
-ValueDefault=ignore
+ValueDefault=join
 
 [Pos Enum Comma]
 Category=5
@@ -6694,7 +6739,7 @@ CallName="align_var_def_star_style="
 CallNameRegex="align_var_def_star_style\s*=\s*"
 MinVal=0
 MaxVal=2
-ValueDefault=0
+ValueDefault=2
 
 [Align Var Def Amp Style]
 Category=7
@@ -6705,7 +6750,7 @@ CallName="align_var_def_amp_style="
 CallNameRegex="align_var_def_amp_style\s*=\s*"
 MinVal=0
 MaxVal=2
-ValueDefault=0
+ValueDefault=2
 
 [Align Var Def Thresh]
 Category=7
@@ -7475,7 +7520,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=cmt_indent_multi=true|cmt_indent_multi=false
 TrueFalseRegex=cmt_indent_multi\s*=\s*true|cmt_indent_multi\s*=\s*false
-ValueDefault=true
+ValueDefault=false
 
 [Cmt Align Doxygen Javadoc Tags]
 Category=8
@@ -7598,7 +7643,7 @@ CallName="cmt_sp_after_star_cont="
 CallNameRegex="cmt_sp_after_star_cont\s*=\s*"
 MinVal=0
 MaxVal=16
-ValueDefault=0
+ValueDefault=1
 
 [Cmt Multi Check Last]
 Category=8
@@ -8274,7 +8319,7 @@ EditorType=multiple
 Choices=pp_indent=ignore|pp_indent=add|pp_indent=remove|pp_indent=force
 ChoicesRegex=pp_indent\s*=\s*ignore|pp_indent\s*=\s*add|pp_indent\s*=\s*remove|pp_indent\s*=\s*force
 ChoicesReadable="Ignore Pp Indent|Add Pp Indent|Remove Pp Indent|Force Pp Indent"
-ValueDefault=ignore
+ValueDefault=remove
 
 [Pp Indent At Level]
 Category=10
@@ -8505,7 +8550,7 @@ Enabled=false
 EditorType=boolean
 TrueFalse=use_indent_continue_only_once=true|use_indent_continue_only_once=false
 TrueFalseRegex=use_indent_continue_only_once\s*=\s*true|use_indent_continue_only_once\s*=\s*false
-ValueDefault=false
+ValueDefault=true
 
 [Indent Cpp Lambda Only Once]
 Category=12

--- a/tests/config/cpp/nl_collapse_one_liner.cfg
+++ b/tests/config/cpp/nl_collapse_one_liner.cfg
@@ -1,0 +1,9 @@
+nl_collapse_if_one_liner     = true
+nl_collapse_for_one_liner    = true
+nl_collapse_while_one_liner  = true
+nl_collapse_do_one_liner     = true
+nl_collapse_switch_one_liner = true
+sp_inside_braces             = force
+sp_sparen_brace              = force
+sp_else_brace                = force
+sp_do_brace_open             = force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -1465,3 +1465,4 @@
 60164  cpp/Issue_3191.cfg                                   cpp/Issue_3191.cpp
 60165  cpp/Issue_4242.cfg                                   cpp/Issue_4242.cpp
 60166  cpp/lambda_with_arith.cfg                            cpp/lambda_with_arith.cpp
+60170  cpp/nl_collapse_one_liner.cfg                       cpp/nl_collapse_one_liner.cpp

--- a/tests/expected/cpp/60170-nl_collapse_one_liner.cpp
+++ b/tests/expected/cpp/60170-nl_collapse_one_liner.cpp
@@ -1,0 +1,52 @@
+// Test nl_collapse_*_one_liner options
+
+void test_if()
+{
+	if (x) { return 1; }
+
+	if (a) { x = 1; }
+	else { x = 2; }
+}
+
+void test_for()
+{
+	for (int i = 0; i < n; i++) { sum += i; }
+
+	for (int i = 0; i < n; i++) { if (a[i]) { count++; } }
+}
+
+void test_while()
+{
+	while (running) { process(); }
+}
+
+void test_do()
+{
+	do { process(); } while (running);
+}
+
+// Should NOT collapse - multiple statements
+void test_no_collapse()
+{
+	if (x)
+	{
+		a = 1;
+		b = 2;
+	}
+
+	for (int i = 0; i < n; i++)
+	{
+		sum += i;
+		count++;
+	}
+}
+
+// Should NOT collapse - contains comment
+void test_no_collapse_comment()
+{
+	if (x)
+	{
+		// comment
+		return 1;
+	}
+}

--- a/tests/input/cpp/nl_collapse_one_liner.cpp
+++ b/tests/input/cpp/nl_collapse_one_liner.cpp
@@ -1,0 +1,76 @@
+// Test nl_collapse_*_one_liner options
+
+void test_if()
+{
+    if (x)
+    {
+        return 1;
+    }
+
+    if (a)
+    {
+        x = 1;
+    }
+    else
+    {
+        x = 2;
+    }
+}
+
+void test_for()
+{
+    for (int i = 0; i < n; i++)
+    {
+        sum += i;
+    }
+
+    for (int i = 0; i < n; i++)
+    {
+        if (a[i])
+        {
+            count++;
+        }
+    }
+}
+
+void test_while()
+{
+    while (running)
+    {
+        process();
+    }
+}
+
+void test_do()
+{
+    do
+    {
+        process();
+    } while (running);
+}
+
+// Should NOT collapse - multiple statements
+void test_no_collapse()
+{
+    if (x)
+    {
+        a = 1;
+        b = 2;
+    }
+
+    for (int i = 0; i < n; i++)
+    {
+        sum += i;
+        count++;
+    }
+}
+
+// Should NOT collapse - contains comment
+void test_no_collapse_comment()
+{
+    if (x)
+    {
+        // comment
+        return 1;
+    }
+}


### PR DESCRIPTION
Adds options to collapse braced single-statement control blocks,
recursively, to inline style:

```cpp
if (cond)      =>    if (cond) { stmt; }
{
    stmt;
}
```

New options:
- `nl_collapse_if_one_liner`
- `nl_collapse_for_one_liner`
- `nl_collapse_while_one_liner`
- `nl_collapse_do_one_liner`
- `nl_collapse_switch_one_liner`

These complement the existing `nl_create_*_one_liner` options:
- `nl_create_*`: collapses **unbraced** statements (`if(b)\n i++;` => `if(b) i++;`)
- `nl_collapse_*`: collapses **braced** blocks (`if(b)\n{\n i++;\n}` => `if(b) { i++; }`)