### PR TITLE
Pop the class-colon indent for macro-no-indent tokens

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1188,6 +1188,8 @@ void indent_text()
                   || pc->Is(E_Token::CT_TYPEDEF) // Issue #2675
                   || pc->Is(E_Token::CT_MACRO_OPEN)
                   || pc->Is(E_Token::CT_MACRO_CLOSE)
+                  || pc->Is(E_Token::CT_MACRO_NO_INDENT)
+                  || pc->Is(E_Token::CT_MACRO_NO_FMT_ARGS)
                   || (  language_is_set(lang_flag_e::LANG_OC)
                      && pc->IsComment()
                      && pc->GetParentType() == E_Token::CT_COMMENT_WHOLE) // Issue #2675

--- a/src/parsing_frame.cpp
+++ b/src/parsing_frame.cpp
@@ -187,6 +187,8 @@ void ParsingFrame::pop(const char *func, int line, Chunk const *pc)
       || pc->GetType() == E_Token::CT_LPAREN_OPEN
       || pc->GetType() == E_Token::CT_MACRO_CLOSE
       || pc->GetType() == E_Token::CT_MACRO_FUNC_CALL          // Issue #4026
+      || pc->GetType() == E_Token::CT_MACRO_NO_FMT_ARGS
+      || pc->GetType() == E_Token::CT_MACRO_NO_INDENT
       || pc->GetType() == E_Token::CT_MACRO_OPEN
       || pc->GetType() == E_Token::CT_MEMBER                   // Issue #3996
       || pc->GetType() == E_Token::CT_NEWLINE

--- a/tests/expected/oc/52002-macro_no_indent.m
+++ b/tests/expected/oc/52002-macro_no_indent.m
@@ -46,6 +46,14 @@ INIT_AND_NEW_UNAVAILABLE;
 - (void)methodTwo;
 @end
 
+// Test 5b: Interface with macro without semicolon - properties and methods should align
+@interface OuterClass2 : NSObject
+INIT_AND_NEW_UNAVAILABLE
+@property (nonatomic) int value;
+- (void)methodOne NS_UNAVAILABLE;
+- (void)methodTwo;
+@end
+
 NS_ASSUME_NONNULL_END
 
 // Test 6: Code after NS_ASSUME_NONNULL_END should be at correct indent level

--- a/tests/input/oc/macro_no_indent.m
+++ b/tests/input/oc/macro_no_indent.m
@@ -46,6 +46,14 @@ INIT_AND_NEW_UNAVAILABLE;
 - (void)methodTwo;
 @end
 
+// Test 5b: Interface with macro without semicolon - properties and methods should align
+@interface OuterClass2 : NSObject
+INIT_AND_NEW_UNAVAILABLE
+@property (nonatomic) int value;
+- (void)methodOne NS_UNAVAILABLE;
+- (void)methodTwo;
+@end
+
 NS_ASSUME_NONNULL_END
 
 // Test 6: Code after NS_ASSUME_NONNULL_END should be at correct indent level


### PR DESCRIPTION
Related to #4627.

In Objective-C, indent_text() raises the indent after a class colon (`@interface Foo : NSObject`) and pops it back on a token that ends the superclass reference: CT_BRACE_OPEN, CT_OC_END, CT_OC_SCOPE, CT_OC_PROPERTY, CT_TYPEDEF, CT_MACRO_OPEN or CT_MACRO_CLOSE.

Tokens configured via `macro-no-indent` and `macro-no-fmt-args` were missing from that list. A macro ending in a semicolon is unaffected, since the semicolon pops the frame instead, but one written without a trailing semicolon stays inside the class-colon frame and is indented under it:

    @interface OuterClass2 : NSObject
        INIT_AND_NEW_UNAVAILABLE
    @property (nonatomic) int value;
    @end

Add both token types to the pop condition. They also have to be added to the whitelist in ParsingFrame::pop(), which otherwise reports the type as "not coded" on stderr and, with debug_use_the_exit_function_pop set, exits.

Adds test 5b to macro_no_indent, covering the semicolon-less form; the existing test 5 keeps covering the semicolon form.