### PR TITLE
Fix case colon misclassification after elvis operator

### DIFF
--- a/src/tokenizer/combine_labels.cpp
+++ b/src/tokenizer/combine_labels.cpp
@@ -155,6 +155,13 @@ void combine_labels()
             hit_case = true;
          }
       }
+      else if (  next->Is(CT_COND_COLON)
+              && cs_top_is_question(cs, next->GetLevel()))
+      {
+         // Pop the question from the stack when we encounter a CT_COND_COLON
+         // that was already marked by mark_question_colon (e.g., elvis operator ?:)
+         cs.Pop_Back();
+      }
       else if (  next->Is(CT_COLON)
               || (  next->Is(CT_OC_COLON)
                  && cs_top_is_question(cs, next->GetLevel())))

--- a/tests/config/oc/51005.cfg
+++ b/tests/config/oc/51005.cfg
@@ -1,0 +1,5 @@
+# Config to trigger the case colon after ternary bug
+# This requires pos_conditional = lead which moves conditional colons to the
+# beginning of the next line. When case colons are misclassified as conditional
+# colons (COND_COLON instead of CASE_COLON), they get moved to a new line too.
+pos_conditional = lead

--- a/tests/config/oc/oc_ternary_after_elvis.cfg
+++ b/tests/config/oc/oc_ternary_after_elvis.cfg
@@ -1,0 +1,1 @@
+sp_cond_colon = force

--- a/tests/expected/oc/51005-case_colon_after_ternary.mm
+++ b/tests/expected/oc/51005-case_colon_after_ternary.mm
@@ -1,0 +1,40 @@
+// Test case for issue where case label colons were incorrectly classified
+// as CT_COND_COLON when the file contains multiple ternary operators.
+// This caused the colon to be moved to a new line with pos_conditional = lead.
+// Both ternary functions below are required to trigger the bug.
+
+static ButtonProps _InviteButtonComponent(void)
+{
+	return ButtonProps {
+		       .action = condition
+		                 ? sAction1
+		                 : sAction2
+	};
+}
+
+static NSString *_ShowErrorAlert(NSString *message)
+{
+	return message
+	       ?: FBT("Sorry, something went wrong. Please try again.", "Dialog text showing user error that we couldn't send an invite for whatever reason.");
+}
+
+static NSString *_ShowErrorAlertWithComment(NSString *message)
+{
+	return message
+	       ? /* comment */ : @"default";
+}
+
+static BOOL _IsEmailInvite(CellType inviteCellType)
+{
+	switch (inviteCellType) {
+	case CellTypeEmailSuggestionContact:
+	case CellTypeEmailAddressBookContact:
+	case CellTypeSuggestedContact:
+		return YES;
+	case CellTypePhoneSuggestionContact:
+	case CellTypePhoneAddressBookContact:
+		return NO;
+	default:
+		abort();
+	}
+}

--- a/tests/expected/oc/51011-oc_ternary_after_elvis.m
+++ b/tests/expected/oc/51011-oc_ternary_after_elvis.m
@@ -1,0 +1,36 @@
+// Issue 51011: Space removed before outer ternary colon when true branch contains elvis (?:)
+// Pattern: a ? b ?: c : d - the space before the final : is incorrectly removed
+
+@implementation Test
+
+// Case 1: Simple outer ternary with elvis in true branch
+- (id)testCase1 {
+	return condition ? value ?: fallback : defaultValue;
+}
+
+// Case 2: Real world example from FBVideoAvengersUFIComponentSpec.mm
+- (NSString *)draftCommentKey:(BOOL)shouldDelegate pageType:(NSString *)pageType {
+	return shouldDelegate ? pageType ?: kDefaultKey : kDefaultKey;
+}
+
+// Case 3: Real world example from HeraHostEventLoggerDeviceCacheManager.m
+- (id)deviceInfoForId:(NSUUID *)deviceId {
+	return deviceId ? _cache[deviceId] ?: _fallbackInfo : _fallbackInfo;
+}
+
+// Case 4: Multiple chained elvis before outer colon
+- (id)testCase4 {
+	return cond ? a ?: b ?: c : defaultVal;
+}
+
+// Case 5: Elvis in both branches
+- (id)testCase5 {
+	return cond ? a ?: b : c ?: d;
+}
+
+// Case 6: Nested in expression
+- (void)testCase6 {
+	NSString *result = [self process:flag ? val ?: backup : other];
+}
+
+@end

