### PR TITLE
Fix return of Chunk::GetOpeningParen and Chunk::GetClosingParen if match not found

### DIFF
--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -819,7 +819,7 @@ Chunk *Chunk::GetClosingParen(E_Scope scope) const
    {
       return(GetNextType(token, m_level, scope));
    }
-   return(const_cast<Chunk *>(this));
+   return(Chunk::NullChunkPtr);
 } // Chunk::GetClosingParen
 
 
@@ -831,7 +831,7 @@ Chunk *Chunk::GetOpeningParen(E_Scope scope) const
    {
       return(GetPrevType(token, m_level, scope));
    }
-   return(const_cast<Chunk *>(this));
+   return(Chunk::NullChunkPtr);
 } // Chunk::GetOpeningParen
 
 

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1615,12 +1615,14 @@ void indent_text()
             log_rule_B("indent_cpp_lambda_body");
             frm.top().SetBraceIndent(frm.prev().GetIndent());
 
-            Chunk *head     = frm.top().GetOpenChunk()->GetPrevNcNnlNpp();
-            Chunk *tail     = Chunk::NullChunkPtr;
-            Chunk *frm_prev = frm.prev().GetOpenChunk();
-            bool  enclosure = (  frm_prev->GetParentType() != E_Token::CT_FUNC_DEF           // Issue #3407
-                              && frm_prev != frm_prev->GetClosingParen());
-            bool  linematch = true;
+            Chunk *head         = frm.top().GetOpenChunk()->GetPrevNcNnlNpp();
+            Chunk *tail         = Chunk::NullChunkPtr;
+            Chunk *frm_prev     = frm.prev().GetOpenChunk();
+            Chunk *frmPrevClose = frm_prev->GetClosingParen();
+            bool  enclosure     = (  frm_prev->GetParentType() != E_Token::CT_FUNC_DEF       // Issue #3407
+                                  && frmPrevClose->IsNotNullChunk()
+                                  && frm_prev != frmPrevClose);
+            bool linematch = true;
 
             for (auto it = frm.rbegin(); it != frm.rend() && tail->IsNullChunk(); ++it)
             {
@@ -1676,21 +1678,24 @@ void indent_text()
             // 2a. If it's an assignment, check that both sides of the assignment operator are on the same line
             // 2b. If it's inside some closure, check that all the frames are on the same line,
             //     and it is in the top level closure, and indent_continue is non-zero
-            bool sameLine = frm.top().GetOpenChunk()->GetClosingParen()->IsOnSameLine(tail);
+            Chunk *frmPrevOpen = frm.prev().GetOpenChunk();
+            Chunk *frmTopOpen  = frm.top().GetOpenChunk();
+            Chunk *frmTopClose = frm.top().GetOpenChunk()->GetClosingParen();
+            bool  sameLine     = frmTopClose->IsNotNullChunk() && frmTopClose->IsOnSameLine(tail);
 
-            bool isAssignSameLine =
+            bool  isAssignSameLine =
                !enclosure
                && options::align_assign_span() == 0
                && !options::indent_align_assign()
-               && frm.prev().GetOpenChunk()->GetPrevNcNnlNpp()->IsOnSameLine(frm.prev().GetOpenChunk())
-               && frm.prev().GetOpenChunk()->IsOnSameLine(frm.prev().GetOpenChunk()->GetNextNcNnlNpp());
+               && frmPrevOpen->GetPrevNcNnlNpp()->IsOnSameLine(frmPrevOpen)
+               && frmPrevOpen->IsOnSameLine(frmPrevOpen->GetNextNcNnlNpp());
 
             bool closureSameLineTopLevel =
                (options::indent_continue() > 0)
                && enclosure
                && linematch
                && toplevel
-               && frm.top().GetOpenChunk()->GetClosingParen()->IsOnSameLine(frm.top().GetOpenChunk());
+               && frmTopClose->IsNotNullChunk() && frmTopClose->IsOnSameLine(frmTopOpen);
 
             if (  sameLine
                && (  (isAssignSameLine)

--- a/src/tokenizer/combine_tools.cpp
+++ b/src/tokenizer/combine_tools.cpp
@@ -201,7 +201,7 @@ bool can_be_full_param(Chunk *start, Chunk *end)
          word_count = 1;
          type_count = 1;
       }
-      else if (word_count >= 1 && pc->Is(CT_PAREN_OPEN))
+      else if (word_count >= 1 && pc->Is(E_Token::CT_PAREN_OPEN))
       {
          // Handle macro-wrapped parameters, e.g. 'void foo(int _MACRO(param), ...)'
          // The previous CT_PAREN_OPEN branch handles function-pointer syntax

--- a/src/tokenizer/flag_parens.cpp
+++ b/src/tokenizer/flag_parens.cpp
@@ -23,7 +23,7 @@ Chunk *flag_parens(Chunk *po, PcfFlags flags, E_Token opentype, E_Token parent_t
       LOG_FMT(LERR, "%s(%d): no match for '%s' at [%zu:%zu]",
               __func__, __LINE__, po->GetLogText(), po->GetOrigLine(), po->GetOrigCol());
       log_func_stack_inline(LERR);
-      exit(EX_SOFTWARE);
+      return(Chunk::NullChunkPtr);
    }
    LOG_FMT(LFLPAREN, "%s(%d): between  po is '%s', orig line is %zu, orig col is %zu, and\n",
            __func__, __LINE__, po->GetLogText(), po->GetOrigLine(), po->GetOrigCol());


### PR DESCRIPTION
Chunk::GetOpeningParen and Chunk::GetClosingParen must return a ChunkNullChunkPtr if a matching parenthesis is not found