### PR TITLE
ci: Fix cache

### DIFF
--- a/.github/workflows/linux_test.yml
+++ b/.github/workflows/linux_test.yml
@@ -44,7 +44,7 @@ jobs:
           # -fsanitize=vla-bound
         run: |
           cmake -B build -G "${{ matrix.generator }}" \
-            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DCMAKE_BUILD_TYPE="${{ matrix.build_type }}" \
             -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS}" \
             -DUNCRUSTIFY_SEPARATE_TESTS=ON
 
@@ -52,11 +52,11 @@ jobs:
         run: |
           cores=$(nproc)
           echo "Detected CPU cores: $cores"
-          cmake --build build --parallel $cores
+          cmake --build build --parallel "$cores"
 
       - name: Run tests
         run: |
           cd build
           cores=$(nproc)
           echo "Detected CPU cores: $cores"
-          UNCRUSTIFY_TEST_JOBS=$cores ../scripts/run_ctest.py -j $cores
+          UNCRUSTIFY_TEST_JOBS=$cores ../scripts/run_ctest.py -j "$cores"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,13 +25,17 @@ jobs:
         with:
           path: ~/cppcheck-install
           key: cppcheck-${{ env.CPPCHECK_VERSION }}-${{ runner.os }}-${{ hashFiles('~/cppcheck-install/cppcheck-build-stamp') }}
+          restore-keys: |
+            cppcheck-${{ env.CPPCHECK_VERSION }}-${{ runner.os }}-cache-${{ github.ref_name }}-
+            cppcheck-${{ env.CPPCHECK_VERSION }}-${{ runner.os }}-cache-${{ github.base_ref }}-
+            cppcheck-${{ env.CPPCHECK_VERSION }}-${{ runner.os }}-cache-
 
       - name: Build and install cppcheck
         if: steps.cache-cppcheck.outputs.cache-hit != 'true'
         run: |
-          git clone --depth 1 --branch ${{ env.CPPCHECK_VERSION }} https://github.com/danmar/cppcheck.git
+          git clone --depth 1 --branch "${{ env.CPPCHECK_VERSION }}" https://github.com/danmar/cppcheck.git
           cd cppcheck
-          make -j$(nproc) FILESDIR=/usr/local/share/cppcheck
+          make "-j$(nproc)" FILESDIR=/usr/local/share/cppcheck
           mkdir -p ~/cppcheck-install
           make DESTDIR=~/cppcheck-install install FILESDIR=/usr/local/share/cppcheck
           echo "$(date +%s)-$(uname -a)" > ~/cppcheck-install/usr/local/share/cppcheck/cppcheck-build-stamp
@@ -48,28 +52,42 @@ jobs:
           path: ~/cppcheck-install
           key: cppcheck-${{ env.CPPCHECK_VERSION }}-${{ runner.os }}-${{ hashFiles('~/cppcheck-install/cppcheck-build-stamp') }}
 
-      # Project specific
       - uses: actions/checkout@v6
+
+      # Install pre-commit & restore pre-commit hook cache
+
       - run: python -m pip install pre-commit
