### PR TITLE
Switch github actions to nodejs 24 explicitly, following deprecation of version 20

### DIFF
--- a/.github/workflows/linux_test.yml
+++ b/.github/workflows/linux_test.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Set up Ninja
         uses: seanmiddleditch/gha-setup-ninja@master
 
+      - name: Set up Node.js v24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
       - name: Configure CMake
         env:
           BADGE: linux

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -49,6 +49,10 @@ jobs:
           key: cppcheck-${{ env.CPPCHECK_VERSION }}-${{ runner.os }}-${{ hashFiles('~/cppcheck-install/cppcheck-build-stamp') }}
 
       # Project specific
+      - name: Set up Node.js v24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - uses: actions/checkout@v4
       - run: python -m pip install pre-commit
       - uses: actions/cache/restore@v4

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Set up Node.js v24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
       - name: Configure CMake
         run: |
           mkdir build


### PR DESCRIPTION
See [here](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) for info about the deprecation of nodejs 20 on github.