### PR TITLE
Fix FTBFS caused by hardcode build path

### DIFF
--- a/src/uncrustify_emscripten.cpp
+++ b/src/uncrustify_emscripten.cpp
@@ -47,8 +47,6 @@
 
 #if defined (__linux__)
 
-
-#include "../build/uncrustify_version.h"
 #include "keywords.h"
 #include "log_levels.h"
 #include "logger.h"


### PR DESCRIPTION
'uncrustify_version.h' is always generated in the build path and is already included later in the same file. There is no need to hard code the build path explicitly since it will break builds when using a different path.

The problem was introduced in PR #4735. I have tested building with and without `emscripten` support using both `build` and a different folder, all successfully.