### PR TITLE
Fix issue #4645: Uncrustify breaks on files longer than 10000 lines.

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -1259,15 +1259,6 @@ inline size_t Chunk::GetOrigLine() const
 
 inline void Chunk::SetOrigLine(size_t line)
 {
-#ifdef DEBUG
-   if (line > uncrustify::limits::TOO_BIG_VALUE)
-   {
-      fprintf(stderr, "%s(%d): the input parameter is too big %zu\n",
-              __func__, __LINE__, line);
-      log_flush(true);
-      exit(EX_SOFTWARE);
-   }
-#endif
    m_origLine = line;
 }
 

--- a/src/parsing_frame.h
+++ b/src/parsing_frame.h
@@ -455,15 +455,6 @@ inline size_t ParenStackEntry::GetOpenLine() const
 
 inline void ParenStackEntry::SetOpenLine(size_t line)
 {
-#ifdef DEBUG
-   if (line > uncrustify::limits::TOO_BIG_VALUE)
-   {
-      fprintf(stderr, "%s(%d): the input parameter is too big %zu\n",
-              __func__, __LINE__, line);
-      log_flush(true);
-      exit(EX_SOFTWARE);
-   }
-#endif
    m_openLine = line;
 }
 


### PR DESCRIPTION
Remove the checks for line numbers being larger than TOO_BIG_VALUE in Chunk::SetOrigLine and ParenStackEntry::SetOpenLine.

Fixes: #4645