### PR TITLE
Fix for #4777: recognize and skip __declspec(...) keyword when detecting variable definitions

### DIFF
--- a/src/newlines/var_def_blk.cpp
+++ b/src/newlines/var_def_blk.cpp
@@ -12,6 +12,7 @@
 #include "newlines/is_func_call_or_def.h"
 #include "newlines/is_var_def.h"
 #include "newlines/min_after.h"
+#include "tokenizer/combine_skip.h"
 
 
 using namespace uncrustify;
@@ -71,6 +72,14 @@ Chunk *newline_var_def_blk(Chunk *start)
       if (pc->Is(E_Token::CT_QUALIFIER))
       {
          pc = pc->GetNext();
+         continue;
+      }
+
+      // skip '__declspec(...)' specifiers -- like a qualifier, they aren't
+      // themselves part of the variable definition that follows
+      if (pc->Is(E_Token::CT_DECLSPEC))
+      {
+         pc = skip_declspec_next(pc);
          continue;
       }
 

--- a/src/tokenizer/combine.cpp
+++ b/src/tokenizer/combine.cpp
@@ -4068,6 +4068,7 @@ void fix_symbols()
             || pc->Is(E_Token::CT_TYPE)
             || pc->Is(E_Token::CT_TYPENAME)
             || pc->Is(E_Token::CT_DC_MEMBER)          // Issue #2478
