### PR TITLE
Stop recompiling import-sorting regexes for every file and comparison

### DIFF
--- a/src/sorting.cpp
+++ b/src/sorting.cpp
@@ -13,9 +13,12 @@
 #include "mark_change.h"
 #include "newlines/add.h"
 #include "newlines/double_newline.h"
+#include "unc_ctype.h"
 
 #include <algorithm>
 #include <cstdio>  // to get fprintf
+#include <cstring>
+#include <memory>
 #include <regex>
 #include <string>
 #include <unordered_map>
@@ -42,14 +45,16 @@ constexpr static int kIncludeCategoriesCount = 3;
 struct include_category
 {
    include_category(const std::string &pattern)
-      : regex(pattern)
+      : pattern(pattern)
+      , regex(pattern)
    {
    }
-   std::regex regex;
+   std::string pattern;
+   std::regex  regex;
 };
 
 
-include_category                      *include_categories[kIncludeCategoriesCount];
+std::unique_ptr<include_category>     include_categories[kIncludeCategoriesCount];
 std::unordered_map<Chunk *, int>      chunk_priority_cache;
 std::unordered_map<std::string, bool> filename_without_ext_cache;
 
@@ -81,11 +86,17 @@ static void prepare_categories()
 
       if (!cat_pattern.empty())
       {
-         include_categories[i] = new include_category(cat_pattern);
+         // compiling a std::regex is expensive, so keep the one built for a
+         // previous file unless the option it came from has changed
+         if (  include_categories[i] == nullptr
+            || include_categories[i]->pattern != cat_pattern)
+         {
+            include_categories[i] = std::make_unique<include_category>(cat_pattern);
+         }
       }
       else
       {
-         include_categories[i] = nullptr;
+         include_categories[i].reset();
       }
    }
 }
@@ -93,18 +104,10 @@ static void prepare_categories()
 
 static void cleanup_categories()
 {
+   // the compiled category regexes deliberately outlive the file; they are
+   // rebuilt by prepare_categories() if the options change
    chunk_priority_cache.clear();
    filename_without_ext_cache.clear();
-
-   for (auto &include_category : include_categories)
-   {
-      if (include_category == nullptr)
-      {
-         continue;
-      }
-      delete include_category;
-      include_category = NULL;
-   }
 }
 
 
@@ -134,39 +137,93 @@ static int get_chunk_priority(Chunk *pc)
 
 
 /**
- * Returns true if the text contains filename without extension.
+ * Strip the directory and the extension off the file being formatted.
  */
-static bool text_contains_filename_without_ext(const char *text)
+static std::string get_current_filename_without_ext()
 {
-   if (filename_without_ext_cache.count(text) > 0)
-   {
-      return(filename_without_ext_cache[text]);
-   }
-   std::string filepath             = cpd.filename;
-   std::string filename_without_ext = filepath;
-   size_t      startIndex           = filepath.find_last_of("/\\");
+   const std::string filename  = cpd.filename;
+   size_t            start_idx = filename.find_last_of("/\\");
 
-   if (startIndex == std::string::npos)
+   if (start_idx == std::string::npos)
    {
-      startIndex = 0;
+      start_idx = 0;
    }
    else
    {
-      startIndex += 1;
+      start_idx += 1;
    }
 
-   if (startIndex < filepath.size())
+   if (start_idx >= filename.size())
    {
-      std::string filename = filepath.substr(startIndex);
-      size_t      dot_idx  = filename.find_last_of('.');
-      filename_without_ext = filename.substr(0, dot_idx);
+      return(filename);
    }
-   const std::regex  special_chars      = std::regex(R"([-[\]{}()*+?.,\^$|#\s])");
-   const std::string sanitized_filename = std::regex_replace(filename_without_ext, special_chars, R"(\$&)");
-   const std::regex  filename_pattern   = std::regex("\\S?" + sanitized_filename + "\\b.*");
+   std::string without_ext = filename.substr(start_idx);
+   size_t      dot_idx     = without_ext.find_last_of('.');
 
-   filename_without_ext_cache[text] = std::regex_match(text, filename_pattern);
-   return(filename_without_ext_cache[text]);
+   if (dot_idx != std::string::npos)
+   {
+      without_ext.erase(dot_idx);
+   }
+   return(without_ext);
+}
+
+
+//! Matches the character class the regex '\w' stands for.
+static bool is_regex_word_char(char ch)
+{
+   return(  unc_isalnum(ch)
+         || ch == '_');
+}
+
+
+//! Matches the regex '\b' assertion at the given offset into text.
+static bool has_word_boundary_at(const char *text, size_t pos)
+{
+   const bool before_is_word = (pos > 0) && is_regex_word_char(text[pos - 1]);
+   const bool after_is_word  = (text[pos] != '\0') && is_regex_word_char(text[pos]);
+
+   return(before_is_word != after_is_word);
+}
+
+
+//! Matches the regex 'filename\b' at the given offset into text.
+static bool matches_filename_at(const char *text, const std::string &filename, size_t offset)
+{
+   return(  std::strncmp(text + offset, filename.c_str(), filename.size()) == 0
+         && has_word_boundary_at(text, offset + filename.size()));
+}
+
+
+/**
+ * Returns true if the text contains filename without extension.
+ *
+ * The text comes from chunk_sort_str(), which yields either a bare identifier
+ * ('using ns;', 'import java.util.List;') or, for a preprocessor include, the
+ * include target with its opening delimiter still attached and its closing one
+ * dropped ('"foo.h', '<foo.h'). The filename therefore sits at offset 0 for the
+ * bare form and at offset 1 for the delimited one, and both have to be tried.
+ *
+ * This used to build the equivalent regex '\S?<filename>\b.*' - the optional
+ * '\S' being what skipped that opening delimiter - and run std::regex_match()
+ * against it, which meant escaping the filename and compiling two regexes on
+ * every call. Match the two possible positions directly instead.
+ */
+static bool text_contains_filename_without_ext(const char *text)
+{
+   const auto cache_entry = filename_without_ext_cache.find(text);
+
+   if (cache_entry != filename_without_ext_cache.end())
+   {
+      return(cache_entry->second);
+   }
+   const std::string filename_without_ext = get_current_filename_without_ext();
+   const bool        contains_filename    = matches_filename_at(text, filename_without_ext, 0)
+                                            || (  text[0] != '\0'
+                                               && !unc_isspace(text[0])
+                                               && matches_filename_at(text, filename_without_ext, 1));
+
+   filename_without_ext_cache[text] = contains_filename;
+   return(contains_filename);
 }
 
 


### PR DESCRIPTION
Import sorting was the single largest source of std::regex compilation in profiles of an Objective-C workload, in two places:

prepare_categories() built a fresh std::regex for each include_category_N option at the start of every file, and cleanup_categories() destroyed them again at the end. Keep the compiled regexes between files and only rebuild one when the option string it came from has changed.

text_contains_filename_without_ext() compiled two regexes on every call that missed the cache: one to escape the filename, and one for the pattern '\S?<filename>\b.*' that it then ran through std::regex_match(). That pattern can only match with the filename at offset 0, or at offset 1 behind a single non-space character, so test those two positions with a plain string compare plus a word-boundary check.

Neither the sort options nor the configured categories change. A differential test of the old regex against the replacement over 1908 filename/text pairs, covering regex metacharacters in filenames, empty filenames, extensionless paths and leading whitespace, reports no behavior difference, and formatting 941 files in a single process produces byte-identical output.

Measured on a large Objective-C corpus: 93.592s before, 79.209s after replacing the filename regex, 60.667s after also caching the category regexes. std::__detail::__compile_nfa no longer appears in the profile.