### PR TITLE
Skip rule-logging work when the log severity is off

### DIFF
--- a/src/log_rules.cpp
+++ b/src/log_rules.cpp
@@ -41,15 +41,22 @@ void log_rule3(log_sev_t sev, const char *func, size_t line, const char *rule)
 void log_rule3(log_sev_t sev, const char *func, const char *rule)
 #endif
 {
+   // log_rule_B() is called from hot loops all over the formatter, so bail out
+   // before doing any work when the severity is off. LOG_FMT() would test this
+   // too, but only after get_unqualified_func_name() has already run.
+   if (!log_sev_on(sev))
+   {
+      return;
+   }
    // some Windows platforms provide a qualified function name ("ABC::XYZ::function_Name")
    // as __func__; call get_unqualified_func_name() to return an unqualified function name
 
    func = get_unqualified_func_name(func);
 
 #ifdef SUPER_LOG
-   LOG_FMT(sev, "log_rule(%s:%zu): rule is '%s'\n", func, line, rule);
+   log_fmt(sev, "log_rule(%s:%zu): rule is '%s'\n", func, line, rule);
 #else
-   LOG_FMT(sev, "log_rule(%s): rule is '%s'\n", func, rule);
+   log_fmt(sev, "log_rule(%s): rule is '%s'\n", func, rule);
 #endif
 }
 


### PR DESCRIPTION
log_rule_B() is invoked from hot loops throughout the formatter. log_rule3() normalized the function name with get_unqualified_func_name() before handing the message to LOG_FMT(), which is where the severity is actually tested, so ordinary formatting runs paid for debug-only string work on every call.

Test the severity first and return early. Because the check has already been made, the LOG_FMT() calls become direct log_fmt() calls.

Measured on a large Objective-C++ corpus, where log_rule3() accounted for 2.29% of self time before the change, total wall time dropped from 233.500s to 229.602s.