### PR TITLE
Fix incorrect use of cpd.in_preproc.

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -343,8 +343,7 @@ static void add_char(uint32_t ch, bool is_literal)
 
          int indent_with_tabs = options::pp_indent_with_tabs();
 
-         if (  cpd.in_preproc != E_Token::CT_PREPROC
-            || indent_with_tabs == -1)
+         if (indent_with_tabs == -1)
          {
             indent_with_tabs = options::indent_with_tabs();
          }


### PR DESCRIPTION
cpd.in_preproc is only meaningful during the tokenizing stage, it should not be use during the output phase