### PR TITLE
Add support to nl_after_c_comment

### DIFF
--- a/src/newlines/after.cpp
+++ b/src/newlines/after.cpp
@@ -28,6 +28,52 @@ void newline_after_label_colon()
    }
 } // newline_after_label_colon
 
+void newline_after_singleline_comment()
+{
+   LOG_FUNC_ENTRY();
+
+   for (Chunk *pc = Chunk::GetHead(); pc->IsNotNullChunk(); pc = pc->GetNext())
+   {
+       if (!pc->Is(E_Token::CT_COMMENT))
+       {
+          continue;
+       }
+
+       // Only handle comments that are alone on their own line, e.g.
+       //   /* tab knowledge base */
+       // NOT trailing comments like:
+       //   int nl;    /* next line */
+       Chunk *prev = pc->GetPrev();
+       if (prev->IsNotNullChunk() && !prev->IsNewline())
+       {
+          continue;              // trailing comment on a code line -> skip
+       }
+
+       Chunk *nl = pc->GetNext(); // the newline ending the comment's own line
+       if (nl == nullptr || !nl->IsNewline())
+       {
+          continue;
+       }
+
+       Chunk *after_nl = nl->GetNext();
+       if (after_nl == nullptr)
+       {
+          continue;
+       }
+
+       if (after_nl->Is(E_Token::CT_BRACE_CLOSE))
+       {
+          continue;   // don't force a blank line right before a closing brace
+       }
+
+       if (nl->GetNlCount() >= 2)
+       {
+          continue;   // already a blank line here
+       }
+
+       double_newline(nl);
+   }
+} // newline_after_singleline_comment
 
 void newline_after_multiline_comment()
 {

--- a/src/newlines/after.h
+++ b/src/newlines/after.h
@@ -12,6 +12,7 @@ class Chunk;
 
 void newline_after_label_colon();
 void newline_after_multiline_comment();
+void newline_after_singleline_comment();
 
 /**
  * Put a empty line after a return statement, unless it is followed by a

--- a/src/options.h
+++ b/src/options.h
@@ -3129,6 +3129,10 @@ nl_before_c_comment;
 extern BoundedOption<unsigned, 0, 16>
 nl_before_cpp_comment;
 
+// Whether to force a newline after a single-line comment.
+extern Option<bool>
+nl_after_c_comment;
+
 // Whether to force a newline after a multi-line comment.
 extern Option<bool>
 nl_after_multiline_comment;

--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -2229,6 +2229,12 @@ void uncrustify_file(const MemoryFile &fm, FILE *pfout, const char *parsed_file,
       newlines_cleanup_braces(first);
       newlines_cleanup_angles();                           // Issue #1167
 
+      if (options::nl_after_c_comment())
+      {
+         log_rule_B("nl_after_c_comment");
+	 newline_after_singleline_comment();
+      }
+
       if (options::nl_after_multiline_comment())
       {
          log_rule_B("nl_after_multiline_comment");


### PR DESCRIPTION
Hi Uncrustify team,

I think uncrustify is the only lint/formatter able to fix almost 95% of source code to fit the NuttX coding style:
https://nuttx.apache.org/docs/latest/components/tools/uncrustify.html

But it doesn't support to add a new line after a comment line:

/* This is a single line comment */
bool code_need_empty_line_after_comment = true;

shold be converted to:

/* This is a single line comment */

bool code_need_empty_line_after_comment = true;