### PR TITLE
Fix names of Windows tests to show up in PR

### DIFF
--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -8,11 +8,12 @@ concurrency:
 
 jobs:
   uncrustify:
-    name: ${{ matrix.build_type }} - ${{ matrix.generator }}
+    name: ${{ matrix.configuration }} - ${{ matrix.generator }}
 
     strategy:
       matrix:
         configuration: [Debug, Release]
+        generator: ["Visual Studio 17 2022"]
 
     runs-on: windows-latest
 


### PR DESCRIPTION
Tests in Windows where showing a name of ` - ` only. This PR adds the config and generator name correctly. 