### PR TITLE
Fix dictionary colon misclassified as ternary colon

### DIFF
--- a/tests/config/oc/oc_ternary_oc_dict.cfg
+++ b/tests/config/oc/oc_ternary_oc_dict.cfg
@@ -1,0 +1,1 @@
+sp_cond_colon = force

--- a/tests/expected/oc/51011-oc_ternary_after_elvis.m
+++ b/tests/expected/oc/51011-oc_ternary_after_elvis.m
@@ -1,4 +1,4 @@
-// Issue 51011: Space removed before outer ternary colon when true branch contains elvis (?:)
+// Test 51011: Space removed before outer ternary colon when true branch contains elvis (?:)
 // Pattern: a ? b ?: c : d - the space before the final : is incorrectly removed
 
 @implementation Test

--- a/tests/expected/oc/51012-oc_ternary_oc_dict.m
+++ b/tests/expected/oc/51012-oc_ternary_oc_dict.m
@@ -1,0 +1,33 @@
+// Test 51012: Dictionary colon misclassified as ternary colon in OC message context
+// When a ternary has an OC dictionary literal @{...} in the true branch,
+// the colon inside the dictionary is incorrectly classified as the ternary colon,
+// causing the real ternary colon to be classified as OC_COLON (no spacing)
+
+@implementation Test
+
+// Case 1: Dictionary with trailing comma in OC message - space before outer : removed
+- (void)testCase1 {
+	id result = [obj method:handler != nil ? @{kKey : handler, } : @{}];
+}
+
+// Case 2: Dictionary without trailing comma - works correctly
+- (void)testCase2 {
+	id result = [obj method:handler != nil ? @{kKey : handler} : @{}];
+}
+
+// Case 3: Multiple key-value pairs with trailing comma
+- (void)testCase3 {
+	id result = [obj method:flag ? @{@"a" : @1, @"b" : @2, } : @{}];
+}
+
+// Case 4: Nested dictionaries
+- (void)testCase4 {
+	id result = [obj method:flag ? @{@"outer" : @{@"inner" : @1}, } : @{}];
+}
+
+// Case 5: Real world pattern from FBInstreamAdCompactOverlayComponentSpec.mm
+- (void)testCase5 {
+	id result = [obj contextWithOptionalDependencies:props.actionHandler != nil ? @{kOptionalDependencyKey : props.actionHandler, } : @{}];
+}
+
+@end

--- a/tests/input/oc/oc_ternary_after_elvis.m
+++ b/tests/input/oc/oc_ternary_after_elvis.m
@@ -1,4 +1,4 @@
-// Issue 51011: Space removed before outer ternary colon when true branch contains elvis (?:)
+// Test 51011: Space removed before outer ternary colon when true branch contains elvis (?:)
 // Pattern: a ? b ?: c : d - the space before the final : is incorrectly removed
 
 @implementation Test

--- a/tests/input/oc/oc_ternary_oc_dict.m
+++ b/tests/input/oc/oc_ternary_oc_dict.m
@@ -1,0 +1,33 @@
+// Test 51012: Dictionary colon misclassified as ternary colon in OC message context
+// When a ternary has an OC dictionary literal @{...} in the true branch,
+// the colon inside the dictionary is incorrectly classified as the ternary colon,
+// causing the real ternary colon to be classified as OC_COLON (no spacing)
+
+@implementation Test
+
+// Case 1: Dictionary with trailing comma in OC message - space before outer : removed
+- (void)testCase1 {
+    id result = [obj method:handler != nil ? @{kKey : handler, } : @{}];
+}
+
+// Case 2: Dictionary without trailing comma - works correctly
+- (void)testCase2 {
+    id result = [obj method:handler != nil ? @{kKey : handler} : @{}];
+}
+
+// Case 3: Multiple key-value pairs with trailing comma
+- (void)testCase3 {
+    id result = [obj method:flag ? @{@"a" : @1, @"b" : @2, } : @{}];
+}
+
+// Case 4: Nested dictionaries
+- (void)testCase4 {
+    id result = [obj method:flag ? @{@"outer" : @{@"inner" : @1}, } : @{}];
+}
+
+// Case 5: Real world pattern from FBInstreamAdCompactOverlayComponentSpec.mm
+- (void)testCase5 {
+    id result = [obj contextWithOptionalDependencies:props.actionHandler != nil ? @{kOptionalDependencyKey : props.actionHandler, } : @{}];
+}
+
+@end

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -220,6 +220,9 @@
 # Issue: Space removed before outer ternary colon when true branch contains elvis (?:)
 51011  oc/oc_ternary_after_elvis.cfg  oc/oc_ternary_after_elvis.m
 
+# Issue: Dictionary colon misclassified as ternary colon in OC message context
+51012  oc/oc_ternary_oc_dict.cfg  oc/oc_ternary_oc_dict.m
+
 #
 # adopt tests from UT
 10018  oc/delete-space-oc.cfg                   oc/delete-space-oc.mm


### PR DESCRIPTION
 ## Summary

  When a ternary expression contains an OC dictionary literal (`@{...}`) in the true branch, the dictionary colon was incorrectly marked as `CT_COND_COLON`, causing the real ternary colon to be
   classified as `OC_COLON` and lose its spacing.

  For example:
  ```objc
  // Before fix - space before outer `:` was removed
  id result = [obj method:handler != nil ? @{kKey : handler, }: @{}];

  // After fix - correct spacing preserved
  id result = [obj method:handler != nil ? @{kKey : handler, } : @{}];
```

  Changes

  - Added brace_depth tracking in search_for_colon() for OC dictionary literals
  - Colons inside @{...} dictionaries are now correctly skipped when searching for the ternary colon
  - Added test 51012 to verify the fix

  Test plan

  - Test 51012 passes
  - All Objective-C tests pass
  - All C/C++ tests pass

  Stack

  This PR is stacked on fix-case-colon-after-ternary