### PR TITLE
Move "shift_the_rest_of_the_line" to a better location.

### DIFF
--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -978,20 +978,3 @@ size_t Chunk::GetNlCountFiltered(LineSkipConfig &skip) const
    }
    return(nl_count); // Return the count of newlines that *could not* be ignored by any budget
 } // Chunk::GetNlCountFiltered
-
-
-void shift_the_rest_of_the_line(Chunk *first)
-{
-   // shift all the tokens in this line to the right  Issue #3236
-   for (Chunk *temp = first; ; temp = temp->GetNext())
-   {
-      temp->SetColumn(temp->GetColumn() + 1);                         // Issue #3236
-      temp->SetOrigCol(temp->GetOrigCol() + 1);                       // Issue #3236
-      temp->SetOrigColEnd(temp->GetOrigColEnd() + 1);                 // Issue #3236
-
-      if (temp->Is(E_Token::CT_NEWLINE))
-      {
-         break;
-      }
-   }
-} // shift_the_rest_of_the_line

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -1904,8 +1904,4 @@ inline Chunk *Chunk::CopyAndAddBefore(Chunk *ref) const
 }
 
 
-// shift all the tokens in this line to the right  Issue #3236
-void shift_the_rest_of_the_line(Chunk *first);
-
-
 #endif /* CHUNK_LIST_H_INCLUDED */

--- a/src/parens.cpp
+++ b/src/parens.cpp
@@ -6,6 +6,7 @@
  * @license GPL v2+
  */
 #include "parens.h"
+#include "reindent_line.h"
 
 #include "log_rules.h"
 

--- a/src/reindent_line.cpp
+++ b/src/reindent_line.cpp
@@ -122,3 +122,20 @@ void reindent_line(Chunk *pc, size_t column)
    } while (  pc->IsNotNullChunk()
            && pc->GetNlCount() == 0);
 } // reindent_line
+
+
+void shift_the_rest_of_the_line(Chunk *first)
+{
+   // shift all the tokens in this line to the right  Issue #3236
+   for (Chunk *temp = first; ; temp = temp->GetNext())
+   {
+      temp->SetColumn(temp->GetColumn() + 1);                         // Issue #3236
+      temp->SetOrigCol(temp->GetOrigCol() + 1);                       // Issue #3236
+      temp->SetOrigColEnd(temp->GetOrigColEnd() + 1);                 // Issue #3236
+
+      if (temp->Is(E_Token::CT_NEWLINE))
+      {
+         break;
+      }
+   }
+} // shift_the_rest_of_the_line

--- a/src/reindent_line.h
+++ b/src/reindent_line.h
@@ -20,4 +20,12 @@
 void reindent_line(Chunk *pc, size_t column);
 
 
+/**
+ * Shift all the tokens in this line to the right
+ *
+ * @param first The chunk from which to start shifting
+ */
+void shift_the_rest_of_the_line(Chunk *first);
+
+
 #endif /* REINDENT_LINE_H_INCLUDED */


### PR DESCRIPTION
The function logic is about indentation/placement of chunks, it does not really belong into "chunk.{h,cpp}".