### PR TITLE
Improve 'write_utf8' by reusing the same vector instead of creating a new object for each character

### DIFF
--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -2050,20 +2050,20 @@ void uncrustify_file(const MemoryFile &fm, FILE *pfout, const char *parsed_file,
    const deque<int> &data = fm.data;
 
    // Save off the encoding and whether a BOM is required
-   cpd.bom = fm.hasBom;
-   cpd.enc = fm.encoding;
+   cpd.bom      = fm.hasBom;
+   cpd.encoding = fm.encoding;
 
    if (  options::utf8_force()
-      || (  (cpd.enc == E_CharEncoding::BYTE)
+      || (  (cpd.encoding == E_CharEncoding::BYTE)
          && options::utf8_byte()))
    {
       log_rule_B("utf8_force");
       log_rule_B("utf8_byte");
-      cpd.enc = E_CharEncoding::UTF8;
+      cpd.encoding = E_CharEncoding::UTF8;
    }
    iarf_e av;
 
-   switch (cpd.enc)
+   switch (cpd.encoding)
    {
    case E_CharEncoding::UTF8:
       log_rule_B("utf8_bom");

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -278,7 +278,7 @@ struct cp_data_t
    bool              output_tab_as_space;
 
    bool              bom;
-   E_CharEncoding    enc;
+   E_CharEncoding    encoding;
 
    // bumped up when a line is split or indented
    int               changes;


### PR DESCRIPTION
As per title.