### PR TITLE
Fix braced initializer indentation without language gating

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1945,7 +1945,7 @@ void indent_text()
             }
             // Issue # 1620, UNI-24090.cs
             else if (  frm.prev().GetOpenChunk()->IsOnSameLine(frm.top().GetOpenChunk())
-                    && language_is_set(lang_flag_e::LANG_CS)             // Issue 4556
+                    && frm.prev().GetIndent() >= indent_size
                     && !options::indent_align_paren()
                     && frm.prev().GetOpenChunk()->IsParenOpen()
                     && !pc->TestFlags(PCF_ONE_LINER))

--- a/tests/config/cpp/Issue_4556_safe.cfg
+++ b/tests/config/cpp/Issue_4556_safe.cfg
@@ -1,0 +1,6 @@
+indent_columns               = 2
+indent_continue              = 0
+indent_ignore_first_continue = true
+indent_paren_open_brace      = true
+indent_func_call_param       = true
+indent_align_paren           = false

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -201,6 +201,7 @@
 30170  common/empty.cfg                                     cpp/Issue_4539.cpp
 30171  cpp/Issue_4556.cfg                                   cpp/Issue_4556.cpp
 30172  cpp/Issue_4593.cfg                                   cpp/Issue_4593.cpp
+30173  cpp/Issue_4556_safe.cfg                              cpp/Issue_4556_safe.cpp
 
 30200  cpp/bug_1862.cfg                                     cpp/bug_1862.cpp
 30201  cpp/cmt_indent-1.cfg                                 cpp/cmt_indent.cpp

--- a/tests/expected/cpp/30173-Issue_4556_safe.cpp
+++ b/tests/expected/cpp/30173-Issue_4556_safe.cpp
@@ -1,0 +1,6 @@
+void f() {
+  methodCall({
+    .x = 10,
+  },
+    arg2);
+}

--- a/tests/expected/oc/60016-Issue_4556_safe.mm
+++ b/tests/expected/oc/60016-Issue_4556_safe.mm
@@ -1,0 +1,6 @@
+void f() {
+  methodCall({
+    .x = 10,
+  },
+    arg2);
+}

--- a/tests/input/cpp/Issue_4556_safe.cpp
+++ b/tests/input/cpp/Issue_4556_safe.cpp
@@ -1,0 +1,6 @@
+void f() {
+  methodCall({
+  .x = 10,
+},
+    arg2);
+}

--- a/tests/input/oc/Issue_4556_safe.mm
+++ b/tests/input/oc/Issue_4556_safe.mm
@@ -1,0 +1,6 @@
+void f() {
+  methodCall({
+  .x = 10,
+},
+    arg2);
+}

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -259,3 +259,4 @@
 60013  oc/60013.cfg                             oc/Issue_4306.mm
 60014  oc/60014.cfg                             oc/4309.mm
 60015  oc/60015.cfg                             oc/4310.mm
+60016  cpp/Issue_4556_safe.cfg                  oc/Issue_4556_safe.mm              OC+


### PR DESCRIPTION
Issue #4556 is a C++ reproducer that hangs while formatting a multiline braced initializer passed as a call argument. The affected branch subtracts indent_size from ParenStackEntry::GetIndent(), both of which are unsigned. When the previous indent is zero, the subtraction wraps and formatting produces unbounded indentation output.

PR #4600, commit 3084d0599d1e62e4483c4259c495994b468e0322 (merged as c21b7ff4595cb560cebd3b4003620ec02e5a5f09), avoided the failing C++ path by restricting it to C#. That restriction reflects the origin of the branch in C# issue #1620, but it is not the actual safety requirement. It also changed established C++ and Objective-C++ formatting whenever the subtraction would have been valid.

PR #4580 previously guarded GetIndent() != 0 inside the selected branch. Besides not covering positive values smaller than indent_size, that consumed the branch without allowing the remaining indentation cases to run. PR #4600 instead let C++ fall through, but did so for every C++ and Objective-C++ input.

Gate the branch on GetIndent() >= indent_size. Unsafe states now fall through to the normal indentation logic used by the #4556 fixture, while safe states retain the pre-0.83 anti-double-indent behavior in every applicable language.

Removing the C# gate without this check reproduced the #4556 hang. With this check, the existing #4556 fixture completes and matches its current golden output, while representative C++ and Objective-C++ call-argument initializers retain their prior indentation. Add regression cases for both languages; they fail against unmodified 0.83 with the extra indentation introduced by #4600.