### PR TITLE
Parameter 'c0' can be declared as reference to const

### DIFF
--- a/src/unc_text.cpp
+++ b/src/unc_text.cpp
@@ -35,12 +35,12 @@ static void toLogTextUtf8(int c, UncText::log_type &container);
  *
  * throws if char is greater than 0x7fffffff
  */
-static int getLogTextUtf8Len(UncText::value_type &c0, size_t end);
+static int getLogTextUtf8Len(const UncText::value_type &c0, size_t end);
 
-static int getLogTextUtf8Len(UncText::value_type &c0, size_t start, size_t end);
+static int getLogTextUtf8Len(const UncText::value_type &c0, size_t start, size_t end);
 
 
-static int getLogTextUtf8Len(UncText::value_type &c0, size_t start, size_t end)
+static int getLogTextUtf8Len(const UncText::value_type &c0, size_t start, size_t end)
 {
    size_t c1_idx = 0;
 
@@ -92,7 +92,7 @@ static int getLogTextUtf8Len(UncText::value_type &c0, size_t start, size_t end)
 } // getLogTextUTF8Len
 
 
-static int getLogTextUtf8Len(UncText::value_type &c0, size_t end)
+static int getLogTextUtf8Len(const UncText::value_type &c0, size_t end)
 {
    return(getLogTextUtf8Len(c0, 0, end));
 }


### PR DESCRIPTION
shown by cppcheck