### PR TITLE
Fix for #4780: add VERSIONINFO for WIN32, match official binary for MSVC, semver+hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,25 @@ endif()
 if(MSVC)
   add_definitions(/D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_WARNINGS /wd4267)
   add_definitions(/utf-8)
+
+  # Match the official MinGW-w64 binaries, which are statically linked
+  # against the CRT (no runtime DLL dependency).
+  foreach(flag_var
+      CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+      CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO
+      CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+      CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
+    string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+  endforeach()
+
+  # Match the official MinGW-w64 binaries, which embed no manifest.
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /MANIFEST:NO")
+
+  # Release builds must not carry debug information. /EMITPOGOPHASEINFO is
+  # an undocumented link.exe switch that strips the .debug section outright.
+  string(REGEX REPLACE "/Z[iI7]" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+  string(REGEX REPLACE "/Z[iI7]" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+  set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /debug:none /EMITPOGOPHASEINFO")
 elseif(CMAKE_COMPILER_IS_GNUCXX)
   set(gcc_warning_flags
     -Wall
@@ -140,6 +159,21 @@ set(UNCRUSTIFY_VERSION "0.83.0_f")
 
 option(NoGitVersionString "Do not use make_version.py and git to build a version string" OFF)
 if(NoGitVersionString)
+  # No git lookup in this mode, so VER_STRING can't carry a commit hash --
+  # derive VER_MAJOR/VER_MINOR/VER_PATCH/VER_STRING from the static fallback
+  # literal above, same as GenerateVersionHeader.cmake does for the git path.
+  string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" _ver_match "${UNCRUSTIFY_VERSION}")
+  if(NOT _ver_match)
+    message(FATAL_ERROR
+      "Could not parse major.minor.patch out of UNCRUSTIFY_VERSION "
+      "'${UNCRUSTIFY_VERSION}'; cannot derive VER_MAJOR/VER_MINOR/VER_PATCH "
+      "for uncrustify.rc")
+  endif()
+  set(VER_MAJOR ${CMAKE_MATCH_1})
+  set(VER_MINOR ${CMAKE_MATCH_2})
+  set(VER_PATCH ${CMAKE_MATCH_3})
+  set(VER_STRING "${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}")
+
   configure_file(src/uncrustify_version.h.in uncrustify_version.h @ONLY)
   add_custom_target(generate_version_header) # Dummy target
 else()
@@ -543,6 +577,14 @@ set(uncrustify_docs
 
 add_executable(uncrustify ${uncrustify_sources} ${uncrustify_headers})
 add_dependencies(uncrustify generate_version_header)
+
+if(WIN32)
+  target_sources(uncrustify PRIVATE src/uncrustify.rc)
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    # cl.exe auto-defines _WIN64 for 64-bit targets; rc.exe does not.
+    set_source_files_properties(src/uncrustify.rc PROPERTIES COMPILE_DEFINITIONS "_WIN64")
+  endif()
+endif()
 target_compile_features(uncrustify PUBLIC cxx_std_17)
 
 set_property(TARGET uncrustify APPEND PROPERTY

--- a/cmake/GenerateVersionHeader.cmake
+++ b/cmake/GenerateVersionHeader.cmake
@@ -6,6 +6,8 @@
 # `OUTPUT` and `UNCRUSTIFY_VERSION` to be set.
 #
 
+# Store fallback version before running make_version.py
+set(FALLBACK_VERSION "${UNCRUSTIFY_VERSION}")
 
 execute_process(
   COMMAND ${PYTHON_EXECUTABLE} ${SOURCE_DIR}/scripts/make_version.py
@@ -31,9 +33,60 @@ if (make_version_error)
     "fallback version '${UNCRUSTIFY_VERSION}' will be used")
   message(STATUS
     "(This is normal if you are building from a zip / tarball)")
+
+  # No git available in this branch -- VER_STRING can't carry a commit hash.
+  set(GIT_SHORT_HASH "")
 else()
-  string(STRIP ${make_version_output} UNCRUSTIFY_VERSION)
+  string(STRIP ${make_version_output} DETECTED_VERSION)
+
+  # If make_version.py returned a valid X.Y version, use it.
+  # If it returned a raw commit hash due to shallow fetch, preserve the fallback version.
+  if (DETECTED_VERSION MATCHES "^[0-9]+\.[0-9]+")
+    set(UNCRUSTIFY_VERSION "${DETECTED_VERSION}")
+  else()
+    set(UNCRUSTIFY_VERSION "${FALLBACK_VERSION}")
+  endif()
+  
   message(STATUS "Version: '${UNCRUSTIFY_VERSION}'")
+
+  # git is known to work at this point (make_version.py just used it),
+  # so grab the short hash of the current commit for VER_STRING below.
+  execute_process(
+    COMMAND git rev-parse --short HEAD
+    WORKING_DIRECTORY ${SOURCE_DIR}
+    RESULT_VARIABLE git_hash_error
+    OUTPUT_VARIABLE GIT_SHORT_HASH
+  )
+  if (git_hash_error)
+    set(GIT_SHORT_HASH "")
+  else()
+    string(STRIP "${GIT_SHORT_HASH}" GIT_SHORT_HASH)
+  endif()
+endif()
+
+# Derive VER_MAJOR/VER_MINOR/VER_PATCH/VER_STRING (for uncrustify.rc) from
+# the same resolved UNCRUSTIFY_VERSION above, whichever branch produced it.
+string(REGEX MATCH "^([0-9]+)\.([0-9]+)\.([0-9]+)" _ver_match "${UNCRUSTIFY_VERSION}")
+if (NOT _ver_match)
+  message(FATAL_ERROR
+    "Could not parse major.minor.patch out of UNCRUSTIFY_VERSION "
+    "'${UNCRUSTIFY_VERSION}'; cannot derive VER_MAJOR/VER_MINOR/VER_PATCH "
+    "for uncrustify.rc")
+endif()
+set(VER_MAJOR ${CMAKE_MATCH_1})
+set(VER_MINOR ${CMAKE_MATCH_2})
+set(VER_PATCH ${CMAKE_MATCH_3})
+
+if (GIT_SHORT_HASH)
+  set(VER_STRING "${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}+${GIT_SHORT_HASH}")
+
+  # Also carry the hash on the CLI-facing UNCRUSTIFY_VERSION (used by
+  # --version et al.) -- the fallback literal (e.g. "0.84.0_f") is left
+  # untouched when no hash is available, so its "_f" marker still tells
+  # fallback builds apart from a real, on-tag git build with no hash.
+  set(UNCRUSTIFY_VERSION "${UNCRUSTIFY_VERSION}+${GIT_SHORT_HASH}")
+else()
+  set(VER_STRING "${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}")
 endif()
 
 configure_file("${INPUT}" "${OUTPUT}" @ONLY)

--- a/src/uncrustify.rc
+++ b/src/uncrustify.rc
@@ -1,0 +1,45 @@
+
+#include <winresrc.h>
+#include "uncrustify_version.h"
+
+#pragma code_page(65001)
+
+VS_VERSION_INFO VERSIONINFO
+	FILEVERSION	VER_MAJOR,VER_MINOR,VER_PATCH,0
+	FILEFLAGSMASK	0x3fL
+#if DEBUG == 1
+	FILEFLAGS	0x1L
+#else
+	FILEFLAGS	0x0L
+#endif
+	FILEOS		0x40004L
+	FILETYPE	0x1L
+	FILESUBTYPE	0x0L
+BEGIN
+	BLOCK "StringFileInfo"
+	BEGIN
+		BLOCK "040904b0"
+		BEGIN
+			VALUE "FileDescription", "A source code beautifier for C, C++, C#, Objective-C, D, Java, Pawn and Vala"
+			VALUE "ProductVersion", VER_STRING
+#if _WIN64 == 1
+#if DEBUG == 1
+			VALUE "ProductName", "Uncrustify (x64, Debug)"
+#else
+			VALUE "ProductName", "Uncrustify (x64)"
+#endif
+#else
+#if DEBUG == 1
+			VALUE "ProductName", "Uncrustify (x86, Debug)"
+#else
+			VALUE "ProductName", "Uncrustify (x86)"
+#endif
+#endif
+			VALUE "OriginalFilename", "uncrustify.exe"
+		END
+	END
+	BLOCK "VarFileInfo"
+	BEGIN
+		VALUE "Translation", 0x409, 1200
+	END
+END

--- a/src/uncrustify_version.h.in
+++ b/src/uncrustify_version.h.in
@@ -15,4 +15,16 @@
 #define UNCRUSTIFY_VERSION    "Uncrustify-@UNCRUSTIFY_VERSION@"
 #endif
 
+/*
+ * VER_MAJOR/VER_MINOR/VER_PATCH and VER_STRING are derived from the same
+ * resolved UNCRUSTIFY_VERSION above (real git describe output, or the
+ * static fallback literal when built without git history/NoGitVersionString)
+ * -- see cmake/GenerateVersionHeader.cmake. VER_STRING additionally carries
+ * the current commit's short hash when one was actually available.
+ */
+#define VER_MAJOR    @VER_MAJOR@
+#define VER_MINOR    @VER_MINOR@
+#define VER_PATCH    @VER_PATCH@
+#define VER_STRING   "@VER_STRING@"
+
 #endif /* UNCRUSTIFY_VERSION_H_INCLUDED */


### PR DESCRIPTION
Fixes #4780.

 - Added src/uncrustify.rc with FileDescription/ProductName/ProductVersion for Windows builds, wired into the executable target on WIN32 only.
 - Defined _WIN64 for the resource compiler on 64-bit builds, since only cl.exe auto-defines it, not rc.exe/windres.
 - Derived VER_MAJOR/VER_MINOR/VER_PATCH/VER_STRING from UNCRUSTIFY_VERSION in both the git and NoGitVersionString paths, and failed the CMake configure/build if UNCRUSTIFY_VERSION doesn't match major.minor.patch.
 - Appended the short commit hash to UNCRUSTIFY_VERSION and VER_STRING when git is available.
 - Switched MSVC builds to the static CRT (/MT, /MTd) to match the statically-linked official binaries.
 - Disabled manifest generation for MSVC builds (/MANIFEST:NO) to match the official MinGW-linked binaries, which embed none.
 - Stripped debug information from MSVC Release builds and passed /debug:none plus the undocumented /EMITPOGOPHASEINFO link.exe switch to the Release linker.
 
 **Note:** Fix co-authored with Claude
