### PR TITLE
Fix mod_enum_last_comma adding comma to #define inside enum

### DIFF
--- a/src/tokenizer/enum_cleanup.cpp
+++ b/src/tokenizer/enum_cleanup.cpp
@@ -73,7 +73,8 @@ void enum_cleanup()
                      comma.SetFlags(PCF_NONE);
                      comma.Str() = ",";
 
-                     if (prev->Is(CT_PP_ENDIF))                // Issue #3604
+                     if (  prev->Is(CT_PP_ENDIF)               // Issue #3604
+                        || prev->TestFlags(PCF_IN_PREPROC))    // Skip #define and other preprocessor directives
                      {
                         prev = prev->GetPrevNcNnlNpp();
                      }

--- a/tests/config/oc/enum_define_comma.cfg
+++ b/tests/config/oc/enum_define_comma.cfg
@@ -1,0 +1,1 @@
+mod_enum_last_comma = force

--- a/tests/expected/oc/51013-enum_define_comma.h
+++ b/tests/expected/oc/51013-enum_define_comma.h
@@ -1,0 +1,8 @@
+// Test: #define inside enum should not get trailing comma added
+typedef NS_CLOSED_ENUM(NSUInteger, TestEnum) {
+	TestEnumValueA,
+	TestEnumValueB,
+	TestEnumValueC,
+
+#define TestEnumLastValue TestEnumValueC
+};

--- a/tests/input/oc/enum_define_comma.h
+++ b/tests/input/oc/enum_define_comma.h
@@ -1,0 +1,8 @@
+// Test: #define inside enum should not get trailing comma added
+typedef NS_CLOSED_ENUM(NSUInteger, TestEnum) {
+    TestEnumValueA,
+    TestEnumValueB,
+    TestEnumValueC,
+
+#define TestEnumLastValue TestEnumValueC
+};

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -226,6 +226,9 @@
 # Issue: Dictionary colon misclassified as ternary colon in OC message context
 51012  oc/oc_ternary_oc_dict.cfg  oc/oc_ternary_oc_dict.m
 
+# Issue: #define inside enum should not get trailing comma added
+51013  oc/enum_define_comma.cfg   oc/enum_define_comma.h                      OC
+
 # Test macro-no-format-args feature for fragile macros with args (like NS_SWIFT_ENUM)
 52000  oc/macro_no_format_args.cfg              oc/macro_no_format_args.m
 52001  oc/macro_no_format_args_edge.cfg         oc/macro_no_format_args_edge.m


### PR DESCRIPTION
When `mod_enum_last_comma = force` is enabled, uncrustify incorrectly adds a trailing comma to `#define` statements inside enum declarations. This happens because the code that adds trailing commas doesn't skip past preprocessor directives when looking for the last enum value.

The fix checks if the previous chunk is inside a preprocessor directive (`PCF_IN_PREPROC` flag) and skips past it, similar to the existing handling for `CT_PP_ENDIF`.

Added test case 51013 to verify the fix.