### PR TITLE
Skip the class-colon newline pass when it cannot change anything

### DIFF
--- a/src/newlines/class_colon_pos.cpp
+++ b/src/newlines/class_colon_pos.cpp
@@ -67,6 +67,20 @@ void newlines_class_colon_pos(E_Token tok)
    LineSkipConfig acv_skip_budget = {};
    Chunk const    *prev_acv_chunk = Chunk::NullChunkPtr;
 
+   // Every edit the loop below can make is gated on one of these: the colon is
+   // only moved when pos_*_colon asks for LEAD or TRAIL, newlines are only
+   // added or removed when nl_*_colon or nl_*_init_args is not IGNORE, and the
+   // alignment stack is only fed when with_acv is set. pos_*_comma merely picks
+   // between branches that nl_*_init_args has already enabled. With all of them
+   // off the pass can only scan, so skip it.
+   if (  !(tpc & (TP_LEAD | TP_TRAIL))
+      && anc == IARF_IGNORE
+      && ncia == IARF_IGNORE
+      && !with_acv)
+   {
+      return;
+   }
+
    if (with_acv)
    {
       int    acv_thresh = options::align_constr_value_thresh();


### PR DESCRIPTION
newlines_class_colon_pos() walks every chunk in the file for both CT_CLASS_COLON and CT_CONSTR_COLON, but each edit it can make is gated on an option: the colon is only repositioned when pos_class_colon or pos_constr_colon selects LEAD or TRAIL, newlines are only added or removed when nl_class_colon/nl_constr_colon or nl_class_init_args/nl_constr_init_args is not IGNORE, and the alignment stack is only fed when align_constr_value_span is enabled for C++. pos_class_comma and pos_constr_comma only choose between branches nl_*_init_args has already enabled, so they cannot enable the pass on their own.

Return before the scan when none of those apply. Configurations that leave the class-colon options alone no longer pay for two full-file walks.

Measured on a large Objective-C++ corpus, where newlines_class_colon_pos() accounted for 2.60% of self time before the change, total wall time dropped from 229.602s to 223.653s.