-      - uses: actions/cache/restore@v5
-        if: github.event_name == 'pull_request'
-        with:
-          path: .cache/cppcheck
-          key: cppcheck-cache-${{ github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            cppcheck-cache-${{ github.base_ref }}-
-            cppcheck-cache-
-      - uses: actions/cache/restore@v5
-        if: github.event_name != 'pull_request'
-        with:
-          path: .cache/cppcheck
-          key: cppcheck-cache-${{ github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            cppcheck-cache-
-      - uses: actions/cache/restore@v5
+
+      - name: Restore pre-commit hook installations
+        uses: actions/cache/restore@v5
+        if: ${{ ! cancelled() }}
         with:
           path: ~/.cache/pre-commit/
           key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
+      # Restore cppcheck cache
+
+      - name: Restore cppcheck analysis cache (PR)
+        uses: actions/cache/restore@v5
+        if: github.event_name == 'pull_request'
+        with:
+          path: .cache/cppcheck
+          key: cppcheck-${{ env.CPPCHECK_VERSION }}-cache-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            cppcheck-${{ env.CPPCHECK_VERSION }}-cache-${{ github.base_ref }}-
+            cppcheck-${{ env.CPPCHECK_VERSION }}-cache-${{ github.ref_name }}-
+            cppcheck-${{ env.CPPCHECK_VERSION }}-cache-
+
+      - name: Restore cppcheck analysis cache (when not a PR)
+        uses: actions/cache/restore@v5
+        if: github.event_name != 'pull_request'
+        with:
+          path: .cache/cppcheck
+          key: cppcheck-${{ env.CPPCHECK_VERSION }}-cache-${{ github.base_ref }}-${{ github.sha }}
+          restore-keys: |
+            cppcheck-${{ env.CPPCHECK_VERSION }}-cache-${{ github.ref_name }}-
+            cppcheck-${{ env.CPPCHECK_VERSION }}-cache-
+
       - name: Run pre-commit hooks
         env:
           SKIP: no-commit-to-branch
@@ -77,23 +95,31 @@ jobs:
           set -o pipefail
           mkdir -p .cache/cppcheck
           pre-commit gc
-          pre-commit run --show-diff-on-failure --color=always --all-files | tee ${RAW_LOG}
+          pre-commit run --show-diff-on-failure --color=always --all-files | tee "${RAW_LOG}"
+
+      # Store caches
+
       - uses: actions/cache/save@v5
         if: ${{ ! cancelled() }}
         with:
           path: .cache/cppcheck
           key: cppcheck-cache-${{ github.ref_name }}-${{ github.sha }}
+
+      - uses: actions/cache/save@v5
+        if: ${{ ! cancelled() }}
+        with:
+          path: ~/.cache/pre-commit/
+          key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
+      # Prepare logs, artifacts
+
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2025.1.1
         if: ${{ failure() }}
         with:
           in: ${{ env.RAW_LOG }}
           # out: ${{ env.CS_XML }}
-      - uses: actions/cache/save@v5
-        if: ${{ ! cancelled() }}
-        with:
-          path: ~/.cache/pre-commit/
-          key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
       - name: Provide log as artifact
         uses: actions/upload-artifact@v7
         if: ${{ ! cancelled() }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       - id: check-case-conflict
       - id: check-toml
   - repo: https://github.com/lovesegfault/beautysh.git
-    rev: v6.4.1
+    rev: v6.4.3
     hooks:
       - id: beautysh
         args: [--indent-size=2]
@@ -52,7 +52,7 @@ repos:
         additional_dependencies:
           - setuptools
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
         # scripts/updateCodespellIgnoreFile.sh updates the ignore file.
@@ -64,8 +64,10 @@ repos:
         #  - pyproject.toml
         additional_dependencies:
           - tomli
-  - repo: https://github.com/pocc/pre-commit-hooks
-    rev: v1.3.5
+  #- repo: https://github.com/pocc/pre-commit-hooks
+  #  rev: v1.3.5
+  - repo: https://github.com/mdeweerd/pre-commit-hooks
+    rev: 3bdd7f1777427abf295953bdb2fa77772f0a641b  # v1.5.6-m-1.0
     # Install dependencies on windows:
     #  choco install llvm uncrustify cppcheck
     hooks:
@@ -74,7 +76,7 @@ repos:
         args: [--replace, --no-backup, -c, forUncrustifySources.cfg, -l, CPP]
 #
       - id: cppcheck
-# WARNING:
+# WARNING: (better with cache)
 # a run of cppcheck with all the files will be too long
 # these files need to be extra
 #       src/detect.cpp|src/indent.cpp|src/space.cpp
@@ -91,25 +93,38 @@ repos:
           - --quiet
           - --force
           - --language=c++
+          - --cppcheck-build-dir=.cache/cppcheck/  # Force cache location
           - -Isrc
           - '--template={file}({line}): {severity} ({id}): {message}'
           - --inline-suppr
           - --check-level=exhaustive
-          - --suppress=returnDanglingLifetime
-          - --suppress=unusedFunction
-          - --suppress=missingIncludeSystem
-          - --suppress=missingInclude
-          - --suppress=noExplicitConstructor
-          - --suppress=unmatchedSuppression
+          # Note: sort suppressions alphabetically for easier merges
           - --suppress=checkersReport
-          - --suppress=useStlAlgorithm
+          - --suppress=compareValueOutOfTypeRangeError ## Comparing expression of type 'signed int' against value 2147483647. Condition is always true.
+          - --suppress=constParameterCallback
+          - --suppress=constParameterPointer           ## Parameter 'xxx' can be declared as pointer to const
+          - --suppress=constParameterReference         ## Parameter 'x' can be declared as reference to const
+          - --suppress=constVariablePointer            ## Variable 'xxx' can be declared as pointer to const
+          - --suppress=containerOutOfBounds            ## Out of bounds access in expression 'xxx[idx]' because 'xxx' is empty.
+          - --suppress=functionStatic                  ## The member function 'xxx::yyy' can be static.
+          - --suppress=knownConditionTrueFalse         ## Condition 'xxx' is always false
+          - --suppress=missingInclude:*.h
+          - --suppress=missingInclude:uncrustify_emscripten.cpp
+          - --suppress=missingIncludeSystem
+          - --suppress=noCopyConstructor
+          - --suppress=noExplicitConstructor
+          - --suppress=noOperatorEq
+          - --suppress=passedByValueCallback  ## Function parameter 'xxx' should be passed by const reference. However it seems that 'yyy' is a callback function.
+          - --suppress=returnDanglingLifetime
+          - --suppress=uninitMemberVarNoCtor  ## Member variable 'xxx::yyy' has no initializer.
+          - --suppress=unknownMacro:uncrustify_emscripten.cpp
+          - --suppress=unmatchedSuppression
+          - --suppress=unusedFunction
+          - --suppress=unusedPrivateFunction
           - --suppress=unusedStructMember
           - --suppress=useInitializationList
-          - --suppress=unusedPrivateFunction
-          - --suppress=constParameterCallback
-          - --suppress=noCopyConstructor
-          - --suppress=noOperatorEq
-          - --suppress=unknownMacro:uncrustify_emscripten.cpp
+          - --suppress=useStlAlgorithm
+          - --suppress=variableScope          ## The scope of the variable 'xxx' can be reduced.
 
   - repo: https://github.com/cpplint/cpplint
     rev: "2.0.2"
@@ -125,3 +140,8 @@ repos:
       - id: shellcheck
         # exclude: (?x)^(__NONE__)$
         # args: [-x,-e1007,-e1009,-e1072,-e1073]
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint


### PR DESCRIPTION
The 'cppcheck' hook of  https://github.com/pocc/pre-commit-hooks is not ok for caching, which I fixed in fork  https://github.com/mdeweerd/pre-commit-hooks .

This PR uses that fork and fixes the cache restoration order in the github action.

With cache:
<img width="1733" height="101" alt="image" src="https://github.com/user-attachments/assets/c66ecb2b-922d-4480-8c8d-2fb6baeb5e16" />

Without cache:
<img width="1733" height="63" alt="image" src="https://github.com/user-attachments/assets/ca326778-87fb-4b9a-8302-978a65179444" />

