### PR TITLE
Fix for #4782: don't mistype ^ as block or ptr

### DIFF
--- a/src/tokenizer/combine.cpp
+++ b/src/tokenizer/combine.cpp
@@ -98,6 +98,54 @@ static void handle_oc_block_type(Chunk *pc);
 
 
 /**
+ * Issue #4782: test whether the template argument list closed by
+ * 'angle_close' (a CT_ANGLE_CLOSE chunk) genuinely begins its enclosing
+ * statement -- i.e. this is a declaration ('array<int>^ Name', optionally
+ * behind a bounded run of declaration-prefix qualifiers like 'static'),
+ * as opposed to being embedded inside an expression that already started
+ * elsewhere ('int y = Mask<4> ^ Mask<8>;', 'return Mask<4> ^ Mask<8>;').
+ *
+ * Both shapes present the exact same immediate token sequence at the '^'
+ * that may follow (CT_ANGLE_CLOSE, then CT_CARET) -- PCF_EXPR_START alone
+ * cannot tell them apart, since it is (correctly) set on the token after
+ * *any* '>', including one that merely continues an already-open
+ * expression. PCF_STMT_START, in contrast, is only ever set on the one
+ * token that truly begins a statement, so walking back from the template
+ * name to see whether it (or a qualifier ahead of it) carries that flag
+ * is sufficient to distinguish the two cases without any semantic
+ * (type-vs-value) knowledge of the template itself.
+ *
+ * @param angle_close  the CT_ANGLE_CLOSE chunk that a '^' or '%' may
+ *                     immediately follow
+ */
+static bool angle_close_starts_declaration(Chunk const *angle_close)
+{
+   Chunk const *angle_open = angle_close->GetOpeningParen();
+
+   if (angle_open->IsNullChunk())
+   {
+      return(false);
+   }
+   Chunk const *pc = angle_open->GetPrevNcNnlNi();   // the template name itself
+
+   while (pc->IsNotNullChunk())
+   {
+      if (pc->TestFlags(PCF_STMT_START))
+      {
+         return(true);
+      }
+      pc = pc->GetPrevNcNnlNi();
+
+      if (pc->IsNot(E_Token::CT_QUALIFIER))
+      {
+         return(false);
+      }
+   }
+   return(false);
+} // angle_close_starts_declaration
+
+
+/**
  * Process an ObjC message spec/dec
  *
  * Specs:
@@ -2500,8 +2548,19 @@ void do_symbol_check(Chunk *prev, Chunk *pc, Chunk *next)
    {
       if (pc->Is(E_Token::CT_CARET))
       {
-         if (  pc->TestFlags(PCF_EXPR_START)
-            || pc->TestFlags(PCF_IN_PREPROC))
+         // Issue #4782: a '^' immediately following the closing '>' of a
+         // template argument list (e.g. 'array<int>^', a C++/CLI handle
+         // suffix, or 'Mask<4> ^ [](){ ... }()' in plain C++14) is not a
+         // fresh expression -- it's continuing the type/value that the
+         // template-close just finished. The generic post-'>' expression-
+         // boundary reset stamps PCF_EXPR_START on it anyway, which would
+         // otherwise make it look like a legitimate Objective-C block
+         // literal start ('^ RTYPE ( ARGS ) { BODY }').
+         Chunk const *prev_nc = pc->GetPrevNcNnlNi();
+
+         if (  (  pc->TestFlags(PCF_EXPR_START)
+               || pc->TestFlags(PCF_IN_PREPROC))
+            && prev_nc->IsNot(E_Token::CT_ANGLE_CLOSE))
          {
             handle_oc_block_literal(pc);
             return;
@@ -3288,7 +3347,8 @@ void do_symbol_check(Chunk *prev, Chunk *pc, Chunk *next)
 
       if (  language_is_set(lang_flag_e::LANG_CPP)
          && pc->Is(E_Token::CT_CARET)
-         && prev->Is(E_Token::CT_ANGLE_CLOSE))
+         && prev->Is(E_Token::CT_ANGLE_CLOSE)
+         && angle_close_starts_declaration(prev))   // Issue #4782
       {
          pc->SetType(E_Token::CT_PTR_TYPE);
       }
@@ -3330,9 +3390,10 @@ void do_symbol_check(Chunk *prev, Chunk *pc, Chunk *next)
 
       else if (pc->Is(E_Token::CT_CARET))
       {
-         if (  language_is_set(lang_flag_e::LANG_C)
-            || language_is_set(lang_flag_e::LANG_CPP)
-            || language_is_set(lang_flag_e::LANG_OC))
+         if (  (  language_is_set(lang_flag_e::LANG_C)
+               || language_is_set(lang_flag_e::LANG_CPP)
+               || language_is_set(lang_flag_e::LANG_OC))
+            && prev->IsNot(E_Token::CT_ANGLE_CLOSE))   // Issue #4782
          {
             // This is likely the start of a block literal
             handle_oc_block_literal(pc);

--- a/tests/config/cpp/Issue_4782.cfg
+++ b/tests/config/cpp/Issue_4782.cfg
@@ -1,0 +1,1 @@
+indent_columns = 4

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -1698,6 +1698,9 @@
 34965  cpp/sp_for_nested.cfg                                cpp/sp_for_nested.cpp
 34966  cpp/bool_and_sizeof.cfg                              cpp/bool_and_sizeof.cpp
 
+34967  cpp/Issue_4782.cfg                                   cpp/Issue_4782_decl.cpp
+34968  cpp/Issue_4782.cfg                                   cpp/Issue_4782_xor.cpp
+
 34970  common/align_pp_define_span_num_empty-1.cfg        cpp/align_pp_define_span_mixed.cpp
 34971  common/align_pp_define_span_num_empty-2.cfg        cpp/align_pp_define_span_mixed.cpp
 34972  common/align_pp_define_span_num_empty-3.cfg        cpp/align_pp_define_span_mixed.cpp

--- a/tests/expected/cpp/34967-Issue_4782_decl.cpp
+++ b/tests/expected/cpp/34967-Issue_4782_decl.cpp
@@ -1,0 +1,29 @@
+// Issue #4782, part A: a '^' immediately after a template's closing '>'
+// must not be misidentified as an Objective-C block literal.
+
+array<int>^ GetData()
+{
+    return m_Data;
+}
+
+array<int>^ m_Data;
+
+String^ GetName()
+{
+    return m_Name;
+}
+
+List<String^>^ GetNames()
+{
+    return m_Names;
+}
+
+List<List<int> >^ nested;
+
+static array<int>^ s_Data;
+
+class Foo
+{
+array<int>^ m_Data;
+static array<int>^ s_Data;
+};

--- a/tests/expected/cpp/34968-Issue_4782_xor.cpp
+++ b/tests/expected/cpp/34968-Issue_4782_xor.cpp
@@ -1,0 +1,58 @@
+// Issue #4782, part B: a '^' following a value-template instantiation's
+// closing '>' must stay a bitwise XOR, not be misclassified as a pointer/
+// handle type, when it is embedded inside an expression rather than
+// genuinely starting a declaration.
+
+template<int N> constexpr int Mask = N;
+template<int N> int GetMask() {
+    return N;
+}
+
+int Case1()
+{
+    int y = Mask<4> ^ Mask<8>;
+    return y;
+}
+
+int Case2()
+{
+    int y = Mask<4> ^ 0xFF;
+    return y;
+}
+
+int Case3()
+{
+    int y = Mask<4> ^ SOME_MACRO;
+    return y;
+}
+
+int Case4()
+{
+    int y = Mask<4> ^ GetValue();
+    return y;
+}
+
+int Case5()
+{
+    int x = Mask<4> ^ [] (){ return 1; } ();
+    return x;
+}
+
+int Case6()
+{
+    Mask<4> ^= 8;
+    return 0;
+}
+
+int Case7()
+{
+    int y = GetMask<4>() ^ GetMask<8>();
+    return y;
+}
+
+int Case8()
+{
+    return Mask<4> ^ Mask<8>;
+}
+
+static array<int>^ s_Data;

--- a/tests/input/cpp/Issue_4782_decl.cpp
+++ b/tests/input/cpp/Issue_4782_decl.cpp
@@ -1,0 +1,29 @@
+// Issue #4782, part A: a '^' immediately after a template's closing '>'
+// must not be misidentified as an Objective-C block literal.
+
+array<int>^ GetData()
+{
+	return m_Data;
+}
+
+array<int>^ m_Data;
+
+String^ GetName()
+{
+	return m_Name;
+}
+
+List<String^>^ GetNames()
+{
+	return m_Names;
+}
+
+List<List<int>>^ nested;
+
+static array<int>^ s_Data;
+
+class Foo
+{
+	array<int>^ m_Data;
+	static array<int>^ s_Data;
+};

--- a/tests/input/cpp/Issue_4782_xor.cpp
+++ b/tests/input/cpp/Issue_4782_xor.cpp
@@ -1,0 +1,56 @@
+// Issue #4782, part B: a '^' following a value-template instantiation's
+// closing '>' must stay a bitwise XOR, not be misclassified as a pointer/
+// handle type, when it is embedded inside an expression rather than
+// genuinely starting a declaration.
+
+template<int N> constexpr int Mask = N;
+template<int N> int GetMask() { return N; }
+
+int Case1()
+{
+	int y = Mask<4> ^ Mask<8>;
+	return y;
+}
+
+int Case2()
+{
+	int y = Mask<4> ^ 0xFF;
+	return y;
+}
+
+int Case3()
+{
+	int y = Mask<4> ^ SOME_MACRO;
+	return y;
+}
+
+int Case4()
+{
+	int y = Mask<4> ^ GetValue();
+	return y;
+}
+
+int Case5()
+{
+	int x = Mask<4> ^ [](){ return 1; }();
+	return x;
+}
+
+int Case6()
+{
+	Mask<4> ^= 8;
+	return 0;
+}
+
+int Case7()
+{
+	int y = GetMask<4>() ^ GetMask<8>();
+	return y;
+}
+
+int Case8()
+{
+	return Mask<4> ^ Mask<8>;
+}
+
+static array<int>^ s_Data;


### PR DESCRIPTION
 - Excluded ^ after CT_ANGLE_CLOSE from Obj-C block-literal detection at both call sites in do_symbol_check() (combine.cpp), which corrupted declarations like array<int>^ GetData().
 - Added angle_close_starts_declaration() (combine.cpp), testing PCF_STMT_START to tell real declarations (array<int>^ Name) apart from value-template expressions (Mask<4> ^ Mask<8>) that look identical at that point.
 - Gated the existing 2015 CT_ANGLE_CLOSE -> CT_PTR_TYPE rule (083e919cda) on that check, so XOR against a template value, literal, macro, call, or lambda now types correctly.
 - Added regression tests cpp/Issue_4782_{decl,xor}.cpp (cpp.test 34967-34968), tests/config/cpp/Issue_4782.cfg.

**Note:** Fix co-authored with Claude.
