### PR TITLE
Fix for #4767: don't propagate PCF_IN_TYPEDEF into nested struct/union/enum/class bodies

### DIFF
--- a/src/tokenizer/combine_fix_mark.cpp
+++ b/src/tokenizer/combine_fix_mark.cpp
@@ -485,6 +485,34 @@ void fix_typedef(Chunk const *start)
    Chunk *the_type = Chunk::NullChunkPtr;
    Chunk *last_op  = Chunk::NullChunkPtr;
 
+   // Look ahead for a nested class/enum/struct/union body, so its member
+   // declarations can be excluded from PCF_IN_TYPEDEF below (Issue #4767).
+   Chunk *body_open  = Chunk::NullChunkPtr;
+   Chunk *body_close = Chunk::NullChunkPtr;
+
+   {
+      Chunk *look = start->GetNextNcNnl(E_Scope::PREPROC);
+
+      if (  look->Is(E_Token::CT_ENUM)
+         || look->Is(E_Token::CT_STRUCT)
+         || look->Is(E_Token::CT_UNION)
+         || look->Is(E_Token::CT_CLASS))
+      {
+         Chunk *tag_next = look->GetNextNcNnl(E_Scope::PREPROC);
+
+         if (tag_next->Is(E_Token::CT_TYPE))
+         {
+            tag_next = tag_next->GetNextNcNnl(E_Scope::PREPROC);
+         }
+
+         if (tag_next->Is(E_Token::CT_BRACE_OPEN))
+         {
+            body_open  = tag_next;
+            body_close = body_open->GetClosingParen(E_Scope::PREPROC);
+         }
+      }
+   }
+
    /*
     * Mark everything in the typedef and scan for ")(", which makes it a
     * function type
@@ -494,6 +522,19 @@ void fix_typedef(Chunk const *start)
         ; next = next->GetNextNcNnl(E_Scope::PREPROC))
    {
       next->SetFlagBits(PCF_IN_TYPEDEF);
+
+      if (  next == body_open
+         && body_close->IsNotNullChunk())
+      {
+         // Members of a nested class/enum/struct/union body are independent
+         // declarations, not part of the typedef's own declarator — do not
+         // propagate PCF_IN_TYPEDEF into them (Issue #4767). The delimiting
+         // braces themselves keep the flag (sp_brace_typedef and friends
+         // rely on it), only their contents are excluded.
+         body_close->SetFlagBits(PCF_IN_TYPEDEF);
+         next = body_close;
+         continue;
+      }
 
       if (start->GetLevel() == next->GetLevel())
       {

--- a/tests/c.test
+++ b/tests/c.test
@@ -793,3 +793,7 @@
 10292  common/global_align_span_pp_define_num_lines-1.cfg c/align_pp_define_span_mixed.c
 10293  common/global_align_span_pp_define_num_lines-2.cfg c/align_pp_define_span_mixed.c
 10294  common/global_align_span_pp_define_num_lines-3.cfg c/align_pp_define_span_mixed.c
+10295  c/Issue_4767.cfg                                   c/Issue_4767.c
+10296  c/Issue_4767.cfg                                   c/Issue_4767_mixed.c
+10297  c/Issue_4767.cfg                                   c/Issue_4767_union.c
+10298  c/Issue_4767.cfg                                   c/Issue_4767_enum.c

--- a/tests/config/c/Issue_4767.cfg
+++ b/tests/config/c/Issue_4767.cfg
@@ -1,0 +1,3 @@
+indent_columns                  = 4
+align_var_def_star_style        = 1
+align_var_struct_span           = 1

--- a/tests/expected/c/10280-Issue_4767.c
+++ b/tests/expected/c/10280-Issue_4767.c
@@ -1,0 +1,8 @@
+typedef struct IMUIShell
+{
+    uint32_t   (*AddRef)(IMUIObject *Self);
+    uint32_t   (*Release)(IMUIObject *Self);
+    uint32_t   (*Version)(IMUIObject *Self);
+    uint32_t   (*IfaceId)(IMUIObject *Self);
+    IMUIObject *(*QueryIface)(IMUIObject *Self, uint32_t IFaceId);
+} IMUIShell;

--- a/tests/expected/c/10281-Issue_4767_mixed.c
+++ b/tests/expected/c/10281-Issue_4767_mixed.c
@@ -1,0 +1,7 @@
+typedef struct Mixed
+{
+    int      count;
+    uint32_t (*AddRef)(IMUIObject *Self);
+    char     *name;
+    void     (*Shutdown)(IMUIObject *Self);
+} Mixed;

--- a/tests/expected/c/10282-Issue_4767_union.c
+++ b/tests/expected/c/10282-Issue_4767_union.c
@@ -1,0 +1,5 @@
+typedef union UShell
+{
+    uint32_t (*AddRef)(IMUIObject *Self);
+    int      raw;
+} UShell;

--- a/tests/expected/c/10283-Issue_4767_enum.c
+++ b/tests/expected/c/10283-Issue_4767_enum.c
@@ -1,0 +1,6 @@
+typedef enum Color
+{
+    RED,
+    GREEN,
+    BLUE
+} Color;

--- a/tests/input/c/Issue_4767.c
+++ b/tests/input/c/Issue_4767.c
@@ -1,0 +1,8 @@
+typedef struct IMUIShell
+{
+	uint32_t (*AddRef)(IMUIObject *Self);
+	uint32_t (*Release)(IMUIObject *Self);
+	uint32_t (*Version)(IMUIObject *Self);
+	uint32_t (*IfaceId)(IMUIObject *Self);
+	IMUIObject *(*QueryIface)(IMUIObject *Self, uint32_t IFaceId);
+} IMUIShell;

--- a/tests/input/c/Issue_4767_enum.c
+++ b/tests/input/c/Issue_4767_enum.c
@@ -1,0 +1,6 @@
+typedef enum Color
+{
+	RED,
+	GREEN,
+	BLUE
+} Color;

--- a/tests/input/c/Issue_4767_mixed.c
+++ b/tests/input/c/Issue_4767_mixed.c
@@ -1,0 +1,7 @@
+typedef struct Mixed
+{
+	int count;
+	uint32_t (*AddRef)(IMUIObject *Self);
+	char *name;
+	void (*Shutdown)(IMUIObject *Self);
+} Mixed;

--- a/tests/input/c/Issue_4767_union.c
+++ b/tests/input/c/Issue_4767_union.c
@@ -1,0 +1,5 @@
+typedef union UShell
+{
+	uint32_t (*AddRef)(IMUIObject *Self);
+	int raw;
+} UShell;


### PR DESCRIPTION
Fixes issue #4767.

 - Looked ahead in fix_typedef() to find a nested class/enum/struct/union body's brace-open/close pair before the marking loop starts.
 - Skipped propagating PCF_IN_TYPEDEF into that body's member declarations in the marking loop, while still setting it on the body's own closing brace.
 - Added 4 regression tests (c/Issue_4767.c, c/Issue_4767_mixed.c, c/Issue_4767_union.c, c/Issue_4767_enum.c) registered as c.test 10295-10298, with a new tests/config/c/Issue_4767.cfg.
 
**Note:** Fix co-authored with Claude