### PR TITLE
Preserve lambda rvalue-reference parameters

### DIFF
--- a/src/tokenizer/combine.cpp
+++ b/src/tokenizer/combine.cpp
@@ -612,6 +612,61 @@ static bool handle_rvalue_angle_close(Chunk const *prev, Chunk *pc)
          }
       }
 
+      // Detect a [...] (...) {...} lambda and exclude default arguments before
+      // preserving && as an rvalue reference in its parameter list.
+      if (  pc->GetLevel() > 0
+         && (  next->Is(E_Token::CT_WORD)
+            || next->Is(E_Token::CT_TYPE)))
+      {
+         Chunk const *after_name = next->GetNextNcNnl();
+
+         if (  after_name->Is(E_Token::CT_COMMA)
+            || after_name->IsParenClose()
+            || after_name->Is(E_Token::CT_ASSIGN))
+         {
+            Chunk const *paren_close = pc->GetNextType(E_Token::CT_FPAREN_CLOSE, pc->GetLevel() - 1);
+
+            if (paren_close->IsNullChunk())
+            {
+               paren_close = pc->GetNextType(E_Token::CT_PAREN_CLOSE, pc->GetLevel() - 1);
+            }
+            Chunk const *paren_open = paren_close->GetOpeningParen();
+            Chunk const *sq_close   = paren_open->GetPrevNcNnlNi();
+            Chunk const *br_open    = paren_close->GetNextNcNnl();
+
+            bool        is_default_arg = false;
+
+            for (Chunk const *tmp = pc->GetPrevNcNnlNi();
+                 tmp->IsNotNullChunk() && tmp != paren_open;
+                 tmp = tmp->GetPrevNcNnlNi())
+            {
+               if (tmp->GetLevel() != pc->GetLevel())
+               {
+                  continue;
+               }
+
+               if (tmp->Is(E_Token::CT_ASSIGN))
+               {
+                  is_default_arg = true;
+                  break;
+               }
+
+               if (tmp->Is(E_Token::CT_COMMA))
+               {
+                  break;
+               }
+            }
+
+            if (  !is_default_arg
+               && sq_close->Is(E_Token::CT_SQUARE_CLOSE)
+               && br_open->Is(E_Token::CT_BRACE_OPEN))
+            {
+               pc->SetType(E_Token::CT_BYREF);
+               return(true);
+            }
+         }
+      }
+
       // Don't convert && to BYREF if we're inside statement parentheses (if, while, for, etc.)
       // and not in a clear template type context
       if (pc->TestFlags(PCF_IN_SPAREN))

--- a/tests/config/oc/lambda_rvalue_ref.cfg
+++ b/tests/config/oc/lambda_rvalue_ref.cfg
@@ -1,0 +1,4 @@
+sp_bool         = force
+sp_before_byref = force
+sp_after_byref  = remove
+sp_angle_word   = force

--- a/tests/expected/oc/60017-lambda_rvalue_ref.mm
+++ b/tests/expected/oc/60017-lambda_rvalue_ref.mm
@@ -1,0 +1,3 @@
+void f() {
+	auto provider = std::make_shared<Provider>([weakSelf](std::function<void()> &&onRender, bool isAsync) {});
+}

--- a/tests/input/oc/lambda_rvalue_ref.mm
+++ b/tests/input/oc/lambda_rvalue_ref.mm
@@ -1,0 +1,3 @@
+void f() {
+auto provider = std::make_shared<Provider>([weakSelf](std::function<void()> &&onRender, bool isAsync) {});
+}

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -260,3 +260,4 @@
 60014  oc/60014.cfg                             oc/4309.mm
 60015  oc/60015.cfg                             oc/4310.mm
 60016  cpp/Issue_4556_safe.cfg                  oc/Issue_4556_safe.mm              OC+
+60017  oc/lambda_rvalue_ref.cfg                 oc/lambda_rvalue_ref.mm            OC+


### PR DESCRIPTION
Objective-C++ lambda parameters whose template type ends before && can be mistaken for boolean expressions. This applies boolean spacing and separates the reference operator from the parameter name.

Recognize the surrounding lambda capture, parameter, and body delimiters while excluding default-argument expressions, so && remains an rvalue reference.