### PR TITLE
Add option to align lambda semicolon

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1614,6 +1614,7 @@ void indent_text()
                  && pc->GetParentType() == E_Token::CT_CPP_LAMBDA)
          {
             log_rule_B("indent_cpp_lambda_body");
+            log_rule_B("indent_cpp_lambda_align_semicolon");
             frm.top().SetBraceIndent(frm.prev().GetIndent());
 
             Chunk const *head         = frm.top().GetOpenChunk()->GetPrevNcNnlNpp();
@@ -1700,7 +1701,8 @@ void indent_text()
 
             if (  sameLine
                && (  (isAssignSameLine)
-                  || (closureSameLineTopLevel)))
+                  || (closureSameLineTopLevel)
+                  || (options::indent_cpp_lambda_align_semicolon())))
             {
                if (indent_size > frm.top().GetBraceIndent())       // if options::indent_indent_columns() is too big
                {

--- a/src/options.h
+++ b/src/options.h
@@ -2011,6 +2011,10 @@ indent_token_after_brace; // = true
 extern Option<bool>
 indent_cpp_lambda_body;
 
+// Align the semicolon of a lambda expression with the indentation of its body.
+extern Option<bool>
+indent_cpp_lambda_align_semicolon;
+
 // How to indent compound literals that are being returned.
 // true: add both the indent from return & the compound literal open brace
 //       (i.e. 2 indent levels)


### PR DESCRIPTION
Introduce a new boolean option indent_cpp_lambda_align_semicolon and wire it into indent logic for C++ lambdas. When enabled, the formatter will consider aligning a lambda's trailing semicolon with the lambda body indentation. Added a log entry and updated the condition in indent_text to respect the new option.