+            || pc->Is(E_Token::CT_DECLSPEC)            // a '__declspec(...)'-prefixed declaration is still a declaration
             || (  pc->Is(E_Token::CT_WORD)
                && !pc->TestFlags(PCF_IN_CONDITIONAL)  // Issue #3558
 //               && language_is_set(lang_flag_e::LANG_CPP)

--- a/src/tokenizer/combine_fix_mark.cpp
+++ b/src/tokenizer/combine_fix_mark.cpp
@@ -681,10 +681,29 @@ Chunk *fix_variable_definition(Chunk *start)
          || pc->Is(E_Token::CT_DC_MEMBER)
          || pc->Is(E_Token::CT_MEMBER)
          || pc->Is(E_Token::CT_PP)                       // Issue #3169
+         || pc->Is(E_Token::CT_DECLSPEC)                 // '__declspec(...)' prefix
          || pc->IsPointerOperator())
    {
       LOG_FMT(LFVD, "%s(%d):   1:text '%s', type is %s\n",
               __func__, __LINE__, pc->GetLogText(), get_token_name(pc->GetType()));
+
+      // A '__declspec(...)' specifier isn't itself part of the type/name
+      // run -- skip it and its parens (pc must still be the DECLSPEC chunk
+      // itself for skip_declspec_next() to act) and re-check the loop
+      // condition against whatever follows.
+      if (pc->Is(E_Token::CT_DECLSPEC))
+      {
+         pc = skip_declspec_next(pc);
+
+         if (pc->IsNullChunk())
+         {
+            LOG_FMT(LFVD, "%s(%d): pc is null chunk\n", __func__, __LINE__);
+            return(Chunk::NullChunkPtr);
+         }
+         LOG_FMT(LFVD, "%s(%d):   1b:text '%s', type is %s\n",
+                 __func__, __LINE__, pc->GetLogText(), get_token_name(pc->GetType()));
+         continue;
+      }
       cs.Push_Back(pc);
       pc = pc->GetNextNcNnl();
 

--- a/tests/config/cpp/declspec_var_def.cfg
+++ b/tests/config/cpp/declspec_var_def.cfg
@@ -1,0 +1,7 @@
+indent_columns                  = 4
+align_var_def_star_style        = 1
+align_var_def_span              = 2
+align_var_def_gap               = 1
+indent_class                    = true
+indent_namespace                = true
+indent_extern                   = true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -1697,3 +1697,9 @@
 34964  cpp/nl_for_operators.cfg                             cpp/nl_for_operators.cpp
 34965  cpp/sp_for_nested.cfg                                cpp/sp_for_nested.cpp
 34966  cpp/bool_and_sizeof.cfg                              cpp/bool_and_sizeof.cpp
+
+60180  cpp/declspec_var_def.cfg                             cpp/declspec_extern_c.cpp
+60181  cpp/declspec_var_def.cfg                             cpp/declspec_single.cpp
+60182  cpp/declspec_var_def.cfg                             cpp/declspec_func_decl.cpp
+60183  cpp/declspec_var_def.cfg                             cpp/declspec_class_namespace.cpp
+60184  cpp/declspec_var_def.cfg                             cpp/declspec_mixed_block.cpp

--- a/tests/expected/cpp/60180-declspec_extern_c.cpp
+++ b/tests/expected/cpp/60180-declspec_extern_c.cpp
@@ -1,0 +1,4 @@
+extern "C" {
+    __declspec(dllexport) DWORD NvOptimusEnablement = 1;
+    __declspec(dllexport) int   AmdPowerXpressRequestHighPerformance = 1;
+}

--- a/tests/expected/cpp/60181-declspec_single.cpp
+++ b/tests/expected/cpp/60181-declspec_single.cpp
@@ -1,0 +1,1 @@
+__declspec(dllexport) DWORD NvOptimusEnablement = 1;

--- a/tests/expected/cpp/60182-declspec_func_decl.cpp
+++ b/tests/expected/cpp/60182-declspec_func_decl.cpp
@@ -1,0 +1,2 @@
+__declspec(dllexport) void Foo(void);
+__declspec(dllexport) int Bar(int x, int y);

--- a/tests/expected/cpp/60183-declspec_class_namespace.cpp
+++ b/tests/expected/cpp/60183-declspec_class_namespace.cpp
@@ -1,0 +1,12 @@
+class Foo
+{
+public:
+    __declspec(dllexport) static int Bar;
+    __declspec(dllexport) static int BazQux;
+};
+
+namespace N
+{
+    __declspec(dllexport) int Bar = 1;
+    __declspec(dllexport) int BazQux = 2;
+}

--- a/tests/expected/cpp/60184-declspec_mixed_block.cpp
+++ b/tests/expected/cpp/60184-declspec_mixed_block.cpp
@@ -1,0 +1,8 @@
+#define EXPORT __declspec(dllexport)
+extern "C" {
+    EXPORT DWORD              NvOptimusEnablement1 = 1;
+    EXPORT DWORD              NvOptimusEnablement2 = 3;
+    __declspec(dllexport) int AmdPowerXpressRequestHighPerformance1 = 1;
+    __declspec(dllexport) int AmdPowerXpressRequestHighPerformance2 = 2;
+    __declspec(dllexport) int AmdPowerXpressRequestHighPerformance3 = 3;
+}

--- a/tests/input/cpp/declspec_class_namespace.cpp
+++ b/tests/input/cpp/declspec_class_namespace.cpp
@@ -1,0 +1,12 @@
+class Foo
+{
+public:
+	__declspec(dllexport) static int Bar;
+	__declspec(dllexport) static int BazQux;
+};
+
+namespace N
+{
+	__declspec(dllexport) int Bar = 1;
+	__declspec(dllexport) int BazQux = 2;
+}

--- a/tests/input/cpp/declspec_extern_c.cpp
+++ b/tests/input/cpp/declspec_extern_c.cpp
@@ -1,0 +1,4 @@
+extern "C" {
+	__declspec(dllexport) DWORD NvOptimusEnablement = 1;
+	__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}

--- a/tests/input/cpp/declspec_func_decl.cpp
+++ b/tests/input/cpp/declspec_func_decl.cpp
@@ -1,0 +1,2 @@
+__declspec(dllexport) void Foo(void);
+__declspec(dllexport) int Bar(int x, int y);

--- a/tests/input/cpp/declspec_mixed_block.cpp
+++ b/tests/input/cpp/declspec_mixed_block.cpp
@@ -1,0 +1,8 @@
+#define EXPORT __declspec(dllexport)
+extern "C" {
+	EXPORT DWORD NvOptimusEnablement1 = 1;
+	EXPORT DWORD NvOptimusEnablement2 = 3;
+	__declspec(dllexport) int AmdPowerXpressRequestHighPerformance1 = 1;
+	__declspec(dllexport) int AmdPowerXpressRequestHighPerformance2 = 2;
+	__declspec(dllexport) int AmdPowerXpressRequestHighPerformance3 = 3;
+}

--- a/tests/input/cpp/declspec_single.cpp
+++ b/tests/input/cpp/declspec_single.cpp
@@ -1,0 +1,1 @@
+__declspec(dllexport) DWORD NvOptimusEnablement = 1;


### PR DESCRIPTION
Fixes #4777.

 - Recognized CT_DECLSPEC as a valid statement-start token in fix_symbols()'s variable-definition gate (combine.cpp) so fix_variable_definition() is actually invoked for declarations prefixed with __declspec(...).
 - Made fix_variable_definition()'s scan loop (combine_fix_mark.cpp) skip a leading __declspec(...) specifier via the existing skip_declspec_next() helper before continuing to scan for the real type/name run.
 - Added a matching CT_DECLSPEC skip to newline_var_def_blk()'s own "skip qualifiers" step (src/newlines/var_def_blk.cpp), via the same skip_declspec_next() helper, mirroring its existing CT_QUALIFIER handling.
 - Added 5 regression tests (cpp/declspec_extern_c.cpp, cpp/declspec_single.cpp, cpp/declspec_func_decl.cpp, cpp/declspec_class_namespace.cpp, cpp/declspec_mixed_block.cpp) registered as cpp.test 60180-60184, with a new tests/config/cpp/declspec_var_def.cfg.
 
**Note:** Fix co-authored with Claude
