### PR TITLE
Fix declaration paren indentation in templates

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2895,7 +2895,8 @@ void indent_text()
                   && pc->GetPrev()->IsNewline())
                && (  (  (  pc->GetParentType() == E_Token::CT_FUNC_PROTO
                         || pc->GetParentType() == E_Token::CT_FUNC_CLASS_PROTO)
-                     && options::indent_paren_after_func_decl())
+                     && options::indent_paren_after_func_decl()
+                     && frm.prev().GetOpenToken() != E_Token::CT_ANGLE_OPEN)
                   || (  (  pc->GetParentType() == E_Token::CT_FUNC_DEF
                         || pc->GetParentType() == E_Token::CT_FUNC_CLASS_DEF)
                      && options::indent_paren_after_func_def())

--- a/tests/config/cpp/indent_paren_after_func_decl_template.cfg
+++ b/tests/config/cpp/indent_paren_after_func_decl_template.cfg
@@ -1,0 +1,9 @@
+indent_paren_after_func_decl = true
+indent_continue              = 8
+nl_func_paren                = force
+nl_func_decl_start           = force
+nl_func_decl_args            = force
+nl_func_decl_end             = force
+sp_inside_fparen             = force
+sp_inside_paren              = force
+sp_paren_paren               = force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -1574,6 +1574,7 @@
 60167  cpp/rvalue_and_ref_qualifiers.cfg                    cpp/rvalue_and_ref_qualifiers.cpp
 60170  cpp/nl_collapse_one_liner.cfg                       cpp/nl_collapse_one_liner.cpp
 60171  cpp/sp_deduction_guide_arrow.cfg                      cpp/deduction_guide.cpp
+60172  cpp/indent_paren_after_func_decl_template.cfg        cpp/indent_paren_after_func_decl_template.cpp
 
 # global_span_num_*_lines tests (mixed lines via global fallback)
 34860  common/global_align_span_var_class_num_lines-1.cfg   cpp/align_var_class_span_num_mixed.cpp

--- a/tests/expected/cpp/60172-indent_paren_after_func_decl_template.cpp
+++ b/tests/expected/cpp/60172-indent_paren_after_func_decl_template.cpp
@@ -1,0 +1,10 @@
+template<typename T>
+struct Traits;
+
+template<typename C, typename R, typename ... Args>
+struct Traits<R ( C::* )
+        (
+        Args...
+        )>
+{
+};

--- a/tests/input/cpp/indent_paren_after_func_decl_template.cpp
+++ b/tests/input/cpp/indent_paren_after_func_decl_template.cpp
@@ -1,0 +1,7 @@
+template<typename T>
+struct Traits;
+
+template<typename C, typename R, typename ... Args>
+struct Traits<R ( C::* )( Args... )>
+{
+};


### PR DESCRIPTION
Do not apply indent_paren_after_func_decl when a function-like parenthesis is nested directly inside a template argument list. This prevents member-function-pointer partial specializations from receiving an extra indentation level on the first formatting pass.

Add a regression case that starts from the single-line specialization syntax and verifies that formatting reaches the stable multiline result in one pass while preserving ordinary declaration indentation.

Change-Id: I33f68fa0e1c7cc77e5e6a35744324e6ae74d9c65