### PR TITLE
Fix update of row number when CRLF newline is found.

### DIFF
--- a/src/tokenizer/tokenize.cpp
+++ b/src/tokenizer/tokenize.cpp
@@ -113,17 +113,17 @@ struct TokenContext
             break;
 
          case '\n':
+            c.row++;
+            c.col = 1;
+            break;
 
-            if (c.last_ch != '\r')
+         case '\r':
+
+            if (peek() != '\n')
             {
                c.row++;
                c.col = 1;
             }
-            break;
-
-         case '\r':
-            c.row++;
-            c.col = 1;
             break;
 
          default:
@@ -1829,12 +1829,11 @@ static bool parse_whitespace(TokenContext &ctx, Chunk &pc)
    size_t nl_count = 0;
    size_t ch       = 0;
 
-   // REVISIT: use a better whitespace detector?
    while (  ctx.more()
          && unc_isspace(ctx.peek()))
    {
       int lastcol = ctx.c.col;
-      ch = ctx.get();   // throw away the whitespace char
+      ch = ctx.get();
 
       switch (ch)
       {
@@ -2143,8 +2142,8 @@ static bool parse_next(TokenContext &ctx, Chunk &pc, const Chunk *prev_pc)
    // Save off the current column
    pc.SetType(E_Token::CT_NONE);
    pc.SetOrigLine(ctx.c.row);
-   pc.SetColumn(ctx.c.col);
    pc.SetOrigCol(ctx.c.col);
+   pc.SetColumn(ctx.c.col);
    pc.SetNlCount(0);
    pc.SetFlags(PCF_NONE);
 
@@ -2730,12 +2729,7 @@ void tokenize(const deque<int> &data, Chunk *ref)
       chunk.SetOrigPrevSp(prev_sp);
       prev_sp = 0;
 
-      if (chunk.GetType() == E_Token::CT_NEWLINE)
-      {
-         last_was_tab = chunk.GetAfterTab();
-         chunk.SetAfterTab(false);
-      }
-      else if (chunk.GetType() == E_Token::CT_NL_CONT)
+      if (chunk.IsNewline())
       {
          last_was_tab = chunk.GetAfterTab();
          chunk.SetAfterTab(false);

--- a/src/tokenizer/tokenize.h
+++ b/src/tokenizer/tokenize.h
@@ -41,14 +41,14 @@ int find_enable_processing_comment_marker(const UncText &text, std::size_t start
 /**
  * @brief Parse the text into chunks
  *
- * This function parses or tokenizes the whole buffer into a list.
- * It has to do some tricks to parse preprocessors.
+ * This function parses or tokenizes the whole buffer into a list of chunks.
+ * It has to do some tricks to parse preprocessor code.
  *
- * If output_text() were called immediately after, two things would happen:
+ * If output_text() were called immediately after this, two things would happen:
  *  - trailing whitespace are removed.
  *  - leading space & tabs are converted to the appropriate format.
  *
- * All the tokens are inserted before ref. If ref is NULL, they are inserted
+ * All the tokens are inserted before ref. If ref is Chunk::NullChunkPtr, they are inserted
  * at the end of the list.  Line numbers are relative to the start of the data.
  */
 void tokenize(const std::deque<int> &data, Chunk *ref);


### PR DESCRIPTION
The row number should be increased after the LF and not after CR in such case.