### PR TITLE
Bound preprocessor-skipping parameter scans

### DIFF
--- a/src/tokenizer/combine_fix_mark.cpp
+++ b/src/tokenizer/combine_fix_mark.cpp
@@ -2051,7 +2051,8 @@ void mark_function(Chunk *pc)
       bool  is_param = true;
       tmp = ref;
 
-      while (tmp != paren_close)
+      while (  tmp->IsNotNullChunk()
+            && tmp != paren_close)
       {
          // Use Npp to skip PP directives (#ifdef, #define, etc.) that may
          // appear inside function parameters at a lower level in nested contexts
@@ -2069,8 +2070,10 @@ void mark_function(Chunk *pc)
          }
          tmp = tmp2;
       }
+      const bool did_scan_params = tmp == paren_close;
 
-      if (  !is_extern
+      if (  did_scan_params
+         && !is_extern
          && is_param
          && ref != tmp)
       {
@@ -2087,7 +2090,8 @@ void mark_function(Chunk *pc)
          LOG_FMT(LFCN, "%s(%d):   3) Marked text '%s' as FUNC_CTOR_VAR on orig line %zu, orig col %zu\n",
                  __func__, __LINE__, pc->GetLogText(), pc->GetOrigLine(), pc->GetOrigCol());
       }
-      else if (pc->GetBraceLevel() > 0)
+      else if (  did_scan_params
+              && pc->GetBraceLevel() > 0)
       {
          Chunk const *br_open = pc->GetPrevType(E_Token::CT_BRACE_OPEN, pc->GetBraceLevel() - 1);
 

--- a/tests/config/oc/constructor_var_with_block.cfg
+++ b/tests/config/oc/constructor_var_with_block.cfg
@@ -1,0 +1,13 @@
+indent_columns = 2
+indent_func_proto_param = true
+indent_func_ctor_var_param = true
+indent_oc_block = true
+indent_oc_block_msg = 0
+indent_oc_block_msg_xcode_style = true
+indent_oc_inside_msg_sel = true
+indent_oc_msg_prioritize_first_colon = false
+nl_func_decl_args_multi_line = true
+nl_oc_msg_args = true
+nl_oc_msg_args_finish_multi_line = true
+nl_oc_msg_args_max_code_width = 200
+nl_oc_msg_args_min_params = 0

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -1697,3 +1697,4 @@
 34964  cpp/nl_for_operators.cfg                             cpp/nl_for_operators.cpp
 34965  cpp/sp_for_nested.cfg                                cpp/sp_for_nested.cpp
 34966  cpp/bool_and_sizeof.cfg                              cpp/bool_and_sizeof.cpp
+34967  common/empty.cfg                                     cpp/preproc_function_macro_alias.cpp

--- a/tests/expected/cpp/34967-preproc_function_macro_alias.cpp
+++ b/tests/expected/cpp/34967-preproc_function_macro_alias.cpp
@@ -1,0 +1,6 @@
+#define BEGIN_ALIASES
+#define END_ALIASES
+
+BEGIN_ALIASES
+#define Foo(x, y) Bar(x, y)
+END_ALIASES

--- a/tests/expected/oc/60018-preproc_function_macro_alias.mm
+++ b/tests/expected/oc/60018-preproc_function_macro_alias.mm
@@ -1,0 +1,6 @@
+#define BEGIN_ALIASES
+#define END_ALIASES
+
+BEGIN_ALIASES
+#define Foo(x, y) Bar(x, y)
+END_ALIASES

--- a/tests/expected/oc/60019-constructor_var_with_block.mm
+++ b/tests/expected/oc/60019-constructor_var_with_block.mm
@@ -1,0 +1,6 @@
+void f()
+{
+  ConstructorScope scope(self, identifier, ^{
+    return [[WidgetState alloc] initWithSectionContext:sectionContext componentContext:componentContext contextFactory:contextFactory];
+  });
+}

--- a/tests/input/cpp/preproc_function_macro_alias.cpp
+++ b/tests/input/cpp/preproc_function_macro_alias.cpp
@@ -1,0 +1,6 @@
+#define BEGIN_ALIASES
+#define END_ALIASES
+
+BEGIN_ALIASES
+#define Foo(x, y) Bar(x, y)
+END_ALIASES

--- a/tests/input/oc/constructor_var_with_block.mm
+++ b/tests/input/oc/constructor_var_with_block.mm
@@ -1,0 +1,6 @@
+void f()
+{
+  ConstructorScope scope(self, identifier, ^{
+    return [[WidgetState alloc] initWithSectionContext:sectionContext componentContext:componentContext contextFactory:contextFactory];
+  });
+}

--- a/tests/input/oc/preproc_function_macro_alias.mm
+++ b/tests/input/oc/preproc_function_macro_alias.mm
@@ -1,0 +1,6 @@
+#define BEGIN_ALIASES
+#define END_ALIASES
+
+BEGIN_ALIASES
+#define Foo(x, y) Bar(x, y)
+END_ALIASES

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -260,3 +260,5 @@
 60014  oc/60014.cfg                             oc/4309.mm
 60015  oc/60015.cfg                             oc/4310.mm
 60016  cpp/Issue_4556_safe.cfg                  oc/Issue_4556_safe.mm              OC+
+60018  common/empty.cfg                         oc/preproc_function_macro_alias.mm  OC+
+60019  oc/constructor_var_with_block.cfg        oc/constructor_var_with_block.mm    OC+


### PR DESCRIPTION
Constructor-variable detection scans function parameters while skipping preprocessor directives. For function-like macro aliases, that skip can move past the expected closing parenthesis, leaving the loop to advance forever on the null chunk.

Stop the scan at the null chunk and only perform constructor-variable classification when the closing parenthesis was reached. Otherwise, fall through to the existing prototype handling.