### PR TITLE
Keep boolean && before sizeof expressions

### DIFF
--- a/src/tokenizer/combine.cpp
+++ b/src/tokenizer/combine.cpp
@@ -627,7 +627,9 @@ static bool handle_rvalue_angle_close(Chunk const *prev, Chunk *pc)
       if (  pc->GetLevel() > pc->GetBraceLevel()
          && (  next->Is(E_Token::CT_WORD)
             || next->Is(E_Token::CT_TYPE)
-            || next->Is(E_Token::CT_DC_MEMBER)))   // ::namespace
+            || next->Is(E_Token::CT_DC_MEMBER)   // ::namespace
+            || next->Is(E_Token::CT_DECLTYPE)
+            || next->Is(E_Token::CT_SIZEOF)))
       {
          LOG_FMT(LFCNR, "%s(%d): orig line is %zu, orig col is %zu - && after > inside parens followed by expression term, keeping as BOOL\n",
                  __func__, __LINE__, pc->GetOrigLine(), pc->GetOrigCol());

--- a/tests/config/cpp/bool_and_sizeof.cfg
+++ b/tests/config/cpp/bool_and_sizeof.cfg
@@ -1,0 +1,4 @@
+sp_bool         = force
+sp_before_byref = force
+sp_after_byref  = remove
+sp_angle_word   = force

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -1695,3 +1695,4 @@
 34963  cpp/sp_sparen_compare.cfg                            cpp/sp_sparen_compare.cpp
 34964  cpp/nl_for_operators.cfg                             cpp/nl_for_operators.cpp
 34965  cpp/sp_for_nested.cfg                                cpp/sp_for_nested.cpp
+34966  cpp/bool_and_sizeof.cfg                              cpp/bool_and_sizeof.cpp

--- a/tests/expected/cpp/34966-bool_and_sizeof.cpp
+++ b/tests/expected/cpp/34966-bool_and_sizeof.cpp
@@ -1,0 +1,8 @@
+#include <type_traits>
+
+static_assert(
+	std::is_integral_v<T>
+	&& std::is_signed_v<T>
+	&& sizeof(int) >= sizeof(T),
+	"msg"
+	);

--- a/tests/input/cpp/bool_and_sizeof.cpp
+++ b/tests/input/cpp/bool_and_sizeof.cpp
@@ -1,0 +1,8 @@
+#include <type_traits>
+
+static_assert(
+  std::is_integral_v<T>
+  && std::is_signed_v<T>
+  && sizeof(int) >= sizeof(T),
+  "msg"
+);


### PR DESCRIPTION
When a parenthesized expression places && after a template-id and before sizeof or decltype, the tokenizer mistakes the operator for an rvalue reference. This causes reference-spacing options to format boolean expressions incorrectly.

Recognize those expression starters as evidence that && remains boolean, and add a regression test for the sizeof case.