### PR TITLE
Rename 'E_CharEncoding::BYTE' to 'E_CharEncoding::BYTES' to silence mingw warnings.

### DIFF
--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -2054,7 +2054,7 @@ void uncrustify_file(const MemoryFile &fm, FILE *pfout, const char *parsed_file,
    cpd.encoding = fm.encoding;
 
    if (  options::utf8_force()
-      || (  (cpd.encoding == E_CharEncoding::BYTE)
+      || (  (cpd.encoding == E_CharEncoding::BYTES)
          && options::utf8_byte()))
    {
       log_rule_B("utf8_force");

--- a/src/uncrustify_types.cpp
+++ b/src/uncrustify_types.cpp
@@ -115,8 +115,8 @@ const char *get_char_encoding(E_CharEncoding encoding)
    case E_CharEncoding::ASCII:
       return("ASCII");
 
-   case E_CharEncoding::BYTE:
-      return("BYTE");
+   case E_CharEncoding::BYTES:
+      return("BYTES");
 
    case E_CharEncoding::UTF8:
       return("UTF8");

--- a/src/uncrustify_types.h
+++ b/src/uncrustify_types.h
@@ -72,7 +72,7 @@ enum class E_CharEncoding : unsigned int
 {
    // see also: const char *get_char_encoding(E_CharEncoding encoding)
    ASCII,     //! 0-127
-   BYTE,      //! 0-255, not UTF-8
+   BYTES,     //! 0-255, not UTF-8
    UTF8,      //! utf 8 bit wide
    UTF16_LE,  //! utf 16 bit wide, little endian
    UTF16_BE   //! utf 16 bit wide, big endian

--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -57,7 +57,7 @@ static bool decode_utf16(MemoryFile &fm);
 static bool decode_bom(MemoryFile &fm);
 
 
-//! Writes a single character to a file using ASCII or BYTE encoding
+//! Writes a single character to a file using ASCII or BYTES encoding
 static void write_byte(int ch);
 
 
@@ -407,7 +407,7 @@ bool decode_unicode(MemoryFile &fm)
       return(true);
    }
    // it is an unrecognized byte sequence
-   fm.encoding = E_CharEncoding::BYTE;
+   fm.encoding = E_CharEncoding::BYTES;
    return(decode_bytes(fm));
 } // decode_unicode
 
@@ -520,7 +520,7 @@ void write_bom()
 
    default:
       // E_CharEncoding::ASCII
-      // E_CharEncoding::BYTE
+      // E_CharEncoding::BYTES
       // do nothing
       // Coveralls will complain
       break;
@@ -534,7 +534,7 @@ void write_char(int ch)
    {
       switch (cpd.encoding)
       {
-      case E_CharEncoding::BYTE:
+      case E_CharEncoding::BYTES:
       case E_CharEncoding::ASCII:
       default:
          write_byte(ch);


### PR DESCRIPTION
When building with mingw, it complains that 'E_CharEncoding::BYTE' is shadowing another type-definition of BYTE. To avoid the warnings, a simple rename was applied.