### PR TITLE
Make MD5::Transform safer.

### DIFF
--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -223,7 +223,7 @@ void MD5::Final(uint8_t digest[16])
    ((w) += f((x), (y), (z)) + (data), (w) = (w) << (s) | (w) >> (32 - (s)), (w) += (x))
 
 
-void MD5::Transform(uint32_t buf[4], const uint32_t in_data[16])
+void MD5::Transform(uint32_t (&buf)[4], const uint32_t (&in_data)[16])
 {
    uint32_t a = buf[0];
    uint32_t b = buf[1];

--- a/src/md5.h
+++ b/src/md5.h
@@ -47,7 +47,7 @@ public:
     * reflect the addition of 16 longwords of new data.  MD5::Update blocks
     * the data and converts bytes into longwords for this routine.
     */
-   static void Transform(uint32_t buf[4], const uint32_t in_data[16]);
+   static void Transform(uint32_t(&buf)[4], const uint32_t(&in_data)[16]);
 
 
    /**


### PR DESCRIPTION
The new syntax ensures that only arrays of the correct size can be passed to the function. The old syntax was possibly unsafe since any array of the correct type could have been passed, even if the size was not matching.