### PR TITLE
Advance directly between matching tokens in newlines_chunk_pos()

### DIFF
--- a/src/newlines/chunk_pos.cpp
+++ b/src/newlines/chunk_pos.cpp
@@ -42,8 +42,18 @@ void newlines_chunk_pos(E_Token chunk_type, uncrustify::token_pos_e mode)
    {
       return;
    }
+   // The whole loop body is gated on pc being a chunk_type chunk, so jump from
+   // one match to the next instead of stepping over every token in the file.
+   // chunk_type is never a comment or a newline, so this reaches exactly the
+   // same chunks a GetNextNcNnl() walk would.
+   Chunk *pc = Chunk::GetHead();
 
-   for (Chunk *pc = Chunk::GetHead(); pc->IsNotNullChunk(); pc = pc->GetNextNcNnl())
+   if (pc->IsNot(chunk_type))
+   {
+      pc = pc->GetNextType(chunk_type);
+   }
+
+   for ( ; pc->IsNotNullChunk(); pc = pc->GetNextType(chunk_type))
    {
       char copy[1000];
       LOG_FMT(LNEWLINE, "%s(%d): pc orig line is %zu, orig col is %zu, text is '%s'\n",


### PR DESCRIPTION
newlines_chunk_pos() is called once per newline-position rule, and each call walked every non-comment token in the file even though the entire loop body sits behind a test for the one token type that rule cares about.

Step from one matching token to the next with GetNextType() instead. Since chunk_type is never a comment or a newline, this visits exactly the chunks the GetNextNcNnl() walk would have acted on, in the same order, so the per-rule ordering and the body itself are unchanged.

Measured on a large Objective-C++ corpus, where newlines_chunk_pos() was the top self-time symbol at 7.68%, total wall time dropped from 234.368s to 233.500s.