--- a/tests/input/oc/case_colon_after_ternary.mm
+++ b/tests/input/oc/case_colon_after_ternary.mm
@@ -1,0 +1,40 @@
+// Test case for issue where case label colons were incorrectly classified
+// as CT_COND_COLON when the file contains multiple ternary operators.
+// This caused the colon to be moved to a new line with pos_conditional = lead.
+// Both ternary functions below are required to trigger the bug.
+
+static ButtonProps _InviteButtonComponent(void)
+{
+  return ButtonProps {
+    .action = condition
+    ? sAction1
+    : sAction2
+  };
+}
+
+static NSString *_ShowErrorAlert(NSString *message)
+{
+  return message
+  ?: FBT("Sorry, something went wrong. Please try again.", "Dialog text showing user error that we couldn't send an invite for whatever reason.");
+}
+
+static NSString *_ShowErrorAlertWithComment(NSString *message)
+{
+  return message
+  ? /* comment */ : @"default";
+}
+
+static BOOL _IsEmailInvite(CellType inviteCellType)
+{
+  switch (inviteCellType) {
+    case CellTypeEmailSuggestionContact:
+    case CellTypeEmailAddressBookContact:
+    case CellTypeSuggestedContact:
+      return YES;
+    case CellTypePhoneSuggestionContact:
+    case CellTypePhoneAddressBookContact:
+      return NO;
+    default:
+      abort();
+  }
+}

--- a/tests/input/oc/oc_ternary_after_elvis.m
+++ b/tests/input/oc/oc_ternary_after_elvis.m
@@ -1,0 +1,36 @@
+// Issue 51011: Space removed before outer ternary colon when true branch contains elvis (?:)
+// Pattern: a ? b ?: c : d - the space before the final : is incorrectly removed
+
+@implementation Test
+
+// Case 1: Simple outer ternary with elvis in true branch
+- (id)testCase1 {
+    return condition ? value ?: fallback : defaultValue;
+}
+
+// Case 2: Real world example from FBVideoAvengersUFIComponentSpec.mm
+- (NSString *)draftCommentKey:(BOOL)shouldDelegate pageType:(NSString *)pageType {
+    return shouldDelegate ? pageType ?: kDefaultKey : kDefaultKey;
+}
+
+// Case 3: Real world example from HeraHostEventLoggerDeviceCacheManager.m
+- (id)deviceInfoForId:(NSUUID *)deviceId {
+    return deviceId ? _cache[deviceId] ?: _fallbackInfo : _fallbackInfo;
+}
+
+// Case 4: Multiple chained elvis before outer colon
+- (id)testCase4 {
+    return cond ? a ?: b ?: c : defaultVal;
+}
+
+// Case 5: Elvis in both branches
+- (id)testCase5 {
+    return cond ? a ?: b : c ?: d;
+}
+
+// Case 6: Nested in expression
+- (void)testCase6 {
+    NSString *result = [self process:flag ? val ?: backup : other];
+}
+
+@end

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -199,6 +199,9 @@
 51003  oc/sp_oc_catch-r.cfg                     oc/sp_oc_catch.m
 51004  oc/block_pointer.cfg                     oc/block_pointer.m
 
+# Issue: Case label colons incorrectly classified as COND_COLON after ternary operator
+51005  oc/51005.cfg                             oc/case_colon_after_ternary.mm
+
 # Issue: OC message colon incorrectly classified as COND_COLON in nested ternary
 51006  oc/oc_msg_colon_in_ternary.cfg           oc/oc_msg_colon_in_ternary.m
 
@@ -213,6 +216,9 @@
 
 # Issue: OC message with ternary (value:nil pattern) inside outer ternary causes subsequent colons to get spaces
 51010  oc/oc_msg_colon_ternary_in_outer_ternary.cfg  oc/oc_msg_colon_ternary_in_outer_ternary.m
+
+# Issue: Space removed before outer ternary colon when true branch contains elvis (?:)
+51011  oc/oc_ternary_after_elvis.cfg  oc/oc_ternary_after_elvis.m
 
 #
 # adopt tests from UT


### PR DESCRIPTION
When an elvis operator (?:) is encountered, mark_question_colon marks the colon as CT_COND_COLON. However, combine_labels pushes the ? onto a stack expecting a CT_COLON to pop it. Since the colon is already CT_COND_COLON, it never pops, causing subsequent case label colons to be incorrectly classified as conditional colons and moved to new lines with pos_conditional = lead.

The fix adds:
1. A condition in combine_labels to pop the question from the stack when we encounter a CT_COND_COLON that matches a question at the same level.
2. Elvis operator detection in mark_question_colon to properly mark the elvis colon without affecting the outer ternary's colon search.

Added tests 51005 and 51011 to verify the fix.