### PR TITLE
Fix "Unmatched BRACE_OPEN" crash with split extern "C" guards.

### DIFF
--- a/src/parsing_frame_stack.cpp
+++ b/src/parsing_frame_stack.cpp
@@ -346,6 +346,7 @@ int ParsingFrameStack::check(ParsingFrame &frm, int &pp_level, Chunk *pc)
              */
             // check if #if block was unbalanced
             size_t brace_level = frm.GetBraceLevel();
+            size_t cur_size    = frm.size();
             pop(frm);
 
             if (brace_level != frm.GetBraceLevel())
@@ -360,6 +361,44 @@ int ParsingFrameStack::check(ParsingFrame &frm, int &pp_level, Chunk *pc)
                {
                   exit(EX_SOFTWARE);
                }
+            }
+
+            /*
+             * If the #if block net-closed more paren-stack entries than it
+             * opened (e.g., it closed a brace that was opened before the #if),
+             * pop those extra entries from the restored (pre-#if) frame to keep
+             * the stack consistent with the current indentation state.
+             * This handles patterns like:
+             *   #ifdef __cplusplus
+             *   extern "C" {
+             *   #else
+             *   #endif
+             *   #ifdef __cplusplus
+             *   }
+             *   #endif
+             */
+            while (frm.size() > cur_size)
+            {
+               const E_Token open_tok = frm.top().GetOpenToken();
+
+               if (  open_tok == E_Token::CT_BRACE_OPEN
+                  || open_tok == E_Token::CT_VBRACE_OPEN)
+               {
+                  if (frm.GetBraceLevel() > 0)
+                  {
+                     frm.SetBraceLevel(frm.GetBraceLevel() - 1);
+                  }
+               }
+
+               if (  open_tok != E_Token::CT_EOF
+                  && open_tok != E_Token::CT_NONE)
+               {
+                  if (frm.GetParenLevel() > 0)
+                  {
+                     frm.SetParenLevel(frm.GetParenLevel() - 1);
+                  }
+               }
+               frm.pop(__func__, __LINE__, pc);
             }
             txt = "endif-pop";
          }

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -1669,3 +1669,5 @@
 34940  cpp/global_align_span_braced_init_list_num_lines-1.cfg  cpp/align_braced_init_list_span_num_mixed.cpp
 34941  cpp/global_align_span_braced_init_list_num_lines-2.cfg  cpp/align_braced_init_list_span_num_mixed.cpp
 34942  cpp/global_align_span_braced_init_list_num_lines-3.cfg  cpp/align_braced_init_list_span_num_mixed.cpp
+
+34943  common/empty.cfg                                      cpp/Issue_4681.cpp

--- a/tests/expected/cpp/34943-Issue_4681.cpp
+++ b/tests/expected/cpp/34943-Issue_4681.cpp
@@ -1,0 +1,7 @@
+#ifdef __cplusplus
+extern "C" {
+#else
+#endif
+#ifdef __cplusplus
+}
+#endif

--- a/tests/input/cpp/Issue_4681.cpp
+++ b/tests/input/cpp/Issue_4681.cpp
@@ -1,0 +1,7 @@
+#ifdef __cplusplus
+extern "C" {
+#else
+#endif
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This fixes the problem described in #4681.

When `{` and `}` of an `extern "C"` block appear in separate `#ifdef __cplusplus` guards containing an `#else` directive, uncrustify would crash with exit code 74.

The Root cause was in `ParsingFrameStack::check()` as described in 0507f862b51ad89bc1196f74e226dee792dd6c8c .

Fixes #4681 .